### PR TITLE
session_disconnect: clear state

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1156,7 +1156,7 @@ libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
                               const char *desc, const char *lang)
 {
     int rc;
-
+    session->state = 0;
     BLOCK_ADJUST(rc, session,
                  session_disconnect(session, reason, desc, lang));
 


### PR DESCRIPTION
If authentication is started but not completed before the application
gives up and instead wants to shut down the session, the '->state' field
might still be set and thus effectively dead-lock session_disconnect.

This happens because both _libssh2_transport_send() and
_libssh2_transport_read() refuse to do anything as long as state is set
without the LIBSSH2_STATE_KEX_ACTIVE bit.

Reported in curl bug https://github.com/curl/curl/issues/3650