### PR TITLE
Fix use-after-free crash in openssl backend without memory leak

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -596,7 +596,8 @@ _libssh2_EVP_aes_128_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     return !aes_128_ctr_cipher ?
-        make_ctr_evp(16, &aes_128_ctr_cipher, NID_aes_128_ctr) : aes_128_ctr_cipher;
+        make_ctr_evp(16, &aes_128_ctr_cipher, NID_aes_128_ctr) : 
+        aes_128_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
     static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
@@ -610,7 +611,8 @@ _libssh2_EVP_aes_192_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     return !aes_192_ctr_cipher ?
-        make_ctr_evp(24, &aes_192_ctr_cipher, NID_aes_192_ctr) : aes_192_ctr_cipher;
+        make_ctr_evp(24, &aes_192_ctr_cipher, NID_aes_192_ctr) : 
+        aes_192_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
     static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
@@ -624,7 +626,8 @@ _libssh2_EVP_aes_256_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     return !aes_256_ctr_cipher ?
-        make_ctr_evp(32, &aes_256_ctr_cipher, NID_aes_256_ctr) : aes_256_ctr_cipher;
+        make_ctr_evp(32, &aes_256_ctr_cipher, NID_aes_256_ctr) : 
+        aes_256_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
     static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -596,7 +596,7 @@ _libssh2_EVP_aes_128_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     return !aes_128_ctr_cipher ?
-        make_ctr_evp(16, &aes_128_ctr_cipher, NID_aes_128_ctr) : 
+        make_ctr_evp(16, &aes_128_ctr_cipher, NID_aes_128_ctr) :
         aes_128_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
@@ -611,7 +611,7 @@ _libssh2_EVP_aes_192_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     return !aes_192_ctr_cipher ?
-        make_ctr_evp(24, &aes_192_ctr_cipher, NID_aes_192_ctr) : 
+        make_ctr_evp(24, &aes_192_ctr_cipher, NID_aes_192_ctr) :
         aes_192_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
@@ -626,7 +626,7 @@ _libssh2_EVP_aes_256_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     return !aes_256_ctr_cipher ?
-        make_ctr_evp(32, &aes_256_ctr_cipher, NID_aes_256_ctr) : 
+        make_ctr_evp(32, &aes_256_ctr_cipher, NID_aes_256_ctr) :
         aes_256_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -433,6 +433,12 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
     return ret == 1 ? 0 : 1;
 }
 
+#ifndef HAVE_EVP_AES_128_CTR
+static EVP_CIPHER * aes_128_ctr_cipher = NULL;
+static EVP_CIPHER * aes_192_ctr_cipher = NULL;
+static EVP_CIPHER * aes_256_ctr_cipher = NULL;
+#endif
+
 #if LIBSSH2_AES_CTR && !defined(HAVE_EVP_AES_128_CTR)
 
 #include <openssl/aes.h>
@@ -589,12 +595,13 @@ const EVP_CIPHER *
 _libssh2_EVP_aes_128_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_CIPHER * aes_ctr_cipher;
-    return make_ctr_evp(16, &aes_ctr_cipher, NID_aes_128_ctr);
+    return !aes_128_ctr_cipher ?
+        make_ctr_evp(16, &aes_128_ctr_cipher, NID_aes_128_ctr) : aes_128_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
-    EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
-    return make_ctr_evp(16, &aes_ctr_cipher_ptr, 0);
+    static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
+    return !aes_ctr_cipher.key_len ?
+        make_ctr_evp(16, &aes_ctr_cipher_ptr, 0) : &aes_ctr_cipher;
 #endif
 }
 
@@ -602,12 +609,13 @@ const EVP_CIPHER *
 _libssh2_EVP_aes_192_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_CIPHER * aes_ctr_cipher;
-    return make_ctr_evp(24, &aes_ctr_cipher, NID_aes_192_ctr);
+    return !aes_192_ctr_cipher ?
+        make_ctr_evp(24, &aes_192_ctr_cipher, NID_aes_192_ctr) : aes_192_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
-    EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
-    return make_ctr_evp(24, &aes_ctr_cipher_ptr, 0);
+    static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
+    return !aes_ctr_cipher.key_len ?
+        make_ctr_evp(24, &aes_ctr_cipher_ptr, 0) : &aes_ctr_cipher;
 #endif
 }
 
@@ -615,22 +623,17 @@ const EVP_CIPHER *
 _libssh2_EVP_aes_256_ctr(void)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_CIPHER * aes_ctr_cipher;
-    return make_ctr_evp(32, &aes_ctr_cipher, NID_aes_256_ctr);
+    return !aes_256_ctr_cipher ?
+        make_ctr_evp(32, &aes_256_ctr_cipher, NID_aes_256_ctr) : aes_256_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
-    EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
-    return make_ctr_evp(32, &aes_ctr_cipher_ptr, 0);
+    static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
+    return !aes_ctr_cipher.key_len ?
+        make_ctr_evp(32, &aes_ctr_cipher_ptr, 0) : &aes_ctr_cipher;
 #endif
 }
 
 #endif /* LIBSSH2_AES_CTR */
-
-#ifndef HAVE_EVP_AES_128_CTR
-static EVP_CIPHER * aes_128_ctr_cipher = NULL;
-static EVP_CIPHER * aes_192_ctr_cipher = NULL;
-static EVP_CIPHER * aes_256_ctr_cipher = NULL;
-#endif
 
 void _libssh2_openssl_crypto_init(void)
 {
@@ -650,11 +653,8 @@ void _libssh2_openssl_crypto_init(void)
 #endif
 #endif
 #ifndef HAVE_EVP_AES_128_CTR
-    if(!aes_128_ctr_cipher)
         aes_128_ctr_cipher = (EVP_CIPHER *) _libssh2_EVP_aes_128_ctr();
-    if(!aes_192_ctr_cipher)
         aes_192_ctr_cipher = (EVP_CIPHER *) _libssh2_EVP_aes_192_ctr();
-    if(!aes_256_ctr_cipher)
         aes_256_ctr_cipher = (EVP_CIPHER *) _libssh2_EVP_aes_256_ctr();
 #endif
 }


### PR DESCRIPTION
In pull request 387 a use-after-free crash in openssl backend was fixed, see https://github.com/libssh2/libssh2/pull/387

I can confirm that this crash also happens in my scenario. 

Pull request 387 was merged into master on 12.Jul 2019. The fix from the pull request fixes the use-after-free bug but also introduces a memory leak as it already has been stated in pull request 413, see https://github.com/libssh2/libssh2/pull/413

I also can confirm this memory leak. Pull request 413 was closed without being merged. When I had a look into it, it basically was a step back to the previous situation, so not a suitable solution.

So, after carefully inspecting the source, I think I understood the original intention of the author of the "#ifdef HAVE_OPAQUE_STRUCTS" blocks and fixed the bug according to this intention. Basically the bug was to store the pointer returned by make_ctr_evp in a function scope static pointer instead of the already existing module global static pointer aes_128_ctr_cipher (192 and 256 all the same). This function scope static pointer wasn't (and certainly could not) be zeroed when the struct was feed in some other line of code in some other function.