### PR TITLE
Define new Diffie-Hellman context for mbedTLS

### DIFF
--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -259,6 +259,14 @@ mbedtls_ctr_drbg_context _libssh2_mbedtls_ctr_drbg;
 
 /*******************************************************************/
 /*
+ * mbedTLS backend: Diffie-Hellman support.
+ */
+
+#define _libssh2_dh_ctx _libssh2_bn *
+
+
+/*******************************************************************/
+/*
  * mbedTLS backend: forward declarations
  */
 void


### PR DESCRIPTION
Sorry for that problem: mbedTLS backend was not yet implemented at the previous PR time.
This commit should fix https://travis-ci.org/libssh2/libssh2/jobs/175349805.
Tested locally: OK.