### PR TITLE
packet.c: improve message parsing

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -419,8 +419,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     size_t datalen, int macstate)
 {
     int rc = 0;
-    char *message = NULL;
-    char *language = NULL;
+    unsigned char *message = NULL;
+    unsigned char *language = NULL;
     size_t message_len = 0;
     size_t language_len = 0;
     LIBSSH2_CHANNEL *channelp = NULL;
@@ -472,33 +472,23 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
         case SSH_MSG_DISCONNECT:
             if(datalen >= 5) {
-                size_t reason = _libssh2_ntohu32(data + 1);
+                uint32_t reason = 0;
+                struct string_buf buf;
+                buf.data = (unsigned char *)data;
+                buf.dataptr = buf.data;
+                buf.len = datalen;
+                buf.dataptr++; /* advance past type */
 
-                if(datalen >= 9) {
-                    message_len = _libssh2_ntohu32(data + 5);
+                _libssh2_get_u32(&buf, &reason);
+                _libssh2_get_string(&buf, &message, &message_len);
+                _libssh2_get_string(&buf, &language, &language_len);
 
-                    if(message_len < datalen-13) {
-                        /* 9 = packet_type(1) + reason(4) + message_len(4) */
-                        message = (char *) data + 9;
-
-                        language_len =
-                            _libssh2_ntohu32(data + 9 + message_len);
-                        language = (char *) data + 9 + message_len + 4;
-
-                        if(language_len > (datalen-13-message_len)) {
-                            /* bad input, clear info */
-                            language = message = NULL;
-                            language_len = message_len = 0;
-                        }
-                    }
-                    else
-                        /* bad size, clear it */
-                        message_len = 0;
-                }
                 if(session->ssh_msg_disconnect) {
-                    LIBSSH2_DISCONNECT(session, reason, message,
-                                       message_len, language, language_len);
+                    LIBSSH2_DISCONNECT(session, reason, (const char *)message,
+                                       message_len, (const char *)language,
+                                       language_len);
                 }
+
                 _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
                                "Disconnect(%d): %s(%s)", reason,
                                message, language);

--- a/src/packet.c
+++ b/src/packet.c
@@ -537,7 +537,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
         case SSH_MSG_DEBUG:
             if(datalen >= 2) {
                 int always_display = data[1];
-            
+
                 if(datalen >= 6) {
                     struct string_buf buf;
                     buf.data = (unsigned char *)data;

--- a/src/packet.c
+++ b/src/packet.c
@@ -569,7 +569,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 uint32_t len = 0;
                 unsigned char want_reply = 0;
                 len = _libssh2_ntohu32(data + 1);
-                if((len <= (UINT_MAX - 6) && (datalen >= (6 + len))) {
+                if(len <= (UINT_MAX - 6) && datalen >= (6 + len)) {
                     want_reply = data[5 + len];
                     _libssh2_debug(session,
                                    LIBSSH2_TRACE_CONN,

--- a/src/packet.c
+++ b/src/packet.c
@@ -569,7 +569,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 uint32_t len = 0;
                 unsigned char want_reply = 0;
                 len = _libssh2_ntohu32(data + 1);
-                if(len <= (UINT_MAX - 6) && datalen >= (6 + len)) {
+                if((len <= (UINT_MAX - 6)) && (datalen >= (6 + len))) {
                     want_reply = data[5 + len];
                     _libssh2_debug(session,
                                    LIBSSH2_TRACE_CONN,


### PR DESCRIPTION
file: packet.c

notes:
Use _libssh2_get_string API in SSH_MSG_DEBUG, additional uint32 bounds check in SSH_MSG_GLOBAL_REQUEST