### PR TITLE
Fix MSVC 14 compilation warning

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -3390,8 +3390,6 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
     sftp->symlink_state = libssh2_NB_state_idle;
 
     if (data[0] == SSH_FXP_STATUS) {
-        int retcode;
-
         retcode = _libssh2_ntohu32(data + 5);
         LIBSSH2_FREE(session, data);
         if (retcode == LIBSSH2_FX_OK)


### PR DESCRIPTION
1>  sftp.c
1>libssh2-files\src\sftp.c(3393): warning C4456: declaration of 'retcode' hides previous local declaration
1>  libssh2-files\src\sftp.c(3315): note: see declaration of 'retcode'
