### PR TITLE
Opaque structs in LibreSSL 3.5

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -94,8 +94,9 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-    !defined(LIBRESSL_VERSION_NUMBER)) || defined(LIBSSH2_WOLFSSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x30500000L) || \
+    defined(LIBSSH2_WOLFSSL)
 /* For wolfSSL, whether the structs are truly opaque or not, it's best to not
  * rely on their internal data members being exposed publicly. */
 # define HAVE_OPAQUE_STRUCTS 1


### PR DESCRIPTION
This fixes the build with LibreSSL 3.5. See [release notes](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.0-relnotes.txt) for the large amount of API additions.