### PR TITLE
Fix Error C2371 'ssize_t': redefinition; different basic types

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -129,7 +129,7 @@ typedef unsigned char uint8_t;
 typedef unsigned int uint32_t;
 typedef unsigned __int64 libssh2_uint64_t;
 typedef __int64 libssh2_int64_t;
-#ifndef ssize_t
+#if !defined HAVE_SSIZE_T && !defined ssize_t
 typedef SSIZE_T ssize_t;
 #endif
 #else


### PR DESCRIPTION
Hi,

the ssize_t typedef clashes with other libraries that also typedef ssize_t, e.g. wxWidgets. It would be nice if libssh2 and ohter libs could get along.

http://trac.wxwidgets.org/ticket/10674

For ex. wxWidgets has this code:
```
/* If we really don't have ssize_t, provide our own version. */
#ifdef HAVE_SSIZE_T
    #ifdef __UNIX__
        #include <sys/types.h>
    #endif
#else /* !HAVE_SSIZE_T */
    #if SIZEOF_SIZE_T == 4
        typedef wxInt32 ssize_t;
    #elif SIZEOF_SIZE_T == 8
        typedef wxInt64 ssize_t;
    #else
        #error "error defining ssize_t, size_t is not 4 or 8 bytes"
    #endif

    /* prevent ssize_t redefinitions in other libraries */
    #define HAVE_SSIZE_T
#endif

```