### PR TITLE
Fix error compiling on Win32 with STDCALL=ON

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -687,7 +687,11 @@ void _libssh2_aes_ctr_increment(unsigned char *ctr,
     }
 }
 
+#ifdef WIN32
+static void * (__cdecl * const volatile memset_libssh)(void *, int, size_t) = memset;
+#else
 static void * (* const volatile memset_libssh)(void *, int, size_t) = memset;
+#endif
 
 void _libssh2_explicit_zero(void *buf, size_t size)
 {


### PR DESCRIPTION
This is necessary for compiling libgit2 with SSH support on 32-bit windows