### PR TITLE
Add missing tests client keys in distribution tarball

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,8 +28,18 @@ EXTRA_DIST =                                                           \
  key_dsa.pub                                                           \
  key_dsa_wrong                                                         \
  key_dsa_wrong.pub                                                     \
+ key_ecdsa                                                             \
+ key_ecdsa.pub                                                         \
+ key_ed25519                                                           \
+ key_ed25519.pub                                                       \
+ key_ed25519_encrypted                                                 \
+ key_ed25519_encrypted.pub                                             \
  key_rsa                                                               \
  key_rsa.pub                                                           \
+ key_rsa_encrypted                                                     \
+ key_rsa_encrypted.pub                                                 \
+ key_rsa_openssh                                                       \
+ key_rsa_openssh.pub                                                   \
  libssh2_config_cmake.h.in                                             \
  mansyntax.sh                                                          \
  openssh_fixture.c                                                     \


### PR DESCRIPTION
Hello,

With the latest [tarball](https://libssh2.org/snapshots/libssh2-1.9.0-20210518.tar.gz), I have these tests failure.
```
The following tests FAILED:
          8 - test_public_key_auth_succeeds_with_correct_encrypted_rsa_key (Failed)
         12 - test_public_key_auth_succeeds_with_correct_rsa_openssh_key (Failed)
```
This is raised by:

```
 libssh2_userauth_publickey_fromfile_ex failed (-16): Unable to open public key file
```

I added the missing client keys and now all the tests work.
Regards,