### PR TITLE
libssh2_priv.h: add iovec on 3ds

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -109,13 +109,18 @@
 #define inline __inline
 #endif
 
-/* Provide iovec / writev on WIN32 platform. */
-#ifdef WIN32
+/* 3DS doesn't seem to have iovec */
+#if defined(WIN32) || defined(_3DS)
 
 struct iovec {
     size_t iov_len;
     void *iov_base;
 };
+
+#endif
+
+/* Provide iovec / writev on WIN32 platform. */
+#ifdef WIN32
 
 static inline int writev(int sock, struct iovec *iov, int nvecs)
 {


### PR DESCRIPTION
Some toolchains like devkitPro's 3DS toolchain don't have iovec defined for whatever reason... This fixes that. I'm not entirely sure how the iovecs are being used since I don't see any calls to writev or readv, but this at least allows it to compile for the system.