### PR TITLE
Resolve improper handling of remote eof responses

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -738,11 +738,13 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
   scp_recv_empty_channel:
     /* the code only jumps here as a result of a zero read from channel_read()
        so we check EOF status to avoid getting stuck in a loop */
-    if(libssh2_channel_eof(session->scpRecv_channel))
+    if(session->scpRecv_channel->remote.eof || session->scpRecv_channel->remote.close) {
         _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                        "Unexpected channel close");
-    else
+    } else {
+        session->scpRecv_state = libssh2_NB_state_idle;
         return session->scpRecv_channel;
+    }
     /* fall-through */
   scp_recv_error:
     tmp_err_code = session->err_code;


### PR DESCRIPTION
1) If we return non-null pointer, we need to clear the session recv
state, otherwise subsequent requests on the session are going to
segfault.
2) The libssh2_channel_eof usage for checking EOF here is
incorrect, because it can mask a real EOF.
