### PR TITLE
kex.c: removed dupe entry from libssh2_kex_methods[]

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -1711,7 +1711,6 @@ static const LIBSSH2_KEX_METHOD *libssh2_kex_methods[] = {
     &kex_method_diffie_helman_group_exchange_sha256,
     &kex_method_diffie_helman_group_exchange_sha1,
     &kex_method_diffie_helman_group14_sha1,
-    &kex_method_diffie_helman_group_exchange_sha1,
     &kex_method_diffie_helman_group1_sha1,
     NULL
 };


### PR DESCRIPTION
This removes a duplicate entry in the libssh2_kex_methods[] array, introduced in https://github.com/libssh2/libssh2/commit/fc4a969a0512e226de9b821496d20b9ddf53b741.