### PR TITLE
sftp: Prevent files from being skipped if the output buffer is too small

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1852,11 +1852,11 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
 
             handle->u.dir.next_name = (char *) s;
             handle->u.dir.names_packet_len = names_packet_len;
-          end:
 
             if((--handle->u.dir.names_left) == 0)
                 LIBSSH2_FREE(session, handle->u.dir.names_packet);
 
+          end:
             _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
                            "libssh2_sftp_readdir_ex() return %d",
                            filename_len);


### PR DESCRIPTION
LIBSSH2_ERROR_BUFFER_TOO_SMALL is returned if the buffer is too small to contain a returned directory entry. On this condition we jump to the label `end`. At this point the number of names left is decremented despite no name being returned.

As suggested in #714, this commit moves the error label after the decrement of `names_left`.

Fixes #714