### PR TITLE
Memory leak when Synology server requests key exchange

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -202,6 +202,10 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
 
         session->server_hostkey_len = _libssh2_ntohu32(exchange_state->s);
         exchange_state->s += 4;
+        
+        if (session->server_hostkey)
+            LIBSSH2_FREE(session, session->server_hostkey);
+
         session->server_hostkey =
             LIBSSH2_ALLOC(session, session->server_hostkey_len);
         if (!session->server_hostkey) {


### PR DESCRIPTION
The leak happens when the Synology server requests the key change in libssh2_sftp_init and sets server_hostkey a second time. The server_hostkey is first set in libssh2_session_handshake:

Here's the call stack when the leak happens (second access):

	diffie_hellman_sha1(_LIBSSH2_SESSION *, bignum_st *, bignum_st *, int, unsigned char, unsigned char, unsigned char *, unsigned long, kmdhgGPsha1kex_state_t *) Line 207	C
 	kex_method_diffie_hellman_group14_sha1_key_exchange(_LIBSSH2_SESSION *, key_exchange_state_low_t *) Line 810	C
 	_libssh2_kex_exchange(_LIBSSH2_SESSION *, int, key_exchange_state_t *) Line 1781	C
 	_libssh2_transport_read(_LIBSSH2_SESSION *) Line 309	C
 	_libssh2_packet_requirev(_LIBSSH2_SESSION *, const unsigned char *, unsigned char * *, unsigned __int64 *, int, const unsigned char *, unsigned __int64, packet_requirev_state_t *) Line 1237	C
 	_libssh2_channel_open(_LIBSSH2_SESSION *, const char *, unsigned int, unsigned int, unsigned int, const unsigned char *, unsigned __int64) Line 228	C
 	sftp_init(_LIBSSH2_SESSION *) Line 735	C
 	libssh2_sftp_init(_LIBSSH2_SESSION *) Line 923	C
