### PR TITLE
Added agent functions libssh2_agent_get_identity_path() and libssh2_a gent_set_identity_path()

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -38,8 +38,10 @@ set(MAN_PAGES
   libssh2_agent_disconnect.3
   libssh2_agent_free.3
   libssh2_agent_get_identity.3
+  libssh2_agent_get_identity_path.3
   libssh2_agent_init.3
   libssh2_agent_list_identities.3
+  libssh2_agent_set_identity_path.3
   libssh2_agent_userauth.3
   libssh2_banner_set.3
   libssh2_base64_decode.3

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -8,8 +8,10 @@ dist_man_MANS = \
 	libssh2_agent_disconnect.3 \
 	libssh2_agent_free.3 \
 	libssh2_agent_get_identity.3 \
+	libssh2_agent_get_identity_path.3 \
 	libssh2_agent_init.3 \
 	libssh2_agent_list_identities.3 \
+	libssh2_agent_set_identity_path.3 \
 	libssh2_agent_userauth.3 \
 	libssh2_banner_set.3 \
 	libssh2_base64_decode.3 \

--- a/docs/libssh2_agent_get_identity_path.3
+++ b/docs/libssh2_agent_get_identity_path.3
@@ -1,0 +1,22 @@
+.\"
+.\" Copyright (c) 2019 by Will Cosgrove
+.\"
+.TH libssh2_agent_get_identity_path 3 "6 Mar 2019" "libssh2 1.9" "libssh2 manual"
+.SH NAME
+libssh2_agent_get_identity_path - gets the custom ssh-agent socket path
+.SH SYNOPSIS
+#include <libssh2.h>
+
+const char *
+libssh2_agent_get_identity_path(LIBSSH2_AGENT *agent);
+.SH DESCRIPTION
+Returns the custom agent identity socket path if set using libssh2_agent_set_identity_path()
+
+.SH RETURN VALUE
+Returns the socket path on disk.
+.SH AVAILABILITY
+Added in libssh2 1.9
+.SH SEE ALSO
+.BR libssh2_agent_init(3)
+.BR libssh2_agent_set_identity_path(3)
+

--- a/docs/libssh2_agent_set_identity_path.3
+++ b/docs/libssh2_agent_set_identity_path.3
@@ -1,0 +1,22 @@
+.\"
+.\" Copyright (c) 2019 by Will Cosgrove
+.\"
+.TH libssh2_agent_set_identity_path 3 "6 Mar 2019" "libssh2 1.9" "libssh2 manual"
+.SH NAME
+libssh2_agent_set_identity_path - set an ssh-agent socket path on disk
+.SH SYNOPSIS
+#include <libssh2.h>
+
+void
+libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path);
+.SH DESCRIPTION
+Allows a custom agent identity socket path instead of the default SSH_AUTH_SOCK env value
+
+.SH RETURN VALUE
+Returns void
+.SH AVAILABILITY
+Added in libssh2 1.9
+.SH SEE ALSO
+.BR libssh2_agent_init(3)
+.BR libssh2_agent_get_identity_path(3)
+

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1261,7 +1261,7 @@ libssh2_agent_free(LIBSSH2_AGENT *agent);
  */
 LIBSSH2_API void
 libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent,
-								const char *path);
+                                const char *path);
 
 /*
  * libssh2_agent_get_identity_path()

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1253,6 +1253,24 @@ libssh2_agent_disconnect(LIBSSH2_AGENT *agent);
 LIBSSH2_API void
 libssh2_agent_free(LIBSSH2_AGENT *agent);
 
+/*
+ * libssh2_agent_set_identity_path()
+ *
+ * Allows a custom agent identity socket path beyond SSH_AUTH_SOCK env
+ *
+ */
+LIBSSH2_API void
+libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent,
+								const char *path);
+
+/*
+ * libssh2_agent_get_identity_path()
+ *
+ * Returns the custom agent identity socket path if set
+ *
+ */
+LIBSSH2_API const char *
+libssh2_agent_get_identity_path(LIBSSH2_AGENT *agent);
 
 /*
  * libssh2_keepalive_config()


### PR DESCRIPTION
Libssh2 uses the `SSH_AUTH_SOCK` env variable to read the system agent location. However, when using a custom agent path you have to set this value using `setenv` which is not thread-safe. The new functions allow for a way to set a custom agent socket path which is thread safe.