### PR TITLE
Get rid of 64-bit build warnings

### DIFF
--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -227,10 +227,10 @@ LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
                                                       unsigned long flags,
                                                       long mode, int open_type);
 #define libssh2_sftp_open(sftp, filename, flags, mode) \
-    libssh2_sftp_open_ex((sftp), (filename), strlen(filename), (flags), \
+    libssh2_sftp_open_ex((sftp), (filename), (unsigned int)strlen(filename), (flags), \
                          (mode), LIBSSH2_SFTP_OPENFILE)
 #define libssh2_sftp_opendir(sftp, path) \
-    libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
+    libssh2_sftp_open_ex((sftp), (path), (unsigned int)strlen(path), 0, 0, \
                          LIBSSH2_SFTP_OPENDIR)
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
@@ -277,8 +277,8 @@ LIBSSH2_API int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
                                        unsigned int dest_filename_len,
                                        long flags);
 #define libssh2_sftp_rename(sftp, sourcefile, destfile) \
-    libssh2_sftp_rename_ex((sftp), (sourcefile), strlen(sourcefile), \
-                           (destfile), strlen(destfile),                \
+    libssh2_sftp_rename_ex((sftp), (sourcefile), (unsigned int)strlen(sourcefile), \
+                           (destfile), (unsigned int)strlen(destfile),                \
                            LIBSSH2_SFTP_RENAME_OVERWRITE | \
                            LIBSSH2_SFTP_RENAME_ATOMIC | \
                            LIBSSH2_SFTP_RENAME_NATIVE)
@@ -287,7 +287,7 @@ LIBSSH2_API int libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp,
                                        const char *filename,
                                        unsigned int filename_len);
 #define libssh2_sftp_unlink(sftp, filename) \
-    libssh2_sftp_unlink_ex((sftp), (filename), strlen(filename))
+    libssh2_sftp_unlink_ex((sftp), (filename), (unsigned int)strlen(filename))
 
 LIBSSH2_API int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
                                       LIBSSH2_SFTP_STATVFS *st);
@@ -301,13 +301,13 @@ LIBSSH2_API int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path,
                                       unsigned int path_len, long mode);
 #define libssh2_sftp_mkdir(sftp, path, mode) \
-    libssh2_sftp_mkdir_ex((sftp), (path), strlen(path), (mode))
+    libssh2_sftp_mkdir_ex((sftp), (path), (unsigned int)strlen(path), (mode))
 
 LIBSSH2_API int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path,
                                       unsigned int path_len);
 #define libssh2_sftp_rmdir(sftp, path) \
-    libssh2_sftp_rmdir_ex((sftp), (path), strlen(path))
+    libssh2_sftp_rmdir_ex((sftp), (path), (unsigned int)strlen(path))
 
 LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                                      const char *path,
@@ -315,13 +315,13 @@ LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                                      int stat_type,
                                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_stat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), strlen(path), LIBSSH2_SFTP_STAT, \
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), LIBSSH2_SFTP_STAT, \
                          (attrs))
 #define libssh2_sftp_lstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), strlen(path), LIBSSH2_SFTP_LSTAT, \
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), LIBSSH2_SFTP_LSTAT, \
                          (attrs))
 #define libssh2_sftp_setstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), strlen(path), LIBSSH2_SFTP_SETSTAT, \
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), LIBSSH2_SFTP_SETSTAT, \
                          (attrs))
 
 LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
@@ -330,13 +330,13 @@ LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         char *target,
                                         unsigned int target_len, int link_type);
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \
-    libssh2_sftp_symlink_ex((sftp), (orig), strlen(orig), (linkpath), \
-                            strlen(linkpath), LIBSSH2_SFTP_SYMLINK)
+    libssh2_sftp_symlink_ex((sftp), (orig), (unsigned int)strlen(orig), (linkpath), \
+                            (unsigned int)strlen(linkpath), LIBSSH2_SFTP_SYMLINK)
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), (path), strlen(path), (target), (maxlen), \
+    libssh2_sftp_symlink_ex((sftp), (path), (unsigned int)strlen(path), (target), (maxlen), \
     LIBSSH2_SFTP_READLINK)
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), (path), strlen(path), (target), (maxlen), \
+    libssh2_sftp_symlink_ex((sftp), (path), (unsigned int)strlen(path), (target), (maxlen), \
                             LIBSSH2_SFTP_REALPATH)
 
 #ifdef __cplusplus


### PR DESCRIPTION
Get rid of all of those:
2>fs\sftp.cpp(1467): warning C4267: 'argument': conversion from 'size_t' to 'unsigned int', possible loss of data
In reference to:
https://github.com/libssh2/libssh2/issues/24
