### PR TITLE
ECDSA support for mbed TLS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_install:
   - if [ $ADDRESS_SIZE = '64' ]; then sudo apt-get install -y libgcrypt11-dev; fi
   - if [ $ADDRESS_SIZE = '32' ]; then export TOOLCHAIN_OPTION="-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-Linux-32.cmake"; fi
   - if [ $CRYPTO_BACKEND = 'mbedTLS' ]; then
-      MBEDTLSVER=mbedtls-2.4.0;
+      MBEDTLSVER=mbedtls-2.7.0;
       curl -L https://github.com/ARMmbed/mbedtls/archive/$MBEDTLSVER.tar.gz | tar -xzf -;
       cd mbedtls-$MBEDTLSVER;
       cmake $TOOLCHAIN_OPTION -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX:PATH=../usr .;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1114,10 +1114,11 @@ _libssh2_mbedtls_mpi_write_binary(unsigned char *buf,
 {
     unsigned char *p = buf;
 
-    if(strlen((const char *) p) > 3) {
-        p += 4;
+    if(sizeof(&p) / sizeof(p[0]) < 4) {
+        goto done;
     }
 
+    p += 4;
     *p = 0;
 
     if(bytes > 0) {
@@ -1129,6 +1130,8 @@ _libssh2_mbedtls_mpi_write_binary(unsigned char *buf,
     }
 
     _libssh2_htonu32(p - 4, bytes);
+
+done:
 
     return p + bytes;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -769,6 +769,9 @@ _libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
     plen = 2 * mbedtls_mpi_size(&(*privkey)->grp.P) + 1;
     *pubkey_oct = LIBSSH2_ALLOC(session, plen);
 
+    if(*pubkey_oct == NULL)
+        goto failed;
+
     if(mbedtls_ecp_point_write_binary(&(*privkey)->grp, &(*privkey)->Q,
                                       MBEDTLS_ECP_PF_UNCOMPRESSED,
                                       pubkey_oct_len, *pubkey_oct, plen) == 0)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -766,7 +766,7 @@ _libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
                             &_libssh2_mbedtls_ctr_drbg) != 0)
         goto failed;
 
-    plen        = 2 * mbedtls_mpi_size(&(*privkey)->grp.P) + 1;
+    plen = 2 * mbedtls_mpi_size(&(*privkey)->grp.P) + 1;
     *pubkey_oct = LIBSSH2_ALLOC(session, plen);
 
     if(mbedtls_ecp_point_write_binary(&(*privkey)->grp, &(*privkey)->Q,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -806,6 +806,8 @@ _libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
     LIBSSH2_MBEDTLS_CHECK
     (*privkey = LIBSSH2_ALLOC(session, sizeof(mbedtls_ecp_keypair)));
 
+    mbedtls_ecdsa_init(*privkey);
+
     LIBSSH2_MBEDTLS_CHECK_RC
     (mbedtls_ecdsa_genkey(*privkey, (mbedtls_ecp_group_id)curve,
                           mbedtls_ctr_drbg_random,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -866,15 +866,16 @@ cleanup:
     return rc;
 }
 
-#define LIBSSH2_MBEDTLS_ECDSA_VERIFY(digest_type)                             \
-{                                                                             \
-    size_t hshlen = SHA##digest_type##_DIGEST_LENGTH;                         \
-    unsigned char hsh[hshlen];                                                \
-                                                                              \
-    if(libssh2_sha##digest_type(m, m_len, hsh) == 0) {                        \
-        rc = mbedtls_ecdsa_verify(&ctx->grp, hsh, hshlen, &ctx->Q, &pr, &ps); \
-    }                                                                         \
-                                                                              \
+#define LIBSSH2_MBEDTLS_ECDSA_VERIFY(digest_type)                   \
+{                                                                   \
+    unsigned char hsh[SHA##digest_type##_DIGEST_LENGTH];            \
+                                                                    \
+    if(libssh2_sha##digest_type(m, m_len, hsh) == 0) {              \
+        rc = mbedtls_ecdsa_verify(&ctx->grp, hsh,                   \
+                                  SHA##digest_type##_DIGEST_LENGTH, \
+                                  &ctx->Q, &pr, &ps);               \
+    }                                                               \
+                                                                    \
 }
 
 /* _libssh2_ecdsa_sign

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1114,12 +1114,17 @@ _libssh2_mbedtls_mpi_write_binary(unsigned char *buf,
 {
     unsigned char *p = buf;
 
-    p += 4;
+    if(strlen((const char *) p) > 3) {
+        p += 4;
+    }
+
     *p = 0;
 
-    mbedtls_mpi_write_binary(mpi, p + 1, bytes - 1);
+    if(bytes > 0) {
+        mbedtls_mpi_write_binary(mpi, p + 1, bytes - 1);
+    }
 
-    if(!(*(p + 1) & 0x80)) {
+    if(bytes > 0 && !(*(p + 1) & 0x80)) {
         memmove(p, p + 1, --bytes);
     }
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -565,6 +565,9 @@ _libssh2_mbedtls_ecdsa_sign(LIBSSH2_SESSION *session,
                             size_t *signature_len);
 libssh2_curve_type
 _libssh2_mbedtls_ecdsa_key_get_curve_type(libssh2_ecdsa_ctx *ctx);
+int
+_libssh2_mbedtls_ecdsa_curve_type_from_name(const char *name,
+                                            libssh2_curve_type *type);
 void
 _libssh2_mbedtls_ecdsa_free(libssh2_ecdsa_ctx *ctx);
 #endif /* LIBSSH2_ECDSA */

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -45,6 +45,12 @@
 #include <mbedtls/rsa.h>
 #include <mbedtls/bignum.h>
 #include <mbedtls/cipher.h>
+#ifdef MBEDTLS_ECDH_C
+# include <mbedtls/ecdh.h>
+#endif
+#ifdef MBEDTLS_ECDSA_C
+# include <mbedtls/ecdsa.h>
+#endif
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/pk.h>
@@ -66,7 +72,11 @@
 
 #define LIBSSH2_RSA             1
 #define LIBSSH2_DSA             0
-#define LIBSSH2_ECDSA           0
+#ifdef MBEDTLS_ECDSA_C
+# define LIBSSH2_ECDSA          1
+#else
+# define LIBSSH2_ECDSA          0
+#endif
 #define LIBSSH2_ED25519         0
 
 #define MD5_DIGEST_LENGTH      16
@@ -77,10 +87,6 @@
 
 #define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
-#if LIBSSH2_ECDSA
-#else
-#define _libssh2_ec_key void
-#endif
 
 /*******************************************************************/
 /*
@@ -210,9 +216,10 @@
 #define libssh2_md5(data, datalen, hash) \
   _libssh2_mbedtls_hash(data, datalen, MBEDTLS_MD_MD5, hash)
 
+
 /*******************************************************************/
 /*
- * mbedTLS backend: RSA structure
+ * mbedTLS backend: RSA functions
  */
 
 #define libssh2_rsa_ctx  mbedtls_rsa_context
@@ -241,6 +248,82 @@
 #define _libssh2_rsa_free(rsactx) \
   _libssh2_mbedtls_rsa_free(rsactx)
 
+
+/*******************************************************************/
+/*
+ * mbedTLS backend: ECDSA structures
+ */
+
+#if LIBSSH2_ECDSA
+
+typedef enum {
+#ifdef MBEDTLS_ECP_DP_SECP256R1_ENABLED
+    LIBSSH2_EC_CURVE_NISTP256 = MBEDTLS_ECP_DP_SECP256R1,
+#else
+    LIBSSH2_EC_CURVE_NISTP256 = MBEDTLS_ECP_DP_NONE,
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP384R1_ENABLED
+    LIBSSH2_EC_CURVE_NISTP384 = MBEDTLS_ECP_DP_SECP384R1,
+#else
+    LIBSSH2_EC_CURVE_NISTP384 = MBEDTLS_ECP_DP_NONE,
+#endif
+#ifdef MBEDTLS_ECP_DP_SECP521R1_ENABLED
+    LIBSSH2_EC_CURVE_NISTP521 = MBEDTLS_ECP_DP_SECP521R1
+#else
+    LIBSSH2_EC_CURVE_NISTP521 = MBEDTLS_ECP_DP_NONE,
+#endif
+} libssh2_curve_type;
+
+# define _libssh2_ec_key mbedtls_ecp_keypair
+#else
+# define _libssh2_ec_key void
+#endif /* LIBSSH2_ECDSA */
+
+
+/*******************************************************************/
+/*
+ * mbedTLS backend: ECDSA functions
+ */
+
+#if LIBSSH2_ECDSA
+
+#define libssh2_ecdsa_ctx mbedtls_ecdsa_context
+
+#define _libssh2_ecdsa_create_key(session, privkey, pubkey_octal, \
+                                  pubkey_octal_len, curve) \
+  _libssh2_mbedtls_ecdsa_create_key(session, privkey, pubkey_octal, \
+                                    pubkey_octal_len, curve)
+
+#define _libssh2_ecdsa_curve_name_with_octal_new(ctx, k, k_len, curve) \
+  _libssh2_mbedtls_ecdsa_curve_name_with_octal_new(ctx, k, k_len, curve)
+
+#define _libssh2_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len) \
+  _libssh2_mbedtls_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len)
+
+#define _libssh2_ecdsa_verify(ctx, r, r_len, s, s_len, m, m_len) \
+  _libssh2_mbedtls_ecdsa_verify(ctx, r, r_len, s, s_len, m, m_len)
+
+#define _libssh2_ecdsa_new_private(ctx, session, filename, passphrase) \
+  _libssh2_mbedtls_ecdsa_new_private(ctx, session, filename, passphrase)
+
+#define _libssh2_ecdsa_new_private_frommemory(ctx, session, filedata, \
+                                              filedata_len, passphrase) \
+  _libssh2_mbedtls_ecdsa_new_private_frommemory(ctx, session, filedata, \
+                                                filedata_len, passphrase)
+
+#define _libssh2_ecdsa_sign(session, ctx, hash, hash_len, sign, sign_len) \
+  _libssh2_mbedtls_ecdsa_sign(session, ctx, hash, hash_len, sign, sign_len)
+
+#define _libssh2_ecdsa_get_curve_type(ctx) \
+  _libssh2_mbedtls_ecdsa_get_curve_type(ctx)
+
+#define _libssh2_ecdsa_free(ctx) \
+  _libssh2_mbedtls_ecdsa_free(ctx)
+
+#endif /* LIBSSH2_ECDSA */
+
+
+/*******************************************************************/
 /*
  * mbedTLS backend: Key functions
  */
@@ -253,10 +336,11 @@
                                                       pk, pk_len, pw)
 
 
- /*******************************************************************/
+/*******************************************************************/
 /*
  * mbedTLS backend: Cipher Context structure
  */
+
 #define _libssh2_cipher_ctx         mbedtls_cipher_context_t
 
 #define _libssh2_cipher_type(algo)  mbedtls_cipher_type_t algo
@@ -272,6 +356,8 @@
 #define _libssh2_cipher_cast5     MBEDTLS_CIPHER_NULL
 #define _libssh2_cipher_3des      MBEDTLS_CIPHER_DES_EDE3_CBC
 
+
+/*******************************************************************/
 /*
  * mbedTLS backend: Cipher functions
  */
@@ -331,6 +417,7 @@
 /*
  * mbedTLS backend: forward declarations
  */
+
 void
 _libssh2_mbedtls_init(void);
 
@@ -436,6 +523,51 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                        const char *privatekeydata,
                                        size_t privatekeydata_len,
                                        const char *passphrase);
+#if LIBSSH2_ECDSA
+int
+_libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
+                                  _libssh2_ec_key **privkey,
+                                  unsigned char **pubkey_octal,
+                                  size_t *pubkey_octal_len,
+                                  libssh2_curve_type curve);
+int
+_libssh2_mbedtls_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx **ctx,
+                                                 const unsigned char *k,
+                                                 size_t k_len,
+                                                 libssh2_curve_type curve);
+int
+_libssh2_mbedtls_ecdh_gen_k(_libssh2_bn **k,
+                            _libssh2_ec_key *privkey,
+                            const unsigned char *server_pubkey,
+                            size_t server_pubkey_len);
+int
+_libssh2_mbedtls_ecdsa_verify(libssh2_ecdsa_ctx *ctx,
+                              const unsigned char *r, size_t r_len,
+                              const unsigned char *s, size_t s_len,
+                              const unsigned char *m, size_t m_len);
+int
+_libssh2_mbedtls_ecdsa_new_private(libssh2_ecdsa_ctx **ctx,
+                                  LIBSSH2_SESSION *session,
+                                  const char *filename,
+                                  const unsigned char *passphrase);
+int
+_libssh2_mbedtls_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ctx,
+                                              LIBSSH2_SESSION *session,
+                                              const char *filedata,
+                                              size_t filedata_len,
+                                              const unsigned char *passphrase);
+int
+_libssh2_mbedtls_ecdsa_sign(LIBSSH2_SESSION *session,
+                            libssh2_ecdsa_ctx *ctx,
+                            const unsigned char *hash,
+                            unsigned long hash_len,
+                            unsigned char **signature,
+                            size_t *signature_len);
+libssh2_curve_type
+_libssh2_mbedtls_ecdsa_key_get_curve_type(libssh2_ecdsa_ctx *ctx);
+void
+_libssh2_mbedtls_ecdsa_free(libssh2_ecdsa_ctx *ctx);
+#endif /* LIBSSH2_ECDSA */
 
 extern void
 _libssh2_dh_init(_libssh2_dh_ctx *dhctx);


### PR DESCRIPTION
## About

This PR adds support for `ECDSA` for both key exchange and host key algorithms.

The following elliptic curves are supported:
- 256-bit curve defined by FIPS 186-4 and SEC1
- 384-bit curve defined by FIPS 186-4 and SEC1
- 521-bit curve defined by FIPS 186-4 and SEC1