### PR TITLE
Fix EVP_Cipher interface change in openssl 3

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -427,10 +427,19 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
 #else
     ret = EVP_Cipher(ctx, buf, block, blocksize);
 #endif
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    if(ret != -1) {
+#else
     if(ret == 1) {
+#endif
         memcpy(block, buf, blocksize);
     }
+
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    return ret != -1 ? 0 : 1;
+#else
     return ret == 1 ? 0 : 1;
+#endif
 }
 
 #if LIBSSH2_AES_CTR && !defined(HAVE_EVP_AES_128_CTR)


### PR DESCRIPTION
Hello,
We discovered that bug when we linked curl with openssl version 3. It has been reported in #463. 
I propose this fix.
Regards,