### PR TITLE
Legacy Agent support for rsa2 key upgrading/downgrading #659

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -508,6 +508,7 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_KEYFILE_AUTH_FAILED       -48
 #define LIBSSH2_ERROR_RANDGEN                   -49
 #define LIBSSH2_ERROR_MISSING_USERAUTH_BANNER   -50
+#define LIBSSH2_ERROR_ALGO_UNSUPPORTED          -51
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV

--- a/src/agent.c
+++ b/src/agent.c
@@ -477,18 +477,8 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     s += method_len;
 
     /* check to see if we match requested */
-    if((size_t)method_len == session->userauth_pblc_method_len) {
-        if(memcmp(method_name, session->userauth_pblc_method, method_len)) {
-            _libssh2_debug(session,
-                           LIBSSH2_TRACE_KEX,
-                           "Agent sign method %.*s",
-                           method_len, method_name);
-
-            rc = LIBSSH2_ERROR_ALGO_UNSUPPORTED;
-            goto error;
-        }
-    }
-    else {
+    if((size_t)method_len != session->userauth_pblc_method_len ||
+        memcmp(method_name, session->userauth_pblc_method, method_len)) {
         _libssh2_debug(session,
                        LIBSSH2_TRACE_KEX,
                        "Agent sign method %.*s",

--- a/src/agent.c
+++ b/src/agent.c
@@ -377,6 +377,7 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     struct agent_publickey *identity = agent->identity;
     ssize_t len = 1 + 4 + identity->external.blob_len + 4 + data_len + 4;
     ssize_t method_len;
+    unsigned char *method_name;
     unsigned char *s;
     int rc;
     uint32_t sign_flags = 0;
@@ -465,7 +466,37 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
+
+    /* method name */
+    method_name = LIBSSH2_ALLOC(session, method_len);
+    if(!method_name) {
+        rc = LIBSSH2_ERROR_ALLOC;
+        goto error;
+    }
+    memcpy(method_name, s, method_len);
     s += method_len;
+
+    /* check to see if we match requested */
+    if(method_len == session->userauth_pblc_method_len) {
+        if(memcmp(method_name, session->userauth_pblc_method, method_len)) {
+            _libssh2_debug(session,
+                           LIBSSH2_TRACE_KEX,
+                           "Agent sign method %.*s",
+                           method_len, method_name);
+
+            rc = LIBSSH2_ERROR_ALGO_UNSUPPORTED;
+            goto error;
+        }
+    }
+    else {
+        _libssh2_debug(session,
+                       LIBSSH2_TRACE_KEX,
+                       "Agent sign method %.*s",
+                       method_len, method_name);
+
+        rc = LIBSSH2_ERROR_ALGO_UNSUPPORTED;
+        goto error;
+    }
 
     /* Read the signature */
     len -= 4;
@@ -494,6 +525,8 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
 
     LIBSSH2_FREE(session, transctx->response);
     transctx->response = NULL;
+
+    transctx->state = agent_NB_state_init;
 
     return _libssh2_error(session, rc, "agent sign failure");
 }

--- a/src/agent.c
+++ b/src/agent.c
@@ -510,6 +510,10 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     memcpy(*sig, s, *sig_len);
 
   error:
+
+    if(method_name)
+        LIBSSH2_FREE(session, method_name);
+
     LIBSSH2_FREE(session, transctx->request);
     transctx->request = NULL;
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -377,9 +377,9 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     struct agent_publickey *identity = agent->identity;
     ssize_t len = 1 + 4 + identity->external.blob_len + 4 + data_len + 4;
     ssize_t method_len;
-    unsigned char *method_name;
     unsigned char *s;
     int rc;
+    unsigned char *method_name = NULL;
     uint32_t sign_flags = 0;
 
     /* Create a request to sign the data */
@@ -477,7 +477,7 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     s += method_len;
 
     /* check to see if we match requested */
-    if(method_len == session->userauth_pblc_method_len) {
+    if((size_t)method_len == session->userauth_pblc_method_len) {
         if(memcmp(method_name, session->userauth_pblc_method, method_len)) {
             _libssh2_debug(session,
                            LIBSSH2_TRACE_KEX,


### PR DESCRIPTION
Files: libssh2.h, agent.c, userauth.c

Notes:
Part 2 of the fix for #659. This adds rsa key downgrading for agents that don't support sha2 upgrading. It also adds better trace output for debugging/logging around key upgrading.

Credit:
Will Cosgrove (signed off by Michael Buckley)