### PR TITLE
ci: Use the GitHub Docker registry rather than caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
       ENABLE_ZLIB_COMPRESSION: ${{ matrix.enable_zlib_compression }}
     steps:
       - uses: actions/checkout@v2
-      - uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Install 32 Bit Dependencies
         if: ${{ matrix.address_size == 32 }}
         run: |
@@ -72,6 +71,22 @@ jobs:
           cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare OpenSSH Server Container for Testing
+        uses: docker/build-push-action@v2
+        with:
+          pull: true
+          load: true
+          push: ${{ github.event_name == 'push' }}
+          context: ./tests/openssh_server
+          tags: |
+            libssh2/openssh_server
+            ghcr.io/libssh2/ci_tests_openssh_server
       - name: Build with Configure
         if: ${{ matrix.b == 'configure' }}
         run: |
@@ -86,10 +101,7 @@ jobs:
           cd bin
           cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
           cmake --build .
-          pushd ../tests
-          docker build -t libssh2/openssh_server openssh_server
-          popd
-          CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --target test
+          DISABLE_DOCKER_BUILD=1 CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --target test
           cmake --build . --target package
   fuzzer:
     runs-on: ubuntu-16.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ script:
       if [ "$B" = "cmake" ]; then
         mkdir bin
         cd tests
+        (docker pull ghcr.io/libssh2/ci_tests_openssh_server && docker tag ghcr.io/libssh2/ci_tests_openssh_server libssh2/openssh_server) || true
         docker build -t libssh2/openssh_server openssh_server
         cd ../bin
         cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION .. && cmake --build . && CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --target test && cmake --build . --target package

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -145,8 +145,14 @@ static int run_command(char **output, const char *command, ...)
 
 static int build_openssh_server_docker_image(void)
 {
-    return run_command(NULL, "docker build -t libssh2/openssh_server "
-                             "openssh_server");
+    int ret = 0;
+
+    if(NULL == getenv("DISABLE_DOCKER_BUILD")) {
+        ret = run_command(NULL, "docker build -t libssh2/openssh_server "
+                          "openssh_server");
+    }
+
+    return ret;
 }
 
 static int start_openssh_server(char **container_id_out)


### PR DESCRIPTION
This uses the docker registry rather than the newer container registry because the container registry needs to be manually enabled for a user/organization while it is still in beta. I obviously don't have the permissions to do that for libssh2, but if a maintainer would like to do that, I can try to move this over to the container registry.

https://docs.github.com/en/packages/working-with-a-github-packages-registry/enabling-improved-container-support-with-the-container-registry

Utilizing the "cached" image from Travis builds would require a personal access token when using the docker registry, which I don't have the permissions to make for the libssh2 organization. This would not be a problem for the container registry.

https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry

Pulling images won't work on the first pass for obvious reasons. Pushing images won't work in the PR as $GITHUB_TOKEN doesn't have the required permissions for pushing for forked repos, which applies to PRs from forked repos as well. If we wish to test pulling from the repository in this PR, a maintainer will need to upload the openssh_server image to the docker registry and then the CI will need to be re-run.

As a side note, I hate how much of this CI stuff I've been working on cannot be fully tested before merging, and it is mostly because of the security measures that GitHub forces on us.