### PR TITLE
openssh_fixture.c: fix warning

### DIFF
--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -208,7 +208,7 @@ static int is_running_inside_a_container()
 #endif
 }
 
-static unsigned int portable_sleep(unsigned int seconds)
+static void portable_sleep(unsigned int seconds)
 {
 #ifdef WIN32
     Sleep(seconds);


### PR DESCRIPTION
File: openssh_fixture.c

Notes:
Fix `portable_sleep` return type warning

Credit:
Will Cosgrove