### PR TITLE
blowfish: fix clang10 false positive warning

### DIFF
--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -81,7 +81,7 @@ bcrypt_hash(uint8_t *sha2pass, uint8_t *sha2salt, uint8_t *out)
         cdata[i] = Blowfish_stream2word(ciphertext, sizeof(ciphertext),
                                         &j);
     for(i = 0; i < 64; i++)
-        blf_enc(&state, cdata, sizeof(cdata) / sizeof(uint64_t));
+        blf_enc(&state, cdata, BCRYPT_BLOCKS / 2);
 
     /* copy out */
     for(i = 0; i < BCRYPT_BLOCKS; i++) {


### PR DESCRIPTION
blf_enc() takes a number of 64-bit blocks to encrypt, but using sizeof(uint64_t) in the calculation triggers a warning with clang 10 because the actual data type is uint32_t. Pass BCRYPT_BLOCKS / 2 for the number of blocks like libc bcrypt(3) does.

Ref: https://github.com/openbsd/src/commit/04a2240bd8f465bcae6b595d912af3e2965856de

Fixes #562
Closes #xxx