### PR TITLE
session_disconnect: don't zero state, just clear the right bit

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1168,7 +1168,7 @@ libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
                               const char *desc, const char *lang)
 {
     int rc;
-    session->state = 0;
+    session->state &= ~LIBSSH2_STATE_EXCHANGING_KEYS;
     BLOCK_ADJUST(rc, session,
                  session_disconnect(session, reason, desc, lang));
 


### PR DESCRIPTION
If we clear the entire field, the freeing of data in session_free() is
skipped. Instead just clear the bit that risk making the code get stuck
in the transport functions.

Regression from 4d66f6762ca3fc45d9.

Reported-by: dimmaq on github
Fixes #338