### PR TITLE
Add RSA-SHA2 support for the mbedtls backend

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -481,7 +481,7 @@ _libssh2_mbedtls_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
         return -1; /* unsupported digest */
     }
     ret = _libssh2_mbedtls_hash(m, m_len, md_type, hash);
-    
+
     if(ret != 0) {
         free(hash);
         return -1; /* failure */
@@ -501,8 +501,8 @@ _libssh2_mbedtls_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
                          unsigned long sig_len,
                          const unsigned char *m, unsigned long m_len)
 {
-    return _libssh2_mbedtls_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH, sig, sig_len, m,
-                                    m_len);
+    return _libssh2_mbedtls_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH,
+                                            sig, sig_len, m, m_len);
 }
 
 int

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -35,6 +35,7 @@
  * OF SUCH DAMAGE.
  */
 
+
 #include "libssh2_priv.h"
 
 #ifdef LIBSSH2_MBEDTLS /* compile only if we build with mbedtls */
@@ -455,28 +456,58 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
 }
 
 int
-_libssh2_mbedtls_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
-                                const unsigned char *sig,
-                                unsigned long sig_len,
-                                const unsigned char *m,
-                                unsigned long m_len)
+_libssh2_mbedtls_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+                         size_t hash_len,
+                         const unsigned char *sig,
+                         unsigned long sig_len,
+                         const unsigned char *m, unsigned long m_len)
 {
-    unsigned char hash[SHA_DIGEST_LENGTH];
     int ret;
+    int md_type;
+    unsigned char *hash = malloc(hash_len);
+    if(hash == NULL)
+        return -1;
 
-    ret = _libssh2_mbedtls_hash(m, m_len, MBEDTLS_MD_SHA1, hash);
-    if(ret)
+    if(hash_len == SHA_DIGEST_LENGTH) {
+        md_type = MBEDTLS_MD_SHA1;
+    }
+    else if(hash_len == SHA256_DIGEST_LENGTH) {
+        md_type = MBEDTLS_MD_SHA256;
+    }
+    else if(hash_len == SHA512_DIGEST_LENGTH) {
+        md_type = MBEDTLS_MD_SHA512;
+    }
+    else{
+        free(hash);
+        return -1; /* unsupported digest */
+    }
+    ret = _libssh2_mbedtls_hash(m, m_len, md_type, hash);
+    
+    if(ret != 0) {
+        free(hash);
         return -1; /* failure */
+    }
 
-    ret = mbedtls_rsa_pkcs1_verify(rsa, NULL, NULL, MBEDTLS_RSA_PUBLIC,
-                                   MBEDTLS_MD_SHA1, SHA_DIGEST_LENGTH,
+    ret = mbedtls_rsa_pkcs1_verify(rsactx, NULL, NULL, MBEDTLS_RSA_PUBLIC,
+                                   md_type, hash_len,
                                    hash, sig);
+    free(hash);
 
-    return (ret == 0) ? 0 : -1;
+    return (ret == 1) ? 0 : -1;
 }
 
 int
-_libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION *session,
+_libssh2_mbedtls_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
+                         const unsigned char *sig,
+                         unsigned long sig_len,
+                         const unsigned char *m, unsigned long m_len)
+{
+    return _libssh2_mbedtls_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH, sig, sig_len, m,
+                                    m_len);
+}
+
+int
+_libssh2_mbedtls_rsa_sha2_sign(LIBSSH2_SESSION *session,
                               libssh2_rsa_ctx *rsa,
                               const unsigned char *hash,
                               size_t hash_len,
@@ -486,7 +517,7 @@ _libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION *session,
     int ret;
     unsigned char *sig;
     unsigned int sig_len;
-
+    int md_type;
     (void)hash_len;
 
     sig_len = rsa->len;
@@ -494,9 +525,22 @@ _libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION *session,
     if(!sig) {
         return -1;
     }
-
+    if(hash_len == SHA_DIGEST_LENGTH) {
+        md_type = MBEDTLS_MD_SHA1;
+    }
+    else if(hash_len == SHA256_DIGEST_LENGTH) {
+        md_type = MBEDTLS_MD_SHA256;
+    }
+    else if(hash_len == SHA512_DIGEST_LENGTH) {
+        md_type = MBEDTLS_MD_SHA512;
+    }
+    else {
+        _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                       "Unsupported hash digest length");
+        ret = -1;
+    }
     ret = mbedtls_rsa_pkcs1_sign(rsa, NULL, NULL, MBEDTLS_RSA_PRIVATE,
-                                 MBEDTLS_MD_SHA1, SHA_DIGEST_LENGTH,
+                                 md_type, hash_len,
                                  hash, sig);
     if(ret) {
         LIBSSH2_FREE(session, sig);
@@ -507,6 +551,17 @@ _libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION *session,
     *signature_len = sig_len;
 
     return (ret == 0) ? 0 : -1;
+}
+
+int
+_libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION * session,
+                       libssh2_rsa_ctx * rsactx,
+                       const unsigned char *hash,
+                       size_t hash_len,
+                       unsigned char **signature, size_t *signature_len)
+{
+    return _libssh2_mbedtls_rsa_sha2_sign(session, rsactx, hash, hash_len,
+                                  signature, signature_len);
 }
 
 void
@@ -1268,3 +1323,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 
 #endif /* LIBSSH2_ECDSA */
 #endif /* LIBSSH2_MBEDTLS */
+

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1314,8 +1314,13 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
                                        size_t key_method_len)
 {
     (void)session;
-    (void)key_method;
-    (void)key_method_len;
+
+#if LIBSSH2_RSA_SHA2
+    if(key_method_len == 7 &&
+       memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
+        return "rsa-sha2-512,rsa-sha2-256,ssh-rsa";
+    }
+#endif
 
     return NULL;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -35,7 +35,6 @@
  * OF SUCH DAMAGE.
  */
 
-
 #include "libssh2_priv.h"
 
 #ifdef LIBSSH2_MBEDTLS /* compile only if we build with mbedtls */
@@ -1323,4 +1322,3 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 
 #endif /* LIBSSH2_ECDSA */
 #endif /* LIBSSH2_MBEDTLS */
-

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -71,7 +71,7 @@
 #define LIBSSH2_3DES            1
 
 #define LIBSSH2_RSA             1
-#define LIBSSH2_RSA_SHA2        0
+#define LIBSSH2_RSA_SHA2        1
 #define LIBSSH2_DSA             0
 #ifdef MBEDTLS_ECDSA_C
 # define LIBSSH2_ECDSA          1
@@ -243,8 +243,15 @@
 #define _libssh2_rsa_sha1_sign(s, rsactx, hash, hash_len, sig, sig_len) \
   _libssh2_mbedtls_rsa_sha1_sign(s, rsactx, hash, hash_len, sig, sig_len)
 
+#define _libssh2_rsa_sha2_sign(s, rsactx, hash, hash_len, sig, sig_len) \
+  _libssh2_mbedtls_rsa_sha2_sign(s, rsactx, hash, hash_len, sig, sig_len)
+
+
 #define _libssh2_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len) \
   _libssh2_mbedtls_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len)
+
+#define _libssh2_rsa_sha2_verify(rsactx,hash_len, sig, sig_len, m, m_len) \
+  _libssh2_mbedtls_rsa_sha2_verify(rsactx,hash_len, sig, sig_len, m, m_len)
 
 #define _libssh2_rsa_free(rsactx) \
   _libssh2_mbedtls_rsa_free(rsactx)

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -250,8 +250,8 @@
 #define _libssh2_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len) \
   _libssh2_mbedtls_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len)
 
-#define _libssh2_rsa_sha2_verify(rsactx,hash_len, sig, sig_len, m, m_len) \
-  _libssh2_mbedtls_rsa_sha2_verify(rsactx,hash_len, sig, sig_len, m, m_len)
+#define _libssh2_rsa_sha2_verify(rsactx, hash_len, sig, sig_len, m, m_len) \
+  _libssh2_mbedtls_rsa_sha2_verify(rsactx, hash_len, sig, sig_len, m, m_len)
 
 #define _libssh2_rsa_free(rsactx) \
   _libssh2_mbedtls_rsa_free(rsactx)


### PR DESCRIPTION
Should fix https://github.com/libssh2/libssh2/issues/687.

I basically did some pattern matching from https://github.com/libssh2/libssh2/commit/64a555d6f5aafed504a10e5b756e85c91b1d56ce. I'm not familiar with the libssh2 codebase so please do tell if there is something to be changed.