### PR TITLE
Add support for SHA256 host key fingerprints

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -403,7 +403,8 @@ typedef struct _LIBSSH2_POLLFD {
 /* Hash Types */
 #define LIBSSH2_HOSTKEY_HASH_MD5                            1
 #define LIBSSH2_HOSTKEY_HASH_SHA1                           2
-
+#define LIBSSH2_HOSTKEY_HASH_SHA256                         3
+    
 /* Hostkey Types */
 #define LIBSSH2_HOSTKEY_TYPE_UNKNOWN			    0
 #define LIBSSH2_HOSTKEY_TYPE_RSA			    1

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -505,7 +505,7 @@ libssh2_hostkey_methods(void)
  * Returns hash signature
  * Returned buffer should NOT be freed
  * Length of buffer is determined by hash type
- * i.e. MD5 == 16, SHA1 == 20
+ * i.e. MD5 == 16, SHA1 == 20, SHA256 == 32
  */
 LIBSSH2_API const char *
 libssh2_hostkey_hash(LIBSSH2_SESSION * session, int hash_type)
@@ -521,6 +521,11 @@ libssh2_hostkey_hash(LIBSSH2_SESSION * session, int hash_type)
     case LIBSSH2_HOSTKEY_HASH_SHA1:
         return (session->server_hostkey_sha1_valid)
           ? (char *) session->server_hostkey_sha1
+          : NULL;
+        break;
+    case LIBSSH2_HOSTKEY_HASH_SHA256:
+        return (session->server_hostkey_sha256_valid)
+          ? (char *) session->server_hostkey_sha256
           : NULL;
         break;
     default:

--- a/src/kex.c
+++ b/src/kex.c
@@ -305,6 +305,35 @@ static int diffie_hellman_sha1(LIBSSH2_SESSION *session,
                            "Server's SHA1 Fingerprint: %s", fingerprint);
         }
 #endif /* LIBSSH2DEBUG */
+        
+        {
+            libssh2_sha256_ctx fingerprint_ctx;
+            
+            if (libssh2_sha256_init(&fingerprint_ctx)) {
+                libssh2_sha256_update(fingerprint_ctx, session->server_hostkey,
+                                    session->server_hostkey_len);
+                libssh2_sha256_final(fingerprint_ctx,
+                                   session->server_hostkey_sha256);
+                session->server_hostkey_sha256_valid = TRUE;
+            }
+            else {
+                session->server_hostkey_sha256_valid = FALSE;
+            }
+        }
+#ifdef LIBSSH2DEBUG
+        {
+            char fingerprint[100], *fprint = fingerprint;
+            int i;
+            
+            for(i = 0; i < 32; i++, fprint += 3) {
+                snprintf(fprint, 4, "%02x:", session->server_hostkey_sha256[i]);
+            }
+            *(--fprint) = '\0';
+            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+                           "Server's SHA256 Fingerprint: %s", fingerprint);
+        }
+#endif /* LIBSSH2DEBUG */
+
 
         if (session->hostkey->init(session, session->server_hostkey,
                                    session->server_hostkey_len,
@@ -929,6 +958,34 @@ static int diffie_hellman_sha256(LIBSSH2_SESSION *session,
             *(--fprint) = '\0';
             _libssh2_debug(session, LIBSSH2_TRACE_KEX,
                            "Server's SHA1 Fingerprint: %s", fingerprint);
+        }
+#endif /* LIBSSH2DEBUG */
+        
+        {
+            libssh2_sha256_ctx fingerprint_ctx;
+            
+            if (libssh2_sha256_init(&fingerprint_ctx)) {
+                libssh2_sha256_update(fingerprint_ctx, session->server_hostkey,
+                                      session->server_hostkey_len);
+                libssh2_sha256_final(fingerprint_ctx,
+                                     session->server_hostkey_sha256);
+                session->server_hostkey_sha256_valid = TRUE;
+            }
+            else {
+                session->server_hostkey_sha256_valid = FALSE;
+            }
+        }
+#ifdef LIBSSH2DEBUG
+        {
+            char fingerprint[100], *fprint = fingerprint;
+            int i;
+            
+            for(i = 0; i < 32; i++, fprint += 3) {
+                snprintf(fprint, 4, "%02x:", session->server_hostkey_sha256[i]);
+            }
+            *(--fprint) = '\0';
+            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+                           "Server's SHA256 Fingerprint: %s", fingerprint);
         }
 #endif /* LIBSSH2DEBUG */
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -609,6 +609,9 @@ struct _LIBSSH2_SESSION
     unsigned char server_hostkey_sha1[SHA_DIGEST_LENGTH];
     int server_hostkey_sha1_valid;
 
+    unsigned char server_hostkey_sha256[SHA256_DIGEST_LENGTH];
+    int server_hostkey_sha256_valid;
+    
     /* (remote as source of data -- packet_read ) */
     libssh2_endpoint_data remote;
 


### PR DESCRIPTION
This commit adds SHA256 host key fingerprint support. This has been the default since OpenSSH 6.8 and now that libssh2 has SHA256 as a crypto lib requirement, this commit should not cause too much trouble.

Because libssh2 computes the host key hash during the kex, we don't know (a priori) if SHA1 or SHA256 fingerprints will be used, if at all, so we need to compute both. This is also true for MD5 fingerprints, if enabled.