### PR TITLE
Check for netinet/in.h in the tests CMake file

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
 check_include_files(arpa/inet.h HAVE_ARPA_INET_H)
 check_include_files(windows.h HAVE_WINDOWS_H)
 check_include_files(winsock2.h HAVE_WINSOCK2_H)
+check_include_files(netinet/in.h HAVE_NETINET_IN_H)
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/libssh2_config_cmake.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/libssh2_config.h")


### PR DESCRIPTION
In tests/openssh_fixture.c, the system header netinet/in.h is included if it was determined to exist. However, no such check for existence was actually being performed, so `#ifdef HAVE_NETINET_IN_H` is always false in the tests. This was causing problems on FreeBSD, since it didn't know about `sockaddr_in` without that header.