### PR TITLE
sftp_read: optimize read ahead for very small reads

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1319,7 +1319,9 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
             size_t max_read_ahead = buffer_size*4;
             unsigned long recv_window;
 
-            if(max_read_ahead > LIBSSH2_CHANNEL_WINDOW_DEFAULT*4)
+            if (max_read_ahead < MIN_SFTP_READ_AHEAD_SIZE)
+                max_read_ahead = MIN_SFTP_READ_AHEAD_SIZE;
+            else if(max_read_ahead > LIBSSH2_CHANNEL_WINDOW_DEFAULT*4)
                 max_read_ahead = LIBSSH2_CHANNEL_WINDOW_DEFAULT*4;
 
             /* if the buffer_size passed in now is smaller than what has

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -49,6 +49,7 @@
  * packets.
  */
 #define MAX_SFTP_READ_SIZE 30000
+#define MIN_SFTP_READ_AHEAD_SIZE 1200
 
 struct sftp_pipeline_chunk {
     struct list_node node;


### PR DESCRIPTION
Until now, the SFTP read ahead size was calculated as buffer_size \* 4
which was very inneficient for programs doing lots of small reads (for
instance, again, a program implementing a "readline" function which
reads bytes one at a time should be considered).

This patch defines a new constant MIN_SFTP_READ_AHEAD_SIZE, that sets
the minimum read ahead size. The value picked for that constant is
1200 as a compromisse between not increasing the network traffic too
much (that load should still fit into an ethernet packet), while still
improving the performance of programs doing small reads appreciably.
