### PR TITLE
Fix 32-bit compilation error

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -130,7 +130,7 @@ typedef unsigned int uint32_t;
 typedef unsigned __int64 libssh2_uint64_t;
 typedef __int64 libssh2_int64_t;
 #ifndef ssize_t
-typedef SSIZE_T ssize_t;
+typedef INT_PTR ssize_t;
 #endif
 #else
 typedef unsigned long long libssh2_uint64_t;


### PR DESCRIPTION
The libssh2 defined ssize_t clashes with other defines since it results in:
typedef long ssize_t; in 32 bit and
typedef __int64 ssize_t; in 64 bit.

"long" is unexpected, instead it should resolve to 
typedef int ssize_t; in 32 bit and
typedef __int64 ssize_t; in 64 bit.

This is achieved with "typedef INT_PTR ssize_t;" while using "SSIZE_T" would lead to an inconsistency in 32 bit and compilation errors.
For comparison also check definition of size_t:
32-bit: typedef unsigned __int64 size_t;
64-bit: typedef unsigned int     size_t;