### PR TITLE
Fix compile for Windows UWP/WinRT platform.

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -249,7 +249,7 @@ struct agent_ops agent_ops_unix = {
 };
 #endif  /* PF_UNIX */
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(WINAPP)
 /* Code to talk to Pageant was taken from PuTTY.
  *
  * Portions copyright Robert de Bath, Joris van Rantwijk, Delian
@@ -358,7 +358,7 @@ static struct {
     const char *name;
     struct agent_ops *ops;
 } supported_backends[] = {
-#ifdef WIN32
+#if defined(WIN32) && !defined(WINAPP)
     {"Pageant", &agent_ops_pageant},
     {"OpenSSH", &agent_ops_openssh},
 #endif  /* WIN32 */

--- a/src/agent_win.c
+++ b/src/agent_win.c
@@ -55,7 +55,7 @@
 #include <stdlib.h>
 #endif
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(WINAPP)
 /* Code to talk to OpenSSH was taken and modified from the Win32 port of
  * Portable OpenSSH by the PowerShell team. Commit
  * 8ab565c53f3619d6a1f5ac229e212cad8a52852c of

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -50,6 +50,11 @@
 #undef WIN32_LEAN_AND_MEAN
 #endif
 
+/* Windows UWP/WinRT platform. */
+#if defined(WINAPI_PARTITION_APP) && WINAPI_PARTITION_APP
+#define WINAPP
+#endif
+
 #ifdef HAVE_WS2TCPIP_H
 #include <ws2tcpip.h>
 #endif


### PR DESCRIPTION
These changes are required to compile for Windows UWP/WinRT because  it does not support full set of WIN32 API.