### PR TITLE
global.c : fixed call to libssh2_crypto_exit #394

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -62,7 +62,7 @@ libssh2_exit(void)
 
     _libssh2_initialized--;
 
-    if(!(_libssh2_init_flags & LIBSSH2_INIT_NO_CRYPTO)) {
+    if(_libssh2_initialized == 0 && !(_libssh2_init_flags & LIBSSH2_INIT_NO_CRYPTO)) {
         libssh2_crypto_exit();
     }
 

--- a/src/global.c
+++ b/src/global.c
@@ -62,7 +62,8 @@ libssh2_exit(void)
 
     _libssh2_initialized--;
 
-    if(_libssh2_initialized == 0 && !(_libssh2_init_flags & LIBSSH2_INIT_NO_CRYPTO)) {
+    if(_libssh2_initialized == 0 &&
+       !(_libssh2_init_flags & LIBSSH2_INIT_NO_CRYPTO)) {
         libssh2_crypto_exit();
     }
 


### PR DESCRIPTION
File: global.c 

Notes: Don't call `libssh2_crypto_exit()` until `_libssh2_initialized` count is down to zero.

Credit: seba30