### PR TITLE
userauth: new error code for 'continue authentication'

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -548,6 +548,7 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_RANDGEN                   -49
 #define LIBSSH2_ERROR_MISSING_USERAUTH_BANNER   -50
 #define LIBSSH2_ERROR_ALGO_UNSUPPORTED          -51
+#define LIBSSH2_ERROR_PUBLICKEY_PARTIAL         -52
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1787,7 +1787,7 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
         return 0;
     }
 
-    if (session->userauth_pblc_data[session->userauth_pblc_data_len - 1] == 1) {
+    if(session->userauth_pblc_data[session->userauth_pblc_data_len - 1] == 1) {
         /* This public key is accepted, but require more authentication */
         LIBSSH2_FREE(session, session->userauth_pblc_data);
         session->userauth_pblc_data = NULL;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1793,7 +1793,7 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
         session->userauth_pblc_data = NULL;
         session->userauth_pblc_state = libssh2_NB_state_idle;
         return _libssh2_error(session, LIBSSH2_ERROR_PUBLICKEY_PARTIAL,
-                            "Publickey authentication partial successful");
+                              "Publickey authentication partially successful");
     }
 
     /* This public key is not allowed for this user on this server */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1787,6 +1787,15 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
         return 0;
     }
 
+    if (session->userauth_pblc_data[session->userauth_pblc_data_len - 1] == 1) {
+        /* This public key is accepted, but require more authentication */
+        LIBSSH2_FREE(session, session->userauth_pblc_data);
+        session->userauth_pblc_data = NULL;
+        session->userauth_pblc_state = libssh2_NB_state_idle;
+        return _libssh2_error(session, LIBSSH2_ERROR_PUBLICKEY_PARTIAL,
+                            "Publickey authentication partial successful");
+    }
+
     /* This public key is not allowed for this user on this server */
     LIBSSH2_FREE(session, session->userauth_pblc_data);
     session->userauth_pblc_data = NULL;


### PR DESCRIPTION
I'm implementing 2FA support and found this PR https://github.com/libssh2/libssh2/pull/757

I think a simpler approach would be return a special error code instead of using LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED