### PR TITLE
Reorder AES crypt methods so stronger ones are first

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -310,11 +310,13 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_3des_cbc = {
 };
 #endif
 
+/* These are the crypt methods that are available to be negotiated. Methods
+   towards the start are chosen in preference to ones further down the list. */
 static const LIBSSH2_CRYPT_METHOD *_libssh2_crypt_methods[] = {
 #if LIBSSH2_AES_CTR
-  &libssh2_crypt_method_aes128_ctr,
-  &libssh2_crypt_method_aes192_ctr,
   &libssh2_crypt_method_aes256_ctr,
+  &libssh2_crypt_method_aes192_ctr,
+  &libssh2_crypt_method_aes128_ctr,
 #endif /* LIBSSH2_AES */
 #if LIBSSH2_AES
     &libssh2_crypt_method_aes256_cbc,


### PR DESCRIPTION
This make it more likely that a stronger one will be negotiated rather
than a weaker variant.