### PR TITLE
Sane wait socket

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -563,6 +563,8 @@ LIBSSH2_API int libssh2_session_disconnect_ex(LIBSSH2_SESSION *session,
 
 LIBSSH2_API int libssh2_session_free(LIBSSH2_SESSION *session);
 
+LIBSSH2_API int libssh2_session_set_socket_disconnected(LIBSSH2_SESSION *session);
+
 LIBSSH2_API const char *libssh2_hostkey_hash(LIBSSH2_SESSION *session,
                                              int hash_type);
 

--- a/src/packet.c
+++ b/src/packet.c
@@ -1001,7 +1001,11 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
          * the key exchange conversation.
          */
         session->readPack_state = libssh2_NB_state_idle;
-        session->packet.total_num = 0;
+        if (session->packet.total_num) {
+            LIBSSH2_FREE(session, session->packet.payload);
+            session->packet.payload = 0;
+            session->packet.total_num = 0;
+        }
         session->packAdd_state = libssh2_NB_state_idle;
         session->fullpacket_state = libssh2_NB_state_idle;
 

--- a/src/session.c
+++ b/src/session.c
@@ -567,7 +567,7 @@ libssh2_session_callback_set(LIBSSH2_SESSION * session,
 int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
 {
     int rc;
-    int seconds_to_next;
+    int seconds_to_next = 0;
     int dir;
     int has_timeout;
     long ms_to_next = 0;
@@ -578,10 +578,6 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
        resetting the error code in this function to reduce the risk of EAGAIN
        being stored as error when a blocking function has returned */
     session->err_code = LIBSSH2_ERROR_NONE;
-
-    rc = libssh2_keepalive_send (session, &seconds_to_next);
-    if (rc < 0)
-        return rc;
 
     ms_to_next = seconds_to_next * 1000;
 

--- a/src/session.c
+++ b/src/session.c
@@ -639,7 +639,9 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
                     has_timeout ? &tv : NULL);
     }
 #endif
-    if(rc < 0) {
+    if(rc < 0 && errno != EINTR) {
+        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
+                       "Internal error: select/poll failed, errno: %d", errno);
         return _libssh2_error(session, LIBSSH2_ERROR_TIMEOUT,
                               "Error waiting on socket");
     }

--- a/src/session.c
+++ b/src/session.c
@@ -1070,6 +1070,18 @@ libssh2_session_free(LIBSSH2_SESSION * session)
 }
 
 /*
+ * libssh2_session_set_socket_disconnected
+ *
+ * Allows user to mark the socket as disconnected
+ */
+LIBSSH2_API int
+libssh2_session_set_socket_disconnected(LIBSSH2_SESSION *session) {
+    session->socket_state = LIBSSH2_SOCKET_DISCONNECTED;
+    return _libssh2_error(session, LIBSSH2_ERROR_SOCKET_DISCONNECT,
+                          "Socket disconnected locally");
+}
+
+/*
  * libssh2_session_disconnect_ex
  */
 static int

--- a/src/session.c
+++ b/src/session.c
@@ -44,6 +44,7 @@
 #endif
 #include <stdlib.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #ifdef HAVE_GETTIMEOFDAY
 #include <sys/time.h>
@@ -1013,6 +1014,9 @@ session_free(LIBSSH2_SESSION *session)
     /* Free payload buffer */
     if (session->packet.total_num) {
         LIBSSH2_FREE(session, session->packet.payload);
+    }
+    else {
+        assert(session->packet.payload == NULL);
     }
 
     /* Cleanup all remaining packets */

--- a/src/session.c
+++ b/src/session.c
@@ -639,10 +639,6 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
                     has_timeout ? &tv : NULL);
     }
 #endif
-    if(rc == 0) {
-        return _libssh2_error(session, LIBSSH2_ERROR_TIMEOUT,
-                              "Timed out waiting on socket");
-    }
     if(rc < 0) {
         return _libssh2_error(session, LIBSSH2_ERROR_TIMEOUT,
                               "Error waiting on socket");

--- a/src/session.c
+++ b/src/session.c
@@ -584,14 +584,9 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
     /* figure out what to wait for */
     dir = libssh2_session_block_directions(session);
 
-    if(!dir) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
-                       "Nothing to wait for in wait_socket");
-        /* To avoid that we hang below just because there's nothing set to
-           wait for, we timeout on 1 second to also avoid busy-looping
-           during this condition */
-        ms_to_next = 1000;
-    }
+    if(!dir)
+        return _libssh2_error(session, LIBSSH2_ERROR_BAD_USE,
+                              "Internal error: nothing to wait for in wait_socket");
 
     if (session->api_timeout > 0 &&
         (seconds_to_next == 0 ||

--- a/src/session.c
+++ b/src/session.c
@@ -639,11 +639,14 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
                     has_timeout ? &tv : NULL);
     }
 #endif
-    if(rc < 0 && errno != EINTR) {
+    if(rc < 0) {
         _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
                        "Internal error: select/poll failed, errno: %d", errno);
-        return _libssh2_error(session, LIBSSH2_ERROR_TIMEOUT,
-                              "Error waiting on socket");
+        if (errno != EINTR) {
+            session->socket_state = LIBSSH2_SOCKET_DISCONNECTED;
+            return _libssh2_error(session, LIBSSH2_ERROR_SOCKET_DISCONNECT,
+                                  "Error waiting on socket");
+        }
     }
 
     return 0; /* ready to try again */


### PR DESCRIPTION
In order to fix #147, this patch solves several issues in `_libssh2_wait_socket` and also adds a new function, `libssh2_set_socket_disconnected` to tell the library that no further interaction with the remote server should be attempted.

For instance, in order to try an ordered session cleanup and if that fails a forced dirty one, the following code can be used:

      if (libssh2_free_session(session) != LIBSSH2_ERROR_NONE) {
          /* force session cleanup */
          libssh2_set_socket_disconnected(session);
          libssh2_free_session(session);
      }

The documentation for `libssh2_set_socket_disconnected` is still missing. I would add it once this patch is reviewed, if it is considered good.