### PR TITLE
win32/GNUmakefile: define HAVE_WINDOWS_H

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -125,7 +125,7 @@ endif
 -include $(OBJDIR)/version.inc
 
 # Global flags for all compilers
-CFLAGS	= $(LIBSSH2_CFLAG_EXTRAS) $(OPT) -D$(DB) -DLIBSSH2_WIN32 # -DHAVE_CONFIG_H
+CFLAGS	= $(LIBSSH2_CFLAG_EXTRAS) $(OPT) -D$(DB) -DLIBSSH2_WIN32 -DHAVE_WINDOWS_H # -DHAVE_CONFIG_H
 LDFLAGS = $(LIBSSH2_LDFLAG_EXTRAS)
 
 ifeq ($(CC),mwcc)


### PR DESCRIPTION
This macro was only used in test/example code before, now it is also used in library code, but only defined automatically by automake/cmake, so let's do the same for the standalone win32 make file.

It'd be probably better to just rely on the built-in `_WIN32` macro to detect the presence of `windows.h` though. It's already used in most of libssh2 library code. There is a 3rd, similar macro named `LIBSSH2_WIN32`, which might also be replaced with `_WIN32`.

Ref: https://github.com/libssh2/libssh2/commit/8b870ad771cbd9cd29edbb3dbb0878e950f868ab