### PR TITLE
wincng: fix multiple definition of `_libssh2_wincng'

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -208,6 +208,8 @@
  * Windows CNG backend: Generic functions
  */
 
+struct _libssh2_wincng_ctx _libssh2_wincng;
+
 void
 _libssh2_wincng_init(void)
 {

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -1,5 +1,7 @@
+#ifndef __LIBSSH2_WINCNG_H
+#define __LIBSSH2_WINCNG_H
 /*
- * Copyright (C) 2013-2015 Marc Hoersken <info@marc-hoersken.de>
+ * Copyright (C) 2013-2020 Marc Hoersken <info@marc-hoersken.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
@@ -101,7 +103,7 @@ struct _libssh2_wincng_ctx {
     BCRYPT_ALG_HANDLE hAlg3DES_CBC;
 };
 
-struct _libssh2_wincng_ctx _libssh2_wincng;
+extern struct _libssh2_wincng_ctx _libssh2_wincng;
 
 
 /*******************************************************************/
@@ -569,3 +571,5 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                    _libssh2_bn *f, _libssh2_bn *p);
 extern void
 _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
+
+#endif /* __LIBSSH2_WINCNG_H */


### PR DESCRIPTION
Add missing include guard and move global state
from header to source file by using extern.