### PR TITLE
cmake: detect HAVE_SNPRINTF for tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
 check_include_files(arpa/inet.h HAVE_ARPA_INET_H)
 check_include_files(winsock2.h HAVE_WINSOCK2_H)
 check_include_files(netinet/in.h HAVE_NETINET_IN_H)
+check_symbol_exists(snprintf stdio.h HAVE_SNPRINTF)
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/libssh2_config_cmake.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/libssh2_config.h")

--- a/tests/libssh2_config_cmake.h.in
+++ b/tests/libssh2_config_cmake.h.in
@@ -42,3 +42,6 @@
 #cmakedefine HAVE_ARPA_INET_H
 #cmakedefine HAVE_NETINET_IN_H
 #cmakedefine HAVE_WINSOCK2_H
+
+/* Functions */
+#cmakedefine HAVE_SNPRINTF


### PR DESCRIPTION
Turns out `test_keyboard_interactive_auth_info_request.c` requires `src/libssh2_priv.h`, which in turn requires a correctly set `HAVE_SNPRINTF`.

Follow-up to 4cdf785cd313c3272d04c2ef7458a35d44533d8b.