### PR TITLE
sftp.c: max_read_ahead should not exceed MAX_SFTP_READ_SIZE

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1313,7 +1313,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
             /* Number of bytes asked for that haven't been acked yet */
             size_t already = (size_t)(filep->offset_sent - filep->offset);
 
-            size_t max_read_ahead = buffer_size*4;
+            size_t max_read_ahead = MIN(MAX_SFTP_READ_SIZE, buffer_size*4);
             unsigned long recv_window;
 
             if(max_read_ahead > LIBSSH2_CHANNEL_WINDOW_DEFAULT*4)


### PR DESCRIPTION
As discussed in https://github.com/libssh2/libssh2/issues/50, the recent changes in the sftp_read() implementation causes data corruption if the buffer_maxlen parameter used in calls to libssh2_sftp_read() is "too large", say 8192 bytes.

It appears that the max_read_ahead value computed in sftp.c must not exceed MAX_SFTP_READ_SIZE (which currently happens if buffer_maxlen > 7500) and this commit limits max_read_ahead in that situation. 

(Also, I'm pretty sure that this is not "the right solution" but it is better than not having it. )