### PR TITLE
tests: fix checksrc warnings

### DIFF
--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -63,13 +63,13 @@ static int run_command(const char *command, char **output)
     FILE *pipe;
     char command_buf[BUFSIZ];
     int ret;
-    if (output) {
+    if(output) {
         *output = NULL;
     }
 
     /* Rewrite the command to redirect stderr to stdout to we can output it */
     ret = snprintf(command_buf, sizeof(command_buf), "%s 2>&1", command);
-    if (ret < 0 || ret >= BUFSIZ) {
+    if(ret < 0 || ret >= BUFSIZ) {
         fprintf(stderr, "Unable to format command (%s)\n", command);
         return -1;
     }
@@ -80,10 +80,10 @@ static int run_command(const char *command, char **output)
 #else
     pipe = popen(command_buf, "r");
 #endif
-    if (pipe) {
+    if(pipe) {
         char buf[BUFSIZ];
         char *p = buf;
-        while (fgets(p, sizeof(buf) - (p - buf), pipe) != NULL)
+        while(fgets(p, sizeof(buf) - (p - buf), pipe) != NULL)
             ;
 
 #ifdef WIN32
@@ -91,12 +91,12 @@ static int run_command(const char *command, char **output)
 #else
         ret = pclose(pipe);
 #endif
-        if (ret == 0) {
-            if (output) {
+        if(ret == 0) {
+            if(output) {
                 /* command output may contain a trailing newline, so we trim
                  * whitespace here */
                 size_t end = strlen(buf) - 1;
-                while (end > 0 && isspace(buf[end])) {
+                while(end > 0 && isspace(buf[end])) {
                     buf[end] = '\0';
                 }
 
@@ -132,7 +132,7 @@ static int stop_openssh_server(char *container_id)
     char command_buf[BUFSIZ];
     int rc = snprintf(command_buf, sizeof(command_buf), "docker stop %s",
                       container_id);
-    if (rc > -1 && rc < BUFSIZ) {
+    if(rc > -1 && rc < BUFSIZ) {
         return run_command(command_buf, NULL);
     }
     else {
@@ -148,22 +148,22 @@ static const char *docker_machine_name()
 static int ip_address_from_container(char *container_id, char **ip_address_out)
 {
     const char *active_docker_machine = docker_machine_name();
-    if (active_docker_machine != NULL) {
+    if(active_docker_machine != NULL) {
 
-        // This can be flaky when tests run in parallel (see
-        // https://github.com/docker/machine/issues/2612), so we retry a few
-        // times with exponential backoff if it fails
+        /* This can be flaky when tests run in parallel (see
+           https://github.com/docker/machine/issues/2612), so we retry a few
+           times with exponential backoff if it fails */
         int attempt_no = 0;
         int wait_time = 500;
-        for (;;) {
+        for(;;) {
             char command_buf[BUFSIZ];
             int rc = snprintf(command_buf, sizeof(command_buf),
                               "docker-machine ip %s", active_docker_machine);
-            if (rc > -1 && rc < BUFSIZ) {
+            if(rc > -1 && rc < BUFSIZ) {
                 return run_command(command_buf, ip_address_out);
             }
 
-            if (attempt_no > 5) {
+            if(attempt_no > 5) {
                 fprintf(
                     stderr,
                     "Unable to get IP from docker-machine after %d attempts\n",
@@ -191,7 +191,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
             "docker inspect --format \"{{ index (index (index "
             ".NetworkSettings.Ports \\\"22/tcp\\\") 0) \\\"HostIp\\\" }}\" %s",
             container_id);
-        if (rc > -1 && rc < BUFSIZ) {
+        if(rc > -1 && rc < BUFSIZ) {
             return run_command(command_buf, ip_address_out);
         }
         else {
@@ -208,7 +208,7 @@ static int port_from_container(char *container_id, char **port_out)
         "docker inspect --format \"{{ index (index (index "
         ".NetworkSettings.Ports \\\"22/tcp\\\") 0) \\\"HostPort\\\" }}\" %s",
         container_id);
-    if (rc > -1 && rc < BUFSIZ) {
+    if(rc > -1 && rc < BUFSIZ) {
         return run_command(command_buf, port_out);
     }
     else {
@@ -221,22 +221,22 @@ static int open_socket_to_container(char *container_id)
     char *ip_address = NULL;
 
     int ret = ip_address_from_container(container_id, &ip_address);
-    if (ret == 0) {
+    if(ret == 0) {
         char *port_string = NULL;
         ret = port_from_container(container_id, &port_string);
-        if (ret == 0) {
+        if(ret == 0) {
             unsigned long hostaddr = inet_addr(ip_address);
-            if (hostaddr != (unsigned long)(-1)) {
+            if(hostaddr != (unsigned long)(-1)) {
                 int sock = socket(AF_INET, SOCK_STREAM, 0);
-                if (sock > -1) {
+                if(sock > -1) {
                     struct sockaddr_in sin;
 
                     sin.sin_family = AF_INET;
                     sin.sin_port = htons((short)strtol(port_string, NULL, 0));
                     sin.sin_addr.s_addr = hostaddr;
 
-                    if (connect(sock, (struct sockaddr *)(&sin),
-                                sizeof(struct sockaddr_in)) == 0) {
+                    if(connect(sock, (struct sockaddr *)(&sin),
+                               sizeof(struct sockaddr_in)) == 0) {
                         ret = sock;
                     }
                     else {
@@ -284,14 +284,14 @@ int start_openssh_fixture()
     WSADATA wsadata;
 
     ret = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if (ret != 0) {
+    if(ret != 0) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", ret);
         return 1;
     }
 #endif
 
     ret = build_openssh_server_docker_image();
-    if (ret == 0) {
+    if(ret == 0) {
         return start_openssh_server(&running_container_id);
     }
     else {
@@ -302,7 +302,7 @@ int start_openssh_fixture()
 
 void stop_openssh_fixture()
 {
-    if (running_container_id) {
+    if(running_container_id) {
         stop_openssh_server(running_container_id);
         free(running_container_id);
         running_container_id = NULL;

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -43,7 +43,7 @@ int main()
 {
     int exit_code = 1;
     LIBSSH2_SESSION *session = start_session_fixture();
-    if (session != NULL) {
+    if(session != NULL) {
         exit_code = (test(session) == 0) ? 0 : 1;
     }
     stop_session_fixture();

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -57,9 +57,9 @@ int connected_socket = -1;
 static int connect_to_server()
 {
     connected_socket = open_socket_to_openssh_server();
-    if (connected_socket > -1) {
+    if(connected_socket > -1) {
         int rc = libssh2_session_handshake(connected_session, connected_socket);
-        if (rc == 0) {
+        if(rc == 0) {
             return 0;
         }
         else {
@@ -75,14 +75,14 @@ static int connect_to_server()
 LIBSSH2_SESSION *start_session_fixture()
 {
     int rc = start_openssh_fixture();
-    if (rc == 0) {
+    if(rc == 0) {
         rc = libssh2_init(0);
-        if (rc == 0) {
+        if(rc == 0) {
             connected_session = libssh2_session_init_ex(NULL, NULL, NULL, NULL);
             libssh2_session_set_blocking(connected_session, 1);
-            if (connected_session != NULL) {
+            if(connected_session != NULL) {
                 rc = connect_to_server();
-                if (rc == 0) {
+                if(rc == 0) {
                     return connected_session;
                 }
                 else {
@@ -106,7 +106,7 @@ LIBSSH2_SESSION *start_session_fixture()
 
 void print_last_session_error(const char *function)
 {
-    if (connected_session) {
+    if(connected_session) {
         char *message;
         int rc =
             libssh2_session_last_error(connected_session, &message, NULL, 0);
@@ -119,7 +119,7 @@ void print_last_session_error(const char *function)
 
 void stop_session_fixture()
 {
-    if (connected_session) {
+    if(connected_session) {
         libssh2_session_disconnect(connected_session, "test ended");
         libssh2_session_free(connected_session);
         shutdown(connected_socket, 2);

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -41,28 +41,27 @@
 
 #include "libssh2.h"
 
-static int test_libssh2_base64_decode (LIBSSH2_SESSION *session)
+static int test_libssh2_base64_decode(LIBSSH2_SESSION *session)
 {
     char *data;
     unsigned int datalen;
     const char *src = "Zm5vcmQ=";
-    unsigned int src_len = strlen (src);
+    unsigned int src_len = strlen(src);
     int ret;
 
     ret = libssh2_base64_decode(session, &data, &datalen,
                                 src, src_len);
-    if (ret)
+    if(ret)
         return ret;
 
-    if (datalen != 5 || strcmp (data, "fnord") != 0)
-    {
-        fprintf (stderr,
-                 "libssh2_base64_decode() failed (%d, %.*s)\n",
-                 datalen, datalen, data);
+    if(datalen != 5 || strcmp(data, "fnord") != 0) {
+        fprintf(stderr,
+                "libssh2_base64_decode() failed (%d, %.*s)\n",
+                datalen, datalen, data);
         return 1;
     }
 
-    free (data);
+    free(data);
 
     return 0;
 }
@@ -74,25 +73,23 @@ int main(int argc, char *argv[])
     (void)argv;
     (void)argc;
 
-    rc = libssh2_init (LIBSSH2_INIT_NO_CRYPTO);
-    if (rc != 0)
-    {
-        fprintf (stderr, "libssh2_init() failed: %d\n", rc);
+    rc = libssh2_init(LIBSSH2_INIT_NO_CRYPTO);
+    if(rc != 0) {
+        fprintf(stderr, "libssh2_init() failed: %d\n", rc);
         return 1;
     }
 
     session = libssh2_session_init();
-    if (!session)
-    {
-        fprintf (stderr, "libssh2_session_init() failed\n");
+    if(!session) {
+        fprintf(stderr, "libssh2_session_init() failed\n");
         return 1;
     }
 
-    test_libssh2_base64_decode (session);
+    test_libssh2_base64_decode(session);
 
     libssh2_session_free(session);
 
-    libssh2_exit ();
+    libssh2_exit();
 
     return 0;
 }

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -39,18 +39,18 @@ int main(int argc, char *argv[])
     char *userauthlist;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
-    const char *pubkeyfile="etc/user.pub";
-    const char *privkeyfile="etc/user";
-    const char *username="username";
-    const char *password="password";
+    const char *pubkeyfile = "etc/user.pub";
+    const char *privkeyfile = "etc/user";
+    const char *username = "username";
+    const char *password = "password";
     int ec = 1;
 
 #ifdef WIN32
     WSADATA wsadata;
     int err;
 
-    err = WSAStartup(MAKEWORD(2,0), &wsadata);
-    if (err != 0) {
+    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(err != 0) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", err);
         return -1;
     }
@@ -59,14 +59,14 @@ int main(int argc, char *argv[])
     (void)argc;
     (void)argv;
 
-    if (getenv ("USER"))
-      username = getenv ("USER");
+    if(getenv("USER"))
+      username = getenv("USER");
 
-    if (getenv ("PRIVKEY"))
-      privkeyfile = getenv ("PRIVKEY");
+    if(getenv ("PRIVKEY"))
+      privkeyfile = getenv("PRIVKEY");
 
-    if (getenv ("PUBKEY"))
-      pubkeyfile = getenv ("PUBKEY");
+    if(getenv("PUBKEY"))
+      pubkeyfile = getenv("PUBKEY");
 
     hostaddr = htonl(0x7F000001);
 
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(4711);
     sin.sin_addr.s_addr = hostaddr;
-    if (connect(sock, (struct sockaddr*)(&sin),
+    if(connect(sock, (struct sockaddr*)(&sin),
                 sizeof(struct sockaddr_in)) != 0) {
         fprintf(stderr, "failed to connect!\n");
         return 1;
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
      * This will trade welcome banners, exchange keys, and setup crypto, compression, and MAC layers
      */
     session = libssh2_session_init();
-    if (libssh2_session_startup(session, sock)) {
+    if(libssh2_session_startup(session, sock)) {
         fprintf(stderr, "Failure establishing SSH session\n");
         return 1;
     }
@@ -106,31 +106,34 @@ int main(int argc, char *argv[])
     /* check what authentication methods are available */
     userauthlist = libssh2_userauth_list(session, username, strlen(username));
     printf("Authentication methods: %s\n", userauthlist);
-    if (strstr(userauthlist, "password") != NULL) {
+    if(strstr(userauthlist, "password") != NULL) {
         auth_pw |= 1;
     }
-    if (strstr(userauthlist, "keyboard-interactive") != NULL) {
+    if(strstr(userauthlist, "keyboard-interactive") != NULL) {
         auth_pw |= 2;
     }
-    if (strstr(userauthlist, "publickey") != NULL) {
+    if(strstr(userauthlist, "publickey") != NULL) {
         auth_pw |= 4;
     }
 
-    if (auth_pw & 4) {
+    if(auth_pw & 4) {
         /* Authenticate by public key */
-        if (libssh2_userauth_publickey_fromfile(session, username, pubkeyfile, privkeyfile, password)) {
+        if(libssh2_userauth_publickey_fromfile(session, username, pubkeyfile, privkeyfile, password)) {
             printf("\tAuthentication by public key failed!\n");
             goto shutdown;
-        } else {
+        }
+        else {
             printf("\tAuthentication by public key succeeded.\n");
         }
-    } else {
+    }
+    else {
         printf("No supported authentication methods found!\n");
         goto shutdown;
     }
 
     /* Request a shell */
-    if (!(channel = libssh2_channel_open_session(session))) {
+    channel = libssh2_channel_open_session(session);
+    if(!channel) {
         fprintf(stderr, "Unable to open a session\n");
         goto shutdown;
     }
@@ -143,13 +146,13 @@ int main(int argc, char *argv[])
     /* Request a terminal with 'vanilla' terminal emulation
      * See /etc/termcap for more options
      */
-    if (libssh2_channel_request_pty(channel, "vanilla")) {
+    if(libssh2_channel_request_pty(channel, "vanilla")) {
         fprintf(stderr, "Failed requesting pty\n");
         goto skip_shell;
     }
 
     /* Open a SHELL on that pty */
-    if (libssh2_channel_shell(channel)) {
+    if(libssh2_channel_shell(channel)) {
         fprintf(stderr, "Unable to request shell on allocated pty\n");
         goto shutdown;
     }
@@ -157,7 +160,7 @@ int main(int argc, char *argv[])
     ec = 0;
 
   skip_shell:
-    if (channel) {
+    if(channel) {
         libssh2_channel_free(channel);
         channel = NULL;
     }

--- a/tests/test_hostkey.c
+++ b/tests/test_hostkey.c
@@ -4,7 +4,7 @@
 
 #include <stdio.h>
 
-const char *EXPECTED_RSA_HOSTKEY =
+static const char *EXPECTED_RSA_HOSTKEY =
     "AAAAB3NzaC1yc2EAAAABIwAAAQEArrr/JuJmaZligyfS8vcNur+mWR2ddDQtVdhHzdKU"
     "UoR6/Om6cvxpe61H1YZO1xCpLUBXmkki4HoNtYOpPB2W4V+8U4BDeVBD5crypEOE1+7B"
     "Am99fnEDxYIOZq2/jTP0yQmzCpWYS3COyFmkOL7sfX1wQMeW5zQT2WKcxC6FSWbhDqrB"
@@ -12,7 +12,7 @@ const char *EXPECTED_RSA_HOSTKEY =
     "i6ELfP3r+q6wdu0P4jWaoo3De1aYxnToV/ldXykpipON4NPamsb6Ph2qlJQKypq7J4iQ"
     "gkIIbCU1A31+4ExvcIVoxLQw/aTSbw==";
 
-const char *EXPECTED_ECDSA_HOSTKEY =
+static const char *EXPECTED_ECDSA_HOSTKEY =
     "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC+/syyeKJD9dC2ZH"
     "9Q7iJGReR4YM3rUCMsSynkyXojdfSClGCMY7JvWlt30ESjYvxoTfSRGx6WvaqYK/vPoYQ4=";
 
@@ -25,16 +25,16 @@ int test(LIBSSH2_SESSION *session)
     char *expected_hostkey = NULL;
 
     const char *hostkey = libssh2_session_hostkey(session, &len, &type);
-    if (hostkey == NULL) {
+    if(hostkey == NULL) {
         print_last_session_error("libssh2_session_hostkey");
         return 1;
     }
 
-    if (type == LIBSSH2_HOSTKEY_TYPE_ECDSA) {
+    if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA) {
         rc = libssh2_base64_decode(session, &expected_hostkey, &expected_len,
                                    EXPECTED_ECDSA_HOSTKEY, strlen(EXPECTED_ECDSA_HOSTKEY));
     }
-    else if (type == LIBSSH2_HOSTKEY_TYPE_RSA) {
+    else if(type == LIBSSH2_HOSTKEY_TYPE_RSA) {
         rc = libssh2_base64_decode(session, &expected_hostkey, &expected_len,
                                    EXPECTED_RSA_HOSTKEY, strlen(EXPECTED_RSA_HOSTKEY));
     }
@@ -43,18 +43,18 @@ int test(LIBSSH2_SESSION *session)
         return 1;
     }
 
-    if (rc != 0) {
+    if(rc != 0) {
         print_last_session_error("libssh2_base64_decode");
         return 1;
     }
 
-    if (len != expected_len) {
+    if(len != expected_len) {
         fprintf(stderr, "Hostkey does not have the expected length %ld != %d\n",
-                len, expected_len);
+                (unsigned long)len, expected_len);
         return 1;
     }
 
-    if (memcmp(hostkey, expected_hostkey, len) != 0) {
+    if(memcmp(hostkey, expected_hostkey, len) != 0) {
         fprintf(stderr, "Hostkeys do not match\n");
         return 1;
     }

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -5,7 +5,7 @@
 
 #include <stdio.h>
 
-const char *EXPECTED_RSA_HOSTKEY =
+static const char *EXPECTED_RSA_HOSTKEY =
     "AAAAB3NzaC1yc2EAAAABIwAAAQEArrr/JuJmaZligyfS8vcNur+mWR2ddDQtVdhHzdKU"
     "UoR6/Om6cvxpe61H1YZO1xCpLUBXmkki4HoNtYOpPB2W4V+8U4BDeVBD5crypEOE1+7B"
     "Am99fnEDxYIOZq2/jTP0yQmzCpWYS3COyFmkOL7sfX1wQMeW5zQT2WKcxC6FSWbhDqrB"
@@ -13,27 +13,27 @@ const char *EXPECTED_RSA_HOSTKEY =
     "i6ELfP3r+q6wdu0P4jWaoo3De1aYxnToV/ldXykpipON4NPamsb6Ph2qlJQKypq7J4iQ"
     "gkIIbCU1A31+4ExvcIVoxLQw/aTSbw==";
 
-const char *EXPECTED_ECDSA_HOSTKEY =
+static const char *EXPECTED_ECDSA_HOSTKEY =
     "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC+/syyeKJD9dC2ZH"
     "9Q7iJGReR4YM3rUCMsSynkyXojdfSClGCMY7JvWlt30ESjYvxoTfSRGx6WvaqYK/vPoYQ4=";
 
-const char *EXPECTED_RSA_MD5_HASH_DIGEST = "0C0ED1A5BB10275F76924CE187CE5C5E";
+static const char *EXPECTED_RSA_MD5_HASH_DIGEST = "0C0ED1A5BB10275F76924CE187CE5C5E";
 
-const char *EXPECTED_RSA_SHA1_HASH_DIGEST =
+static const char *EXPECTED_RSA_SHA1_HASH_DIGEST =
     "F3CD59E2913F4422B80F7B0A82B2B89EAE449387";
 
-const char *EXPECTED_RSA_SHA256_HASH_DIGEST = "92E3DA49DF3C7F99A828F505ED8239397A5D1F62914459760F878F7510F563A3";
+static const char *EXPECTED_RSA_SHA256_HASH_DIGEST = "92E3DA49DF3C7F99A828F505ED8239397A5D1F62914459760F878F7510F563A3";
 
-const char *EXPECTED_ECDSA_MD5_HASH_DIGEST = "0402E4D897580BBC911379CBD88BCD3D";
+static const char *EXPECTED_ECDSA_MD5_HASH_DIGEST = "0402E4D897580BBC911379CBD88BCD3D";
 
-const char *EXPECTED_ECDSA_SHA1_HASH_DIGEST =
+static const char *EXPECTED_ECDSA_SHA1_HASH_DIGEST =
     "12FDAD1E3B31B10BABB00F2A8D1B9A62C326BD2F";
 
-const char *EXPECTED_ECDSA_SHA256_HASH_DIGEST = "56FCD975B166C3F0342D0036E44C311A86C0EAE40713B53FC776369BAE7F5264";
+static const char *EXPECTED_ECDSA_SHA256_HASH_DIGEST = "56FCD975B166C3F0342D0036E44C311A86C0EAE40713B53FC776369BAE7F5264";
 
-const int MD5_HASH_SIZE = 16;
-const int SHA1_HASH_SIZE = 20;
-const int SHA256_HASH_SIZE = 32;
+static const int MD5_HASH_SIZE = 16;
+static const int SHA1_HASH_SIZE = 20;
+static const int SHA256_HASH_SIZE = 32;
 
 static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
                              size_t buffer_len)
@@ -42,7 +42,7 @@ static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
     char *p = buffer;
     char *end = buffer + buffer_len;
 
-    for (i = 0; i < hash_len && p < end; ++i) {
+    for(i = 0; i < hash_len && p < end; ++i) {
         p += snprintf(p, end - p, "%02X", (unsigned char)hash[i]);
     }
 }
@@ -58,15 +58,15 @@ int test(LIBSSH2_SESSION *session)
     size_t len;
 
     const char *hostkey = libssh2_session_hostkey(session, &len, &type);
-    if (hostkey == NULL) {
+    if(hostkey == NULL) {
         print_last_session_error("libssh2_session_hostkey");
         return 1;
     }
 
-    if (type == LIBSSH2_HOSTKEY_TYPE_ECDSA) {
+    if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA) {
 
         md5_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_MD5);
-        if (md5_hash == NULL) {
+        if(md5_hash == NULL) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_MD5)");
             return 1;
@@ -74,14 +74,14 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(md5_hash, MD5_HASH_SIZE, buf, BUFSIZ);
 
-        if (strcmp(buf, EXPECTED_ECDSA_MD5_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_ECDSA_MD5_HASH_DIGEST) != 0) {
             fprintf(stderr, "ECDSA MD5 hash not as expected - digest %s != %s\n", buf,
                     EXPECTED_ECDSA_MD5_HASH_DIGEST);
             return 1;
         }
 
         sha1_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
-        if (sha1_hash == NULL) {
+        if(sha1_hash == NULL) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA1)");
             return 1;
@@ -89,14 +89,14 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha1_hash, SHA1_HASH_SIZE, buf, BUFSIZ);
 
-        if (strcmp(buf, EXPECTED_ECDSA_SHA1_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_ECDSA_SHA1_HASH_DIGEST) != 0) {
             fprintf(stderr, "ECDSA SHA1 hash not as expected - digest %s != %s\n", buf,
                     EXPECTED_ECDSA_SHA1_HASH_DIGEST);
             return 1;
         }
 
         sha256_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA256);
-        if (sha256_hash == NULL) {
+        if(sha256_hash == NULL) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA256)");
             return 1;
@@ -104,16 +104,17 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha256_hash, SHA256_HASH_SIZE, buf, BUFSIZ);
 
-        if (strcmp(buf, EXPECTED_ECDSA_SHA256_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_ECDSA_SHA256_HASH_DIGEST) != 0) {
             fprintf(stderr, "ECDSA SHA256 hash not as expected - digest %s != %s\n", buf,
                     EXPECTED_ECDSA_SHA256_HASH_DIGEST);
             return 1;
         }
 
-    } else if ( type == LIBSSH2_HOSTKEY_TYPE_RSA ) {
+    }
+    else if(type == LIBSSH2_HOSTKEY_TYPE_RSA) {
 
         md5_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_MD5);
-        if (md5_hash == NULL) {
+        if(md5_hash == NULL) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_MD5)");
             return 1;
@@ -121,14 +122,14 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(md5_hash, MD5_HASH_SIZE, buf, BUFSIZ);
 
-        if (strcmp(buf, EXPECTED_RSA_MD5_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_RSA_MD5_HASH_DIGEST) != 0) {
             fprintf(stderr, "MD5 hash not as expected - digest %s != %s\n", buf,
                     EXPECTED_RSA_MD5_HASH_DIGEST);
             return 1;
         }
 
         sha1_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
-        if (sha1_hash == NULL) {
+        if(sha1_hash == NULL) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA1)");
             return 1;
@@ -136,14 +137,14 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha1_hash, SHA1_HASH_SIZE, buf, BUFSIZ);
 
-        if (strcmp(buf, EXPECTED_RSA_SHA1_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_RSA_SHA1_HASH_DIGEST) != 0) {
             fprintf(stderr, "SHA1 hash not as expected - digest %s != %s\n", buf,
                     EXPECTED_RSA_SHA1_HASH_DIGEST);
             return 1;
         }
 
         sha256_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA256);
-        if (sha256_hash == NULL) {
+        if(sha256_hash == NULL) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA256)");
             return 1;
@@ -151,12 +152,13 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha256_hash, SHA256_HASH_SIZE, buf, BUFSIZ);
 
-        if (strcmp(buf, EXPECTED_RSA_SHA256_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_RSA_SHA256_HASH_DIGEST) != 0) {
             fprintf(stderr, "SHA256 hash not as expected - digest %s != %s\n", buf,
                     EXPECTED_RSA_SHA256_HASH_DIGEST);
             return 1;
         }
-    } else {
+    }
+    else {
         fprintf(stderr, "Unexpected type of hostkey: %i\n", type);
         return 1;
     }

--- a/tests/test_keyboard_interactive_auth_fails_with_wrong_response.c
+++ b/tests/test_keyboard_interactive_auth_fails_with_wrong_response.c
@@ -4,8 +4,8 @@
 
 #include <stdio.h>
 
-const char *USERNAME = "libssh2"; /* configured in Dockerfile */
-const char *WRONG_PASSWORD = "i'm not the password";
+static const char *USERNAME = "libssh2"; /* configured in Dockerfile */
+static const char *WRONG_PASSWORD = "i'm not the password";
 
 static void kbd_callback(const char *name, int name_len,
                          const char *instruction, int instruction_len,
@@ -18,12 +18,12 @@ static void kbd_callback(const char *name, int name_len,
     (void)abstract;
     fprintf(stdout, "Kb-int name: %.*s\n", name_len, name);
     fprintf(stdout, "Kb-int instruction: %.*s\n", instruction_len, instruction);
-    for (i = 0; i < num_prompts; ++i) {
+    for(i = 0; i < num_prompts; ++i) {
         fprintf(stdout, "Kb-int prompt %d: %.*s\n", i, prompts[i].length,
                 prompts[i].text);
     }
 
-    if (num_prompts == 1) {
+    if(num_prompts == 1) {
         responses[0].text = strdup(WRONG_PASSWORD);
         responses[0].length = strlen(WRONG_PASSWORD);
     }
@@ -35,12 +35,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME, strlen(USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "keyboard-interactive") == NULL) {
+    if(strstr(userauth_list, "keyboard-interactive") == NULL) {
         fprintf(stderr,
                 "'keyboard-interactive' was expected in userauth list: %s\n",
                 userauth_list);
@@ -49,7 +49,7 @@ int test(LIBSSH2_SESSION *session)
 
     rc = libssh2_userauth_keyboard_interactive_ex(
         session, USERNAME, strlen(USERNAME), kbd_callback);
-    if (rc == 0) {
+    if(rc == 0) {
         fprintf(stderr,
                 "Keyboard-interactive auth succeeded with wrong response\n");
         return 1;

--- a/tests/test_keyboard_interactive_auth_succeeds_with_correct_response.c
+++ b/tests/test_keyboard_interactive_auth_succeeds_with_correct_response.c
@@ -4,8 +4,8 @@
 
 #include <stdio.h>
 
-const char *USERNAME = "libssh2";          /* configured in Dockerfile */
-const char *PASSWORD = "my test password"; /* configured in Dockerfile */
+static const char *USERNAME = "libssh2";          /* configured in Dockerfile */
+static const char *PASSWORD = "my test password"; /* configured in Dockerfile */
 
 static void kbd_callback(const char *name, int name_len,
                          const char *instruction, int instruction_len,
@@ -19,12 +19,12 @@ static void kbd_callback(const char *name, int name_len,
 
     fprintf(stdout, "Kb-int name: %.*s\n", name_len, name);
     fprintf(stdout, "Kb-int instruction: %.*s\n", instruction_len, instruction);
-    for (i = 0; i < num_prompts; ++i) {
+    for(i = 0; i < num_prompts; ++i) {
         fprintf(stdout, "Kb-int prompt %d: %.*s\n", i, prompts[i].length,
                 prompts[i].text);
     }
 
-    if (num_prompts == 1) {
+    if(num_prompts == 1) {
         responses[0].text = strdup(PASSWORD);
         responses[0].length = strlen(PASSWORD);
     }
@@ -36,12 +36,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME, strlen(USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "keyboard-interactive") == NULL) {
+    if(strstr(userauth_list, "keyboard-interactive") == NULL) {
         fprintf(stderr,
                 "'keyboard-interactive' was expected in userauth list: %s\n",
                 userauth_list);
@@ -50,7 +50,7 @@ int test(LIBSSH2_SESSION *session)
 
     rc = libssh2_userauth_keyboard_interactive_ex(
         session, USERNAME, strlen(USERNAME), kbd_callback);
-    if (rc != 0) {
+    if(rc != 0) {
         print_last_session_error("libssh2_userauth_keyboard_interactive_ex");
         return 1;
     }

--- a/tests/test_password_auth_fails_with_wrong_password.c
+++ b/tests/test_password_auth_fails_with_wrong_password.c
@@ -4,8 +4,8 @@
 
 #include <stdio.h>
 
-const char *USERNAME = "libssh2"; /* configured in Dockerfile */
-const char *WRONG_PASSWORD = "i'm not the password";
+static const char *USERNAME = "libssh2"; /* configured in Dockerfile */
+static const char *WRONG_PASSWORD = "i'm not the password";
 
 int test(LIBSSH2_SESSION *session)
 {
@@ -13,12 +13,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME, strlen(USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "password") == NULL) {
+    if(strstr(userauth_list, "password") == NULL) {
         fprintf(stderr, "'password' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
     rc = libssh2_userauth_password_ex(session, USERNAME, strlen(USERNAME),
                                       WRONG_PASSWORD, strlen(WRONG_PASSWORD),
                                       NULL);
-    if (rc == 0) {
+    if(rc == 0) {
         fprintf(stderr, "Password auth succeeded with wrong password\n");
         return 1;
     }

--- a/tests/test_password_auth_fails_with_wrong_username.c
+++ b/tests/test_password_auth_fails_with_wrong_username.c
@@ -4,8 +4,8 @@
 
 #include <stdio.h>
 
-const char *PASSWORD = "my test password"; /* configured in Dockerfile */
-const char *WRONG_USERNAME = "i dont exist";
+static const char *PASSWORD = "my test password"; /* configured in Dockerfile */
+static const char *WRONG_USERNAME = "i dont exist";
 
 int test(LIBSSH2_SESSION *session)
 {
@@ -13,12 +13,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, WRONG_USERNAME, strlen(WRONG_USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "password") == NULL) {
+    if(strstr(userauth_list, "password") == NULL) {
         fprintf(stderr, "'password' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
     rc = libssh2_userauth_password_ex(session, WRONG_USERNAME,
                                       strlen(WRONG_USERNAME), PASSWORD,
                                       strlen(PASSWORD), NULL);
-    if (rc == 0) {
+    if(rc == 0) {
         fprintf(stderr, "Password auth succeeded with wrong username\n");
         return 1;
     }

--- a/tests/test_password_auth_succeeds_with_correct_credentials.c
+++ b/tests/test_password_auth_succeeds_with_correct_credentials.c
@@ -4,8 +4,8 @@
 
 #include <stdio.h>
 
-const char *USERNAME = "libssh2";          /* configured in Dockerfile */
-const char *PASSWORD = "my test password"; /* configured in Dockerfile */
+static const char *USERNAME = "libssh2";          /* configured in Dockerfile */
+static const char *PASSWORD = "my test password"; /* configured in Dockerfile */
 
 int test(LIBSSH2_SESSION *session)
 {
@@ -13,12 +13,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME, strlen(USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "password") == NULL) {
+    if(strstr(userauth_list, "password") == NULL) {
         fprintf(stderr, "'password' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;
@@ -26,12 +26,12 @@ int test(LIBSSH2_SESSION *session)
 
     rc = libssh2_userauth_password_ex(session, USERNAME, strlen(USERNAME),
                                       PASSWORD, strlen(PASSWORD), NULL);
-    if (rc != 0) {
+    if(rc != 0) {
         print_last_session_error("libssh2_userauth_password_ex");
         return 1;
     }
 
-    if (libssh2_userauth_authenticated(session) == 0) {
+    if(libssh2_userauth_authenticated(session) == 0) {
         fprintf(stderr, "Password auth appeared to succeed but "
                         "libssh2_userauth_authenticated returned 0\n");
         return 1;

--- a/tests/test_public_key_auth_fails_with_wrong_key.c
+++ b/tests/test_public_key_auth_fails_with_wrong_key.c
@@ -4,9 +4,9 @@
 
 #include <stdio.h>
 
-const char *USERNAME = "libssh2"; /* configured in Dockerfile */
-const char *KEY_FILE_PRIVATE = "key_dsa_wrong";
-const char *KEY_FILE_PUBLIC = "key_dsa_wrong.pub";
+static const char *USERNAME = "libssh2"; /* configured in Dockerfile */
+static const char *KEY_FILE_PRIVATE = "key_dsa_wrong";
+static const char *KEY_FILE_PUBLIC = "key_dsa_wrong.pub";
 
 int test(LIBSSH2_SESSION *session)
 {
@@ -14,12 +14,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME, strlen(USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "publickey") == NULL) {
+    if(strstr(userauth_list, "publickey") == NULL) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;
@@ -28,7 +28,7 @@ int test(LIBSSH2_SESSION *session)
     rc = libssh2_userauth_publickey_fromfile_ex(
         session, USERNAME, strlen(USERNAME), KEY_FILE_PUBLIC, KEY_FILE_PRIVATE,
         NULL);
-    if (rc == 0) {
+    if(rc == 0) {
         fprintf(stderr, "Public-key auth succeeded with wrong key\n");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_dsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_dsa_key.c
@@ -4,9 +4,9 @@
 
 #include <stdio.h>
 
-const char *USERNAME = "libssh2"; /* configured in Dockerfile */
-const char *KEY_FILE_PRIVATE = "key_dsa";
-const char *KEY_FILE_PUBLIC = "key_dsa.pub"; /* configured in Dockerfile */
+static const char *USERNAME = "libssh2"; /* configured in Dockerfile */
+static const char *KEY_FILE_PRIVATE = "key_dsa";
+static const char *KEY_FILE_PUBLIC = "key_dsa.pub"; /* configured in Dockerfile */
 
 int test(LIBSSH2_SESSION *session)
 {
@@ -14,12 +14,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME, strlen(USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "publickey") == NULL) {
+    if(strstr(userauth_list, "publickey") == NULL) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;
@@ -28,7 +28,7 @@ int test(LIBSSH2_SESSION *session)
     rc = libssh2_userauth_publickey_fromfile_ex(
         session, USERNAME, strlen(USERNAME), KEY_FILE_PUBLIC, KEY_FILE_PRIVATE,
         NULL);
-    if (rc != 0) {
+    if(rc != 0) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_encrypted_rsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_encrypted_rsa_key.c
@@ -4,10 +4,10 @@
 
 #include <stdio.h>
 
-const char *USERNAME = "libssh2"; /* configured in Dockerfile */
-const char *PASSWORD = "libssh2";
-const char *KEY_FILE_PRIVATE = "key_rsa_encrypted";
-const char *KEY_FILE_PUBLIC = "key_rsa_encrypted.pub"; /* configured in Dockerfile */
+static const char *USERNAME = "libssh2"; /* configured in Dockerfile */
+static const char *PASSWORD = "libssh2";
+static const char *KEY_FILE_PRIVATE = "key_rsa_encrypted";
+static const char *KEY_FILE_PUBLIC = "key_rsa_encrypted.pub"; /* configured in Dockerfile */
 
 int test(LIBSSH2_SESSION *session)
 {
@@ -15,12 +15,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME, strlen(USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "publickey") == NULL) {
+    if(strstr(userauth_list, "publickey") == NULL) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;
@@ -29,7 +29,7 @@ int test(LIBSSH2_SESSION *session)
     rc = libssh2_userauth_publickey_fromfile_ex(
         session, USERNAME, strlen(USERNAME), KEY_FILE_PUBLIC, KEY_FILE_PRIVATE,
         PASSWORD);
-    if (rc != 0) {
+    if(rc != 0) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_rsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_rsa_key.c
@@ -4,9 +4,9 @@
 
 #include <stdio.h>
 
-const char *USERNAME = "libssh2"; /* configured in Dockerfile */
-const char *KEY_FILE_PRIVATE = "key_rsa";
-const char *KEY_FILE_PUBLIC = "key_rsa.pub"; /* configured in Dockerfile */
+static const char *USERNAME = "libssh2"; /* configured in Dockerfile */
+static const char *KEY_FILE_PRIVATE = "key_rsa";
+static const char *KEY_FILE_PUBLIC = "key_rsa.pub"; /* configured in Dockerfile */
 
 int test(LIBSSH2_SESSION *session)
 {
@@ -14,12 +14,12 @@ int test(LIBSSH2_SESSION *session)
 
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME, strlen(USERNAME));
-    if (userauth_list == NULL) {
+    if(userauth_list == NULL) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if (strstr(userauth_list, "publickey") == NULL) {
+    if(strstr(userauth_list, "publickey") == NULL) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;
@@ -28,7 +28,7 @@ int test(LIBSSH2_SESSION *session)
     rc = libssh2_userauth_publickey_fromfile_ex(
         session, USERNAME, strlen(USERNAME), KEY_FILE_PUBLIC, KEY_FILE_PRIVATE,
         NULL);
-    if (rc != 0) {
+    if(rc != 0) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }


### PR DESCRIPTION
Also:
* add 'static' qualifier to file-wide const buffers
* fix a non-ANSI C89 comment
* silence a mismatched fprintf() mask warning by adding a cast