### PR TITLE
cmake: bump minimum version to 3.1 (from 2.8.12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 # OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -41,13 +41,7 @@ project(libssh2 C)
 set(PROJECT_URL "https://www.libssh2.org/")
 set(PROJECT_DESCRIPTION "The SSH library")
 
-if (CMAKE_VERSION VERSION_LESS "3.1")
-  if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    set (CMAKE_C_FLAGS "--std=gnu90 ${CMAKE_C_FLAGS}")
-  endif()
-else()
-  set (CMAKE_C_STANDARD 90)
-endif()
+set(CMAKE_C_STANDARD 90)
 
 option(BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -362,12 +362,7 @@ if(MSVC)
   set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} /DEBUG")
 endif()
 
-if(CMAKE_VERSION VERSION_LESS "2.8.12")
-  # Fall back to over-linking dependencies
-  target_link_libraries(libssh2 ${LIBRARIES})
-else()
-  target_link_libraries(libssh2 PRIVATE ${LIBRARIES})
-endif()
+target_link_libraries(libssh2 PRIVATE ${LIBRARIES})
 
 ## Installation
 


### PR DESCRIPTION
This allows to delete some fallback code.

CMake release dates:
- 2014-12-15: 3.1
- 2013-10-07: 2.8.12

Closes #813
