### PR TITLE
alternative functions added to fill LIBSSH2_SFTP_ATTRIBUTES on sftp_open

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -134,7 +134,9 @@ dist_man_MANS = \
 	libssh2_sftp_mkdir.3 \
 	libssh2_sftp_mkdir_ex.3 \
 	libssh2_sftp_open.3 \
+	libssh2_sftp_open_r.3 \
 	libssh2_sftp_open_ex.3 \
+	libssh2_sftp_open_ex_r.3 \
 	libssh2_sftp_opendir.3 \
 	libssh2_sftp_read.3 \
 	libssh2_sftp_readdir.3 \

--- a/docs/libssh2_sftp_open_ex_r.3
+++ b/docs/libssh2_sftp_open_ex_r.3
@@ -1,0 +1,71 @@
+.TH libssh2_sftp_open_ex_r 3 "5 Aug 2020" "libssh2 1.9.1" "libssh2 manual"
+.SH NAME
+libssh2_sftp_open_r - open filehandle for file on SFTP.
+.SH SYNOPSIS
+.nf
+#include <libssh2.h>
+#include <libssh2_sftp.h>
+
+LIBSSH2_SFTP_HANDLE *
+libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
+                     unsigned int filename_len, unsigned long flags,
+                     long mode, int open_type, LIBSSH2_SFTP_ATTRIBUTES *attrs);
+.SH DESCRIPTION
+\fIsftp\fP - SFTP instance as returned by \fIlibssh2_sftp_init(3)\fP
+
+\fIfilename\fP - Remote file/directory resource to open
+
+\fIfilename_len\fP - Length of filename
+
+\fIflags\fP - Any reasonable combination of the LIBSSH2_FXF_* constants:
+.RS
+.IP LIBSSH2_FXF_READ
+Open the file for reading.
+.IP LIBSSH2_FXF_WRITE
+Open the file for writing.  If both this and LIBSSH2_FXF_READ are specified,
+the file is opened for both reading and writing.
+.IP LIBSSH2_FXF_APPEND
+Force all writes to append data at the end of the file.
+.IP LIBSSH2_FXF_CREAT,
+If this flag is specified, then a new file will be created if one does not
+already exist (if LIBSSH2_FXF_TRUNC is specified, the new file will be
+truncated to zero length if it previously exists)
+.IP LIBSSH2_FXF_TRUNC
+Forces an existing file with the same name to be truncated to zero length when
+creating a file by specifying LIBSSH2_FXF_CREAT. LIBSSH2_FXF_CREAT MUST also
+be specified if this flag is used.
+.IP LIBSSH2_FXF_EXCL
+Causes the request to fail if the named file already exists.
+LIBSSH2_FXF_CREAT MUST also be specified if this flag is used.
+
+.RE
+\fImode\fP - POSIX file permissions to assign if the file is being newly
+created. See the LIBSSH2_SFTP_S_* convenience defines in <libssh2_sftp.h>
+
+\fIopen_type\fP - Either of LIBSSH2_SFTP_OPENFILE (to open a file) or
+LIBSSH2_SFTP_OPENDIR (to open a directory).
+
+\fIattrs\fP - Pointer to LIBSSH2_SFTP_ATTRIBUTES struct. See
+libssh2_sftp_fstat_ex for detailed usage!
+
+.SH RETURN VALUE
+A pointer to the newly created LIBSSH2_SFTP_HANDLE instance or NULL on
+failure.
+.SH ERRORS
+\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+
+\fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
+
+\fILIBSSH2_ERROR_SOCKET_TIMEOUT\fP -
+
+\fILIBSSH2_ERROR_SFTP_PROTOCOL\fP - An invalid SFTP protocol response was
+received on the socket, or an SFTP operation caused an errorcode to be
+returned by the server.
+
+\fILIBSSH2_ERROR_EAGAIN\fP - Marked for non-blocking I/O but the call would
+block.
+.SH SEE ALSO
+.BR libssh2_sftp_close_handle(3)
+
+.BR libssh2_sftp_fstat_ex(3)
+

--- a/docs/libssh2_sftp_open_r.3
+++ b/docs/libssh2_sftp_open_r.3
@@ -1,0 +1,18 @@
+.TH libssh2_sftp_open 3 "5 Aug 2020" "libssh2 1.9.1" "libssh2 manual"
+.SH NAME
+libssh2_sftp_open_r - convenience macro for \fIlibssh2_sftp_open_ex_r(3)\fP calls
+.SH SYNOPSIS
+#include <libssh2.h>
+
+LIBSSH2_SFTP_HANDLE *
+libssh2_sftp_open(LIBSSH2_SFTP *sftp, const char *path, unsigned long flags, long mode, LIBSSH2_SFTP_ATTRIBUTES *attrs);
+
+.SH DESCRIPTION
+This is a macro defined in a public libssh2 header file that is using the
+underlying function \fIlibssh2_sftp_open_ex_r(3)\fP.
+.SH RETURN VALUE
+See \fIlibssh2_sftp_open_ex_r(3)\fP
+.SH ERRORS
+See \fIlibssh2_sftp_open_ex_r(3)\fP
+.SH SEE ALSO
+.BR libssh2_sftp_open_ex_r(3)

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -243,7 +243,7 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
                      unsigned long flags,
                      long mode, int open_type,
                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
-#define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs \
+#define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs) \
     libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), (flags), \
                          (mode), LIBSSH2_SFTP_OPENFILE, (attrs))
 #define libssh2_sftp_opendir_r(sftp, path) \

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -246,9 +246,6 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
 #define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs) \
     libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), (flags), \
                          (mode), LIBSSH2_SFTP_OPENFILE, (attrs))
-#define libssh2_sftp_opendir_r(sftp, path) \
-    libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
-                         LIBSSH2_SFTP_OPENDIR, (attr_in))
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                                       char *buffer, size_t buffer_maxlen);

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -236,6 +236,19 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
 #define libssh2_sftp_opendir(sftp, path) \
     libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
                          LIBSSH2_SFTP_OPENDIR)
+LIBSSH2_API LIBSSH2_SFTP_HANDLE *
+libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
+                     const char *filename,
+                     unsigned int filename_len,
+                     unsigned long flags,
+                     long mode, int open_type,
+                     LIBSSH2_SFTP_ATTRIBUTES *attrs_in);
+#define libssh2_sftp_open_r(sftp, filename, flags, mode, attr_in)                  \
+    libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), (flags), \
+                         (mode), LIBSSH2_SFTP_OPENFILE, (attr_in))
+#define libssh2_sftp_opendir_r(sftp, path) \
+    libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
+                         LIBSSH2_SFTP_OPENDIR,(attr_in))
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                                       char *buffer, size_t buffer_maxlen);

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -243,7 +243,7 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
                      unsigned long flags,
                      long mode, int open_type,
                      LIBSSH2_SFTP_ATTRIBUTES *attrs_in);
-#define libssh2_sftp_open_r(sftp, filename, flags, mode, attr_in)                  \
+#define libssh2_sftp_open_r(sftp, filename, flags, mode, attr_in) \
     libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), (flags), \
                          (mode), LIBSSH2_SFTP_OPENFILE, (attr_in))
 #define libssh2_sftp_opendir_r(sftp, path) \

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -248,7 +248,7 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
                          (mode), LIBSSH2_SFTP_OPENFILE, (attr_in))
 #define libssh2_sftp_opendir_r(sftp, path) \
     libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
-                         LIBSSH2_SFTP_OPENDIR,(attr_in))
+                         LIBSSH2_SFTP_OPENDIR, (attr_in))
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                                       char *buffer, size_t buffer_maxlen);

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -242,10 +242,10 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
                      unsigned int filename_len,
                      unsigned long flags,
                      long mode, int open_type,
-                     LIBSSH2_SFTP_ATTRIBUTES *attrs_in);
-#define libssh2_sftp_open_r(sftp, filename, flags, mode, attr_in) \
+                     LIBSSH2_SFTP_ATTRIBUTES *attrs);
+#define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs \
     libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), (flags), \
-                         (mode), LIBSSH2_SFTP_OPENFILE, (attr_in))
+                         (mode), LIBSSH2_SFTP_OPENFILE, (attrs))
 #define libssh2_sftp_opendir_r(sftp, path) \
     libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
                          LIBSSH2_SFTP_OPENDIR, (attr_in))

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1114,11 +1114,10 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
     unsigned char *s;
     ssize_t rc;
     int open_file = (open_type == LIBSSH2_SFTP_OPENFILE)?1:0;
-    if (attrs_in)
-    {
-        memcpy(&attrs,attrs_in,sizeof(LIBSSH2_SFTP_ATTRIBUTES));
+    if(attrs_in) {
+        memcpy(&attrs, attrs_in, sizeof(LIBSSH2_SFTP_ATTRIBUTES));
     }
-    
+
 
     if(sftp->open_state == libssh2_NB_state_idle) {
         /* packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) +
@@ -1336,7 +1335,7 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
 LIBSSH2_API LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
                      unsigned int filename_len, unsigned long flags, long mode,
-                     int open_type,LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
+                     int open_type, LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
 {
     LIBSSH2_SFTP_HANDLE *hnd;
 

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1124,7 +1124,11 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
            flags(4) */
         sftp->open_packet_len = filename_len + 13 +
             (open_file? (4 +
-                         sftp_attrsize(LIBSSH2_SFTP_ATTR_PERMISSIONS)) : 0);
+                         sftp_attrsize(LIBSSH2_SFTP_ATTR_PERMISSIONS)
+                         +sftp_attrsize(LIBSSH2_SFTP_ATTR_SIZE)
+                         +sftp_attrsize(LIBSSH2_SFTP_ATTR_ACMODTIME)
+                         +sftp_attrsize(LIBSSH2_SFTP_ATTR_EXTENDED)
+                         +sftp_attrsize(LIBSSH2_SFTP_ATTR_UIDGID)) : 0);
 
         /* surprise! this starts out with nothing sent */
         sftp->open_packet_sent = 0;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1123,7 +1123,7 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
         /* packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) +
            flags(4) */
         sftp->open_packet_len = filename_len + 13 +
-            (open_file? (4+sizeof(LIBSSH2_SFTP_ATTRIBUTES)) : 0);
+            (open_file? (sizeof(LIBSSH2_SFTP_ATTRIBUTES)) : 0);
 
         /* surprise! this starts out with nothing sent */
         sftp->open_packet_sent = 0;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1123,7 +1123,7 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
         /* packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) +
            flags(4) */
         sftp->open_packet_len = filename_len + 13 +
-            (open_file? (4 +sizeof LIBSSH2_SFTP_ATTRIBUTES) : 0);
+            (open_file? (sizeof(LIBSSH2_SFTP_ATTRIBUTES)) : 0);
 
         /* surprise! this starts out with nothing sent */
         sftp->open_packet_sent = 0;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1123,12 +1123,7 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
         /* packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) +
            flags(4) */
         sftp->open_packet_len = filename_len + 13 +
-            (open_file? (4 +
-                         sftp_attrsize(LIBSSH2_SFTP_ATTR_PERMISSIONS)
-                         +sftp_attrsize(LIBSSH2_SFTP_ATTR_SIZE)
-                         +sftp_attrsize(LIBSSH2_SFTP_ATTR_ACMODTIME)
-                         +sftp_attrsize(LIBSSH2_SFTP_ATTR_EXTENDED)
-                         +sftp_attrsize(LIBSSH2_SFTP_ATTR_UIDGID)) : 0);
+            (open_file? (4 +sizeof LIBSSH2_SFTP_ATTRIBUTES) : 0);
 
         /* surprise! this starts out with nothing sent */
         sftp->open_packet_sent = 0;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1103,7 +1103,7 @@ libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp)
 static LIBSSH2_SFTP_HANDLE *
 sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
           size_t filename_len, uint32_t flags, long mode,
-          int open_type)
+          int open_type, LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -1113,6 +1113,10 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
     };
     unsigned char *s;
     ssize_t rc;
+    if (attrs_in)
+    {
+        memcpy(&attrs,attrs_in,sizeof(LIBSSH2_SFTP_ATTRIBUTES));
+    }
     int open_file = (open_type == LIBSSH2_SFTP_OPENFILE)?1:0;
 
     if(sftp->open_state == libssh2_NB_state_idle) {
@@ -1324,10 +1328,25 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
 
     BLOCK_ADJUST_ERRNO(hnd, sftp->channel->session,
                        sftp_open(sftp, filename, filename_len, flags, mode,
-                                 open_type));
+                                 open_type, NULL));
     return hnd;
 }
 
+LIBSSH2_API LIBSSH2_SFTP_HANDLE *
+libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
+                     unsigned int filename_len, unsigned long flags, long mode,
+                     int open_type,LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
+{
+    LIBSSH2_SFTP_HANDLE *hnd;
+
+    if(!sftp)
+        return NULL;
+
+    BLOCK_ADJUST_ERRNO(hnd, sftp->channel->session,
+                       sftp_open(sftp, filename, filename_len, flags, mode,
+                                 open_type, attrs_in));
+    return hnd;
+}
 /*
  * sftp_read
  *

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1335,7 +1335,7 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
 LIBSSH2_API LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
                      unsigned int filename_len, unsigned long flags, long mode,
-                     int open_type, LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
+                     int open_type, LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
     LIBSSH2_SFTP_HANDLE *hnd;
 
@@ -1344,7 +1344,7 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
 
     BLOCK_ADJUST_ERRNO(hnd, sftp->channel->session,
                        sftp_open(sftp, filename, filename_len, flags, mode,
-                                 open_type, attrs_in));
+                                 open_type, attrs));
     return hnd;
 }
 /*

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1123,7 +1123,7 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
         /* packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) +
            flags(4) */
         sftp->open_packet_len = filename_len + 13 +
-            (open_file? (sizeof(LIBSSH2_SFTP_ATTRIBUTES)) : 0);
+            (open_file? (4+sizeof(LIBSSH2_SFTP_ATTRIBUTES)) : 0);
 
         /* surprise! this starts out with nothing sent */
         sftp->open_packet_sent = 0;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1113,11 +1113,12 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
     };
     unsigned char *s;
     ssize_t rc;
+    int open_file = (open_type == LIBSSH2_SFTP_OPENFILE)?1:0;
     if (attrs_in)
     {
         memcpy(&attrs,attrs_in,sizeof(LIBSSH2_SFTP_ATTRIBUTES));
     }
-    int open_file = (open_type == LIBSSH2_SFTP_OPENFILE)?1:0;
+    
 
     if(sftp->open_state == libssh2_NB_state_idle) {
         /* packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) +


### PR DESCRIPTION
Currently, libssh2 sends hardcoded LIBSSH2_SFTP_ATTRIBUTES struct on handle opening. This can be problematic on some special OS, where the file size should be known on new file creation. I added some function variations to resolve this issue.