### PR TITLE
src: add missing and align existing include guards in header files

### DIFF
--- a/src/blf.h
+++ b/src/blf.h
@@ -1,3 +1,5 @@
+#ifndef __LIBSSH2_BLF_H
+#define __LIBSSH2_BLF_H
 /* $OpenBSD: blf.h,v 1.7 2007/03/14 17:59:41 grunk Exp $ */
 /*
  * Blowfish - a fast block cipher designed by Bruce Schneier
@@ -30,9 +32,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-#ifndef _BLF_H_
-#define _BLF_H_
 
 #if !defined(HAVE_BCRYPT_PBKDF) && !defined(HAVE_BLH_H)
 
@@ -87,4 +86,4 @@ int bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
                  uint8_t *key, size_t keylen, unsigned int rounds);
 
 #endif /* !defined(HAVE_BCRYPT_PBKDF) && !defined(HAVE_BLH_H) */
-#endif /* _BLF_H */
+#endif /* __LIBSSH2_BLF_H */

--- a/src/comp.h
+++ b/src/comp.h
@@ -1,6 +1,5 @@
 #ifndef __LIBSSH2_COMP_H
 #define __LIBSSH2_COMP_H
-
 /* Copyright (C) 2009-2010 by Daniel Stenberg
  *
  * Redistribution and use in source and binary forms,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -1,3 +1,5 @@
+#ifndef __LIBSSH2_CRYPTO_H
+#define __LIBSSH2_CRYPTO_H
 /* Copyright (C) 2009, 2010 Simon Josefsson
  * Copyright (C) 2006, 2007 The Written Word, Inc.  All rights reserved.
  * Copyright (C) 2010-2019 Daniel Stenberg
@@ -35,8 +37,6 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  */
-#ifndef LIBSSH2_CRYPTO_H
-#define LIBSSH2_CRYPTO_H
 
 #ifdef LIBSSH2_OPENSSL
 #include "openssl.h"
@@ -245,4 +245,4 @@ int _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                     size_t privatekeydata_len,
                                     const char *passphrase);
 
-#endif
+#endif /* __LIBSSH2_CRYPTO_H */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -1,3 +1,5 @@
+#ifndef __LIBSSH2_LIBGCRYPT_H
+#define __LIBSSH2_LIBGCRYPT_H
 /*
  * Copyright (C) 2008, 2009, 2010 Simon Josefsson
  * Copyright (C) 2006, 2007, The Written Word, Inc.
@@ -232,3 +234,4 @@ extern int _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                               _libssh2_bn *f, _libssh2_bn *p);
 extern void _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
 
+#endif /* __LIBSSH2_LIBGCRYPT_H */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1,3 +1,5 @@
+#ifndef __LIBSSH2_PRIV_H
+#define __LIBSSH2_PRIV_H
 /* Copyright (c) 2004-2008, 2010, Sara Golemon <sarag@libssh2.org>
  * Copyright (c) 2009-2014 by Daniel Stenberg
  * Copyright (c) 2010 Simon Josefsson
@@ -36,9 +38,6 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  */
-
-#ifndef LIBSSH2_PRIV_H
-#define LIBSSH2_PRIV_H 1
 
 #define LIBSSH2_LIBRARY
 #include "libssh2_config.h"
@@ -1147,4 +1146,4 @@ endings either CRLF or LF so 't' is appropriate.
 #define FOPEN_APPENDTEXT "a"
 #endif
 
-#endif /* LIBSSH2_H */
+#endif /* __LIBSSH2_PRIV_H */

--- a/src/mac.h
+++ b/src/mac.h
@@ -1,6 +1,5 @@
 #ifndef __LIBSSH2_MAC_H
 #define __LIBSSH2_MAC_H
-
 /* Copyright (C) 2009-2010 by Daniel Stenberg
  *
  * Redistribution and use in source and binary forms,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -1,3 +1,5 @@
+#ifndef __LIBSSH2_MBEDTLS_H
+#define __LIBSSH2_MBEDTLS_H
 /* Copyright (c) 2016, Art <https://github.com/wildart>
  * All rights reserved.
  *
@@ -445,3 +447,5 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                   _libssh2_bn *f, _libssh2_bn *p);
 extern void
 _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
+
+#endif /* __LIBSSH2_MBEDTLS_H */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -1,3 +1,5 @@
+#ifndef __LIBSSH2_OPENSSL_H
+#define __LIBSSH2_OPENSSL_H
 /* Copyright (C) 2009, 2010 Simon Josefsson
  * Copyright (C) 2006, 2007 The Written Word, Inc.  All rights reserved.
  *
@@ -392,3 +394,5 @@ extern void _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
 const EVP_CIPHER *_libssh2_EVP_aes_128_ctr(void);
 const EVP_CIPHER *_libssh2_EVP_aes_192_ctr(void);
 const EVP_CIPHER *_libssh2_EVP_aes_256_ctr(void);
+
+#endif /* __LIBSSH2_OPENSSL_H */

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -1,3 +1,5 @@
+#ifndef __LIBSSH2_OS400QC3_H
+#define __LIBSSH2_OS400QC3_H
 /*
  * Copyright (C) 2015-2016 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * Copyright (C) 2020 Patrick Monnerat <patrick@monnerat.net>.
@@ -36,9 +38,6 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  */
-
-#ifndef LIBSSH2_OS400QC3_H
-#define LIBSSH2_OS400QC3_H
 
 #include <stdlib.h>
 #include <string.h>
@@ -387,6 +386,6 @@ extern int      _libssh2_os400qc3_dh_secret(_libssh2_dh_ctx *dhctx,
                                             _libssh2_bn *f, _libssh2_bn *p);
 extern void     _libssh2_os400qc3_dh_dtor(_libssh2_dh_ctx *dhctx);
 
-#endif
+#endif /* __LIBSSH2_OS400QC3_H */
 
 /* vim: set expandtab ts=4 sw=4: */

--- a/src/packet.h
+++ b/src/packet.h
@@ -1,5 +1,5 @@
-#ifndef LIBSSH2_PACKET_H
-#define LIBSSH2_PACKET_H
+#ifndef __LIBSSH2_PACKET_H
+#define __LIBSSH2_PACKET_H
 /*
  * Copyright (C) 2010 by Daniel Stenberg
  * Author: Daniel Stenberg <daniel@haxx.se>
@@ -73,4 +73,4 @@ int _libssh2_packet_write(LIBSSH2_SESSION * session, unsigned char *data,
 int _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                         size_t datalen, int macstate);
 
-#endif /* LIBSSH2_PACKET_H */
+#endif /* __LIBSSH2_PACKET_H */

--- a/src/session.h
+++ b/src/session.h
@@ -1,5 +1,5 @@
-#ifndef LIBSSH2_SESSION_H
-#define LIBSSH2_SESSION_H
+#ifndef __LIBSSH2_SESSION_H
+#define __LIBSSH2_SESSION_H
 /* Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
  * Copyright (c) 2009-2010 by Daniel Stenberg
  * Copyright (c) 2010 Simon Josefsson <simon@josefsson.org>
@@ -90,4 +90,4 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t entry_time);
 /* this is the lib-internal set blocking function */
 int _libssh2_session_set_blocking(LIBSSH2_SESSION * session, int blocking);
 
-#endif /* LIBSSH2_SESSION_H */
+#endif /* __LIBSSH2_SESSION_H */

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -1,5 +1,5 @@
-#ifndef _LIBSSH2_SFTP_H
-#define _LIBSSH2_SFTP_H
+#ifndef __LIBSSH2_SFTP_H
+#define __LIBSSH2_SFTP_H
 /*
  * Copyright (C) 2010 - 2012 by Daniel Stenberg
  * Author: Daniel Stenberg <daniel@haxx.se>
@@ -235,4 +235,4 @@ struct _LIBSSH2_SFTP
     uint32_t symlink_request_id;
 };
 
-#endif
+#endif /* __LIBSSH2_SFTP_H */

--- a/src/transport.h
+++ b/src/transport.h
@@ -1,6 +1,5 @@
 #ifndef __LIBSSH2_TRANSPORT_H
 #define __LIBSSH2_TRANSPORT_H
-
 /* Copyright (C) 2007 The Written Word, Inc.  All rights reserved.
  * Copyright (C) 2009-2010 by Daniel Stenberg
  * Author: Daniel Stenberg <daniel@haxx.se>

--- a/src/userauth.h
+++ b/src/userauth.h
@@ -1,5 +1,5 @@
-#ifndef LIBSSH2_USERAUTH_H
-#define LIBSSH2_USERAUTH_H
+#ifndef __LIBSSH2_USERAUTH_H
+#define __LIBSSH2_USERAUTH_H
 /* Copyright (c) 2004-2007, Sara Golemon <sarag@libssh2.org>
  * Copyright (c) 2009-2010 by Daniel Stenberg
  * All rights reserved.
@@ -48,4 +48,4 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                             ((*sign_callback)),
                             void *abstract);
 
-#endif /* LIBSSH2_USERAUTH_H */
+#endif /* __LIBSSH2_USERAUTH_H */


### PR DESCRIPTION
Make sure all include guards exist and follow the same format.