### PR TITLE
cmake: use only socket libs when checking non-blocking sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,17 +84,18 @@ include(FeatureSummary)
 
 # Add socket libraries
 if(WIN32)
-  list(APPEND LIBRARIES ws2_32)
+  list(APPEND SOCKET_LIBRARIES ws2_32)
 else()
   check_function_exists_may_need_library(socket HAVE_SOCKET socket)
   if(NEED_LIB_SOCKET)
-    list(APPEND LIBRARIES socket)
+    list(APPEND SOCKET_LIBRARIES socket)
   endif()
   check_function_exists_may_need_library(inet_addr HAVE_INET_ADDR nsl)
   if(NEED_LIB_NSL)
-    list(APPEND LIBRARIES nsl)
+    list(APPEND SOCKET_LIBRARIES nsl)
   endif()
 endif()
+list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
 
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -342,10 +342,11 @@ if(WIN32)
   list(APPEND PC_LIBS -lws2_32)
 endif()
 
-# Non-blocking socket support tests.  Must be after library tests to
-# link correctly
+# Non-blocking socket support tests. Use a separate, yet unset variable
+# for the socket libraries to not link against the other configured
+# dependencies which might not have been built yet.
 set(SAVE_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
-set(CMAKE_REQUIRED_LIBRARIES ${LIBRARIES})
+set(CMAKE_REQUIRED_LIBRARIES ${SOCKET_LIBRARIES})
 check_nonblocking_socket_support()
 set(CMAKE_REQUIRED_LIBRARIES ${SAVE_CMAKE_REQUIRED_LIBRARIES})
 


### PR DESCRIPTION
Based on patch by Christian Beier:

When building libssh2 and the libraries it depends on from source
using a single CMakeLists.txt (as is common on Android), libssh2's
CMake has to be hinted at where to find other libs by setting
variables like OPENSSL_SSL_LIBRARY and so on.

Now, as under Android there's one single CMakeLists.txt that has to
`add_subdirectory()` all other CMakeLists.txt, there's only one
configure phase and one build phase. That means when libssh2 is
configured, the libs it is configured to use are actually not built
yet.

In this case it's a problem to use the libs in LIBRARIES when checking
for nonblocking sockets as some libs in there are not yet built,
failing the test and ending up with HAVE_DISABLED_NONBLOCKING in
libssh2_config.h.

Fix this by using a separate, clean library list for the nonblocking
socket checks.

Fixes #694
Closes #712
