### PR TITLE
Must init ctx

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -418,6 +418,7 @@ knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                        stored hash.
                     */
                     libssh2_hmac_ctx ctx;
+                    libssh2_hmac_ctx_init(ctx);
                     unsigned char hash[SHA_DIGEST_LENGTH];
 
                     if(SHA_DIGEST_LENGTH != node->name_len) {

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -82,6 +82,7 @@
   gcry_md_hash_buffer (GCRY_MD_MD5, out, message, len)
 
 #define libssh2_hmac_ctx gcry_md_hd_t
+#define libssh2_hmac_ctx_init(ctx)
 #define libssh2_hmac_sha1_init(ctx, key, keylen) \
   gcry_md_open (ctx, GCRY_MD_SHA1, GCRY_MD_FLAG_HMAC), \
     gcry_md_setkey (*ctx, key, keylen)

--- a/src/mac.c
+++ b/src/mac.c
@@ -113,6 +113,7 @@ mac_method_hmac_sha1_hash(LIBSSH2_SESSION * session,
 
     _libssh2_htonu32(seqno_buf, seqno);
 
+    libssh2_hmac_ctx_init(ctx);
     libssh2_hmac_sha1_init(&ctx, *abstract, 20);
     libssh2_hmac_update(ctx, seqno_buf, 4);
     libssh2_hmac_update(ctx, packet, packet_len);

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -121,6 +121,8 @@ int libssh2_md5_init(libssh2_md5_ctx *);
 void libssh2_md5(const unsigned char *message, unsigned long len, unsigned char *out);
 
 #define libssh2_hmac_ctx HMAC_CTX
+#define libssh2_hmac_ctx_init(ctx) \
+  HMAC_CTX_init(&ctx)
 #define libssh2_hmac_sha1_init(ctx, key, keylen) \
   HMAC_Init(ctx, key, keylen, EVP_sha1())
 #define libssh2_hmac_md5_init(ctx, key, keylen) \


### PR DESCRIPTION
Must init ctx before using it or openssl will reuse the hmac which is not thread safe and causes a crash.