### PR TITLE
Fix a couple errors in code that was changed from memmem to memcmp

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1147,7 +1147,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
             f = strchr(a, ',');
             f_len = f ? (f - a) : (int) strlen(a);
 
-            if(f_len == p_len && memcmp(a, s, p_len)) {
+            if(f_len == p_len && memcmp(a, s, p_len) == 0) {
 
                 if(i != filtered_algs) {
                     memcpy(i, ",", 1);
@@ -1185,7 +1185,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
             f = strchr(a, ',');
             f_len = f ? (f - a) : (int) strlen(a);
 
-            if(f_len == p_len && memcmp(a, s, p_len)) {
+            if(f_len == p_len && memcmp(a, s, p_len) == 0) {
                 /* found a match, upgrade key method */
                 match = s;
                 match_len = p_len;


### PR DESCRIPTION
Some code was recently changed from using memmem to memcmp, a good change, but memmem returns non-NULL on a match, whereas memcmp returns 0 on a match, so the return value has to be checked in the opposite way.

The code affected could result in a failure to authenticte, depending on which public key accepted algorithms the server supports. This is unlikely to happen in practice, as most servers support enough algorithms that even after incorrectly filtering out some algorithms, some options will remain.