### PR TITLE
tests: workaround for intermittent first test failures

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ if(CRYPTO_BACKEND STREQUAL "mbedTLS" OR NOT CRYPTO_BACKEND)
 endif()
 
 set(TESTS
+  warmup
   hostkey
   hostkey_hash
   password_auth_succeeds_with_correct_credentials
@@ -164,7 +165,11 @@ target_include_directories(runner PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 
 foreach(test ${TESTS})
   add_executable(test_${test} test_${test}.c)
-  target_link_libraries(test_${test} libssh2 runner ${LIBRARIES})
+  if(TESTS STREQUAL "warmup")
+    target_link_libraries(test_${test} libssh2 ${LIBRARIES})
+  else()
+    target_link_libraries(test_${test} libssh2 runner ${LIBRARIES})
+  endif()
   target_include_directories(test_${test} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
   list(APPEND TEST_TARGETS test_${test})
   add_definitions(-DFIXTURE_WORKDIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,7 @@ check_PROGRAMS += ssh2
 endif
 
 INTEGRATION_TESTS = \
+  test_warmup \
   test_agent_forward_succeeds \
   test_hostkey \
   test_hostkey_hash \

--- a/tests/test_warmup.c
+++ b/tests/test_warmup.c
@@ -1,0 +1,27 @@
+/* Warm-up test. Always return 0.
+   Workaround for CI/docker/etc flakiness on the first run. */
+
+#include "session_fixture.h"
+#include "runner.h"
+
+#include <libssh2.h>
+
+#include <stdio.h>
+
+int main(void)
+{
+    LIBSSH2_SESSION *session = start_session_fixture();
+    if(session != NULL) {
+        size_t len = 0;
+        int type = 0;
+        const char *hostkey = libssh2_session_hostkey(session, &len, &type);
+
+        (void)hostkey;
+
+        fprintf(stdout,
+                "libssh2_session_hostkey returned len, type: %d, %d\n",
+                (int)len, type);
+    }
+    stop_session_fixture();
+    return 0;
+}


### PR DESCRIPTION
Flakiness got continously worse these last days. It didn't seem related to recent commits. Flakiness also picked up in GitHub CI runs, something rarely seen before. Manual restart consistently fixed them.

The repeating pattern was the _first_ test (`test_hostkey`) failing, with `libssh2_session_handshake failed (-13): Failed getting banner`. Failures came after a lengthy wait, suggesting a timeout.

I then reversed the order of the first two tests, and it turned out that the _first_ test failed again (`test_hostkey_hash`). Also pointing to a timeout issue.

Then I added a dummy test to "warm up" whatever needs warming up in the layers of CI + Docker + ssh server and their interconnects. This helped, and GitHub CI tests run without failure right for the first time. AppVeyor CI also improved a little.

This patch adds a new first test called `test_warmup`, that creates a new libssh2 session, and exits with success even if that attempt failed.

A stop-gap solution at best, and there is no guarantee it will continue to fix this or similar future issues, but it's also untenable to have almost every CI run fail for intermittent reasons.

In [some](#804) [cases](https://ci.appveyor.com/project/libssh2org/libssh2/builds/46440828/job/8rej6cq6itg7vc4w#L500) it's not the first test failing intermittently. That's a different issue, and this patch doesn't fix it.

---
[ IMO the existing testing technique is on the heavy side with launching Docker machines for each test. It also prevents running tests without Docker, e.g. locally on macOS. It also fails in some of the existing CI machines (seen with the GitHub CI MSYS jobs), due to Docker [issues](https://github.com/libssh2/libssh2/pull/814#issuecomment-1455264450). There was #762 to help with this, as a first step. The curl project solved this without Docker. We might tap on those ideas. ]
