### PR TITLE
appveyor.yml: reorder tests to return relevant feedback earlier

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,19 +33,9 @@ environment:
       BUILD_SHARED_LIBS: ON
       CRYPTO_BACKEND: "OpenSSL"
 
-    - job_name: "VS2015, OpenSSL, Static"
-      GENERATOR: "Visual Studio 14 2015"
-      BUILD_SHARED_LIBS: OFF
-      CRYPTO_BACKEND: "OpenSSL"
-
     - job_name: "VS2013, OpenSSL, Shared"
       GENERATOR: "Visual Studio 12 2013"
       BUILD_SHARED_LIBS: ON
-      CRYPTO_BACKEND: "OpenSSL"
-
-    - job_name: "VS2013, OpenSSL, Static"
-      GENERATOR: "Visual Studio 12 2013"
-      BUILD_SHARED_LIBS: OFF
       CRYPTO_BACKEND: "OpenSSL"
 
     - job_name: "VS2015, WinCNG, Shared"
@@ -53,14 +43,24 @@ environment:
       BUILD_SHARED_LIBS: ON
       CRYPTO_BACKEND: "WinCNG"
 
-    - job_name: "VS2015, WinCNG, Static"
-      GENERATOR: "Visual Studio 14 2015"
-      BUILD_SHARED_LIBS: OFF
-      CRYPTO_BACKEND: "WinCNG"
-
     - job_name: "VS2013, WinCNG, Shared"
       GENERATOR: "Visual Studio 12 2013"
       BUILD_SHARED_LIBS: ON
+      CRYPTO_BACKEND: "WinCNG"
+
+    - job_name: "VS2015, OpenSSL, Static"
+      GENERATOR: "Visual Studio 14 2015"
+      BUILD_SHARED_LIBS: OFF
+      CRYPTO_BACKEND: "OpenSSL"
+
+    - job_name: "VS2013, OpenSSL, Static"
+      GENERATOR: "Visual Studio 12 2013"
+      BUILD_SHARED_LIBS: OFF
+      CRYPTO_BACKEND: "OpenSSL"
+
+    - job_name: "VS2015, WinCNG, Static"
+      GENERATOR: "Visual Studio 14 2015"
+      BUILD_SHARED_LIBS: OFF
       CRYPTO_BACKEND: "WinCNG"
 
     - job_name: "VS2013, WinCNG, Static"
@@ -69,8 +69,8 @@ environment:
       CRYPTO_BACKEND: "WinCNG"
 
 platform:
-  - x86
   - x64
+  - x86
 
 configuration:
 # - Debug
@@ -78,9 +78,6 @@ configuration:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - GENERATOR: "Visual Studio 9 2008"
-      platform: x64
 
 install:
   # prepare local SSH server for reverse tunneling from GitHub Actions hosting our docker container


### PR DESCRIPTION
- build x64 first

  x64 is the more interesting target. Most type conversion issues are revealed here. Also more commonly used by now.

- test VS 2013 earlier

- test WinCNG earlier

- delete reference to no longer used VS 2008

After this patch we end up starting with all Shared builds (2015, 2013, OpenSSL, WinCNG), then continue with Static ones. Shared/Static makes a minor if any difference in builds/tests compared to different VS versions of TLS backends.

--

CI run times:

Preparation + build takes:
8 x VS2015 4.5 mins -> total: 36
8 x VS2013 2   mins -> total: 16
Total: 52 mins

with our 30 tests, it increases to:
8 x VS2015 8-10 mins -> total: 72
8 x VS2013 6- 9 mins -> total: 60
Total: 132 mins

Without tests: https://ci.appveyor.com/project/libssh2org/libssh2/builds/46475315
With    tests: https://ci.appveyor.com/project/libssh2org/libssh2/builds/46480549