### PR TITLE
ECDSA key types are now explicit

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -409,7 +409,9 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_HOSTKEY_TYPE_UNKNOWN            0
 #define LIBSSH2_HOSTKEY_TYPE_RSA                1
 #define LIBSSH2_HOSTKEY_TYPE_DSS                2
-#define LIBSSH2_HOSTKEY_TYPE_ECDSA              3
+#define LIBSSH2_HOSTKEY_TYPE_ECDSA_256          3
+#define LIBSSH2_HOSTKEY_TYPE_ECDSA_384          4
+#define LIBSSH2_HOSTKEY_TYPE_ECDSA_521          5
 
 /* Disconnect Codes (defined by SSH protocol) */
 #define SSH_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT          1
@@ -963,13 +965,15 @@ libssh2_knownhost_init(LIBSSH2_SESSION *session);
 #define LIBSSH2_KNOWNHOST_KEYENC_BASE64   (2<<16)
 
 /* type of key (2 bits) */
-#define LIBSSH2_KNOWNHOST_KEY_MASK     (7<<18)
-#define LIBSSH2_KNOWNHOST_KEY_SHIFT    18
-#define LIBSSH2_KNOWNHOST_KEY_RSA1     (1<<18)
-#define LIBSSH2_KNOWNHOST_KEY_SSHRSA   (2<<18)
-#define LIBSSH2_KNOWNHOST_KEY_SSHDSS   (3<<18)
-#define LIBSSH2_KNOWNHOST_KEY_ECDSA    (4<<18)
-#define LIBSSH2_KNOWNHOST_KEY_UNKNOWN  (7<<18)
+#define LIBSSH2_KNOWNHOST_KEY_MASK         (7<<18)
+#define LIBSSH2_KNOWNHOST_KEY_SHIFT        18
+#define LIBSSH2_KNOWNHOST_KEY_RSA1         (1<<18)
+#define LIBSSH2_KNOWNHOST_KEY_SSHRSA       (2<<18)
+#define LIBSSH2_KNOWNHOST_KEY_SSHDSS       (3<<18)
+#define LIBSSH2_KNOWNHOST_KEY_ECDSA_256    (4<<18)
+#define LIBSSH2_KNOWNHOST_KEY_ECDSA_384    (5<<18)
+#define LIBSSH2_KNOWNHOST_KEY_ECDSA_521    (6<<18)
+#define LIBSSH2_KNOWNHOST_KEY_UNKNOWN      (7<<18)
 
 LIBSSH2_API int
 libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -864,13 +864,13 @@ static int hostkey_type(const unsigned char *hostkey, size_t len)
         return LIBSSH2_HOSTKEY_TYPE_UNKNOWN;
 
     if(!memcmp(ecdsa_256, hostkey, 23))
-        return LIBSSH2_HOSTKEY_TYPE_ECDSA;
+        return LIBSSH2_HOSTKEY_TYPE_ECDSA_256;
 
     if(!memcmp(ecdsa_384, hostkey, 23))
-        return LIBSSH2_HOSTKEY_TYPE_ECDSA;
+        return LIBSSH2_HOSTKEY_TYPE_ECDSA_384;
 
     if(!memcmp(ecdsa_521, hostkey, 23))
-        return LIBSSH2_HOSTKEY_TYPE_ECDSA;
+        return LIBSSH2_HOSTKEY_TYPE_ECDSA_521;
 
     return LIBSSH2_HOSTKEY_TYPE_UNKNOWN;
 }

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -778,12 +778,12 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
             key_type = LIBSSH2_KNOWNHOST_KEY_SSHDSS;
         else if(!strncmp(key_type_name, "ssh-rsa", key_type_len))
             key_type = LIBSSH2_KNOWNHOST_KEY_SSHRSA;
-		else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp256", key_type_len))
-			key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_256;
-		else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp384", key_type_len))
-			key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_384;
-		else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp521", key_type_len))
-			key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_521;
+        else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp256", key_type_len))
+            key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_256;
+        else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp384", key_type_len))
+            key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_384;
+        else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp521", key_type_len))
+            key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_521;
         else
             key_type = LIBSSH2_KNOWNHOST_KEY_UNKNOWN;
 
@@ -1023,18 +1023,18 @@ knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
         key_type_name = "ssh-dss";
         key_type_len = 7;
         break;
-	case LIBSSH2_KNOWNHOST_KEY_ECDSA_256:
-		key_type_name = "ecdsa-sha2-nistp256";
-		key_type_len = 19;
-		break;
-	case LIBSSH2_KNOWNHOST_KEY_ECDSA_384:
-		key_type_name = "ecdsa-sha2-nistp384";
-		key_type_len = 19;
-		break;
-	case LIBSSH2_KNOWNHOST_KEY_ECDSA_521:
-		key_type_name = "ecdsa-sha2-nistp521";
-		key_type_len = 19;
-		break;
+    case LIBSSH2_KNOWNHOST_KEY_ECDSA_256:
+        key_type_name = "ecdsa-sha2-nistp256";
+        key_type_len = 19;
+        break;
+    case LIBSSH2_KNOWNHOST_KEY_ECDSA_384:
+        key_type_name = "ecdsa-sha2-nistp384";
+        key_type_len = 19;
+        break;
+    case LIBSSH2_KNOWNHOST_KEY_ECDSA_521:
+        key_type_name = "ecdsa-sha2-nistp521";
+        key_type_len = 19;
+        break;
     case LIBSSH2_KNOWNHOST_KEY_UNKNOWN:
         key_type_name = node->key_type_name;
         if(key_type_name) {

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -778,11 +778,11 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
             key_type = LIBSSH2_KNOWNHOST_KEY_SSHDSS;
         else if(!strncmp(key_type_name, "ssh-rsa", key_type_len))
             key_type = LIBSSH2_KNOWNHOST_KEY_SSHRSA;
-        else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp256", key_type_len))
+        else if (!strncmp(key_type_name, "ecdsa-sha2-nistp256", key_type_len))
             key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_256;
-        else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp384", key_type_len))
+        else if (!strncmp(key_type_name, "ecdsa-sha2-nistp384", key_type_len))
             key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_384;
-        else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp521", key_type_len))
+        else if (!strncmp(key_type_name, "ecdsa-sha2-nistp521", key_type_len))
             key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_521;
         else
             key_type = LIBSSH2_KNOWNHOST_KEY_UNKNOWN;

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -778,6 +778,12 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
             key_type = LIBSSH2_KNOWNHOST_KEY_SSHDSS;
         else if(!strncmp(key_type_name, "ssh-rsa", key_type_len))
             key_type = LIBSSH2_KNOWNHOST_KEY_SSHRSA;
+		else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp256", key_type_len))
+			key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_256;
+		else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp384", key_type_len))
+			key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_384;
+		else if ( !strncmp(key_type_name, "ecdsa-sha2-nistp521", key_type_len))
+			key_type = LIBSSH2_KNOWNHOST_KEY_ECDSA_521;
         else
             key_type = LIBSSH2_KNOWNHOST_KEY_UNKNOWN;
 
@@ -1017,6 +1023,18 @@ knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
         key_type_name = "ssh-dss";
         key_type_len = 7;
         break;
+	case LIBSSH2_KNOWNHOST_KEY_ECDSA_256:
+		key_type_name = "ecdsa-sha2-nistp256";
+		key_type_len = 19;
+		break;
+	case LIBSSH2_KNOWNHOST_KEY_ECDSA_384:
+		key_type_name = "ecdsa-sha2-nistp384";
+		key_type_len = 19;
+		break;
+	case LIBSSH2_KNOWNHOST_KEY_ECDSA_521:
+		key_type_name = "ecdsa-sha2-nistp521";
+		key_type_len = 19;
+		break;
     case LIBSSH2_KNOWNHOST_KEY_UNKNOWN:
         key_type_name = node->key_type_name;
         if(key_type_name) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1812,6 +1812,12 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                         pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH_DSA */
+#if LIBSSH2_ECDSA
+    case EVP_PKEY_EC :
+        st = gen_publickey_from_ec_evp(session, method, method_len,
+                                       pubkeydata, pubkeydata_len, pk);
+    break;
+#endif
     default :
         st = _libssh2_error(session,
                             LIBSSH2_ERROR_FILE,

--- a/tests/test_hostkey.c
+++ b/tests/test_hostkey.c
@@ -30,7 +30,7 @@ int test(LIBSSH2_SESSION *session)
         return 1;
     }
 
-    if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA) {
+    if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA_256) {
         rc = libssh2_base64_decode(session, &expected_hostkey, &expected_len,
                                    EXPECTED_ECDSA_HOSTKEY, strlen(EXPECTED_ECDSA_HOSTKEY));
     }

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -63,7 +63,7 @@ int test(LIBSSH2_SESSION *session)
         return 1;
     }
 
-    if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA) {
+    if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA_256) {
 
         md5_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_MD5);
         if(md5_hash == NULL) {


### PR DESCRIPTION
Issue was brough up in pull request #248. Also added ECDSA call to _libssh2_pub_priv_keyfilememory().