### PR TITLE
Preserve error info from agent_transact_pageant()

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -522,7 +522,9 @@ agent_list_identities(LIBSSH2_AGENT *agent)
 
     rc = agent->ops->transact(agent, transctx);
     if(rc) {
-        goto error;
+        LIBSSH2_FREE(agent->session, transctx->response);
+        transctx->response = NULL;
+        return rc;
     }
     transctx->request = NULL;
 


### PR DESCRIPTION
Currently the error details as returned by agent_transact_pageant() are overwritten by a generic "agent list id failed" message by int agent_list_identities(LIBSSH2_AGENT* agent).
The patch fixes that.

PS: I'm not entirely sure if the
```````
    LIBSSH2_FREE(agent->session, transctx->response);
    transctx->response = NULL;
```````
part is needed, or if these fields are already null upon entering agent_list_identities(). If so, they could be removed, since a failed agent_transact_pageant() doesn't fill them.
