### PR TITLE
Fix MSVC 14 compilation errors

### DIFF
--- a/win32/libssh2_config.h
+++ b/win32/libssh2_config.h
@@ -24,6 +24,7 @@
 #define HAVE_SELECT
 
 #ifdef _MSC_VER
+#if _MSC_VER < 1900
 #define snprintf _snprintf
 #if _MSC_VER < 1500
 #define vsnprintf _vsnprintf
@@ -31,6 +32,7 @@
 #define strdup _strdup
 #define strncasecmp _strnicmp
 #define strcasecmp _stricmp
+#endif
 #else
 #ifndef __MINGW32__
 #define strncasecmp strnicmp


### PR DESCRIPTION

For _MSC_VER == 1900 these macros are not needed and create problems:

1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(1925): warning C4005: 'snprintf': macro redefinition (compiling source file libssh2-files\src\mac.c)
1> \win32\libssh2_config.h(27): note: see previous definition of 'snprintf' (compiling source file libssh2-files\src\mac.c)
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(1927): fatal error C1189: #error: Macro definition of snprintf conflicts with Standard Library function declaration (compiling source file libssh2-files\src\mac.c)