### PR TITLE
Add comment to the command line parameter

### DIFF
--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -115,6 +115,21 @@ int main(int argc, char *argv[])
         password = argv[3];
     }
     if(argc > 4) {
+        /*
+        Please pay some attention to this parameter; if it includes space, it needs quotation marks.
+        Another thing is, not all the shell command output to stdout. Some of them are naughty and prefer stderr.
+
+        For example, the following command needs quotation marks.
+        Without proper quotation, it becomes two parameters. That leaves an interactive python shell waiting for your input and never returns.
+
+            python -V becomes a "python" and a "-V"; Add quotation marks "python -V" to tell it is 
+
+        Also, please note that "python -V" output goes through the stderr, so remember to change your channel behavior like the following, or you'll miss the output:
+            libssh2_channel_handle_extended_data2(channel, LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE);
+
+        Or, As an alternative, calling below function to read stderr separately:
+            libssh2_channel_read_stderr(channel, buf, buflen);
+        */
         commandline = argv[4];
     }
 


### PR DESCRIPTION
File: ssh2_exec.c

Note: Sometimes, people forget the basic principle of their OS;  This comment helps them avoid runs into a hard time.

By the way, I’m not a native English speaker; Following lines sound weird or incomplete; better make it clear by elaborate a little bit. Please give a hand and fix it.

A. [note] This comment helps them avoid runs into a hard time.
B. [comment] Add quotation marks "python -V" to tell it is

Please feel free to revise! 

Thanks!