### PR TITLE
packet.c: Reset read timeout after received a packet (#576)

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -1323,9 +1323,11 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
 
         if(strchr((char *) packet_types, ret)) {
             /* Be lazy, let packet_ask pull it out of the brigade */
-            return _libssh2_packet_askv(session, packet_types, data,
+            int ret = _libssh2_packet_askv(session, packet_types, data,
                                         data_len, match_ofs, match_buf,
                                         match_len);
+            state->start = 0;
+            return ret;
         }
     }
 


### PR DESCRIPTION
File:
packet.c

Notes:
Attempt keyboard interactive login (Azure AD 2FA login) and use more than 60 seconds to complete the login, the connection fails.

The _libssh2_packet_require function does almost the same as _libssh2_packet_requirev but this function sets state->start = 0 before returning.

Credit:
teottin, Co-authored-by: Tor Erik Ottinsen <tor.ottinsen@kdi.kongsberg.com>