### PR TITLE
Don't quote ~[username]/ in scp paths.

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -218,7 +218,7 @@ shell_quotearg(const char *path, unsigned char *buf,
         default:
             switch(state) {
             case INITIAL:
-                if (*src == '~') {
+                if(*src == '~') {
                     state = HOMEDIR;
                     break;
                 }
@@ -228,9 +228,9 @@ shell_quotearg(const char *path, unsigned char *buf,
                 *dst++ = '\'';
                 break;
             case HOMEDIR:
-                if (isalnum(*src))
+                if(isalnum(*src))
                     break;
-                if (*src == '/') {
+                if(*src == '/') {
                     state = UQSTRING;
                     break;
                 }


### PR DESCRIPTION
In order for tilde expansion to work, a leading tilde and
any subsequent alphanumeric characters up to and including
the first slash must not be quoted.

This commit changes the quoting algorithm to forego quoting
the initial tilde (if present), any subsequent
alphanumerics, and the first slash. If the first character
is not a tilde then there is no change.

```
PATH       BEFORE       AFTER
~          '~'          ~
~user      '~user'      ~user
foo~bar    'foo~bar'    'foo~bar'
~/foo      '~/foo'      ~/'foo'
~ foo bar  '~ foo bar'  ~' foo bar'
```

See issue #349