### PR TITLE
libssh2_channel_open: more detailed error message

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -266,8 +266,28 @@ _libssh2_channel_open(LIBSSH2_SESSION * session, const char *channel_type,
         }
 
         if (session->open_data[0] == SSH_MSG_CHANNEL_OPEN_FAILURE) {
-            _libssh2_error(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
-                           "Channel open failure");
+			unsigned int reason_code = _libssh2_ntohu32(session->open_data + 5);
+			switch (reason_code) {
+				case SSH_OPEN_ADMINISTRATIVELY_PROHIBITED:
+					_libssh2_error(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
+								   "Channel open failure (admininstratively prohibited)");
+					break;
+				case SSH_OPEN_CONNECT_FAILED:
+					_libssh2_error(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
+								   "Channel open failure (connect failed)");
+					break;
+				case SSH_OPEN_UNKNOWN_CHANNELTYPE:
+					_libssh2_error(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
+								   "Channel open failure (unknown channel type)");
+					break;
+				case SSH_OPEN_RESOURCE_SHORTAGE:
+					_libssh2_error(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
+								   "Channel open failure (resource shortage)");
+					break;
+				default:
+					_libssh2_error(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
+								   "Channel open failure");
+			}
         }
     }
 


### PR DESCRIPTION
The error message returned by libssh2_channel_open in case of a server side channel open failure is now more detailed and includes the four standard error conditions in RFC 4254.