### PR TITLE
Fix typos in manual page

### DIFF
--- a/docs/libssh2_userauth_keyboard_interactive_ex.3
+++ b/docs/libssh2_userauth_keyboard_interactive_ex.3
@@ -52,7 +52,7 @@ number, it isn't really a failure per se.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 
-\fLIBSSH2_ERROR_AUTHENTICATION_FAILED\fP - failed, invalid username/password
+\fILIBSSH2_ERROR_AUTHENTICATION_FAILED\fP - failed, invalid username/password
 or public/private key.
 .SH SEE ALSO
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_userauth_password_ex.3
+++ b/docs/libssh2_userauth_password_ex.3
@@ -51,7 +51,7 @@ Some of the errors this function may return include:
 
 \fILIBSSH2_ERROR_PASSWORD_EXPIRED\fP - 
 
-\fLIBSSH2_ERROR_AUTHENTICATION_FAILED\fP - failed, invalid username/password
+\fILIBSSH2_ERROR_AUTHENTICATION_FAILED\fP - failed, invalid username/password
 or public/private key.
 .SH SEE ALSO
 .BR libssh2_session_init_ex(3)


### PR DESCRIPTION
I noticed a typo in the manual page [libssh2_userauth_keyboard_interactive_ex](https://www.libssh2.org/libssh2_userauth_keyboard_interactive_ex.html)  in the ERRORS section. There is  a `f` before `LIBSSH2_ERROR_AUTHENTICATION_FAILED`.
The other errors are displayed in italic.

This pull request will fix that issue.