### PR TITLE
ci: Swap from Travis to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run Fuzzer
-        run: GIT_BRANCH=${GITHUB_REF#refs/heads/} ./ci/ossfuzz.sh
+        run: GIT_REF=$GITHUB_REF ./ci/ossfuzz.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run Fuzzer
-        run: TRAVIS_BRANCH=${GITHUB_REF#refs/heads/} ./tests/ossfuzz/travisoss.sh
+        run: GIT_BRANCH=${GITHUB_REF#refs/heads/} ./ci/ossfuzz.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  style-check:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check Style
+        run: ./ci/checksrc.sh
+  build:
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        address_size: [32, 64]
+        crypto_backend: [OpenSSL, Libgcrypt, mbedTLS]
+        build_shared_libs: [OFF, ON]
+        enable_zlib_compression: [OFF, ON]
+        b: [cmake]
+        include:
+          - compiler: gcc
+            address_size: 64
+            crypto_backend: OpenSSL
+            build_shared_libs: OFF
+            enable_zlib_compression: OFF
+            b: configure
+          - compiler: clang
+            address_size: 64
+            crypto_backend: OpenSSL
+            build_shared_libs: OFF
+            enable_zlib_compression: OFF
+            b: configure
+    env:
+      CC: ${{ matrix.compiler }}
+      CC_FOR_BUILD: ${{ matrix.compiler }}
+      CRYPTO_BACKEND: ${{ matrix.crypto_backend }}
+      BUILD_SHARED_LIBS: ${{ matrix.build_shared_libs }}
+      ENABLE_ZLIB_COMPRESSION: ${{ matrix.enable_zlib_compression }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install 32 Bit Dependencies
+        if: ${{ matrix.address_size == 32 }}
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq
+          sudo apt-get install -y gcc-multilib
+          sudo apt-get install -y libssl-dev:i386 libgcrypt20-dev:i386 zlib1g-dev:i386 build-essential gcc-multilib
+          sudo dpkg --purge --force-depends gcc-multilib
+          sudo dpkg --purge --force-depends libssl-dev
+          echo "TOOLCHAIN_OPTION=-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-Linux-32.cmake" >> $GITHUB_ENV
+      - name: Install 64 Bit Dependencies
+        if: ${{ matrix.address_size == 64 }}
+        run: |
+          sudo apt-get install -y libssl-dev
+          sudo apt-get install -y libgcrypt11-dev
+      - name: Install mbedTLS Dependencies
+        if: ${{ matrix.crypto_backend == 'mbedTLS' }}
+        run: |
+          MBEDTLSVER=mbedtls-2.7.0
+          curl -L https://github.com/ARMmbed/mbedtls/archive/$MBEDTLSVER.tar.gz | tar -xzf -
+          cd mbedtls-$MBEDTLSVER
+          cmake $TOOLCHAIN_OPTION -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX:PATH=../usr .
+          make -j3 install
+          cd ..
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+      - name: Build with Configure
+        if: ${{ matrix.b == 'configure' }}
+        run: |
+          autoreconf -fi
+          ./configure --enable-debug --enable-werror
+          make
+          make check
+      - name: Build with CMake
+        if: ${{ matrix.b == 'cmake' }}
+        run: |
+          mkdir bin
+          cd bin
+          cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
+          cmake --build .
+          CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --target test
+          cmake --build . --target package
+  fuzzer:
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+    env:
+      CC: ${{ matrix.compiler }}
+      CC_FOR_BUILD: ${{ matrix.compiler }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Fuzzer
+        run: TRAVIS_BRANCH=${GITHUB_REF#refs/heads/} ./tests/ossfuzz/travisoss.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ script:
       fi
   - |
       if [ "$B" = "fuzzer" ]; then
-        ./tests/ossfuzz/travisoss.sh
+        GIT_BRANCH=$TRAVIS_BRANCH ./ci/ossfuzz.sh
       fi
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ script:
       fi
   - |
       if [ "$B" = "fuzzer" ]; then
-        GIT_BRANCH=$TRAVIS_BRANCH ./ci/ossfuzz.sh
+        GIT_REF=$TRAVIS_COMMIT ./ci/ossfuzz.sh
       fi
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)

--- a/ci/ossfuzz.sh
+++ b/ci/ossfuzz.sh
@@ -17,7 +17,10 @@ then
 fi
 
 # Modify the oss-fuzz Dockerfile so that we're checking out the current branch in the CI system.
-sed -i "s@https://github.com/libssh2/libssh2.git@-b $GIT_BRANCH https://github.com/libssh2/libssh2.git@" /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
+sed -i \
+    -e "s@--depth 1@--no-checkout@" \
+    -e "s@/src/libssh2@/src/libssh2 ; git -C /src/libssh2 fetch origin $GIT_REF:ci; git -C /src/libssh2 checkout ci@" \
+    /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
 
 # Try and build the fuzzers
 pushd /tmp/ossfuzz

--- a/ci/ossfuzz.sh
+++ b/ci/ossfuzz.sh
@@ -16,8 +16,8 @@ then
     exit 0
 fi
 
-# Modify the oss-fuzz Dockerfile so that we're checking out the current branch on travis.
-sed -i "s@https://github.com/libssh2/libssh2.git@-b $TRAVIS_BRANCH https://github.com/libssh2/libssh2.git@" /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
+# Modify the oss-fuzz Dockerfile so that we're checking out the current branch in the CI system.
+sed -i "s@https://github.com/libssh2/libssh2.git@-b $GIT_BRANCH https://github.com/libssh2/libssh2.git@" /tmp/ossfuzz/projects/${PROJECT_NAME}/Dockerfile
 
 # Try and build the fuzzers
 pushd /tmp/ossfuzz

--- a/tests/ossfuzz/ossfuzz.sh
+++ b/tests/ossfuzz/ossfuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # This script is called by the oss-fuzz main project when compiling the fuzz
-# targets. This script is regression tested by travisoss.sh.
+# targets. This script is regression tested by ci/ossfuzz.sh.
 
 # Save off the current folder as the build root.
 export BUILD_ROOT=$PWD


### PR DESCRIPTION
I saw in the mailing list that there was some desire to move from Travis (and maybe Appveyor) to Github Actions. I also wanted to do this in the hope that it will cut down CI times and spurious CI failures that I have seen over and over.

To have the workflows I've added run for this PR, I believe a maintainer will need to approve the workflow for this PR because I am not yet marked as a contributor.
https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks

In testing I've seen Linux builds ~8 minutes in length.

Notes:
- `ubuntu-16.04` was selected as the virtual environment to run on as this matches what Travis has been using.
- For 32 builds, `zlib1g-dev:i386` needed to be installed for whatever reason. I'm guessing this was installed by the `chrome` addon on Travis, but I honestly don't know.