### PR TITLE
Correct typo which may lead to stack overflow

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -219,7 +219,7 @@ banner_send(LIBSSH2_SESSION * session)
         }
         else {
             memcpy(banner_dup, banner, 255);
-            banner[255] = '\0';
+            banner_dup[255] = '\0';
         }
 
         _libssh2_debug(session, LIBSSH2_TRACE_TRANS, "Sending Banner: %s",


### PR DESCRIPTION
Seems the author intend to terminate "banner_dup" buffer, later print to the debug console.