### PR TITLE
Fix crash with delayed compression (Bitvise 8.37)

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -765,7 +765,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
         ((session->state & LIBSSH2_STATE_AUTHENTICATED) ||
          session->local.comp->use_in_auth);
 
-    if(encrypted && compressed) {
+    if(encrypted && compressed && session->local.comp_abstract) {
         /* the idea here is that these function must fail if the output gets
            larger than what fits in the assigned buffer so thus they don't
            check the input size as we don't know how much it compresses */


### PR DESCRIPTION
Hi,

one of my users is having trouble with crashes in the libssh2 component of my program. The crash is happening inside libssh2_session_handshake() during key exchange:

https://github.com/libssh2/libssh2/blob/f1b6fca89b2c3ca5ea0f47290ad7010d4381bbad/src/transport.c#L768-L779

session->local.comp_abstract is empty, therfore comp_method_zlib_comp() will crash.
To be precise, this is during a second key exchange ("Renegotiating Keys") when compression is active, after a first key exchange had been successful without compression.

The crash can be easily reproduced with the most recent Bitvise 8.37 (https://www.bitvise.com/download-area) when the "delay compression" option is set:

![delayed](https://user-images.githubusercontent.com/7656530/71660333-005b4500-2d4b-11ea-951f-77f93844fd63.PNG)

With the patch attached, the crash is apparently avoided, and the SFTP access seems to work as expected, but I'm not an expert on the subject of "delayed compression" during key exchange. So it would be great if someone with deeper knowledge on the subject could give this patch a proper review to see if this is in fact the right way to fix the crash.

Best, Zenju