### PR TITLE
Fix openssh_server build not working (#616)

### DIFF
--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -145,7 +145,8 @@ static int run_command(char **output, const char *command, ...)
 
 static int build_openssh_server_docker_image(void)
 {
-    return run_command(NULL, "docker build -t libssh2/openssh_server "
+    return run_command(NULL, "docker build --quiet "
+                             "-t libssh2/openssh_server "
                              "openssh_server");
 }
 


### PR DESCRIPTION
Ok following #616, instead of increasing the buffer for an output we don't care (output of the docker build), let's just stop logging the whole image construction. We will still get the error message if any.

Don't hesitate to tell me if you prefer something else.