### PR TITLE
Add libssh2_userauth_keyboard_interactive2_ex

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -295,6 +295,13 @@ typedef struct _LIBSSH2_USERAUTH_KBDINT_RESPONSE
             const LIBSSH2_USERAUTH_KBDINT_PROMPT *prompts,              \
             LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses, void **abstract)
 
+/* 'keyboard-interactive' authentication callback */
+#define LIBSSH2_USERAUTH_KBDINT2_RESPONSE_FUNC(name_) \
+ int name_(const char *name, int name_len, const char *instruction, \
+            int instruction_len, int num_prompts, \
+            const LIBSSH2_USERAUTH_KBDINT_PROMPT *prompts,              \
+            LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses, void **abstract)
+
 /* Callbacks for special SSH packets */
 #define LIBSSH2_IGNORE_FUNC(name) \
  void name(LIBSSH2_SESSION *session, const char *message, int message_len, \
@@ -698,6 +705,14 @@ libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION* session,
                                          unsigned int username_len,
                                          LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(
                                                        (*response_callback)));
+
+LIBSSH2_API int
+libssh2_userauth_keyboard_interactive2_ex(LIBSSH2_SESSION* session,
+                                         const char *username,
+                                         unsigned int username_len,
+                                         LIBSSH2_USERAUTH_KBDINT2_RESPONSE_FUNC
+                                         ((*response_callback)),
+                                         void **abstract);
 
 #define libssh2_userauth_keyboard_interactive(session, username,        \
                                               response_callback)        \

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1630,7 +1630,10 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
                               const char *username,
                               unsigned int username_len,
                               LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC
-                              ((*response_callback)))
+                              ((*old_response_cb)),
+                              LIBSSH2_USERAUTH_KBDINT2_RESPONSE_FUNC
+                              ((*response_cb)),
+                              void **abstract)
 {
     unsigned char *s;
     int rc;
@@ -1963,15 +1966,40 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
                     }
                 }
             }
+            session->userauth_kybd_state = libssh2_NB_state_sent1;
+        }
 
-            response_callback(session->userauth_kybd_auth_name,
-                              session->userauth_kybd_auth_name_len,
-                              session->userauth_kybd_auth_instruction,
-                              session->userauth_kybd_auth_instruction_len,
-                              session->userauth_kybd_num_prompts,
-                              session->userauth_kybd_prompts,
-                              session->userauth_kybd_responses,
-                              &session->abstract);
+        if(session->userauth_kybd_state == libssh2_NB_state_sent1) {
+            if(response_cb) {
+                rc = response_cb(session->userauth_kybd_auth_name,
+                                 session->userauth_kybd_auth_name_len,
+                                 session->userauth_kybd_auth_instruction,
+                                 session->userauth_kybd_auth_instruction_len,
+                                 session->userauth_kybd_num_prompts,
+                                 session->userauth_kybd_prompts,
+                                 session->userauth_kybd_responses,
+                                 abstract);
+                if(rc == LIBSSH2_ERROR_EAGAIN) {
+                    return _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
+                                          "Would block");
+                }
+                if(rc) {
+                    _libssh2_error(session, LIBSSH2_ERROR_SOCKET_SEND,
+                                   "Unable to send userauth keyboard "
+                                   "interactive request");
+                    goto cleanup;
+                }
+            }
+            else {
+                old_response_cb(session->userauth_kybd_auth_name,
+                                session->userauth_kybd_auth_name_len,
+                                session->userauth_kybd_auth_instruction,
+                                session->userauth_kybd_auth_instruction_len,
+                                session->userauth_kybd_num_prompts,
+                                session->userauth_kybd_prompts,
+                                session->userauth_kybd_responses,
+                                &session->abstract);
+            }
 
             _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
                            "Keyboard-interactive response callback function"
@@ -2020,10 +2048,10 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
                                    session->userauth_kybd_responses[i].length);
             }
 
-            session->userauth_kybd_state = libssh2_NB_state_sent1;
+            session->userauth_kybd_state = libssh2_NB_state_sent2;
         }
 
-        if(session->userauth_kybd_state == libssh2_NB_state_sent1) {
+        if(session->userauth_kybd_state == libssh2_NB_state_sent2) {
             rc = _libssh2_transport_send(session, session->userauth_kybd_data,
                                          session->userauth_kybd_packet_len,
                                          NULL, 0);
@@ -2105,6 +2133,28 @@ libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION *session,
     int rc;
     BLOCK_ADJUST(rc, session,
                  userauth_keyboard_interactive(session, user, user_len,
-                                               response_callback));
+                                               response_callback, NULL,
+                                               NULL));
+    return rc;
+}
+
+/*
+ * libssh2_userauth_keyboard_interactive2_ex
+ *
+ * Authenticate using a challenge-response authentication
+ */
+LIBSSH2_API int
+libssh2_userauth_keyboard_interactive2_ex(LIBSSH2_SESSION *session,
+                                         const char *user,
+                                         unsigned int user_len,
+                                         LIBSSH2_USERAUTH_KBDINT2_RESPONSE_FUNC
+                                         ((*response_callback)),
+                                         void **abstract)
+{
+    int rc;
+    BLOCK_ADJUST(rc, session,
+                 userauth_keyboard_interactive(session, user, user_len,
+                                               NULL, response_callback,
+                                               abstract));
     return rc;
 }


### PR DESCRIPTION
  Adds a new function to the public API that allows
  the caller to work around two issues with the previous
  version:
  1) Allow the callback to return EAGAIN so that it can
  be used in an asychronous context.  This now works
  in the same was as LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC
  2) Allow the caller to pass in their own state.  Again
  similar to libssh2_userauth_publickey, the caller
  can pass in their own abstract pointer.

  Extend the internal function userauth_keyboard_interactive
  to preserve the existing legacy behavior to avoid
  duplicating the core functionality