### PR TITLE
Fix an LTO -Wundefined warning when mixing with LTO-enabled libcurl.

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -589,7 +589,7 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
     session->err_code = LIBSSH2_ERROR_NONE;
 
     rc = libssh2_keepalive_send(session, &seconds_to_next);
-    if(rc < 0)
+    if(rc)
         return rc;
 
     ms_to_next = seconds_to_next * 1000;


### PR DESCRIPTION
With gcc 9, libssh2, libcurl and LTO enabled for all binaries I see this
warning (error with -Werror):

vssh/libssh2.c: In function ‘ssh_statemach_act’:
/data/mwrep/rgeissler/ospack/ssh2/BUILD/libssh2-libssh2-03c7c4a/src/session.c:579:9: error: ‘seconds_to_next’ is used uninitialized in this function [-Werror=uninitialized]
  579 |     int seconds_to_next;
      |         ^
lto1: all warnings being treated as errors

Gcc normally issues -Wuninitialized when it is sure there is a problem,
and -Wmaybe-uninitialized when it's not sure, but it's possible. Here
the compiler seems to have find a real case where this could happen. I
looked in your code and overall it seems you always check if the return
code is non null, not often that it's below zero. I think we should do
the same here. With this patch, gcc is fine.