### PR TITLE
Simplified _libssh2_check_length

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -811,10 +811,7 @@ int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf)
 
 int _libssh2_check_length(struct string_buf *buf, size_t len)
 {
-    if(len > buf->len)
-        return 0;
-
-    return ((int)(buf->dataptr - buf->data) <= (int)(buf->len - len)) ? 1 : 0;
+    return (len <= (size_t)((buf->data + buf->len) - buf->dataptr));
 }
 
 /* Wrappers */

--- a/src/misc.c
+++ b/src/misc.c
@@ -811,7 +811,9 @@ int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf)
 
 int _libssh2_check_length(struct string_buf *buf, size_t len)
 {
-    return (len <= (size_t)((buf->data + buf->len) - buf->dataptr));
+    unsigned char *endp = &buf->data[buf->len];
+    size_t left = endp - buf->dataptr;
+    return ((len <= left) && (left <= buf->len));
 }
 
 /* Wrappers */


### PR DESCRIPTION
misc.c : _libssh2_check_length()

Removed cast and one-lined check. 

Credit : Yuriy M. Kaminskiy