### PR TITLE
buildsystem: drop custom buildconf script, rely on autoreconf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache
+compile
+test-driver
 config.guess
 config.log
 config.status

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ script:
       fi
   - |
       if [ "$B" = "configure" ]; then
-        ./buildconf
+        autoreconf -fi
         ./configure --enable-debug --enable-werror
         make
         make check

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,7 @@ os400/libssh2rpg/libssh2_publickey.rpgle				\
 os400/libssh2rpg/libssh2_sftp.rpgle					\
 Makefile.os400qc3.inc
 
-EXTRA_DIST = $(WIN32FILES) buildconf $(NETWAREFILES) get_ver.awk \
+EXTRA_DIST = $(WIN32FILES) $(NETWAREFILES) get_ver.awk \
  maketgz NMakefile RELEASE-NOTES libssh2.pc.in $(VMSFILES) config.rpath \
  CMakeLists.txt cmake $(OS400FILES)
 

--- a/buildconf
+++ b/buildconf
@@ -1,22 +1,8 @@
 #!/bin/sh
 
-LIBTOOLIZE="libtoolize"
+echo "***" >&2
+echo "*** Do not use buildconf. Instead, just use: autoreconf -fi" >&2
+echo "*** Doing it for you now, but buildconf may disapear in the future." >&2
+echo "***" >&2
 
-if [ "x`which $LIBTOOLIZE`" = "x" ]; then
-    LIBTOOLIZE="glibtoolize"
-fi
-
-if [ "x`which $LIBTOOLIZE`" = "x" ]; then
-    echo "Neither libtoolize nor glibtoolize could be found!"
-    exit 1
-fi
-
-${LIBTOOLIZE} --copy --automake --force
-${ACLOCAL:-aclocal} -I m4 $ACLOCAL_FLAGS
-${AUTOHEADER:-autoheader}
-# copy the private libssh2_config.h.in to the examples dir so that
-# it can be included without pointing the include path to the private
-# source dir
-cp src/libssh2_config.h.in example/libssh2_config.h.in
-${AUTOCONF:-autoconf}
-${AUTOMAKE:-automake} --add-missing --copy
+${AUTORECONF:-autoreconf} -fi "${@}"

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 AC_INIT(libssh2, [-], libssh2-devel@cool.haxx.se)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src])
-AC_CONFIG_HEADERS([src/libssh2_config.h example/libssh2_config.h])
+AC_CONFIG_HEADERS([src/libssh2_config.h])
 AM_MAINTAINER_MODE
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 

--- a/docs/INSTALL_AUTOTOOLS
+++ b/docs/INSTALL_AUTOTOOLS
@@ -14,9 +14,9 @@ If you want to build directly from the git repository, you must first
 generate the configure script and Makefile using autotools. There is
 a convenience script that calls all tools in the correct order. Make
 sure that autoconf, automake and libtool are installed on your system,
-then execute the following script:
+then execute:
 
-  ./buildconf
+  autoreconf -fi
 
 After executing this script, you can build the project as usual:
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -21,8 +21,6 @@ config.h.in
 ssh2_exec
 ssh2_agent
 ssh2_agent_forwarding
-libssh2_config.h
-libssh2_config.h.in
 stamp-h2
 sftp_append
 sftp_write_sliding

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -13,5 +13,5 @@ if HAVE_SYS_UN_H
 noinst_PROGRAMS += x11
 endif
 
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/example
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/example -I../src
 LDADD = $(top_builddir)/src/libssh2.la


### PR DESCRIPTION
The buildconf script is currently required, because we need to copy a
header around, because it is used both from the library and the examples
sources.

However, having a custom 'buildconf'-like script is not needed if we can
ensure that the header / exists by the time it is needed. For That, we
can just append the src/ directory to the headers search path for the
examples.

And then it means we no longer need to generate the same header twice,
so we remove the second one from configure.ac.

Now, we can just call "autoreconf -fi" to generate the autotools files,
instead of relying on the canned sequence in "buildconf", since
autoreconf has now long known what to do at the correct moment (future
versions of autotools, automake, autopoint, autoheader etc... may
require an other ordering, or other intermediate steps, etc...).

Eventually, get rid of buildconf now it is no longer needed. In fact, we
really keep it for legacy, but have it just call autoreconf (and print a
nice user-friendly warning).

Update gitignore accordingly, too.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
Cc: Sam Voss <sam.voss@rockwellcollins.com>