### PR TITLE
 Fix potential typecast error for `_libssh2_ecdsa_key_get_curve_type`

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -170,7 +170,7 @@ int _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx ** ec_ctx,
                                           unsigned const char *passphrase);
 
 libssh2_curve_type
-_libssh2_ecdsa_key_get_curve_type(libssh2_ecdsa_ctx *ec_ctx);
+_libssh2_ecdsa_get_curve_type(libssh2_ecdsa_ctx *ec_ctx);
 
 int
 _libssh2_ecdsa_curve_type_from_name(const char *name,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -170,7 +170,7 @@ int _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx ** ec_ctx,
                                           unsigned const char *passphrase);
 
 libssh2_curve_type
-_libssh2_ecdsa_key_get_curve_type(_libssh2_ec_key *key);
+_libssh2_ecdsa_key_get_curve_type(libssh2_ecdsa_ctx *ec_ctx);
 
 int
 _libssh2_ecdsa_curve_type_from_name(const char *name,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -709,7 +709,7 @@ hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION * session,
                                void **abstract)
 {
     libssh2_ecdsa_ctx *ec_ctx = (libssh2_ecdsa_ctx *) (*abstract);
-    libssh2_curve_type type = _libssh2_ecdsa_key_get_curve_type(ec_ctx);
+    libssh2_curve_type type = _libssh2_ecdsa_get_curve_type(ec_ctx);
     int ret = 0;
 
     if(type == LIBSSH2_EC_CURVE_NISTP256) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -259,14 +259,14 @@ _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
 
 #if LIBSSH2_ECDSA
 
-/* _libssh2_ecdsa_key_get_curve_type
+/* _libssh2_ecdsa_get_curve_type
  *
  * returns key curve type that maps to libssh2_curve_type
  *
  */
 
 libssh2_curve_type
-_libssh2_ecdsa_key_get_curve_type(libssh2_ecdsa_ctx *ec_ctx)
+_libssh2_ecdsa_get_curve_type(libssh2_ecdsa_ctx *ec_ctx)
 {
     const EC_GROUP *group = EC_KEY_get0_group(ec_ctx);
     return EC_GROUP_get_curve_name(group);
@@ -355,7 +355,7 @@ _libssh2_ecdsa_verify(libssh2_ecdsa_ctx * ctx,
 {
     int ret = 0;
     EC_KEY *ec_key = (EC_KEY*)ctx;
-    libssh2_curve_type type = _libssh2_ecdsa_key_get_curve_type(ec_key);
+    libssh2_curve_type type = _libssh2_ecdsa_get_curve_type(ec_key);
 
 #ifdef HAVE_OPAQUE_STRUCTS
     ECDSA_SIG *ecdsa_sig = ECDSA_SIG_new();
@@ -2251,7 +2251,7 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
 
     public_key = EC_KEY_get0_public_key(ec);
     group = EC_KEY_get0_group(ec);
-    type = _libssh2_ecdsa_key_get_curve_type(ec);
+    type = _libssh2_ecdsa_get_curve_type(ec);
 
     method_buf = LIBSSH2_ALLOC(session, 19);
     if(method_buf == NULL) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -266,9 +266,9 @@ _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
  */
 
 libssh2_curve_type
-_libssh2_ecdsa_key_get_curve_type(_libssh2_ec_key *key)
+_libssh2_ecdsa_key_get_curve_type(libssh2_ecdsa_ctx *ec_ctx)
 {
-    const EC_GROUP *group = EC_KEY_get0_group(key);
+    const EC_GROUP *group = EC_KEY_get0_group(ec_ctx);
     return EC_GROUP_get_curve_name(group);
 }
 


### PR DESCRIPTION
This is the fix for #383.