### PR TITLE
alternative functions added to fill LIBSSH2_SFTP_ATTRIBUTES on sftp_open - declaration-after-statement corrected

### DIFF
--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -236,6 +236,19 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
 #define libssh2_sftp_opendir(sftp, path) \
     libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
                          LIBSSH2_SFTP_OPENDIR)
+LIBSSH2_API LIBSSH2_SFTP_HANDLE *
+libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
+                     const char *filename,
+                     unsigned int filename_len,
+                     unsigned long flags,
+                     long mode, int open_type,
+                     LIBSSH2_SFTP_ATTRIBUTES *attrs_in);
+#define libssh2_sftp_open_r(sftp, filename, flags, mode, attr_in)                  \
+    libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), (flags), \
+                         (mode), LIBSSH2_SFTP_OPENFILE, (attr_in))
+#define libssh2_sftp_opendir_r(sftp, path) \
+    libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
+                         LIBSSH2_SFTP_OPENDIR,(attr_in))
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                                       char *buffer, size_t buffer_maxlen);

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1111,12 +1111,12 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
     LIBSSH2_SFTP_ATTRIBUTES attrs = {
         LIBSSH2_SFTP_ATTR_PERMISSIONS, 0, 0, 0, 0, 0, 0
     };
+    unsigned char *s;
+    ssize_t rc;
     if (attrs_in)
     {
         memcpy(&attrs,attrs_in,sizeof(LIBSSH2_SFTP_ATTRIBUTES));
     }
-    unsigned char *s;
-    ssize_t rc;
     int open_file = (open_type == LIBSSH2_SFTP_OPENFILE)?1:0;
 
     if(sftp->open_state == libssh2_NB_state_idle) {

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1103,7 +1103,7 @@ libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp)
 static LIBSSH2_SFTP_HANDLE *
 sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
           size_t filename_len, uint32_t flags, long mode,
-          int open_type)
+          int open_type, LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -1111,6 +1111,10 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
     LIBSSH2_SFTP_ATTRIBUTES attrs = {
         LIBSSH2_SFTP_ATTR_PERMISSIONS, 0, 0, 0, 0, 0, 0
     };
+    if (attrs_in)
+    {
+        memcpy(&attrs,attrs_in,sizeof(LIBSSH2_SFTP_ATTRIBUTES));
+    }
     unsigned char *s;
     ssize_t rc;
     int open_file = (open_type == LIBSSH2_SFTP_OPENFILE)?1:0;
@@ -1324,10 +1328,25 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
 
     BLOCK_ADJUST_ERRNO(hnd, sftp->channel->session,
                        sftp_open(sftp, filename, filename_len, flags, mode,
-                                 open_type));
+                                 open_type, NULL));
     return hnd;
 }
 
+LIBSSH2_API LIBSSH2_SFTP_HANDLE *
+libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
+                     unsigned int filename_len, unsigned long flags, long mode,
+                     int open_type,LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
+{
+    LIBSSH2_SFTP_HANDLE *hnd;
+
+    if(!sftp)
+        return NULL;
+
+    BLOCK_ADJUST_ERRNO(hnd, sftp->channel->session,
+                       sftp_open(sftp, filename, filename_len, flags, mode,
+                                 open_type, attrs_in));
+    return hnd;
+}
 /*
  * sftp_read
  *


### PR DESCRIPTION
Currently, libssh2 sends hardcoded LIBSSH2_SFTP_ATTRIBUTES struct on handle opening. This can be problematic on some special OS, where the file size should be known on handle creation. I added some function variations to resolve this issue.