### PR TITLE
Fix memory leakage in _libssh2_EVP_aes_128_ctr

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -589,8 +589,14 @@ const EVP_CIPHER *
 _libssh2_EVP_aes_128_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_CIPHER * aes_ctr_cipher;
-    return make_ctr_evp(16, &aes_ctr_cipher, NID_aes_128_ctr);
+    static EVP_CIPHER * aes_ctr_cipher = NULL;
+
+    if(!aes_ctr_cipher) {
+        return make_ctr_evp(16, &aes_ctr_cipher, NID_aes_128_ctr);
+    }
+    else {
+        return aes_ctr_cipher;
+    }
 #else
     static EVP_CIPHER aes_ctr_cipher;
     EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
@@ -602,8 +608,14 @@ const EVP_CIPHER *
 _libssh2_EVP_aes_192_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_CIPHER * aes_ctr_cipher;
-    return make_ctr_evp(24, &aes_ctr_cipher, NID_aes_192_ctr);
+    static EVP_CIPHER * aes_ctr_cipher = NULL;
+
+    if(!aes_ctr_cipher) {
+        return make_ctr_evp(24, &aes_ctr_cipher, NID_aes_192_ctr);
+    }
+    else {
+        return aes_ctr_cipher;
+    }
 #else
     static EVP_CIPHER aes_ctr_cipher;
     EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
@@ -615,8 +627,14 @@ const EVP_CIPHER *
 _libssh2_EVP_aes_256_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_CIPHER * aes_ctr_cipher;
-    return make_ctr_evp(32, &aes_ctr_cipher, NID_aes_256_ctr);
+    static EVP_CIPHER * aes_ctr_cipher = NULL;
+
+    if(!aes_ctr_cipher) {
+        return make_ctr_evp(32, &aes_ctr_cipher, NID_aes_256_ctr);
+    }
+    else {
+        return aes_ctr_cipher;
+    }
 #else
     static EVP_CIPHER aes_ctr_cipher;
     EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;


### PR DESCRIPTION
This problem is caused by _libssh2_EVP_aes_128_ctr, it get called several times, as a result, cipher get constructed several times. Seen from openssl RC4 example, the intended usage is construct only one time.

Backtrace A:

    example-sftpdir.exe!_libssh2_EVP_aes_128_ctr() Line 594 C
    example-sftpdir.exe!_libssh2_openssl_crypto_init() Line 672 C
    example-sftpdir.exe!libssh2_init(int flags) Line 51 C
    example-sftpdir.exe!main(int argc, char * * argv) Line 111 C

Backtrace B:

    example-sftpdir.exe!_libssh2_EVP_aes_128_ctr() Line 594 C
    example-sftpdir.exe!_libssh2_cipher_init(evp_cipher_ctx_st * * h, const evp_cipher_st ()() algo, unsigned char * iv, unsigned char * secret, int encrypt) Line 408 C
    example-sftpdir.exe!crypt_init(_LIBSSH2_SESSION * session, const _LIBSSH2_CRYPT_METHOD * method, unsigned char * iv, int * free_iv, unsigned char * secret, int * free_secret, int encrypt, void * * abstract) Line 88 C
    example-sftpdir.exe!ecdh_sha2_nistp(_LIBSSH2_SESSION * session, libssh2_curve_type type, unsigned char * data, unsigned int data_len, unsigned char * public_key, unsigned int public_key_len, ec_key_st * private_key, kmdhgGPshakex_state_t * exchange_state) Line 2344 C
    example-sftpdir.exe!kex_method_ecdh_key_exchange(_LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state) Line 2607 C
    example-sftpdir.exe!_libssh2_kex_exchange(_LIBSSH2_SESSION * session, int reexchange, key_exchange_state_t * key_state) Line 4149 C
    example-sftpdir.exe!session_startup(_LIBSSH2_SESSION * session, unsigned int sock) Line 739 C
    example-sftpdir.exe!libssh2_session_handshake(_LIBSSH2_SESSION * session, unsigned int sock) Line 827 C
    example-sftpdir.exe!main(int argc, char * * argv) Line 142 C