### PR TITLE
segfault, variable mismatch

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -723,7 +723,7 @@ sign_frommemory(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     if (privkeyobj->signv(session, sig, sig_len, 1, &datavec,
                           &hostkey_abstract)) {
         if (privkeyobj->dtor) {
-            privkeyobj->dtor(session, abstract);
+            privkeyobj->dtor(session, &hostkey_abstract);
         }
         return -1;
     }


### PR DESCRIPTION
Wrong variable - if "signv()" fails