### PR TITLE
userauth: fix off by one error when loading public keys with no id

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -629,7 +629,7 @@ file_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
 
     sp1++;
 
-    sp_len = sp1 > pubkey ? (sp1 - pubkey) - 1 : 0;
+    sp_len = sp1 > pubkey ? (sp1 - pubkey) : 0;
     sp2 = memchr(sp1, ' ', pubkey_len - sp_len);
     if(sp2 == NULL) {
         /* Assume that the id string is missing, but that it's okay */


### PR DESCRIPTION
Caught by ASAN:

```
=================================================================
==73797==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60700001bcf0 at pc 0x00010026198d bp 0x7ffeefbfed30 sp 0x7ffeefbfe4d8
READ of size 69 at 0x60700001bcf0 thread T0
2019-07-04 08:35:30.292502+0200 atos[73890:2639175] examining /Users/USER/*/libssh2_clar [73797]
    #0 0x10026198c in wrap_memchr (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1f98c)
    #1 0x1000f8e66 in file_read_publickey userauth.c:633
    #2 0x1000f2dc9 in userauth_publickey_fromfile userauth.c:1513
    #3 0x1000f2948 in libssh2_userauth_publickey_fromfile_ex userauth.c:1590
    #4 0x10000e254 in test_userauth_publickey__ed25519_auth_ok publickey.c:69
    #5 0x1000090c3 in clar_run_test clar.c:260
    #6 0x1000038f3 in clar_run_suite clar.c:343
    #7 0x100003272 in clar_test_run clar.c:522
    #8 0x10000c3cc in main runner.c:60
    #9 0x7fff5b43b3d4 in start (libdyld.dylib:x86_64+0x163d4)

0x60700001bcf0 is located 0 bytes to the right of 80-byte region [0x60700001bca0,0x60700001bcf0)
allocated by thread T0 here:
    #0 0x10029e053 in wrap_malloc (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x5c053)
    #1 0x1000b4978 in libssh2_default_alloc session.c:67
    #2 0x1000f8aba in file_read_publickey userauth.c:597
    #3 0x1000f2dc9 in userauth_publickey_fromfile userauth.c:1513
    #4 0x1000f2948 in libssh2_userauth_publickey_fromfile_ex userauth.c:1590
    #5 0x10000e254 in test_userauth_publickey__ed25519_auth_ok publickey.c:69
    #6 0x1000090c3 in clar_run_test clar.c:260
    #7 0x1000038f3 in clar_run_suite clar.c:343
    #8 0x100003272 in clar_test_run clar.c:522
    #9 0x10000c3cc in main runner.c:60
    #10 0x7fff5b43b3d4 in start (libdyld.dylib:x86_64+0x163d4)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1f98c) in wrap_memchr
Shadow bytes around the buggy address:
  0x1c0e00003740: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fd fd
  0x1c0e00003750: fd fd fd fd fd fd fd fa fa fa fa fa 00 00 00 00
  0x1c0e00003760: 00 00 00 00 00 00 fa fa fa fa 00 00 00 00 00 00
  0x1c0e00003770: 00 00 00 fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x1c0e00003780: fd fd fa fa fa fa fd fd fd fd fd fd fd fd fd fa
=>0x1c0e00003790: fa fa fa fa 00 00 00 00 00 00 00 00 00 00[fa]fa
  0x1c0e000037a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0e000037b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0e000037c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0e000037d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0e000037e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
```