### PR TITLE
libssh2.h: Update Diffie Hellman group values

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -235,9 +235,9 @@ typedef off_t libssh2_struct_stat_size;
 
 /* Default generate and safe prime sizes for
    diffie-hellman-group-exchange-sha1 */
-#define LIBSSH2_DH_GEX_MINGROUP     1024
-#define LIBSSH2_DH_GEX_OPTGROUP     1536
-#define LIBSSH2_DH_GEX_MAXGROUP     2048
+#define LIBSSH2_DH_GEX_MINGROUP     2048
+#define LIBSSH2_DH_GEX_OPTGROUP     4096
+#define LIBSSH2_DH_GEX_MAXGROUP     8192
 
 /* Defaults for pty requests */
 #define LIBSSH2_TERM_WIDTH      80


### PR DESCRIPTION
File: libssh2.h

Notes:
Update the min, preferred and max DH group values based on RFC 8270.

Credit:
Will Cosgrove, noted from email list by Mitchell Holland