### PR TITLE
Make sure the error code is set.

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -236,6 +236,7 @@ _libssh2_channel_open(LIBSSH2_SESSION * session, const char *channel_type,
             return NULL;
         }
         else if(rc) {
+            _libssh2_error(session, rc, "Unexpected error");
             goto channel_error;
         }
 


### PR DESCRIPTION
Even though "unexpected error" is vague, it is still more helpful than errno not being set at all.