### PR TITLE
cmake: add os400qc3.c to SOURCES

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -218,6 +218,7 @@ set(SOURCES
   mac.h
   misc.c
   misc.h
+  os400qc3.c
   packet.c
   packet.h
   pem.c


### PR DESCRIPTION
This re-syncs the list of compiled objects in cmake builds with non-cmake builds.

Follow-up to 16619a8eddec35bb8582d1c334db0fc13b0817c4.