### PR TITLE
Revive introduction of libssh2_userauth_banner

### DIFF
--- a/docs/libssh2_userauth_banner.3
+++ b/docs/libssh2_userauth_banner.3
@@ -1,0 +1,25 @@
+.TH libssh2_userauth_banner 3 "27 Nov 2018" "libssh2 0.15" "libssh2 manual"
+.SH NAME
+libssh2_userauth_banner - get the server's pre-auth banner message
+.SH SYNOPSIS
+.nf
+#include <libssh2.h>
+
+char *
+libssh2_userauth_banner(LIBSSH2_SESSION *session,
+                        size_t *banner_len_out);
+.SH DESCRIPTION
+\fIsession\fP - Session instance as returned by
+.BR libssh2_session_init_ex(3)
+
+\fIbanner_len_out\fP - The length of the server banner returned.
+
+After an authentication has been attempted, such as a \fBSSH_USERAUTH_NONE\fP request sent by
+.BR libssh2_userauth_list(3) ,
+this function  can be called to retrieve the pre-auth banner sent by the server. If no such banner is sent, or if an authentication has not yet been attempted, returns NULL.
+.SH RETURN VALUE
+On success a UTF-8 pre-authentication banner message from the server.
+On failure returns NULL.
+.SH SEE ALSO
+.BR libssh2_session_init_ex(3),
+.BR libssh2_userauth_list(3)

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -503,6 +503,7 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_KNOWN_HOSTS               -46
 #define LIBSSH2_ERROR_CHANNEL_WINDOW_FULL       -47
 #define LIBSSH2_ERROR_KEYFILE_AUTH_FAILED       -48
+#define LIBSSH2_ERROR_MISSING_AUTH_BANNER       -49
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV
@@ -611,8 +612,8 @@ LIBSSH2_API const char *libssh2_session_banner_get(LIBSSH2_SESSION *session);
 LIBSSH2_API char *libssh2_userauth_list(LIBSSH2_SESSION *session,
                                         const char *username,
                                         unsigned int username_len);
-LIBSSH2_API char *libssh2_userauth_banner(LIBSSH2_SESSION * session,
-                                          size_t *banner_len_out);
+LIBSSH2_API int libssh2_userauth_banner(LIBSSH2_SESSION* session,
+                                        char **banner_out);
 LIBSSH2_API int libssh2_userauth_authenticated(LIBSSH2_SESSION *session);
 
 LIBSSH2_API int

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -611,6 +611,8 @@ LIBSSH2_API const char *libssh2_session_banner_get(LIBSSH2_SESSION *session);
 LIBSSH2_API char *libssh2_userauth_list(LIBSSH2_SESSION *session,
                                         const char *username,
                                         unsigned int username_len);
+LIBSSH2_API char *libssh2_userauth_banner(LIBSSH2_SESSION * session,
+                                          size_t *banner_len_out);
 LIBSSH2_API int libssh2_userauth_authenticated(LIBSSH2_SESSION *session);
 
 LIBSSH2_API int

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -989,7 +989,7 @@ libssh2_knownhost_init(LIBSSH2_SESSION *session);
 #define LIBSSH2_KNOWNHOST_KEYENC_RAW      (1<<16)
 #define LIBSSH2_KNOWNHOST_KEYENC_BASE64   (2<<16)
 
-/* type of key (3 bits) */
+/* type of key (4 bits) */
 #define LIBSSH2_KNOWNHOST_KEY_MASK         (15<<18)
 #define LIBSSH2_KNOWNHOST_KEY_SHIFT        18
 #define LIBSSH2_KNOWNHOST_KEY_RSA1         (1<<18)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -709,6 +709,8 @@ struct _LIBSSH2_SESSION
     libssh2_nonblocking_states userauth_list_state;
     unsigned char *userauth_list_data;
     size_t userauth_list_data_len;
+    char *userauth_banner;
+    size_t userauth_banner_len;
     packet_requirev_state_t userauth_list_packet_requirev_state;
 
     /* State variables used in libssh2_userauth_password_ex() */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -143,7 +143,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                 methods_len =
                   _libssh2_ntohu32(session->userauth_list_data + 1);
 
-                /* Cap to 512 bytes. */
+                /* Cap to 2048 bytes. */
                 if(methods_len > LIBSSH2_USERAUTH_MAX_BANNER) {
                     _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
                              "Banner length %u exceeds max allowed (%u)",

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -237,24 +237,25 @@ libssh2_userauth_list(LIBSSH2_SESSION * session, const char *user,
  *
  * Retrieve banner message from server, if available.
  * If no such message is sent by the server or if no authentication attempt has
- * been made, this function returns NULL.
+ * been made, this function returns LIBSSH2_ERROR_MISSING_AUTH_BANNER.
  * libssh2_userauth_list makes a "none" authentication attempt and is
  * sufficient to collect the pre-auth banner message.
  *
  * Banner ought to be UTF-8 encoded, and will be truncated to
- * LIBSSH2_USERAUTH_MAX_BANNER bytes. Length will be returned in
- * banner_len_out.
+ * LIBSSH2_USERAUTH_MAX_BANNER bytes.
  */
-LIBSSH2_API char *
-libssh2_userauth_banner(LIBSSH2_SESSION * session,
-                       size_t *banner_len_out)
+LIBSSH2_API int
+libssh2_userauth_banner(LIBSSH2_SESSION* session,
+                        char **banner_out)
 {
-    char *ptr = NULL;
-    if(session->userauth_banner) {
-        ptr = session->userauth_banner;
-        *banner_len_out = session->userauth_banner_len;
+    if(!session->userauth_banner) {
+        return _libssh2_error(session,
+                              LIBSSH2_ERROR_MISSING_AUTH_BANNER,
+                              "Missing authentication banner");
     }
-    return ptr;
+
+    *banner_out = session->userauth_banner;
+    return LIBSSH2_ERROR_NONE;
 }
 
 /*


### PR DESCRIPTION
This PR tries to revive #274 by @dmiller-nmap and @bonsaiviking from late 2018.

It includes bounds checks as requested by @willco007 and merges cleanly with libssh 1.9.0.