### PR TITLE
cmake: unset forced CMAKE_C_STANDARD 90

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,6 @@ project(libssh2 C)
 set(PROJECT_URL "https://www.libssh2.org/")
 set(PROJECT_DESCRIPTION "The SSH library")
 
-set(CMAKE_C_STANDARD 90)
-
 option(BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
 
 # Parse version


### PR DESCRIPTION
Added in cf80f2f4b5255cc85a04ee43b27a29c678c1edb1 (on 2016-08-14), with the title "Basic dockerised test suite".

It's not clear why a C standard was explicitly set, but a side-effect of this is that CMake-built binaries diverged from ones built with autotools or GNU Make (using the same compiler and configuration).

Another issue is that this may introduce ABI incompatibility with binaries built with a different C standard flag, e.g. the C compiler default or one used for other components of a final app.

Seems unlikely, but if our tests require this option, we should set it for the CI builds only?