### PR TITLE
userauth.c: don't error if using keys without RSA

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -828,11 +828,6 @@ userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
 {
     int rc;
 
-#if !LIBSSH2_RSA
-    return _libssh2_error(session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
-                          "RSA is not supported by crypto backend");
-#endif
-
     if(session->userauth_host_state == libssh2_NB_state_idle) {
         const LIBSSH2_HOSTKEY_METHOD *privkeyobj;
         unsigned char *pubkeydata = NULL;
@@ -1438,11 +1433,6 @@ userauth_publickey_frommemory(LIBSSH2_SESSION *session,
     void *abstract = &privkey_file;
     int rc;
 
-#if !LIBSSH2_RSA
-    return _libssh2_error(session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
-                          "RSA is not supported by crypto backend");
-#endif
-
     privkey_file.filename = privatekeydata;
     privkey_file.passphrase = passphrase;
 
@@ -1499,11 +1489,6 @@ userauth_publickey_fromfile(LIBSSH2_SESSION *session,
     struct privkey_file privkey_file;
     void *abstract = &privkey_file;
     int rc;
-
-#if !LIBSSH2_RSA
-    return _libssh2_error(session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
-                          "RSA is not supported by crypto backend");
-#endif
 
     privkey_file.filename = privatekey;
     privkey_file.passphrase = passphrase;


### PR DESCRIPTION
file: userauth.c
notes: libssh2 now supports many other key types besides RSA, if the library is built without RSA support and a user attempts key auth it shouldn't be an automatic error.
credit: 
Will Cosgrove