### PR TITLE
Fix name clash with ZLIB macro "compress"

### DIFF
--- a/src/comp.c
+++ b/src/comp.c
@@ -369,6 +369,7 @@ static const LIBSSH2_COMP_METHOD *no_comp_methods[] = {
 const LIBSSH2_COMP_METHOD **
 _libssh2_comp_methods(LIBSSH2_SESSION *session)
 {
+    #undef compress /* dodge name clash with ZLIB macro */
     if(session->flag.compress)
         return comp_methods;
     else

--- a/src/comp.c
+++ b/src/comp.c
@@ -38,7 +38,8 @@
 
 #include "libssh2_priv.h"
 #ifdef LIBSSH2_HAVE_ZLIB
-# include <zlib.h>
+#include <zlib.h>
+#undef compress /* dodge name clash with ZLIB macro */
 #endif
 
 #include "comp.h"
@@ -369,7 +370,6 @@ static const LIBSSH2_COMP_METHOD *no_comp_methods[] = {
 const LIBSSH2_COMP_METHOD **
 _libssh2_comp_methods(LIBSSH2_SESSION *session)
 {
-    #undef compress /* dodge name clash with ZLIB macro */
     if(session->flag.compress)
         return comp_methods;
     else


### PR DESCRIPTION
Hi,

when libssh2 is compiled with ZLIB support, and ZLIB happens to be compiled with the Z_PREFIX_ macro set, the compress function name (which is a macro) is replaced with "prefix_compress", and comp.c fails to compile:

comp.c(390,23): error C2039: 'wx_zlib_compress': is not a member of 'flags'

In my case the Z_PREFIX_ = "wx_zlib_" is coming from the GUI library (wxWidgets) which is packaging zlib. The attached patch fixes the problem in a minimal way. But if it is still too ugly, maybe the _LIBSSH2_SESSION :: flags :: compress member should be renamed instead?

Best, Zenju