### PR TITLE
Disable deprecated warnings for OpenSSL 3 #805

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -41,6 +41,9 @@
 
 #ifdef LIBSSH2_WOLFSSL
 
+/* disable deprecated warnings in OpenSSL 3 */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <wolfssl/options.h>
 #include <openssl/ecdh.h>
 
@@ -93,9 +96,6 @@
 #include <openssl/bn.h>
 #include <openssl/pem.h>
 #include <openssl/rand.h>
-
-/* disable deprecated warnings in OpenSSL 3 */
-#define OPENSSL_SUPPRESS_DEPRECATED
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(LIBRESSL_VERSION_NUMBER)) || defined(LIBSSH2_WOLFSSL) || \

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -39,10 +39,10 @@
  * OF SUCH DAMAGE.
  */
 
-#ifdef LIBSSH2_WOLFSSL
-
 /* disable deprecated warnings in OpenSSL 3 */
 #define OPENSSL_SUPPRESS_DEPRECATED
+
+#ifdef LIBSSH2_WOLFSSL
 
 #include <wolfssl/options.h>
 #include <openssl/ecdh.h>

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -94,6 +94,9 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 
+/* disable deprecated warnings in OpenSSL 3 */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(LIBRESSL_VERSION_NUMBER)) || defined(LIBSSH2_WOLFSSL) || \
     LIBRESSL_VERSION_NUMBER >= 0x3050000fL


### PR DESCRIPTION
For now disable OpenSSL 3 warnings for clean builds.