### PR TITLE
Allowing ssh2.sh to work with cross-compiled version of libssh

### DIFF
--- a/tests/ssh2.sh
+++ b/tests/ssh2.sh
@@ -20,6 +20,10 @@ if test -n "$DEBUG"; then
     libssh2_sshd_params="-d -d"
 fi
 
+# save current LD_LIBRARY_PATH with user provided libraries
+CURRENT_LDLIBPATH=$LD_LIBRARY_PATH
+# revert LD_LIBRARY_PATH to empty value, to allow sshd to start
+LD_LIBRARY_PATH=
 chmod go-rwx "$srcdir"/etc/host*
 $SSHD -f /dev/null -h "$srcdir"/etc/host \
     -o 'Port 4711' \
@@ -38,6 +42,7 @@ trap "kill ${sshdpid}; echo signal killing sshd; exit 1;" EXIT
 sleep 3
 
 : Invoking $cmd...
+LD_LIBRARY_PATH=$CURRENT_LDLIBPATH
 eval $cmd
 ec=$?
 : Self-test exit code $ec


### PR DESCRIPTION
Where I work, we repack quite a lot of open source libraries for use with our internal build system.
I tried to add a call to "make check" to ensure the library is working correctly, but the ssh2.sh test fails.

The most probable reason is that we are cross compiling the library with a recent toolchain, but the test script is trying to run the sshd from the system, which is itself not built with the toolchain.

The error I get in the tests/test-suite.log is the following:

/usr/sbin/sshd: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /remote/users/wollivier/mwp/osp/ssh2/rpm-bms-scripts/DEPS/osp/ZLib/18-0-0-0/lib/x86_64-2.6.32-v4/Debug/libz.so.1)

It appears that this test will not work with cross compiled libraries, because il LD_LIBRARY_PATH is setup with the cross compiled libraries, sshd will try to use those, even if not compiled with the same toolchain.

This pull request is aimed at solving this issue.

I'm not entirely sure this would work all the time (empty LD_LIBRARY_PATH might not work on all systems), but I tested it successfully on my machine.