### PR TITLE
snprintf: add missing prototype for local replacement

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -119,6 +119,7 @@
 #if !defined(HAVE_SNPRINTF)
 #define LIBSSH2_SNPRINTF
 #define snprintf _libssh2_snprintf
+int _libssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...);
 #endif
 
 /* "inline" keyword is valid only with C++ engine! */


### PR DESCRIPTION
Should fix these warnings with MSVS 2013 and older:
`agent.c(294): warning C4013: '_libssh2_snprintf' undefined; assuming extern returning int`

Follow-up to 4cdf785cd313c3272d04c2ef7458a35d44533d8b.
