### PR TITLE
cmake: restore non-Windows socket lib detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 # OF SUCH DAMAGE.
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
+include(CheckFunctionExistsMayNeedLibrary)
+
 cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -79,8 +82,18 @@ install(
 include(max_warnings)
 include(FeatureSummary)
 
+# Add socket libraries
 if(WIN32)
   list(APPEND LIBRARIES ws2_32)
+else()
+  check_function_exists_may_need_library(socket HAVE_SOCKET socket)
+  if(NEED_LIB_SOCKET)
+    list(APPEND LIBRARIES socket)
+  endif()
+  check_function_exists_may_need_library(inet_addr HAVE_INET_ADDR nsl)
+  if(NEED_LIB_NSL)
+    list(APPEND LIBRARIES nsl)
+  endif()
 endif()
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,6 @@
 
 include(CheckFunctionExists)
 include(CheckSymbolExists)
-include(CheckFunctionExistsMayNeedLibrary)
 include(CheckIncludeFiles)
 include(CheckTypeSize)
 include(CheckSymbolExists)


### PR DESCRIPTION
I mistakenly pruned some non-Windows logic, also missing the fact that
our local `check_function_exists_may_need_library()` set the `NEED_*`
variables. Oddly, only `src` imported this function, yet also `examples`
and `tests` called it indirectly. The referenced `HAVE_SOCKET` /
`HAVE_INET_ADDR` variables might be coming from an upstream CMake
project? Leaving those there also, just in case.

Regression from 31fb8860dbaae3e0b7d38f2a647ee527b4b2a95f
