### PR TITLE
openssl: fix dereferencing ambiguity potentially causing build failure

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -571,13 +571,13 @@ make_ctr_evp (size_t keylen, EVP_CIPHER **aes_ctr_cipher, int type)
         EVP_CIPHER_meth_set_cleanup(*aes_ctr_cipher, aes_ctr_cleanup);
     }
 #else
-    *aes_ctr_cipher->nid = type;
-    *aes_ctr_cipher->block_size = 16;
-    *aes_ctr_cipher->key_len = keylen;
-    *aes_ctr_cipher->iv_len = 16;
-    *aes_ctr_cipher->init = aes_ctr_init;
-    *aes_ctr_cipher->do_cipher = aes_ctr_do_cipher;
-    *aes_ctr_cipher->cleanup = aes_ctr_cleanup;
+    (*aes_ctr_cipher)->nid = type;
+    (*aes_ctr_cipher)->block_size = 16;
+    (*aes_ctr_cipher)->key_len = keylen;
+    (*aes_ctr_cipher)->iv_len = 16;
+    (*aes_ctr_cipher)->init = aes_ctr_init;
+    (*aes_ctr_cipher)->do_cipher = aes_ctr_do_cipher;
+    (*aes_ctr_cipher)->cleanup = aes_ctr_cleanup;
 #endif
 
     return *aes_ctr_cipher;


### PR DESCRIPTION
When dereferencing from *aes_ctr_cipher, being a pointer itself,
ambiguity can occur with compiler and build can fail reporting:
openssl.c:574:20: error: ‘*aes_ctr_cipher’ is a pointer; did you mean to use ‘->’?
     *aes_ctr_cipher->nid = type;

Sorround every *aes_ctr_cipher-> occurence with paranthesis like this
(*aes_ctr_cipher)->

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>