### PR TITLE
libssh2_channel_read_ex: 0 means EOF

### DIFF
--- a/docs/libssh2_channel_read_ex.3
+++ b/docs/libssh2_channel_read_ex.3
@@ -34,8 +34,8 @@ Actual number of bytes read or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it isn't really a failure per se.
 
-Note that a return value of zero (0) can in fact be a legitimate value and
-only signals that no payload data was read. It is not an error.
+A return value of zero (0) indicates EOF.
+
 .SH ERRORS
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/src/scp.c
+++ b/src/scp.c
@@ -738,11 +738,9 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
   scp_recv_empty_channel:
     /* the code only jumps here as a result of a zero read from channel_read()
        so we check EOF status to avoid getting stuck in a loop */
-    if(libssh2_channel_eof(session->scpRecv_channel))
-        _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                       "Unexpected channel close");
-    else
-        return session->scpRecv_channel;
+    _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
+                   "Unexpected channel close");
+
     /* fall-through */
   scp_recv_error:
     tmp_err_code = session->err_code;


### PR DESCRIPTION
Until now, libssh2_channel_read_ex was returning 0 for two cases:

1) At EOF

2) After the data transport layer had produced data, but not for the
current channel.

And it was not possible to discern between the two conditions in any
way (note that libssh2_channel_eof would not return true when data is
still queued for the the other channel stream - !ext).

This patch, changes that behavior such that now, only on the first
case (at EOF) a zero is returned.

And the second case is converted to an EAGAIN.
