### PR TITLE
[WIP] Fixed twice assigned values

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -993,6 +993,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
             session->packAdd_state = libssh2_NB_state_sent2;
         }
+        else
+          session->packAdd_state = libssh2_NB_state_idle;
 
         /*
          * The KEXINIT message has been added to the queue.  The packAdd and
@@ -1002,7 +1004,6 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
          */
         session->readPack_state = libssh2_NB_state_idle;
         session->packet.total_num = 0;
-        session->packAdd_state = libssh2_NB_state_idle;
         session->fullpacket_state = libssh2_NB_state_idle;
 
         memset(&session->startup_key_state, 0, sizeof(key_exchange_state_t));


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
libssh2/src/packet.c        1005    warn    V519 The 'session->packAdd_state' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 994, 1005.

Which case is true:
1) `session->packAdd_state` always should be `libssh2_NB_state_idle`
or
2) `session->packAdd_state` equals` libssh2_NB_state_sent2`  if condition `if (session->packAdd_state == libssh2_NB_state_sent1)` is true?