### PR TITLE
ci: more timeout adjustments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           make
           make check
       - name: Build with CMake
+        timeout-minutes: 10
         if: ${{ matrix.b == 'cmake' }}
         run: |
           mkdir bin
@@ -91,7 +92,7 @@ jobs:
           cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
           cmake --build .
           export OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:../tests/openssh_server)
-          ctest -VV --output-on-failure --timeout 450
+          ctest -VV --output-on-failure
           cmake --build . --target package
 
   build_msys2:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,7 +95,8 @@ before_test:
   - appveyor-retry choco install -y --no-progress --limit-output --timeout 180 docker-cli
   - ps: |
       Write-Host "Waiting for SSH connection from GitHub Actions" -NoNewline
-      while((Get-Process -Name "sshd" -ErrorAction SilentlyContinue).Count -eq 1) {
+      $endDate = (Get-Date).AddMinutes(2)
+      while((Get-Process -Name "sshd" -ErrorAction SilentlyContinue).Count -eq 1 -and (Get-Date) -lt $endDate) {
         Write-Host "." -NoNewline
         Start-Sleep -Seconds 1
       }


### PR DESCRIPTION
- add timeout to SSH connection wait loop in AppVeyor test prep. (2 minutes)

- switch to per-step timeout for GitHub CI cmake/ctest runs. (10 minutes)

  ctest timeout (of 450 seconds) didn't seem to make any difference.
