### PR TITLE
Various fixes to the BigNum and DH handling in WinCNG

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1982,9 +1982,7 @@ _libssh2_wincng_bignum_mod_exp(_libssh2_bn *r,
     memcpy(key + offset, m->bignum, m->length);
 
     ret = BCryptImportKeyPair(_libssh2_wincng.hAlgRSA, NULL,
-                              BCRYPT_RSAPUBLIC_BLOB, &hKey, key, keylen,
-                              BCRYPT_NO_KEY_VALIDATION);
-
+                              BCRYPT_RSAPUBLIC_BLOB, &hKey, key, keylen, 0);
     if(BCRYPT_SUCCESS(ret)) {
         ret = BCryptEncrypt(hKey, a->bignum, a->length, NULL, NULL, 0,
                             NULL, 0, &length, BCRYPT_PAD_NONE);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2156,8 +2156,7 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                    _libssh2_bn *f, _libssh2_bn *p)
 {
     /* Compute the shared secret */
-    _libssh2_wincng_bignum_mod_exp(secret, f, *dhctx, p);
-    return 0;
+    return _libssh2_wincng_bignum_mod_exp(secret, f, *dhctx, p);
 }
 
 void

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2052,21 +2052,18 @@ _libssh2_wincng_bignum_bits(const _libssh2_bn *bn)
     unsigned char number;
     unsigned long offset, length, bits;
 
-    if(!bn)
+    if(!bn || !bn->bignum || !bn->length)
         return 0;
 
-    length = bn->length - 1;
-
     offset = 0;
-    while(!(*(bn->bignum + offset)) && (offset < length))
+    length = bn->length - 1;
+    while(!bn->bignum[offset] && offset < length)
         offset++;
 
     bits = (length - offset) * 8;
     number = bn->bignum[offset];
-
     while(number >>= 1)
         bits++;
-
     bits++;
 
     return bits;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1916,7 +1916,8 @@ _libssh2_wincng_bignum_rand(_libssh2_bn *rnd, int bits, int top, int bottom)
     if(!rnd)
         return -1;
 
-    length = (unsigned long)(ceil((float)bits / 8) * sizeof(unsigned char));
+    length = (unsigned long) (ceil(((double)bits) / 8.0) *
+                              sizeof(unsigned char));
     if(_libssh2_wincng_bignum_resize(rnd, length))
         return -1;
 
@@ -2032,8 +2033,9 @@ _libssh2_wincng_bignum_set_word(_libssh2_bn *bn, unsigned long word)
     number = word;
     while(number >>= 1)
         bits++;
+    bits++;
 
-    length = (unsigned long) (ceil(((double)(bits + 1)) / 8.0) *
+    length = (unsigned long) (ceil(((double)bits) / 8.0) *
                               sizeof(unsigned char));
     if(_libssh2_wincng_bignum_resize(bn, length))
         return -1;


### PR DESCRIPTION
- wincng: add and improve checks in bit counting function
- wincng: align bits to bytes calculation in all functions
- wincng: do not disable key validation that can be enabled
- wincng: fix return value in _libssh2_dh_secret