### PR TITLE
ci: Remove caching of docker image layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
       ENABLE_ZLIB_COMPRESSION: ${{ matrix.enable_zlib_compression }}
     steps:
       - uses: actions/checkout@v2
-      - uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Install 32 Bit Dependencies
         if: ${{ matrix.address_size == 32 }}
         run: |


### PR DESCRIPTION
This PR removes the caching of docker image layers entirely to avoid CI failures due to the caching action failing. Honestly, the OpenSSH test server docker image built takes so little time to build that caching the layers doesn't get us much.

An alternative to the work in #588.