### PR TITLE
Fixing bug where if timeout was reached the memory was not cleand up

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -737,6 +737,11 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 
     if(session->startup_state == libssh2_NB_state_sent1) {
         rc = _libssh2_kex_exchange(session, 0, &session->startup_key_state);
+
+        if (session->err_code == LIBSSH2_ERROR_TIMEOUT)
+            return  _libssh2_error(session, LIBSSH2_ERROR_TIMEOUT,			
+                                  "API Timeout expired");
+
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
         else if(rc)

--- a/src/session.c
+++ b/src/session.c
@@ -738,8 +738,8 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
     if(session->startup_state == libssh2_NB_state_sent1) {
         rc = _libssh2_kex_exchange(session, 0, &session->startup_key_state);
 
-        if (session->err_code == LIBSSH2_ERROR_TIMEOUT)
-            return  _libssh2_error(session, LIBSSH2_ERROR_TIMEOUT,			
+        if(session->err_code == LIBSSH2_ERROR_TIMEOUT)
+            return  _libssh2_error(session, LIBSSH2_ERROR_TIMEOUT,
                                   "API Timeout expired");
 
         if(rc == LIBSSH2_ERROR_EAGAIN)


### PR DESCRIPTION
While researching #299 I found that the LIBSSH2_ERROR_TIMEOUT value was being set in the session but being ignored. I added @dimmaq's test into the ssh2 example and was able to see memory being lost in valgrind and this no longer happening after I compiled this fix in.