### PR TITLE
Support for direct-streamlocal@openssh.com UNIX socket connection

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -16,6 +16,7 @@ dist_man_MANS = \
 	libssh2_channel_close.3 \
 	libssh2_channel_direct_tcpip.3 \
 	libssh2_channel_direct_tcpip_ex.3 \
+	libssh2_channel_direct_streamlocal_ex.3 \
 	libssh2_channel_eof.3 \
 	libssh2_channel_exec.3 \
 	libssh2_channel_flush.3 \

--- a/docs/libssh2_channel_direct_streamlocal_ex.3
+++ b/docs/libssh2_channel_direct_streamlocal_ex.3
@@ -1,0 +1,33 @@
+.TH libssh2_channel_direct_streamlocal_ex 3 "1 Jun 2007" "libssh2 0.15" "libssh2 manual"
+.SH NAME
+libssh2_channel_direct_streamlocal_ex - Tunnel a UNIX socket connection through an SSH session
+.SH SYNOPSIS
+#include <libssh2.h>
+
+LIBSSH2_CHANNEL * 
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION *session, const char *socket_path, const char *shost, int sport);
+
+LIBSSH2_CHANNEL * 
+libssh2_channel_direct_streamlocal(LIBSSH2_SESSION *session, const char *socket_path, const char *shost, int sport);
+
+.SH DESCRIPTION
+\fIsession\fP - Session instance as returned by 
+.BR libssh2_session_init_ex(3)
+
+\fIsocket_path\fP - UNIX socket to connect to using the SSH host as a proxy.
+
+\fIshost\fP - Host to tell the SSH server the connection originated on.
+
+\fIsport\fP - Port to tell the SSH server the connection originated from.
+
+Tunnel a UNIX socket connection through the SSH transport via the remote host to 
+a third party. Communication from the client to the SSH server remains 
+encrypted, communication from the server to the 3rd party host travels 
+in cleartext.
+
+.SH RETURN VALUE
+Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
+.SH ERRORS
+\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+.SH SEE ALSO
+.BR libssh2_session_init_ex(3)

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -716,6 +716,10 @@ libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
 #define libssh2_channel_direct_tcpip(session, host, port) \
   libssh2_channel_direct_tcpip_ex((session), (host), (port), "127.0.0.1", 22)
 
+LIBSSH2_API LIBSSH2_CHANNEL *
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session, const char *socket_path,
+                                const char *shost, int sport);
+
 LIBSSH2_API LIBSSH2_LISTENER *
 libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session, const char *host,
                                   int port, int *bound_port, int queue_maxsize);

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -717,7 +717,8 @@ libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
   libssh2_channel_direct_tcpip_ex((session), (host), (port), "127.0.0.1", 22)
 
 LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session, const char *socket_path,
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
+                                const char *socket_path,
                                 const char *shost, int sport);
 
 LIBSSH2_API LIBSSH2_LISTENER *

--- a/src/channel.c
+++ b/src/channel.c
@@ -439,12 +439,13 @@ libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
 static LIBSSH2_CHANNEL *
-channel_direct_streamlocal(LIBSSH2_SESSION * session, const char *socket_path, const char *shost, int sport)
+channel_direct_streamlocal(LIBSSH2_SESSION * session, const char *socket_path,
+                           const char *shost, int sport)
 {
     LIBSSH2_CHANNEL *channel;
     unsigned char *s;
 
-    if (session->direct_state == libssh2_NB_state_idle) {
+    if(session->direct_state == libssh2_NB_state_idle) {
         session->direct_host_len = strlen(socket_path);
         session->direct_shost_len = strlen(shost);
         session->direct_message_len =
@@ -456,9 +457,9 @@ channel_direct_streamlocal(LIBSSH2_SESSION * session, const char *socket_path, c
 
         s = session->direct_message =
             LIBSSH2_ALLOC(session, session->direct_message_len);
-        if (!session->direct_message) {
+        if(!session->direct_message) {
             _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                           "Unable to allocate memory for direct-streamlocal connection");
+                "Unable to allocate memory for direct-streamlocal connection");
             return NULL;
         }
         _libssh2_store_str(&s, socket_path, session->direct_host_len);
@@ -474,7 +475,7 @@ channel_direct_streamlocal(LIBSSH2_SESSION * session, const char *socket_path, c
                               session->direct_message,
                               session->direct_message_len);
 
-    if (!channel &&
+    if(!channel &&
         libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
         /* The error code is still set to LIBSSH2_ERROR_EAGAIN, set our state
            to created to avoid re-creating the package on next invoke */
@@ -496,7 +497,9 @@ channel_direct_streamlocal(LIBSSH2_SESSION * session, const char *socket_path, c
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
 LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session, const char *socket_path, const char *shost, int sport)
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
+                                      const char *socket_path,
+                                      const char *shost, int sport)
 {
     LIBSSH2_CHANNEL *ptr;
 
@@ -504,7 +507,7 @@ libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session, const char *soc
         return NULL;
 
     BLOCK_ADJUST_ERRNO(ptr, session,
-                       channel_direct_streamlocal(session, socket_path, shost, sport));
+              channel_direct_streamlocal(session, socket_path, shost, sport));
     return ptr;
 }
 
@@ -2221,6 +2224,9 @@ libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
 
     if(!channel)
         return LIBSSH2_ERROR_BAD_USE;
+
+    if(!channel->session)
+        return LIBSSH2_ERROR_SOCKET_RECV;
 
     BLOCK_ADJUST(rc, channel->session,
                  _libssh2_channel_write(channel, stream_id,


### PR DESCRIPTION
This patch allow to use direct-streamlocal service from OpenSSH 6.7, that allows UNIX socket connections.