### PR TITLE
configure.ac: don't undefine scoped variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,8 +128,6 @@ fi
 m4_set_foreach([crypto_backends], [backend],
   [AM_CONDITIONAL(m4_toupper(backend), test "$found_crypto" = "backend")]
 )
-m4_undefine([backend])
-
 
 # libz
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,12 +36,9 @@ case "$host" in
     CFLAGS="$CFLAGS -DLIBSSH2_WIN32"
     LIBS="$LIBS -lws2_32"
     ;;
-	*-cygwin)
-	CFLAGS="$CFLAGS -DLIBSSH2_WIN32"
+    *darwin*)
+    CFLAGS="$CFLAGS -DLIBSSH2_DARWIN"
     ;;
-	*darwin*)
-	CFLAGS="$CFLAGS -DLIBSSH2_DARWIN"
-	;;
     *hpux*)
     ;;
     *osf*)


### PR DESCRIPTION
To get this script to run with Autoconf 2.71 on macOS I had to remove the undefine of the backend for loop variable. It seems scoped to the for loop and also isn't referenced later in the script so it seems OK to remove it.