### PR TITLE
Add support for an OSS Fuzzer fuzzing target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ env:
    - ADDRESS_SIZE=32 CRYPTO_BACKEND=mbedTLS BUILD_SHARED_LIBS=ON ENABLE_ZLIB_COMPRESSION=OFF B=cmake
    - ADDRESS_SIZE=32 CRYPTO_BACKEND=mbedTLS BUILD_SHARED_LIBS=OFF ENABLE_ZLIB_COMPRESSION=ON B=cmake
    - ADDRESS_SIZE=32 CRYPTO_BACKEND=mbedTLS BUILD_SHARED_LIBS=ON ENABLE_ZLIB_COMPRESSION=ON B=cmake
+   - B=fuzzer
 
 before_install:
   - if [ $ADDRESS_SIZE = '32' ]; then sudo dpkg --add-architecture i386; fi
@@ -115,6 +116,10 @@ script:
         mkdir bin
         cd bin
         cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION .. && cmake --build . && CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --target test && cmake --build . --target package
+      fi
+  - |
+      if [ "$B" = "fuzzer" ]; then
+        ./tests/ossfuzz/travisoss.sh
       fi
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,7 @@ AC_SEARCH_LIBS(inet_addr, nsl)
 AC_SUBST(LIBS)
 
 AC_PROG_CC
+AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
@@ -284,6 +285,21 @@ esac], [build_examples='yes'])
 AC_MSG_RESULT($build_examples)
 AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$build_examples" != "xno"])
 
+
+# Build OSS fuzzing targets?
+AC_ARG_ENABLE([ossfuzzers],
+  [AS_HELP_STRING([--enable-ossfuzzers],
+    [Whether to generate the fuzzers for OSS-Fuzz])],
+  [have_ossfuzzers=yes], [have_ossfuzzers=no])
+AM_CONDITIONAL([USE_OSSFUZZERS], [test "x$have_ossfuzzers" = "xyes"])
+
+
+# Set the correct flags for the given fuzzing engine.
+AC_SUBST([LIB_FUZZING_ENGINE])
+AM_CONDITIONAL([USE_OSSFUZZ_FLAG], [test "x$LIB_FUZZING_ENGINE" = "x-fsanitize=fuzzer"])
+AM_CONDITIONAL([USE_OSSFUZZ_STATIC], [test -f "$LIB_FUZZING_ENGINE"])
+
+
 # Checks for header files.
 # AC_HEADER_STDC
 AC_CHECK_HEADERS([errno.h fcntl.h stdio.h stdlib.h unistd.h sys/uio.h])
@@ -373,6 +389,7 @@ LIBSSH2_CHECK_OPTION_WERROR
 AC_CONFIG_FILES([Makefile
                  src/Makefile
                  tests/Makefile
+                 tests/ossfuzz/Makefile
                  example/Makefile
                  docs/Makefile
                  libssh2.pc])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = ossfuzz
+
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include -I$(top_builddir)/src
 LDADD = ../src/libssh2.la
 

--- a/tests/ossfuzz/.gitignore
+++ b/tests/ossfuzz/.gitignore
@@ -1,0 +1,2 @@
+*.a
+ssh2_client_fuzzer

--- a/tests/ossfuzz/Makefile.am
+++ b/tests/ossfuzz/Makefile.am
@@ -1,0 +1,32 @@
+AM_CPPFLAGS = -I$(top_builddir)/include
+LDADD = $(top_builddir)/src/libssh2.la
+
+if USE_OSSFUZZ_FLAG
+FUZZ_FLAG = $(LIB_FUZZING_ENGINE)
+else
+if USE_OSSFUZZ_STATIC
+LDADD += $(LIB_FUZZING_ENGINE)
+FUZZ_FLAG =
+else
+LDADD += libstandaloneengine.a
+FUZZ_FLAG =
+endif
+endif
+
+noinst_PROGRAMS =
+noinst_LIBRARIES =
+
+if USE_OSSFUZZERS
+noinst_PROGRAMS += \
+	ssh2_client_fuzzer
+
+noinst_LIBRARIES += \
+	libstandaloneengine.a
+endif
+
+ssh2_client_fuzzer_SOURCES = ssh2_client_fuzzer.cc testinput.h
+ssh2_client_fuzzer_CXXFLAGS = $(AM_CXXFLAGS) $(FUZZ_FLAG)
+ssh2_client_fuzzer_LDFLAGS = $(AM_LDFLAGS) -static
+
+libstandaloneengine_a_SOURCES = standaloneengine.cc
+libstandaloneengine_a_CXXFLAGS = $(AM_CXXFLAGS)

--- a/tests/ossfuzz/ossfuzz.sh
+++ b/tests/ossfuzz/ossfuzz.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+
+# This script is called by the oss-fuzz main project when compiling the fuzz
+# targets. This script is regression tested by travisoss.sh.
+
+# Save off the current folder as the build root.
+export BUILD_ROOT=$PWD
+
+echo "CC: $CC"
+echo "CXX: $CXX"
+echo "LIB_FUZZING_ENGINE: $LIB_FUZZING_ENGINE"
+echo "CFLAGS: $CFLAGS"
+echo "CXXFLAGS: $CXXFLAGS"
+echo "OUT: $OUT"
+
+export MAKEFLAGS+="-j$(nproc)"
+
+# Install dependencies
+apt-get -y install automake libtool libssl-dev zlib1g-dev
+
+# Compile the fuzzer.
+./buildconf
+./configure --disable-shared \
+            --enable-ossfuzzers \
+            --disable-examples-build \
+            --enable-debug
+make V=1
+
+# Copy the fuzzer to the output directory.
+cp -v tests/ossfuzz/ssh2_client_fuzzer $OUT/

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -1,0 +1,74 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <libssh2.h>
+#include "testinput.h"
+
+#define FUZZ_ASSERT(COND)                                                     \
+        if(!(COND))                                                           \
+        {                                                                     \
+          fprintf(stderr, "Assertion failed: " #COND "\n%s",                  \
+                  strerror(errno));                                           \
+          assert((COND));                                                     \
+        }
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  int socket_fds[2] = {-1, -1};
+  ssize_t written;
+  int rc;
+  LIBSSH2_SESSION *session = NULL;
+  int handshake_completed = 0;
+
+  rc = libssh2_init(0);
+
+  if(rc != 0) {
+    fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
+    goto EXIT_LABEL;
+  }
+
+  // Create a socket pair so data can be sent in.
+  rc = socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds);
+  FUZZ_ASSERT(rc == 0);
+
+  written = send(socket_fds[1], data, size, 0);
+  FUZZ_ASSERT(written == size);
+
+  rc = shutdown(socket_fds[1], SHUT_WR);
+  FUZZ_ASSERT(rc == 0);
+
+  // Create a session and start the handshake using the fuzz data passed in.
+  session = libssh2_session_init();
+
+  if(libssh2_session_handshake(session, socket_fds[0])) {
+    goto EXIT_LABEL;
+  }
+
+  // If we get here the handshake actually completed.
+  handshake_completed = 1;
+
+EXIT_LABEL:
+
+  if (session != NULL)
+  {
+    if (handshake_completed)
+    {
+      libssh2_session_disconnect(session,
+                                 "Normal Shutdown, Thank you for playing");
+    }
+
+    libssh2_session_free(session);
+  }
+
+  libssh2_exit();
+
+  close(socket_fds[0]);
+  close(socket_fds[1]);
+
+  return 0;
+}

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -37,10 +37,23 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   FUZZ_ASSERT(rc == 0);
 
   written = send(socket_fds[1], data, size, 0);
-  FUZZ_ASSERT(written == size);
+
+  if (written != size)
+  {
+    // Handle whatever error case we're in.
+    fprintf(stderr, "send() of %zu bytes returned %zu (%d)\n",
+            size,
+            written,
+            errno);
+    goto EXIT_LABEL;
+  }
 
   rc = shutdown(socket_fds[1], SHUT_WR);
-  FUZZ_ASSERT(rc == 0);
+  if (rc != 0)
+  {
+    fprintf(stderr, "socket shutdown failed (%d)\n", rc);
+    goto EXIT_LABEL;
+  }
 
   // Create a session and start the handshake using the fuzz data passed in.
   session = libssh2_session_init();

--- a/tests/ossfuzz/standaloneengine.cc
+++ b/tests/ossfuzz/standaloneengine.cc
@@ -1,0 +1,74 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "testinput.h"
+
+/**
+ * Main procedure for standalone fuzzing engine.
+ *
+ * Reads filenames from the argument array. For each filename, read the file
+ * into memory and then call the fuzzing interface with the data.
+ */
+int main(int argc, char **argv)
+{
+  int ii;
+  for(ii = 1; ii < argc; ii++)
+  {
+    FILE *infile;
+    printf("[%s] ", argv[ii]);
+
+    /* Try and open the file. */
+    infile = fopen(argv[ii], "rb");
+    if(infile)
+    {
+      uint8_t *buffer = NULL;
+      size_t buffer_len;
+
+      printf("Opened.. ");
+
+      /* Get the length of the file. */
+      fseek(infile, 0L, SEEK_END);
+      buffer_len = ftell(infile);
+
+      /* Reset the file indicator to the beginning of the file. */
+      fseek(infile, 0L, SEEK_SET);
+
+      /* Allocate a buffer for the file contents. */
+      buffer = (uint8_t *)calloc(buffer_len, sizeof(uint8_t));
+      if(buffer)
+      {
+        /* Read all the text from the file into the buffer. */
+        fread(buffer, sizeof(uint8_t), buffer_len, infile);
+        printf("Read %zu bytes, fuzzing.. ", buffer_len);
+
+        /* Call the fuzzer with the data. */
+        LLVMFuzzerTestOneInput(buffer, buffer_len);
+
+        printf("complete !!");
+
+        /* Free the buffer as it's no longer needed. */
+        free(buffer);
+        buffer = NULL;
+      }
+      else
+      {
+        fprintf(stderr,
+                "[%s] Failed to allocate %zu bytes \n",
+                argv[ii],
+                buffer_len);
+      }
+
+      /* Close the file as it's no longer needed. */
+      fclose(infile);
+      infile = NULL;
+    }
+    else
+    {
+      /* Failed to open the file. Maybe wrong name or wrong permissions? */
+      fprintf(stderr, "[%s] Open failed. \n", argv[ii]);
+    }
+
+    printf("\n");
+  }
+}

--- a/tests/ossfuzz/testinput.h
+++ b/tests/ossfuzz/testinput.h
@@ -1,0 +1,3 @@
+#include <inttypes.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);

--- a/tests/ossfuzz/travisoss.sh
+++ b/tests/ossfuzz/travisoss.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ex
+
+PROJECT_NAME=libssh2
+
+# Clone the oss-fuzz repository
+git clone https://github.com/google/oss-fuzz.git /tmp/ossfuzz
+
+if [[ ! -d /tmp/ossfuzz/projects/${PROJECT_NAME} ]]
+then
+    echo "Could not find the ${PROJECT_NAME} project in ossfuzz"
+
+    # Exit with a success code while the libssh2 project is not expected to exist
+    # on oss-fuzz.
+    exit 0
+fi
+
+# Modify the oss-fuzz Dockerfile so that we're checking out the current branch on travis.
+sed -i "s@https://github.com/libssh2/libssh2.git@-b $TRAVIS_BRANCH https://github.com/libssh2/libssh2.git@" /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
+
+# Try and build the fuzzers
+pushd /tmp/ossfuzz
+python infra/helper.py build_image --pull ${PROJECT_NAME}
+python infra/helper.py build_fuzzers ${PROJECT_NAME}
+popd


### PR DESCRIPTION
This adds support for an OSS-Fuzz fuzzing target in ssh2_client_fuzzer,
which is a cut down example of ssh2.c. Future enhancements can improve
coverage.

---

I've tested this with the oss-fuzz framework and it appears to find repeated READ access bugs in one particular function, so I think it's definitely worth getting in!