### PR TITLE
_libssh2_string_buf_free: use correct free

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -722,7 +722,7 @@ void _libssh2_string_buf_free(LIBSSH2_SESSION *session, struct string_buf *buf)
         return;
 
     if(buf->data != NULL)
-        free(buf->data);
+        LIBSSH2_FREE(session, buf->data);
 
     LIBSSH2_FREE(session, buf);
     buf = NULL;


### PR DESCRIPTION
Use LIBSSH2_FREE() here, not free(). We allow memory function
replacements so free() is rarely the right choice...