### PR TITLE
Fix for security issue CVE-2016-0787

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -133,7 +133,7 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
         memset(&exchange_state->req_state, 0, sizeof(packet_require_state_t));
 
         /* Generate x and e */
-        _libssh2_bn_rand(exchange_state->x, group_order, 0, -1);
+        _libssh2_bn_rand(exchange_state->x, group_order * 8 - 1, 0, -1);
         _libssh2_bn_mod_exp(exchange_state->e, g, exchange_state->x, p,
                             exchange_state->ctx);
 


### PR DESCRIPTION
Ported SHA256 fix to SHA1 until a better fix is committed.