### PR TITLE
example/x11: Add null-termination

### DIFF
--- a/example/x11.c
+++ b/example/x11.c
@@ -129,7 +129,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
             display[0] == ':') {
             /* Connect to the local unix domain */
             ptr = strrchr(display, ':');
-            temp_buff = (char *) calloc(strlen(ptr + 1), sizeof(char));
+            temp_buff = (char *) calloc(strlen(ptr + 1) + 1, sizeof(char));
             if(!temp_buff) {
                 perror("calloc");
                 return;


### PR DESCRIPTION
If you do not add one byte for the terminating zero, then you allow the possibility of information disclosure through changing the value of the port.