### PR TITLE
src: check for NULL pointer passed to _libssh2_get_string

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -834,7 +834,7 @@ int _libssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
                         size_t *outlen)
 {
     uint32_t data_len;
-    if(_libssh2_get_u32(buf, &data_len) != 0) {
+    if(!buf || _libssh2_get_u32(buf, &data_len) != 0) {
         return -1;
     }
     if(!_libssh2_check_length(buf, data_len)) {


### PR DESCRIPTION
Callers should be protecting against this, but it's prudent to check
here anyway.

Fixes #802
Closes #848