### PR TITLE
Fix for use of uninitialized aes_ctr_cipher.key_len

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -600,9 +600,11 @@ _libssh2_EVP_aes_128_ctr(void)
         aes_128_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
-    static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
-    return !aes_ctr_cipher.key_len ?
-        make_ctr_evp(16, &aes_ctr_cipher_ptr, 0) : &aes_ctr_cipher;
+    if(!aes_128_ctr_cipher) {
+        aes_128_ctr_cipher = &aes_ctr_cipher; 
+        make_ctr_evp(16, &aes_128_ctr_cipher, 0);
+    }
+    return aes_128_ctr_cipher;
 #endif
 }
 
@@ -615,9 +617,11 @@ _libssh2_EVP_aes_192_ctr(void)
         aes_192_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
-    static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
-    return !aes_ctr_cipher.key_len ?
-        make_ctr_evp(24, &aes_ctr_cipher_ptr, 0) : &aes_ctr_cipher;
+    if(!aes_192_ctr_cipher) {
+        aes_192_ctr_cipher = &aes_ctr_cipher;
+        make_ctr_evp(24, &aes_192_ctr_cipher, 0);
+    }       
+    return aes_192_ctr_cipher;
 #endif
 }
 
@@ -630,9 +634,11 @@ _libssh2_EVP_aes_256_ctr(void)
         aes_256_ctr_cipher;
 #else
     static EVP_CIPHER aes_ctr_cipher;
-    static EVP_CIPHER * aes_ctr_cipher_ptr = &aes_ctr_cipher;
-    return !aes_ctr_cipher.key_len ?
-        make_ctr_evp(32, &aes_ctr_cipher_ptr, 0) : &aes_ctr_cipher;
+    if(!aes_256_ctr_cipher) {
+        aes_256_ctr_cipher = &aes_ctr_cipher;
+        make_ctr_evp(32, &aes_256_ctr_cipher, 0);
+    }
+    return aes_256_ctr_cipher;
 #endif
 }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -601,7 +601,7 @@ _libssh2_EVP_aes_128_ctr(void)
 #else
     static EVP_CIPHER aes_ctr_cipher;
     if(!aes_128_ctr_cipher) {
-        aes_128_ctr_cipher = &aes_ctr_cipher; 
+        aes_128_ctr_cipher = &aes_ctr_cipher;
         make_ctr_evp(16, &aes_128_ctr_cipher, 0);
     }
     return aes_128_ctr_cipher;
@@ -620,7 +620,7 @@ _libssh2_EVP_aes_192_ctr(void)
     if(!aes_192_ctr_cipher) {
         aes_192_ctr_cipher = &aes_ctr_cipher;
         make_ctr_evp(24, &aes_192_ctr_cipher, 0);
-    }       
+    }
     return aes_192_ctr_cipher;
 #endif
 }


### PR DESCRIPTION
This is a follow up for my pull request #439 ...

With #439 I introduced a "use of uninitialized variable" warning within a code section that is only active if HAVE_OPAQUE_STRUCTS is NOT defined. Here, in my environment HAVE_OPAQUE_STRUCTS is defined ...

The problem is that aes_ctr_cipher.key_len is uninitialized when entering the function for the first time. It also cannot easily be initialized in a "static way". Therefore it cannot be used to determine whether make_ctr_evp still has to be called. Sorry for missing that. This pull request here fixes this now.

Thanks to @tsengjun for reporting this! For some reason I don't understand I only got this comment by email. When looking on https://github.com/libssh2/libssh2/pull/439 this comment doesn't appear.