### PR TITLE
wincng: fix random big number generation to match openssl

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2044,15 +2044,17 @@ _libssh2_wincng_bignum_rand(_libssh2_bn *rnd, int bits, int top, int bottom)
 
     /* calculate significant bits in most significant byte */
     bits %= 8;
+    if(bits == 0)
+        bits = 8;
 
     /* fill most significant byte with zero padding */
-    bignum[0] &= (1 << (8 - bits)) - 1;
+    bignum[0] &= ((1 << bits) - 1);
 
-    /* set some special last bits in most significant byte */
+    /* set most significant bits in most significant byte */
     if(top == 0)
-        bignum[0] |= (1 << (7 - bits));
+        bignum[0] |= (1 << (bits - 1));
     else if(top == 1)
-        bignum[0] |= (3 << (6 - bits));
+        bignum[0] |= (3 << (bits - 2));
 
     /* make odd by setting first bit in least significant byte */
     if(bottom)


### PR DESCRIPTION
The old function would set the least significant bits in
the most significant byte instead of the most significant bits.

The old function would also zero pad too much bits in the
most significant byte. This lead to a reduction of key space
in the most significant byte according to the following listing:
- 8 bits reduced to 0 bits => eg. 2048 bits to 2040 bits DH key
- 7 bits reduced to 1 bits => eg. 2047 bits to 2041 bits DH key
- 6 bits reduced to 2 bits => eg. 2046 bits to 2042 bits DH key
- 5 bits reduced to 3 bits => eg. 2045 bits to 2043 bits DH key

No change would occur for the case of 4 significant bits.
For 1 to 3 significant bits in the most significant byte
the DH key would actually be expanded instead of reduced:
- 3 bits expanded to 5 bits => eg. 2043 bits to 2045 bits DH key
- 2 bits expanded to 6 bits => eg. 2042 bits to 2046 bits DH key
- 1 bits expanded to 7 bits => eg. 2041 bits to 2047 bits DH key

There is no case of 0 significant bits in the most significant byte
since this would be a case of 8 significant bits in the next byte.