### PR TITLE
Add missing include netinet/in.h inside openssh_fixture.c

### DIFF
--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -44,6 +44,9 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
+#ifdef HAVE_NETINET_IN_H
+# include <netinet/in.h>
+#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
This little fix add the missing include netinet/in.h if HAVE_NETINET_IN_H is defined, in the openssh_fixture.c closing #125 