### PR TITLE
add header guards to file `src/libssh2_config_cmake.h.in`

### DIFF
--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -35,6 +35,8 @@
  * OF SUCH DAMAGE.
  */
 
+#ifndef SRC_LIBSSH2_CONFIG_CMAKE_H
+#define SRC_LIBSSH2_CONFIG_CMAKE_H
 /* Headers */
 #cmakedefine HAVE_UNISTD_H
 #cmakedefine HAVE_INTTYPES_H
@@ -103,3 +105,5 @@ static int snprintf(char * cp, int cp_max_len, const char * fmt, ...)
 
 #define HAVE_SNPRINTF
 #endif
+
+#endif // SRC_LIBSSH2_CONFIG_CMAKE_H


### PR DESCRIPTION
This fixes `redefinition` errors like below [reported](https://ci.appveyor.com/project/conda-forge/staged-recipes/build/1.0.7889/job/54fkxc6bl0bovm2u#L550) by Visual Studio 14 2005.

`C:\Miniconda35\conda-bld\work\libssh2-libssh2-1.6.0\build\src\libssh2_config.h(90): error C2375: 'snprintf': redefinition; different linkage [C:\Miniconda35\conda-bld\work\libssh2-libssh2-1.6.0\build\src\libssh2.vcxproj]`

The builds can be accessed [here](https://ci.appveyor.com/project/conda-forge/staged-recipes/build/1.0.7889).

With the fix proposed here `libssh2` seems to [build](https://ci.appveyor.com/project/GorgonCryoEM/libssh2-feedstock/build/1.0.9) successfully with `Visual Studio 2014 2005`.





