### PR TITLE
CI: report AppVeyor build status for each individual job

### DIFF
--- a/.github/workflows/appveyor_status.yml
+++ b/.github/workflows/appveyor_status.yml
@@ -1,0 +1,56 @@
+# Copyright (c) 2022 Marc Hoersken
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: AppVeyor Status Report
+
+on:
+  status
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.sha }}-${{ github.event.target_url }}
+  cancel-in-progress: true
+
+jobs:
+  split:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.sender.login == 'appveyor[bot]' }}
+    steps:
+      - name: Create individual AppVeyor build statuses
+        if: ${{ github.event.sha && github.event.target_url }}
+        env:
+          APPVEYOR_COMMIT_SHA: ${{ github.event.sha }}
+          APPVEYOR_TARGET_URL: ${{ github.event.target_url }}
+          APPVEYOR_REPOSITORY: ${{ github.event.repository.full_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo ${APPVEYOR_TARGET_URL} | sed 's/\/project\//\/api\/projects\//' | xargs -t -n1 curl -s | \
+            jq -c '.build.jobs[] | {target_url: (($target_url | sub("s\\/\\d+"; "/job/")) + .jobId),
+                                    context: (.name | sub("^(Environment: )?"; "AppVeyor / ")),
+                                    state: (.status | sub("queued"; "pending")
+                                                    | sub("running"; "pending")
+                                                    | sub("failed"; "failure")
+                                                    | sub("cancelled"; "error")),
+                                    description: .status}' \
+                --arg target_url ${APPVEYOR_TARGET_URL} | parallel --pipe -j 1 -N 1 \
+              gh api --silent --input - repos/${APPVEYOR_REPOSITORY}/statuses/${APPVEYOR_COMMIT_SHA}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,35 +28,43 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - GENERATOR: "Visual Studio 14 2015"
+    - job_name: "VS2015, OpenSSL, Shared"
+      GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: ON
       CRYPTO_BACKEND: "OpenSSL"
 
-    - GENERATOR: "Visual Studio 14 2015"
+    - job_name: "VS2015, OpenSSL, Static"
+      GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: OFF
       CRYPTO_BACKEND: "OpenSSL"
 
-    - GENERATOR: "Visual Studio 12 2013"
+    - job_name: "VS2013, OpenSSL, Shared"
+      GENERATOR: "Visual Studio 12 2013"
       BUILD_SHARED_LIBS: ON
       CRYPTO_BACKEND: "OpenSSL"
 
-    - GENERATOR: "Visual Studio 12 2013"
+    - job_name: "VS2013, OpenSSL, Static"
+      GENERATOR: "Visual Studio 12 2013"
       BUILD_SHARED_LIBS: OFF
       CRYPTO_BACKEND: "OpenSSL"
 
-    - GENERATOR: "Visual Studio 14 2015"
+    - job_name: "VS2015, WinCNG, Shared"
+      GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: ON
       CRYPTO_BACKEND: "WinCNG"
 
-    - GENERATOR: "Visual Studio 14 2015"
+    - job_name: "VS2015, WinCNG, Static"
+      GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: OFF
       CRYPTO_BACKEND: "WinCNG"
 
-    - GENERATOR: "Visual Studio 12 2013"
+    - job_name: "VS2013, WinCNG, Shared"
+      GENERATOR: "Visual Studio 12 2013"
       BUILD_SHARED_LIBS: ON
       CRYPTO_BACKEND: "WinCNG"
 
-    - GENERATOR: "Visual Studio 12 2013"
+    - job_name: "VS2013, WinCNG, Static"
+      GENERATOR: "Visual Studio 12 2013"
       BUILD_SHARED_LIBS: OFF
       CRYPTO_BACKEND: "WinCNG"
 


### PR DESCRIPTION
Also give each job on AppVeyor CI a human-readable name.

This aims to make job and therefore build failures more visible.

--

Example commit status: https://github.com/mback2k/libssh2/commit/f8d623e2d14430f7b39c640ecc4107bee8ab75a0

On GitHub:
![image](https://user-images.githubusercontent.com/231943/196007376-3a8b5bf4-71b2-4ed3-87c2-0e3882c8239f.png)

On AppVeyor:
![image](https://user-images.githubusercontent.com/231943/196007389-1130b1f1-2939-4a40-a008-82392644383d.png)

I am testing this with the libssh2 project first and then plan to bring this to the curl project as well.