### PR TITLE
ssh_client_fuzzer.cc: set blocking mode on

### DIFF
--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -57,6 +57,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
   // Create a session and start the handshake using the fuzz data passed in.
   session = libssh2_session_init();
+  if(session) {
+    libssh2_session_set_blocking(session, 1);
+  }
 
   if(libssh2_session_handshake(session, socket_fds[0])) {
     goto EXIT_LABEL;
@@ -84,4 +87,5 @@ EXIT_LABEL:
   close(socket_fds[1]);
 
   return 0;
-}
+
+                                 "Normal Shutdown, Thank you for playing")


### PR DESCRIPTION
file: ssh_client_fuzzer.cc

notes: the session needs blocking mode turned on to avoid EAGAIN being returned from libssh2_session_handshake()

credit:
Will Cosgrove, reviewed by Michael Buckley