### PR TITLE
Host Key RSA 256/512 support libssh2 #536

### DIFF
--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -637,6 +637,32 @@ Note: this procedure is not used if macro _libssh2_rsa_sha1_signv() is defined.
 void _libssh2_rsa_free(libssh2_rsa_ctx *rsactx);
 Releases the RSA computation context at rsactx.
 
+LIBSSH2_RSA_SHA2
+#define as 1 if the crypto library supports RSA SHA2 256/512, else 0.
+If defined as 0, the rest of this section can be omitted.
+
+int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
+                           libssh2_rsa_ctx * rsactx,
+                           const unsigned char *hash,
+                           size_t hash_len,
+                           unsigned char **signature,
+                           size_t *signature_len);
+RSA signs the (hash, hashlen) SHA-2 hash bytes based on hash length and stores
+the allocated signature at (signature, signature_len).
+Signature buffer must be allocated from the given session.
+Returns 0 if OK, else -1.
+This procedure is already prototyped in crypto.h.
+Note: this procedure is not used if macro _libssh2_rsa_sha1_signv() is defined.
+
+int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsa,
+                             size_t hash_len,
+                             const unsigned char *sig,
+                             unsigned long sig_len,
+                             const unsigned char *m, unsigned long m_len);
+Verify (sig, sig_len) signature of (m, m_len) using an SHA-2 hash based on
+hash length and the RSA context.
+Return 0 if OK, else -1.
+This procedure is already prototyped in crypto.h.
 
 7.2) DSA
 LIBSSH2_DSA

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -93,6 +93,19 @@ int _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
                            size_t hash_len,
                            unsigned char **signature,
                            size_t *signature_len);
+#if LIBSSH2_RSA_SHA2
+int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
+                           libssh2_rsa_ctx * rsactx,
+                           const unsigned char *hash,
+                           size_t hash_len,
+                           unsigned char **signature,
+                           size_t *signature_len);
+int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsa,
+                             size_t hash_len,
+                             const unsigned char *sig,
+                             unsigned long sig_len,
+                             const unsigned char *m, unsigned long m_len);
+#endif
 int _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
                                         LIBSSH2_SESSION * session,
                                         const char *filedata,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -232,6 +232,7 @@ hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION * session,
  *
  * Verify signature created by remote
  */
+#if LIBSSH2_RSA_SHA2
 
 static int
 hostkey_method_ssh_rsa_sha2_256_sig_verify(LIBSSH2_SESSION * session,
@@ -359,6 +360,8 @@ hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION * session,
 #endif
 }
 
+#endif /* LIBSSH2_RSA_SHA2 */
+
 
 /*
  * hostkey_method_ssh_rsa_dtor
@@ -394,6 +397,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa = {
     hostkey_method_ssh_rsa_dtor,
 };
 
+#if LIBSSH2_RSA_SHA2
 
 static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_256 = {
     "rsa-sha2-256",
@@ -418,6 +422,8 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_512 = {
     NULL,                       /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
+
+#endif /* LIBSSH2_RSA_SHA2 */
 
 #endif /* LIBSSH2_RSA */
 
@@ -1202,8 +1208,10 @@ static const LIBSSH2_HOSTKEY_METHOD *hostkey_methods[] = {
     &hostkey_method_ssh_ed25519,
 #endif
 #if LIBSSH2_RSA
+#if LIBSSH2_RSA_SHA2
     &hostkey_method_ssh_rsa_sha2_512,
     &hostkey_method_ssh_rsa_sha2_256,
+#endif /* LIBSSH2_RSA_SHA2 */
     &hostkey_method_ssh_rsa,
 #endif /* LIBSSH2_RSA */
 #if LIBSSH2_DSA

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -228,6 +228,139 @@ hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION * session,
 }
 
 /*
+ * hostkey_method_ssh_rsa_sha2_256_sig_verify
+ *
+ * Verify signature created by remote
+ */
+
+static int
+hostkey_method_ssh_rsa_sha2_256_sig_verify(LIBSSH2_SESSION * session,
+                                   const unsigned char *sig,
+                                   size_t sig_len,
+                                   const unsigned char *m,
+                                   size_t m_len, void **abstract)
+{
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    (void) session;
+
+    /* Skip past keyname_len(4) + keyname(12){"rsa-sha2-256"} + signature_len(4) */
+    if(sig_len < 20)
+        return -1;
+
+    sig += 20;
+    sig_len -= 20;
+    return _libssh2_rsa_sha2_verify(rsactx, SHA256_DIGEST_LENGTH, sig, sig_len, m, m_len);
+}
+
+/*
+ * hostkey_method_ssh_rsa_sha2_256_signv
+ *
+ * Construct a signature from an array of vectors
+ */
+
+static int
+hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION * session,
+                             unsigned char **signature,
+                             size_t *signature_len,
+                             int veccount,
+                             const struct iovec datavec[],
+                             void **abstract)
+{
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+
+#ifdef _libssh2_rsa_sha2_256_signv
+    return _libssh2_rsa_sha2_256_signv(session, signature, signature_len,
+                                       veccount, datavec, rsactx);
+#else
+    int ret;
+    int i;
+    unsigned char hash[SHA256_DIGEST_LENGTH];
+    libssh2_sha256_ctx ctx;
+
+    libssh2_sha256_init(&ctx);
+    for(i = 0; i < veccount; i++) {
+        libssh2_sha256_update(ctx, datavec[i].iov_base, datavec[i].iov_len);
+    }
+    libssh2_sha256_final(ctx, hash);
+
+    ret = _libssh2_rsa_sha2_sign(session, rsactx, hash, SHA256_DIGEST_LENGTH,
+                                 signature, signature_len);
+    if(ret) {
+        return -1;
+    }
+
+    return 0;
+#endif
+}
+
+/*
+ * hostkey_method_ssh_rsa_sha2_512_sig_verify
+ *
+ * Verify signature created by remote
+ */
+
+static int
+hostkey_method_ssh_rsa_sha2_512_sig_verify(LIBSSH2_SESSION * session,
+                                   const unsigned char *sig,
+                                   size_t sig_len,
+                                   const unsigned char *m,
+                                   size_t m_len, void **abstract)
+{
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    (void) session;
+
+    /* Skip past keyname_len(4) + keyname(12){"rsa-sha2-512"} + signature_len(4) */
+    if(sig_len < 20)
+        return -1;
+
+    sig += 20;
+    sig_len -= 20;
+    return _libssh2_rsa_sha2_verify(rsactx, SHA512_DIGEST_LENGTH, sig, sig_len, m, m_len);
+}
+
+
+/*
+ * hostkey_method_ssh_rsa_sha2_512_signv
+ *
+ * Construct a signature from an array of vectors
+ */
+static int
+hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION * session,
+                             unsigned char **signature,
+                             size_t *signature_len,
+                             int veccount,
+                             const struct iovec datavec[],
+                             void **abstract)
+{
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+
+#ifdef _libssh2_rsa_sha2_512_signv
+    return _libssh2_rsa_sha2_512_signv(session, signature, signature_len,
+                                       veccount, datavec, rsactx);
+#else
+    int ret;
+    int i;
+    unsigned char hash[SHA512_DIGEST_LENGTH];
+    libssh2_sha512_ctx ctx;
+
+    libssh2_sha512_init(&ctx);
+    for(i = 0; i < veccount; i++) {
+        libssh2_sha512_update(ctx, datavec[i].iov_base, datavec[i].iov_len);
+    }
+    libssh2_sha512_final(ctx, hash);
+
+    ret = _libssh2_rsa_sha2_sign(session, rsactx, hash, SHA512_DIGEST_LENGTH,
+                                 signature, signature_len);
+    if(ret) {
+        return -1;
+    }
+
+    return 0;
+#endif
+}
+
+
+/*
  * hostkey_method_ssh_rsa_dtor
  *
  * Shutdown the hostkey
@@ -260,6 +393,32 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa = {
     NULL,                       /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
+
+
+static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_256 = {
+    "rsa-sha2-256",
+    SHA256_DIGEST_LENGTH,
+    hostkey_method_ssh_rsa_init,
+    hostkey_method_ssh_rsa_initPEM,
+    hostkey_method_ssh_rsa_initPEMFromMemory,
+    hostkey_method_ssh_rsa_sha2_256_sig_verify,
+    hostkey_method_ssh_rsa_sha2_256_signv,
+    NULL,                       /* encrypt */
+    hostkey_method_ssh_rsa_dtor,
+};
+
+static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_512 = {
+    "rsa-sha2-512",
+    SHA512_DIGEST_LENGTH,
+    hostkey_method_ssh_rsa_init,
+    hostkey_method_ssh_rsa_initPEM,
+    hostkey_method_ssh_rsa_initPEMFromMemory,
+    hostkey_method_ssh_rsa_sha2_512_sig_verify,
+    hostkey_method_ssh_rsa_sha2_512_signv,
+    NULL,                       /* encrypt */
+    hostkey_method_ssh_rsa_dtor,
+};
+
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
@@ -1043,6 +1202,8 @@ static const LIBSSH2_HOSTKEY_METHOD *hostkey_methods[] = {
     &hostkey_method_ssh_ed25519,
 #endif
 #if LIBSSH2_RSA
+    &hostkey_method_ssh_rsa_sha2_512,
+    &hostkey_method_ssh_rsa_sha2_256,
     &hostkey_method_ssh_rsa,
 #endif /* LIBSSH2_RSA */
 #if LIBSSH2_DSA

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -55,6 +55,7 @@
 #define LIBSSH2_3DES 1
 
 #define LIBSSH2_RSA 1
+#define LIBSSH2_RSA_SHA2 0
 #define LIBSSH2_DSA 1
 #define LIBSSH2_ECDSA 0
 #define LIBSSH2_ED25519 0

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -71,6 +71,7 @@
 #define LIBSSH2_3DES            1
 
 #define LIBSSH2_RSA             1
+#define LIBSSH2_RSA_SHA2        0
 #define LIBSSH2_DSA             0
 #ifdef MBEDTLS_ECDSA_C
 # define LIBSSH2_ECDSA          1

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -154,19 +154,55 @@ _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
 }
 
 int
+_libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+                         size_t hash_len,
+                         const unsigned char *sig,
+                         unsigned long sig_len,
+                         const unsigned char *m, unsigned long m_len)
+{
+    int ret;
+    int nid_type;
+    unsigned char *hash = malloc(hash_len);
+    if (hash == NULL)
+        return -1;
+
+    if(hash_len == SHA_DIGEST_LENGTH) {
+        nid_type = NID_sha1;
+        ret = _libssh2_sha1(m, m_len, hash);
+    }
+    else if(hash_len == SHA256_DIGEST_LENGTH) {
+        nid_type = NID_sha256;
+        ret = _libssh2_sha256(m, m_len, hash);
+
+    }
+    else if(hash_len == SHA512_DIGEST_LENGTH) {
+        nid_type = NID_sha512;
+        ret = _libssh2_sha512(m, m_len, hash);
+    }
+    else
+        ret = -1; /* unsupported digest */
+
+    if(ret != 0)
+    {
+        free(hash);
+        return -1; /* failure */
+    }
+
+    ret = RSA_verify(nid_type, hash, hash_len,
+                     (unsigned char *) sig, sig_len, rsactx);
+
+    free(hash);
+
+    return (ret == 1) ? 0 : -1;
+}
+
+int
 _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
                          const unsigned char *sig,
                          unsigned long sig_len,
                          const unsigned char *m, unsigned long m_len)
 {
-    unsigned char hash[SHA_DIGEST_LENGTH];
-    int ret;
-
-    if(_libssh2_sha1(m, m_len, hash))
-        return -1; /* failure */
-    ret = RSA_verify(NID_sha1, hash, SHA_DIGEST_LENGTH,
-                     (unsigned char *) sig, sig_len, rsactx);
-    return (ret == 1) ? 0 : -1;
+    return _libssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH, sig, sig_len, m, m_len);
 }
 
 #if LIBSSH2_DSA
@@ -1876,7 +1912,7 @@ _libssh2_ed25519_new_public(libssh2_ed25519_ctx ** ed_ctx,
 
 
 int
-_libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
+_libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
                        libssh2_rsa_ctx * rsactx,
                        const unsigned char *hash,
                        size_t hash_len,
@@ -1893,7 +1929,17 @@ _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
         return -1;
     }
 
-    ret = RSA_sign(NID_sha1, hash, hash_len, sig, &sig_len, rsactx);
+    if(hash_len == SHA_DIGEST_LENGTH)
+        ret = RSA_sign(NID_sha1, hash, hash_len, sig, &sig_len, rsactx);
+    else if(hash_len == SHA256_DIGEST_LENGTH)
+        ret = RSA_sign(NID_sha256, hash, hash_len, sig, &sig_len, rsactx);
+    else if(hash_len == SHA512_DIGEST_LENGTH)
+        ret = RSA_sign(NID_sha512, hash, hash_len, sig, &sig_len, rsactx);
+    else {
+        _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                       "Unsupported hash digest length");
+        ret = -1;
+    }
 
     if(!ret) {
         LIBSSH2_FREE(session, sig);
@@ -1905,6 +1951,19 @@ _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
 
     return 0;
 }
+
+
+int
+_libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
+                       libssh2_rsa_ctx * rsactx,
+                       const unsigned char *hash,
+                       size_t hash_len,
+                       unsigned char **signature, size_t *signature_len)
+ {
+     return _libssh2_rsa_sha2_sign(session, rsactx, hash, hash_len,
+                                   signature, signature_len);
+ }
+
 
 #if LIBSSH2_DSA
 int
@@ -3282,5 +3341,33 @@ _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
     BN_clear_free(*dhctx);
     *dhctx = NULL;
 }
+
+#pragma mark PANIC
+
+int
+_libssh2_cipher_crypt_buffer(_libssh2_cipher_ctx * ctx,
+                             _libssh2_cipher_type(algo),
+                             int encrypt, unsigned int seqno, unsigned char *buf,
+                             size_t buf_len, unsigned char *out_buf, int blocksize)
+{
+    int ret = 0;
+
+    while (buf_len >= blocksize) {
+
+#ifdef HAVE_OPAQUE_STRUCTS
+        ret = EVP_Cipher(*ctx, out_buf, buf, blocksize);
+#else
+        ret = EVP_Cipher(ctx, out_buf, buf, blocksize);
+#endif
+
+        buf_len -= blocksize;     /* less bytes left */
+        out_buf += blocksize;     /* advance write pointer */
+        buf += blocksize;            /* advance read pointer */
+    }
+
+    return ret == 1 ? 0 : 1;
+}
+
+#pragma mark END PANIC
 
 #endif /* LIBSSH2_OPENSSL */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3342,32 +3342,4 @@ _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
     *dhctx = NULL;
 }
 
-#pragma mark PANIC
-
-int
-_libssh2_cipher_crypt_buffer(_libssh2_cipher_ctx * ctx,
-                             _libssh2_cipher_type(algo),
-                             int encrypt, unsigned int seqno, unsigned char *buf,
-                             size_t buf_len, unsigned char *out_buf, int blocksize)
-{
-    int ret = 0;
-
-    while (buf_len >= blocksize) {
-
-#ifdef HAVE_OPAQUE_STRUCTS
-        ret = EVP_Cipher(*ctx, out_buf, buf, blocksize);
-#else
-        ret = EVP_Cipher(ctx, out_buf, buf, blocksize);
-#endif
-
-        buf_len -= blocksize;     /* less bytes left */
-        out_buf += blocksize;     /* advance write pointer */
-        buf += blocksize;            /* advance read pointer */
-    }
-
-    return ret == 1 ? 0 : 1;
-}
-
-#pragma mark END PANIC
-
 #endif /* LIBSSH2_OPENSSL */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -64,8 +64,10 @@
 
 #ifdef OPENSSL_NO_RSA
 # define LIBSSH2_RSA 0
+# define LIBSSH2_RSA_SHA2 0
 #else
 # define LIBSSH2_RSA 1
+# define LIBSSH2_RSA_SHA2 1
 #endif
 
 #ifdef OPENSSL_NO_DSA

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -175,6 +175,7 @@
 #define LIBSSH2_3DES            1
 
 #define LIBSSH2_RSA             1
+#define LIBSSH2_RSA_SHA2        0
 #define LIBSSH2_DSA             0
 #define LIBSSH2_ECDSA           0
 #define LIBSSH2_ED25519         0

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -63,6 +63,7 @@
 #define LIBSSH2_3DES 1
 
 #define LIBSSH2_RSA 1
+#define LIBSSH2_RSA_SHA2 0
 #define LIBSSH2_DSA 1
 #define LIBSSH2_ECDSA 0
 #define LIBSSH2_ED25519 0


### PR DESCRIPTION
Files: openssl.h, openssl.c, crypto.h, hostkey.c, HACKING-CRYPTO

Notes:
Added `rsa-sha2-256` and `rsa-sha2-512` as described in RFC 8332 to OpenSSL backend. To implement in other backends implementers need to define `LIBSSH2_RSA_SHA2` and implement `_libssh2_rsa_sha2_sign` and `_libssh2_rsa_sha2_verify`.

Credit:
Will Cosgrove