### PR TITLE
Explicitly state the default branch it GitHub Action CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 jobs:
   style-check:


### PR DESCRIPTION
It looks like the $default-branch macro only works in templates, not
workflows. This is not explicitly stated anywhere except the linked PR
comment.

https://github.com/actions/starter-workflows/pull/590#issuecomment-672360634