### PR TITLE
Proper error checking for bn_rand/bn_mod_exp

### DIFF
--- a/docs/HACKING.CRYPTO
+++ b/docs/HACKING.CRYPTO
@@ -362,19 +362,19 @@ Converts the absolute value of bn into big-endian form and store it at
 val. val must point to _libssh2_bn_bytes(bn) bytes of memory.
 Returns the length of the big-endian number.
 
-void _libssh2_bn_rand(_libssh2_bn *bn, int bits, int top, int bottom);
+int _libssh2_bn_rand(_libssh2_bn *bn, int bits, int top, int bottom);
 Generates a cryptographically strong pseudo-random number of bits in
 length and stores it in bn. If top is -1, the most significant bit of the
 random number can be zero. If top is 0, it is set to 1, and if top is 1, the
 two most significant bits of the number will be set to 1, so that the product
 of two such random numbers will always have 2*bits length. If bottom is true,
-the number will be odd.
+the number will be odd. Returns 1 on success, 0 otherwise.
 
-void _libssh2_bn_mod_exp(_libssh2_bn *r, _libssh2_bn *a,
+int _libssh2_bn_mod_exp(_libssh2_bn *r, _libssh2_bn *a,
 	                 _libssh2_bn *p, _libssh2_bn *m,
 	                 _libssh2_bn_ctx *ctx);
 Computes a to the p-th power modulo m and stores the result into r (r=a^p % m).
-May use the given context.
+May use the given context. Returns 1 on success, 0 otherwise.
 
 
 6) Private key algorithms.

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -482,6 +482,7 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_ENCRYPT                   -44
 #define LIBSSH2_ERROR_BAD_SOCKET                -45
 #define LIBSSH2_ERROR_KNOWN_HOSTS               -46
+#define LIBSSH2_ERROR_BIGNUM                    -47
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV

--- a/src/kex.c
+++ b/src/kex.c
@@ -133,9 +133,15 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
         memset(&exchange_state->req_state, 0, sizeof(packet_require_state_t));
 
         /* Generate x and e */
-        _libssh2_bn_rand(exchange_state->x, group_order * 8 - 1, 0, -1);
-        _libssh2_bn_mod_exp(exchange_state->e, g, exchange_state->x, p,
-                            exchange_state->ctx);
+        if (!_libssh2_bn_rand(exchange_state->x, group_order * 8 - 1, 0, -1)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_BIGNUM,  "Random number generation failed");
+            goto clean_exit;
+        }
+        if (!_libssh2_bn_mod_exp(exchange_state->e, g, exchange_state->x, p,
+                            exchange_state->ctx)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_BIGNUM,  "ModExp failed");
+            goto clean_exit;
+        }
 
         /* Send KEX init */
         /* packet_type(1) + String Length(4) + leading 0(1) */
@@ -325,8 +331,11 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
         exchange_state->h_sig = exchange_state->s;
 
         /* Compute the shared secret */
-        _libssh2_bn_mod_exp(exchange_state->k, exchange_state->f,
-                            exchange_state->x, p, exchange_state->ctx);
+        if (!_libssh2_bn_mod_exp(exchange_state->k, exchange_state->f,
+                            exchange_state->x, p, exchange_state->ctx)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_BIGNUM,  "ModExp failed");
+            goto clean_exit;
+        }
         exchange_state->k_value_len = _libssh2_bn_bytes(exchange_state->k) + 5;
         if (_libssh2_bn_bits(exchange_state->k) % 8) {
             /* don't need leading 00 */
@@ -753,9 +762,15 @@ static int diffie_hellman_sha256(LIBSSH2_SESSION *session,
         memset(&exchange_state->req_state, 0, sizeof(packet_require_state_t));
 
         /* Generate x and e */
-        _libssh2_bn_rand(exchange_state->x, group_order * 8 - 1, 0, -1);
-        _libssh2_bn_mod_exp(exchange_state->e, g, exchange_state->x, p,
-                            exchange_state->ctx);
+        if (!_libssh2_bn_rand(exchange_state->x, group_order * 8 - 1, 0, -1)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_BIGNUM,  "Random number generation failed");
+            goto clean_exit;
+        }
+        if (!_libssh2_bn_mod_exp(exchange_state->e, g, exchange_state->x, p,
+                            exchange_state->ctx)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_BIGNUM,  "ModExp failed");
+            goto clean_exit;
+        }
 
         /* Send KEX init */
         /* packet_type(1) + String Length(4) + leading 0(1) */
@@ -945,8 +960,11 @@ static int diffie_hellman_sha256(LIBSSH2_SESSION *session,
         exchange_state->h_sig = exchange_state->s;
 
         /* Compute the shared secret */
-        _libssh2_bn_mod_exp(exchange_state->k, exchange_state->f,
-                            exchange_state->x, p, exchange_state->ctx);
+        if (!_libssh2_bn_mod_exp(exchange_state->k, exchange_state->f,
+                            exchange_state->x, p, exchange_state->ctx)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_BIGNUM,  "ModExp failed");
+            goto clean_exit;
+        }
         exchange_state->k_value_len = _libssh2_bn_bytes(exchange_state->k) + 5;
         if (_libssh2_bn_bits(exchange_state->k) % 8) {
             /* don't need leading 00 */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -172,8 +172,8 @@
 #define _libssh2_bn_ctx_free(bnctx) ((void)0)
 #define _libssh2_bn_init() gcry_mpi_new(0)
 #define _libssh2_bn_init_from_bin() NULL /* because gcry_mpi_scan() creates a new bignum */
-#define _libssh2_bn_rand(bn, bits, top, bottom) gcry_mpi_randomize (bn, bits, GCRY_WEAK_RANDOM)
-#define _libssh2_bn_mod_exp(r, a, p, m, ctx) gcry_mpi_powm (r, a, p, m)
+#define _libssh2_bn_rand(bn, bits, top, bottom) (gcry_mpi_randomize (bn, bits, GCRY_WEAK_RANDOM),1)
+#define _libssh2_bn_mod_exp(r, a, p, m, ctx) (gcry_mpi_powm (r, a, p, m),1)
 #define _libssh2_bn_set_word(bn, val) gcry_mpi_set_ui(bn, val)
 #define _libssh2_bn_from_bin(bn, len, val) gcry_mpi_scan(&((bn)), GCRYMPI_FMT_USG, val, len, NULL)
 #define _libssh2_bn_to_bin(bn, val) gcry_mpi_print (GCRYMPI_FMT_USG, val, _libssh2_bn_bytes(bn), NULL, bn)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -890,10 +890,10 @@ _libssh2_bn_rand(_libssh2_bn *bn, int bits, int top, int bottom)
     int i;
 
     if (!bn || bits <= 0)
-        return -1;
+        return 0;
     len = (bits + 7) >> 3;
     if (_libssh2_bn_resize(bn, len))
-        return -1;
+        return 0;
     _libssh2_random(bn->bignum, len);
     i = ((bits - 1) & 07) + 1;
     bn->bignum[len - 1] &= (1 << i) - 1;
@@ -911,7 +911,7 @@ _libssh2_bn_rand(_libssh2_bn *bn, int bits, int top, int bottom)
     }
     if (bottom)
         *bn->bignum |= 0x01;
-    return 0;
+    return 1;
 }
 
 static int
@@ -1013,7 +1013,7 @@ _libssh2_os400qc3_bn_mod_exp(_libssh2_bn *r, _libssh2_bn *a, _libssh2_bn *p,
     Qus_EC_t errcode;
     int sc;
     int outlen;
-    int ret = -1;
+    int ret = 0;
 
     /* There is no support for this function in the Qc3 crypto-library.
        Since a RSA encryption performs this function, we can emulate it
@@ -1077,7 +1077,7 @@ _libssh2_os400qc3_bn_mod_exp(_libssh2_bn *r, _libssh2_bn *a, _libssh2_bn *p,
         if (!errcode.Bytes_Available) {
             _libssh2_bn_from_bin(r, outlen, rv);
             if (!sc)
-                ret = 0;
+                ret = 1;
             else {
                 rp = _libssh2_bn_init();
                 if (rp) {
@@ -1087,7 +1087,7 @@ _libssh2_os400qc3_bn_mod_exp(_libssh2_bn *r, _libssh2_bn *a, _libssh2_bn *p,
                             _libssh2_bn_swap(r, rp);
                     } while (--sc);
                     _libssh2_bn_free(rp);
-                    ret = 0;
+                    ret = 1;
                 }
             }
         }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1847,16 +1847,16 @@ _libssh2_wincng_bignum_rand(_libssh2_bn *rnd, int bits, int top, int bottom)
     unsigned long length;
 
     if (!rnd)
-        return -1;
+        return 0;
 
     length = (unsigned long)(ceil((float)bits / 8) * sizeof(unsigned char));
     if (_libssh2_wincng_bignum_resize(rnd, length))
-        return -1;
+        return 0;
 
     bignum = rnd->bignum;
 
     if (_libssh2_wincng_random(bignum, length))
-        return -1;
+        return 0;
 
     /* calculate significant bits in most significant byte */
     bits %= 8;
@@ -1874,7 +1874,7 @@ _libssh2_wincng_bignum_rand(_libssh2_bn *rnd, int bits, int top, int bottom)
     if (bottom)
         bignum[length - 1] |= 1;
 
-    return 0;
+    return 1;
 }
 
 int
@@ -1893,14 +1893,14 @@ _libssh2_wincng_bignum_mod_exp(_libssh2_bn *r,
     (void)bnctx;
 
     if (!r || !a || !p || !m)
-        return -1;
+        return 0;
 
     offset = sizeof(BCRYPT_RSAKEY_BLOB);
     keylen = offset + p->length + m->length;
 
     key = malloc(keylen);
     if (!key)
-        return -1;
+        return 0;
 
 
     /* https://msdn.microsoft.com/library/windows/desktop/aa375531.aspx */
@@ -1953,7 +1953,7 @@ _libssh2_wincng_bignum_mod_exp(_libssh2_bn *r,
 
     _libssh2_wincng_safe_free(key, keylen);
 
-    return BCRYPT_SUCCESS(ret) ? 0 : -1;
+    return BCRYPT_SUCCESS(ret) ? 1 : 0;
 }
 
 int


### PR DESCRIPTION
On most backends these functions can fail, but they weren't checked, so the key exchange could proceed with invalid bignums. Since this is on the error path, it shouldn't affect security, but it would be good to have this for proper error reporting. Since I didn't think any of the existing error categories was applicable, I created a new one. There are likely other bn functions in the same situation, but before doing a massive pull request, I wanted to start with this to see if it was acceptable, and figure out if this is the proper way to handle this.
