### PR TITLE
src: C89-compliant _libssh2_debug() macro

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -478,10 +478,10 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     /* check to see if we match requested */
     if((size_t)method_len != session->userauth_pblc_method_len ||
         memcmp(method_name, session->userauth_pblc_method, method_len)) {
-        _libssh2_debug(session,
+        _libssh2_debug((session,
                        LIBSSH2_TRACE_KEX,
                        "Agent sign method %.*s",
-                       method_len, method_name);
+                       method_len, method_name));
 
         rc = LIBSSH2_ERROR_ALGO_UNSUPPORTED;
         goto error;

--- a/src/channel.c
+++ b/src/channel.c
@@ -81,8 +81,8 @@ _libssh2_channel_nextid(LIBSSH2_SESSION * session)
      * told...
      */
     session->next_channel = id + 1;
-    _libssh2_debug(session, LIBSSH2_TRACE_CONN, "Allocated new channel ID#%lu",
-                   id);
+    _libssh2_debug((session, LIBSSH2_TRACE_CONN,
+                   "Allocated new channel ID#%lu", id));
     return id;
 }
 
@@ -154,9 +154,9 @@ _libssh2_channel_open(LIBSSH2_SESSION * session, const char *channel_type,
         memset(&session->open_packet_requirev_state, 0,
                sizeof(session->open_packet_requirev_state));
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Opening Channel - win %d pack %d", window_size,
-                       packet_size);
+                       packet_size));
         session->open_channel =
             LIBSSH2_CALLOC(session, sizeof(LIBSSH2_CHANNEL));
         if(!session->open_channel) {
@@ -262,7 +262,7 @@ _libssh2_channel_open(LIBSSH2_SESSION * session, const char *channel_type,
                 _libssh2_ntohu32(session->open_data + 9);
             session->open_channel->local.packet_size =
                 _libssh2_ntohu32(session->open_data + 13);
-            _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+            _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                            "Connection Established - ID: %lu/%lu win: %lu/%lu"
                            " pack: %lu/%lu",
                            session->open_channel->local.id,
@@ -270,7 +270,7 @@ _libssh2_channel_open(LIBSSH2_SESSION * session, const char *channel_type,
                            session->open_channel->local.window_size,
                            session->open_channel->remote.window_size,
                            session->open_channel->local.packet_size,
-                           session->open_channel->remote.packet_size);
+                           session->open_channel->remote.packet_size));
             LIBSSH2_FREE(session, session->open_packet);
             session->open_packet = NULL;
             LIBSSH2_FREE(session, session->open_data);
@@ -390,9 +390,9 @@ channel_direct_tcpip(LIBSSH2_SESSION * session, const char *host,
         session->direct_message_len =
             session->direct_host_len + session->direct_shost_len + 16;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Requesting direct-tcpip session from %s:%d to %s:%d",
-                       shost, sport, host, port);
+                       shost, sport, host, port));
 
         s = session->direct_message =
             LIBSSH2_ALLOC(session, session->direct_message_len);
@@ -480,9 +480,9 @@ channel_forward_listen(LIBSSH2_SESSION * session, const char *host,
         memset(&session->fwdLstn_packet_requirev_state, 0,
                sizeof(session->fwdLstn_packet_requirev_state));
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Requesting tcpip-forward session for %s:%d", host,
-                       port);
+                       port));
 
         s = session->fwdLstn_packet =
             LIBSSH2_ALLOC(session, session->fwdLstn_packet_len);
@@ -567,10 +567,10 @@ channel_forward_listen(LIBSSH2_SESSION * session, const char *host,
                     listener->host[session->fwdLstn_host_len] = 0;
                     if(data_len >= 5 && !port) {
                         listener->port = _libssh2_ntohu32(data + 1);
-                        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+                        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                        "Dynamic tcpip-forward port "
                                        "allocated: %d",
-                                       listener->port);
+                                       listener->port));
                     }
                     else
                         listener->port = port;
@@ -647,9 +647,9 @@ int _libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
     int retcode = 0;
 
     if(listener->chanFwdCncl_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Cancelling tcpip-forward session for %s:%d",
-                       listener->host, listener->port);
+                       listener->host, listener->port));
 
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
@@ -818,10 +818,10 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
         memset(&channel->setenv_packet_requirev_state, 0,
                sizeof(channel->setenv_packet_requirev_state));
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Setting remote environment variable: %s=%s on "
                        "channel %lu/%lu",
-                       varname, value, channel->local.id, channel->remote.id);
+                       varname, value, channel->local.id, channel->remote.id));
 
         s = channel->setenv_packet =
             LIBSSH2_ALLOC(session, channel->setenv_packet_len);
@@ -953,9 +953,9 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
         memset(&channel->reqPTY_packet_requirev_state, 0,
                sizeof(channel->reqPTY_packet_requirev_state));
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Allocating tty on channel %lu/%lu", channel->local.id,
-                       channel->remote.id);
+                       channel->remote.id));
 
         s = channel->reqPTY_packet;
 
@@ -1056,9 +1056,9 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
         memset(&channel->req_auth_agent_requirev_state, 0,
                sizeof(channel->req_auth_agent_requirev_state));
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Requesting auth agent on channel %lu/%lu",
-                       channel->local.id, channel->remote.id);
+                       channel->local.id, channel->remote.id));
 
         /*
          *  byte      SSH_MSG_CHANNEL_REQUEST
@@ -1218,10 +1218,10 @@ channel_request_pty_size(LIBSSH2_CHANNEL * channel, int width,
         memset(&channel->reqPTY_packet_requirev_state, 0,
                sizeof(channel->reqPTY_packet_requirev_state));
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
             "changing tty size on channel %lu/%lu",
             channel->local.id,
-            channel->remote.id);
+            channel->remote.id));
 
         s = channel->reqPTY_packet;
 
@@ -1307,13 +1307,13 @@ channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
         memset(&channel->reqX11_packet_requirev_state, 0,
                sizeof(channel->reqX11_packet_requirev_state));
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Requesting x11-req for channel %lu/%lu: single=%d "
                        "proto=%s cookie=%s screen=%d",
                        channel->local.id, channel->remote.id,
                        single_connection,
                        auth_proto ? auth_proto : "MIT-MAGIC-COOKIE-1",
-                       auth_cookie ? auth_cookie : "<random>", screen_number);
+                       auth_cookie ? auth_cookie : "<random>", screen_number));
 
         s = channel->reqX11_packet =
             LIBSSH2_ALLOC(session, channel->reqX11_packet_len);
@@ -1465,10 +1465,10 @@ _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
         if(message)
             channel->process_packet_len += + 4;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "starting request(%s) on channel %lu/%lu, message=%s",
                        request, channel->local.id, channel->remote.id,
-                       message ? message : "<null>");
+                       message ? message : "<null>"));
         s = channel->process_packet =
             LIBSSH2_ALLOC(session, channel->process_packet_len);
         if(!channel->process_packet)
@@ -1597,8 +1597,8 @@ _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
 
             if(packet->data_len < 1) {
                 packet = next;
-                _libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
-                               "Unexpected packet length");
+                _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
+                               "Unexpected packet length"));
                 continue;
             }
 
@@ -1634,11 +1634,11 @@ _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
                     size_t bytes_to_flush = packet->data_len -
                         packet->data_head;
 
-                    _libssh2_debug(channel->session, LIBSSH2_TRACE_CONN,
+                    _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
                                    "Flushing %d bytes of data from stream "
                                    "%lu on channel %lu/%lu",
                                    bytes_to_flush, packet_stream_id,
-                                   channel->local.id, channel->remote.id);
+                                   channel->local.id, channel->remote.id));
 
                     /* It's one of the streams we wanted to flush */
                     channel->flush_refund_bytes += packet->data_len - 13;
@@ -1797,10 +1797,10 @@ _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL * channel,
         if(!force
             && (adjustment + channel->adjust_queue <
                 LIBSSH2_CHANNEL_MINADJUST)) {
-            _libssh2_debug(channel->session, LIBSSH2_TRACE_CONN,
+            _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
                            "Queueing %lu bytes for receive window adjustment "
                            "for channel %lu/%lu",
-                           adjustment, channel->local.id, channel->remote.id);
+                           adjustment, channel->local.id, channel->remote.id));
             channel->adjust_queue += adjustment;
             return 0;
         }
@@ -1816,10 +1816,10 @@ _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL * channel,
         channel->adjust_adjust[0] = SSH_MSG_CHANNEL_WINDOW_ADJUST;
         _libssh2_htonu32(&channel->adjust_adjust[1], channel->remote.id);
         _libssh2_htonu32(&channel->adjust_adjust[5], adjustment);
-        _libssh2_debug(channel->session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
                        "Adjusting window %lu bytes for data on "
                        "channel %lu/%lu",
-                       adjustment, channel->local.id, channel->remote.id);
+                       adjustment, channel->local.id, channel->remote.id));
 
         channel->adjust_state = libssh2_NB_state_created;
     }
@@ -1911,10 +1911,10 @@ int
 _libssh2_channel_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode)
 {
     if(channel->extData2_state == libssh2_NB_state_idle) {
-        _libssh2_debug(channel->session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
                        "Setting channel %lu/%lu handle_extended_data"
                        " mode to %d",
-                       channel->local.id, channel->remote.id, ignore_mode);
+                       channel->local.id, channel->remote.id, ignore_mode));
         channel->remote.extended_data_ignore_mode = (char)ignore_mode;
 
         channel->extData2_state = libssh2_NB_state_created;
@@ -1994,11 +1994,11 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
     LIBSSH2_PACKET *read_packet;
     LIBSSH2_PACKET *read_next;
 
-    _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+    _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                    "channel_read() wants %d bytes from channel %lu/%lu "
                    "stream #%d",
                    (int) buflen, channel->local.id, channel->remote.id,
-                   stream_id);
+                   stream_id));
 
     /* expand the receiving window first if it has become too narrow */
     if((channel->read_state == libssh2_NB_state_jump1) ||
@@ -2050,8 +2050,8 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
 
             if(readpkt->data_len != 1 ||
                 readpkt->data[0] != SSH_MSG_REQUEST_FAILURE) {
-                _libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
-                               "Unexpected packet length");
+                _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
+                               "Unexpected packet length"));
             }
 
             continue;
@@ -2091,11 +2091,11 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
                 unlink_packet = TRUE;
             }
 
-            _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+            _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                            "channel_read() got %d of data from %lu/%lu/%d%s",
                            bytes_want, channel->local.id,
                            channel->remote.id, stream_id,
-                           unlink_packet?" [ul]":"");
+                           unlink_packet?" [ul]":""));
 
             /* copy data from this struct to the target buffer */
             memcpy(&buf[bytes_read],
@@ -2200,8 +2200,8 @@ _libssh2_channel_packet_data_len(LIBSSH2_CHANNEL * channel, int stream_id)
 
         if(read_packet->data_len < 5) {
             read_packet = next_packet;
-            _libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
-                           "Unexpected packet length");
+            _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
+                           "Unexpected packet length"));
             continue;
         }
 
@@ -2269,10 +2269,10 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
     if(channel->write_state == libssh2_NB_state_idle) {
         unsigned char *s = channel->write_packet;
 
-        _libssh2_debug(channel->session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
                        "Writing %d bytes on channel %lu/%lu, stream #%d",
                        (int) buflen, channel->local.id, channel->remote.id,
-                       stream_id);
+                       stream_id));
 
         if(channel->local.close)
             return _libssh2_error(channel->session,
@@ -2318,19 +2318,19 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         /* Don't exceed the remote end's limits */
         /* REMEMBER local means local as the SOURCE of the data */
         if(channel->write_bufwrite > channel->local.window_size) {
-            _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+            _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                            "Splitting write block due to %lu byte "
                            "window_size on %lu/%lu/%d",
                            channel->local.window_size, channel->local.id,
-                           channel->remote.id, stream_id);
+                           channel->remote.id, stream_id));
             channel->write_bufwrite = channel->local.window_size;
         }
         if(channel->write_bufwrite > channel->local.packet_size) {
-            _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+            _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                            "Splitting write block due to %lu byte "
                            "packet_size on %lu/%lu/%d",
                            channel->local.packet_size, channel->local.id,
-                           channel->remote.id, stream_id);
+                           channel->remote.id, stream_id));
             channel->write_bufwrite = channel->local.packet_size;
         }
         /* store the size here only, the buffer is passed in as-is to
@@ -2338,10 +2338,10 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         _libssh2_store_u32(&s, channel->write_bufwrite);
         channel->write_packet_len = s - channel->write_packet;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Sending %d bytes on channel %lu/%lu, stream_id=%d",
                        (int) channel->write_bufwrite, channel->local.id,
-                       channel->remote.id, stream_id);
+                       channel->remote.id, stream_id));
 
         channel->write_state = libssh2_NB_state_created;
     }
@@ -2413,9 +2413,9 @@ static int channel_send_eof(LIBSSH2_CHANNEL *channel)
     unsigned char packet[5];    /* packet_type(1) + channelno(4) */
     int rc;
 
-    _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+    _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                    "Sending EOF on channel %lu/%lu",
-                   channel->local.id, channel->remote.id);
+                   channel->local.id, channel->remote.id));
     packet[0] = SSH_MSG_CHANNEL_EOF;
     _libssh2_htonu32(packet + 1, channel->remote.id);
     rc = _libssh2_transport_send(session, packet, 5, NULL, 0);
@@ -2474,8 +2474,8 @@ libssh2_channel_eof(LIBSSH2_CHANNEL * channel)
 
         if(packet->data_len < 1) {
             packet = next_packet;
-            _libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
-                           "Unexpected packet length");
+            _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
+                           "Unexpected packet length"));
             continue;
         }
 
@@ -2503,9 +2503,9 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
     int rc;
 
     if(channel->wait_eof_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Awaiting EOF for channel %lu/%lu", channel->local.id,
-                       channel->remote.id);
+                       channel->remote.id));
 
         channel->wait_eof_state = libssh2_NB_state_created;
     }
@@ -2585,8 +2585,8 @@ int _libssh2_channel_close(LIBSSH2_CHANNEL * channel)
        late for us to wait for it. Continue closing! */
 
     if(channel->close_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN, "Closing channel %lu/%lu",
-                       channel->local.id, channel->remote.id);
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN, "Closing channel %lu/%lu",
+                       channel->local.id, channel->remote.id));
 
         channel->close_packet[0] = SSH_MSG_CHANNEL_CLOSE;
         _libssh2_htonu32(channel->close_packet + 1, channel->remote.id);
@@ -2675,9 +2675,9 @@ static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
     }
 
     if(channel->wait_closed_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Awaiting close of channel %lu/%lu", channel->local.id,
-                       channel->remote.id);
+                       channel->remote.id));
 
         channel->wait_closed_state = libssh2_NB_state_created;
     }
@@ -2738,9 +2738,9 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
     assert(session);
 
     if(channel->free_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Freeing channel %lu/%lu resources", channel->local.id,
-                       channel->remote.id);
+                       channel->remote.id));
 
         channel->free_state = libssh2_NB_state_created;
     }
@@ -2857,8 +2857,8 @@ libssh2_channel_window_read_ex(LIBSSH2_CHANNEL *channel,
 
             if(packet->data_len < 1) {
                 packet = next_packet;
-                _libssh2_debug(channel->session, LIBSSH2_TRACE_ERROR,
-                               "Unexpected packet length");
+                _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
+                               "Unexpected packet length"));
                 continue;
             }
 

--- a/src/comp.c
+++ b/src/comp.c
@@ -163,8 +163,8 @@ comp_method_zlib_init(LIBSSH2_SESSION * session, int compr,
 
     if(status != Z_OK) {
         LIBSSH2_FREE(session, strm);
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-                       "unhandled zlib error %d", status);
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                       "unhandled zlib error %d", status));
         return LIBSSH2_ERROR_COMPRESS;
     }
     *abstract = strm;
@@ -204,9 +204,9 @@ comp_method_zlib_comp(LIBSSH2_SESSION *session,
         return 0;
     }
 
-    _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
+    _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                    "unhandled zlib compression error %d, avail_out",
-                   status, strm->avail_out);
+                   status, strm->avail_out));
     return _libssh2_error(session, LIBSSH2_ERROR_ZLIB, "compression failure");
 }
 
@@ -276,8 +276,8 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
         else {
             /* error state */
             LIBSSH2_FREE(session, out);
-            _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-                           "unhandled zlib error %d", status);
+            _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                           "unhandled zlib error %d", status));
             return _libssh2_error(session, LIBSSH2_ERROR_ZLIB,
                                   "decompression failure");
         }

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -73,8 +73,8 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
     }
 
     if(hostkey_data_len < 19) {
-        _libssh2_debug(session, LIBSSH2_TRACE_ERROR,
-                       "host key length too short");
+        _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
+                       "host key length too short"));
         return -1;
     }
 
@@ -99,8 +99,8 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
     }
 #endif
     else {
-        _libssh2_debug(session, LIBSSH2_TRACE_ERROR,
-                       "unexpected rsa type: %.*s", type_len, type);
+        _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
+                       "unexpected rsa type: %.*s", type_len, type));
         return -1;
     }
 
@@ -498,8 +498,8 @@ hostkey_method_ssh_dss_init(LIBSSH2_SESSION * session,
     }
 
     if(hostkey_data_len < 27) {
-        _libssh2_debug(session, LIBSSH2_TRACE_ERROR,
-                       "host key length too short");
+        _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
+                       "host key length too short"));
         return -1;
     }
 
@@ -725,8 +725,8 @@ hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION * session,
     }
 
     if(hostkey_data_len < 39) {
-        _libssh2_debug(session, LIBSSH2_TRACE_ERROR,
-                       "host key length too short");
+        _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
+                       "host key length too short"));
         return -1;
     }
 
@@ -1064,8 +1064,8 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
     }
 
     if(hostkey_data_len < 19) {
-        _libssh2_debug(session, LIBSSH2_TRACE_ERROR,
-                       "host key length too short");
+        _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
+                       "host key length too short"));
         return -1;
     }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -296,8 +296,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                exchange_state->e_packet + 6);
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sending KEX packet %d",
-                       (int) packet_type_init);
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX, "Sending KEX packet %d",
+                       (int) packet_type_init));
         exchange_state->state = libssh2_NB_state_created;
     }
 
@@ -323,9 +323,9 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
              * need to silently ignore it */
             int burn_type;
 
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                            "Waiting for badly guessed KEX packet "
-                           "(to be ignored)");
+                           "(to be ignored)"));
             burn_type =
                 _libssh2_packet_burn(session, &exchange_state->burn_state);
             if(burn_type == LIBSSH2_ERROR_EAGAIN) {
@@ -338,9 +338,9 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             }
             session->burn_optimistic_kexinit = 0;
 
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                            "Burnt packet of type: %02x",
-                           (unsigned int) burn_type);
+                           (unsigned int) burn_type));
         }
 
         exchange_state->state = libssh2_NB_state_sent1;
@@ -411,8 +411,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                 snprintf(fprint, 4, "%02x:", session->server_hostkey_md5[i]);
             }
             *(--fprint) = '\0';
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                           "Server's MD5 Fingerprint: %s", fingerprint);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Server's MD5 Fingerprint: %s", fingerprint));
         }
 #endif /* LIBSSH2DEBUG */
 #endif /* ! LIBSSH2_MD5 */
@@ -440,8 +440,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                 snprintf(fprint, 4, "%02x:", session->server_hostkey_sha1[i]);
             }
             *(--fprint) = '\0';
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                           "Server's SHA1 Fingerprint: %s", fingerprint);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Server's SHA1 Fingerprint: %s", fingerprint));
         }
 #endif /* LIBSSH2DEBUG */
 
@@ -467,9 +467,9 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                    session->server_hostkey_sha256,
                                    SHA256_DIGEST_LENGTH, &base64Fingerprint);
             if(base64Fingerprint != NULL) {
-                _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+                _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                                "Server's SHA256 Fingerprint: %s",
-                               base64Fingerprint);
+                               base64Fingerprint));
                 LIBSSH2_FREE(session, base64Fingerprint);
             }
         }
@@ -633,7 +633,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sending NEWKEYS message");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Sending NEWKEYS message"));
         exchange_state->c = SSH_MSG_NEWKEYS;
 
         exchange_state->state = libssh2_NB_state_sent2;
@@ -668,7 +669,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         /* The first key exchange has been performed,
            switch to active crypt/comp/mac mode */
         session->state |= LIBSSH2_STATE_NEWKEYS;
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Received NEWKEYS message");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Received NEWKEYS message"));
 
         /* This will actually end up being just packet_type(1)
            for this packet type anyway */
@@ -685,8 +687,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             memcpy(session->session_id, exchange_state->h_sig_comp,
                    digest_len);
             session->session_id_len = digest_len;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                           "session_id calculated");
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "session_id calculated"));
         }
 
         /* Cleanup any existing cipher */
@@ -739,8 +741,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                 LIBSSH2_FREE(session, secret);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Client to Server IV and Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server IV and Key calculated"));
 
         if(session->remote.crypt->dtor) {
             /* Cleanup any existing cipher */
@@ -789,8 +791,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                 LIBSSH2_FREE(session, secret);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Server to Client IV and Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client IV and Key calculated"));
 
         if(session->local.mac->dtor) {
             session->local.mac->dtor(session, &session->local.mac_abstract);
@@ -816,8 +818,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                 LIBSSH2_FREE(session, key);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Client to Server HMAC Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server HMAC Key calculated"));
 
         if(session->remote.mac->dtor) {
             session->remote.mac->dtor(session, &session->remote.mac_abstract);
@@ -843,8 +845,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                 LIBSSH2_FREE(session, key);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Server to Client HMAC Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client HMAC Key calculated"));
 
         /* Initialize compression for each direction */
 
@@ -861,8 +863,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                 goto clean_exit;
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Client to Server compression initialized");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server compression initialized"));
 
         if(session->remote.comp && session->remote.comp->dtor) {
             session->remote.comp->dtor(session, 0,
@@ -876,8 +878,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                 goto clean_exit;
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Server to Client compression initialized");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client compression initialized"));
 
     }
 
@@ -954,8 +956,8 @@ kex_method_diffie_hellman_group1_sha1_key_exchange(LIBSSH2_SESSION *session,
         _libssh2_bn_set_word(key_state->g, 2);
         _libssh2_bn_from_bin(key_state->p, 128, p_value);
 
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group1 Key Exchange");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating Diffie-Hellman Group1 Key Exchange"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1047,8 +1049,8 @@ kex_method_diffie_hellman_group14_key_exchange(LIBSSH2_SESSION *session,
         _libssh2_bn_set_word(key_state->g, 2);
         _libssh2_bn_from_bin(key_state->p, 256, p_value);
 
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group14 Key Exchange");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating Diffie-Hellman Group14 Key Exchange"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1169,8 +1171,8 @@ kex_method_diffie_hellman_group16_sha512_key_exchange(LIBSSH2_SESSION *session,
         _libssh2_bn_set_word(key_state->g, 2);
         _libssh2_bn_from_bin(key_state->p, 512, p_value);
 
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group16 Key Exchange");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating Diffie-Hellman Group16 Key Exchange"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1302,8 +1304,8 @@ kex_method_diffie_hellman_group18_sha512_key_exchange(LIBSSH2_SESSION *session,
         _libssh2_bn_set_word(key_state->g, 2);
         _libssh2_bn_from_bin(key_state->p, 1024, p_value);
 
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group18 Key Exchange");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating Diffie-Hellman Group18 Key Exchange"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1346,16 +1348,16 @@ kex_method_diffie_hellman_group_exchange_sha1_key_exchange
         _libssh2_htonu32(key_state->request + 5, LIBSSH2_DH_GEX_OPTGROUP);
         _libssh2_htonu32(key_state->request + 9, LIBSSH2_DH_GEX_MAXGROUP);
         key_state->request_len = 13;
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                        "Initiating Diffie-Hellman Group-Exchange "
-                       "(New Method)");
+                       "(New Method)"));
 #else
         key_state->request[0] = SSH_MSG_KEX_DH_GEX_REQUEST_OLD;
         _libssh2_htonu32(key_state->request + 1, LIBSSH2_DH_GEX_OPTGROUP);
         key_state->request_len = 5;
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                        "Initiating Diffie-Hellman Group-Exchange "
-                       "(Old Method)");
+                       "(Old Method)"));
 #endif
 
         key_state->state = libssh2_NB_state_created;
@@ -1473,16 +1475,16 @@ kex_method_diffie_hellman_group_exchange_sha256_key_exchange
         _libssh2_htonu32(key_state->request + 5, LIBSSH2_DH_GEX_OPTGROUP);
         _libssh2_htonu32(key_state->request + 9, LIBSSH2_DH_GEX_MAXGROUP);
         key_state->request_len = 13;
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                        "Initiating Diffie-Hellman Group-Exchange "
-                       "(New Method SHA256)");
+                       "(New Method SHA256)"));
 #else
         key_state->request[0] = SSH_MSG_KEX_DH_GEX_REQUEST_OLD;
         _libssh2_htonu32(key_state->request + 1, LIBSSH2_DH_GEX_OPTGROUP);
         key_state->request_len = 5;
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                        "Initiating Diffie-Hellman Group-Exchange "
-                       "(Old Method SHA256)");
+                       "(Old Method SHA256)"));
 #endif
 
         key_state->state = libssh2_NB_state_created;
@@ -1794,8 +1796,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                 snprintf(fprint, 4, "%02x:", session->server_hostkey_md5[i]);
             }
             *(--fprint) = '\0';
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                           "Server's MD5 Fingerprint: %s", fingerprint);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Server's MD5 Fingerprint: %s", fingerprint));
         }
 #endif /* LIBSSH2DEBUG */
 #endif /* ! LIBSSH2_MD5 */
@@ -1823,8 +1825,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                 snprintf(fprint, 4, "%02x:", session->server_hostkey_sha1[i]);
             }
             *(--fprint) = '\0';
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                           "Server's SHA1 Fingerprint: %s", fingerprint);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Server's SHA1 Fingerprint: %s", fingerprint));
         }
 #endif /* LIBSSH2DEBUG */
 
@@ -1851,9 +1853,9 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                                    session->server_hostkey_sha256,
                                    SHA256_DIGEST_LENGTH, &base64Fingerprint);
             if(base64Fingerprint != NULL) {
-                _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+                _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                                "Server's SHA256 Fingerprint: %s",
-                               base64Fingerprint);
+                               base64Fingerprint));
                 LIBSSH2_FREE(session, base64Fingerprint);
             }
         }
@@ -1969,7 +1971,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
         /* The first key exchange has been performed,
          switch to active crypt/comp/mac mode */
         session->state |= LIBSSH2_STATE_NEWKEYS;
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Received NEWKEYS message");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Received NEWKEYS message"));
 
         /* This will actually end up being just packet_type(1)
          for this packet type anyway */
@@ -2001,8 +2004,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
             memcpy(session->session_id, exchange_state->h_sig_comp,
                    digest_length);
              session->session_id_len = digest_length;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                           "session_id calculated");
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "session_id calculated"));
         }
 
         /* Cleanup any existing cipher */
@@ -2053,8 +2056,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                 LIBSSH2_FREE(session, secret);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Client to Server IV and Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server IV and Key calculated"));
 
         if(session->remote.crypt->dtor) {
             /* Cleanup any existing cipher */
@@ -2103,8 +2106,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                 LIBSSH2_FREE(session, secret);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Server to Client IV and Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client IV and Key calculated"));
 
         if(session->local.mac->dtor) {
             session->local.mac->dtor(session, &session->local.mac_abstract);
@@ -2130,8 +2133,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                 LIBSSH2_FREE(session, key);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Client to Server HMAC Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server HMAC Key calculated"));
 
         if(session->remote.mac->dtor) {
             session->remote.mac->dtor(session, &session->remote.mac_abstract);
@@ -2157,8 +2160,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                 LIBSSH2_FREE(session, key);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Server to Client HMAC Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client HMAC Key calculated"));
 
         /* Initialize compression for each direction */
 
@@ -2175,8 +2178,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                 goto clean_exit;
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Client to Server compression initialized");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server compression initialized"));
 
         if(session->remote.comp && session->remote.comp->dtor) {
             session->remote.comp->dtor(session, 0,
@@ -2190,8 +2193,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                 goto clean_exit;
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Server to Client compression initialized");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client compression initialized"));
 
     }
 
@@ -2256,8 +2259,8 @@ kex_method_ecdh_key_exchange
                            key_state->public_key_oct_len);
         key_state->request_len = key_state->public_key_oct_len + 5;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                       "Initiating ECDH SHA2 NISTP256");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating ECDH SHA2 NISTP256"));
 
         key_state->state = libssh2_NB_state_sent;
     }
@@ -2420,8 +2423,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                 snprintf(fprint, 4, "%02x:", session->server_hostkey_md5[i]);
             }
             *(--fprint) = '\0';
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                             "Server's MD5 Fingerprint: %s", fingerprint);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Server's MD5 Fingerprint: %s", fingerprint));
         }
 #endif /* LIBSSH2DEBUG */
 #endif /* ! LIBSSH2_MD5 */
@@ -2449,8 +2452,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                 snprintf(fprint, 4, "%02x:", session->server_hostkey_sha1[i]);
             }
             *(--fprint) = '\0';
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                             "Server's SHA1 Fingerprint: %s", fingerprint);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Server's SHA1 Fingerprint: %s", fingerprint));
         }
 #endif /* LIBSSH2DEBUG */
 
@@ -2477,9 +2480,9 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                                    session->server_hostkey_sha256,
                                    SHA256_DIGEST_LENGTH, &base64Fingerprint);
             if(base64Fingerprint != NULL) {
-                _libssh2_debug(session, LIBSSH2_TRACE_KEX,
+                _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                                "Server's SHA256 Fingerprint: %s",
-                               base64Fingerprint);
+                               base64Fingerprint));
                 LIBSSH2_FREE(session, base64Fingerprint);
             }
         }
@@ -2591,7 +2594,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
            crypt/comp/mac mode */
 
         session->state |= LIBSSH2_STATE_NEWKEYS;
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Received NEWKEYS message");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Received NEWKEYS message"));
 
         /* This will actually end up being just packet_type(1) for this packet
            type anyway */
@@ -2610,8 +2614,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
             memcpy(session->session_id, exchange_state->h_sig_comp,
                    digest_length);
             session->session_id_len = digest_length;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                           "session_id calculated");
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "session_id calculated"));
         }
 
         /* Cleanup any existing cipher */
@@ -2662,8 +2666,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                 LIBSSH2_FREE(session, secret);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                        "Client to Server IV and Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server IV and Key calculated"));
 
         if(session->remote.crypt->dtor) {
             /* Cleanup any existing cipher */
@@ -2712,8 +2716,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                 LIBSSH2_FREE(session, secret);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                        "Server to Client IV and Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client IV and Key calculated"));
 
         if(session->local.mac->dtor) {
             session->local.mac->dtor(session, &session->local.mac_abstract);
@@ -2739,8 +2743,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                 LIBSSH2_FREE(session, key);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                        "Client to Server HMAC Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server HMAC Key calculated"));
 
         if(session->remote.mac->dtor) {
             session->remote.mac->dtor(session, &session->remote.mac_abstract);
@@ -2766,8 +2770,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                 LIBSSH2_FREE(session, key);
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                        "Server to Client HMAC Key calculated");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client HMAC Key calculated"));
 
         /* Initialize compression for each direction */
 
@@ -2784,8 +2788,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                 goto clean_exit;
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                        "Client to Server compression initialized");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Client to Server compression initialized"));
 
         if(session->remote.comp && session->remote.comp->dtor) {
             session->remote.comp->dtor(session, 0,
@@ -2799,8 +2803,8 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
                 goto clean_exit;
             }
         }
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                        "Server to Client compression initialized");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Server to Client compression initialized"));
     }
 
 clean_exit:
@@ -2865,8 +2869,8 @@ kex_method_curve25519_key_exchange
                            LIBSSH2_ED25519_KEY_LEN);
         key_state->request_len = LIBSSH2_ED25519_KEY_LEN + 5;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_KEX,
-                        "Initiating curve25519 SHA2");
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating curve25519 SHA2"));
 
         key_state->state = libssh2_NB_state_sent;
     }
@@ -3234,25 +3238,35 @@ static int kexinit(LIBSSH2_SESSION * session)
             /* Funnily enough, they'll all "appear" to be '\0' terminated */
             unsigned char *p = data + 21;   /* type(1) + cookie(16) + len(4) */
 
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent KEX: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent KEX: %s", p));
             p += kex_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent HOSTKEY: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent HOSTKEY: %s", p));
             p += hostkey_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent CRYPT_CS: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent CRYPT_CS: %s", p));
             p += crypt_cs_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent CRYPT_SC: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent CRYPT_SC: %s", p));
             p += crypt_sc_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent MAC_CS: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent MAC_CS: %s", p));
             p += mac_cs_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent MAC_SC: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent MAC_SC: %s", p));
             p += mac_sc_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent COMP_CS: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent COMP_CS: %s", p));
             p += comp_cs_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent COMP_SC: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent COMP_SC: %s", p));
             p += comp_sc_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent LANG_CS: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent LANG_CS: %s", p));
             p += lang_cs_len + 4;
-            _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Sent LANG_SC: %s", p);
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Sent LANG_SC: %s", p));
             p += lang_sc_len + 4;
         }
 #endif /* LIBSSH2DEBUG */
@@ -3768,22 +3782,30 @@ static int kex_agree_methods(LIBSSH2_SESSION * session, unsigned char *data,
     }
 #endif
 
-    _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Agreed on KEX method: %s",
-                   session->kex->name);
-    _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Agreed on HOSTKEY method: %s",
-                   session->hostkey->name);
-    _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Agreed on CRYPT_CS method: %s",
-                   session->local.crypt->name);
-    _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Agreed on CRYPT_SC method: %s",
-                   session->remote.crypt->name);
-    _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Agreed on MAC_CS method: %s",
-                   session->local.mac->name);
-    _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Agreed on MAC_SC method: %s",
-                   session->remote.mac->name);
-    _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Agreed on COMP_CS method: %s",
-                   session->local.comp->name);
-    _libssh2_debug(session, LIBSSH2_TRACE_KEX, "Agreed on COMP_SC method: %s",
-                   session->remote.comp->name);
+    _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                   "Agreed on KEX method: %s",
+                   session->kex->name));
+    _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                   "Agreed on HOSTKEY method: %s",
+                   session->hostkey->name));
+    _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                   "Agreed on CRYPT_CS method: %s",
+                   session->local.crypt->name));
+    _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                   "Agreed on CRYPT_SC method: %s",
+                   session->remote.crypt->name));
+    _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                   "Agreed on MAC_CS method: %s",
+                   session->local.mac->name));
+    _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                   "Agreed on MAC_SC method: %s",
+                   session->remote.mac->name));
+    _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                   "Agreed on COMP_CS method: %s",
+                   session->local.comp->name));
+    _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                   "Agreed on COMP_SC method: %s",
+                   session->remote.comp->name));
 
     return 0;
 }

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -993,23 +993,12 @@ struct _LIBSSH2_COMP_METHOD
 };
 
 #ifdef LIBSSH2DEBUG
-void _libssh2_debug(LIBSSH2_SESSION * session, int context, const char *format,
-                    ...);
+void
+_libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
+                   ...);
+#define _libssh2_debug(x) _libssh2_debug_low x
 #else
-#if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) ||     \
-    (defined(__GNUC__) && !defined(__clang__))
-/* C99 supported and also by older GCC */
-#define _libssh2_debug(x,y,...) do {} while (0)
-#else
-/* no gcc and not C99, do static and hopefully inline */
-static inline void
-_libssh2_debug(LIBSSH2_SESSION * session, int context, const char *format, ...)
-{
-    (void)session;
-    (void)context;
-    (void)format;
-}
-#endif
+#define _libssh2_debug(x) do {} while (0)
 #endif
 
 #define LIBSSH2_SOCKET_UNKNOWN                   1

--- a/src/misc.c
+++ b/src/misc.c
@@ -119,8 +119,8 @@ int _libssh2_error_flags(LIBSSH2_SESSION* session, int errcode,
         /* if this is EAGAIN and we're in non-blocking mode, don't generate
            a debug output for this */
         return errcode;
-    _libssh2_debug(session, LIBSSH2_TRACE_ERROR, "%d - %s", session->err_code,
-                   session->err_msg);
+    _libssh2_debug((session, LIBSSH2_TRACE_ERROR, "%d - %s", session->err_code,
+                   session->err_msg));
 #endif
 
     return errcode;
@@ -477,7 +477,8 @@ libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *handler_context,
 }
 
 void
-_libssh2_debug(LIBSSH2_SESSION * session, int context, const char *format, ...)
+_libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
+                   ...)
 {
     char buffer[1536];
     int len, msglen, buflen = sizeof(buffer);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -898,9 +898,9 @@ gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
     unsigned char *method_buf = NULL;
     size_t  key_len;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing public key from RSA private key envelope");
+                   "Computing public key from RSA private key envelope"));
 
     rsa = EVP_PKEY_get1_RSA(pk);
     if(rsa == NULL) {
@@ -1025,9 +1025,9 @@ gen_publickey_from_rsa_openssh_priv_data(LIBSSH2_SESSION *session,
     unsigned char *n, *e, *d, *p, *q, *coeff, *comment;
     RSA *rsa = NULL;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing RSA keys from private key data");
+                   "Computing RSA keys from private key data"));
 
     /* public key data */
     if(_libssh2_get_bignum_bytes(decrypted, &n, &nlen)) {
@@ -1076,9 +1076,9 @@ gen_publickey_from_rsa_openssh_priv_data(LIBSSH2_SESSION *session,
     if((rc = _libssh2_rsa_new(&rsa, e, elen, n, nlen, d, dlen, p, plen,
                               q, qlen, NULL, 0, NULL, 0,
                               coeff, coefflen)) != 0) {
-        _libssh2_debug(session,
+        _libssh2_debug((session,
                        LIBSSH2_TRACE_AUTH,
-                       "Could not create RSA private key");
+                       "Could not create RSA private key"));
         goto fail;
     }
 
@@ -1287,9 +1287,9 @@ gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
     unsigned char *method_buf = NULL;
     size_t  key_len;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing public key from DSA private key envelope");
+                   "Computing public key from DSA private key envelope"));
 
     dsa = EVP_PKEY_get1_DSA(pk);
     if(dsa == NULL) {
@@ -1342,9 +1342,9 @@ gen_publickey_from_dsa_openssh_priv_data(LIBSSH2_SESSION *session,
     unsigned char *p, *q, *g, *pub_key, *priv_key;
     DSA *dsa = NULL;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing DSA keys from private key data");
+                   "Computing DSA keys from private key data"));
 
     if(_libssh2_get_bignum_bytes(decrypted, &p, &plen)) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
@@ -1379,9 +1379,9 @@ gen_publickey_from_dsa_openssh_priv_data(LIBSSH2_SESSION *session,
     rc = _libssh2_dsa_new(&dsa, p, plen, q, qlen, g, glen, pub_key, pub_len,
                           priv_key, priv_len);
     if(rc != 0) {
-        _libssh2_debug(session,
+        _libssh2_debug((session,
                        LIBSSH2_ERROR_PROTO,
-                       "Could not create DSA private key");
+                       "Could not create DSA private key"));
         goto fail;
     }
 
@@ -1638,8 +1638,8 @@ gen_publickey_from_ed_evp(LIBSSH2_SESSION *session,
     size_t bufLen = 0;
     unsigned char *bufPos = NULL;
 
-    _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from ED private key envelope");
+    _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                   "Computing public key from ED private key envelope"));
 
     methodBuf = LIBSSH2_ALLOC(session, sizeof(methodName) - 1);
     if(!methodBuf) {
@@ -1705,9 +1705,9 @@ gen_publickey_from_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
     size_t key_len = 0, tmp_len = 0;
     unsigned char *p;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing ED25519 keys from private key data");
+                   "Computing ED25519 keys from private key data"));
 
     if(_libssh2_get_string(decrypted, &pub_key, &tmp_len) ||
        tmp_len != LIBSSH2_ED25519_KEY_LEN) {
@@ -1744,8 +1744,8 @@ gen_publickey_from_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
             memcpy(comment, buf, tmp_len);
             memcpy(comment + tmp_len, "\0", 1);
 
-            _libssh2_debug(session, LIBSSH2_TRACE_AUTH, "Key comment: %s",
-                           comment);
+            _libssh2_debug((session, LIBSSH2_TRACE_AUTH, "Key comment: %s",
+                           comment));
 
             LIBSSH2_FREE(session, comment);
         }
@@ -1765,10 +1765,10 @@ gen_publickey_from_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
     }
 
     if(ret == 0) {
-        _libssh2_debug(session,
+        _libssh2_debug((session,
                        LIBSSH2_TRACE_AUTH,
                        "Computing public key from ED25519 "
-                       "private key envelope");
+                       "private key envelope"));
 
         method_buf = LIBSSH2_ALLOC(session, 11);  /* ssh-ed25519. */
         if(method_buf == NULL) {
@@ -1855,9 +1855,9 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
     size_t key_len = 0, app_len = 0, tmp_len = 0;
     unsigned char *p;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing sk-ED25519 keys from private key data");
+                   "Computing sk-ED25519 keys from private key data"));
 
     if(_libssh2_get_string(decrypted, &pub_key, &tmp_len) ||
        tmp_len != LIBSSH2_ED25519_KEY_LEN) {
@@ -1900,10 +1900,10 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
                                       LIBSSH2_ED25519_KEY_LEN);
 
     if(ret == 0) {
-        _libssh2_debug(session,
+        _libssh2_debug((session,
                        LIBSSH2_TRACE_AUTH,
                        "Computing public key from ED25519 "
-                       "private key envelope");
+                       "private key envelope"));
 
         /* sk-ssh-ed25519@openssh.com. */
         method_buf = LIBSSH2_ALLOC(session, strlen(key_type));
@@ -2645,9 +2645,9 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     BN_CTX *bn_ctx;
     libssh2_curve_type type;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
        LIBSSH2_TRACE_AUTH,
-       "Computing public key from EC private key envelope");
+       "Computing public key from EC private key envelope"));
 
     bn_ctx = BN_CTX_new();
     if(bn_ctx == NULL)
@@ -2683,9 +2683,9 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     else if(type == LIBSSH2_EC_CURVE_NISTP521)
         memcpy(method_buf, "ecdsa-sha2-nistp521", *method_len);
     else {
-        _libssh2_debug(session,
+        _libssh2_debug((session,
             LIBSSH2_TRACE_ERROR,
-            "Unsupported EC private key type");
+            "Unsupported EC private key type"));
         rc = -1;
         goto clean_exit;
     }
@@ -2779,9 +2779,9 @@ gen_publickey_from_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
     EC_KEY *ec_key = NULL;
     BIGNUM *bn_exponent;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing ECDSA keys from private key data");
+                   "Computing ECDSA keys from private key data"));
 
     if(_libssh2_get_string(decrypted, &curve, &curvelen) ||
         curvelen == 0) {
@@ -2865,9 +2865,9 @@ gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
     unsigned char *curve, *point_buf, *p, *key, *app;
     EC_KEY *ec_key = NULL;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Extracting ECDSA-SK public key");
+                   "Extracting ECDSA-SK public key"));
 
     if(_libssh2_get_string(decrypted, &curve, &curvelen) ||
         curvelen == 0) {
@@ -3574,10 +3574,10 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     int       pktype;
     int       rc;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing public key from private key file: %s",
-                   privatekey);
+                   privatekey));
 
     bp = BIO_new_file(privatekey, "r");
     if(bp == NULL) {
@@ -3919,9 +3919,9 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     EVP_PKEY* pk;
     int       pktype;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing public key from private key.");
+                   "Computing public key from private key."));
 
     bp = BIO_new_mem_buf((char *)privatekeydata, privatekeydata_len);
     if(!bp)
@@ -4009,9 +4009,9 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
     BIO*      bp;
     EVP_PKEY* pk;
 
-    _libssh2_debug(session,
+    _libssh2_debug((session,
                    LIBSSH2_TRACE_AUTH,
-                   "Computing public key from private key.");
+                   "Computing public key from private key."));
 
     bp = BIO_new_mem_buf((char *)privatekeydata, privatekeydata_len);
     if(!bp)

--- a/src/packet.c
+++ b/src/packet.c
@@ -133,10 +133,10 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
                                   "Data too short extracting sport");
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Remote received connection from %s:%ld to %s:%ld",
                        listen_state->shost, listen_state->sport,
-                       listen_state->host, listen_state->port);
+                       listen_state->host, listen_state->port));
 
         listen_state->state = libssh2_NB_state_allocated;
     }
@@ -156,8 +156,8 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
                         (listn->queue_maxsize <= listn->queue_size)) {
                         /* Queue is full */
                         failure_code = SSH_OPEN_RESOURCE_SHORTAGE;
-                        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
-                                       "Listener queue full, ignoring");
+                        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
+                                       "Listener queue full, ignoring"));
                         listen_state->state = libssh2_NB_state_sent;
                         break;
                     }
@@ -206,14 +206,14 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
                         listen_state->initial_window_size;
                     channel->local.packet_size = listen_state->packet_size;
 
-                    _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+                    _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                    "Connection queued: channel %lu/%lu "
                                    "win %lu/%lu packet %lu/%lu",
                                    channel->local.id, channel->remote.id,
                                    channel->local.window_size,
                                    channel->remote.window_size,
                                    channel->local.packet_size,
-                                   channel->remote.packet_size);
+                                   channel->remote.packet_size));
 
                     p = listen_state->packet;
                     *(p++) = SSH_MSG_CHANNEL_OPEN_CONFIRMATION;
@@ -346,10 +346,10 @@ packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
             goto x11_exit;
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "X11 Connection Received from %s:%ld on channel %lu",
                        x11open_state->shost, x11open_state->sport,
-                       x11open_state->sender_channel);
+                       x11open_state->sender_channel));
 
         x11open_state->state = libssh2_NB_state_allocated;
     }
@@ -391,14 +391,14 @@ packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
             channel->local.window_size = x11open_state->initial_window_size;
             channel->local.packet_size = x11open_state->packet_size;
 
-            _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+            _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                            "X11 Connection established: channel %lu/%lu "
                            "win %lu/%lu packet %lu/%lu",
                            channel->local.id, channel->remote.id,
                            channel->local.window_size,
                            channel->remote.window_size,
                            channel->local.packet_size,
-                           channel->remote.packet_size);
+                           channel->remote.packet_size));
             p = x11open_state->packet;
             *(p++) = SSH_MSG_CHANNEL_OPEN_CONFIRMATION;
             _libssh2_store_u32(&p, channel->remote.id);
@@ -487,9 +487,9 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
     switch(session->packAdd_state) {
     case libssh2_NB_state_idle:
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                        "Packet type %d received, length=%d",
-                       (int) msg, (int) datalen);
+                       (int) msg, (int) datalen));
 
         if((macstate == LIBSSH2_MAC_INVALID) &&
             (!session->macerror ||
@@ -547,9 +547,9 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                                        language_len);
                 }
 
-                _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
+                _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                                "Disconnect(%d): %s(%s)", reason,
-                               message, language);
+                               message, language));
             }
 
             LIBSSH2_FREE(session, data);
@@ -609,8 +609,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
              * _libssh2_debug will actually truncate this for us so
              * that it's not an inordinate about of data
              */
-            _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-                           "Debug Packet: %s", message);
+            _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                           "Debug Packet: %s", message));
             LIBSSH2_FREE(session, data);
             session->packAdd_state = libssh2_NB_state_idle;
             return 0;
@@ -650,10 +650,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     _libssh2_get_string(&buf, &value, &value_len);
 
                     if(name != NULL && value != NULL) {
-                        _libssh2_debug(session,
+                        _libssh2_debug((session,
                                        LIBSSH2_TRACE_KEX,
                                        "Server to Client extension %.*s: %.*s",
-                                       name_len, name, value_len, value);
+                                       name_len, name, value_len, value));
                     }
 
                     if(name_len == 15 &&
@@ -698,10 +698,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 len = _libssh2_ntohu32(data + 1);
                 if((len <= (UINT_MAX - 6)) && (datalen >= (6 + len))) {
                     want_reply = data[5 + len];
-                    _libssh2_debug(session,
+                    _libssh2_debug((session,
                                    LIBSSH2_TRACE_CONN,
                                    "Received global request type %.*s (wr %X)",
-                                   len, data + 5, want_reply);
+                                   len, data + 5, want_reply));
                 }
 
 
@@ -760,12 +760,12 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 if(msg == SSH_MSG_CHANNEL_EXTENDED_DATA)
                     stream_id = _libssh2_ntohu32(data + 5);
 
-                _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+                _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                "%d bytes packet_add() for %lu/%lu/%lu",
                                (int) (datalen - data_head),
                                channelp->local.id,
                                channelp->remote.id,
-                               stream_id);
+                               stream_id));
             }
 #endif
             if((channelp->remote.extended_data_ignore_mode ==
@@ -774,21 +774,21 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 /* Pretend we didn't receive this */
                 LIBSSH2_FREE(session, data);
 
-                _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+                _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                "Ignoring extended data and refunding %d bytes",
-                               (int) (datalen - 13));
+                               (int) (datalen - 13)));
                 if(channelp->read_avail + datalen - data_head >=
                     channelp->remote.window_size)
                     datalen = channelp->remote.window_size -
                         channelp->read_avail + data_head;
 
                 channelp->remote.window_size -= datalen - data_head;
-                _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+                _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                "shrinking window size by %lu bytes to %lu, "
                                "read_avail %lu",
                                datalen - data_head,
                                channelp->remote.window_size,
-                               channelp->read_avail);
+                               channelp->read_avail));
 
                 session->packAdd_channelp = channelp;
 
@@ -852,11 +852,11 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
              * from an upper layer */
             channelp->read_avail += datalen - data_head;
 
-            _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+            _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                            "increasing read_avail by %lu bytes to %lu/%lu",
                            (long)(datalen - data_head),
                            (long)channelp->read_avail,
-                           (long)channelp->remote.window_size);
+                           (long)channelp->remote.window_size));
 
             break;
 
@@ -874,11 +874,11 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 /* We may have freed already, just quietly ignore this... */
                 ;
             else {
-                _libssh2_debug(session,
+                _libssh2_debug((session,
                                LIBSSH2_TRACE_CONN,
                                "EOF received for channel %lu/%lu",
                                channelp->local.id,
-                               channelp->remote.id);
+                               channelp->remote.id));
                 channelp->remote.eof = 1;
             }
             LIBSSH2_FREE(session, data);
@@ -902,10 +902,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 if((len + 9) < datalen)
                     want_reply = data[len + 9];
 
-                _libssh2_debug(session,
+                _libssh2_debug((session,
                                LIBSSH2_TRACE_CONN,
                                "Channel %d received request type %.*s (wr %X)",
-                               channel, len, data + 9, want_reply);
+                               channel, len, data + 9, want_reply));
 
                 if(len == sizeof("exit-status") - 1
                     && (sizeof("exit-status") - 1 + 9) <= datalen
@@ -920,12 +920,12 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     if(channelp && (sizeof("exit-status") + 13) <= datalen) {
                         channelp->exit_status =
                             _libssh2_ntohu32(data + 9 + sizeof("exit-status"));
-                        _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+                        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                        "Exit status %lu received for "
                                        "channel %lu/%lu",
                                        channelp->exit_status,
                                        channelp->local.id,
-                                       channelp->remote.id);
+                                       channelp->remote.id));
                     }
 
                 }
@@ -959,12 +959,12 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                                    data + 13 + sizeof("exit-signal"), namelen);
                             channelp->exit_signal[namelen] = '\0';
                             /* TODO: save error message and language tag */
-                            _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+                            _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                            "Exit signal %s received for "
                                            "channel %lu/%lu",
                                            channelp->exit_signal,
                                            channelp->local.id,
-                                           channelp->remote.id);
+                                           channelp->remote.id));
                         }
                     }
                 }
@@ -1001,10 +1001,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 session->packAdd_state = libssh2_NB_state_idle;
                 return 0;
             }
-            _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+            _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                            "Close received for channel %lu/%lu",
                            channelp->local.id,
-                           channelp->remote.id);
+                           channelp->remote.id));
 
             channelp->remote.close = 1;
             channelp->remote.eof = 1;
@@ -1076,13 +1076,13 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 if(channelp) {
                     channelp->local.window_size += bytestoadd;
 
-                    _libssh2_debug(session, LIBSSH2_TRACE_CONN,
+                    _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                    "Window adjust for channel %lu/%lu, "
                                    "adding %lu bytes, new window_size=%lu",
                                    channelp->local.id,
                                    channelp->remote.id,
                                    bytestoadd,
-                                   channelp->local.window_size);
+                                   channelp->local.window_size));
                 }
             }
             LIBSSH2_FREE(session, data);
@@ -1099,8 +1099,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
         LIBSSH2_PACKET *packetp =
             LIBSSH2_ALLOC(session, sizeof(LIBSSH2_PACKET));
         if(!packetp) {
-            _libssh2_debug(session, LIBSSH2_ERROR_ALLOC,
-                           "memory for packet");
+            _libssh2_debug((session, LIBSSH2_ERROR_ALLOC,
+                           "memory for packet"));
             LIBSSH2_FREE(session, data);
             session->packAdd_state = libssh2_NB_state_idle;
             return LIBSSH2_ERROR_ALLOC;
@@ -1123,7 +1123,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
              * Well, it's already in the brigade,
              * let's just call back into ourselves
              */
-            _libssh2_debug(session, LIBSSH2_TRACE_TRANS, "Renegotiating Keys");
+            _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                           "Renegotiating Keys"));
 
             session->packAdd_state = libssh2_NB_state_sent2;
         }
@@ -1168,8 +1169,8 @@ _libssh2_packet_ask(LIBSSH2_SESSION * session, unsigned char packet_type,
 {
     LIBSSH2_PACKET *packet = _libssh2_list_first(&session->packets);
 
-    _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-                   "Looking for packet of type: %d", (int) packet_type);
+    _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                   "Looking for packet of type: %d", (int) packet_type));
 
     while(packet) {
         if(packet->data[0] == packet_type
@@ -1310,8 +1311,8 @@ _libssh2_packet_burn(LIBSSH2_SESSION * session,
             return i;
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-                       "Blocking until packet becomes available to burn");
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                       "Blocking until packet becomes available to burn"));
         *state = libssh2_NB_state_created;
     }
 

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -310,8 +310,8 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
         session->pkeyInit_pkey = NULL;
         session->pkeyInit_channel = NULL;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_PUBLICKEY,
-                       "Initializing publickey subsystem");
+        _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
+                       "Initializing publickey subsystem"));
 
         session->pkeyInit_state = libssh2_NB_state_allocated;
     }
@@ -387,9 +387,9 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
 
         session->pkeyInit_buffer_sent = 0;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_PUBLICKEY,
+        _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
                        "Sending publickey advertising version %d support",
-                       (int) LIBSSH2_PUBLICKEY_VERSION);
+                       (int) LIBSSH2_PUBLICKEY_VERSION));
 
         session->pkeyInit_state = libssh2_NB_state_sent2;
     }
@@ -511,16 +511,16 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
                 session->pkeyInit_pkey->version = _libssh2_ntohu32(s);
                 if(session->pkeyInit_pkey->version >
                     LIBSSH2_PUBLICKEY_VERSION) {
-                    _libssh2_debug(session, LIBSSH2_TRACE_PUBLICKEY,
+                    _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
                                    "Truncate remote publickey version "
                                    "from %lu",
-                                   session->pkeyInit_pkey->version);
+                                   session->pkeyInit_pkey->version));
                     session->pkeyInit_pkey->version =
                         LIBSSH2_PUBLICKEY_VERSION;
                 }
-                _libssh2_debug(session, LIBSSH2_TRACE_PUBLICKEY,
+                _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
                                "Enabling publickey subsystem version %lu",
-                               session->pkeyInit_pkey->version);
+                               session->pkeyInit_pkey->version));
                 LIBSSH2_FREE(session, session->pkeyInit_data);
                 session->pkeyInit_data = NULL;
                 session->pkeyInit_state = libssh2_NB_state_idle;
@@ -607,8 +607,8 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
     if(pkey->add_state == libssh2_NB_state_idle) {
         pkey->add_packet = NULL;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_PUBLICKEY, "Adding %s publickey",
-                       name);
+        _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
+                       "Adding %s publickey", name));
 
         if(pkey->version == 1) {
             for(i = 0; i < num_attrs; i++) {
@@ -689,10 +689,10 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
             }
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_PUBLICKEY,
+        _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
                        "Sending publickey \"add\" packet: "
                        "type=%s blob_len=%ld num_attrs=%ld",
-                       name, blob_len, num_attrs);
+                       name, blob_len, num_attrs));
 
         pkey->add_state = libssh2_NB_state_created;
     }
@@ -773,10 +773,10 @@ libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY * pkey,
         memcpy(pkey->remove_s, blob, blob_len);
         pkey->remove_s += blob_len;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_PUBLICKEY,
+        _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
                        "Sending publickey \"remove\" packet: "
                        "type=%s blob_len=%ld",
-                       name, blob_len);
+                       name, blob_len));
 
         pkey->remove_state = libssh2_NB_state_created;
     }
@@ -842,8 +842,8 @@ libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY * pkey, unsigned long *num_keys,
         memcpy(pkey->listFetch_s, "list", sizeof("list") - 1);
         pkey->listFetch_s += sizeof("list") - 1;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_PUBLICKEY,
-                       "Sending publickey \"list\" packet");
+        _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
+                       "Sending publickey \"list\" packet"));
 
         pkey->listFetch_state = libssh2_NB_state_created;
     }

--- a/src/scp.c
+++ b/src/scp.c
@@ -306,8 +306,8 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
         /* the command to exec should _not_ be NUL-terminated */
         session->scpRecv_command_len = cmd_len;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_SCP,
-                       "Opening channel for SCP receive");
+        _libssh2_debug((session, LIBSSH2_TRACE_SCP,
+                       "Opening channel for SCP receive"));
 
         session->scpRecv_state = libssh2_NB_state_created;
     }
@@ -356,7 +356,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
         LIBSSH2_FREE(session, session->scpRecv_command);
         session->scpRecv_command = NULL;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_SCP, "Sending initial wakeup");
+        _libssh2_debug((session, LIBSSH2_TRACE_SCP, "Sending initial wakeup"));
         /* SCP ACK */
         session->scpRecv_response[0] = '\0';
 
@@ -435,9 +435,9 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
                     /* zero terminate the error */
                     err_msg[err_len] = 0;
 
-                    _libssh2_debug(session, LIBSSH2_TRACE_SCP,
+                    _libssh2_debug((session, LIBSSH2_TRACE_SCP,
                                    "got %02x %s", session->scpRecv_response[0],
-                                   err_msg);
+                                   err_msg));
 
                     _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                                    "Failed to recv file");
@@ -561,9 +561,10 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
                     goto scp_recv_error;
                 }
 
-                _libssh2_debug(session, LIBSSH2_TRACE_SCP,
+                _libssh2_debug((session, LIBSSH2_TRACE_SCP,
                                "mtime = %ld, atime = %ld",
-                               session->scpRecv_mtime, session->scpRecv_atime);
+                               session->scpRecv_mtime,
+                               session->scpRecv_atime));
 
                 /* We *should* check that atime.usec is valid, but why let
                    that stop use? */
@@ -723,9 +724,9 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
                 else if(rc != 1) {
                     goto scp_recv_error;
                 }
-                _libssh2_debug(session, LIBSSH2_TRACE_SCP,
+                _libssh2_debug((session, LIBSSH2_TRACE_SCP,
                                "mode = 0%lo size = %ld", session->scpRecv_mode,
-                               session->scpRecv_size);
+                               session->scpRecv_size));
 
                 /* We *should* check that basename is valid, but why let that
                    stop us? */
@@ -864,8 +865,8 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
         /* the command to exec should _not_ be NUL-terminated */
         session->scpSend_command_len = cmd_len;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_SCP,
-                       "Opening channel for SCP send");
+        _libssh2_debug((session, LIBSSH2_TRACE_SCP,
+                       "Opening channel for SCP send"));
         /* Allocate a channel */
 
         session->scpSend_state = libssh2_NB_state_created;
@@ -947,8 +948,8 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
                 snprintf((char *) session->scpSend_response,
                          LIBSSH2_SCP_RESPONSE_BUFLEN, "T%ld 0 %ld 0\n",
                          (long)mtime, (long)atime);
-            _libssh2_debug(session, LIBSSH2_TRACE_SCP, "Sent %s",
-                           session->scpSend_response);
+            _libssh2_debug((session, LIBSSH2_TRACE_SCP, "Sent %s",
+                           session->scpSend_response));
         }
 
         session->scpSend_state = libssh2_NB_state_sent2;
@@ -1018,8 +1019,8 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
                      LIBSSH2_SCP_RESPONSE_BUFLEN, "C0%o %"
                      LIBSSH2_INT64_T_FORMAT " %s\n", mode,
                      size, base);
-        _libssh2_debug(session, LIBSSH2_TRACE_SCP, "Sent %s",
-                       session->scpSend_response);
+        _libssh2_debug((session, LIBSSH2_TRACE_SCP, "Sent %s",
+                       session->scpSend_response));
 
         session->scpSend_state = libssh2_NB_state_sent5;
     }
@@ -1077,9 +1078,9 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
                                        err_msg, err_len);
             if(rc > 0) {
                 err_msg[err_len] = 0;
-                _libssh2_debug(session, LIBSSH2_TRACE_SCP,
+                _libssh2_debug((session, LIBSSH2_TRACE_SCP,
                                "got %02x %s", session->scpSend_response[0],
-                               err_msg);
+                               err_msg));
             }
             LIBSSH2_FREE(session, err_msg);
             _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,

--- a/src/session.c
+++ b/src/session.c
@@ -120,12 +120,12 @@ banner_receive(LIBSSH2_SESSION * session)
         if(ret < 0) {
             if(session->api_block_mode || (ret != -EAGAIN))
                 /* ignore EAGAIN when non-blocking */
-                _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
-                               "Error recving %d bytes: %d", 1, -ret);
+                _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
+                               "Error recving %d bytes: %d", 1, -ret));
         }
         else
-            _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
-                           "Recved %d bytes banner", ret);
+            _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
+                           "Recved %d bytes banner", ret));
 
         if(ret < 0) {
             if(ret == -EAGAIN) {
@@ -183,8 +183,8 @@ banner_receive(LIBSSH2_SESSION * session)
     }
     memcpy(session->remote.banner, session->banner_TxRx_banner, banner_len);
     session->remote.banner[banner_len] = '\0';
-    _libssh2_debug(session, LIBSSH2_TRACE_TRANS, "Received Banner: %s",
-                   session->remote.banner);
+    _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Received Banner: %s",
+                   session->remote.banner));
     return LIBSSH2_ERROR_NONE;
 }
 
@@ -225,8 +225,8 @@ banner_send(LIBSSH2_SESSION * session)
             banner_dup[255] = '\0';
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS, "Sending Banner: %s",
-                       banner_dup);
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Sending Banner: %s",
+                       banner_dup));
 #endif
 
         session->banner_TxRx_state = libssh2_NB_state_created;
@@ -240,14 +240,14 @@ banner_send(LIBSSH2_SESSION * session)
                         banner_len - session->banner_TxRx_total_send,
                         LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(ret < 0)
-        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
+        _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
                        "Error sending %d bytes: %d",
-                       banner_len - session->banner_TxRx_total_send, -ret);
+                       banner_len - session->banner_TxRx_total_send, -ret));
     else
-        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
+        _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
                        "Sent %d/%d bytes at %p+%d", ret,
                        banner_len - session->banner_TxRx_total_send,
-                       banner, session->banner_TxRx_total_send);
+                       banner, session->banner_TxRx_total_send));
 
     if(ret != (banner_len - session->banner_TxRx_total_send)) {
         if(ret >= 0 || ret == -EAGAIN) {
@@ -445,8 +445,8 @@ libssh2_session_banner_set(LIBSSH2_SESSION * session, const char *banner)
 
     /* first zero terminate like this so that the debug output is nice */
     session->local.banner[banner_len] = '\0';
-    _libssh2_debug(session, LIBSSH2_TRACE_TRANS, "Setting local Banner: %s",
-                   session->local.banner);
+    _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Setting local Banner: %s",
+                   session->local.banner));
     session->local.banner[banner_len++] = '\r';
     session->local.banner[banner_len++] = '\n';
     session->local.banner[banner_len] = '\0';
@@ -503,8 +503,8 @@ libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC((*my_alloc)),
         session->abstract = abstract;
         session->api_timeout = 0; /* timeout-free API by default */
         session->api_block_mode = 1; /* blocking API by default */
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-                       "New session resource allocated");
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                       "New session resource allocated"));
         _libssh2_init_if_needed();
     }
     return session;
@@ -569,8 +569,8 @@ libssh2_session_callback_set(LIBSSH2_SESSION * session,
         session->recv = callback;
         return oldcb;
     }
-    _libssh2_debug(session, LIBSSH2_TRACE_TRANS, "Setting Callback %d",
-                   cbtype);
+    _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Setting Callback %d",
+                   cbtype));
 
     return NULL;
 }
@@ -611,8 +611,8 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
     dir = libssh2_session_block_directions(session);
 
     if(!dir) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
-                       "Nothing to wait for in wait_socket");
+        _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
+                       "Nothing to wait for in wait_socket"));
         /* To avoid that we hang below just because there's nothing set to
            wait for, we timeout on 1 second to also avoid busy-looping
            during this condition */
@@ -698,8 +698,8 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
     int rc;
 
     if(session->startup_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-                       "session_startup for socket %d", sock);
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                       "session_startup for socket %d", sock));
         if(LIBSSH2_INVALID_SOCKET == sock) {
             /* Did we forget something? */
             return _libssh2_error(session, LIBSSH2_ERROR_BAD_SOCKET,
@@ -760,8 +760,8 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
     }
 
     if(session->startup_state == libssh2_NB_state_sent2) {
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-                       "Requesting userauth service");
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                       "Requesting userauth service"));
 
         /* Request the userauth service */
         session->startup_service[0] = SSH_MSG_SERVICE_REQUEST;
@@ -877,9 +877,9 @@ session_free(LIBSSH2_SESSION *session)
     int packets_left = 0;
 
     if(session->free_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                        "Freeing session resource",
-                       session->remote.banner);
+                       session->remote.banner));
 
         session->free_state = libssh2_NB_state_created;
     }
@@ -1084,8 +1084,8 @@ session_free(LIBSSH2_SESSION *session)
     /* Cleanup all remaining packets */
     while((pkg = _libssh2_list_first(&session->packets)) != NULL) {
         packets_left++;
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-            "packet left with id %d", pkg->data[0]);
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                       "packet left with id %d", pkg->data[0]));
         /* unlink the node */
         _libssh2_list_remove(&pkg->node);
 
@@ -1094,15 +1094,15 @@ session_free(LIBSSH2_SESSION *session)
         LIBSSH2_FREE(session, pkg);
     }
     (void)packets_left;
-    _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-         "Extra packets left %d", packets_left);
+    _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                   "Extra packets left %d", packets_left));
 
     if(session->socket_prev_blockstate) {
         /* if the socket was previously blocking, put it back so */
         rc = session_nonblock(session->socket_fd, 0);
         if(rc) {
-            _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
-             "unable to reset socket's blocking state");
+            _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                           "unable to reset socket's blocking state"));
         }
     }
 
@@ -1150,9 +1150,9 @@ session_disconnect(LIBSSH2_SESSION *session, int reason,
     int rc;
 
     if(session->disconnect_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                        "Disconnecting: reason=%d, desc=%s, lang=%s", reason,
-                       description, lang);
+                       description, lang));
         if(description)
             descr_len = strlen(description);
 
@@ -1395,8 +1395,8 @@ int
 _libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
 {
     int bl = session->api_block_mode;
-    _libssh2_debug(session, LIBSSH2_TRACE_CONN,
-                   "Setting blocking mode %s", blocking?"ON":"OFF");
+    _libssh2_debug((session, LIBSSH2_TRACE_CONN,
+                   "Setting blocking mode %s", blocking?"ON":"OFF"));
     session->api_block_mode = blocking;
 
     return bl;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -160,10 +160,10 @@ remove_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
     struct sftp_zombie_requests *zombie = find_zombie_request(sftp,
                                                               request_id);
     if(zombie) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                        "Removing request ID %ld from the list of "
                        "zombie requests",
-                       request_id);
+                       request_id));
 
         _libssh2_list_remove(&zombie->node);
         LIBSSH2_FREE(session, zombie);
@@ -177,8 +177,8 @@ add_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
 
     struct sftp_zombie_requests *zombie;
 
-    _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                   "Marking request ID %ld as a zombie request", request_id);
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                   "Marking request ID %ld as a zombie request", request_id));
 
     zombie = LIBSSH2_ALLOC(sftp->channel->session,
                            sizeof(struct sftp_zombie_requests));
@@ -209,9 +209,9 @@ sftp_packet_add(LIBSSH2_SFTP *sftp, unsigned char *data,
         return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
     }
 
-    _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                    "Received packet type %d (len %d)",
-                   (int) data[0], data_len);
+                   (int) data[0], data_len));
 
     /*
      * Experience shows that if we mess up EAGAIN handling somewhere or
@@ -256,8 +256,8 @@ sftp_packet_add(LIBSSH2_SFTP *sftp, unsigned char *data,
 
     request_id = _libssh2_ntohu32(&data[1]);
 
-    _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Received packet id %d",
-                   request_id);
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Received packet id %d",
+                   request_id));
 
     /* Don't add the packet if it answers a request we've given up on. */
     if((data[0] == SSH_FXP_STATUS || data[0] == SSH_FXP_DATA)
@@ -302,7 +302,7 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
     unsigned long recv_window;
     int packet_type;
 
-    _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "recv packet");
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "recv packet"));
 
     switch(sftp->packet_state) {
     case libssh2_NB_state_sent: /* EAGAIN from window adjusting */
@@ -316,11 +316,11 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
 
         packet = sftp->partial_packet;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                       "partial read cont, len: %lu", sftp->partial_len);
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "partial read cont, len: %lu", sftp->partial_len));
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                        "partial read cont, already recvd: %lu",
-                       sftp->partial_received);
+                       sftp->partial_received));
         /* fall-through */
     default:
         if(!packet) {
@@ -359,9 +359,9 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
                                       LIBSSH2_ERROR_ALLOC,
                                       "Unable to allocate empty SFTP packet");
 
-            _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+            _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                            "Data begin - Packet Length: %lu",
-                           sftp->partial_len);
+                           sftp->partial_len));
             packet = LIBSSH2_ALLOC(session, sftp->partial_len);
             if(!packet)
                 return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -527,13 +527,13 @@ sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
         return LIBSSH2_ERROR_BAD_USE;
     }
 
-    _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Requiring packet %d id %ld",
-                   (int) packet_type, request_id);
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Requiring packet %d id %ld",
+                   (int) packet_type, request_id));
 
     if(sftp_packet_ask(sftp, packet_type, request_id, data, data_len) == 0) {
         /* The right packet was available in the packet brigade */
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Got %d",
-                       (int) packet_type);
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %d",
+                       (int) packet_type));
 
         if (*data_len < required_size) {
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
@@ -550,8 +550,8 @@ sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
         /* data was read, check the queue again */
         if(!sftp_packet_ask(sftp, packet_type, request_id, data, data_len)) {
             /* The right packet was available in the packet brigade */
-            _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Got %d",
-                           (int) packet_type);
+            _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %d",
+                           (int) packet_type));
 
             if (*data_len < required_size) {
                 return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
@@ -772,8 +772,8 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
     unsigned char *endp;
 
     if(session->sftpInit_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                       "Initializing SFTP subsystem");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "Initializing SFTP subsystem"));
 
         /*
          * The 'sftpInit_sftp' and 'sftpInit_channel' struct fields within the
@@ -860,10 +860,10 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         _libssh2_htonu32(session->sftpInit_buffer + 5, LIBSSH2_SFTP_VERSION);
         session->sftpInit_sent = 0; /* nothing's sent yet */
 
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                        "Sending FXP_INIT packet advertising "
                        "version %d support",
-                       (int) LIBSSH2_SFTP_VERSION);
+                       (int) LIBSSH2_SFTP_VERSION));
 
         session->sftpInit_state = libssh2_NB_state_sent2;
     }
@@ -929,14 +929,14 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
     }
 
     if(sftp_handle->version > LIBSSH2_SFTP_VERSION) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                        "Truncating remote SFTP version from %lu",
-                       sftp_handle->version);
+                       sftp_handle->version));
         sftp_handle->version = LIBSSH2_SFTP_VERSION;
     }
-    _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                    "Enabling SFTP version %lu compatibility",
-                   sftp_handle->version);
+                   sftp_handle->version));
     while(buf.dataptr < endp) {
         unsigned char *extname, *extdata;
 
@@ -1147,8 +1147,8 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
             s += sftp_attr2bin(s, &attrs);
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Sending %s open request",
-                       open_file? "file" : "directory");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Sending %s open request",
+                       open_file? "file" : "directory"));
 
         sftp->open_state = libssh2_NB_state_created;
     }
@@ -1228,8 +1228,8 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
             sftp->last_errno = _libssh2_ntohu32(data + 5);
 
             if(LIBSSH2_FX_OK == sftp->last_errno) {
-                _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                               "got HANDLE FXOK!");
+                _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                               "got HANDLE FXOK!"));
 
                 LIBSSH2_FREE(session, data);
 
@@ -1258,9 +1258,9 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
             if(badness) {
                 _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                "Failed opening remote file");
-                _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+                _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                                "got FXP_STATUS %d",
-                               sftp->last_errno);
+                               sftp->last_errno));
                 LIBSSH2_FREE(session, data);
                 return NULL;
             }
@@ -1304,7 +1304,8 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
         fp->u.file.offset = 0;
         fp->u.file.offset_sent = 0;
 
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Open command successful");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "Open command successful"));
         return fp;
     }
     return NULL;
@@ -1504,9 +1505,9 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
             _libssh2_list_add(&handle->packet_list, &chunk->node);
             count -= MIN(size, count); /* deduct the size we used, as we might
                                         * have to create more packets */
-            _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+            _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                            "read request id %d sent (offset: %d, size: %d)",
-                           request_id, (int)chunk->offset, (int)chunk->len);
+                           request_id, (int)chunk->offset, (int)chunk->len));
         }
         /* FALL-THROUGH */
     case libssh2_NB_state_sent:
@@ -1857,9 +1858,9 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                 LIBSSH2_FREE(session, handle->u.dir.names_packet);
 
           end:
-            _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
+            _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                            "libssh2_sftp_readdir_ex() return %d",
-                           filename_len);
+                           filename_len));
             return (ssize_t)filename_len;
         }
 
@@ -1881,8 +1882,8 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
     }
 
     if(sftp->readdir_state == libssh2_NB_state_created) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                       "Reading entries from directory handle");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "Reading entries from directory handle"));
         retcode = _libssh2_channel_write(channel, 0, sftp->readdir_packet,
                                          packet_len);
         if(retcode == LIBSSH2_ERROR_EAGAIN) {
@@ -1938,8 +1939,8 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
     sftp->readdir_state = libssh2_NB_state_idle;
 
     num_names = _libssh2_ntohu32(data + 5);
-    _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "%lu entries returned",
-                   num_names);
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "%lu entries returned",
+                   num_names));
     if(!num_names) {
         LIBSSH2_FREE(session, data);
         return 0;
@@ -2251,8 +2252,8 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
     uint32_t retcode;
 
     if(sftp->fsync_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                       "Issuing fsync command");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "Issuing fsync command"));
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -2360,8 +2361,8 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
     ssize_t rc;
 
     if(sftp->fstat_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Issuing %s command",
-                       setstat ? "set-stat" : "stat");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Issuing %s command",
+                       setstat ? "set-stat" : "stat"));
         s = sftp->fstat_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->fstat_packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -2582,7 +2583,7 @@ sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
     int rc = 0;
 
     if(handle->close_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Closing handle");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Closing handle"));
         s = handle->close_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!handle->close_packet) {
             handle->close_state = libssh2_NB_state_idle;
@@ -2713,7 +2714,8 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename,
     int rc;
 
     if(sftp->unlink_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Unlinking %s", filename);
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "Unlinking %s", filename));
         s = sftp->unlink_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->unlink_packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -2825,8 +2827,8 @@ static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
     }
 
     if(sftp->rename_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Renaming %s to %s",
-                       source_filename, dest_filename);
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Renaming %s to %s",
+                       source_filename, dest_filename));
         sftp->rename_s = sftp->rename_packet =
             LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->rename_packet) {
@@ -2961,8 +2963,8 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
         { SSH_FXP_EXTENDED_REPLY, SSH_FXP_STATUS };
 
     if(sftp->fstatvfs_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                       "Getting file system statistics");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "Getting file system statistics"));
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3097,8 +3099,8 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
         { SSH_FXP_EXTENDED_REPLY, SSH_FXP_STATUS };
 
     if(sftp->statvfs_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                       "Getting file system statistics of %s", path);
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "Getting file system statistics of %s", path));
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3241,8 +3243,8 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
     packet_len = path_len + 13 + sftp_attrsize(attrs.flags);
 
     if(sftp->mkdir_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP,
-                       "Creating directory %s with mode 0%lo", path, mode);
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
+                       "Creating directory %s with mode 0%lo", path, mode));
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3305,7 +3307,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
     LIBSSH2_FREE(session, data);
 
     if(retcode == LIBSSH2_FX_OK) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "OK!");
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "OK!"));
         return 0;
     }
     else {
@@ -3348,8 +3350,8 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
     int rc;
 
     if(sftp->rmdir_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "Removing directory: %s",
-                       path);
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Removing directory: %s",
+                       path));
         s = sftp->rmdir_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->rmdir_packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3454,10 +3456,10 @@ static int sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
     int rc;
 
     if(sftp->stat_state == libssh2_NB_state_idle) {
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "%s %s",
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "%s %s",
                        (stat_type == LIBSSH2_SFTP_SETSTAT) ? "Set-statting" :
                        (stat_type ==
-                        LIBSSH2_SFTP_LSTAT ? "LStatting" : "Statting"), path);
+                        LIBSSH2_SFTP_LSTAT ? "LStatting" : "Statting"), path));
         s = sftp->stat_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->stat_packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3603,11 +3605,12 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
                                   "SYMLINK/READLINK/REALPATH packet");
         }
 
-        _libssh2_debug(session, LIBSSH2_TRACE_SFTP, "%s %s on %s",
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "%s %s on %s",
                        (link_type ==
                         LIBSSH2_SFTP_SYMLINK) ? "Creating" : "Reading",
                        (link_type ==
-                        LIBSSH2_SFTP_REALPATH) ? "realpath" : "symlink", path);
+                        LIBSSH2_SFTP_REALPATH) ? "realpath" : "symlink",
+                       path));
 
         _libssh2_store_u32(&s, packet_len - 4);
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -308,8 +308,8 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
         /* Whoever wants a packet won't get anything until the key re-exchange
          * is done!
          */
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS, "Redirecting into the"
-                       " key re-exchange from _libssh2_transport_read");
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Redirecting into the"
+                       " key re-exchange from _libssh2_transport_read"));
         rc = _libssh2_kex_exchange(session, 1, &session->startup_key_state);
         if(rc)
             return rc;
@@ -383,14 +383,14 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
                         LIBSSH2_SESSION_BLOCK_INBOUND;
                     return LIBSSH2_ERROR_EAGAIN;
                 }
-                _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
+                _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
                                "Error recving %d bytes (got %d)",
-                               PACKETBUFSIZE - remainbuf, -nread);
+                               PACKETBUFSIZE - remainbuf, -nread));
                 return LIBSSH2_ERROR_SOCKET_RECV;
             }
-            _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
+            _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
                            "Recved %d/%d bytes to %p+%d", nread,
-                           PACKETBUFSIZE - remainbuf, p->buf, remainbuf);
+                           PACKETBUFSIZE - remainbuf, p->buf, remainbuf));
 
             debugdump(session, "libssh2_transport_read() raw",
                       &p->buf[remainbuf], nread);
@@ -659,12 +659,12 @@ send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
     rc = LIBSSH2_SEND(session, &p->outbuf[p->osent], length,
                        LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(rc < 0)
-        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
-                       "Error sending %d bytes: %d", length, -rc);
+        _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
+                       "Error sending %d bytes: %d", length, -rc));
     else {
-        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
+        _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
                        "Sent %d/%d bytes at %p+%d", rc, length, p->outbuf,
-                       p->osent);
+                       p->osent));
         debugdump(session, "libssh2_transport_write send()",
                   &p->outbuf[p->osent], rc);
     }
@@ -745,8 +745,8 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
         !(session->state & LIBSSH2_STATE_KEX_ACTIVE)) {
         /* Don't write any new packets if we're still in the middle of a key
          * exchange. */
-        _libssh2_debug(session, LIBSSH2_TRACE_TRANS, "Redirecting into the"
-                       " key re-exchange from _libssh2_transport_send");
+        _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Redirecting into the"
+                       " key re-exchange from _libssh2_transport_send"));
         rc = _libssh2_kex_exchange(session, 1, &session->startup_key_state);
         if(rc)
             return rc;
@@ -902,11 +902,12 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
     ret = LIBSSH2_SEND(session, p->outbuf, total_length,
                         LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(ret < 0)
-        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET,
-                       "Error sending %d bytes: %d", total_length, -ret);
+        _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
+                       "Error sending %d bytes: %d", total_length, -ret));
     else {
-        _libssh2_debug(session, LIBSSH2_TRACE_SOCKET, "Sent %d/%d bytes at %p",
-                       ret, total_length, p->outbuf);
+        _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
+                       "Sent %d/%d bytes at %p",
+                       ret, total_length, p->outbuf));
         debugdump(session, "libssh2_transport_write send()", p->outbuf, ret);
     }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -164,9 +164,9 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
             memcpy(session->userauth_banner, session->userauth_list_data + 5,
                     banner_len);
             session->userauth_banner[banner_len] = '\0';
-            _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
+            _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
                            "Banner: %s",
-                           session->userauth_banner);
+                           session->userauth_banner));
             LIBSSH2_FREE(session, session->userauth_list_data);
             session->userauth_list_data = NULL;
             /* SSH_MSG_USERAUTH_BANNER has been handled */
@@ -217,9 +217,9 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
         memmove(session->userauth_list_data, session->userauth_list_data + 5,
                 methods_len);
         session->userauth_list_data[methods_len] = '\0';
-        _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
+        _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
                        "Permitted auth methods: %s",
-                       session->userauth_list_data);
+                       session->userauth_list_data));
     }
 
     session->userauth_list_state = libssh2_NB_state_idle;
@@ -329,8 +329,8 @@ userauth_password(LIBSSH2_SESSION *session,
         _libssh2_store_u32(&s, password_len);
         /* 'password' is sent separately */
 
-        _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                       "Attempting to login using password authentication");
+        _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                       "Attempting to login using password authentication"));
 
         session->userauth_pswd_state = libssh2_NB_state_created;
     }
@@ -384,8 +384,8 @@ userauth_password(LIBSSH2_SESSION *session,
             }
 
             if(session->userauth_pswd_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
-                _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                               "Password authentication successful");
+                _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                               "Password authentication successful"));
                 LIBSSH2_FREE(session, session->userauth_pswd_data);
                 session->userauth_pswd_data = NULL;
                 session->state |= LIBSSH2_STATE_AUTHENTICATED;
@@ -394,8 +394,8 @@ userauth_password(LIBSSH2_SESSION *session,
             }
             else if(session->userauth_pswd_data[0] ==
                     SSH_MSG_USERAUTH_FAILURE) {
-                _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                               "Password authentication failed");
+                _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                               "Password authentication failed"));
                 LIBSSH2_FREE(session, session->userauth_pswd_data);
                 session->userauth_pswd_data = NULL;
                 session->userauth_pswd_state = libssh2_NB_state_idle;
@@ -426,8 +426,8 @@ userauth_password(LIBSSH2_SESSION *session,
             if((session->userauth_pswd_state == libssh2_NB_state_sent1) ||
                 (session->userauth_pswd_state == libssh2_NB_state_sent2)) {
                 if(session->userauth_pswd_state == libssh2_NB_state_sent1) {
-                    _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                                   "Password change required");
+                    _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                                   "Password change required"));
                     LIBSSH2_FREE(session, session->userauth_pswd_data);
                     session->userauth_pswd_data = NULL;
                 }
@@ -653,8 +653,8 @@ file_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
     size_t pubkey_len = 0, sp_len;
     unsigned int tmp_len;
 
-    _libssh2_debug(session, LIBSSH2_TRACE_AUTH, "Loading public key file: %s",
-                   pubkeyfile);
+    _libssh2_debug((session, LIBSSH2_TRACE_AUTH, "Loading public key file: %s",
+                   pubkeyfile));
     /* Read Public Key */
     fd = fopen(pubkeyfile, FOPEN_READTEXT);
     if(!fd) {
@@ -784,8 +784,8 @@ file_read_privatekey(LIBSSH2_SESSION * session,
     const LIBSSH2_HOSTKEY_METHOD **hostkey_methods_avail =
         libssh2_hostkey_methods();
 
-    _libssh2_debug(session, LIBSSH2_TRACE_AUTH, "Loading private key file: %s",
-                   privkeyfile);
+    _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                   "Loading private key file: %s", privkeyfile));
     *hostkey_method = NULL;
     *hostkey_abstract = NULL;
     while(*hostkey_methods_avail && (*hostkey_methods_avail)->name) {
@@ -941,9 +941,9 @@ libssh2_sign_sk(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
                 _libssh2_store_u32(&x, *sig_len - 4);
             }
             else {
-                _libssh2_debug(session,
+                _libssh2_debug((session,
                                LIBSSH2_ERROR_ALLOC,
-                               "Unable to allocate ecdsa-sk signature.");
+                               "Unable to allocate ecdsa-sk signature."));
                 rc = LIBSSH2_ERROR_ALLOC;
             }
         }
@@ -960,9 +960,9 @@ libssh2_sign_sk(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
                                    sig_info.sig_r_len);
             }
             else {
-                _libssh2_debug(session,
+                _libssh2_debug((session,
                                LIBSSH2_ERROR_ALLOC,
-                               "Unable to allocate ed25519-sk signature.");
+                               "Unable to allocate ed25519-sk signature."));
                 rc = LIBSSH2_ERROR_ALLOC;
             }
         }
@@ -982,9 +982,9 @@ libssh2_sign_sk(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
         }
     }
     else {
-        _libssh2_debug(session,
+        _libssh2_debug((session,
                        LIBSSH2_ERROR_DECRYPT,
-                       "sign_callback failed or returned invalid signature.");
+                       "sign_callback failed or returned invalid signature."));
         *sig_len = 0;
     }
 
@@ -1156,8 +1156,8 @@ userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                            sig_len);
         LIBSSH2_FREE(session, sig);
 
-        _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                       "Attempting hostbased authentication");
+        _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                       "Attempting hostbased authentication"));
 
         session->userauth_host_state = libssh2_NB_state_created;
     }
@@ -1205,8 +1205,8 @@ userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         }
 
         if(session->userauth_host_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
-            _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                           "Hostbased authentication successful");
+            _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                           "Hostbased authentication successful"));
             /* We are us and we've proved it. */
             LIBSSH2_FREE(session, session->userauth_host_data);
             session->userauth_host_data = NULL;
@@ -1485,11 +1485,11 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
 
         if(session->userauth_pblc_method_len &&
            session->userauth_pblc_method) {
-            _libssh2_debug(session,
+            _libssh2_debug((session,
                            LIBSSH2_TRACE_KEX,
                            "Signing using %.*s",
                            session->userauth_pblc_method_len,
-                           session->userauth_pblc_method);
+                           session->userauth_pblc_method));
         }
 
         /*
@@ -1536,8 +1536,8 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                            session->userauth_pblc_method_len);
         _libssh2_store_str(&s, (const char *)pubkeydata, pubkeydata_len);
 
-        _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                       "Attempting publickey authentication");
+        _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                       "Attempting publickey authentication"));
 
         session->userauth_pblc_state = libssh2_NB_state_created;
     }
@@ -1584,8 +1584,8 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
         }
 
         if(session->userauth_pblc_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
-            _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                           "Pubkey authentication prematurely successful");
+            _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                           "Pubkey authentication prematurely successful"));
             /*
              * God help any SSH server that allows an UNVERIFIED
              * public key to validate the user
@@ -1730,8 +1730,8 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
 
         LIBSSH2_FREE(session, sig);
 
-        _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                       "Attempting publickey authentication -- phase 2");
+        _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                       "Attempting publickey authentication -- phase 2"));
 
         session->userauth_pblc_s = s;
         session->userauth_pblc_state = libssh2_NB_state_sent2;
@@ -1777,8 +1777,8 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
     }
 
     if(session->userauth_pblc_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
-        _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                       "Publickey authentication successful");
+        _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                       "Publickey authentication successful"));
         /* We are us and we've proved it. */
         LIBSSH2_FREE(session, session->userauth_pblc_data);
         session->userauth_pblc_data = NULL;
@@ -2057,8 +2057,8 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
         /* submethods */
         _libssh2_store_u32(&s, 0);
 
-        _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                       "Attempting keyboard-interactive authentication");
+        _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                       "Attempting keyboard-interactive authentication"));
 
         session->userauth_kybd_state = libssh2_NB_state_created;
     }
@@ -2106,9 +2106,9 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
             }
 
             if(session->userauth_kybd_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
-                _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
+                _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
                                "Keyboard-interactive "
-                               "authentication successful");
+                               "authentication successful"));
                 LIBSSH2_FREE(session, session->userauth_kybd_data);
                 session->userauth_kybd_data = NULL;
                 session->state |= LIBSSH2_STATE_AUTHENTICATED;
@@ -2117,8 +2117,8 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
             }
 
             if(session->userauth_kybd_data[0] == SSH_MSG_USERAUTH_FAILURE) {
-                _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
-                               "Keyboard-interactive authentication failed");
+                _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
+                               "Keyboard-interactive authentication failed"));
                 LIBSSH2_FREE(session, session->userauth_kybd_data);
                 session->userauth_kybd_data = NULL;
                 session->userauth_kybd_state = libssh2_NB_state_idle;
@@ -2144,9 +2144,9 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
                               session->userauth_kybd_responses,
                               &session->abstract);
 
-            _libssh2_debug(session, LIBSSH2_TRACE_AUTH,
+            _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
                            "Keyboard-interactive response callback function"
-                           " invoked");
+                           " invoked"));
 
             session->userauth_kybd_packet_len =
                 1 /* byte      SSH_MSG_USERAUTH_INFO_RESPONSE */


### PR DESCRIPTION
Before this patch, with debug logging disabled, libssh2 code used a
variadic macro to catch `_libssh2_debug()` calls, and convert them to
no-ops. In certain conditions, it used an empty inline function instead.

Variadic macro is a C99 feature. It means that depending on compiler,
and build settings, it littered the build log with warnings about this.

The new solution uses the trick of passing the variable arg list as a
single argument and pass that down to the debug function with a regular
macro. When disabled, another regular C89-compatible macro converts it
to a no-op.

This makes inlining, C99 variadic macros and maintaining the conditions
for each unnecessary and also makes the codebase compile more
consistently, e.g. with forced C standards and/or picky warnings.

TL;DR: It makes this feature C89-compliant.
