### PR TITLE
update crypt.c to fix a bug in FIPS scenario

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -311,11 +311,6 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_3des_cbc = {
 #endif
 
 static const LIBSSH2_CRYPT_METHOD *_libssh2_crypt_methods[] = {
-#if LIBSSH2_AES_CTR
-  &libssh2_crypt_method_aes128_ctr,
-  &libssh2_crypt_method_aes192_ctr,
-  &libssh2_crypt_method_aes256_ctr,
-#endif /* LIBSSH2_AES */
 #if LIBSSH2_AES
     &libssh2_crypt_method_aes256_cbc,
     &libssh2_crypt_method_rijndael_cbc_lysator_liu_se,  /* == aes256-cbc */
@@ -335,9 +330,15 @@ static const LIBSSH2_CRYPT_METHOD *_libssh2_crypt_methods[] = {
 #if LIBSSH2_3DES
     &libssh2_crypt_method_3des_cbc,
 #endif /*  LIBSSH2_DES */
+#if LIBSSH2_AES_CTR
+    &libssh2_crypt_method_aes128_ctr,
+    &libssh2_crypt_method_aes192_ctr,
+    &libssh2_crypt_method_aes256_ctr,
+#endif /* LIBSSH2_AES_CTR */
 #ifdef LIBSSH2_CRYPT_NONE
     &libssh2_crypt_method_none,
 #endif
+  
     NULL
 };
 


### PR DESCRIPTION
Problem Description: when FipsAlgorithmPolicy is ON(1) in Windows, remote linux connect through libssh2, fails.
Post cipher exchange, packet length becomes garbage value.
Decrypt of packet failed or / gave errored result in libssh2, post cipher / key exchange happened.- Ciphers used -aes-128-ctr [erroneous]
Fix:
We should disable CTR methods in windows FIPS case. But reordering will solve the issue. as it will give priority to AES_CBC ciphers.
Tested: Windows to Linux , Linux to Linux