### PR TITLE
Non-blocking examples don't handle all LIBSSH2_ERROR_EAGAIN

### DIFF
--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -270,7 +270,8 @@ int main(int argc, char *argv[])
 #endif
 
     libssh2_sftp_close(sftp_handle);
-    libssh2_sftp_shutdown(sftp_session);
+    while (libssh2_sftp_shutdown(sftp_session) == LIBSSH2_ERROR_EAGAIN)
+           ;
 
 shutdown:
 


### PR DESCRIPTION
This is just an example bug-fix, but unless I'm missing something, all the libssh2 non-blocking examples fail to handle "LIBSSH2_ERROR_EAGAIN" when calling clean-up functions like "libssh2_sftp_close, libssh2_sftp_shutdown, libssh2_session_disconnect"
