### PR TITLE
userauth: fix "Function call argument is an uninitialized value"

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -830,7 +830,8 @@ userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
 
     if(session->userauth_host_state == libssh2_NB_state_idle) {
         const LIBSSH2_HOSTKEY_METHOD *privkeyobj;
-        unsigned char *pubkeydata, *sig = NULL;
+        unsigned char *pubkeydata = NULL;
+        unsigned char *sig = NULL;
         size_t pubkeydata_len = 0;
         size_t sig_len = 0;
         void *abstract;


### PR DESCRIPTION
Detected by scan-build.