### PR TITLE
Allow default permissions to be used in sftp_mkdir

### DIFF
--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -79,6 +79,9 @@ typedef struct _LIBSSH2_SFTP_STATVFS        LIBSSH2_SFTP_STATVFS;
 #define LIBSSH2_SFTP_READLINK           1
 #define LIBSSH2_SFTP_REALPATH           2
 
+/* Flags for sftp_mkdir() */
+#define LIBSSH2_SFTP_DEFAULT_MODE      -1
+
 /* SFTP attribute flag bits */
 #define LIBSSH2_SFTP_ATTR_SIZE              0x00000001
 #define LIBSSH2_SFTP_ATTR_UIDGID            0x00000002

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -3009,15 +3009,22 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
     LIBSSH2_SFTP_ATTRIBUTES attrs = {
-        LIBSSH2_SFTP_ATTR_PERMISSIONS, 0, 0, 0, 0, 0, 0
+        0, 0, 0, 0, 0, 0, 0
     };
     size_t data_len;
     int retcode;
-    /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
-    ssize_t packet_len = path_len + 13 +
-        sftp_attrsize(LIBSSH2_SFTP_ATTR_PERMISSIONS);
+    ssize_t packet_len;
     unsigned char *packet, *s, *data;
     int rc;
+
+    if(mode != LIBSSH2_SFTP_DEFAULT_MODE) {
+        /* Filetype in SFTP 3 and earlier */
+        attrs.flags = LIBSSH2_SFTP_ATTR_PERMISSIONS;
+        attrs.permissions = mode | LIBSSH2_SFTP_ATTR_PFILETYPE_DIR;
+    }
+
+    /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
+    packet_len = path_len + 13 + sftp_attrsize(attrs.flags);
 
     if(sftp->mkdir_state == libssh2_NB_state_idle) {
         _libssh2_debug(session, LIBSSH2_TRACE_SFTP,


### PR DESCRIPTION
Added constant LIBSSH2_SFTP_DEFAULT_MODE to use the server default permissions when making a new directory