### PR TITLE
Fix build since openssl 1.1.0 when ECDSA and/or RIPEMD are disabled

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -115,7 +115,7 @@
 # define LIBSSH2_DSA 1
 #endif
 
-#ifdef OPENSSL_NO_ECDSA
+#if defined(OPENSSL_NO_ECDSA) || defined(OPENSSL_NO_EC)
 # define LIBSSH2_ECDSA 0
 #else
 # define LIBSSH2_ECDSA 1
@@ -135,7 +135,7 @@
 # define LIBSSH2_MD5 1
 #endif
 
-#ifdef OPENSSL_NO_RIPEMD
+#if defined(OPENSSL_NO_RIPEMD) || defined(OPENSSL_NO_RMD160)
 # define LIBSSH2_HMAC_RIPEMD 0
 #else
 # define LIBSSH2_HMAC_RIPEMD 1


### PR DESCRIPTION
In openssl 1.1.0 and later openssl decided to change some of the defines used to check if certain features are not compiled in the libraries.

The particular changes that caused the problem libssh2 are:
> - OPENSSL_NO_EC{DH,DSA} merged into OPENSSL_NO_EC
> - OPENSSL_NO_RIPEMD160, OPENSSL_NO_RIPEMD merged into OPENSSL_NO_RMD160

Needless to say, any code that depended on the old defines broke as a consequence. This is my proposed fix for libssh2.