### PR TITLE
Fix typo in crypt.c

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -53,7 +53,7 @@ crypt_none_crypt(LIBSSH2_SESSION * session, unsigned char *buf,
 
 static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_none = {
     "none",
-    "DEK-Info: NONE"
+    "DEK-Info: NONE",
     8,                     /* blocksize (SSH2 defines minimum blocksize as 8) */
     0,                     /* iv_len */
     0,                     /* secret_len */


### PR DESCRIPTION
Master branch cmake compile currently failing with 

```
src/crypt.c:57:5: error: expected ‘}’ before numeric constant
     8,                     /* blocksize (SSH2 defines minimum blocksize as 8) */
     ^
```
