### PR TITLE
openssl: fix build with OpenSSL 1.1 API

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1056,6 +1056,7 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                               "Unable to extract public key from private key "
                               "file: Unable to open private key file");
     }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!EVP_get_cipherbyname("des")) {
         /* If this cipher isn't loaded it's a pretty good indication that none
          * are.  I have *NO DOUBT* that there's a better way to deal with this
@@ -1064,6 +1065,7 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
          */
         OpenSSL_add_all_ciphers();
     }
+#endif
     BIO_reset(bp);
     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void*)passphrase);
     BIO_free(bp);
@@ -1132,6 +1134,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     if (!bp) {
         return -1;
     }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!EVP_get_cipherbyname("des")) {
         /* If this cipher isn't loaded it's a pretty good indication that none
          * are.  I have *NO DOUBT* that there's a better way to deal with this
@@ -1140,6 +1143,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
          */
         OpenSSL_add_all_ciphers();
     }
+#endif
     BIO_reset(bp);
     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void*)passphrase);
     BIO_free(bp);

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -226,10 +226,16 @@ int _libssh2_md5_init(libssh2_md5_ctx *ctx);
 #define libssh2_hmac_cleanup(ctx) HMAC_cleanup(ctx)
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#define libssh2_crypto_init() \
+  ENGINE_load_builtin_engines(); \
+  ENGINE_register_all_complete()
+#else
 #define libssh2_crypto_init() \
   OpenSSL_add_all_algorithms(); \
   ENGINE_load_builtin_engines(); \
   ENGINE_register_all_complete()
+#endif
 
 #define libssh2_crypto_exit()
 


### PR DESCRIPTION
When building with OPENSSL_API_COMPAT=0x10100000L, OpenSSL_add_all_algorithms
and OpenSSL_add_all_ciphers don't exist. The corresponding functionality is
handled automatically with OpenSSL 1.1.