### PR TITLE
Add function to provide connected host information

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -66,6 +66,7 @@ set(MAN_PAGES
   libssh2_channel_process_startup.3
   libssh2_channel_read.3
   libssh2_channel_read_ex.3
+  libssh2_channel_read_host_info.3
   libssh2_channel_read_stderr.3
   libssh2_channel_receive_window_adjust.3
   libssh2_channel_receive_window_adjust2.3

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -36,6 +36,7 @@ dist_man_MANS = \
 	libssh2_channel_process_startup.3 \
 	libssh2_channel_read.3 \
 	libssh2_channel_read_ex.3 \
+	libssh2_channel_read_host_info.3 \
 	libssh2_channel_read_stderr.3 \
 	libssh2_channel_receive_window_adjust.3 \
 	libssh2_channel_receive_window_adjust2.3 \

--- a/docs/libssh2_channel_read_host_info.3
+++ b/docs/libssh2_channel_read_host_info.3
@@ -1,0 +1,36 @@
+.TH libssh2_channel_read_host_info 3 "23 Jan 2019" "libssh2 1.8.0" "libssh2 manual"
+.SH NAME
+libssh2_channel_read_host_info - read host information.
+.SH SYNOPSIS
+#include <libssh2.h>
+
+LIBSSH2_API int libssh2_channel_read_host_info(LIBSSH2_CHANNEL *channel,
+                                               unsigned char *shost,
+                                               size_t shost_buffer_size,
+                                               unsigned int *sport,
+                                               unsigned int *shost_len);
+
+.SH DESCRIPTION
+This function is used to pass shost, sport, and shost_len from library to user space application.
+underlying function \fIlibssh2_channel_read_ex(3)\fP.
+
+\fIchannel\fP - Active channel stream to read from.
+
+\fIshost\fP - Pointer to host to tell the application where the connection originated from.
+
+\fIshost_buffer_size\fP - Size of buffer allocated for shost.
+
+\fIsport\fP - Pointer to port to tell the application where the connection originated from.
+
+\fIshost_len\fP - Pointer to length of shost.
+
+.SH RETURN VALUE
+Return 0 on successful and error values if failed.
+
+.SH ERRORS
+\fILIBSSH2_ERROR_BAD_USE\fP - channel/shost is not initialized.
+
+\fILIBSSH2_ERROR_INVAL\fP - shost_buffer_size is too small and overflow would occur.
+
+.SH SEE ALSO
+N/A

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -737,6 +737,11 @@ libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session, const char *host,
  libssh2_channel_forward_listen_ex((session), NULL, (port), NULL, 16)
 
 LIBSSH2_API int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener);
+LIBSSH2_API int libssh2_channel_read_host_info(LIBSSH2_CHANNEL *channel,
+                                               unsigned char *shost,
+                                               size_t shost_buffer_size,
+                                               unsigned int *sport,
+                                               unsigned int *shost_len);
 
 LIBSSH2_API LIBSSH2_CHANNEL *
 libssh2_channel_forward_accept(LIBSSH2_LISTENER *listener);

--- a/src/channel.c
+++ b/src/channel.c
@@ -54,6 +54,34 @@
 #include "session.h"
 
 /*
+ * libssh2_channel_read_host_info
+ *
+ * Pass shost, sport, and shost_len from library to user space application.
+ *
+ * Return 0 on success, LIBSSH2_ERROR_BAD_USE if channel/shost is not initialized
+ * and LIBSSH2_ERROR_INVAL if buffer overflow would occur.
+ */
+LIBSSH2_API int
+libssh2_channel_read_host_info(LIBSSH2_CHANNEL *channel, unsigned char *shost,
+                               size_t shost_buffer_size, unsigned int *sport,
+                               unsigned int *shost_len)
+{
+    int rc = 0;
+
+    if (!channel || !channel->shost)
+        return LIBSSH2_ERROR_BAD_USE;
+
+    if (shost_buffer_size < strlen((char*)channel->shost))
+        return LIBSSH2_ERROR_INVAL;
+
+    memcpy(shost, channel->shost, strlen((char*)channel->shost));
+    *sport = channel->sport;
+    *shost_len = channel->shost_len;
+
+    return rc;
+}
+
+/*
  *  _libssh2_channel_nextid
  *
  * Determine the next channel ID we can use at our end
@@ -2529,6 +2557,11 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
     /* free "channel_type" */
     if(channel->channel_type) {
         LIBSSH2_FREE(session, channel->channel_type);
+    }
+
+    /* free "shost" */
+    if (channel->shost) {
+        LIBSSH2_FREE(session, channel->shost);
     }
 
     /* Unlink from channel list */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -440,6 +440,11 @@ struct _LIBSSH2_CHANNEL
     /* State variables used in libssh2_channel_handle_extended_data2() */
     libssh2_nonblocking_states extData2_state;
 
+    /* Variables used in packet_queue_listener to store host,port and length */
+    unsigned char *shost;
+    uint32_t sport;
+    uint32_t shost_len;
+
 };
 
 struct _LIBSSH2_LISTENER

--- a/src/packet.c
+++ b/src/packet.c
@@ -156,7 +156,8 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
                                                           channel->
                                                           channel_type_len +
                                                           1);
-                    if(!channel->channel_type) {
+                    channel->shost = LIBSSH2_ALLOC(session, strlen((char *)listen_state->shost) + 1);
+                    if(!channel->channel_type || !channel->shost) {
                         _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                        "Unable to allocate a channel for new"
                                        " connection");
@@ -167,7 +168,11 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
                     }
                     memcpy(channel->channel_type, "forwarded-tcpip",
                            channel->channel_type_len + 1);
+                    memcpy(channel->shost, listen_state->shost, strlen((char *)listen_state->shost));
 
+                    channel->shost[strlen((char *)listen_state->shost)] = 0;
+                    channel->sport = listen_state->sport;
+                    channel->shost_len = listen_state->shost_len;
                     channel->remote.id = listen_state->sender_channel;
                     channel->remote.window_size_initial =
                         LIBSSH2_CHANNEL_WINDOW_DEFAULT;


### PR DESCRIPTION
Update to add 'libssh2_channel_read_host_info' function to provide
host information which is connected to remote server.

Signed-off-by: Paresh Chaudhary <paresh.chaudhary@rockwellcollins.com>
Signed-off-by: Jared Bents <jared.bents@rockwellcollins.com>