### PR TITLE
Avoid OpenSSL latent error in FIPS mode

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2217,7 +2217,7 @@ _libssh2_md5_init(libssh2_md5_ctx *ctx)
      * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"
      * So, just return 0 in FIPS mode
      */
-     if (FIPS_mode() != 0)
+     if(FIPS_mode() != 0)
          return 0;
 #ifdef HAVE_OPAQUE_STRUCTS
     *ctx = EVP_MD_CTX_new();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2212,6 +2212,13 @@ _libssh2_sha512(const unsigned char *message, unsigned long len,
 int
 _libssh2_md5_init(libssh2_md5_ctx *ctx)
 {
+    /* MD5 digest is not supported in OpenSSL FIPS mode
+     * Trying to init it will result in a latent OpenSSL error:
+     * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"
+     * So, just return 0 in FIPS mode
+     */
+     if (FIPS_mode() != 0)
+         return 0;
 #ifdef HAVE_OPAQUE_STRUCTS
     *ctx = EVP_MD_CTX_new();
 


### PR DESCRIPTION
Avoid initing MD5 digest, which is not permitted in OpenSSL FIPS certified cryptography mode.
Fixes: https://github.com/libssh2/libssh2/issues/527