### PR TITLE
Fix compiling ERROR when OPENSSL_NO_MD5 is defined.

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -235,6 +235,10 @@ hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION * session, void **abstract)
     return 0;
 }
 
+#ifdef OPENSSL_NO_MD5
+#define MD5_DIGEST_LENGTH 16
+#endif
+
 static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa = {
     "ssh-rsa",
     MD5_DIGEST_LENGTH,


### PR DESCRIPTION
Background
---
I am working on system security and evaluating our system running under openssl-fips lib. As known that, in the fips build of openssl, MD5 is deprecated, so marco **OPENSSL_NO_MD5** is defined.
Issue
---
We are trying to use libssh under fips mode which disabling MD5, but I find once **OPENSSL_NO_MD5** is defined, there comes a compiling error:
``` shell
/bin/sh ../libtool --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H   -I../include -I../src   -g -O2 -MT hostkey.lo -MD -MP -MF .deps/hostkey.Tpo -c -o hostkey.lo hostkey.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I../include -I../src -g -O2 -MT hostkey.lo -MD -MP -MF .deps/hostkey.Tpo -c hostkey.c  -fPIC -DPIC -o .libs/hostkey.o
hostkey.c:240:5: error: 'MD5_DIGEST_LENGTH' undeclared here (not in a function)
     MD5_DIGEST_LENGTH,
     ^
```
**MD5_DIGEST_LENGTH** is not defined here, so I just put the definition if **OPENSSL_NO_MD5** is defined and the compile passes.