### PR TITLE
win32: set HAVE_STRTOLL with MSVS 2013 and newer

### DIFF
--- a/win32/libssh2_config.h
+++ b/win32/libssh2_config.h
@@ -22,6 +22,9 @@
 # define HAVE_GETTIMEOFDAY
 # define HAVE_STRTOLL
 #elif defined(_MSC_VER)
+# if _MSC_VER >= 1800
+#  define HAVE_STRTOLL
+# endif
 # if _MSC_VER < 1900
 #  undef HAVE_SNPRINTF
 #  if _MSC_VER < 1500


### PR DESCRIPTION
As in curl:
https://github.com/curl/curl/blob/7fa6e36583b52dd8f1e639b370c9a2849be81b54/lib/config-win32.h#L221
