### PR TITLE
GNUmakefile: add -m64 CFLAGS when targeting mingw64, -m32/-m64 to LDFLAGS

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -14,7 +14,7 @@ endif
 
 # Edit the path below to point to the base of your OpenSSL package.
 ifndef OPENSSL_PATH
-OPENSSL_PATH = ../../openssl-0.9.8zc
+OPENSSL_PATH = ../../openssl-1.0.2c
 endif
 
 # Edit the path below to point to your Distribution folder.
@@ -142,10 +142,12 @@ CFLAGS	+= -fno-builtin
 CFLAGS	+= -fno-strict-aliasing
 CFLAGS	+= -Wall # -pedantic
 ifeq ($(ARCH),w64)
-CFLAGS	+= -D_AMD64_
+CFLAGS	+= -m64 -D_AMD64_
+LDFLAGS += -m64
 RCFLAGS	+= -F pe-x86-64
 else
 CFLAGS	+= -m32
+LDFLAGS += -m32
 RCFLAGS	+= -F pe-i386
 endif
 endif

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -14,7 +14,7 @@ endif
 
 # Edit the path below to point to the base of your OpenSSL package.
 ifndef OPENSSL_PATH
-OPENSSL_PATH = ../../openssl-1.0.2c
+OPENSSL_PATH = ../../openssl-1.0.2d
 endif
 
 # Edit the path below to point to your Distribution folder.


### PR DESCRIPTION
`libssh2` mirror of `curl` patch https://github.com/bagder/curl/commit/d21b66835f2af781a3c2a685abc92ef9f0cd86be

This allows to build for the non-default target when using a multi-target mingw distro.
Also bump default OpenSSL dependency path to 1.0.2d.