### PR TITLE
mingw build: allow to pass custom CFLAGS

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -110,7 +110,7 @@ endif
 -include $(OBJDIR)/version.inc
 
 # Global flags for all compilers
-CFLAGS	= $(OPT) -D$(DB) -DLIBSSH2_WIN32 # -DHAVE_CONFIG_H
+CFLAGS	= $(LIBSSH2_CFLAG_EXTRAS) $(OPT) -D$(DB) -DLIBSSH2_WIN32 # -DHAVE_CONFIG_H
 
 ifeq ($(CC),mwcc)
 LD	= mwld


### PR DESCRIPTION
Allow to pass custom `CFLAGS` options via environment variable `LIBSSH2_CFLAG_EXTRAS`. Default and automatically added options of `GNUmakefile` have preference over custom ones. This addition is useful for passing f.e. custom CPU tuning or LTO optimization (`-flto -ffat-lto-objects`) options. The only current way to do this is to edit `GNUmakefile`. This patch makes it unnecessary.

This is a mirror of similar libcurl patch: https://github.com/bagder/curl/pull/136