### PR TITLE
Clean up a variable redefinition warning

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -738,7 +738,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
             }
 
             /*
-             * REMEMBER! remote means remote as a source of data,
+             * REMEMBER! remote means remote as source of data,
              * NOT remote window!
              */
             if(channelp->remote.packet_size < (datalen - data_head)) {
@@ -1280,7 +1280,7 @@ _libssh2_packet_burn(LIBSSH2_SESSION * session,
  *
  * Loops _libssh2_transport_read() until one of a list of packet types
  * requested is available. SSH_DISCONNECT or a SOCKET_DISCONNECTED will cause
- * a bailout. packet_types is a null-terminated list of packet_type numbers
+ * a bailout. packet_types is a null terminated list of packet_type numbers
  */
 
 int

--- a/src/packet.c
+++ b/src/packet.c
@@ -631,9 +631,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     want_reply = data[5 + len];
                     _libssh2_debug(session,
                                    LIBSSH2_TRACE_CONN,
-                                   "Received global request type: %s"
-                                   "(len=%d, want_reply=%X)",
-                                   data + 5, len, want_reply);
+                                   "Received global request type %.*s (wr %X)",
+                                   len, data + 5, want_reply);
                 }
 
 
@@ -836,9 +835,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
                 _libssh2_debug(session,
                                LIBSSH2_TRACE_CONN,
-                               "Channel %d received request type: %s"
-                               "(len=%d, want_reply=%X)",
-                               channel, data + 9, len, want_reply);
+                               "Channel %d received request type %.*s (wr %X)",
+                               channel, len, data + 9, want_reply);
 
                 if(len == sizeof("exit-status") - 1
                     && (sizeof("exit-status") - 1 + 9) <= datalen

--- a/src/packet.c
+++ b/src/packet.c
@@ -631,7 +631,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     want_reply = data[5 + len];
                     _libssh2_debug(session,
                                    LIBSSH2_TRACE_CONN,
-                                   "Received global request type %.*s (wr %X)",
+                                   "Received global request type %d: %s (wr %X)",
                                    len, data + 5, want_reply);
                 }
 

--- a/src/packet.c
+++ b/src/packet.c
@@ -836,8 +836,9 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
                 _libssh2_debug(session,
                                LIBSSH2_TRACE_CONN,
-                               "Channel %d received request type %.*s (wr %X)",
-                               channel, len, data + 9, want_reply);
+                               "Channel %d received request type: %s"
+                               "(len=%d, want_reply=%X)",
+                               channel, data + 9, len, want_reply);
 
                 if(len == sizeof("exit-status") - 1
                     && (sizeof("exit-status") - 1 + 9) <= datalen

--- a/src/packet.c
+++ b/src/packet.c
@@ -1323,9 +1323,8 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
 
         if(strchr((char *) packet_types, ret)) {
             /* Be lazy, let packet_ask pull it out of the brigade */
-            int ret = _libssh2_packet_askv(session, packet_types, data,
-                                        data_len, match_ofs, match_buf,
-                                        match_len);
+            ret = _libssh2_packet_askv(session, packet_types, data, data_len,
+                                       match_ofs, match_buf, match_len);
             state->start = 0;
             return ret;
         }

--- a/src/packet.c
+++ b/src/packet.c
@@ -1280,7 +1280,7 @@ _libssh2_packet_burn(LIBSSH2_SESSION * session,
  *
  * Loops _libssh2_transport_read() until one of a list of packet types
  * requested is available. SSH_DISCONNECT or a SOCKET_DISCONNECTED will cause
- * a bailout. packet_types is a null terminated list of packet_type numbers
+ * a bailout. packet_types is a null-terminated list of packet_type numbers
  */
 
 int
@@ -1322,7 +1322,7 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
         }
 
         if(strchr((char *) packet_types, ret)) {
-            /* Be lazy, let packet_ask pull it out of the brigade */
+            /* Be lazy, let packet_askv pull it out of the brigade */
             ret = _libssh2_packet_askv(session, packet_types, data, data_len,
                                        match_ofs, match_buf, match_len);
             state->start = 0;

--- a/src/packet.c
+++ b/src/packet.c
@@ -738,7 +738,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
             }
 
             /*
-             * REMEMBER! remote means remote as source of data,
+             * REMEMBER! remote means remote as a source of data,
              * NOT remote window!
              */
             if(channelp->remote.packet_size < (datalen - data_head)) {

--- a/src/packet.c
+++ b/src/packet.c
@@ -631,8 +631,9 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     want_reply = data[5 + len];
                     _libssh2_debug(session,
                                    LIBSSH2_TRACE_CONN,
-                                   "Received global request type %d: %s (wr %X)",
-                                   len, data + 5, want_reply);
+                                   "Received global request type: %s"
+                                   "(len=%d, want_reply=%X)",
+                                   data + 5, len, want_reply);
                 }
 
 


### PR DESCRIPTION
Clean up a variable redefinition warning to satisfy the compiler.