### PR TITLE
Fix detailed _libssh2_error being overwritten

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3085,7 +3085,8 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
 
    if(rc != 0 || buf == NULL)
        return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
-                             "Public key type in decrypted key data not found");
+                             "Public key type in decrypted "
+                             "key data not found");
 
    rc = LIBSSH2_ERROR_FILE;
 
@@ -3143,8 +3144,8 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
 
     if(rc == LIBSSH2_ERROR_FILE)
         rc = _libssh2_error(session, LIBSSH2_ERROR_FILE,
-                          "Unable to extract public key from private key file: "
-                           "invalid/unrecognized private key file format");
+                         "Unable to extract public key from private key file: "
+                         "invalid/unrecognized private key file format");
 
     if(decrypted)
         _libssh2_string_buf_free(session, decrypted);

--- a/src/pem.c
+++ b/src/pem.c
@@ -773,7 +773,8 @@ _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
                 ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                                     "Unable to allocate memory for PEM parsing");
+                                     "Unable to allocate memory for "
+                                     "PEM parsing");
                 goto out;
             }
             memcpy(tmp + b64datalen, line, linelen);

--- a/src/pem.c
+++ b/src/pem.c
@@ -744,17 +744,17 @@ _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
     size_t off = 0;
     int ret;
 
-    if(filedata == NULL || filedata_len <= 0) {
-        return -1;
-    }
+    if(filedata == NULL || filedata_len <= 0)
+        return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                              "Error parsing PEM: filedata missing");
 
     do {
 
         *line = '\0';
 
-        if(off >= filedata_len) {
-            return -1;
-        }
+        if(off >= filedata_len)
+            return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                                  "Error parsing PEM: offset out of bounds");
 
         if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
             return -1;
@@ -772,9 +772,8 @@ _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
             linelen = strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
-                _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                               "Unable to allocate memory for PEM parsing");
-                ret = -1;
+                ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                     "Unable to allocate memory for PEM parsing");
                 goto out;
             }
             memcpy(tmp + b64datalen, line, linelen);
@@ -785,7 +784,8 @@ _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
         *line = '\0';
 
         if(off >= filedata_len) {
-            ret = -1;
+            ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                                 "Error parsing PEM: offset out of bounds");
             goto out;
         }
 
@@ -795,9 +795,9 @@ _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
         }
     } while(strcmp(line, OPENSSH_HEADER_END) != 0);
 
-    if(!b64data) {
-        return -1;
-    }
+    if(!b64data)
+        return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                              "Error parsing PEM: base 64 data missing");
 
     ret = _libssh2_openssh_pem_parse_data(session, passphrase, b64data,
                                           b64datalen, decrypted_buf);

--- a/src/pem.c
+++ b/src/pem.c
@@ -176,6 +176,8 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
             linelen = strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
+                _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                               "Unable to allocate memory for PEM parsing");
                 ret = -1;
                 goto out;
             }
@@ -319,6 +321,8 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION * session,
             linelen = strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
+                _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                               "Unable to allocate memory for PEM parsing");
                 ret = -1;
                 goto out;
             }
@@ -690,6 +694,8 @@ _libssh2_openssh_pem_parse(LIBSSH2_SESSION * session,
             linelen = strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
+                _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                               "Unable to allocate memory for PEM parsing");
                 ret = -1;
                 goto out;
             }
@@ -766,6 +772,8 @@ _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
             linelen = strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
+                _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                               "Unable to allocate memory for PEM parsing");
                 ret = -1;
                 goto out;
             }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1457,15 +1457,14 @@ userauth_publickey_frommemory(LIBSSH2_SESSION *session,
         }
         else if(privatekeydata_len && privatekeydata) {
             /* Compute public key from private key. */
-            if(_libssh2_pub_priv_keyfilememory(session,
+            rc = _libssh2_pub_priv_keyfilememory(session,
                                             &session->userauth_pblc_method,
                                             &session->userauth_pblc_method_len,
                                             &pubkeydata, &pubkeydata_len,
                                             privatekeydata, privatekeydata_len,
-                                            passphrase))
-                return _libssh2_error(session, LIBSSH2_ERROR_FILE,
-                                      "Unable to extract public key "
-                                      "from private key.");
+                                            passphrase);
+            if(rc)
+                return rc;
         }
         else {
             return _libssh2_error(session, LIBSSH2_ERROR_FILE,


### PR DESCRIPTION
Hi,

_libssh2_pub_priv_keyfilememory in src\openssl.c already sets _libssh2_error() with detailed error messages, while its caller, src\userauth.c, userauth_publickey_frommemory() overwrites it with a generic "Unable to extract public key from private key."
The patch fixes this to facilitate troubleshooting userauth_publickey_frommemory issues.

Best