### PR TITLE
Update INSTALL_CMAKE.md

### DIFF
--- a/docs/INSTALL_CMAKE.md
+++ b/docs/INSTALL_CMAKE.md
@@ -20,10 +20,12 @@ Getting started
 If you are happy with the default options, make a new build directory,
 change to it, configure the build environment and build the project:
 
+```
   mkdir bin
   cd bin
   cmake ..
   cmake --build .
+```
 
 libssh2 will be built as a static library and will use any
 cryptography library available.  The library binary will be put in
@@ -119,20 +121,27 @@ Tests
 To test the build, run the appropriate test target for your build
 system.  For example:
 
+```
   cmake --build . --target test
+```
 or
+```
   cmake --build . --target RUN_TESTS
+```
 
 How do I use libssh2 in my project if my project doesn't use CMake?
 -------------------------------------------------------------------
 
 If you are not using CMake for your own project, install libssh2
-
+```
   cmake <libssh2 source location>
   cmake --build .
   cmake --build . --target install
+```
 or
+```
   cmake --build . --target INSTALL
+```
 
 and then specify the install location to your project in the normal
 way for your build environment.  If you don't like the default install


### PR DESCRIPTION
Although the original text would be immediately clear to seasoned users of CMAKE and/or Unix shell, the lack of newlines may cause some confusion for newcomers. Hence, wrapping the texts in a code-block such that the newlines appear as intended.