### PR TITLE
Fix channel write loop in direct_tcpip example

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -275,14 +275,17 @@ int main(int argc, char *argv[])
                 goto shutdown;
             }
             wr = 0;
-            do {
-                i = libssh2_channel_write(channel, buf, len);
+            while(wr < len) {
+                i = libssh2_channel_write(channel, buf + wr, len - wr);
+                if (LIBSSH2_ERROR_EAGAIN == i) {
+                    continue;
+                }
                 if (i < 0) {
                     fprintf(stderr, "libssh2_channel_write: %d\n", i);
                     goto shutdown;
                 }
                 wr += i;
-            } while(i > 0 && wr < len);
+            }
         }
         while (1) {
             len = libssh2_channel_read(channel, buf, sizeof(buf));


### PR DESCRIPTION
This pull request fixes the channel write loop in the direct_tcpip sample.

https://trac.libssh2.org/ticket/281
https://trac.libssh2.org/ticket/293