### PR TITLE
openssl: add support for LibreSSL 3.5.x

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -95,7 +95,8 @@
 #include <openssl/rand.h>
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-    !defined(LIBRESSL_VERSION_NUMBER)) || defined(LIBSSH2_WOLFSSL)
+    !defined(LIBRESSL_VERSION_NUMBER)) || defined(LIBSSH2_WOLFSSL) || \
+    LIBRESSL_VERSION_NUMBER >= 0x3050000fL
 /* For wolfSSL, whether the structs are truly opaque or not, it's best to not
  * rely on their internal data members being exposed publicly. */
 # define HAVE_OPAQUE_STRUCTS 1


### PR DESCRIPTION
LibreSSL 3.5.0 made more structures opaque, so let's enable existing
support for that when building against these LibreSSL versions.

Ref: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.0-relnotes.txt