### PR TITLE
libssh2_sftp_init hang: last error not set

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -836,8 +836,11 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
 
     rc = sftp_packet_require(sftp_handle, SSH_FXP_VERSION,
                              0, &data, &data_len);
-    if (rc == LIBSSH2_ERROR_EAGAIN)
-        return NULL;
+    if (rc == LIBSSH2_ERROR_EAGAIN) {
+         _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
+                        "Would block receiving SSH_FXP_VERSION");
+         return NULL;
+    }
     else if (rc) {
         _libssh2_error(session, rc,
                        "Timeout waiting for response from SFTP subsystem");


### PR DESCRIPTION
The problem is that the original if statement simply returns NULL, but does not set the session last error code. The consequence is that libssh2_sftp_init() also returns NULL and libssh2_session_last_errno(sshSession) == LIBSSH2_ERROR_NONE.

In my test the LIBSSH2_ERROR_EAGAIN is coming from sftp.c row 337:
            if(4 != sftp->partial_size_len)
                /\* we got a short read for the length part */
                return LIBSSH2_ERROR_EAGAIN;

with "partial_size_len == 0". Not sure if this is expected.
