### PR TITLE
openssl: clean up curve25519 code

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -181,8 +181,8 @@ _libssh2_ecdsa_curve_type_from_name(const char *name,
 #if LIBSSH2_ED25519
 
 int
-_libssh2_curve25519_new(LIBSSH2_SESSION *session, libssh2_ed25519_ctx **ctx,
-                        uint8_t **out_public_key, uint8_t **out_private_key);
+_libssh2_curve25519_new(LIBSSH2_SESSION *session, uint8_t **out_public_key,
+                        uint8_t **out_private_key);
 
 int
 _libssh2_curve25519_gen_k(_libssh2_bn **k,

--- a/src/kex.c
+++ b/src/kex.c
@@ -3195,7 +3195,7 @@ kex_method_curve25519_key_exchange
             goto clean_exit;
         }
 
-        rc = _libssh2_curve25519_new(session, NULL,
+        rc = _libssh2_curve25519_new(session,
                                      &key_state->curve25519_public_key,
                                      &key_state->curve25519_private_key);
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -325,10 +325,8 @@ libssh2_curve_type;
 
 #if LIBSSH2_ED25519
 #define libssh2_ed25519_ctx EVP_PKEY
-#define libssh2_x25519_ctx EVP_PKEY
 
 #define _libssh2_ed25519_free(ctx) EVP_PKEY_free(ctx)
-#define _libssh2_x25519_free(ctx) EVP_PKEY_free(ctx)
 #endif /* ED25519 */
 
 #define _libssh2_cipher_type(name) const EVP_CIPHER *(*name)(void)


### PR DESCRIPTION
This cleans up a few things in the curve25519 implementation:

- There is no need to create X509_PUBKEYs or PKCS8_PRIV_KEY_INFOs to
  extract key material. EVP_PKEY_get_raw_private_key and
  EVP_PKEY_get_raw_public_key work fine.

- libssh2_x25519_ctx was never used (and occasionally mis-typedefed to
  libssh2_ed25519_ctx). Remove it. The _libssh2_curve25519_new and
  _libssh2_curve25519_gen_k interfaces use the bytes. Note, if it needs
  to be added back, there is no need to roundtrip through
  EVP_PKEY_new_raw_private_key. EVP_PKEY_keygen already generated an
  EVP_PKEY.

- Add some missing error checks.

NB: I was able to check this compiled, but it looks like the tests requires some docker setup. So probably wait for the CI to clear here.