### PR TITLE
channel: Refactor closed tracking logic to be more robust.

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -358,8 +358,8 @@ typedef struct _libssh2_channel_data
     /* Limits and restrictions */
     uint32_t window_size_initial, window_size, packet_size;
 
-    /* Set to 1 when CHANNEL_CLOSE / CHANNEL_EOF sent/received */
-    char close, eof, extended_data_ignore_mode;
+    /* Set to 1 when CHANNEL_EOF sent/received */
+    char eof, extended_data_ignore_mode;
 } libssh2_channel_data;
 
 struct _LIBSSH2_CHANNEL
@@ -374,6 +374,9 @@ struct _LIBSSH2_CHANNEL
 
     /* channel's program exit signal (without the SIG prefix) */
     char *exit_signal;
+
+    /* set to 1 when the channel is closed */
+    char closed;
 
     libssh2_channel_data local, remote;
     /* Amount of bytes to be refunded to receive window (but not yet sent) */

--- a/src/packet.c
+++ b/src/packet.c
@@ -937,7 +937,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                            channelp->local.id,
                            channelp->remote.id);
 
-            channelp->remote.close = 1;
+            channelp->closed = 1;
             channelp->remote.eof = 1;
 
             LIBSSH2_FREE(session, data);

--- a/src/session.c
+++ b/src/session.c
@@ -1633,8 +1633,7 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
                             poll_channel_write(fds[i].fd. channel) ?
                             LIBSSH2_POLLFD_POLLOUT : 0;
                     }
-                    if(fds[i].fd.channel->remote.close
-                        || fds[i].fd.channel->local.close) {
+                    if(fds[i].fd.channel->closed) {
                         fds[i].revents |= LIBSSH2_POLLFD_CHANNEL_CLOSED;
                     }
                     if(fds[i].fd.channel->session->socket_state ==


### PR DESCRIPTION
Previously, there was a "close" flag in both the local and remote
state structures, but only the local one was checked in
_libssh2_channel_close, meaning that if someone invoked "channel_close"
after the channel had already been closed by the server,
an indefinite hang would occur.

Now, there is only one "closed" field, which is set when the
server replies that the channel is in fact closed.