### PR TITLE
agent: add backend API

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1202,6 +1202,7 @@ libssh2_knownhost_get(LIBSSH2_KNOWNHOSTS *hosts,
                       struct libssh2_knownhost *prev);
 
 #define HAVE_LIBSSH2_AGENT_API 0x010202 /* since 1.2.2 */
+#define HAVE_LIBSSH2_AGENT_BACKEND_API 1
 
 struct libssh2_agent_publickey {
     unsigned int magic;              /* magic stored by the library */
@@ -1210,6 +1211,33 @@ struct libssh2_agent_publickey {
     size_t blob_len;               /* length of the public key blob */
     char *comment;                 /* comment in printable format */
 };
+
+/*
+ * libssh2_agent_get_backend_list_size
+ *
+ * Returns size the backend list.
+ *
+ */
+LIBSSH2_API int
+libssh2_agent_get_backend_list_size();
+
+/*
+ * libssh2_agent_set_backend_idx
+ *
+ * Set the index of the backend to use. 
+ *
+ */
+LIBSSH2_API void
+libssh2_agent_set_backend_idx(LIBSSH2_AGENT *agent, int idx);
+
+/*
+ * libssh2_agent_get_backend_name
+ *
+ * Returns the name of the backend used. 
+ *
+ */
+LIBSSH2_API const char *
+libssh2_agent_get_backend_name(LIBSSH2_AGENT *agent);
 
 /*
  * libssh2_agent_init

--- a/src/agent.h
+++ b/src/agent.h
@@ -98,6 +98,8 @@ struct _LIBSSH2_AGENT
 
     char *identity_agent_path; /* Path to a custom identity agent socket */
 
+    int backend_idx; /* Index of the backed to use or used */
+    
 #ifdef WIN32
     OVERLAPPED overlapped;
     HANDLE pipe;


### PR DESCRIPTION
Add an agent backend API to search identities one all running agents, not only the first one found. 
Currently, this is only relevant under Windows. 