### PR TITLE
Fixing description of libssh2_channel_flush_ex() in docs

### DIFF
--- a/docs/libssh2_channel_flush_ex.3
+++ b/docs/libssh2_channel_flush_ex.3
@@ -27,6 +27,6 @@ Flush the read buffer for a given channel instance. Individual substreams may
 be flushed by number or using one of the provided macros.
 
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
-LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
+Return the number of bytes flushed or negative on failure.
+It returns LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it isn't really a failure per se.


### PR DESCRIPTION
In https://github.com/libssh2/libssh2/issues/614 it was identified the docs do not accurately show how libssh2_channel_flush_ex() return value is set. I have updated the doc's to correctly show what the function is returning.