### PR TITLE
Unfussy wait closed

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -482,6 +482,7 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_ENCRYPT                   -44
 #define LIBSSH2_ERROR_BAD_SOCKET                -45
 #define LIBSSH2_ERROR_KNOWN_HOSTS               -46
+#define LIBSSH2_ERROR_CHANNEL_WINDOW_FULL       -47
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV

--- a/src/channel.c
+++ b/src/channel.c
@@ -2259,7 +2259,7 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
 
         if ((channel->remote.window_size == channel->read_avail) &&
             session->api_block_mode)
-            return _libssh2_error(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
+            return _libssh2_error(session, LIBSSH2_ERROR_CHANNEL_WINDOW_FULL,
                                   "Receiving channel window has been exhausted");
 
         rc = _libssh2_transport_read(session);

--- a/src/channel.c
+++ b/src/channel.c
@@ -2242,7 +2242,7 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
 
     if (channel->wait_eof_state == libssh2_NB_state_idle) {
         _libssh2_debug(session, LIBSSH2_TRACE_CONN,
-                       "Awaiting close of channel %lu/%lu", channel->local.id,
+                       "Awaiting EOF for channel %lu/%lu", channel->local.id,
                        channel->remote.id);
 
         channel->wait_eof_state = libssh2_NB_state_created;

--- a/src/channel.c
+++ b/src/channel.c
@@ -2256,6 +2256,12 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
         if (channel->remote.eof) {
             break;
         }
+
+        if ((channel->remote.window_size == channel->read_avail) &&
+            session->api_block_mode)
+            return _libssh2_error(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
+                                  "Receiving channel window has been exhausted");
+
         rc = _libssh2_transport_read(session);
         if (rc == LIBSSH2_ERROR_EAGAIN) {
             return rc;

--- a/src/channel.c
+++ b/src/channel.c
@@ -2396,7 +2396,7 @@ static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
     LIBSSH2_SESSION *session = channel->session;
     int rc;
 
-    if (!libssh2_channel_eof(channel)) {
+    if (!channel->remote.eof) {
         return _libssh2_error(session, LIBSSH2_ERROR_INVAL,
                               "libssh2_channel_wait_closed() invoked when "
                               "channel is not in EOF state");


### PR DESCRIPTION
commit 8e9e70d514619c8ceabfa852444ad40ffbf8c0d9
Author: Salvador Fandino sfandino@yahoo.com
Date:   Mon May 9 13:48:31 2016 +0200

```
channel_wait_eof: handle receive window exhaustion

Until now, if the remote receiving window is exhausted this function
hangs forever as data is not read and the remote side just keeps
waiting for the window to grow before sending more data.

This patch, makes this function check for that condition and abort
with an error when it happens.
```

commit 311a4f1fc7d4003eb56afe02f1c80d7f383cdb2d
Author: Salvador Fandino sfandino@yahoo.com
Date:   Mon May 9 13:20:40 2016 +0200

```
channel_wait_closed: don't fail when unread data is queued

This function was calling channel_wait_eof to ensure that the EOF
packet has already been received, but that function also checks that
the read data queue is empty before reporting the EOF. That caused
channel_wait_closed to fail with a LIBSSH2_ERROR_INVAL when some data
was queued even after a successful call to libssh2_channel_wait_eof.

This patch changes libssh2_channel_wait_closed to look directly into
channel->remote.eof so that both libssh2_channel_wait_eof and
libssh2_channel_wait_closed bahave consistently.
```

commit 77ac132dc76edb282a22938a7a95962d9015041d
Author: Salvador Fandino sfandino@yahoo.com
Date:   Mon May 9 13:17:54 2016 +0200

```
channel_wait_eof: fix debug message
```
