### PR TITLE
ci: Speed up docker builds for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       ENABLE_ZLIB_COMPRESSION: ${{ matrix.enable_zlib_compression }}
     steps:
       - uses: actions/checkout@v2
+      - uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Install 32 Bit Dependencies
         if: ${{ matrix.address_size == 32 }}
         run: |
@@ -85,6 +86,9 @@ jobs:
           cd bin
           cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
           cmake --build .
+          pushd ../tests
+          docker build -t libssh2/openssh_server openssh_server
+          popd
           CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --target test
           cmake --build . --target package
   fuzzer:

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,9 @@ script:
   - |
       if [ "$B" = "cmake" ]; then
         mkdir bin
-        cd bin
+        cd tests
+        docker build -t libssh2/openssh_server openssh_server
+        cd ../bin
         cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION .. && cmake --build . && CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --target test && cmake --build . --target package
       fi
   - |


### PR DESCRIPTION
The OpenSSH server docker image used for tests is pre-built to prevent
wasting time building it during a test, and unneeded rebuilds are
prevented by caching the image layers.