### PR TITLE
Fix unused variables warning

### DIFF
--- a/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c
@@ -13,7 +13,6 @@ int read_file(const char *path, char **buf, size_t *len);
 int test(LIBSSH2_SESSION *session)
 {
     int rc;
-    FILE *fp = NULL;
     char *buffer = NULL;
     size_t len = 0;
     const char *userauth_list = NULL;
@@ -53,7 +52,6 @@ int test(LIBSSH2_SESSION *session)
 
 int read_file(const char *path, char **out_buffer, size_t *out_len)
 {
-    int rc;
     FILE *fp = NULL;
     char *buffer = NULL;
     size_t len = 0;


### PR DESCRIPTION
Hello,
This PR fixes:
```
/home/ubuntu/opensource/libssh2/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c: In function ‘test’:
/home/ubuntu/opensource/libssh2/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c:16:11: warning: unused variable ‘fp’ [-Wunused-variable]
   16 |     FILE *fp = NULL;
      |           ^~
/home/ubuntu/opensource/libssh2/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c: In function ‘read_file’:
/home/ubuntu/opensource/libssh2/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c:56:9: warning: unused variable ‘rc’ [-Wunused-variable]
   56 |     int rc;
      |         ^~
```