### PR TITLE
cmake: reposition `ws2_32` to make binutils `ld` work again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ else()
     list(APPEND SOCKET_LIBRARIES nsl)
   endif()
 endif()
-list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
 
 add_subdirectory(src)
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -62,6 +62,8 @@ set(EXAMPLES
   subsystem_netconf
   tcpip-forward)
 
+list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
+
 foreach(example ${EXAMPLES})
   add_executable(example-${example} ${example}.c)
   list(APPEND EXAMPLE_TARGETS example-${example})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -361,6 +361,8 @@ else()
   check_function_exists(poll HAVE_POLL)
 endif()
 
+list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
+
 if(WIN32)
   set(HAVE_SELECT 1)
   list(APPEND PC_LIBS -lws2_32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,8 @@ configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/libssh2_config_cmake.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/libssh2_config.h")
 
+list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
+
 ## Cryptography backend choice
 
 set(CRYPTO_BACKEND


### PR DESCRIPTION
This restores socket libs to their pre-regression positions.

Without this, `ld` doesn't find `ws2_32` symbols when referenced from TLS libs.

Regression from 31fb8860dbaae3e0b7d38f2a647ee527b4b2a95f