### PR TITLE
src: address compiler warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           mkdir bin
           cd bin
-          cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=ON -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
+          cmake $TOOLCHAIN_OPTION -DENABLE_WERROR=ON -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=ON -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
           cmake --build . --parallel 2
           export OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:../tests/openssh_server)
           ctest -VV --output-on-failure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,7 @@ build_script:
           $env:CMAKE_ARG = "-DOPENSSL_ROOT_DIR=C:/OpenSSL-v111-Win32"
         }
       }
-  - cmake . -B _builds "-G%GENERATOR%" %CMAKE_ARG% -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS% -DCRYPTO_BACKEND=%CRYPTO_BACKEND%
+  - cmake . -B _builds "-G%GENERATOR%" %CMAKE_ARG% -DENABLE_WERROR=ON -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS% -DCRYPTO_BACKEND=%CRYPTO_BACKEND%
   - cmake --build _builds --config "%CONFIGURATION%" --parallel 2
 
 before_test:

--- a/src/agent.c
+++ b/src/agent.c
@@ -170,7 +170,7 @@ agent_transact_unix(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
 
     /* Send the length of the request */
     if(transctx->state == agent_NB_state_request_created) {
-        _libssh2_htonu32(buf, transctx->request_len);
+        _libssh2_htonu32(buf, (uint32_t)transctx->request_len);
         rc = (int)_send_all(agent->session->send, agent->fd,
                             buf, sizeof buf, 0,
                             &agent->session->abstract);

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -88,7 +88,7 @@ bcrypt_hash(uint8_t *sha2pass, uint8_t *sha2salt, uint8_t *out)
 
     /* copy out */
     for(i = 0; i < BCRYPT_BLOCKS; i++) {
-        out[4 * i + 3] = (cdata[i] >> 24) & 0xff;
+        out[4 * i + 3] = (uint8_t)((cdata[i] >> 24) & 0xff);
         out[4 * i + 2] = (cdata[i] >> 16) & 0xff;
         out[4 * i + 1] = (cdata[i] >> 8) & 0xff;
         out[4 * i + 0] = cdata[i] & 0xff;
@@ -136,7 +136,7 @@ bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
 
     /* generate key, sizeof(out) at a time */
     for(count = 1; keylen > 0; count++) {
-        countsalt[saltlen + 0] = (count >> 24) & 0xff;
+        countsalt[saltlen + 0] = (uint8_t)((count >> 24) & 0xff);
         countsalt[saltlen + 1] = (count >> 16) & 0xff;
         countsalt[saltlen + 2] = (count >> 8) & 0xff;
         countsalt[saltlen + 3] = count & 0xff;

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -422,9 +422,9 @@ Blowfish_stream2word(const uint8_t *data, uint16_t databytes,
 void
 Blowfish_expand0state(blf_ctx *c, const uint8_t *key, uint16_t keybytes)
 {
-    uint16_t i;
+    int i;
+    int k;
     uint16_t j;
-    uint16_t k;
     uint32_t temp;
     uint32_t datal;
     uint32_t datar;
@@ -461,9 +461,9 @@ void
 Blowfish_expandstate(blf_ctx *c, const uint8_t *data, uint16_t databytes,
                      const uint8_t *key, uint16_t keybytes)
 {
-    uint16_t i;
+    int i;
+    int k;
     uint16_t j;
-    uint16_t k;
     uint32_t temp;
     uint32_t datal;
     uint32_t datar;

--- a/src/channel.c
+++ b/src/channel.c
@@ -474,7 +474,8 @@ channel_forward_listen(LIBSSH2_SESSION * session, const char *host,
         /* 14 = packet_type(1) + request_len(4) + want_replay(1) + host_len(4)
            + port(4) */
         session->fwdLstn_packet_len =
-            session->fwdLstn_host_len + (sizeof("tcpip-forward") - 1) + 14;
+            session->fwdLstn_host_len +
+            (uint32_t)(sizeof("tcpip-forward") - 1) + 14;
 
         /* Zero the whole thing out */
         memset(&session->fwdLstn_packet_requirev_state, 0,

--- a/src/channel.c
+++ b/src/channel.c
@@ -470,7 +470,7 @@ channel_forward_listen(LIBSSH2_SESSION * session, const char *host,
         host = "0.0.0.0";
 
     if(session->fwdLstn_state == libssh2_NB_state_idle) {
-        session->fwdLstn_host_len = strlen(host);
+        session->fwdLstn_host_len = (uint32_t)strlen(host);
         /* 14 = packet_type(1) + request_len(4) + want_replay(1) + host_len(4)
            + port(4) */
         session->fwdLstn_packet_len =
@@ -1663,8 +1663,8 @@ _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
     if(channel->flush_refund_bytes) {
         int rc =
             _libssh2_channel_receive_window_adjust(channel,
-                                                   channel->flush_refund_bytes,
-                                                   1, NULL);
+                                         (uint32_t)channel->flush_refund_bytes,
+                                         1, NULL);
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
     }
@@ -2007,8 +2007,8 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
        (channel->remote.window_size <
         channel->remote.window_size_initial / 4 * 3 + buflen) ) {
 
-        uint32_t adjustment = channel->remote.window_size_initial + buflen -
-            channel->remote.window_size;
+        uint32_t adjustment = (uint32_t)(channel->remote.window_size_initial +
+            buflen - channel->remote.window_size);
         if(adjustment < LIBSSH2_CHANNEL_MINADJUST)
             adjustment = LIBSSH2_CHANNEL_MINADJUST;
 
@@ -2169,8 +2169,8 @@ libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id, char *buf,
 
     if(buflen > recv_window) {
         BLOCK_ADJUST(rc, channel->session,
-                     _libssh2_channel_receive_window_adjust(channel, buflen,
-                                                            1, NULL));
+                     _libssh2_channel_receive_window_adjust(channel,
+                                                   (uint32_t)buflen, 1, NULL));
     }
 
     BLOCK_ADJUST(rc, channel->session,
@@ -2337,7 +2337,7 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         }
         /* store the size here only, the buffer is passed in as-is to
            _libssh2_transport_send() */
-        _libssh2_store_u32(&s, channel->write_bufwrite);
+        _libssh2_store_u32(&s, (uint32_t)channel->write_bufwrite);
         channel->write_packet_len = s - channel->write_packet;
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,

--- a/src/channel.c
+++ b/src/channel.c
@@ -1658,7 +1658,7 @@ _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
     }
 
     channel->read_avail -= channel->flush_flush_bytes;
-    channel->remote.window_size -= channel->flush_flush_bytes;
+    channel->remote.window_size -= (uint32_t)channel->flush_flush_bytes;
 
     if(channel->flush_refund_bytes) {
         int rc =
@@ -2136,7 +2136,7 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
     }
 
     channel->read_avail -= bytes_read;
-    channel->remote.window_size -= bytes_read;
+    channel->remote.window_size -= (uint32_t)bytes_read;
 
     return bytes_read;
 }
@@ -2362,7 +2362,7 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
                                   "Unable to send channel data");
         }
         /* Shrink local window size */
-        channel->local.window_size -= channel->write_bufwrite;
+        channel->local.window_size -= (uint32_t)channel->write_bufwrite;
 
         wrote += channel->write_bufwrite;
 

--- a/src/comp.c
+++ b/src/comp.c
@@ -189,11 +189,11 @@ comp_method_zlib_comp(LIBSSH2_SESSION *session,
                       void **abstract)
 {
     z_stream *strm = *abstract;
-    int out_maxlen = *dest_len;
+    uInt out_maxlen = (uInt)*dest_len;
     int status;
 
     strm->next_in = (unsigned char *) src;
-    strm->avail_in = src_len;
+    strm->avail_in = (uInt)src_len;
     strm->next_out = dest;
     strm->avail_out = out_maxlen;
 

--- a/src/comp.c
+++ b/src/comp.c
@@ -227,10 +227,10 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
     /* A short-term alloc of a full data chunk is better than a series of
        reallocs */
     char *out;
-    size_t out_maxlen = src_len;
+    size_t out_maxlen;
 
     if(src_len <= SIZE_MAX / 4)
-        out_maxlen = src_len * 4;
+        out_maxlen = (uInt)src_len * 4;
     else
         out_maxlen = payload_limit;
 
@@ -247,10 +247,11 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
         out_maxlen = payload_limit;
 
     strm->next_in = (unsigned char *) src;
-    strm->avail_in = src_len;
-    strm->next_out = (unsigned char *) LIBSSH2_ALLOC(session, out_maxlen);
+    strm->avail_in = (uInt)src_len;
+    strm->next_out = (unsigned char *) LIBSSH2_ALLOC(session,
+                                                     (uInt)out_maxlen);
     out = (char *) strm->next_out;
-    strm->avail_out = out_maxlen;
+    strm->avail_out = (uInt)out_maxlen;
     if(!strm->next_out)
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                               "Unable to allocate decompression buffer");
@@ -299,7 +300,7 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
         }
         out = newout;
         strm->next_out = (unsigned char *) out + out_ofs;
-        strm->avail_out = out_maxlen - out_ofs;
+        strm->avail_out = (uInt)(out_maxlen - out_ofs);
     }
 
     *dest = (unsigned char *) out;

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -130,7 +130,7 @@ int _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
                              unsigned const char *passphrase);
 int _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
                              const unsigned char *sig,
-                             const unsigned char *m, unsigned long m_len);
+                             const unsigned char *m, size_t m_len);
 int _libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
                            const unsigned char *hash,
                            unsigned long hash_len, unsigned char *sig);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -246,7 +246,7 @@ int
 _libssh2_ed25519_new_public(libssh2_ed25519_ctx **ed_ctx,
                             LIBSSH2_SESSION *session,
                             const unsigned char *raw_pub_key,
-                            const uint8_t key_len);
+                            const size_t key_len);
 
 int
 _libssh2_ed25519_sign(libssh2_ed25519_ctx *ctx, LIBSSH2_SESSION *session,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -85,8 +85,8 @@ int _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
                              unsigned const char *passphrase);
 int _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
                              const unsigned char *sig,
-                             unsigned long sig_len,
-                             const unsigned char *m, unsigned long m_len);
+                             size_t sig_len,
+                             const unsigned char *m, size_t m_len);
 int _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
                            libssh2_rsa_ctx * rsactx,
                            const unsigned char *hash,
@@ -103,8 +103,8 @@ int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
 int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsa,
                              size_t hash_len,
                              const unsigned char *sig,
-                             unsigned long sig_len,
-                             const unsigned char *m, unsigned long m_len);
+                             size_t sig_len,
+                             const unsigned char *m, size_t m_len);
 #endif
 int _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
                                         LIBSSH2_SESSION * session,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -528,8 +528,12 @@ hostkey_method_ssh_dss_init(LIBSSH2_SESSION * session,
     if(!_libssh2_eob(&buf))
         return -1;
 
-    if(_libssh2_dsa_new(&dsactx, p, p_len, q, q_len,
-                        g, g_len, y, y_len, NULL, 0)) {
+    if(_libssh2_dsa_new(&dsactx,
+                        p, (unsigned long)p_len,
+                        q, (unsigned long)q_len,
+                        g, (unsigned long)g_len,
+                        y, (unsigned long)y_len,
+                        NULL, 0)) {
         return -1;
     }
 

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -113,8 +113,11 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
     if(!_libssh2_eob(&buf))
         return -1;
 
-    if(_libssh2_rsa_new(&rsactx, e, e_len, n, n_len, NULL, 0,
-                        NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0)) {
+    if(_libssh2_rsa_new(&rsactx,
+                        e, (unsigned long)e_len,
+                        n, (unsigned long)n_len,
+                        NULL, 0, NULL, 0, NULL, 0,
+                        NULL, 0, NULL, 0, NULL, 0)) {
         return -1;
     }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -71,13 +71,13 @@
                                           reqlen, version)                  \
 {                                                                           \
     libssh2_sha##digest_type##_ctx hash;                                    \
-    unsigned long len = 0;                                                  \
+    size_t len = 0;                                                         \
     if(!(value)) {                                                          \
         value = LIBSSH2_ALLOC(session,                                      \
                               reqlen + SHA##digest_type##_DIGEST_LENGTH);   \
     }                                                                       \
     if(value)                                                               \
-        while(len < (unsigned long)reqlen) {                                \
+        while(len < (size_t)reqlen) {                                       \
             (void)libssh2_sha##digest_type##_init(&hash);                   \
             libssh2_sha##digest_type##_update(hash,                         \
                                               exchange_state->k_value,      \
@@ -217,7 +217,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                    unsigned char packet_type_init,
                                    unsigned char packet_type_reply,
                                    unsigned char *midhash,
-                                   unsigned long midhash_len,
+                                   size_t midhash_len,
                                    kmdhgGPshakex_state_t *exchange_state)
 {
     int ret = 0;
@@ -285,7 +285,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
         exchange_state->e_packet[0] = packet_type_init;
         _libssh2_htonu32(exchange_state->e_packet + 1,
-                         exchange_state->e_packet_len - 5);
+                         (uint32_t)(exchange_state->e_packet_len - 5));
         if(_libssh2_bn_bits(exchange_state->e) % 8) {
             _libssh2_bn_to_bin(exchange_state->e,
                                exchange_state->e_packet + 5);
@@ -517,7 +517,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
         _libssh2_htonu32(exchange_state->k_value,
-                         exchange_state->k_value_len - 4);
+                         (uint32_t)(exchange_state->k_value_len - 4));
         if(_libssh2_bn_bits(exchange_state->k) % 8) {
             _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 4);
         }
@@ -610,7 +610,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                      exchange_state->e_packet_len - 1);
 
         _libssh2_htonu32(exchange_state->h_sig_comp,
-                         exchange_state->f_value_len);
+                         (uint32_t)exchange_state->f_value_len);
         _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
                                      exchange_state->h_sig_comp, 4);
         _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
@@ -992,7 +992,7 @@ typedef int (*diffie_hellman_hash_func_t)(LIBSSH2_SESSION *,
                                           unsigned char,
                                           unsigned char,
                                           unsigned char *,
-                                          unsigned long,
+                                          size_t,
                                           kmdhgGPshakex_state_t *);
 static int
 kex_method_diffie_hellman_group14_key_exchange(LIBSSH2_SESSION *session,
@@ -3397,8 +3397,8 @@ kex_get_method_by_name(const char *name, size_t name_len,
  * Agree on a Hostkey which works with this kex
  */
 static int kex_agree_hostkey(LIBSSH2_SESSION * session,
-                             unsigned long kex_flags,
-                             unsigned char *hostkey, unsigned long hostkey_len)
+                             size_t kex_flags,
+                             unsigned char *hostkey, size_t hostkey_len)
 {
     const LIBSSH2_HOSTKEY_METHOD **hostkeyp = libssh2_hostkey_methods();
     unsigned char *s;
@@ -3474,8 +3474,8 @@ static int kex_agree_hostkey(LIBSSH2_SESSION * session,
  * Agree on a Key Exchange method and a hostkey encoding type
  */
 static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
-                                 unsigned long kex_len, unsigned char *hostkey,
-                                 unsigned long hostkey_len)
+                                 size_t kex_len, unsigned char *hostkey,
+                                 size_t hostkey_len)
 {
     const LIBSSH2_KEX_METHOD **kexp = libssh2_kex_methods;
     unsigned char *s;
@@ -3552,7 +3552,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
 static int kex_agree_crypt(LIBSSH2_SESSION * session,
                            libssh2_endpoint_data *endpoint,
                            unsigned char *crypt,
-                           unsigned long crypt_len)
+                           size_t crypt_len)
 {
     const LIBSSH2_CRYPT_METHOD **cryptp = libssh2_crypt_methods();
     unsigned char *s;
@@ -3608,7 +3608,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION * session,
  */
 static int kex_agree_mac(LIBSSH2_SESSION * session,
                          libssh2_endpoint_data * endpoint, unsigned char *mac,
-                         unsigned long mac_len)
+                         size_t mac_len)
 {
     const LIBSSH2_MAC_METHOD **macp = _libssh2_mac_methods();
     unsigned char *s;
@@ -3661,7 +3661,7 @@ static int kex_agree_mac(LIBSSH2_SESSION * session,
  */
 static int kex_agree_comp(LIBSSH2_SESSION *session,
                           libssh2_endpoint_data *endpoint, unsigned char *comp,
-                          unsigned long comp_len)
+                          size_t comp_len)
 {
     const LIBSSH2_COMP_METHOD **compp = _libssh2_comp_methods(session);
     unsigned char *s;
@@ -4043,7 +4043,7 @@ libssh2_session_method_pref(LIBSSH2_SESSION * session, int method_type,
 
     while(s && *s && mlist) {
         char *p = strchr(s, ',');
-        int method_len = (int)(p ? (p - s) : strlen(s));
+        size_t method_len = (p ? (size_t)(p - s) : strlen(s));
 
         if(!kex_get_method_by_name(s, method_len, mlist)) {
             /* Strip out unsupported method */

--- a/src/kex.c
+++ b/src/kex.c
@@ -1912,7 +1912,7 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
             goto clean_exit;
         }
         _libssh2_htonu32(exchange_state->k_value,
-                         exchange_state->k_value_len - 4);
+                         (uint32_t)(exchange_state->k_value_len - 4));
         if(_libssh2_bn_bits(exchange_state->k) % 8) {
             _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 4);
         }
@@ -2008,7 +2008,7 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
             }
             memcpy(session->session_id, exchange_state->h_sig_comp,
                    digest_length);
-             session->session_id_len = digest_length;
+             session->session_id_len = (uint32_t)digest_length;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                            "session_id calculated"));
         }
@@ -2552,7 +2552,7 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
             goto clean_exit;
         }
         _libssh2_htonu32(exchange_state->k_value,
-                         exchange_state->k_value_len - 4);
+                         (uint32_t)(exchange_state->k_value_len - 4));
         if(_libssh2_bn_bits(exchange_state->k) % 8) {
             _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 4);
         }
@@ -2624,7 +2624,7 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
             }
             memcpy(session->session_id, exchange_state->h_sig_comp,
                    digest_length);
-            session->session_id_len = digest_length;
+            session->session_id_len = (uint32_t)digest_length;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                            "session_id calculated"));
         }

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -170,14 +170,14 @@ knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         break;
     case LIBSSH2_KNOWNHOST_TYPE_SHA1:
         rc = libssh2_base64_decode(hosts->session, &ptr, &ptrlen,
-                                   host, hostlen);
+                                   host, (unsigned int)hostlen);
         if(rc)
             goto error;
         entry->name = ptr;
         entry->name_len = ptrlen;
 
         rc = libssh2_base64_decode(hosts->session, &ptr, &ptrlen,
-                                   salt, strlen(salt));
+                                   salt, (unsigned int)strlen(salt));
         if(rc)
             goto error;
         entry->salt = ptr;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -595,7 +595,7 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
                       _libssh2_cipher_type(algo),
                       int encrypt, unsigned char *block, size_t blklen)
 {
-    int cipher = _libssh2_gcry_cipher(algo);
+    int cipher = _libssh2_gcry_cipher(algo);  /* FIXME: unused variable */
     int ret;
 
     if(encrypt) {

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -595,8 +595,9 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
                       _libssh2_cipher_type(algo),
                       int encrypt, unsigned char *block, size_t blklen)
 {
-    int cipher = _libssh2_gcry_cipher(algo);  /* FIXME: unused variable */
     int ret;
+
+    (void)algo;
 
     if(encrypt) {
         ret = gcry_cipher_encrypt(*ctx, block, blklen, block, blklen);

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -525,7 +525,7 @@ _libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
 int
 _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
                          const unsigned char *sig,
-                         const unsigned char *m, unsigned long m_len)
+                         const unsigned char *m, size_t m_len)
 {
     unsigned char hash[SHA_DIGEST_LENGTH + 1];
     gcry_sexp_t s_sig, s_hash;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -88,8 +88,8 @@ _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
 int
 _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
                          const unsigned char *sig,
-                         unsigned long sig_len,
-                         const unsigned char *m, unsigned long m_len)
+                         size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     unsigned char hash[SHA_DIGEST_LENGTH];
     gcry_sexp_t s_sig, s_hash;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -637,7 +637,7 @@ struct _LIBSSH2_SESSION
 
     /* Agreed Key Exchange Method */
     const LIBSSH2_KEX_METHOD *kex;
-    unsigned int burn_optimistic_kexinit:1;
+    unsigned int burn_optimistic_kexinit;
 
     unsigned char *session_id;
     uint32_t session_id_len;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -164,10 +164,11 @@ struct iovec {
 #include "crypto.h"
 
 #ifdef HAVE_WINSOCK2_H
-
 #include <winsock2.h>
 #include <ws2tcpip.h>
-
+/* Force parameter type. */
+#define recv(s, b, l, f)  recv((s), (b), (int)(l), (f))
+#define send(s, b, l, f)  send((s), (b), (int)(l), (f))
 #endif
 
 #ifndef SIZE_MAX

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -409,7 +409,7 @@ struct _LIBSSH2_CHANNEL
     /* Amount of bytes to be refunded to receive window (but not yet sent) */
     uint32_t adjust_queue;
     /* Data immediately available for reading */
-    uint32_t read_avail;
+    size_t read_avail;
 
     LIBSSH2_SESSION *session;
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -849,8 +849,8 @@ struct _LIBSSH2_SESSION
     LIBSSH2_CHANNEL *sftpInit_channel;
     unsigned char sftpInit_buffer[9];   /* sftp_header(5){excludes request_id}
                                            + version_id(4) */
-    int sftpInit_sent; /* number of bytes from the buffer that have been
-                          sent */
+    size_t sftpInit_sent; /* number of bytes from the buffer that have been
+                             sent */
 
     /* State variables used in libssh2_scp_recv() / libssh_scp_recv2() */
     libssh2_nonblocking_states scpRecv_state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1146,7 +1146,7 @@ void _libssh2_init_if_needed(void);
 #define ARRAY_SIZE(a) (sizeof ((a)) / sizeof ((a)[0]))
 
 /* define to output the libssh2_int64_t type in a *printf() */
-#if defined(__BORLANDC__) || defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(__BORLANDC__) || defined(_MSC_VER)
 #define LIBSSH2_INT64_T_FORMAT "I64d"
 #else
 #define LIBSSH2_INT64_T_FORMAT "lld"

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -566,7 +566,7 @@ struct transportpacket
     /* ------------- for outgoing data --------------- */
     unsigned char outbuf[MAX_SSH_PACKET_LEN]; /* area for the outgoing data */
 
-    int ototal_num;         /* size of outbuf in number of bytes */
+    ssize_t ototal_num;     /* size of outbuf in number of bytes */
     const unsigned char *odata; /* original pointer to the data */
     size_t olen;            /* original size of the data we stored in
                                outbuf */

--- a/src/mac.c
+++ b/src/mac.c
@@ -45,8 +45,8 @@
 static int
 mac_none_MAC(LIBSSH2_SESSION * session, unsigned char *buf,
              uint32_t seqno, const unsigned char *packet,
-             uint32_t packet_len, const unsigned char *addtl,
-             uint32_t addtl_len, void **abstract)
+             size_t packet_len, const unsigned char *addtl,
+             size_t addtl_len, void **abstract)
 {
     return 0;
 }
@@ -104,9 +104,9 @@ static int
 mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION * session,
                           unsigned char *buf, uint32_t seqno,
                           const unsigned char *packet,
-                          uint32_t packet_len,
+                          size_t packet_len,
                           const unsigned char *addtl,
-                          uint32_t addtl_len, void **abstract)
+                          size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -149,9 +149,9 @@ static int
 mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION * session,
                           unsigned char *buf, uint32_t seqno,
                           const unsigned char *packet,
-                          uint32_t packet_len,
+                          size_t packet_len,
                           const unsigned char *addtl,
-                          uint32_t addtl_len, void **abstract)
+                          size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -194,9 +194,9 @@ static int
 mac_method_hmac_sha1_hash(LIBSSH2_SESSION * session,
                           unsigned char *buf, uint32_t seqno,
                           const unsigned char *packet,
-                          uint32_t packet_len,
+                          size_t packet_len,
                           const unsigned char *addtl,
-                          uint32_t addtl_len, void **abstract)
+                          size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -235,9 +235,9 @@ static int
 mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION * session,
                              unsigned char *buf, uint32_t seqno,
                              const unsigned char *packet,
-                             uint32_t packet_len,
+                             size_t packet_len,
                              const unsigned char *addtl,
-                             uint32_t addtl_len, void **abstract)
+                             size_t addtl_len, void **abstract)
 {
     unsigned char temp[SHA_DIGEST_LENGTH];
 
@@ -267,9 +267,9 @@ static int
 mac_method_hmac_md5_hash(LIBSSH2_SESSION * session, unsigned char *buf,
                          uint32_t seqno,
                          const unsigned char *packet,
-                         uint32_t packet_len,
+                         size_t packet_len,
                          const unsigned char *addtl,
-                         uint32_t addtl_len, void **abstract)
+                         size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -308,9 +308,9 @@ static int
 mac_method_hmac_md5_96_hash(LIBSSH2_SESSION * session,
                             unsigned char *buf, uint32_t seqno,
                             const unsigned char *packet,
-                            uint32_t packet_len,
+                            size_t packet_len,
                             const unsigned char *addtl,
-                            uint32_t addtl_len, void **abstract)
+                            size_t addtl_len, void **abstract)
 {
     unsigned char temp[MD5_DIGEST_LENGTH];
     mac_method_hmac_md5_hash(session, temp, seqno, packet, packet_len,
@@ -339,9 +339,9 @@ static int
 mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION * session,
                                unsigned char *buf, uint32_t seqno,
                                const unsigned char *packet,
-                               uint32_t packet_len,
+                               size_t packet_len,
                                const unsigned char *addtl,
-                               uint32_t addtl_len,
+                               size_t addtl_len,
                                void **abstract)
 {
     libssh2_hmac_ctx ctx;

--- a/src/mac.h
+++ b/src/mac.h
@@ -54,8 +54,8 @@ struct _LIBSSH2_MAC_METHOD
                  void **abstract);
     int (*hash) (LIBSSH2_SESSION * session, unsigned char *buf,
                  uint32_t seqno, const unsigned char *packet,
-                 uint32_t packet_len, const unsigned char *addtl,
-                 uint32_t addtl_len, void **abstract);
+                 size_t packet_len, const unsigned char *addtl,
+                 size_t addtl_len, void **abstract);
     int (*dtor) (LIBSSH2_SESSION * session, void **abstract);
 };
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -83,7 +83,7 @@ _libssh2_mbedtls_free(void)
 }
 
 int
-_libssh2_mbedtls_random(unsigned char *buf, int len)
+_libssh2_mbedtls_random(unsigned char *buf, size_t len)
 {
     int ret;
     ret = mbedtls_ctr_drbg_random(&_libssh2_mbedtls_ctr_drbg, buf, len);

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -448,7 +448,7 @@ void
 _libssh2_mbedtls_free(void);
 
 int
-_libssh2_mbedtls_random(unsigned char *buf, int len);
+_libssh2_mbedtls_random(unsigned char *buf, size_t len);
 
 int
 _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,

--- a/src/misc.c
+++ b/src/misc.c
@@ -215,13 +215,13 @@ _libssh2_send(libssh2_socket_t sock, const void *buffer, size_t length,
 
 /* libssh2_ntohu32
  */
-unsigned int
+uint32_t
 _libssh2_ntohu32(const unsigned char *buf)
 {
-    return (((unsigned int)buf[0] << 24)
-           | ((unsigned int)buf[1] << 16)
-           | ((unsigned int)buf[2] << 8)
-           | ((unsigned int)buf[3]));
+    return ((uint32_t)buf[0] << 24)
+         | ((uint32_t)buf[1] << 16)
+         | ((uint32_t)buf[2] << 8)
+         | ((uint32_t)buf[3]);
 }
 
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -319,6 +319,7 @@ static const short base64_reverse_table[256] = {
  *
  * Decode a base64 chunk and store it into a newly alloc'd buffer
  */
+/* FIXME: datalen, src_len -> size_t */
 LIBSSH2_API int
 libssh2_base64_decode(LIBSSH2_SESSION *session, char **data,
                       unsigned int *datalen, const char *src,

--- a/src/misc.c
+++ b/src/misc.c
@@ -230,14 +230,18 @@ _libssh2_ntohu32(const unsigned char *buf)
 libssh2_uint64_t
 _libssh2_ntohu64(const unsigned char *buf)
 {
-    unsigned long msl, lsl;
+    uint32_t msl, lsl;
 
-    msl = ((libssh2_uint64_t)buf[0] << 24) | ((libssh2_uint64_t)buf[1] << 16)
-        | ((libssh2_uint64_t)buf[2] << 8) | (libssh2_uint64_t)buf[3];
-    lsl = ((libssh2_uint64_t)buf[4] << 24) | ((libssh2_uint64_t)buf[5] << 16)
-        | ((libssh2_uint64_t)buf[6] << 8) | (libssh2_uint64_t)buf[7];
+    msl = ((uint32_t)buf[0] << 24)
+        | ((uint32_t)buf[1] << 16)
+        | ((uint32_t)buf[2] <<  8)
+        |  (uint32_t)buf[3];
+    lsl = ((uint32_t)buf[4] << 24)
+        | ((uint32_t)buf[5] << 16)
+        | ((uint32_t)buf[6] <<  8)
+        |  (uint32_t)buf[7];
 
-    return ((libssh2_uint64_t)msl <<32) | lsl;
+    return ((libssh2_uint64_t)msl << 32) | lsl;
 }
 
 /* _libssh2_htonu32

--- a/src/misc.c
+++ b/src/misc.c
@@ -79,7 +79,7 @@ int _libssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
     va_start(args, fmt);
     n = vsnprintf(cp, cp_max_len, fmt, args);
     va_end(args);
-    return (n < (int)cp_max_len) ? n : (cp_max_len - 1);
+    return (n < (int)cp_max_len) ? n : (int)(cp_max_len - 1);
 }
 #endif
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -245,7 +245,7 @@ _libssh2_ntohu64(const unsigned char *buf)
 void
 _libssh2_htonu32(unsigned char *buf, uint32_t value)
 {
-    buf[0] = (value >> 24) & 0xFF;
+    buf[0] = (unsigned char)((value >> 24) & 0xFF);
     buf[1] = (value >> 16) & 0xFF;
     buf[2] = (value >> 8) & 0xFF;
     buf[3] = value & 0xFF;

--- a/src/misc.c
+++ b/src/misc.c
@@ -230,18 +230,14 @@ _libssh2_ntohu32(const unsigned char *buf)
 libssh2_uint64_t
 _libssh2_ntohu64(const unsigned char *buf)
 {
-    uint32_t msl, lsl;
-
-    msl = ((uint32_t)buf[0] << 24)
-        | ((uint32_t)buf[1] << 16)
-        | ((uint32_t)buf[2] <<  8)
-        |  (uint32_t)buf[3];
-    lsl = ((uint32_t)buf[4] << 24)
-        | ((uint32_t)buf[5] << 16)
-        | ((uint32_t)buf[6] <<  8)
-        |  (uint32_t)buf[7];
-
-    return ((libssh2_uint64_t)msl << 32) | lsl;
+    return ((libssh2_uint64_t)buf[0] << 56)
+         | ((libssh2_uint64_t)buf[1] << 48)
+         | ((libssh2_uint64_t)buf[2] << 40)
+         | ((libssh2_uint64_t)buf[3] << 32)
+         | ((libssh2_uint64_t)buf[4] << 24)
+         | ((libssh2_uint64_t)buf[5] << 16)
+         | ((libssh2_uint64_t)buf[6] <<  8)
+         | ((libssh2_uint64_t)buf[7]);
 }
 
 /* _libssh2_htonu32

--- a/src/misc.c
+++ b/src/misc.c
@@ -281,7 +281,7 @@ void _libssh2_store_bignum2_bytes(unsigned char **buf,
     for(p = bytes; len > 0 && *p == 0; --len, ++p) {}
 
     extraByte = (len > 0 && (p[0] & 0x80) != 0);
-    _libssh2_store_u32(buf, len + extraByte);
+    _libssh2_store_u32(buf, (uint32_t)(len + extraByte));
 
     if(extraByte) {
         *buf[0] = 0;

--- a/src/misc.h
+++ b/src/misc.h
@@ -97,7 +97,7 @@ void _libssh2_list_remove(struct list_node *entry);
 size_t _libssh2_base64_encode(LIBSSH2_SESSION *session,
                               const char *inp, size_t insize, char **outptr);
 
-unsigned int _libssh2_ntohu32(const unsigned char *buf);
+uint32_t _libssh2_ntohu32(const unsigned char *buf);
 libssh2_uint64_t _libssh2_ntohu64(const unsigned char *buf);
 void _libssh2_htonu32(unsigned char *buf, uint32_t val);
 void _libssh2_store_u32(unsigned char **buf, uint32_t value);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -287,7 +287,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
 int
 _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
                          const unsigned char *sig,
-                         const unsigned char *m, unsigned long m_len)
+                         const unsigned char *m, size_t m_len)
 {
     unsigned char hash[SHA_DIGEST_LENGTH];
     DSA_SIG * dsasig;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1160,8 +1160,12 @@ gen_publickey_from_dsa_openssh_priv_data(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = _libssh2_dsa_new(&dsa, p, plen, q, qlen, g, glen, pub_key, pub_len,
-                          priv_key, priv_len);
+    rc = _libssh2_dsa_new(&dsa,
+                          p, (unsigned long)plen,
+                          q, (unsigned long)qlen,
+                          g, (unsigned long)glen,
+                          pub_key, (unsigned long)pub_len,
+                          priv_key, (unsigned long)priv_len);
     if(rc != 0) {
         _libssh2_debug((session,
                        LIBSSH2_ERROR_PROTO,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1981,7 +1981,7 @@ int
 _libssh2_ed25519_new_public(libssh2_ed25519_ctx ** ed_ctx,
                             LIBSSH2_SESSION * session,
                             const unsigned char *raw_pub_key,
-                            const uint8_t key_len)
+                            const size_t key_len)
 {
     libssh2_ed25519_ctx *ctx = NULL;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -174,8 +174,8 @@ int
 _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
                          size_t hash_len,
                          const unsigned char *sig,
-                         unsigned long sig_len,
-                         const unsigned char *m, unsigned long m_len)
+                         size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     int ret;
     int nid_type;
@@ -222,8 +222,8 @@ _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
 int
 _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
                          const unsigned char *sig,
-                         unsigned long sig_len,
-                         const unsigned char *m, unsigned long m_len)
+                         size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     return _libssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH, sig, sig_len, m,
                                     m_len);
@@ -2188,7 +2188,7 @@ _libssh2_sha1_init(libssh2_sha1_ctx *ctx)
 }
 
 int
-_libssh2_sha1(const unsigned char *message, unsigned long len,
+_libssh2_sha1(const unsigned char *message, size_t len,
               unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -2240,7 +2240,7 @@ _libssh2_sha256_init(libssh2_sha256_ctx *ctx)
 }
 
 int
-_libssh2_sha256(const unsigned char *message, unsigned long len,
+_libssh2_sha256(const unsigned char *message, size_t len,
                 unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -2292,8 +2292,8 @@ _libssh2_sha384_init(libssh2_sha384_ctx *ctx)
 }
 
 int
-_libssh2_sha384(const unsigned char *message, unsigned long len,
-    unsigned char *out)
+_libssh2_sha384(const unsigned char *message, size_t len,
+                unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     EVP_MD_CTX * ctx = EVP_MD_CTX_new();
@@ -2344,8 +2344,8 @@ _libssh2_sha512_init(libssh2_sha512_ctx *ctx)
 }
 
 int
-_libssh2_sha512(const unsigned char *message, unsigned long len,
-    unsigned char *out)
+_libssh2_sha512(const unsigned char *message, size_t len,
+                unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     EVP_MD_CTX * ctx = EVP_MD_CTX_new();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -573,7 +573,11 @@ read_private_key_from_memory(void **key_ctx,
 
     *key_ctx = NULL;
 
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+    bp = BIO_new_mem_buf(filedata, (int)filedata_len);
+#else
     bp = BIO_new_mem_buf((char *)filedata, (int)filedata_len);
+#endif
     if(!bp) {
         return -1;
     }
@@ -3724,7 +3728,11 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing public key from private key."));
 
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+    bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
+#else
     bp = BIO_new_mem_buf((char *)privatekeydata, (int)privatekeydata_len);
+#endif
     if(!bp)
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                               "Unable to allocate memory when"
@@ -3814,7 +3822,11 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing public key from private key."));
 
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+    bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
+#else
     bp = BIO_new_mem_buf((char *)privatekeydata, (int)privatekeydata_len);
+#endif
     if(!bp)
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                               "Unable to allocate memory when"

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -92,6 +92,16 @@ write_bn(unsigned char *buf, const BIGNUM *bn, int bn_bytes)
 }
 
 int
+_libssh2_openssl_random(void *buf, size_t len)
+{
+    if(len > INT_MAX) {
+        return -1;
+    }
+
+    return RAND_bytes(buf, (int)len) == 1 ? 0 : -1;
+}
+
+int
 _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
                  const unsigned char *edata,
                  unsigned long elen,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -852,9 +852,14 @@ gen_publickey_from_rsa_openssh_priv_data(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    if((rc = _libssh2_rsa_new(&rsa, e, elen, n, nlen, d, dlen, p, plen,
-                              q, qlen, NULL, 0, NULL, 0,
-                              coeff, coefflen)) != 0) {
+    if((rc = _libssh2_rsa_new(&rsa,
+                              e, (unsigned long)elen,
+                              n, (unsigned long)nlen,
+                              d, (unsigned long)dlen,
+                              p, (unsigned long)plen,
+                              q, (unsigned long)qlen,
+                              NULL, 0, NULL, 0,
+                              coeff, (unsigned long)coefflen)) != 0) {
         _libssh2_debug((session,
                        LIBSSH2_TRACE_AUTH,
                        "Could not create RSA private key"));

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -204,7 +204,7 @@ int _libssh2_sha1_init(libssh2_sha1_ctx *ctx);
 #define libssh2_sha1_update(ctx, data, len) EVP_DigestUpdate(&(ctx), data, len)
 #define libssh2_sha1_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
 #endif
-int _libssh2_sha1(const unsigned char *message, unsigned long len,
+int _libssh2_sha1(const unsigned char *message, size_t len,
                   unsigned char *out);
 #define libssh2_sha1(x,y,z) _libssh2_sha1(x,y,z)
 
@@ -228,8 +228,8 @@ int _libssh2_sha256_init(libssh2_sha256_ctx *ctx);
     EVP_DigestUpdate(&(ctx), data, len)
 #define libssh2_sha256_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
 #endif
-int _libssh2_sha256(const unsigned char *message, unsigned long len,
-                  unsigned char *out);
+int _libssh2_sha256(const unsigned char *message, size_t len,
+                    unsigned char *out);
 #define libssh2_sha256(x,y,z) _libssh2_sha256(x,y,z)
 
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -252,7 +252,7 @@ int _libssh2_sha384_init(libssh2_sha384_ctx *ctx);
     EVP_DigestUpdate(&(ctx), data, len)
 #define libssh2_sha384_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
 #endif
-int _libssh2_sha384(const unsigned char *message, unsigned long len,
+int _libssh2_sha384(const unsigned char *message, size_t len,
                     unsigned char *out);
 #define libssh2_sha384(x,y,z) _libssh2_sha384(x,y,z)
 
@@ -276,7 +276,7 @@ int _libssh2_sha512_init(libssh2_sha512_ctx *ctx);
     EVP_DigestUpdate(&(ctx), data, len)
 #define libssh2_sha512_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
 #endif
-int _libssh2_sha512(const unsigned char *message, unsigned long len,
+int _libssh2_sha512(const unsigned char *message, size_t len,
                     unsigned char *out);
 #define libssh2_sha512(x,y,z) _libssh2_sha512(x,y,z)
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -181,7 +181,8 @@
 
 #define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
-#define _libssh2_random(buf, len) (RAND_bytes((buf), (len)) == 1 ? 0 : -1)
+#define _libssh2_random(buf, len) \
+  _libssh2_openssl_random((buf), (len))
 
 #define libssh2_prepare_iovec(vec, len)  /* Empty. */
 
@@ -426,6 +427,8 @@ extern int _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                               _libssh2_bn *f, _libssh2_bn *p,
                               _libssh2_bn_ctx *bnctx);
 extern void _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
+
+extern int _libssh2_openssl_random(void *buf, size_t len);
 
 const EVP_CIPHER *_libssh2_EVP_aes_128_ctr(void);
 const EVP_CIPHER *_libssh2_EVP_aes_192_ctr(void);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -883,7 +883,7 @@ _libssh2_bn_from_bn(_libssh2_bn *to, _libssh2_bn *from)
 }
 
 int
-_libssh2_random(unsigned char *buf, int len)
+_libssh2_random(unsigned char *buf, size_t len)
 {
     Qc3GenPRNs(buf, len,
         Qc3PRN_TYPE_NORMAL, Qc3PRN_NO_PARITY, (char *) &ecnull);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2379,12 +2379,12 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 
 int
 _libssh2_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
-                         const unsigned char *sig, unsigned long sig_len,
-                         const unsigned char *m, unsigned long m_len)
+                         const unsigned char *sig, size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     Qus_EC_t errcode;
-    int slen = sig_len;
-    int mlen = m_len;
+    int slen = (int)sig_len;
+    int mlen = (int)m_len;
 
     set_EC_length(errcode, sizeof errcode);
     Qc3VerifySignature((char *) sig, &slen, (char *) m, &mlen, Qc3_Data,

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -361,7 +361,7 @@ extern int      _libssh2_bn_from_bin(_libssh2_bn *bn, int len,
                                      const unsigned char *v);
 extern int      _libssh2_bn_set_word(_libssh2_bn *bn, unsigned long val);
 extern int      _libssh2_bn_to_bin(_libssh2_bn *bn, unsigned char *val);
-extern int      _libssh2_random(unsigned char *buf, int len);
+extern int      _libssh2_random(unsigned char *buf, size_t len);
 extern void     _libssh2_os400qc3_crypto_dtor(_libssh2_os400qc3_crypto_ctx *x);
 extern int      libssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x,
                                            unsigned int algo);

--- a/src/packet.c
+++ b/src/packet.c
@@ -782,7 +782,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     datalen = channelp->remote.window_size -
                         channelp->read_avail + data_head;
 
-                channelp->remote.window_size -= datalen - data_head;
+                channelp->remote.window_size -= (uint32_t)(datalen -
+                                                           data_head);
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                "shrinking window size by %lu bytes to %lu, "
                                "read_avail %lu",

--- a/src/packet.c
+++ b/src/packet.c
@@ -72,21 +72,21 @@
  */
 static inline int
 packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
-                      unsigned long datalen,
+                      size_t datalen,
                       packet_queue_listener_state_t *listen_state)
 {
     /*
      * Look for a matching listener
      */
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */
-    unsigned long packet_len = 17 + (sizeof(FwdNotReq) - 1);
+    size_t packet_len = 17 + (sizeof(FwdNotReq) - 1);
     unsigned char *p;
     LIBSSH2_LISTENER *listn = _libssh2_list_first(&session->listeners);
     char failure_code = SSH_OPEN_ADMINISTRATIVELY_PROHIBITED;
     int rc;
 
     if(listen_state->state == libssh2_NB_state_idle) {
-        unsigned long offset = (sizeof("forwarded-tcpip") - 1) + 5;
+        size_t offset = (sizeof("forwarded-tcpip") - 1) + 5;
         size_t temp_len = 0;
         struct string_buf buf;
         buf.data = data;
@@ -285,19 +285,19 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
  */
 static inline int
 packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
-                unsigned long datalen,
+                size_t datalen,
                 packet_x11_open_state_t *x11open_state)
 {
     int failure_code = SSH_OPEN_CONNECT_FAILED;
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */
-    unsigned long packet_len = 17 + (sizeof(X11FwdUnAvil) - 1);
+    size_t packet_len = 17 + (sizeof(X11FwdUnAvil) - 1);
     unsigned char *p;
     LIBSSH2_CHANNEL *channel = x11open_state->channel;
     int rc;
 
     if(x11open_state->state == libssh2_NB_state_idle) {
 
-        unsigned long offset = (sizeof("x11") - 1) + 5;
+        size_t offset = (sizeof("x11") - 1) + 5;
         size_t temp_len = 0;
         struct string_buf buf;
         buf.data = data;
@@ -797,7 +797,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 session->packAdd_state = libssh2_NB_state_jump1;
                 rc = _libssh2_channel_receive_window_adjust(session->
                                                             packAdd_channelp,
-                                                            datalen - 13,
+                                                    (uint32_t)(datalen - 13),
                                                             1, NULL);
                 if(rc == LIBSSH2_ERROR_EAGAIN)
                     return rc;

--- a/src/pem.c
+++ b/src/pem.c
@@ -157,7 +157,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
 
         /* Decode IV from hex */
         for(i = 0; i < method->iv_len; ++i) {
-            iv[i]  = hex_decode(iv[2*i]) << 4;
+            iv[i]  = (unsigned char)(hex_decode(iv[2*i]) << 4);
             iv[i] |= hex_decode(iv[2*i + 1]);
         }
 
@@ -171,9 +171,9 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
     do {
         if(*line) {
             char *tmp;
-            size_t linelen;
+            unsigned int linelen;
 
-            linelen = strlen(line);
+            linelen = (unsigned int)strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
                 _libssh2_error(session, LIBSSH2_ERROR_ALLOC,

--- a/src/pem.c
+++ b/src/pem.c
@@ -100,7 +100,8 @@ static const char *crypt_annotation = "Proc-Type: 4,ENCRYPTED";
 
 static unsigned char hex_decode(char digit)
 {
-    return (digit >= 'A') ? 0xA + (digit - 'A') : (digit - '0');
+    return (unsigned char)
+        ((digit >= 'A') ? (0xA + (digit - 'A')) : (digit - '0'));
 }
 
 int

--- a/src/pem.c
+++ b/src/pem.c
@@ -391,7 +391,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 
     /* decode file */
     if(libssh2_base64_decode(session, (char **)&f, &f_len,
-                             b64data, b64datalen)) {
+                             b64data, (unsigned int)b64datalen)) {
        ret = -1;
        goto out;
     }

--- a/src/pem.c
+++ b/src/pem.c
@@ -113,7 +113,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
     char line[LINE_SIZE];
     unsigned char iv[LINE_SIZE];
     char *b64data = NULL;
-    unsigned int b64datalen = 0;
+    size_t b64datalen = 0;
     int ret;
     const LIBSSH2_CRYPT_METHOD *method = NULL;
 
@@ -171,9 +171,9 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
     do {
         if(*line) {
             char *tmp;
-            unsigned int linelen;
+            size_t linelen;
 
-            linelen = (unsigned int)strlen(line);
+            linelen = strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
                 _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -199,7 +199,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
     }
 
     if(libssh2_base64_decode(session, (char **) data, datalen,
-                              b64data, b64datalen)) {
+                             b64data, (unsigned int)b64datalen)) {
         ret = -1;
         goto out;
     }
@@ -298,7 +298,7 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION * session,
 {
     char line[LINE_SIZE];
     char *b64data = NULL;
-    unsigned int b64datalen = 0;
+    size_t b64datalen = 0;
     size_t off = 0;
     int ret;
 
@@ -344,7 +344,7 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION * session,
     }
 
     if(libssh2_base64_decode(session, (char **) data, datalen,
-                              b64data, b64datalen)) {
+                             b64data, (unsigned int)b64datalen)) {
         ret = -1;
         goto out;
     }
@@ -668,7 +668,7 @@ _libssh2_openssh_pem_parse(LIBSSH2_SESSION * session,
 {
     char line[LINE_SIZE];
     char *b64data = NULL;
-    unsigned int b64datalen = 0;
+    size_t b64datalen = 0;
     int ret = 0;
 
     /* read file */
@@ -719,7 +719,7 @@ _libssh2_openssh_pem_parse(LIBSSH2_SESSION * session,
     ret = _libssh2_openssh_pem_parse_data(session,
                                           passphrase,
                                           (const char *)b64data,
-                                          (size_t)b64datalen,
+                                          b64datalen,
                                           decrypted_buf);
 
     if(b64data) {
@@ -740,7 +740,7 @@ _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
 {
     char line[LINE_SIZE];
     char *b64data = NULL;
-    unsigned int b64datalen = 0;
+    size_t b64datalen = 0;
     size_t off = 0;
     int ret;
 

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -640,25 +640,25 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
         }
 
         pkey->add_s = pkey->add_packet;
-        _libssh2_htonu32(pkey->add_s, packet_len - 4);
+        _libssh2_htonu32(pkey->add_s, (uint32_t)(packet_len - 4));
         pkey->add_s += 4;
         _libssh2_htonu32(pkey->add_s, sizeof("add") - 1);
         pkey->add_s += 4;
         memcpy(pkey->add_s, "add", sizeof("add") - 1);
         pkey->add_s += sizeof("add") - 1;
         if(pkey->version == 1) {
-            _libssh2_htonu32(pkey->add_s, comment_len);
+            _libssh2_htonu32(pkey->add_s, (uint32_t)comment_len);
             pkey->add_s += 4;
             if(comment) {
                 memcpy(pkey->add_s, comment, comment_len);
                 pkey->add_s += comment_len;
             }
 
-            _libssh2_htonu32(pkey->add_s, name_len);
+            _libssh2_htonu32(pkey->add_s, (uint32_t)name_len);
             pkey->add_s += 4;
             memcpy(pkey->add_s, name, name_len);
             pkey->add_s += name_len;
-            _libssh2_htonu32(pkey->add_s, blob_len);
+            _libssh2_htonu32(pkey->add_s, (uint32_t)blob_len);
             pkey->add_s += 4;
             memcpy(pkey->add_s, blob, blob_len);
             pkey->add_s += blob_len;
@@ -666,23 +666,23 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
         else {
             /* Version == 2 */
 
-            _libssh2_htonu32(pkey->add_s, name_len);
+            _libssh2_htonu32(pkey->add_s, (uint32_t)name_len);
             pkey->add_s += 4;
             memcpy(pkey->add_s, name, name_len);
             pkey->add_s += name_len;
-            _libssh2_htonu32(pkey->add_s, blob_len);
+            _libssh2_htonu32(pkey->add_s, (uint32_t)blob_len);
             pkey->add_s += 4;
             memcpy(pkey->add_s, blob, blob_len);
             pkey->add_s += blob_len;
             *(pkey->add_s++) = overwrite ? 0x01 : 0;
-            _libssh2_htonu32(pkey->add_s, num_attrs);
+            _libssh2_htonu32(pkey->add_s, (uint32_t)num_attrs);
             pkey->add_s += 4;
             for(i = 0; i < num_attrs; i++) {
-                _libssh2_htonu32(pkey->add_s, attrs[i].name_len);
+                _libssh2_htonu32(pkey->add_s, (uint32_t)attrs[i].name_len);
                 pkey->add_s += 4;
                 memcpy(pkey->add_s, attrs[i].name, attrs[i].name_len);
                 pkey->add_s += attrs[i].name_len;
-                _libssh2_htonu32(pkey->add_s, attrs[i].value_len);
+                _libssh2_htonu32(pkey->add_s, (uint32_t)attrs[i].value_len);
                 pkey->add_s += 4;
                 memcpy(pkey->add_s, attrs[i].value, attrs[i].value_len);
                 pkey->add_s += attrs[i].value_len;
@@ -760,17 +760,17 @@ libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY * pkey,
         }
 
         pkey->remove_s = pkey->remove_packet;
-        _libssh2_htonu32(pkey->remove_s, packet_len - 4);
+        _libssh2_htonu32(pkey->remove_s, (uint32_t)(packet_len - 4));
         pkey->remove_s += 4;
         _libssh2_htonu32(pkey->remove_s, sizeof("remove") - 1);
         pkey->remove_s += 4;
         memcpy(pkey->remove_s, "remove", sizeof("remove") - 1);
         pkey->remove_s += sizeof("remove") - 1;
-        _libssh2_htonu32(pkey->remove_s, name_len);
+        _libssh2_htonu32(pkey->remove_s, (uint32_t)name_len);
         pkey->remove_s += 4;
         memcpy(pkey->remove_s, name, name_len);
         pkey->remove_s += name_len;
-        _libssh2_htonu32(pkey->remove_s, blob_len);
+        _libssh2_htonu32(pkey->remove_s, (uint32_t)blob_len);
         pkey->remove_s += 4;
         memcpy(pkey->remove_s, blob, blob_len);
         pkey->remove_s += blob_len;
@@ -838,7 +838,7 @@ libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY * pkey, unsigned long *num_keys,
         pkey->listFetch_data = NULL;
 
         pkey->listFetch_s = pkey->listFetch_buffer;
-        _libssh2_htonu32(pkey->listFetch_s, buffer_len - 4);
+        _libssh2_htonu32(pkey->listFetch_s, (uint32_t)(buffer_len - 4));
         pkey->listFetch_s += 4;
         _libssh2_htonu32(pkey->listFetch_s, sizeof("list") - 1);
         pkey->listFetch_s += 4;

--- a/src/scp.c
+++ b/src/scp.c
@@ -270,7 +270,7 @@ shell_quotearg(const char *path, unsigned char *buf,
 static LIBSSH2_CHANNEL *
 scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
 {
-    int cmd_len;
+    size_t cmd_len;
     int rc;
     int tmp_err_code;
     const char *tmp_err_msg;
@@ -298,10 +298,10 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
                  session->scpRecv_command_len,
                  "scp -%sf ", sb?"p":"");
 
-        cmd_len = (int)strlen((char *)session->scpRecv_command);
-        cmd_len += (int)shell_quotearg(path,
-                                       &session->scpRecv_command[cmd_len],
-                                       session->scpRecv_command_len - cmd_len);
+        cmd_len = strlen((char *)session->scpRecv_command);
+        cmd_len += shell_quotearg(path,
+                                  &session->scpRecv_command[cmd_len],
+                                  session->scpRecv_command_len - cmd_len);
 
         /* the command to exec should _not_ be NUL-terminated */
         session->scpRecv_command_len = cmd_len;
@@ -835,7 +835,7 @@ static LIBSSH2_CHANNEL *
 scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
          libssh2_int64_t size, time_t mtime, time_t atime)
 {
-    int cmd_len;
+    size_t cmd_len;
     int rc;
     int tmp_err_code;
     const char *tmp_err_msg;
@@ -859,10 +859,10 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
                  session->scpSend_command_len,
                  "scp -%st ", (mtime || atime)?"p":"");
 
-        cmd_len = (int)strlen((char *)session->scpSend_command);
-        cmd_len += (int)shell_quotearg(path,
-                                       &session->scpSend_command[cmd_len],
-                                       session->scpSend_command_len - cmd_len);
+        cmd_len = strlen((char *)session->scpSend_command);
+        cmd_len += shell_quotearg(path,
+                                  &session->scpSend_command[cmd_len],
+                                  session->scpSend_command_len - cmd_len);
 
         /* the command to exec should _not_ be NUL-terminated */
         session->scpSend_command_len = cmd_len;

--- a/src/session.c
+++ b/src/session.c
@@ -95,7 +95,7 @@ LIBSSH2_REALLOC_FUNC(libssh2_default_realloc)
 static int
 banner_receive(LIBSSH2_SESSION * session)
 {
-    int ret;
+    ssize_t ret;
     size_t banner_len;
 
     if(session->banner_TxRx_state == libssh2_NB_state_idle) {
@@ -121,11 +121,11 @@ banner_receive(LIBSSH2_SESSION * session)
             if(session->api_block_mode || (ret != -EAGAIN))
                 /* ignore EAGAIN when non-blocking */
                 _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                               "Error recving %d bytes: %d", 1, -ret));
+                               "Error recving %d bytes: %d", 1, (int)-ret));
         }
         else
             _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                           "Recved %d bytes banner", ret));
+                           "Recved %d bytes banner", (int)ret));
 
         if(ret < 0) {
             if(ret == -EAGAIN) {

--- a/src/session.c
+++ b/src/session.c
@@ -1547,7 +1547,7 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
         switch(fds[i].type) {
         case LIBSSH2_POLLFD_SOCKET:
             sockets[i].fd = fds[i].fd.socket;
-            sockets[i].events = fds[i].events;
+            sockets[i].events = (short)fds[i].events;
             sockets[i].revents = 0;
             break;
 

--- a/src/session.c
+++ b/src/session.c
@@ -680,7 +680,7 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
             writefd = &wfd;
         }
 
-        rc = select(session->socket_fd + 1, readfd, writefd, NULL,
+        rc = select((int)(session->socket_fd + 1), readfd, writefd, NULL,
                     has_timeout ? &tv : NULL);
     }
 #endif
@@ -1772,7 +1772,7 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
             struct timeval tv_begin, tv_end;
 
             _libssh2_gettimeofday((struct timeval *) &tv_begin, NULL);
-            sysret = select(maxfd + 1, &rfds, &wfds, NULL, &tv);
+            sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
             _libssh2_gettimeofday((struct timeval *) &tv_end, NULL);
 
             timeout_remaining -= (tv_end.tv_sec - tv_begin.tv_sec) * 1000;
@@ -1782,7 +1782,7 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
         /* If the platform doesn't support gettimeofday,
          * then just make the call non-blocking and walk away
          */
-        sysret = select(maxfd + 1, &rfds, &wfds, NULL, &tv);
+        sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
         timeout_remaining = 0;
 #endif
 

--- a/src/session.c
+++ b/src/session.c
@@ -651,7 +651,7 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
         if(dir & LIBSSH2_SESSION_BLOCK_OUTBOUND)
             sockets[0].events |= POLLOUT;
 
-        rc = poll(sockets, 1, has_timeout?ms_to_next: -1);
+        rc = poll(sockets, 1, has_timeout ? (int)ms_to_next : -1);
     }
 #else
     {
@@ -1714,7 +1714,7 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
             struct timeval tv_begin, tv_end;
 
             _libssh2_gettimeofday((struct timeval *) &tv_begin, NULL);
-            sysret = poll(sockets, nfds, timeout_remaining);
+            sysret = poll(sockets, nfds, (int)timeout_remaining);
             _libssh2_gettimeofday((struct timeval *) &tv_end, NULL);
             timeout_remaining -= (tv_end.tv_sec - tv_begin.tv_sec) * 1000;
             timeout_remaining -= (tv_end.tv_usec - tv_begin.tv_usec) / 1000;
@@ -1723,7 +1723,7 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
         /* If the platform doesn't support gettimeofday,
          * then just make the call non-blocking and walk away
          */
-        sysret = poll(sockets, nfds, timeout_remaining);
+        sysret = poll(sockets, nfds, (int)timeout_remaining);
         timeout_remaining = 0;
 #endif /* HAVE_GETTIMEOFDAY */
 

--- a/src/session.c
+++ b/src/session.c
@@ -330,6 +330,8 @@ session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
 #endif
 
 #ifdef HAVE_DISABLED_NONBLOCKING
+    (void)sockfd;
+    (void)nonblock;
     return 0;                   /* returns success */
 #undef SETBLOCK
 #define SETBLOCK 6
@@ -409,6 +411,7 @@ get_socket_nonblocking(libssh2_socket_t sockfd)
 #endif
 
 #ifdef HAVE_DISABLED_NONBLOCKING
+    (void)sockfd;
     return 1;                   /* returns blocking */
 #undef GETBLOCK
 #define GETBLOCK 7

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1470,7 +1470,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
 
             /* 25 = packet_len(4) + packet_type(1) + request_id(4) +
                handle_len(4) + offset(8) + count(4) */
-            uint32_t packet_len = (uint32_t)handle->handle_len + 25;
+            uint32_t packet_len = (uint32_t)(handle->handle_len + 25);
             uint32_t request_id;
 
             uint32_t size = count;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -2850,7 +2850,7 @@ static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
         _libssh2_store_str(&sftp->rename_s, dest_filename, dest_filename_len);
 
         if(sftp->version >= 5)
-            _libssh2_store_u32(&sftp->rename_s, flags);
+            _libssh2_store_u32(&sftp->rename_s, (uint32_t)flags);
 
         sftp->rename_state = libssh2_NB_state_created;
     }

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1923,14 +1923,15 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
     }
 
     if(data[0] == SSH_FXP_STATUS) {
-        retcode = _libssh2_ntohu32(data + 5);
+        unsigned int rerrno;
+        rerrno = _libssh2_ntohu32(data + 5);
         LIBSSH2_FREE(session, data);
-        if(retcode == LIBSSH2_FX_EOF) {
+        if(rerrno == LIBSSH2_FX_EOF) {
             sftp->readdir_state = libssh2_NB_state_idle;
             return 0;
         }
         else {
-            sftp->last_errno = retcode;
+            sftp->last_errno = rerrno;
             sftp->readdir_state = libssh2_NB_state_idle;
             return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                   "SFTP Protocol Error");

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -2653,7 +2653,7 @@ sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
 
     }
     else {
-        int retcode = _libssh2_ntohu32(data + 5);
+        uint32_t retcode = _libssh2_ntohu32(data + 5);
         LIBSSH2_FREE(session, data);
 
         if(retcode != LIBSSH2_FX_OK) {
@@ -2710,7 +2710,7 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename,
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
     size_t data_len = 0;
-    int retcode;
+    uint32_t retcode;
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) */
     uint32_t packet_len = (uint32_t)(filename_len + 13);
     unsigned char *s, *data = NULL;
@@ -3028,7 +3028,7 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
     }
 
     if(data[0] == SSH_FXP_STATUS) {
-        int retcode = _libssh2_ntohu32(data + 5);
+        uint32_t retcode = _libssh2_ntohu32(data + 5);
         sftp->fstatvfs_state = libssh2_NB_state_idle;
         LIBSSH2_FREE(session, data);
         sftp->last_errno = retcode;
@@ -3163,7 +3163,7 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
     }
 
     if(data[0] == SSH_FXP_STATUS) {
-        int retcode = _libssh2_ntohu32(data + 5);
+        uint32_t retcode = _libssh2_ntohu32(data + 5);
         sftp->statvfs_state = libssh2_NB_state_idle;
         LIBSSH2_FREE(session, data);
         sftp->last_errno = retcode;
@@ -3232,7 +3232,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
         0, 0, 0, 0, 0, 0, 0
     };
     size_t data_len = 0;
-    int retcode;
+    uint32_t retcode;
     ssize_t packet_len;
     unsigned char *packet, *s, *data = NULL;
     int rc;
@@ -3348,7 +3348,7 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
     size_t data_len = 0;
-    int retcode;
+    uint32_t retcode;
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
     ssize_t packet_len = path_len + 13;
     unsigned char *s, *data = NULL;
@@ -3538,7 +3538,7 @@ static int sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
     sftp->stat_state = libssh2_NB_state_idle;
 
     if(data[0] == SSH_FXP_STATUS) {
-        int retcode;
+        uint32_t retcode;
 
         retcode = _libssh2_ntohu32(data + 5);
         LIBSSH2_FREE(session, data);
@@ -3677,7 +3677,7 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
     }
     else if(retcode) {
         sftp->symlink_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, (int)retcode,
+        return _libssh2_error(session, retcode,
                               "Error waiting for status message");
     }
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -720,7 +720,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
     int blocksize =
         (session->state & LIBSSH2_STATE_NEWKEYS) ?
         session->local.crypt->blocksize : 8;
-    int padding_length;
+    ssize_t padding_length;
     size_t packet_length;
     ssize_t total_length;
 #ifdef RANDOM_PADDING

--- a/src/transport.c
+++ b/src/transport.c
@@ -130,7 +130,7 @@ debugdump(LIBSSH2_SESSION * session,
 
 static int
 decrypt(LIBSSH2_SESSION * session, unsigned char *source,
-        unsigned char *dest, int len)
+        unsigned char *dest, ssize_t len)
 {
     struct transportpacket *p = &session->packet;
     int blocksize = session->remote.crypt->blocksize;
@@ -275,13 +275,14 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
 {
     int rc;
     struct transportpacket *p = &session->packet;
-    int remainpack; /* how much there is left to add to the current payload
-                       package */
-    int remainbuf;  /* how much data there is remaining in the buffer to deal
-                       with before we should read more from the network */
-    int numbytes;   /* how much data to deal with from the buffer on this
-                       iteration through the loop */
-    int numdecrypt; /* number of bytes to decrypt this iteration */
+    ssize_t remainpack; /* how much there is left to add to the current payload
+                           package */
+    ssize_t remainbuf;  /* how much data there is remaining in the buffer to
+                           deal with before we should read more from the
+                           network */
+    ssize_t numbytes;   /* how much data to deal with from the buffer on this
+                           iteration through the loop */
+    ssize_t numdecrypt; /* number of bytes to decrypt this iteration */
     unsigned char block[MAX_BLOCKSIZE]; /* working block buffer */
     int blocksize;  /* minimum number of bytes we need before we can
                        use them */
@@ -533,7 +534,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
                 numdecrypt = (p->total_num - skip) - p->data_num;
             }
             else {
-                int frac;
+                ssize_t frac;
                 numdecrypt = numbytes;
                 frac = numdecrypt % blocksize;
                 if(frac) {
@@ -575,7 +576,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
            copy them as-is to the target buffer */
         if(numbytes > 0) {
 
-            if(numbytes <= (int)(p->total_num - (p->wptr - p->payload))) {
+            if((size_t)numbytes <= (p->total_num - (p->wptr - p->payload))) {
                 memcpy(p->wptr, &p->buf[p->readidx], numbytes);
             }
             else {
@@ -721,7 +722,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
         session->local.crypt->blocksize : 8;
     int padding_length;
     size_t packet_length;
-    int total_length;
+    ssize_t total_length;
 #ifdef RANDOM_PADDING
     int rand_max;
     int seed = data[0];         /* FIXME: make this random */

--- a/src/transport.c
+++ b/src/transport.c
@@ -865,7 +865,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
 
     /* store packet_length, which is the size of the whole packet except
        the MAC and the packet_length field itself */
-    _libssh2_htonu32(p->outbuf, packet_length - 4);
+    _libssh2_htonu32(p->outbuf, (uint32_t)(packet_length - 4));
     /* store padding_length */
     p->outbuf[4] = (unsigned char)padding_length;
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -611,7 +611,7 @@ memory_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
     }
 
     if(libssh2_base64_decode(session, (char **) &tmp, &tmp_len,
-                              (char *) sp1, sp2 - sp1)) {
+                              (char *) sp1, (unsigned int)(sp2 - sp1))) {
         LIBSSH2_FREE(session, pubkey);
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                                   "Invalid key data, not base64 encoded");
@@ -715,7 +715,7 @@ file_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
     }
 
     if(libssh2_base64_decode(session, (char **) &tmp, &tmp_len,
-                              (char *) sp1, sp2 - sp1)) {
+                              (char *) sp1, (unsigned int)(sp2 - sp1))) {
         LIBSSH2_FREE(session, pubkey);
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                               "Invalid key data, not base64 encoded");

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -611,7 +611,8 @@ memory_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
     }
 
     if(libssh2_base64_decode(session, (char **) &tmp, &tmp_len,
-                              (char *) sp1, (unsigned int)(sp2 - sp1))) {
+                              (const char *) sp1,
+                              (unsigned int)(sp2 - sp1))) {
         LIBSSH2_FREE(session, pubkey);
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                                   "Invalid key data, not base64 encoded");
@@ -715,7 +716,8 @@ file_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
     }
 
     if(libssh2_base64_decode(session, (char **) &tmp, &tmp_len,
-                              (char *) sp1, (unsigned int)(sp2 - sp1))) {
+                              (const char *) sp1,
+                              (unsigned int)(sp2 - sp1))) {
         LIBSSH2_FREE(session, pubkey);
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                               "Invalid key data, not base64 encoded");

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -938,7 +938,7 @@ libssh2_sign_sk(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
 
                 *sig_len = p - *sig;
 
-                _libssh2_store_u32(&x, *sig_len - 4);
+                _libssh2_store_u32(&x, (uint32_t)(*sig_len - 4));
             }
             else {
                 _libssh2_debug((session,
@@ -1144,8 +1144,8 @@ userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
             session->userauth_host_packet + session->userauth_host_packet_len;
 
         _libssh2_store_u32(&session->userauth_host_s,
-                           4 + session->userauth_host_method_len +
-                           4 + sig_len);
+                           (uint32_t)(4 + session->userauth_host_method_len +
+                                      4 + sig_len));
         _libssh2_store_str(&session->userauth_host_s,
                            (const char *)session->userauth_host_method,
                            session->userauth_host_method_len);
@@ -1709,8 +1709,8 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                    "sk-ssh-ed25519@openssh.com",
                    session->userauth_pblc_method_len) == 0) {
             _libssh2_store_u32(&s,
-                               4 + session->userauth_pblc_method_len +
-                               sig_len);
+                             (uint32_t)(4 + session->userauth_pblc_method_len +
+                                        sig_len));
             _libssh2_store_str(&s, (const char *)session->userauth_pblc_method,
                                session->userauth_pblc_method_len);
             memcpy(s, sig, sig_len);
@@ -1718,8 +1718,8 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
         }
         else {
             _libssh2_store_u32(&s,
-                               4 + session->userauth_pblc_method_len + 4 +
-                               sig_len);
+                             (uint32_t)(4 + session->userauth_pblc_method_len +
+                                        4 + sig_len));
             _libssh2_store_str(&s, (const char *)session->userauth_pblc_method,
                                session->userauth_pblc_method_len);
             _libssh2_store_str(&s, (const char *)sig, sig_len);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1925,7 +1925,8 @@ _libssh2_wincng_cipher_init(_libssh2_cipher_ctx *ctx,
     }
 
 
-    keylen = sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) + type.dwKeyLength;
+    keylen = (unsigned long)sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) +
+             type.dwKeyLength;
     header = (BCRYPT_KEY_DATA_BLOB_HEADER *)malloc(keylen);
     if(!header) {
         free(pbKeyObject);
@@ -2137,13 +2138,13 @@ _libssh2_wincng_bignum_rand(_libssh2_bn *rnd, int bits, int top, int bottom)
         bits = 8;
 
     /* fill most significant byte with zero padding */
-    bignum[0] &= ((1 << bits) - 1);
+    bignum[0] &= (unsigned char)((1 << bits) - 1);
 
     /* set most significant bits in most significant byte */
     if(top == 0)
-        bignum[0] |= (1 << (bits - 1));
+        bignum[0] |= (unsigned char)(1 << (bits - 1));
     else if(top == 1)
-        bignum[0] |= (3 << (bits - 2));
+        bignum[0] |= (unsigned char)(3 << (bits - 2));
 
     /* make odd by setting first bit in least significant byte */
     if(bottom)
@@ -2406,7 +2407,8 @@ _libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
             return -1;
         }
 
-        dh_params_len = sizeof(*dh_params) + 2 * key_length_bytes;
+        dh_params_len = (unsigned long)sizeof(*dh_params) +
+                        2 * key_length_bytes;
         dh_params = (BCRYPT_DH_PARAMETER_HEADER *)malloc(dh_params_len);
         if(!dh_params) {
             return -1;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -885,23 +885,23 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
                                unsigned long *pcbCount)
 {
     PCRYPT_DER_BLOB pBlob;
-    unsigned char *pbDecoded, **rpbDecoded;
+    unsigned char **rpbDecoded;
+    PCRYPT_DATA_BLOB pbDecoded;
     unsigned long cbDecoded, *rcbDecoded, index, length;
     int ret;
 
     ret = _libssh2_wincng_asn_decode(pbEncoded, cbEncoded,
                                      X509_SEQUENCE_OF_ANY,
-                                     &pbDecoded, &cbDecoded);
+                                     (void *)&pbDecoded, &cbDecoded);
     if(!ret) {
-        length = ((PCRYPT_DATA_BLOB)pbDecoded)->cbData;
+        length = pbDecoded->cbData;
 
         rpbDecoded = malloc(sizeof(PBYTE) * length);
         if(rpbDecoded) {
             rcbDecoded = malloc(sizeof(DWORD) * length);
             if(rcbDecoded) {
                 for(index = 0; index < length; index++) {
-                    pBlob = &((PCRYPT_DER_BLOB)
-                              ((PCRYPT_DATA_BLOB)pbDecoded)->pbData)[index];
+                    pBlob = &((PCRYPT_DER_BLOB)(pbDecoded)->pbData)[index];
                     ret = _libssh2_wincng_asn_decode_bn(pBlob->pbData,
                                                         pBlob->cbData,
                                                         &rpbDecoded[index],

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1539,10 +1539,10 @@ int
 _libssh2_wincng_dsa_sha1_verify(libssh2_dsa_ctx *dsa,
                                 const unsigned char *sig_fixed,
                                 const unsigned char *m,
-                                unsigned long m_len)
+                                size_t m_len)
 {
     return _libssh2_wincng_key_sha_verify(dsa, SHA_DIGEST_LENGTH, sig_fixed,
-                                          40, m, m_len, 0);
+                                          40, m, (unsigned long)m_len, 0);
 }
 
 int

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -419,11 +419,15 @@ _libssh2_wincng_free(void)
 }
 
 int
-_libssh2_wincng_random(void *buf, int len)
+_libssh2_wincng_random(void *buf, size_t len)
 {
     int ret;
 
-    ret = BCryptGenRandom(_libssh2_wincng.hAlgRNG, buf, len, 0);
+    if(len > ULONG_MAX) {
+        return -1;
+    }
+
+    ret = BCryptGenRandom(_libssh2_wincng.hAlgRNG, buf, (ULONG)len, 0);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -589,7 +589,7 @@ _libssh2_wincng_hmac_cleanup(_libssh2_wincng_hash_ctx *ctx)
 
 int
 _libssh2_wincng_key_sha_verify(_libssh2_wincng_key_ctx *ctx,
-                                size_t hashlen,
+                                unsigned long hashlen,
                                 const unsigned char *sig,
                                 unsigned long sig_len,
                                 const unsigned char *m,
@@ -662,7 +662,7 @@ _libssh2_wincng_key_sha_verify(_libssh2_wincng_key_ctx *ctx,
     memcpy(data, sig, datalen);
 
     ret = BCryptVerifySignature(ctx->hKey, pPaddingInfo,
-                                hash, (ULONG)hashlen, data, datalen, flags);
+                                hash, hashlen, data, datalen, flags);
 
     _libssh2_wincng_safe_free(hash, hashlen);
     _libssh2_wincng_safe_free(data, datalen);
@@ -1219,8 +1219,10 @@ _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                                 const unsigned char *m,
                                 size_t m_len)
 {
-    return _libssh2_wincng_key_sha_verify(rsa, SHA_DIGEST_LENGTH, sig, sig_len,
-                                          m, m_len, BCRYPT_PAD_PKCS1);
+    return _libssh2_wincng_key_sha_verify(rsa, SHA_DIGEST_LENGTH,
+                                          sig, (unsigned long)sig_len,
+                                          m, (unsigned long)m_len,
+                                          BCRYPT_PAD_PKCS1);
 }
 
 int
@@ -1231,8 +1233,10 @@ _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx* rsa,
                                 const unsigned char *m,
                                 size_t m_len)
 {
-    return _libssh2_wincng_key_sha_verify(rsa, hash_len, sig, sig_len, m,
-                                          m_len, BCRYPT_PAD_PKCS1);
+    return _libssh2_wincng_key_sha_verify(rsa, (unsigned long)hash_len,
+                                          sig, (unsigned long)sig_len,
+                                          m, (unsigned long)m_len,
+                                          BCRYPT_PAD_PKCS1);
 }
 
 int

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -855,16 +855,17 @@ _libssh2_wincng_asn_decode_bn(unsigned char *pbEncoded,
                               unsigned char **ppbDecoded,
                               unsigned long *pcbDecoded)
 {
-    unsigned char *pbDecoded = NULL, *pbInteger;
+    unsigned char *pbDecoded = NULL;
+    PCRYPT_DATA_BLOB pbInteger;
     unsigned long cbDecoded = 0, cbInteger;
     int ret;
 
     ret = _libssh2_wincng_asn_decode(pbEncoded, cbEncoded,
                                      X509_MULTI_BYTE_UINT,
-                                     &pbInteger, &cbInteger);
+                                     (void *)&pbInteger, &cbInteger);
     if(!ret) {
-        ret = _libssh2_wincng_bn_ltob(((PCRYPT_DATA_BLOB)pbInteger)->pbData,
-                                      ((PCRYPT_DATA_BLOB)pbInteger)->cbData,
+        ret = _libssh2_wincng_bn_ltob(pbInteger->pbData,
+                                      pbInteger->cbData,
                                       &pbDecoded, &cbDecoded);
         if(!ret) {
             *ppbDecoded = pbDecoded;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1215,9 +1215,9 @@ _libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
 int
 _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                                 const unsigned char *sig,
-                                unsigned long sig_len,
+                                size_t sig_len,
                                 const unsigned char *m,
-                                unsigned long m_len)
+                                size_t m_len)
 {
     return _libssh2_wincng_key_sha_verify(rsa, SHA_DIGEST_LENGTH, sig, sig_len,
                                           m, m_len, BCRYPT_PAD_PKCS1);
@@ -1227,9 +1227,9 @@ int
 _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx* rsa,
                                 size_t hash_len,
                                 const unsigned char *sig,
-                                unsigned long sig_len,
+                                size_t sig_len,
                                 const unsigned char *m,
-                                unsigned long m_len)
+                                size_t m_len)
 {
     return _libssh2_wincng_key_sha_verify(rsa, hash_len, sig, sig_len, m,
                                           m_len, BCRYPT_PAD_PKCS1);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -886,7 +886,7 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
 {
     PCRYPT_DER_BLOB pBlob;
     unsigned char **rpbDecoded;
-    PCRYPT_DATA_BLOB pbDecoded;
+    PCRYPT_SEQUENCE_OF_ANY pbDecoded;
     unsigned long cbDecoded, *rcbDecoded, index, length;
     int ret;
 
@@ -894,14 +894,14 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
                                      X509_SEQUENCE_OF_ANY,
                                      (void *)&pbDecoded, &cbDecoded);
     if(!ret) {
-        length = pbDecoded->cbData;
+        length = pbDecoded->cValue;
 
         rpbDecoded = malloc(sizeof(PBYTE) * length);
         if(rpbDecoded) {
             rcbDecoded = malloc(sizeof(DWORD) * length);
             if(rcbDecoded) {
                 for(index = 0; index < length; index++) {
-                    pBlob = &((PCRYPT_DER_BLOB)(pbDecoded)->pbData)[index];
+                    pBlob = &pbDecoded->rgValue[index];
                     ret = _libssh2_wincng_asn_decode_bn(pBlob->pbData,
                                                         pBlob->cbData,
                                                         &rpbDecoded[index],

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -219,18 +219,22 @@ typedef struct __libssh2_wincng_hash_ctx {
 #define libssh2_hmac_ctx_init(ctx)
 #define libssh2_hmac_sha1_init(ctx, key, keylen) \
   _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacSHA1, \
-                            SHA_DIGEST_LENGTH, key, keylen)
+                            SHA_DIGEST_LENGTH, \
+                            key, (unsigned long) keylen)
 #define libssh2_hmac_md5_init(ctx, key, keylen) \
   _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacMD5, \
-                            MD5_DIGEST_LENGTH, key, keylen)
+                            MD5_DIGEST_LENGTH, \
+                            key, (unsigned long) keylen)
 #define libssh2_hmac_ripemd160_init(ctx, key, keylen)
   /* not implemented */
 #define libssh2_hmac_sha256_init(ctx, key, keylen) \
   _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacSHA256, \
-                            SHA256_DIGEST_LENGTH, key, keylen)
+                            SHA256_DIGEST_LENGTH, \
+                            key, (unsigned long) keylen)
 #define libssh2_hmac_sha512_init(ctx, key, keylen) \
   _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacSHA512, \
-                            SHA512_DIGEST_LENGTH, key, keylen)
+                            SHA512_DIGEST_LENGTH, \
+                            key, (unsigned long) keylen)
 #define libssh2_hmac_update(ctx, data, datalen) \
   _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, \
                                     (unsigned long) datalen)

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -251,7 +251,7 @@ typedef struct __libssh2_wincng_hash_ctx {
 
 typedef struct __libssh2_wincng_key_ctx {
     BCRYPT_KEY_HANDLE hKey;
-    unsigned char *pbKeyObject;
+    void *pbKeyObject;
     unsigned long cbKeyObject;
 } _libssh2_wincng_key_ctx;
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -546,7 +546,7 @@ int
 _libssh2_wincng_dsa_sha1_verify(libssh2_dsa_ctx *dsa,
                                 const unsigned char *sig_fixed,
                                 const unsigned char *m,
-                                unsigned long m_len);
+                                size_t m_len);
 int
 _libssh2_wincng_dsa_sha1_sign(libssh2_dsa_ctx *dsa,
                               const unsigned char *hash,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -445,7 +445,7 @@ typedef struct {
  */
 void _libssh2_wincng_init(void);
 void _libssh2_wincng_free(void);
-int _libssh2_wincng_random(void *buf, int len);
+int _libssh2_wincng_random(void *buf, size_t len);
 
 int
 _libssh2_wincng_hash_init(_libssh2_wincng_hash_ctx *ctx,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -505,9 +505,9 @@ _libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
 int
 _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                                 const unsigned char *sig,
-                                unsigned long sig_len,
+                                size_t sig_len,
                                 const unsigned char *m,
-                                unsigned long m_len);
+                                size_t m_len);
 int
 _libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
                               libssh2_rsa_ctx *rsa,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -148,10 +148,11 @@ typedef struct __libssh2_wincng_hash_ctx {
 
 #define libssh2_sha1_ctx _libssh2_wincng_hash_ctx
 #define libssh2_sha1_init(ctx) \
-  (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashSHA1, \
+ (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashSHA1, \
                             SHA_DIGEST_LENGTH, NULL, 0) == 0)
 #define libssh2_sha1_update(ctx, data, datalen) \
-  _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, datalen)
+  _libssh2_wincng_hash_update(&ctx, (const unsigned char *) data, \
+                                    (unsigned long) datalen)
 #define libssh2_sha1_final(ctx, hash) \
   _libssh2_wincng_hash_final(&ctx, hash)
 #define libssh2_sha1(data, datalen, hash) \
@@ -160,32 +161,37 @@ typedef struct __libssh2_wincng_hash_ctx {
 
 #define libssh2_sha256_ctx _libssh2_wincng_hash_ctx
 #define libssh2_sha256_init(ctx) \
-  (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashSHA256, \
+ (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashSHA256, \
                             SHA256_DIGEST_LENGTH, NULL, 0) == 0)
 #define libssh2_sha256_update(ctx, data, datalen) \
-  _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, datalen)
+  _libssh2_wincng_hash_update(&ctx, (const unsigned char *) data, \
+                                    (unsigned long) datalen)
 #define libssh2_sha256_final(ctx, hash) \
   _libssh2_wincng_hash_final(&ctx, hash)
 #define libssh2_sha256(data, datalen, hash) \
   _libssh2_wincng_hash(data, datalen, _libssh2_wincng.hAlgHashSHA256, \
                        hash, SHA256_DIGEST_LENGTH)
+
 #define libssh2_sha384_ctx _libssh2_wincng_hash_ctx
 #define libssh2_sha384_init(ctx) \
  (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashSHA384, \
-                           SHA384_DIGEST_LENGTH, NULL, 0) == 0)
+                            SHA384_DIGEST_LENGTH, NULL, 0) == 0)
 #define libssh2_sha384_update(ctx, data, datalen) \
- _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, datalen)
+  _libssh2_wincng_hash_update(&ctx, (const unsigned char *) data, \
+                                    (unsigned long) datalen)
 #define libssh2_sha384_final(ctx, hash) \
- _libssh2_wincng_hash_final(&ctx, hash)
+  _libssh2_wincng_hash_final(&ctx, hash)
 #define libssh2_sha384(data, datalen, hash) \
-_libssh2_wincng_hash(data, datalen, _libssh2_wincng.hAlgHashSHA384, \
-                     hash, SHA384_DIGEST_LENGTH)
+  _libssh2_wincng_hash(data, datalen, _libssh2_wincng.hAlgHashSHA384, \
+                       hash, SHA384_DIGEST_LENGTH)
+
 #define libssh2_sha512_ctx _libssh2_wincng_hash_ctx
 #define libssh2_sha512_init(ctx) \
-  (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashSHA512, \
+ (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashSHA512, \
                             SHA512_DIGEST_LENGTH, NULL, 0) == 0)
 #define libssh2_sha512_update(ctx, data, datalen) \
-  _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, datalen)
+  _libssh2_wincng_hash_update(&ctx, (const unsigned char *) data, \
+                                    (unsigned long) datalen)
 #define libssh2_sha512_final(ctx, hash) \
   _libssh2_wincng_hash_final(&ctx, hash)
 #define libssh2_sha512(data, datalen, hash) \
@@ -194,10 +200,11 @@ _libssh2_wincng_hash(data, datalen, _libssh2_wincng.hAlgHashSHA384, \
 
 #define libssh2_md5_ctx _libssh2_wincng_hash_ctx
 #define libssh2_md5_init(ctx) \
-  (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashMD5, \
+ (_libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHashMD5, \
                             MD5_DIGEST_LENGTH, NULL, 0) == 0)
 #define libssh2_md5_update(ctx, data, datalen) \
-  _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, datalen)
+  _libssh2_wincng_hash_update(&ctx, (const unsigned char *) data, \
+                                    (unsigned long) datalen)
 #define libssh2_md5_final(ctx, hash) \
   _libssh2_wincng_hash_final(&ctx, hash)
 #define libssh2_md5(data, datalen, hash) \
@@ -225,7 +232,8 @@ _libssh2_wincng_hash(data, datalen, _libssh2_wincng.hAlgHashSHA384, \
   _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacSHA512, \
                             SHA512_DIGEST_LENGTH, key, keylen)
 #define libssh2_hmac_update(ctx, data, datalen) \
-  _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, datalen)
+  _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, \
+                                    (unsigned long) datalen)
 #define libssh2_hmac_final(ctx, hash) \
   _libssh2_wincng_hmac_final(&ctx, hash)
 #define libssh2_hmac_cleanup(ctx) \
@@ -396,7 +404,7 @@ _libssh2_bn *_libssh2_wincng_bignum_init(void);
 #define _libssh2_bn_set_word(bn, word) \
   _libssh2_wincng_bignum_set_word(bn, word)
 #define _libssh2_bn_from_bin(bn, len, bin) \
-  _libssh2_wincng_bignum_from_bin(bn, len, bin)
+  _libssh2_wincng_bignum_from_bin(bn, (unsigned long) len, bin)
 #define _libssh2_bn_to_bin(bn, bin) \
   _libssh2_wincng_bignum_to_bin(bn, bin)
 #define _libssh2_bn_bytes(bn) bn->length

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -236,7 +236,7 @@ typedef struct __libssh2_wincng_hash_ctx {
                             SHA512_DIGEST_LENGTH, \
                             key, (unsigned long) keylen)
 #define libssh2_hmac_update(ctx, data, datalen) \
-  _libssh2_wincng_hash_update(&ctx, (unsigned char *) data, \
+  _libssh2_wincng_hash_update(&ctx, (const unsigned char *) data, \
                                     (unsigned long) datalen)
 #define libssh2_hmac_final(ctx, hash) \
   _libssh2_wincng_hmac_final(&ctx, hash)

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -466,7 +466,7 @@ _libssh2_wincng_hmac_cleanup(_libssh2_wincng_hash_ctx *ctx);
 
 int
 _libssh2_wincng_key_sha_verify(_libssh2_wincng_key_ctx *ctx,
-                                size_t hashlen,
+                                unsigned long hashlen,
                                 const unsigned char *sig,
                                 unsigned long sig_len,
                                 const unsigned char *m,


### PR DESCRIPTION
Bring down C compiler warnings (as seen in CI and local builds) from around 400 to zero.

To reach this: add casts, adjust (mostly extending) types, add missing declarations, stop reusing variables, add a few size checks, add FIXMEs where type extension to a public API would be useful, adjusted platform guards and printfs masks, simplify `_libssh2_ntohu64()`, rework WinCNG Win32 interfaces with alignment warnings.

Also:
- set `ENABLE_WERROR` in CMake CI builds.

Pending:
- [x] Close this without merging once #876, #877, #878, #879, #880 were merged.
- [x] Delete public header changes in favour of #862
- [x] Delete example/tests changes in favour of #861
- [x] WinCNG alignment [warnings](https://github.com/libssh2/libssh2/pull/846#issuecomment-1474805261).
- [x] Rebase on: `_libssh2_dh_secret()` memory leak fix → #858
- [x] Rebase on: #857
  - `ENABLE_WERROR=ON` seems to enable this for feature tests, causing `Performing Test HAVE_O_NONBLOCK - Failed` on Linux.
  - `ENABLE_WERROR=ON` breaks detection of `HAVE_IOCTLSOCKET` on Windows.
  - Rebase on: `ENABLE_WERROR=ON` breaks detection of `strtoll`, `_strtoi64`, `snprintf`, `_stricmp` on Windows with MSVC.
  - Rebase on: Use `cmake_push_check_state()` in `src/CMakeLists.txt` in place of `SAVE_*` methods (2x).
  - Rebase on: example: Replace `strcasecmp()` with `strcmp()` or other method, and delete detection logic.
  - Rebase on: example: Replace a single `__func__` with the function name, and delete detection logic.
