### PR TITLE
fix compiling with LIBSSH2_NO_CLEAR_MEMORY and OpenSSL

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -40,8 +40,8 @@
 
 #ifdef LIBSSH2_NO_CLEAR_MEMORY
 #define _libssh2_explicit_zero(buf, size) do { \
-                                              (void)buf; \
-                                              (void)size; \
+                                              (void)(buf); \
+                                              (void)(size); \
                                           } while(0)
 #else
 #ifdef WIN32


### PR DESCRIPTION
Regression from a0e424a51c27cc27af611ba20d134f9a9ae35273

Fixes #824
