### PR TITLE
scp: fix state when empty channel is returned

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -2616,6 +2616,7 @@ kex_method_ecdh_key_exchange
         }
 
         LIBSSH2_FREE(session, key_state->data);
+        key_state->data = NULL;
     }
 
 ecdh_clean_exit:

--- a/src/scp.c
+++ b/src/scp.c
@@ -755,7 +755,10 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
         _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                        "Unexpected channel close");
     else
+    {
+        session->scpRecv_state = libssh2_NB_state_idle;
         return session->scpRecv_channel;
+    }
     /* fall-through */
   scp_recv_error:
     tmp_err_code = session->err_code;
@@ -1099,7 +1102,10 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
                        "Unexpected channel close");
     }
     else
+    {
+        session->scpSend_state = libssh2_NB_state_idle;
         return session->scpSend_channel;
+    }
     /* fall-through */
   scp_send_error:
     tmp_err_code = session->err_code;

--- a/src/scp.c
+++ b/src/scp.c
@@ -754,8 +754,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
     if(libssh2_channel_eof(session->scpRecv_channel))
         _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                        "Unexpected channel close");
-    else
-    {
+    else {
         session->scpRecv_state = libssh2_NB_state_idle;
         return session->scpRecv_channel;
     }
@@ -1101,8 +1100,7 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
         _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                        "Unexpected channel close");
     }
-    else
-    {
+    else {
         session->scpSend_state = libssh2_NB_state_idle;
         return session->scpSend_channel;
     }

--- a/src/session.c
+++ b/src/session.c
@@ -985,7 +985,8 @@ session_free(LIBSSH2_SESSION *session)
     /* Free startup_key_state.key_state_low variables */
 #if LIBSSH2_ECDSA
     if(session->startup_key_state.key_state_low.private_key != NULL)
-        _libssh2_ecdsa_free(session->startup_key_state.key_state_low.private_key);
+        _libssh2_ecdsa_free(
+		session->startup_key_state.key_state_low.private_key);
 #endif
     if(session->startup_key_state.key_state_low.public_key_oct != NULL)
        free(session->startup_key_state.key_state_low.public_key_oct);

--- a/src/session.c
+++ b/src/session.c
@@ -986,7 +986,7 @@ session_free(LIBSSH2_SESSION *session)
 #if LIBSSH2_ECDSA
     if(session->startup_key_state.key_state_low.private_key)
         _libssh2_ecdsa_free(
-               session->startup_key_state.key_state_low.private_key);
+                         session->startup_key_state.key_state_low.private_key);
 #endif
     if(session->startup_key_state.key_state_low.public_key_oct)
         free(session->startup_key_state.key_state_low.public_key_oct);

--- a/src/session.c
+++ b/src/session.c
@@ -984,11 +984,11 @@ session_free(LIBSSH2_SESSION *session)
 
     /* Free startup_key_state.key_state_low variables */
 #if LIBSSH2_ECDSA
-    if(session->startup_key_state.key_state_low.private_key != NULL)
+    if(session->startup_key_state.key_state_low.private_key)
         _libssh2_ecdsa_free(
                session->startup_key_state.key_state_low.private_key);
 #endif
-    if(session->startup_key_state.key_state_low.public_key_oct != NULL)
+    if(session->startup_key_state.key_state_low.public_key_oct)
         free(session->startup_key_state.key_state_low.public_key_oct);
 
     /*

--- a/src/session.c
+++ b/src/session.c
@@ -989,7 +989,7 @@ session_free(LIBSSH2_SESSION *session)
                session->startup_key_state.key_state_low.private_key);
 #endif
     if(session->startup_key_state.key_state_low.public_key_oct != NULL)
-       free(session->startup_key_state.key_state_low.public_key_oct);
+        free(session->startup_key_state.key_state_low.public_key_oct);
 
     /*
      * Make sure all memory used in the state variables are free

--- a/src/session.c
+++ b/src/session.c
@@ -986,7 +986,7 @@ session_free(LIBSSH2_SESSION *session)
 #if LIBSSH2_ECDSA
     if(session->startup_key_state.key_state_low.private_key != NULL)
         _libssh2_ecdsa_free(
-		session->startup_key_state.key_state_low.private_key);
+               session->startup_key_state.key_state_low.private_key);
 #endif
     if(session->startup_key_state.key_state_low.public_key_oct != NULL)
        free(session->startup_key_state.key_state_low.public_key_oct);

--- a/src/session.c
+++ b/src/session.c
@@ -983,9 +983,10 @@ session_free(LIBSSH2_SESSION *session)
     }
 
     /* Free startup_key_state.key_state_low variables */
+#if LIBSSH2_ECDSA
     if(session->startup_key_state.key_state_low.private_key != NULL)
         _libssh2_ecdsa_free(session->startup_key_state.key_state_low.private_key);
-
+#endif
     if(session->startup_key_state.key_state_low.public_key_oct != NULL)
        free(session->startup_key_state.key_state_low.public_key_oct);
 

--- a/src/session.c
+++ b/src/session.c
@@ -982,6 +982,13 @@ session_free(LIBSSH2_SESSION *session)
         LIBSSH2_FREE(session, session->remote.lang_prefs);
     }
 
+    /* Free startup_key_state.key_state_low variables */
+    if(session->startup_key_state.key_state_low.private_key != NULL)
+        _libssh2_ecdsa_free(session->startup_key_state.key_state_low.private_key);
+
+    if(session->startup_key_state.key_state_low.public_key_oct != NULL)
+       free(session->startup_key_state.key_state_low.public_key_oct);
+
     /*
      * Make sure all memory used in the state variables are free
      */


### PR DESCRIPTION
This allows the calling app to get the stderr data from the channel.
Then when it is closed and free'd, the next call to scp_recv will be in the correct state.
