### PR TITLE
Fix musl build warning on sys/poll.h

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -66,7 +66,7 @@
    would break backwards compatibility.
 */
 #ifdef HAVE_POLL
-# include <sys/poll.h>
+# include <poll.h>
 #else
 # if defined(HAVE_SELECT) && !defined(WIN32)
 # ifdef HAVE_SYS_SELECT_H


### PR DESCRIPTION
musl prints `redirecting incorrect #include <sys/poll.h> to <poll.h>`
http://git.musl-libc.org/cgit/musl/commit/include/sys/poll.h?id=54446d730cfb17c5f7bcf57f139458678f5066cc

poll is defined by POSIX to be in poll.h:
http://pubs.opengroup.org/onlinepubs/7908799/xsh/poll.html

---

libssh2 configure does not check which header file provides poll, only that it is present in the libc. I think it is not necessary to add such a check because `poll.h` should work everywhere.