### PR TITLE
hostkey_method_ssh_ed25519_init() check key bounds

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -872,7 +872,7 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
         return -1;
     }
 
-    *abstract = ctx; 
+    *abstract = ctx;
 
     return 0;
 }

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -841,9 +841,10 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
                                 size_t hostkey_data_len,
                                 void **abstract)
 {
-    const unsigned char *s;
-    unsigned long len, key_len;
+    size_t key_len;
+    unsigned char *key;
     libssh2_ed25519_ctx *ctx = NULL;
+    struct string_buf buf;
 
     if(*abstract) {
         hostkey_method_ssh_ed25519_dtor(session, abstract);
@@ -856,25 +857,22 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
         return -1;
     }
 
-    s = hostkey_data;
-    len = _libssh2_ntohu32(s);
-    s += 4;
+    buf.data = (unsigned char *)hostkey_data;
+    buf.dataptr = buf.data;
+    buf.len = hostkey_data_len;
 
-    if(len != 11 || strncmp((char *) s, "ssh-ed25519", 11) != 0) {
+    if(_libssh2_match_string(&buf, "ssh-ed25519"))
         return -1;
-    }
-
-    s += 11;
 
     /* public key */
-    key_len = _libssh2_ntohu32(s);
-    s += 4;
+    if(_libssh2_get_string(&buf, &key, &key_len))
+        return -1;
 
-    if(_libssh2_ed25519_new_public(&ctx, session, s, key_len) != 0) {
+    if(_libssh2_ed25519_new_public(&ctx, session, key, key_len) != 0) {
         return -1;
     }
 
-    *abstract = ctx;
+    *abstract = ctx; 
 
     return 0;
 }


### PR DESCRIPTION
File: hostkey.c

Notes:
Additional key length checking before calling _libssh2_ed25519_new_public()

Credit:
Will Cosgrove