### PR TITLE
Fix heap buffer overflow in _libssh2_key_sign_algorithm

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -642,7 +642,6 @@ struct _LIBSSH2_SESSION
 
     /* public key algorithms accepted as comma separated list */
     char *server_sign_algorithms;
-    size_t server_sign_algorithms_len;
 
     /* key signing algorithm preferences -- NULL yields server order */
     char *sign_algo_prefs;

--- a/src/packet.c
+++ b/src/packet.c
@@ -665,12 +665,13 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
                         session->server_sign_algorithms =
                                                 LIBSSH2_ALLOC(session,
-                                                              value_len);
+                                                              value_len+1);
 
                         if(session->server_sign_algorithms) {
                             session->server_sign_algorithms_len = value_len;
                             memcpy(session->server_sign_algorithms,
                                    value, value_len);
+                            session->server_sign_algorithms[value_len] = '\0';
                         }
                         else {
                             rc = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,

--- a/src/packet.c
+++ b/src/packet.c
@@ -665,10 +665,9 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
                         session->server_sign_algorithms =
                                                 LIBSSH2_ALLOC(session,
-                                                              value_len+1);
+                                                              value_len + 1);
 
                         if(session->server_sign_algorithms) {
-                            session->server_sign_algorithms_len = value_len;
                             memcpy(session->server_sign_algorithms,
                                    value, value_len);
                             session->server_sign_algorithms[value_len] = '\0';


### PR DESCRIPTION
When allocating `session->server_sign_algorithms` which is a `char*` is is important to also allocate space for the string-terminating null byte at the end and make sure the string is actually null terminated.

Without this fix, the `strchr()` call inside the `_libssh2_key_sign_algorithm` (line 1219) function will try to parse the string and go out of buffer on the last invocation.


EDIT:
Dunno why i didn't directly just link to the bug lol.
Heap buffer overflow (without this fix) happens here https://github.com/libssh2/libssh2/blob/de7a74aff24c47b2f2e9815f0a98598195d602e4/src/userauth.c#L1212-L1219