### PR TITLE
free RSA2 memory

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -987,7 +987,7 @@ session_free(LIBSSH2_SESSION *session)
     if(session->sign_algo_prefs) {
         LIBSSH2_FREE(session, session->sign_algo_prefs);
     }
-    
+
     /*
      * Make sure all memory used in the state variables are free
      */

--- a/src/session.c
+++ b/src/session.c
@@ -982,11 +982,12 @@ session_free(LIBSSH2_SESSION *session)
         LIBSSH2_FREE(session, session->remote.lang_prefs);
     }
     if(session->server_sign_algorithms) {
-		LIBSSH2_FREE(session, session->server_sign_algorithms);
-	}
-	if(session->sign_algo_prefs) {
-		LIBSSH2_FREE(session, session->sign_algo_prefs);
-	}
+        LIBSSH2_FREE(session, session->server_sign_algorithms);
+    }
+    if(session->sign_algo_prefs) {
+        LIBSSH2_FREE(session, session->sign_algo_prefs);
+    }
+    
     /*
      * Make sure all memory used in the state variables are free
      */

--- a/src/session.c
+++ b/src/session.c
@@ -984,7 +984,7 @@ session_free(LIBSSH2_SESSION *session)
     if(session->server_sign_algorithms) {
 		LIBSSH2_FREE(session, session->server_sign_algorithms);
 	}
-	if ( session->sign_algo_prefs) {
+	if(session->sign_algo_prefs) {
 		LIBSSH2_FREE(session, session->sign_algo_prefs);
 	}
     /*

--- a/src/session.c
+++ b/src/session.c
@@ -981,7 +981,12 @@ session_free(LIBSSH2_SESSION *session)
     if(session->remote.lang_prefs) {
         LIBSSH2_FREE(session, session->remote.lang_prefs);
     }
-
+    if(session->server_sign_algorithms) {
+		LIBSSH2_FREE(session, session->server_sign_algorithms);
+	}
+	if ( session->sign_algo_prefs) {
+		LIBSSH2_FREE(session, session->sign_algo_prefs);
+	}
     /*
      * Make sure all memory used in the state variables are free
      */


### PR DESCRIPTION
Missed freeing `server_sign_algorithms` and `sign_algo_prefs` when porting over rsa2 additions.