### PR TITLE
Fix unportable test(1) operator.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -119,7 +119,7 @@ $(DSP): win32/msvcproj.head win32/msvcproj.foot Makefile.am
 	for file in $$sorted_hdrs; do \
 		echo "# Begin Source File"; \
 		echo ""; \
-		if [ "$$file" == "libssh2_config.h" ]; \
+		if [ "$$file" = "libssh2_config.h" ]; \
 		then \
 			echo "SOURCE=.\\"$$file; \
 		else \


### PR DESCRIPTION
The POSIX comparison operator for test(1) is `=`; bash supports `==` but not even test from GNU coreutils does.