### PR TITLE
os400qc3.h: define EC types to fix building #426

### DIFF
--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -176,12 +176,20 @@
 
 #define LIBSSH2_RSA             1
 #define LIBSSH2_DSA             0
+#define LIBSSH2_ECDSA           0
+#define LIBSSH2_ED25519         0
 
 #define MD5_DIGEST_LENGTH       16
 #define SHA_DIGEST_LENGTH       20
 #define SHA256_DIGEST_LENGTH    32
 #define SHA512_DIGEST_LENGTH    64
 
+#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
+
+#if LIBSSH2_ECDSA
+#else
+#define _libssh2_ec_key void
+#endif
 
 /*******************************************************************
  *


### PR DESCRIPTION
File: os400qc3.h
Notes: define missing EC types which prevents building
Credit: hjindra