### PR TITLE
Fixed error handling of _libssh2_packet_requirev callers

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -878,7 +878,8 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
         if(rc) {
             channel->setenv_state = libssh2_NB_state_idle;
             return _libssh2_error(session, rc,
-                                  "Failed getting response for channel-setenv");
+                                  "Failed getting response for "
+                                  "channel-setenv");
         }
         else if(data_len < 1) {
             channel->setenv_state = libssh2_NB_state_idle;

--- a/src/channel.c
+++ b/src/channel.c
@@ -877,7 +877,8 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
         }
         if(rc) {
             channel->setenv_state = libssh2_NB_state_idle;
-            return rc;
+            return _libssh2_error(session, rc,
+                                  "Failed getting response for channel-setenv");
         }
         else if(data_len < 1) {
             channel->setenv_state = libssh2_NB_state_idle;

--- a/src/session.c
+++ b/src/session.c
@@ -781,7 +781,8 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
                                      &session->startup_req_state);
         if(rc)
             return _libssh2_error(session, rc,
-                                  "Failed to get response to ssh-userauth request");
+                                  "Failed to get response to "
+                                  "ssh-userauth request");
 
         if(session->startup_data_len < 5) {
             return _libssh2_error(session, LIBSSH2_ERROR_PROTO,

--- a/src/session.c
+++ b/src/session.c
@@ -780,7 +780,8 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
                                      &session->startup_data_len, 0, NULL, 0,
                                      &session->startup_req_state);
         if(rc)
-            return rc;
+            return _libssh2_error(session, rc,
+                                  "Failed to get response to ssh-userauth request");
 
         if(session->startup_data_len < 5) {
             return _libssh2_error(session, LIBSSH2_ERROR_PROTO,


### PR DESCRIPTION
Hi,

some callers of _libssh2_packet_requirev() fail to set _libssh2_error(). This creates the situation where e.g. libssh2_session_handshake() fails, but libssh2_session_last_error() confusingly returns LIBSSH2_ERROR_NONE.

Best, Zenju