### PR TITLE
Make hashing generic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,12 +175,14 @@ endif()
 include(GNUInstallDirs)
 set(SOURCES
   ${CRYPTO_SOURCES}
+  backend.h
   agent.c
   channel.c
   channel.h
   comp.c
   comp.h
   crypt.c
+  crypto.c
   crypto.h
   global.c
   hostkey.c
@@ -274,8 +276,8 @@ else()
 endif()
 option(ENABLE_DEBUG_LOGGING "log execution with debug trace"
   ${DEBUG_LOGGING_DEFAULT})
-add_feature_info(Logging ENABLE_DEBUG_LOGGING
-   "Logging of execution with debug trace")
+  add_feature_info(Logging ENABLE_DEBUG_LOGGING
+  "Logging of execution with debug trace")
 if(ENABLE_DEBUG_LOGGING)
   target_compile_definitions(libssh2 PRIVATE LIBSSH2DEBUG)
 endif()

--- a/src/backend.h
+++ b/src/backend.h
@@ -1,0 +1,218 @@
+/* Copyright (C) 2016, Etienne Samson
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above
+ *   copyright notice, this list of conditions and the
+ *   following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ *   Neither the name of the copyright holder nor the names
+ *   of any other contributors may be used to endorse or
+ *   promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#ifndef LIBSSH2_BACKEND_H
+#define LIBSSH2_BACKEND_H
+
+/**
+ * Definitions needed to implement a specific crypto library
+ *
+ * This document offers some hints about implementing a new crypto library
+ * interface.
+ *
+ * A crypto library interface consists of at least a header file, defining
+ * entities referenced from the libssh2 core modules.
+ * Real code implementation (if needed), is left at the implementor's choice.
+ *
+ * This document lists the entities that must/may be defined in the header file.
+ *
+ * Procedures listed as "void" may indeed have a result type: void indicates
+ * the libssh2 core modules never use the function result.
+ */
+
+#define MD5_DIGEST_LENGTH 16
+#define SHA1_DIGEST_LENGTH 20
+#define SHA256_DIGEST_LENGTH 32
+#define SHA384_DIGEST_LENGTH 48
+#define SHA512_DIGEST_LENGTH 64
+#define RIPEMD160_DIGEST_LENGTH 20
+
+typedef enum {
+    libssh2_hash_MD5 = 1,
+    libssh2_hash_SHA1,
+    libssh2_hash_SHA256,
+    libssh2_hash_SHA384,
+    libssh2_hash_SHA512,
+    libssh2_hash_RIPEMD160,
+} libssh2_hash_algorithm;
+
+/* Initializes the crypto library. */
+extern void libssh2_crypto_init(void);
+
+/* Terminates the crypto library use. */
+extern void libssh2_crypto_exit(void);
+
+/* Hashing */
+typedef struct libssh2_hash_ctx {
+    char __private[256];
+} libssh2_hash_ctx;
+
+/*
+ * Hash a message.
+ *
+ * This function hashes the given message with the given algorithm and
+ * returns the result in out.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int libssh2_hash(libssh2_hash_algorithm algo,
+                 const void *message, size_t len,
+                 void *output);
+
+/*
+ * Initialise a hashing context.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int libssh2_hash_init(libssh2_hash_ctx *ctx, libssh2_hash_algorithm algo);
+
+/*
+ * Update a hash
+ *
+ * Updates the hash with the given data.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int libssh2_hash_update(libssh2_hash_ctx ctx,
+                        const void *data, size_t datalen);
+
+/*
+ * Finalize a hash.
+ *
+ * Returns the final result of the hashing.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int libssh2_hash_final(libssh2_hash_ctx ctx, void *output);
+
+/*
+ * Return the hash size for a given algorithm.
+ *
+ * Returns the hash length on success, -1 on error.
+ */
+int libssh2_hash_size(libssh2_hash_algorithm algo);
+
+
+/* HMAC */
+
+/* Type of an HMAC computation context. Generally a struct.
+ * Used for all hash algorithms.
+ */
+typedef struct libssh2_hmac_ctx {
+    char __private[288];
+} libssh2_hmac_ctx;
+
+/*
+ * Initialize a HMAC context.
+ *
+ * Setup the HMAC for hashing with the given hash algorithm and key.
+ * Returns 0 on success, -1 on error.
+ */
+int libssh2_hmac_init(libssh2_hmac_ctx *ctx,
+                      libssh2_hash_algorithm algo,
+                      const void *key,
+                      size_t keylen);
+
+/*
+ * Update a HMAC
+ *
+ * Continue computation of an HMAC on datalen bytes at data using context ctx.
+ * Returns 0 on success, -1 on error.
+ */
+int libssh2_hmac_update(libssh2_hmac_ctx ctx,
+                        const void *data, size_t datalen);
+
+/*
+ * Finalize a HMAC
+ *
+ * Get the computed HMAC from context ctx into the output buffer.
+ * The minimum data buffer size depends on the HMAC hash algorithm.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int libssh2_hmac_final(libssh2_hmac_ctx ctx, void *output);
+
+/*
+ * Releases the HMAC computation context at ctx.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int libssh2_hmac_cleanup(libssh2_hmac_ctx ctx);
+
+/** Compatibility layer */
+
+#define libssh2_sha1_ctx libssh2_hash_ctx
+#define libssh2_sha1_init(c) (libssh2_hash_init(c, libssh2_hash_SHA1) == 0)
+#define libssh2_sha1_update(c, d, l) libssh2_hash_update(c, d, l)
+#define libssh2_sha1_final(c, o) libssh2_hash_final(c, o)
+#define libssh2_sha1(m, l, o) libssh2_hash(libssh2_hash_SHA1, m, l, o)
+
+#define libssh2_sha256_ctx libssh2_hash_ctx
+#define libssh2_sha256_init(c) (libssh2_hash_init(c, libssh2_hash_SHA256) == 0)
+#define libssh2_sha256_update(c, d, l) libssh2_hash_update(c, d, l)
+#define libssh2_sha256_final(c, o) libssh2_hash_final(c, o)
+#define libssh2_sha256(m, l, o) libssh2_hash(libssh2_hash_SHA256, m, l, o)
+
+#define libssh2_sha384_ctx libssh2_hash_ctx
+#define libssh2_sha384_init(c) (libssh2_hash_init(c, libssh2_hash_SHA384) == 0)
+#define libssh2_sha384_update(c, d, l) libssh2_hash_update(c, d, l)
+#define libssh2_sha384_final(c, o) libssh2_hash_final(c, o)
+#define libssh2_sha384(m,l,o) libssh2_hash(libssh2_hash_SHA384, m, l, o)
+
+#define libssh2_sha512_ctx libssh2_hash_ctx
+#define libssh2_sha512_init(c) (libssh2_hash_init(c, libssh2_hash_SHA512) == 0)
+#define libssh2_sha512_update(c, d, l) libssh2_hash_update(c, d, l)
+#define libssh2_sha512_final(c, o) libssh2_hash_final(c, o)
+#define libssh2_sha512(m,l,o) libssh2_hash(libssh2_hash_SHA512, m, l, o)
+
+#define libssh2_md5_ctx libssh2_hash_ctx
+#define libssh2_md5_init(c) (libssh2_hash_init(c, libssh2_hash_MD5) == 0)
+#define libssh2_md5_update(c, d, l) libssh2_hash_update(c, d, l)
+#define libssh2_md5_final(c, o) libssh2_hash_final(c, o)
+
+#define libssh2_hmac_ctx_init(ctx) /* Nothing */
+#define libssh2_hmac_md5_init(ctx, data, len) \
+    libssh2_hmac_init(ctx, libssh2_hash_MD5, data, len)
+#define libssh2_hmac_sha1_init(ctx, data, len) \
+    libssh2_hmac_init(ctx, libssh2_hash_SHA1, data, len)
+#define libssh2_hmac_sha256_init(ctx, data, len) \
+    libssh2_hmac_init(ctx, libssh2_hash_SHA256, data, len)
+#define libssh2_hmac_sha512_init(ctx, data, len) \
+    libssh2_hmac_init(ctx, libssh2_hash_SHA512, data, len)
+#define libssh2_hmac_ripemd160_init(ctx, data, len) \
+    libssh2_hmac_init(ctx, libssh2_hash_RIPEMD160, data, len)
+
+#endif /* LIBSSH2_BACKEND_H */

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1,0 +1,85 @@
+/* Copyright (C) 2016, Etienne Samson
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above
+ *   copyright notice, this list of conditions and the
+ *   following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ *   Neither the name of the copyright holder nor the names
+ *   of any other contributors may be used to endorse or
+ *   promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#include "libssh2_priv.h"
+#include <stdarg.h>
+
+int libssh2_hash(libssh2_hash_algorithm algo,
+                 const void *message, unsigned long len,
+                 void *out)
+{
+    libssh2_hash_ctx ctx;
+    int err = libssh2_hash_init(&ctx, algo);
+    if (err != 0) {
+        libssh2_crypto_trace("libssh2_hash: hash_ctx fail %d\n", err);
+        return -1;
+    }
+
+    libssh2_hash_update(ctx, message, len);
+    libssh2_hash_final(ctx, out);
+
+    return 0;
+}
+
+int libssh2_hash_size(libssh2_hash_algorithm algo) {
+    switch (algo) {
+#ifdef LIBSSH2_MD5
+        case libssh2_hash_MD5: return MD5_DIGEST_LENGTH;
+#endif
+        case libssh2_hash_SHA1: return SHA1_DIGEST_LENGTH;
+        case libssh2_hash_SHA256: return SHA256_DIGEST_LENGTH;
+        case libssh2_hash_SHA384: return SHA384_DIGEST_LENGTH;
+#ifdef LIBSSH2_HMAC_SHA512
+        case libssh2_hash_SHA512: return SHA512_DIGEST_LENGTH;
+#endif
+#ifdef LIBSSH2_HMAC_RIPEMD
+        case libssh2_hash_RIPEMD160: return RIPEMD160_DIGEST_LENGTH;
+#endif
+        default: return -1;
+    }
+}
+
+void libssh2_crypto_trace(const char *fmt, ...)
+{
+    va_list args;
+    char msg[2048];
+
+    va_start(args, fmt);
+    vsprintf(msg, fmt, args);
+    va_end(args);
+
+    fprintf(stderr, "%s", msg);
+}

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -38,6 +38,8 @@
 #ifndef LIBSSH2_CRYPTO_H
 #define LIBSSH2_CRYPTO_H
 
+#include "backend.h"
+
 #ifdef LIBSSH2_OPENSSL
 #include "openssl.h"
 #endif
@@ -57,6 +59,8 @@
 #ifdef LIBSSH2_MBEDTLS
 #include "mbedtls.h"
 #endif
+
+void libssh2_crypto_trace(const char *fmt, ...);
 
 #if LIBSSH2_RSA
 int _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -432,7 +432,7 @@ knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                     libssh2_hmac_update(ctx, (unsigned char *)host,
                                         strlen(host));
                     libssh2_hmac_final(ctx, hash);
-                    libssh2_hmac_cleanup(&ctx);
+                    libssh2_hmac_cleanup(ctx);
 
                     if(!memcmp(hash, node->name, SHA_DIGEST_LENGTH))
                         /* this is a node we're interested in */

--- a/src/mac.c
+++ b/src/mac.c
@@ -122,7 +122,7 @@ mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION * session,
         libssh2_hmac_update(ctx, addtl, addtl_len);
     }
     libssh2_hmac_final(ctx, buf);
-    libssh2_hmac_cleanup(&ctx);
+    libssh2_hmac_cleanup(ctx);
 
     return 0;
 }
@@ -167,7 +167,7 @@ mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION * session,
         libssh2_hmac_update(ctx, addtl, addtl_len);
     }
     libssh2_hmac_final(ctx, buf);
-    libssh2_hmac_cleanup(&ctx);
+    libssh2_hmac_cleanup(ctx);
 
     return 0;
 }
@@ -212,7 +212,7 @@ mac_method_hmac_sha1_hash(LIBSSH2_SESSION * session,
         libssh2_hmac_update(ctx, addtl, addtl_len);
     }
     libssh2_hmac_final(ctx, buf);
-    libssh2_hmac_cleanup(&ctx);
+    libssh2_hmac_cleanup(ctx);
 
     return 0;
 }
@@ -285,7 +285,7 @@ mac_method_hmac_md5_hash(LIBSSH2_SESSION * session, unsigned char *buf,
         libssh2_hmac_update(ctx, addtl, addtl_len);
     }
     libssh2_hmac_final(ctx, buf);
-    libssh2_hmac_cleanup(&ctx);
+    libssh2_hmac_cleanup(ctx);
 
     return 0;
 }
@@ -358,7 +358,7 @@ mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION * session,
         libssh2_hmac_update(ctx, addtl, addtl_len);
     }
     libssh2_hmac_final(ctx, buf);
-    libssh2_hmac_cleanup(&ctx);
+    libssh2_hmac_cleanup(ctx);
 
     return 0;
 }

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -56,6 +56,9 @@
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(LIBRESSL_VERSION_NUMBER)
 # define HAVE_OPAQUE_STRUCTS 1
+# define OPAQUE_PTR(ptr) ptr
+#else
+# define OPAQUE_PTR(ptr) &ptr
 #endif
 
 #ifdef OPENSSL_NO_RSA
@@ -128,157 +131,6 @@
 #define _libssh2_random(buf, len) RAND_bytes ((buf), (len))
 
 #define libssh2_prepare_iovec(vec, len)  /* Empty. */
-
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_sha1_ctx EVP_MD_CTX *
-#else
-#define libssh2_sha1_ctx EVP_MD_CTX
-#endif
-
-/* returns 0 in case of failure */
-int _libssh2_sha1_init(libssh2_sha1_ctx *ctx);
-#define libssh2_sha1_init(x) _libssh2_sha1_init(x)
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_sha1_update(ctx, data, len) EVP_DigestUpdate(ctx, data, len)
-#define libssh2_sha1_final(ctx, out) do { \
-                                         EVP_DigestFinal(ctx, out, NULL); \
-                                         EVP_MD_CTX_free(ctx); \
-                                     } while(0)
-#else
-#define libssh2_sha1_update(ctx, data, len) EVP_DigestUpdate(&(ctx), data, len)
-#define libssh2_sha1_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
-#endif
-int _libssh2_sha1(const unsigned char *message, unsigned long len,
-                  unsigned char *out);
-#define libssh2_sha1(x,y,z) _libssh2_sha1(x,y,z)
-
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_sha256_ctx EVP_MD_CTX *
-#else
-#define libssh2_sha256_ctx EVP_MD_CTX
-#endif
-
-/* returns 0 in case of failure */
-int _libssh2_sha256_init(libssh2_sha256_ctx *ctx);
-#define libssh2_sha256_init(x) _libssh2_sha256_init(x)
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_sha256_update(ctx, data, len) EVP_DigestUpdate(ctx, data, len)
-#define libssh2_sha256_final(ctx, out) do { \
-                                           EVP_DigestFinal(ctx, out, NULL); \
-                                           EVP_MD_CTX_free(ctx); \
-                                       } while(0)
-#else
-#define libssh2_sha256_update(ctx, data, len) EVP_DigestUpdate(&(ctx), data, len)
-#define libssh2_sha256_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
-#endif
-int _libssh2_sha256(const unsigned char *message, unsigned long len,
-                  unsigned char *out);
-#define libssh2_sha256(x,y,z) _libssh2_sha256(x,y,z)
-
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_sha384_ctx EVP_MD_CTX *
-#else
-#define libssh2_sha384_ctx EVP_MD_CTX
-#endif
-
-/* returns 0 in case of failure */
-int _libssh2_sha384_init(libssh2_sha384_ctx *ctx);
-#define libssh2_sha384_init(x) _libssh2_sha384_init(x)
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_sha384_update(ctx, data, len) EVP_DigestUpdate(ctx, data, len)
-#define libssh2_sha384_final(ctx, out) do { \
-                                            EVP_DigestFinal(ctx, out, NULL); \
-                                            EVP_MD_CTX_free(ctx); \
-                                       } while(0)
-#else
-#define libssh2_sha384_update(ctx, data, len) EVP_DigestUpdate(&(ctx), data, len)
-#define libssh2_sha384_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
-#endif
-int _libssh2_sha384(const unsigned char *message, unsigned long len,
-                    unsigned char *out);
-#define libssh2_sha384(x,y,z) _libssh2_sha384(x,y,z)
-
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_sha512_ctx EVP_MD_CTX *
-#else
-#define libssh2_sha512_ctx EVP_MD_CTX
-#endif
-
-/* returns 0 in case of failure */
-int _libssh2_sha512_init(libssh2_sha512_ctx *ctx);
-#define libssh2_sha512_init(x) _libssh2_sha512_init(x)
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_sha512_update(ctx, data, len) EVP_DigestUpdate(ctx, data, len)
-#define libssh2_sha512_final(ctx, out) do { \
-                                            EVP_DigestFinal(ctx, out, NULL); \
-                                            EVP_MD_CTX_free(ctx); \
-                                       } while(0)
-#else
-#define libssh2_sha512_update(ctx, data, len) EVP_DigestUpdate(&(ctx), data, len)
-#define libssh2_sha512_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
-#endif
-int _libssh2_sha512(const unsigned char *message, unsigned long len,
-                    unsigned char *out);
-#define libssh2_sha512(x,y,z) _libssh2_sha512(x,y,z)
-
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_md5_ctx EVP_MD_CTX *
-#else
-#define libssh2_md5_ctx EVP_MD_CTX
-#endif
-
-/* returns 0 in case of failure */
-int _libssh2_md5_init(libssh2_md5_ctx *ctx);
-#define libssh2_md5_init(x) _libssh2_md5_init(x)
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_md5_update(ctx, data, len) EVP_DigestUpdate(ctx, data, len)
-#define libssh2_md5_final(ctx, out) do { \
-                                        EVP_DigestFinal(ctx, out, NULL); \
-                                        EVP_MD_CTX_free(ctx); \
-                                    } while(0)
-#else
-#define libssh2_md5_update(ctx, data, len) EVP_DigestUpdate(&(ctx), data, len)
-#define libssh2_md5_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
-#endif
-
-#ifdef HAVE_OPAQUE_STRUCTS
-#define libssh2_hmac_ctx HMAC_CTX *
-#define libssh2_hmac_ctx_init(ctx) ctx = HMAC_CTX_new()
-#define libssh2_hmac_sha1_init(ctx, key, keylen) \
-  HMAC_Init_ex(*(ctx), key, keylen, EVP_sha1(), NULL)
-#define libssh2_hmac_md5_init(ctx, key, keylen) \
-  HMAC_Init_ex(*(ctx), key, keylen, EVP_md5(), NULL)
-#define libssh2_hmac_ripemd160_init(ctx, key, keylen) \
-  HMAC_Init_ex(*(ctx), key, keylen, EVP_ripemd160(), NULL)
-#define libssh2_hmac_sha256_init(ctx, key, keylen) \
-  HMAC_Init_ex(*(ctx), key, keylen, EVP_sha256(), NULL)
-#define libssh2_hmac_sha512_init(ctx, key, keylen) \
-  HMAC_Init_ex(*(ctx), key, keylen, EVP_sha512(), NULL)
-
-#define libssh2_hmac_update(ctx, data, datalen) \
-  HMAC_Update(ctx, data, datalen)
-#define libssh2_hmac_final(ctx, data) HMAC_Final(ctx, data, NULL)
-#define libssh2_hmac_cleanup(ctx) HMAC_CTX_free(*(ctx))
-#else
-#define libssh2_hmac_ctx HMAC_CTX
-#define libssh2_hmac_ctx_init(ctx) \
-  HMAC_CTX_init(&ctx)
-#define libssh2_hmac_sha1_init(ctx, key, keylen) \
-  HMAC_Init_ex(ctx, key, keylen, EVP_sha1(), NULL)
-#define libssh2_hmac_md5_init(ctx, key, keylen) \
-  HMAC_Init_ex(ctx, key, keylen, EVP_md5(), NULL)
-#define libssh2_hmac_ripemd160_init(ctx, key, keylen) \
-  HMAC_Init_ex(ctx, key, keylen, EVP_ripemd160(), NULL)
-#define libssh2_hmac_sha256_init(ctx, key, keylen) \
-  HMAC_Init_ex(ctx, key, keylen, EVP_sha256(), NULL)
-#define libssh2_hmac_sha512_init(ctx, key, keylen) \
-  HMAC_Init_ex(ctx, key, keylen, EVP_sha512(), NULL)
-
-#define libssh2_hmac_update(ctx, data, datalen) \
-  HMAC_Update(&(ctx), data, datalen)
-#define libssh2_hmac_final(ctx, data) HMAC_Final(&(ctx), data, NULL)
-#define libssh2_hmac_cleanup(ctx) HMAC_cleanup(ctx)
-#endif
 
 extern void _libssh2_openssl_crypto_init(void);
 #define libssh2_crypto_init() _libssh2_openssl_crypto_init()


### PR DESCRIPTION
This is based on top of #198 (because I need the Xcode support for testing), so only commits marked `crypto` are really relevant here, and is starting to "date" a little (I worked on that while investigating the CommonCrypto support branches, so, maybe 1 year ago ?).

This PR is a preliminary attempt at making the crypto layer more generic by moving code from #defines to functions, as well as (hopefully) saner (ie. no more "0 means error OpenSSL" madness, there's only a couple hashing/HMAC functions instead of 1 per algorithm).

For an example of the gains, see [this](https://github.com/tiennou/libssh2/compare/backend-cleanup/generic-hash-stackalloc...tiennou:backend-cleanup/wip-kex-merge). I've also noticed a few "hash" macros were added since I wrote this which could be cleaned up.

I've pondered quite a bit between having stack-allocated versus heap-allocated contexts. My first draft was heap-allocated, because it seems that, apart from non-OPAQUE OpenSSL, that's what the crypto landscape uses. But I hit the conundrum of the allocators in the LIBSSH2_SESSION (I mailed the list about that at the time), and the crypto layer is initialized before any is available. This means the ~`_init`~ => `_new` functions should have a `session` parameter, which ripples a *lot* (and IIRC I hit one where there was no session around).

So now it's heap-allocated, which means the `ctx` sizes must somehow be changed depending on the backend (which, as stated above are usually pointers except for non-OPAQUE OpenSSL (thanks…)). Right now it's using "magic" values, but this is obviously not pretty.

Only the OpenSSL backend is updated, and I only tested the non-OPAQUE version (that's the version I'm linking against, but I think the code should work against > 1.1).

Opinions on whether this is worth pursing are very welcome !