### PR TITLE
transport.c : scope local total_num var

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -281,7 +281,6 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
     unsigned char block[MAX_BLOCKSIZE];
     int blocksize;
     int encrypted = 1;
-    size_t total_num;
 
     /* default clear the bit */
     session->socket_block_directions &= ~LIBSSH2_SESSION_BLOCK_INBOUND;
@@ -401,6 +400,8 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
         numbytes = remainbuf;
 
         if(!p->total_num) {
+            size_t total_num;
+
             /* No payload package area allocated yet. To know the
                size of this payload, we need to decrypt the first
                blocksize data. */


### PR DESCRIPTION
file : transport.c
notes : move local `total_num` variable inside of if block to prevent scope access issues which caused #360.