### PR TITLE
sftp: remove packet limit for directory reading

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -364,10 +364,10 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
                                       "SFTP packet too large");
             }
 
-            if(sftp->partial_len == 0)
+            if(sftp->partial_len < 5)
                 return _libssh2_error(session,
                                       LIBSSH2_ERROR_ALLOC,
-                                      "Unable to allocate empty SFTP packet");
+                                      "Invalid SFTP packet size");
 
             _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
                            "Data begin - Packet Length: %lu",

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -301,6 +301,7 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
     ssize_t rc;
     unsigned long recv_window;
     int packet_type;
+    uint32_t request_id;
 
     _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "recv packet");
 
@@ -329,26 +330,35 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
 
             /* each packet starts with a 32 bit length field */
             rc = _libssh2_channel_read(channel, 0,
-                                       (char *)&sftp->partial_size[
-                                           sftp->partial_size_len],
-                                       4 - sftp->partial_size_len);
+                                       (char*)&sftp->packet_header[
+                                           sftp->packet_header_len],
+                                       sizeof(sftp->packet_header) -
+                                       sftp->packet_header_len);
             if(rc == LIBSSH2_ERROR_EAGAIN)
                 return rc;
             else if(rc < 0)
                 return _libssh2_error(session, rc, "channel read");
 
-            sftp->partial_size_len += rc;
+            sftp->packet_header_len += rc;
 
-            if(4 != sftp->partial_size_len)
-                /* we got a short read for the length part */
+            if (sftp->packet_header_len != sizeof(sftp->packet_header))
+                /* we got a short read for the header part */
                 return LIBSSH2_ERROR_EAGAIN;
 
-            sftp->partial_len = _libssh2_ntohu32(sftp->partial_size);
+            //parse SFTP packet header
+            sftp->partial_len = _libssh2_ntohu32(sftp->packet_header);
+            packet_type = sftp->packet_header[4];
+            request_id = _libssh2_ntohu32(sftp->packet_header + 5);
+
             /* make sure we don't proceed if the packet size is unreasonably
                large */
-            if(sftp->partial_len > LIBSSH2_SFTP_PACKET_MAXLEN) {
+            if ((sftp->partial_len > LIBSSH2_SFTP_PACKET_MAXLEN) &&
+                //exception: response to SSH_FXP_READDIR request
+                !(sftp->readdir_state != libssh2_NB_state_idle && 
+                  sftp->readdir_request_id == request_id && 
+                  packet_type == SSH_FXP_NAME)) {
                 libssh2_channel_flush(channel);
-                sftp->partial_size_len = 0;
+                sftp->packet_header_len = 0;
                 return _libssh2_error(session,
                                       LIBSSH2_ERROR_CHANNEL_PACKET_EXCEEDED,
                                       "SFTP packet too large");
@@ -366,10 +376,11 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
             if(!packet)
                 return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                       "Unable to allocate SFTP packet");
-            sftp->partial_size_len = 0;
-            sftp->partial_received = 0; /* how much of the packet already
-                                           received */
+            sftp->packet_header_len = 0;
             sftp->partial_packet = packet;
+            //copy over packet type(4) and request id(1)
+            sftp->partial_received = 5;
+            memcpy(packet, sftp->packet_header + 4, 5);
 
           window_adjust:
             recv_window = libssh2_channel_window_read_ex(channel, NULL, NULL);

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -330,7 +330,7 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
 
             /* each packet starts with a 32 bit length field */
             rc = _libssh2_channel_read(channel, 0,
-                                       (char*)&sftp->packet_header[
+                                       (char *)&sftp->packet_header[
                                            sftp->packet_header_len],
                                        sizeof(sftp->packet_header) -
                                        sftp->packet_header_len);
@@ -341,22 +341,22 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
 
             sftp->packet_header_len += rc;
 
-            if (sftp->packet_header_len != sizeof(sftp->packet_header))
+            if(sftp->packet_header_len != sizeof(sftp->packet_header))
                 /* we got a short read for the header part */
                 return LIBSSH2_ERROR_EAGAIN;
 
-            //parse SFTP packet header
+            /* parse SFTP packet header */
             sftp->partial_len = _libssh2_ntohu32(sftp->packet_header);
             packet_type = sftp->packet_header[4];
             request_id = _libssh2_ntohu32(sftp->packet_header + 5);
 
             /* make sure we don't proceed if the packet size is unreasonably
                large */
-            if ((sftp->partial_len > LIBSSH2_SFTP_PACKET_MAXLEN) &&
-                //exception: response to SSH_FXP_READDIR request
-                !(sftp->readdir_state != libssh2_NB_state_idle && 
-                  sftp->readdir_request_id == request_id && 
-                  packet_type == SSH_FXP_NAME)) {
+            if(sftp->partial_len > LIBSSH2_SFTP_PACKET_MAXLEN &&
+               /* exception: response to SSH_FXP_READDIR request */
+               !(sftp->readdir_state != libssh2_NB_state_idle &&
+                 sftp->readdir_request_id == request_id &&
+                 packet_type == SSH_FXP_NAME)) {
                 libssh2_channel_flush(channel);
                 sftp->packet_header_len = 0;
                 return _libssh2_error(session,
@@ -378,7 +378,7 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
                                       "Unable to allocate SFTP packet");
             sftp->packet_header_len = 0;
             sftp->partial_packet = packet;
-            //copy over packet type(4) and request id(1)
+            /* copy over packet type(4) and request id(1) */
             sftp->partial_received = 5;
             memcpy(packet, sftp->packet_header + 4, 5);
 

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -153,9 +153,10 @@ struct _LIBSSH2_SFTP
     uint32_t last_errno;
 
     /* Holder for partial packet, use in libssh2_sftp_packet_read() */
-    unsigned char partial_size[4];      /* buffer for size field   */
-    size_t partial_size_len;            /* size field length       */
-    unsigned char *partial_packet;      /* The data                */
+    unsigned char packet_header[9];
+    /*packet size (4) packet type (1) request id (4) */
+    size_t packet_header_len;            /* packet_header length     */
+    unsigned char *partial_packet;      /* The data, including header */
     uint32_t partial_len;               /* Desired number of bytes */
     size_t partial_received;            /* Bytes received so far   */
 

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -154,7 +154,7 @@ struct _LIBSSH2_SFTP
 
     /* Holder for partial packet, use in libssh2_sftp_packet_read() */
     unsigned char packet_header[9];
-    /*packet size (4) packet type (1) request id (4) */
+    /* packet size (4) packet type (1) request id (4) */
     size_t packet_header_len;            /* packet_header length     */
     unsigned char *partial_packet;      /* The data, including header */
     uint32_t partial_len;               /* Desired number of bytes */

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -156,7 +156,7 @@ struct _LIBSSH2_SFTP
     unsigned char packet_header[9];
     /* packet size (4) packet type (1) request id (4) */
     size_t packet_header_len;           /* packet_header length    */
-    unsigned char *partial_packet;      /* The data, including header */
+    unsigned char *partial_packet;      /* The data, with header   */
     uint32_t partial_len;               /* Desired number of bytes */
     size_t partial_received;            /* Bytes received so far   */
 

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -155,7 +155,7 @@ struct _LIBSSH2_SFTP
     /* Holder for partial packet, use in libssh2_sftp_packet_read() */
     unsigned char packet_header[9];
     /* packet size (4) packet type (1) request id (4) */
-    size_t packet_header_len;            /* packet_header length     */
+    size_t packet_header_len;           /* packet_header length    */
     unsigned char *partial_packet;      /* The data, including header */
     uint32_t partial_len;               /* Desired number of bytes */
     size_t partial_received;            /* Bytes received so far   */


### PR DESCRIPTION
Hi,

currently libssh2 cannot read huge directory listings when the package size of LIBSSH2_SFTP_PACKET_MAXLEN (256KB) is hit.
For example AWS always sends a single package with all files of a directory, no matter how big it is:
https://freefilesync.org/forum/viewtopic.php?t=10020
Package size is probably around 7 MB in this case!

LIBSSH2_SFTP_PACKET_MAXLEN is a good idea in general, but there doesn't seem to be a one size fits all.
While almost all(?) SFTP responses come in very small packages, I believe the SSH_FXP_READDIR request should be exempted.

The proposed patch, enhances the package size reading to include parsing the full SFTP packet header. And in case a package is of type SSH_FXP_NAME and matches an expected readdir_request_id, it does not fail if LIBSSH2_SFTP_PACKET_MAXLEN is hit.
The chances of accidentally hiding data-corruption are pretty non-existent, because both SFTP request_id and packet type must match. No change in behavior otherwise.

Best, Zenju

PS: Previous discussion: https://github.com/libssh2/libssh2/pull/268 https://github.com/libssh2/libssh2/pull/269

With the above changes, the LIBSSH2_SFTP_PACKET_MAXLEN value could (and should?) probably be set back to a small number again.