### PR TITLE
openssl.c: guards around calling FIPS_mode() #596

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2230,8 +2230,14 @@ _libssh2_md5_init(libssh2_md5_ctx *ctx)
      * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"
      * So, just return 0 in FIPS mode
      */
+#if OPENSSL_VERSION_NUMBER >= 0x000907000L && \
+    defined(OPENSSL_VERSION_MAJOR) && \
+    OPENSSL_VERSION_MAJOR < 3 && \
+    !defined(LIBRESSL_VERSION_NUMBER)
      if(FIPS_mode() != 0)
          return 0;
+#endif
+
 #ifdef HAVE_OPAQUE_STRUCTS
     *ctx = EVP_MD_CTX_new();
 


### PR DESCRIPTION
Notes:
FIPS_mode() is not implemented in LibreSSL, removed in OpenSSL 3.0 and introduced in 0.9.7. Added guards around making this call.

Credit:
Will Cosgrove