### PR TITLE
docs: correctly describe channel_wait_eof

### DIFF
--- a/docs/libssh2_channel_wait_eof.3
+++ b/docs/libssh2_channel_wait_eof.3
@@ -8,7 +8,7 @@ int
 libssh2_channel_wait_eof(LIBSSH2_CHANNEL *channel);
 
 .SH DESCRIPTION
-Wait for the remote end to acknowledge an EOF request.
+Wait for the remote end to send EOF.
 
 .SH RETURN VALUE
 Return 0 on success or negative on failure. It returns


### PR DESCRIPTION
channel_wait_eof waits for channel->remote.eof, which is set on
receiving a `SSH_MSG_CHANNEL_EOF` message. This message is sent
when a party has no more data to send on a channel.

See https://github.com/alexcrichton/ssh2-rs/issues/34#issuecomment-184850856 if you want a complete run-through of me coming to this conclusion
