### PR TITLE
build: silence bogus C4127 warnings with MSVS 2013 and earlier

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -39,6 +39,11 @@
  * OF SUCH DAMAGE.
  */
 
+/* Disable warnings: C4127: conditional expression is constant */
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#pragma warning(disable:4127)
+#endif
+
 #define LIBSSH2_LIBRARY
 #include "libssh2_config.h"
 


### PR DESCRIPTION
E.g.:
`channel.c(370): warning C4127: conditional expression is constant`
Ref:
https://ci.appveyor.com/project/libssh2org/libssh2/builds/46437333/job/5rak1vcl9hue31ei#L190