### PR TITLE
mbedtls: allow private-key from memory

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -414,15 +414,28 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
     int ret;
     mbedtls_pk_context pkey;
     mbedtls_rsa_context *pk_rsa;
+    void *filedata_nullterm;
 
     *rsa = (libssh2_rsa_ctx *) mbedtls_calloc(1, sizeof(libssh2_rsa_ctx));
     if(*rsa == NULL)
         return -1;
 
+    /*
+    Hack: mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
+    Using a private-key from memory will fail if the last byte is not a null terminator
+    */
+    filedata_nullterm = mbedtls_calloc(filedata_len + 1, 1);
+    if(filedata_nullterm == NULL) {
+        return -1;
+    }
+    memcpy(filedata_nullterm, filedata, filedata_len);
+
     mbedtls_pk_init(&pkey);
 
-    ret = mbedtls_pk_parse_key(&pkey, (unsigned char *)filedata,
-                              filedata_len, NULL, 0);
+    ret = mbedtls_pk_parse_key(&pkey, (unsigned char *)filedata_nullterm,
+                               filedata_len + 1, passphrase, passphrase != NULL ? strlen((const char *)passphrase) : 0);
+    _libssh2_mbedtls_safe_free(filedata_nullterm, filedata_len);
+
     if(ret != 0 || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);
         mbedtls_rsa_free(*rsa);
@@ -635,10 +648,24 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     mbedtls_pk_context pkey;
     char buf[1024];
     int ret;
+    void *privatekeydata_nullterm;
+
+    /*
+    Hack: mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
+    Using a private-key from memory will fail if the last byte is not a null terminator
+    */
+    privatekeydata_nullterm = mbedtls_calloc(privatekeydata_len + 1, 1);
+    if(privatekeydata_nullterm == NULL) {
+        return -1;
+    }
+    memcpy(privatekeydata_nullterm, privatekeydata, privatekeydata_len);
 
     mbedtls_pk_init(&pkey);
-    ret = mbedtls_pk_parse_key(&pkey, (unsigned char *)privatekeydata,
-                              privatekeydata_len, NULL, 0);
+
+    ret = mbedtls_pk_parse_key(&pkey, (unsigned char *)privatekeydata_nullterm,
+                               privatekeydata_len + 1, (const unsigned char *)passphrase, passphrase != NULL ? strlen((const char *)passphrase) : 0);
+    _libssh2_mbedtls_safe_free(privatekeydata_nullterm, privatekeydata_len);
+
     if(ret != 0) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));
         mbedtls_pk_free(&pkey);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -436,8 +436,7 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
     pwd_len = passphrase != NULL ? strlen((const char *)passphrase) : 0;
     ret = mbedtls_pk_parse_key(&pkey, (unsigned char *)filedata_nullterm,
                                filedata_len + 1,
-                               passphrase,
-                               pwd_len);
+                               passphrase, pwd_len);
     _libssh2_mbedtls_safe_free(filedata_nullterm, filedata_len);
 
     if(ret != 0 || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
@@ -671,7 +670,7 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     ret = mbedtls_pk_parse_key(&pkey,
                                (unsigned char *)privatekeydata_nullterm,
                                privatekeydata_len + 1,
-                               (const unsigned char *)passphrase, pwd_len );
+                               (const unsigned char *)passphrase, pwd_len);
     _libssh2_mbedtls_safe_free(privatekeydata_nullterm, privatekeydata_len);
 
     if(ret != 0) {

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -415,14 +415,15 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
     mbedtls_pk_context pkey;
     mbedtls_rsa_context *pk_rsa;
     void *filedata_nullterm;
+    size_t pwd_len;
 
     *rsa = (libssh2_rsa_ctx *) mbedtls_calloc(1, sizeof(libssh2_rsa_ctx));
     if(*rsa == NULL)
         return -1;
 
     /*
-    Hack: mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
-    Using a private-key from memory will fail if the last byte is not a null terminator
+    mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
+    private-key from memory will fail if the last byte is not a null byte
     */
     filedata_nullterm = mbedtls_calloc(filedata_len + 1, 1);
     if(filedata_nullterm == NULL) {
@@ -432,8 +433,11 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
 
     mbedtls_pk_init(&pkey);
 
+    pwd_len = passphrase != NULL ? strlen((const char *)passphrase) : 0;
     ret = mbedtls_pk_parse_key(&pkey, (unsigned char *)filedata_nullterm,
-                               filedata_len + 1, passphrase, passphrase != NULL ? strlen((const char *)passphrase) : 0);
+                               filedata_len + 1,
+                               passphrase,
+                               pwd_len);
     _libssh2_mbedtls_safe_free(filedata_nullterm, filedata_len);
 
     if(ret != 0 || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
@@ -649,10 +653,11 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     char buf[1024];
     int ret;
     void *privatekeydata_nullterm;
+    size_t pwd_len;
 
     /*
-    Hack: mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
-    Using a private-key from memory will fail if the last byte is not a null terminator
+    mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
+    private-key from memory will fail if the last byte is not a null byte
     */
     privatekeydata_nullterm = mbedtls_calloc(privatekeydata_len + 1, 1);
     if(privatekeydata_nullterm == NULL) {
@@ -662,8 +667,11 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 
     mbedtls_pk_init(&pkey);
 
-    ret = mbedtls_pk_parse_key(&pkey, (unsigned char *)privatekeydata_nullterm,
-                               privatekeydata_len + 1, (const unsigned char *)passphrase, passphrase != NULL ? strlen((const char *)passphrase) : 0);
+    pwd_len = passphrase != NULL ? strlen((const char *)passphrase) : 0;
+    ret = mbedtls_pk_parse_key(&pkey,
+                               (unsigned char *)privatekeydata_nullterm,
+                               privatekeydata_len + 1,
+                               (const unsigned char *)passphrase, pwd_len );
     _libssh2_mbedtls_safe_free(privatekeydata_nullterm, privatekeydata_len);
 
     if(ret != 0) {


### PR DESCRIPTION
@willco007 

Thanks a lot!
The "trailing whitespaces" from https://github.com/libssh2/libssh2/pull/358