### PR TITLE
make agent.c compile on VS 2015 with UNICODE

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -269,7 +269,7 @@ static int
 agent_connect_pageant(LIBSSH2_AGENT *agent)
 {
     HWND hwnd;
-    hwnd = FindWindow("Pageant", "Pageant");
+    hwnd = FindWindow(TEXT("Pageant"), TEXT("Pageant"));
     if (!hwnd)
         return _libssh2_error(agent->session, LIBSSH2_ERROR_AGENT_PROTOCOL,
                               "failed connecting agent");
@@ -292,7 +292,7 @@ agent_transact_pageant(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
         return _libssh2_error(agent->session, LIBSSH2_ERROR_INVAL,
                               "illegal input");
 
-    hwnd = FindWindow("Pageant", "Pageant");
+    hwnd = FindWindow(TEXT("Pageant"), TEXT("Pageant"));
     if (!hwnd)
         return _libssh2_error(agent->session, LIBSSH2_ERROR_AGENT_PROTOCOL,
                               "found no pageant");

--- a/src/agent.c
+++ b/src/agent.c
@@ -282,6 +282,7 @@ agent_transact_pageant(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
 {
     HWND hwnd;
     char mapname[23];
+    wchar_t mapnamew[23];
     HANDLE filemap;
     unsigned char *p;
     unsigned char *p2;
@@ -297,9 +298,10 @@ agent_transact_pageant(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
         return _libssh2_error(agent->session, LIBSSH2_ERROR_AGENT_PROTOCOL,
                               "found no pageant");
 
-    sprintf(mapname, "PageantRequest%08x", (unsigned)GetCurrentThreadId());
+    sprintf (mapname,   "PageantRequest%08x", (unsigned)GetCurrentThreadId());
+    wsprintf(mapnamew, L"PageantRequest%08x", (unsigned)GetCurrentThreadId());
     filemap = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
-                                0, PAGEANT_MAX_MSGLEN, mapname);
+                                0, PAGEANT_MAX_MSGLEN, mapnamew);
 
     if (filemap == NULL || filemap == INVALID_HANDLE_VALUE)
         return _libssh2_error(agent->session, LIBSSH2_ERROR_AGENT_PROTOCOL,


### PR DESCRIPTION
The patch uses TEXT-macros to be backwards-compatible with ANSI, but this is probably overly-cautious as ANSI is dead.