### PR TITLE
Drop advertisement clause on Blowfish

### DIFF
--- a/src/blf.h
+++ b/src/blf.h
@@ -15,10 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *      This product includes software developed by Niels Provos.
- * 4. The name of the author may not be used to endorse or promote products
+ * 3. The name of the author may not be used to endorse or promote products
  *    derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -14,10 +14,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *      This product includes software developed by Niels Provos.
- * 4. The name of the author may not be used to endorse or promote products
+ * 3. The name of the author may not be used to endorse or promote products
  *    derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR


### PR DESCRIPTION
Originally driven by https://github.com/pyca/bcrypt/issues/169, OpenBSD removed Niels Provos's BSD advertisement clause in version 7.1:

https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/lib/libsa/blowfish.c.diff?r1=1.1&r2=1.2
https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/lib/libsa/blowfish.h.diff?r1=1.1&r2=1.2

This enables using libssh2 in GPL software.