### PR TITLE
_libssh2_check_length() : additional bounds check

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -811,6 +811,9 @@ int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf)
 
 int _libssh2_check_length(struct string_buf *buf, size_t len)
 {
+    if(len > buf->len)
+        return 0;
+
     return ((int)(buf->dataptr - buf->data) <= (int)(buf->len - len)) ? 1 : 0;
 }
 


### PR DESCRIPTION
Misc.c : _libssh2_check_length()

Ensure the requested length is less than the total length before doing the additional bounds check