### PR TITLE
[1.10.0] Add missing key in case openssl > 1.1.0

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,6 +30,9 @@ EXTRA_DIST =                                                           \
  key_dsa_wrong.pub                                                     \
  key_ecdsa                                                             \
  key_ecdsa.pub                                                         \
+ signed_key_ecdsa                                                      \
+ signed_key_ecdsa.pub                                                  \
+ signed_key_ecdsa-cert.pub                                             \
  key_ed25519                                                           \
  key_ed25519.pub                                                       \
  key_ed25519_encrypted                                                 \


### PR DESCRIPTION
Hello,
I just spot that building and running the tests (CMake build) some keys are missing in the release tarball:
```
      Start 17: test_public_key_auth_succeeds_with_correct_signed_ecdsa_key
17/19 Test #17: test_public_key_auth_succeeds_with_correct_signed_ecdsa_key ........***Failed    1.36 sec
libssh2_userauth_publickey_fromfile_ex failed (-16): Unable to open public key file
```
Regards,