### PR TITLE
Use libssh2_EXPORTS as an alternative to _WINDLL

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -100,7 +100,7 @@ extern "C" {
 /* Allow alternate API prefix from CFLAGS or calling app */
 #ifndef LIBSSH2_API
 # ifdef LIBSSH2_WIN32
-#  ifdef _WINDLL
+#  if defined(_WINDLL) || defined(libssh2_EXPORTS)
 #   ifdef LIBSSH2_LIBRARY
 #    define LIBSSH2_API __declspec(dllexport)
 #   else


### PR DESCRIPTION
`_WINDLL` is only defined when a Visual Studio CMake generator is used, `libssh2_EXPORTS` is used though for all CMake generator if a shared libssh2 library is being built.

The corresponding CMake issue is at https://gitlab.kitware.com/cmake/cmake/issues/16370