### PR TITLE
acinclude.m4: add mbedtls to LIBS

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -441,6 +441,7 @@ m4_case([$1],
 [mbedtls], [
   LIBSSH2_LIB_HAVE_LINKFLAGS([mbedcrypto], [], [#include <mbedtls/version.h>], [
     AC_DEFINE(LIBSSH2_MBEDTLS, 1, [Use $1])
+    LIBS="$LIBS $LIBMBEDCRYPTO"
     found_crypto="$1"
     support_clear_memory=yes
   ])


### PR DESCRIPTION
This is useful for static builds so that the Libs.private field in
libssh2.pc contains correct info for the benefit of pkg-config users.
Static link with libssh2 requires this information.