### PR TITLE
Make libssh2 work again on os400.

### DIFF
--- a/docs/HACKING.CRYPTO
+++ b/docs/HACKING.CRYPTO
@@ -305,10 +305,50 @@ TripleDES-CBC algorithm identifier initializer.
 #define with constant value of type _libssh2_cipher_type().
 
 
-5) Big numbers.
+5) Diffie-Hellman support.
+If the crypto-library supports opaque Diffie-Hellman computations, symbol
+`libssh2_dh_key_pair' should be #defined as described below andhe rest of this
+section applies.
+Else, the Diffie-Hellman context MUST be defined as `_libssh2_bn *' and
+the computation is emulated via calls to _libssh2_bn_rand() and
+_libssh2_bn_mod_exp(): all other symbols in this section are unused in this
+case.
+
+5.1) Diffie-Hellman context.
+_libssh2_dh_ctx
+Type of a Diffie-Hellman computation context.
+Must always be defined.
+
+5.2) Diffie-Hellman computation procedures.
+void libssh2_dh_init(_libssh2_dh_ctx *dhctx);
+Initializes the Diffie-Hellman context at `dhctx'. No effective context
+creation needed here.
+
+int libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+                        _libssh2_bn *g, _libssh2_bn *p, int group_order,
+                        _libssh2_bn_ctx *bnctx);
+Generates a Diffie-Hellman key pair using base `g', prime `p' and the given
+`group_order'. Can use the give big number context `bnctx' if needed.
+The private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
+the public key is returned in `public'.
+0 is returned upon success, else -1.
+If defined, this procedure MUST be implemented as a #define'd macro.
+
+int libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+                      _libssh2_bn *f, _libssh2_bn *p, _libssh2_bn_ctx * bnctx)
+Computes the Diffie-Hellman secret from the previouly created context `*dhctx',
+the public key `f' from the other party and the same prime `p' used at
+context creation. The result is stored in `secret'.
+0 is returned upon success, else -1.
+
+void libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
+Destroys Diffie-Hellman context at `dhctx' and reset its storage.
+
+
+6) Big numbers.
 Positive multi-byte integers support is sufficient.
 
-5.1) Computation contexts.
+6.1) Computation contexts.
 This has a real meaning if the big numbers computations need some context
 storage. If not, use a dummy type and functions (macros).
 
@@ -322,7 +362,7 @@ Returns a new multiple precision computation context.
 void _libssh2_bn_ctx_free(_libssh2_bn_ctx ctx);
 Releases a multiple precision computation context.
 
-5.2) Computation support.
+6.2) Computation support.
 _libssh2_bn
 Type of multiple precision numbers (aka bignumbers or huge integers) for the
 crypto library.
@@ -369,15 +409,17 @@ random number can be zero. If top is 0, it is set to 1, and if top is 1, the
 two most significant bits of the number will be set to 1, so that the product
 of two such random numbers will always have 2*bits length. If bottom is true,
 the number will be odd.
+This procedure is only needed if no specific Diffie-Hellman support is provided.
 
 void _libssh2_bn_mod_exp(_libssh2_bn *r, _libssh2_bn *a,
 	                 _libssh2_bn *p, _libssh2_bn *m,
 	                 _libssh2_bn_ctx *ctx);
 Computes a to the p-th power modulo m and stores the result into r (r=a^p % m).
 May use the given context.
+This procedure is only needed if no specific Diffie-Hellman support is provided.
 
 
-6) Private key algorithms.
+7) Private key algorithms.
 Format of an RSA public key:
 a) "ssh-rsa".
 b) RSA exponent, MSB first, with high order bit = 0.
@@ -421,7 +463,7 @@ Both buffers have to be allocated using LIBSSH2_ALLOC().
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-6.1) RSA
+7.1) RSA
 LIBSSH2_RSA
 #define as 1 if the crypto library supports RSA, else 0.
 If defined as 0, the rest of this section can be omitted.
@@ -515,7 +557,7 @@ void _libssh2_rsa_free(libssh2_rsa_ctx *rsactx);
 Releases the RSA computation context at rsactx.
 
 
-6.2) DSA
+7.2) DSA
 LIBSSH2_DSA
 #define as 1 if the crypto library supports DSA, else 0.
 If defined as 0, the rest of this section can be omitted.
@@ -581,7 +623,7 @@ void _libssh2_dsa_free(libssh2_dsa_ctx *dsactx);
 Releases the DSA computation context at dsactx.
 
 
-7) Miscellaneous
+8) Miscellaneous
 
 void libssh2_prepare_iovec(struct iovec *vector, unsigned int len);
 Prepare len consecutive iovec slots before using them.

--- a/docs/HACKING.CRYPTO
+++ b/docs/HACKING.CRYPTO
@@ -61,7 +61,7 @@ SHA_DIGEST_LENGTH
 #define to 20, the SHA-1 digest length.
 
 libssh2_sha1_ctx
-Type of an SHA1 computation context. Generally a struct.
+Type of an SHA-1 computation context. Generally a struct.
 
 int libssh2_sha1_init(libssh2_sha1_ctx *x);
 Initializes the SHA-1 computation context at x.
@@ -75,7 +75,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 
 void libssh2_sha1_final(libssh2_sha1_ctx ctx,
-                        unsigned char output[SHA1_DIGEST_LEN]);
+                        unsigned char output[SHA_DIGEST_LEN]);
 Get the computed SHA-1 signature from context ctx and store it into the
 output buffer.
 Release the context.
@@ -196,7 +196,7 @@ the keylen-byte key. Is invoked just after libssh2_hmac_ctx_init().
 Returns 1 for success and 0 for failure.
 
 
-4) Bidirectional Key ciphers.
+4) Bidirectional key ciphers.
 
 _libssh2_cipher_ctx
 Type of a cipher computation context.
@@ -307,8 +307,8 @@ TripleDES-CBC algorithm identifier initializer.
 
 5) Diffie-Hellman support.
 If the crypto-library supports opaque Diffie-Hellman computations, symbol
-`libssh2_dh_key_pair' should be #defined as described below andhe rest of this
-section applies.
+`libssh2_dh_key_pair' should be #defined as described below and the rest of
+this section applies.
 Else, the Diffie-Hellman context MUST be defined as `_libssh2_bn *' and
 the computation is emulated via calls to _libssh2_bn_rand() and
 _libssh2_bn_mod_exp(): all other symbols in this section are unused in this
@@ -328,7 +328,7 @@ int libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
                         _libssh2_bn *g, _libssh2_bn *p, int group_order,
                         _libssh2_bn_ctx *bnctx);
 Generates a Diffie-Hellman key pair using base `g', prime `p' and the given
-`group_order'. Can use the give big number context `bnctx' if needed.
+`group_order'. Can use the given big number context `bnctx' if needed.
 The private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
 the public key is returned in `public'.
 0 is returned upon success, else -1.
@@ -342,7 +342,7 @@ context creation. The result is stored in `secret'.
 0 is returned upon success, else -1.
 
 void libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
-Destroys Diffie-Hellman context at `dhctx' and reset its storage.
+Destroys Diffie-Hellman context at `dhctx' and resets its storage.
 
 
 6) Big numbers.
@@ -607,7 +607,7 @@ This procedure is already prototyped in crypto.h.
 int _libssh2_dsa_sha1_verify(libssh2_dsa_ctx *dsactx,
                              const unsigned char *sig,
                              const unsigned char *m, unsigned long m_len);
-Verify (sig, siglen) signature of (m, m_len) using an SHA1 hash and the
+Verify (sig, siglen) signature of (m, m_len) using an SHA-1 hash and the
 DSA context.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.

--- a/os400/initscript.sh
+++ b/os400/initscript.sh
@@ -49,7 +49,7 @@ setenv TGTCCSID         '500'                   # Target CCSID of objects.
 setenv DEBUG            '*ALL'                  # Debug level.
 setenv OPTIMIZE         '10'                    # Optimisation level
 setenv OUTPUT           '*NONE'                 # Compilation output option.
-setenv TGTRLS           'V5R3M0'                # Target OS release.
+setenv TGTRLS           'V6R1M0'                # Target OS release.
 setenv IFSDIR           '/libssh2'              # Installation IFS directory.
 
 #       Define ZLIB availability and locations.
@@ -180,7 +180,7 @@ make_module()
         CMD="CRTCMOD MODULE(${TARGETLIB}/${1}) SRCSTMF('__tmpsrcf.c')"
 #       CMD="${CMD} SYSIFCOPT(*IFS64IO) OPTION(*INCDIRFIRST *SHOWINC *SHOWSYS)"
         CMD="${CMD} SYSIFCOPT(*IFS64IO) OPTION(*INCDIRFIRST)"
-        CMD="${CMD} LOCALETYPE(*LOCALE)"
+        CMD="${CMD} LOCALETYPE(*LOCALE) FLAG(10)"
         CMD="${CMD} INCDIR('${TOPDIR}/os400/include'"
         CMD="${CMD} '/QIBM/ProdData/qadrt/include' '${TOPDIR}/include'"
         CMD="${CMD} '${TOPDIR}/os400' '${SRCDIR}'"

--- a/src/kex.c
+++ b/src/kex.c
@@ -98,6 +98,44 @@
             }                                                              \
     }
 
+/*
+ * Generic Diffie-Hellman computation support.
+ *
+ * DH context should be a _libssh2_bn *.
+ */
+
+#ifndef libssh2_dh_key_pair
+static void libssh2_dh_init(_libssh2_dh_ctx *dhctx)
+{
+    *dhctx = _libssh2_bn_init();                    /* Random from client */
+}
+
+static int libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+                               _libssh2_bn *g, _libssh2_bn *p, int group_order,
+                               _libssh2_bn_ctx *bnctx)
+{
+    /* Generate x and e */
+    _libssh2_bn_rand(*dhctx, group_order * 8 - 1, 0, -1);
+    _libssh2_bn_mod_exp(public, g, *dhctx, p, bnctx);
+    return 0;
+}
+
+static int libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+                             _libssh2_bn *f, _libssh2_bn *p,
+                             _libssh2_bn_ctx * bnctx)
+{
+    /* Compute the shared secret */
+    _libssh2_bn_mod_exp(secret, f, *dhctx, p, bnctx);
+    return 0;
+}
+
+static void libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
+{
+    _libssh2_bn_free(*dhctx);
+    *dhctx = NULL;
+}
+#endif
+
 
 /*
  * diffie_hellman_sha1
@@ -124,7 +162,7 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
         exchange_state->s_packet = NULL;
         exchange_state->k_value = NULL;
         exchange_state->ctx = _libssh2_bn_ctx_new();
-        exchange_state->x = _libssh2_bn_init(); /* Random from client */
+        libssh2_dh_init(&exchange_state->x);
         exchange_state->e = _libssh2_bn_init(); /* g^x mod p */
         exchange_state->f = _libssh2_bn_init_from_bin(); /* g^(Random from server) mod p */
         exchange_state->k = _libssh2_bn_init(); /* The shared secret: f^x mod p */
@@ -133,9 +171,8 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
         memset(&exchange_state->req_state, 0, sizeof(packet_require_state_t));
 
         /* Generate x and e */
-        _libssh2_bn_rand(exchange_state->x, group_order * 8 - 1, 0, -1);
-        _libssh2_bn_mod_exp(exchange_state->e, g, exchange_state->x, p,
-                            exchange_state->ctx);
+        libssh2_dh_key_pair(&exchange_state->x, exchange_state->e, g, p,
+                            group_order, exchange_state->ctx);
 
         /* Send KEX init */
         /* packet_type(1) + String Length(4) + leading 0(1) */
@@ -325,8 +362,8 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
         exchange_state->h_sig = exchange_state->s;
 
         /* Compute the shared secret */
-        _libssh2_bn_mod_exp(exchange_state->k, exchange_state->f,
-                            exchange_state->x, p, exchange_state->ctx);
+        libssh2_dh_secret(&exchange_state->x, exchange_state->k,
+                          exchange_state->f, p, exchange_state->ctx);
         exchange_state->k_value_len = _libssh2_bn_bytes(exchange_state->k) + 5;
         if (_libssh2_bn_bits(exchange_state->k) % 8) {
             /* don't need leading 00 */
@@ -687,8 +724,7 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
     }
 
   clean_exit:
-    _libssh2_bn_free(exchange_state->x);
-    exchange_state->x = NULL;
+    libssh2_dh_dtor(&exchange_state->x);
     _libssh2_bn_free(exchange_state->e);
     exchange_state->e = NULL;
     _libssh2_bn_free(exchange_state->f);
@@ -744,7 +780,7 @@ static int diffie_hellman_sha256(LIBSSH2_SESSION *session,
         exchange_state->s_packet = NULL;
         exchange_state->k_value = NULL;
         exchange_state->ctx = _libssh2_bn_ctx_new();
-        exchange_state->x = _libssh2_bn_init(); /* Random from client */
+        libssh2_dh_init(&exchange_state->x);
         exchange_state->e = _libssh2_bn_init(); /* g^x mod p */
         exchange_state->f = _libssh2_bn_init_from_bin(); /* g^(Random from server) mod p */
         exchange_state->k = _libssh2_bn_init(); /* The shared secret: f^x mod p */
@@ -753,9 +789,8 @@ static int diffie_hellman_sha256(LIBSSH2_SESSION *session,
         memset(&exchange_state->req_state, 0, sizeof(packet_require_state_t));
 
         /* Generate x and e */
-        _libssh2_bn_rand(exchange_state->x, group_order * 8 - 1, 0, -1);
-        _libssh2_bn_mod_exp(exchange_state->e, g, exchange_state->x, p,
-                            exchange_state->ctx);
+        libssh2_dh_key_pair(&exchange_state->x, exchange_state->e, g, p,
+                            group_order, exchange_state->ctx);
 
         /* Send KEX init */
         /* packet_type(1) + String Length(4) + leading 0(1) */
@@ -945,8 +980,8 @@ static int diffie_hellman_sha256(LIBSSH2_SESSION *session,
         exchange_state->h_sig = exchange_state->s;
 
         /* Compute the shared secret */
-        _libssh2_bn_mod_exp(exchange_state->k, exchange_state->f,
-                            exchange_state->x, p, exchange_state->ctx);
+        libssh2_dh_secret(&exchange_state->x, exchange_state->k,
+                          exchange_state->f, p, exchange_state->ctx);
         exchange_state->k_value_len = _libssh2_bn_bytes(exchange_state->k) + 5;
         if (_libssh2_bn_bits(exchange_state->k) % 8) {
             /* don't need leading 00 */
@@ -1309,8 +1344,7 @@ static int diffie_hellman_sha256(LIBSSH2_SESSION *session,
     }
 
   clean_exit:
-    _libssh2_bn_free(exchange_state->x);
-    exchange_state->x = NULL;
+    libssh2_dh_dtor(&exchange_state->x);
     _libssh2_bn_free(exchange_state->e);
     exchange_state->e = NULL;
     _libssh2_bn_free(exchange_state->f);

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -181,3 +181,5 @@
 #define _libssh2_bn_bits(bn) gcry_mpi_get_nbits (bn)
 #define _libssh2_bn_free(bn) gcry_mpi_release(bn)
 
+#define _libssh2_dh_ctx _libssh2_bn *
+

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -248,7 +248,7 @@ typedef struct kmdhgGPshakex_state_t
     size_t s_packet_len;
     size_t tmp_len;
     _libssh2_bn_ctx *ctx;
-    _libssh2_bn *x;
+    _libssh2_dh_ctx x;
     _libssh2_bn *e;
     _libssh2_bn *f;
     _libssh2_bn *k;

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -287,6 +287,8 @@ int _libssh2_md5_init(libssh2_md5_ctx *ctx);
 #define _libssh2_bn_bits(bn) BN_num_bits(bn)
 #define _libssh2_bn_free(bn) BN_clear_free(bn)
 
+#define _libssh2_dh_ctx _libssh2_bn *
+
 const EVP_CIPHER *_libssh2_EVP_aes_128_ctr(void);
 const EVP_CIPHER *_libssh2_EVP_aes_192_ctr(void);
 const EVP_CIPHER *_libssh2_EVP_aes_256_ctr(void);

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) 2015-2016 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
@@ -210,6 +210,10 @@ typedef struct {        /* Algorithm description. */
     int                     keylen;         /* Key length. */
 }       _libssh2_os400qc3_cipher_t;
 
+typedef struct {        /* Diffie-Hellman context. */
+    char                    token[8];       /* Context token. */
+}       _libssh2_os400qc3_dh_ctx;
+
 /*******************************************************************
  *
  * OS/400 QC3 crypto-library backend: Define global types/codes.
@@ -277,8 +281,6 @@ typedef struct {        /* Algorithm description. */
 #define _libssh2_bn_ctx_free(bnctx)     ((void) 0)
 
 #define _libssh2_bn_init_from_bin() _libssh2_bn_init()
-#define _libssh2_bn_mod_exp(r, a, p, m, ctx)                                \
-                                _libssh2_os400qc3_bn_mod_exp(r, a, p, m)
 #define _libssh2_bn_bytes(bn)   ((bn)->length)
 
 #define _libssh2_cipher_type(name)  _libssh2_os400qc3_cipher_t name
@@ -309,6 +311,14 @@ typedef struct {        /* Algorithm description. */
             _libssh2_os400qc3_rsa_sha1_signv(session, sig, siglen,          \
                                              count, vector, ctx)
 
+#define _libssh2_dh_ctx         _libssh2_os400qc3_dh_ctx
+#define libssh2_dh_init(dhctx)  _libssh2_os400qc3_dh_init(dhctx)
+#define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx)        \
+            _libssh2_os400qc3_dh_key_pair(dhctx, public, g, p, group_order)
+#define libssh2_dh_secret(dhctx, secret, f, p, bnctx)                       \
+            _libssh2_os400qc3_dh_secret(dhctx, secret, f, p)
+#define libssh2_dh_dtor(dhctx)  _libssh2_os400qc3_dh_dtor(dhctx)
+
 
 /*******************************************************************
  *
@@ -324,10 +334,6 @@ extern int      _libssh2_bn_from_bin(_libssh2_bn *bn, int len,
 extern int      _libssh2_bn_set_word(_libssh2_bn *bn, unsigned long val);
 extern int      _libssh2_bn_to_bin(_libssh2_bn *bn, unsigned char *val);
 extern void     _libssh2_random(unsigned char *buf, int len);
-extern int      _libssh2_bn_rand(_libssh2_bn *bn, int bits,
-                                int top, int bottom);
-extern int      _libssh2_os400qc3_bn_mod_exp(_libssh2_bn *r, _libssh2_bn *a,
-                                             _libssh2_bn *p, _libssh2_bn *m);
 extern void     _libssh2_os400qc3_crypto_dtor(_libssh2_os400qc3_crypto_ctx *x);
 extern int      libssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x,
                                            unsigned int algo);
@@ -352,6 +358,15 @@ extern int      _libssh2_os400qc3_rsa_sha1_signv(LIBSSH2_SESSION *session,
                                                  int veccount,
                                                  const struct iovec vector[],
                                                  libssh2_rsa_ctx *ctx);
+extern void     _libssh2_os400qc3_dh_init(_libssh2_dh_ctx *dhctx);
+extern int      _libssh2_os400qc3_dh_key_pair(_libssh2_dh_ctx *dhctx,
+                                              _libssh2_bn *public,
+                                              _libssh2_bn *g,
+                                              _libssh2_bn *p, int group_order);
+extern int      _libssh2_os400qc3_dh_secret(_libssh2_dh_ctx *dhctx,
+                                            _libssh2_bn *secret,
+                                            _libssh2_bn *f, _libssh2_bn *p);
+extern void     _libssh2_os400qc3_dh_dtor(_libssh2_dh_ctx *dhctx);
 
 #endif
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -374,6 +374,8 @@ _libssh2_bn *_libssh2_wincng_bignum_init(void);
 #define _libssh2_bn_free(bn) \
   _libssh2_wincng_bignum_free(bn)
 
+#define _libssh2_dh_ctx _libssh2_bn *
+
 /*******************************************************************/
 /*
  * Windows CNG backend: forward declarations


### PR DESCRIPTION
Hi,

The CVE-2016-0787 fixes broke libssh2 on os400.
This pull request makes it work again.
See comment of commit 0b482a378f23d82b4dca104373d341bb423e501a and HACKING.CRYPTO for more information.

I tested it successfully with all crypto backends except wincng (not tested).

Thanks for pulling,

Patrick
