### PR TITLE
agent_disconnect_unix: unset the agent fd after closing it

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -239,8 +239,9 @@ agent_disconnect_unix(LIBSSH2_AGENT *agent)
 {
     int ret;
     ret = close(agent->fd);
-
-    if(ret == -1)
+    if(ret != -1)
+        agent->fd = LIBSSH2_INVALID_SOCKET;
+    else
         return _libssh2_error(agent->session, LIBSSH2_ERROR_SOCKET_DISCONNECT,
                               "failed closing the agent socket");
     return LIBSSH2_ERROR_NONE;


### PR DESCRIPTION
"agent_disconnect_unix", called by "libssh2_agent_disconnect", was
leaving the file descriptor in the agent structure unchanged. Later,
"libssh2_agent_free" would call again "libssh2_agent_disconnect" under
the hood and it would try to close again the same file descriptor. In
most cases that resulted in just a harmless error, but it is also
possible that the file descriptor had been reused between the two
calls resulting in the closing of an unrelated file descriptor.

This patch sets agent->fd to LIBSSH2_INVALID_SOCKET avoiding that
issue.

Signed-off-by: Salvador Fandiño <sfandino@yahoo.com>