### PR TITLE
ci: retry choco install on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ install:
       $env:OPENSSH_SERVER_PORT = Get-Random -Minimum 2000 -Maximum 2300
       [System.Environment]::SetEnvironmentVariable("OPENSSH_SERVER_PORT", $env:OPENSSH_SERVER_PORT)
   - ps: .\ci\appveyor\docker-bridge.ps1
-  - choco install -y docker-cli
+  - appveyor-retry choco install -y docker-cli
 
 build_script:
   - ps: if($env:PLATFORM -eq "x64") { $env:CMAKE_GEN_SUFFIX=" Win64" }


### PR DESCRIPTION
Trying to mitigate occasional intermittent failures while installing docker.

Ref: https://ci.appveyor.com/project/libssh2org/libssh2/builds/46460704/job/g3t7bro6ta6n3pk6#L52