### PR TITLE
mbedTLS: Avoid multiple definition errors for context handles

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -4,6 +4,14 @@
 
 /*******************************************************************/
 /*
+ * mbedTLS backend: Global context handles
+ */
+
+static mbedtls_entropy_context  _libssh2_mbedtls_entropy;
+static mbedtls_ctr_drbg_context _libssh2_mbedtls_ctr_drbg;
+
+/*******************************************************************/
+/*
  * mbedTLS backend: Generic functions
  */
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -35,14 +35,6 @@
 
 /*******************************************************************/
 /*
- * mbedTLS backend: Global context handles
- */
-
-mbedtls_entropy_context  _libssh2_mbedtls_entropy;
-mbedtls_ctr_drbg_context _libssh2_mbedtls_ctr_drbg;
-
-/*******************************************************************/
-/*
  * mbedTLS backend: Generic functions
  */
 


### PR DESCRIPTION
These handles are only used in `mbedtls.c`, and CodeWarrior (on classic MacOS) throws multiple-definition linker errors when they're defined in the header file