### PR TITLE
Fix regression with rsa_sha2_verify #758

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -541,7 +541,7 @@ _libssh2_mbedtls_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
 #endif
     free(hash);
 
-    return (ret == 1) ? 0 : -1;
+    return (ret == 0) ? 0 : -1;
 }
 
 int


### PR DESCRIPTION
Fixes comparison with the result value coming from `mbedtls_rsa_pkcs1_verify`. Success is 0, not 1. Fixes #758