### PR TITLE
transport.c: socket is disconnected, return error

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -323,7 +323,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
 
     do {
         if(session->socket_state == LIBSSH2_SOCKET_DISCONNECTED) {
-            return LIBSSH2_ERROR_NONE;
+            return LIBSSH2_ERROR_SOCKET_DISCONNECT;
         }
 
         if(session->state & LIBSSH2_STATE_NEWKEYS) {


### PR DESCRIPTION
File: transport.c

Notes:
This is to fix #102, instead of continuing to attempt to read a disconnected socket, it will now error out. 

Credit:
TDi-jonesds