### PR TITLE
Fixes out of bounds memory access

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -76,7 +76,7 @@ readline_memory(char *line, size_t line_size,
 
     off = *filedata_offset;
 
-    for (len = 0; off + len < filedata_len && len < line_size; len++) {
+    for (len = 0; off + len < filedata_len && len < line_size - 1; len++) {
         if (filedata[off + len] == '\n' ||
             filedata[off + len] == '\r') {
                 break;


### PR DESCRIPTION
If an invalid PEM file is read and the lines are longer than 128 characters it will go out of bounds and crash on line 91.