### PR TITLE
Update instructions for building with Autotools

### DIFF
--- a/docs/INSTALL_AUTOTOOLS
+++ b/docs/INSTALL_AUTOTOOLS
@@ -11,8 +11,7 @@ When Building directly from Master
 ==================================
 
 If you want to build directly from the git repository, you must first
-generate the configure script and Makefile using autotools. There is
-a convenience script that calls all tools in the correct order. Make
+generate the configure script and Makefile using autotools. Make
 sure that autoconf, automake and libtool are installed on your system,
 then execute:
 


### PR DESCRIPTION
The "convenience script" mentioned in the file is the "buildconf" file, which is no longer recommended.