### PR TITLE
[CMake] Set the visibility to hidden and only export the API symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,11 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 # OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 project(libssh2 C)
 set(PROJECT_URL "https://www.libssh2.org/")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -216,6 +216,10 @@ if(WIN32)
 endif()
 
 add_library(libssh2 ${SOURCES})
+
+include(GenerateExportHeader)
+generate_export_header(libssh2 EXPORT_MACRO_NAME "LIBSSH2_API")
+
 # we want it to be called libssh2 on all platforms
 set_target_properties(libssh2 PROPERTIES PREFIX "")
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -35,6 +35,7 @@
  * OF SUCH DAMAGE.
  */
 
+#include "libssh2_export.h"
 /* Headers */
 #cmakedefine HAVE_UNISTD_H
 #cmakedefine HAVE_INTTYPES_H


### PR DESCRIPTION
Hello,
I just find out a discrepancy in the shared libs produced by autotools and by CMake. It seems by default the CMake build does not hide any symbols.

```
>abidiff ~/libssh2.so.cmake libssh2.so.autotools
Functions changes summary: 0 Removed, 0 Changed, 0 Added function
Variables changes summary: 0 Removed, 0 Changed, 0 Added variable
Function symbols changes summary: 119 Removed, 0 Added function symbols not referenced by debug info
Variable symbols changes summary: 1 Removed, 0 Added variable symbol not referenced by debug info

119 Removed function symbols not referenced by debug info:

  [D] Blowfish_decipher
  [D] Blowfish_encipher
  [D] Blowfish_expand0state
  [D] Blowfish_expandstate
  [D] Blowfish_initstate
  [D] Blowfish_stream2word
  [D] _fini
  [D] _init
  [D] _libssh2_aes_ctr_increment
  [D] _libssh2_base64_encode
  [D] _libssh2_bcrypt_pbkdf
  [D] _libssh2_calloc
  [D] _libssh2_channel_close
  [D] _libssh2_channel_extended_data
  [D] _libssh2_channel_flush
  [D] _libssh2_channel_forward_cancel
  [D] _libssh2_channel_free
  [D] _libssh2_channel_locate
  [D] _libssh2_channel_nextid
  [D] _libssh2_channel_open
...
```
From CMake 3.12, we can set the default symbol visibility to 'hidden' and generate the macro `LIBSSH2_API` in a portable way. (https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html)

I send you a proposal. Maybe we can rework it so that we only enable hidden symbols visibility by default only when CMake version >=3.12.
Though I feel, the minimal required version of CMake is outdated. It is perhaps worth upgrading it.
Whatever the decision, I can resubmit the PR with your comments.

Regards,
Laurent