### PR TITLE
Add Instructions for building from Master

### DIFF
--- a/docs/INSTALL_AUTOTOOLS
+++ b/docs/INSTALL_AUTOTOOLS
@@ -7,6 +7,22 @@ Software Foundation, Inc.
 This file is free documentation; the Free Software Foundation gives
 unlimited permission to copy, distribute and modify it.
 
+When Building directly from Master
+==================================
+
+If you want to build directly from the git repository, you must first
+generate the configure script and Makefile using autotools. There is
+a convenience script that calls all tools in the correct order. Make
+sure that autoconf, automake and libtool are installed on your system,
+then execute the following script:
+
+  ./buildconf
+
+After executing this script, you can build the project as usual:
+
+  ./configure
+  make
+
 Basic Installation
 ==================
 


### PR DESCRIPTION
I've previously only built libssh2 from tarballs, and it took me a lot of time to figure out how to build from master. 

Then I discovered that all I needed to do was call `./buildconf`

This pull request updates the build instructions to mention this.

(See also #221)