### PR TITLE
String buffer improvements

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -2618,7 +2618,8 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         buf.dataptr = buf.data;
         buf.dataptr++; /* advance past packet type */
 
-        if(_libssh2_get_string(&buf, &server_host_key, &(session->server_hostkey_len)) != 0) {
+        if(_libssh2_get_string(&buf, &server_host_key, 
+           &(session->server_hostkey_len)) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Unexpected key length");
             goto clean_exit;
@@ -2706,7 +2707,10 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
 #ifdef LIBSSH2DEBUG
         {
             char *base64Fingerprint = NULL;
-            _libssh2_base64_encode(session, (const char*)session->server_hostkey_sha256, SHA256_DIGEST_LENGTH, &base64Fingerprint);
+            _libssh2_base64_encode(session, 
+                                   (const char *)session->server_hostkey_sha256,
+                                   SHA256_DIGEST_LENGTH, &base64Fingerprint);
+
             if( base64Fingerprint != NULL) {
                 _libssh2_debug(session, LIBSSH2_TRACE_KEX,
                                   "Server's SHA256 Fingerprint: %s", base64Fingerprint);
@@ -2737,11 +2741,11 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         }
 
         /* server signature */
-        if(_libssh2_get_string(&buf, &exchange_state->h_sig, &(exchange_state->h_sig_len)) != 0) {
+        if(_libssh2_get_string(&buf, &exchange_state->h_sig,
+           &(exchange_state->h_sig_len)) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                                  "Unexpected curve25519 server sig length");
             goto clean_exit;
-
         }
 
         /* Compute the shared secret K */

--- a/src/kex.c
+++ b/src/kex.c
@@ -1665,7 +1665,7 @@ kex_method_diffie_hellman_group_exchange_sha1_key_exchange
     }
 
     if(key_state->state == libssh2_NB_state_sent1) {
-        unsigned int p_len, g_len;
+        size_t p_len, g_len;
         unsigned char *p, *g;
         struct string_buf buf;
 
@@ -1682,13 +1682,13 @@ kex_method_diffie_hellman_group_exchange_sha1_key_exchange
 
         buf.dataptr++; /* increment to big num */
 
-        if((p_len = _libssh2_get_bignum_bytes(&buf, &p)) <= 0) {
+        if(_libssh2_get_bignum_bytes(&buf, &p, &p_len) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Unexpected value");
             goto dh_gex_clean_exit;
         }
 
-        if((g_len = _libssh2_get_bignum_bytes(&buf, &g)) <= 0) {
+        if(_libssh2_get_bignum_bytes(&buf, &g, &g_len) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Unexpected value");
             goto dh_gex_clean_exit;
@@ -1789,7 +1789,7 @@ kex_method_diffie_hellman_group_exchange_sha256_key_exchange
 
     if(key_state->state == libssh2_NB_state_sent1) {
         unsigned char *p, *g;
-        unsigned long p_len, g_len;
+        size_t p_len, g_len;
         struct string_buf buf;
 
         if(key_state->data_len < 9) {
@@ -1805,13 +1805,13 @@ kex_method_diffie_hellman_group_exchange_sha256_key_exchange
 
         buf.dataptr++; /* increment to big num */
 
-        if((p_len = _libssh2_get_bignum_bytes(&buf, &p)) <= 0) {
+        if(_libssh2_get_bignum_bytes(&buf, &p, &p_len) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Unexpected value");
             goto dh_gex_clean_exit;
         }
 
-        if((g_len = _libssh2_get_bignum_bytes(&buf, &g)) <= 0) {
+        if(_libssh2_get_bignum_bytes(&buf, &g, &g_len) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Unexpected value");
             goto dh_gex_clean_exit;
@@ -2603,7 +2603,7 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
     if(exchange_state->state == libssh2_NB_state_created) {
         /* parse INIT reply data */
         unsigned char *server_public_key, *server_host_key;
-        unsigned int server_public_key_len;
+        size_t server_public_key_len;
         struct string_buf buf;
 
         if(data_len < 5) {
@@ -2618,7 +2618,7 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         buf.dataptr = buf.data;
         buf.dataptr++; /* advance past packet type */
 
-        if((session->server_hostkey_len = _libssh2_get_c_string(&buf, &server_host_key)) <= 0) {
+        if(_libssh2_get_string(&buf, &server_host_key, &(session->server_hostkey_len)) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Unexpected key length");
             goto clean_exit;
@@ -2724,8 +2724,7 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         }
 
         /* server public key Q_S */
-        if((server_public_key_len =
-            _libssh2_get_c_string(&buf, &server_public_key)) <= 0) {
+        if(_libssh2_get_string(&buf, &server_public_key, &server_public_key_len) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                      "Unexpected key length");
             goto clean_exit;
@@ -2738,8 +2737,7 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         }
 
         /* server signature */
-        if((exchange_state->h_sig_len =
-            _libssh2_get_c_string(&buf, &exchange_state->h_sig)) <= 0) {
+        if(_libssh2_get_string(&buf, &exchange_state->h_sig, &(exchange_state->h_sig_len)) != 0) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                                  "Unexpected curve25519 server sig length");
             goto clean_exit;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -606,7 +606,7 @@ struct _LIBSSH2_SESSION
      * Or read from server in (eg) KEXDH_INIT (for client mode)
      */
     unsigned char *server_hostkey;
-    uint32_t server_hostkey_len;
+    size_t server_hostkey_len;
 #if LIBSSH2_MD5
     unsigned char server_hostkey_md5[MD5_DIGEST_LENGTH];
     int server_hostkey_md5_valid;

--- a/src/misc.c
+++ b/src/misc.c
@@ -749,13 +749,13 @@ int _libssh2_match_string(struct string_buf *buf, const char *match)
     unsigned char *out;
     size_t len = 0;
     if(_libssh2_get_string(buf, &out, &len) != 0 || len != strlen(match) ||
-        strncmp((char*)out, match, strlen(match)) != 0) {
+        strncmp((char *)out, match, strlen(match)) != 0) {
         return -1;
     }
     return 0;
 }
 
-int _libssh2_get_string(struct string_buf *buf, unsigned char **outbuf, 
+int _libssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
                         size_t *outlen)
 {
     uint32_t data_len;
@@ -775,7 +775,7 @@ int _libssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
     return 0;
 }
 
-int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf, 
+int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf,
                               size_t *outlen)
 {
     uint32_t data_len;
@@ -803,7 +803,7 @@ int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf,
     buf->dataptr += data_len;
     buf->offset += data_len;
 
-    if (outlen != NULL)
+    if(outlen != NULL)
         *outlen = (size_t)bn_len;
 
     return 0;
@@ -811,7 +811,8 @@ int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf,
 
 int _libssh2_check_length(struct string_buf *buf, size_t len)
 {
-    return ((ssize_t)(buf->dataptr - buf->data) <= (ssize_t)(buf->len - len)) ? 1 : 0;
+    return ((ssize_t)(buf->dataptr - buf->data) <= 
+            (ssize_t)(buf->len - len)) ? 1 : 0;
 }
 
 /* Wrappers */

--- a/src/misc.h
+++ b/src/misc.h
@@ -92,9 +92,9 @@ struct string_buf* _libssh2_string_buf_new(LIBSSH2_SESSION *session);
 void _libssh2_string_buf_free(LIBSSH2_SESSION *session, struct string_buf *buf);
 int _libssh2_get_u32(struct string_buf *buf, uint32_t *out);
 int _libssh2_match_string(struct string_buf *buf, const char *match);
-int _libssh2_get_string(struct string_buf *buf, unsigned char **outbuf, 
+int _libssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
                         size_t *outlen);
-int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf, 
+int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf,
                               size_t *outlen);
 int _libssh2_check_length(struct string_buf *buf, size_t requested_len);
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -92,8 +92,10 @@ struct string_buf* _libssh2_string_buf_new(LIBSSH2_SESSION *session);
 void _libssh2_string_buf_free(LIBSSH2_SESSION *session, struct string_buf *buf);
 int _libssh2_get_u32(struct string_buf *buf, uint32_t *out);
 int _libssh2_match_string(struct string_buf *buf, const char *match);
-int _libssh2_get_c_string(struct string_buf *buf, unsigned char **outbuf);
-int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf);
+int _libssh2_get_string(struct string_buf *buf, unsigned char **outbuf, 
+                        size_t *outlen);
+int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf, 
+                              size_t *outlen);
 int _libssh2_check_length(struct string_buf *buf, size_t requested_len);
 
 #if defined(LIBSSH2_WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN__)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1566,8 +1566,8 @@ gen_publickey_from_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
                                              libssh2_ed25519_ctx **out_ctx)
 {
     libssh2_ed25519_ctx *ctx = NULL;
-    unsigned char* method_buf = NULL;
-    unsigned char* key = NULL;
+    unsigned char *method_buf = NULL;
+    unsigned char *key = NULL;
     int i, ret = 0;
     unsigned char *pub_key, *priv_key, *buf;
     size_t key_len = 0, tmp_len = 0;
@@ -1577,14 +1577,14 @@ gen_publickey_from_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing ED25519 keys from private key data");
 
-    if(_libssh2_get_string(decrypted, &pub_key, &tmp_len) != 0 || 
+    if(_libssh2_get_string(decrypted, &pub_key, &tmp_len) != 0 ||
        tmp_len != LIBSSH2_ED25519_KEY_LEN) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Wrong public key length");
         return -1;
     }
 
-    if(_libssh2_get_string(decrypted, &priv_key, &tmp_len) != 0 || 
+    if(_libssh2_get_string(decrypted, &priv_key, &tmp_len) != 0 ||
        tmp_len != LIBSSH2_ED25519_PRIVATE_KEY_LEN) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Wrong private key length");
@@ -2328,26 +2328,26 @@ gen_publickey_from_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing ECDSA keys from private key data");
 
-    if (_libssh2_get_string(decrypted, &curve, &curvelen) != 0 || 
+    if(_libssh2_get_string(decrypted, &curve, &curvelen) != 0 ||
         curvelen == 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "ECDSA no curve");
         return -1;
     }
 
-    if (_libssh2_get_string(decrypted, &point_buf, &pointlen) != 0) {
+    if(_libssh2_get_string(decrypted, &point_buf, &pointlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "ECDSA no point");
         return -1;
     }
 
-    if (_libssh2_get_bignum_bytes(decrypted, &exponent, &exponentlen) != 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &exponent, &exponentlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "ECDSA no exponent");
         return -1;
     }
 
-    if ((rc = _libssh2_ecdsa_curve_name_with_octal_new(&ec_key, point_buf,
+    if((rc = _libssh2_ecdsa_curve_name_with_octal_new(&ec_key, point_buf,
         pointlen, curve_type)) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "ECDSA could not create key");

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -949,9 +949,8 @@ gen_publickey_from_rsa_openssh_priv_data(LIBSSH2_SESSION *session,
                                          libssh2_rsa_ctx **rsa_ctx)
 {
     int rc = 0;
-    int nlen, elen, dlen, plen, qlen, coefflen;
+    size_t nlen, elen, dlen, plen, qlen, coefflen, commentlen;
     unsigned char *n, *e, *d, *p, *q, *coeff, *comment;
-    int commentlen;
     RSA *rsa = NULL;
 
     _libssh2_debug(session,
@@ -959,44 +958,44 @@ gen_publickey_from_rsa_openssh_priv_data(LIBSSH2_SESSION *session,
                    "Computing RSA keys from private key data");
 
     /* public key data */
-    if((nlen = _libssh2_get_bignum_bytes(decrypted, &n)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &n, &nlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "RSA no n");
         return -1;
     }
 
-    if((elen = _libssh2_get_bignum_bytes(decrypted, &e)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &e, &elen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "RSA no e");
         return -1;
     }
 
     /* private key data */
-    if((dlen = _libssh2_get_bignum_bytes(decrypted, &d)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &d, &dlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "RSA no d");
         return -1;
     }
 
-    if((coefflen = _libssh2_get_bignum_bytes(decrypted, &coeff)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &coeff, &coefflen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "RSA no coeff");
         return -1;
     }
 
-    if((plen = _libssh2_get_bignum_bytes(decrypted, &p)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &p, &plen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "RSA no p");
         return -1;
     }
 
-    if((qlen = _libssh2_get_bignum_bytes(decrypted, &q)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &q, &qlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "RSA no q");
         return -1;
     }
 
-    if((commentlen = _libssh2_get_c_string(decrypted, &comment)) < 0) {
+    if(_libssh2_get_string(decrypted, &comment, &commentlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "RSA no comment");
         return -1;
@@ -1075,9 +1074,9 @@ _libssh2_rsa_new_openssh_private(libssh2_rsa_ctx ** rsa,
     }
 
     /* We have a new key file, now try and parse it using supported types  */
-    rc = _libssh2_get_c_string(decrypted, &buf);
+    rc = _libssh2_get_string(decrypted, &buf, NULL);
 
-    if(rc < 1 || buf == NULL) {
+    if(rc != 0 || buf == NULL) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Public key type in decrypted key data not found");
         return -1;
@@ -1266,7 +1265,7 @@ gen_publickey_from_dsa_openssh_priv_data(LIBSSH2_SESSION *session,
                                          libssh2_dsa_ctx **dsa_ctx)
 {
     int rc = 0;
-    int plen, qlen, glen, pub_len, priv_len;
+    size_t plen, qlen, glen, pub_len, priv_len;
     unsigned char *p, *q, *g, *pub_key, *priv_key;
     DSA *dsa = NULL;
 
@@ -1274,31 +1273,31 @@ gen_publickey_from_dsa_openssh_priv_data(LIBSSH2_SESSION *session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing DSA keys from private key data");
 
-    if((plen = _libssh2_get_bignum_bytes(decrypted, &p)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &p, &plen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "DSA no p");
         return -1;
     }
 
-    if((qlen = _libssh2_get_bignum_bytes(decrypted, &q)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &q, &qlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "DSA no q");
         return -1;
     }
 
-    if((glen = _libssh2_get_bignum_bytes(decrypted, &g)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &g, &glen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "DSA no g");
         return -1;
     }
 
-    if((pub_len = _libssh2_get_bignum_bytes(decrypted, &pub_key)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &pub_key, &pub_len) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "DSA no public key");
         return -1;
     }
 
-    if((priv_len = _libssh2_get_bignum_bytes(decrypted, &priv_key)) <= 0) {
+    if(_libssh2_get_bignum_bytes(decrypted, &priv_key, &priv_len) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "DSA no private key");
         return -1;
@@ -1374,9 +1373,9 @@ _libssh2_dsa_new_openssh_private(libssh2_dsa_ctx ** dsa,
     }
 
     /* We have a new key file, now try and parse it using supported types  */
-    rc = _libssh2_get_c_string(decrypted, &buf);
+    rc = _libssh2_get_string(decrypted, &buf, NULL);
 
-    if(rc < 1 || buf == NULL) {
+    if(rc != 0 || buf == NULL) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Public key type in decrypted key data not found");
         return -1;
@@ -1568,22 +1567,24 @@ gen_publickey_from_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
     libssh2_ed25519_ctx *ctx = NULL;
     unsigned char* method_buf = NULL;
     unsigned char* key = NULL;
-    int i, rc, ret = 0;
+    int i, ret = 0;
     unsigned char *pub_key, *priv_key, *buf;
-    size_t  key_len = 0;
+    size_t key_len = 0, tmp_len = 0;
     unsigned char *p;
 
     _libssh2_debug(session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing ED25519 keys from private key data");
 
-    if(_libssh2_get_c_string(decrypted, &pub_key) != LIBSSH2_ED25519_KEY_LEN) {
+    if(_libssh2_get_string(decrypted, &pub_key, &tmp_len) != 0 || 
+       tmp_len != LIBSSH2_ED25519_KEY_LEN) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Wrong public key length");
         return -1;
     }
 
-    if(_libssh2_get_c_string(decrypted, &priv_key) != LIBSSH2_ED25519_PRIVATE_KEY_LEN) {
+    if(_libssh2_get_string(decrypted, &priv_key, &tmp_len) != 0 || 
+       tmp_len != LIBSSH2_ED25519_PRIVATE_KEY_LEN) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Wrong private key length");
         ret = -1;
@@ -1606,18 +1607,18 @@ gen_publickey_from_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
                         (const unsigned char*)pub_key, LIBSSH2_ED25519_KEY_LEN);
 
     /* comment */
-    if((rc = _libssh2_get_c_string(decrypted, &buf)) < 0) {
+    if(_libssh2_get_string(decrypted, &buf, &tmp_len) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Unable to read comment");
         ret = -1;
         goto clean_exit;
     }
 
-    if(rc > 0) {
-        unsigned char *comment = LIBSSH2_CALLOC(session, rc + 1);
+    if(tmp_len > 0) {
+        unsigned char *comment = LIBSSH2_CALLOC(session, tmp_len + 1);
         if(comment != NULL) {
-            memcpy(comment, buf, rc);
-            memcpy(comment + rc, "\0", 1);
+            memcpy(comment, buf, tmp_len);
+            memcpy(comment + tmp_len, "\0", 1);
 
             _libssh2_debug(session, LIBSSH2_TRACE_AUTH, "Key comment: %s", comment);
 
@@ -1733,9 +1734,9 @@ _libssh2_ed25519_new_private(libssh2_ed25519_ctx ** ed_ctx,
     }
 
     /* We have a new key file, now try and parse it using supported types  */
-    rc = _libssh2_get_c_string(decrypted, &buf);
+    rc = _libssh2_get_string(decrypted, &buf, NULL);
 
-    if(rc < 1 || buf == NULL) {
+    if(rc != 0 || buf == NULL) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Public key type in decrypted key data not found");
         return -1;
@@ -2314,7 +2315,7 @@ gen_publickey_from_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
                                            libssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
-    int curvelen, exponentlen, pointlen;
+    size_t curvelen, exponentlen, pointlen;
     unsigned char *curve, *exponent, *point_buf;
     EC_KEY *ec_key = NULL;
     BIGNUM *bn_exponent;
@@ -2323,19 +2324,20 @@ gen_publickey_from_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing ECDSA keys from private key data");
 
-    if ((curvelen = _libssh2_get_c_string(decrypted, &curve)) <= 0) {
+    if (_libssh2_get_string(decrypted, &curve, &curvelen) != 0 || 
+        curvelen == 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "ECDSA no curve");
         return -1;
     }
 
-    if ((pointlen = _libssh2_get_c_string(decrypted, &point_buf)) <= 0) {
+    if (_libssh2_get_string(decrypted, &point_buf, &pointlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "ECDSA no point");
         return -1;
     }
 
-    if ((exponentlen = _libssh2_get_bignum_bytes(decrypted, &exponent)) <= 0) {
+    if (_libssh2_get_bignum_bytes(decrypted, &exponent, &exponentlen) != 0) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "ECDSA no exponent");
         return -1;
@@ -2421,9 +2423,9 @@ _libssh2_ecdsa_new_openssh_private(libssh2_ecdsa_ctx ** ec_ctx,
     }
 
     /* We have a new key file, now try and parse it using supported types  */
-    rc = _libssh2_get_c_string(decrypted, &buf);
+    rc = _libssh2_get_string(decrypted, &buf, NULL);
 
-    if(rc < 1 || buf == NULL) {
+    if(rc != 0 || buf == NULL) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Public key type in decrypted key data not found");
         return -1;
@@ -2790,9 +2792,9 @@ _libssh2_pub_priv_openssh_keyfile(LIBSSH2_SESSION *session,
     }
 
     /* We have a new key file, now try and parse it using supported types  */
-    rc = _libssh2_get_c_string(decrypted, &buf);
+    rc = _libssh2_get_string(decrypted, &buf, NULL);
 
-    if(rc < 1 || buf == NULL){
+    if(rc != 0 || buf == NULL){
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Public key type in decrypted key data not found");
         return -1;
@@ -2977,9 +2979,9 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
     }
 
    /* We have a new key file, now try and parse it using supported types  */
-   rc = _libssh2_get_c_string(decrypted, &buf);
+   rc = _libssh2_get_string(decrypted, &buf, NULL);
 
-   if(rc < 1 || buf == NULL) {
+   if(rc != 0 || buf == NULL) {
        _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                       "Public key type in decrypted key data not found");
        return -1;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1086,7 +1086,8 @@ _libssh2_rsa_new_openssh_private(libssh2_rsa_ctx ** rsa,
         rc = gen_publickey_from_rsa_openssh_priv_data(session, decrypted,
                                                       NULL, 0,
                                                       NULL, 0, rsa);
-    } else {
+    } 
+    else {
         rc = -1;
     }
 
@@ -1750,6 +1751,9 @@ _libssh2_ed25519_new_private(libssh2_ed25519_ctx ** ed_ctx,
                                                           NULL,
                                                           NULL,
                                                           &ctx);
+    }
+    else {
+        rc = -1;
     }
 
     if(decrypted)
@@ -2986,6 +2990,8 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
                       "Public key type in decrypted key data not found");
        return -1;
    }
+
+   rc = -1;
 
 #if LIBSSH2_ED25519
     if(strcmp("ssh-ed25519", (const char*)buf) == 0) {

--- a/src/pem.c
+++ b/src/pem.c
@@ -424,7 +424,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         goto out;
     }
 
-    if(_libssh2_get_string(&decoded, &kdf, &kdf_len) != 0 || kdf_len == 0)
+    if(_libssh2_get_string(&decoded, &kdf, &kdf_len) != 0)
     {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "kdf is missing");

--- a/src/pem.c
+++ b/src/pem.c
@@ -410,7 +410,8 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 
     decoded.dataptr += strlen(AUTH_MAGIC) + 1;
 
-    if(_libssh2_get_string(&decoded, &ciphername, &tmp_len) != 0 || tmp_len == 0)
+    if(_libssh2_get_string(&decoded, &ciphername, &tmp_len) != 0 ||
+       tmp_len == 0)
     {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                              "ciphername is missing");
@@ -437,20 +438,22 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         kdf_buf.len = kdf_len;
     }
 
-    if((passphrase == NULL || strlen((const char*)passphrase) == 0) &&
-        strcmp((const char*)ciphername, "none") != 0) {
+    if((passphrase == NULL || strlen((const char *)passphrase) == 0) &&
+        strcmp((const char *)ciphername, "none") != 0) {
         /* passphrase required */
         ret = LIBSSH2_ERROR_KEYFILE_AUTH_FAILED;
         goto out;
     }
 
-    if(strcmp((const char*)kdfname, "none") != 0 && strcmp((const char*)kdfname, "bcrypt") != 0) {
+    if(strcmp((const char *)kdfname, "none") != 0 &&
+       strcmp((const char *)kdfname, "bcrypt") != 0) {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                              "unknown cipher");
         goto out;
     }
 
-    if(!strcmp((const char*)kdfname, "none") && strcmp((const char*)ciphername, "none") != 0) {
+    if(!strcmp((const char *)kdfname, "none") &&
+       strcmp((const char *)ciphername, "none") != 0) {
         ret =_libssh2_error(session, LIBSSH2_ERROR_PROTO,
                             "invalid format");
         goto out;

--- a/src/pem.c
+++ b/src/pem.c
@@ -372,14 +372,15 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
     unsigned char *kdf = NULL;
     unsigned char *buf = NULL;
     unsigned char *salt = NULL;
-    uint32_t nkeys, check1, check2, salt_len;
+    uint32_t nkeys, check1, check2;
     uint32_t rounds = 0;
     unsigned char *key = NULL;
     unsigned char *key_part = NULL;
     unsigned char *iv_part = NULL;
     unsigned char *f = NULL;
     unsigned int f_len = 0;
-    int ret = 0, rc = 0, kdf_len = 0, keylen = 0, ivlen = 0, total_len = 0;
+    int ret = 0, keylen = 0, ivlen = 0, total_len = 0;
+    size_t kdf_len = 0, tmp_len = 0, salt_len = 0;
 
     if(decrypted_buf)
         *decrypted_buf = NULL;
@@ -409,22 +410,21 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 
     decoded.dataptr += strlen(AUTH_MAGIC) + 1;
 
-    if(_libssh2_get_c_string(&decoded, &ciphername) == 0)
+    if(_libssh2_get_string(&decoded, &ciphername, &tmp_len) != 0 || tmp_len == 0)
     {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                              "ciphername is missing");
         goto out;
     }
 
-    if(_libssh2_get_c_string(&decoded, &kdfname) == 0)
+    if(_libssh2_get_string(&decoded, &kdfname, &tmp_len) != 0 || tmp_len == 0)
     {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "kdfname is missing");
         goto out;
     }
 
-    kdf_len = _libssh2_get_c_string(&decoded, &kdf);
-    if(kdf == NULL )
+    if(_libssh2_get_string(&decoded, &kdf, &kdf_len) != 0 || kdf_len == 0)
     {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "kdf is missing");
@@ -464,15 +464,13 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 
     /* unencrypted public key */
 
-    if(_libssh2_get_c_string(&decoded, &buf) < 0) {
+    if(_libssh2_get_string(&decoded, &buf, &tmp_len) != 0 || tmp_len == 0) {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
-                             "Invalid private key; expect embedded public key");
+                             "Invalid private key; expect embedded public key");                             
         goto out;
     }
 
-    rc = _libssh2_get_c_string(&decoded, &buf);
-    if(rc <= 0)
-    {
+    if(_libssh2_get_string(&decoded, &buf, &tmp_len) != 0 || tmp_len == 0) {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Private key data not found");
         goto out;
@@ -480,10 +478,9 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 
     /* decode encrypted private key */
     decrypted.data = decrypted.dataptr = buf;
-    decrypted.len = rc;
+    decrypted.len = tmp_len;
 
-    if(ciphername && strcmp((const char*)ciphername, "none") != 0)
-    {
+    if(ciphername && strcmp((const char*)ciphername, "none") != 0) {
         const LIBSSH2_CRYPT_METHOD **all_methods, *cur_method;
 
         all_methods = libssh2_crypt_methods();
@@ -520,7 +517,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         }
 
         if(strcmp((const char*)kdfname, "bcrypt") == 0 && passphrase != NULL) {
-            if(((salt_len = _libssh2_get_c_string(&kdf_buf, &salt)) <= 0) ||
+            if((_libssh2_get_string(&kdf_buf, &salt, &salt_len) != 0) ||
                 (_libssh2_get_u32(&kdf_buf, &rounds) != 0) ) {
                 ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                      "kdf contains unexpected values");


### PR DESCRIPTION
Changed `_libssh2_get_c_string` to `_libssh2_get_string` and now returns -1 on error and 0 on success. Also changed `_libssh2_get_bignum_bytes` to return -1 on error and 0 on success. Both now take `size_t` as a parameter to return the length of the buffer. This is to attempt to keep the data going in/out of these functions unsigned to better impedance match the existing API.