### PR TITLE
Don't erroneously log SSH_MSG_REQUEST_FAILURE packets from keepalive …

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2046,7 +2046,7 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
         if(readpkt->data_len < 5) {
             read_packet = read_next;
 
-            if (readpkt->data_len != 1 ||
+            if(readpkt->data_len != 1 ||
                 readpkt->data[0] != SSH_MSG_REQUEST_FAILURE) {
                 _libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
                                "Unexpected packet length");

--- a/src/channel.c
+++ b/src/channel.c
@@ -2045,8 +2045,13 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
 
         if(readpkt->data_len < 5) {
             read_packet = read_next;
-            _libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
-                           "Unexpected packet length");
+
+			if (readpkt->data_len != 1 ||
+				readpkt->data[0] != SSH_MSG_REQUEST_FAILURE) {
+				_libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
+							   "Unexpected packet length");
+			}
+
             continue;
         }
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -2046,11 +2046,11 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
         if(readpkt->data_len < 5) {
             read_packet = read_next;
 
-			if (readpkt->data_len != 1 ||
-				readpkt->data[0] != SSH_MSG_REQUEST_FAILURE) {
-				_libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
-							   "Unexpected packet length");
-			}
+            if (readpkt->data_len != 1 ||
+                readpkt->data[0] != SSH_MSG_REQUEST_FAILURE) {
+                _libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
+                               "Unexpected packet length");
+            }
 
             continue;
         }


### PR DESCRIPTION
…requests.

When setting a ServerAliveInterval using libssh2_keepalive_config() with want_reply set to true, some servers will reply to the keep-alive requests with a single SSH_MSG_REQUEST_FAILURE packet. This is an allowed behavior in RFC 4254, section 4.

However, in _libssh2_channel_read(), we assume that all patckets are at least 5 bytes long, and emit a debug logging line if not. We recieved a report from a user who had enabled debug logging that their logs had swollen to 20 GB in a day when connected to a server that required a very short keep-alive interval.

There may be a better place in code to add this check, and I'll be happy to move it if so, but this seemed like a reasonable location to me, and at least enough to begin a discussion in this pull request.