### PR TITLE
build: improve a test build workaround with bcrypt

### DIFF
--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -100,7 +100,7 @@ bcrypt_hash(uint8_t *sha2pass, uint8_t *sha2salt, uint8_t *out)
     _libssh2_explicit_zero(&state, sizeof(state));
 }
 
-int
+static int
 bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
              size_t saltlen,
              uint8_t *key, size_t keylen, unsigned int rounds)

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -15,10 +15,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "libssh2_priv.h"
 
 #ifndef HAVE_BCRYPT_PBKDF
 
-#include "libssh2_priv.h"
 #include <stdlib.h>
 #include <sys/types.h>
 #ifdef HAVE_SYS_PARAM_H
@@ -181,3 +181,22 @@ bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
     return 0;
 }
 #endif /* HAVE_BCRYPT_PBKDF */
+
+/* Wrapper */
+
+int _libssh2_bcrypt_pbkdf(const char *pass,
+                          size_t passlen,
+                          const uint8_t *salt,
+                          size_t saltlen,
+                          uint8_t *key,
+                          size_t keylen,
+                          unsigned int rounds)
+{
+    return bcrypt_pbkdf(pass,
+                        passlen,
+                        salt,
+                        saltlen,
+                        key,
+                        keylen,
+                        rounds);
+}

--- a/src/blf.h
+++ b/src/blf.h
@@ -77,10 +77,5 @@ void blf_cbc_decrypt(blf_ctx *, uint8_t *, uint8_t *, uint32_t);
 /* Converts uint8_t to uint32_t */
 uint32_t Blowfish_stream2word(const uint8_t *, uint16_t, uint16_t *);
 
-/* bcrypt with pbkd */
-int bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
-                 size_t saltlen,
-                 uint8_t *key, size_t keylen, unsigned int rounds);
-
 #endif /* !defined(HAVE_BCRYPT_PBKDF) && !defined(HAVE_BLH_H) */
 #endif /* __LIBSSH2_BLF_H */

--- a/src/misc.c
+++ b/src/misc.c
@@ -39,7 +39,6 @@
 
 #include "libssh2_priv.h"
 #include "misc.h"
-#include "blf.h"
 
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
@@ -926,24 +925,4 @@ int _libssh2_eob(struct string_buf *buf)
 {
     unsigned char *endp = &buf->data[buf->len];
     return buf->dataptr >= endp;
-}
-
-/* Wrappers */
-
-int _libssh2_bcrypt_pbkdf(const char *pass,
-                          size_t passlen,
-                          const uint8_t *salt,
-                          size_t saltlen,
-                          uint8_t *key,
-                          size_t keylen,
-                          unsigned int rounds)
-{
-    /* defined in bcrypt_pbkdf.c */
-    return bcrypt_pbkdf(pass,
-                        passlen,
-                        salt,
-                        saltlen,
-                        key,
-                        keylen,
-                        rounds);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -232,7 +232,6 @@ endforeach()
 if(WIN32 AND BUILD_SHARED_LIBS)
   # Workaround for platforms not exporting internal functions from libssh2 shared lib
   add_executable(test_keyboard_interactive_auth_info_request test_keyboard_interactive_auth_info_request.c ../src/userauth_kbd_packet.c ../src/misc.c)
-  target_compile_definitions(test_keyboard_interactive_auth_info_request PRIVATE USE_BCRYPT_STUB)
 else()
   add_executable(test_keyboard_interactive_auth_info_request test_keyboard_interactive_auth_info_request.c ../src/userauth_kbd_packet.c)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -230,8 +230,9 @@ foreach(test ${TESTS})
 endforeach()
 
 if(WIN32 AND BUILD_SHARED_LIBS)
-  # Workaround for Visual Studio
+  # Workaround for platforms not exporting internal functions from libssh2 shared lib
   add_executable(test_keyboard_interactive_auth_info_request test_keyboard_interactive_auth_info_request.c ../src/userauth_kbd_packet.c ../src/misc.c)
+  target_compile_definitions(test_keyboard_interactive_auth_info_request PRIVATE USE_BCRYPT_STUB)
 else()
   add_executable(test_keyboard_interactive_auth_info_request test_keyboard_interactive_auth_info_request.c ../src/userauth_kbd_packet.c)
 endif()

--- a/tests/test_keyboard_interactive_auth_info_request.c
+++ b/tests/test_keyboard_interactive_auth_info_request.c
@@ -315,27 +315,3 @@ int main(void)
 
     return 0;
 }
-
-/* Provide stub to not require this internal function from libssh2 */
-#ifdef USE_BCRYPT_STUB
-int
-bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
-             size_t saltlen,
-             uint8_t *key, size_t keylen, unsigned int rounds);
-
-int
-bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
-             size_t saltlen,
-             uint8_t *key, size_t keylen, unsigned int rounds)
-{
-    (void)pass;
-    (void)passlen;
-    (void)salt;
-    (void)saltlen;
-    (void)key;
-    (void)keylen;
-    (void)rounds;
-
-    return -1;
-}
-#endif

--- a/tests/test_keyboard_interactive_auth_info_request.c
+++ b/tests/test_keyboard_interactive_auth_info_request.c
@@ -316,8 +316,13 @@ int main(void)
     return 0;
 }
 
-/* Workaround for Visual Studio */
-#ifdef _MSC_VER
+/* Provide stub to not require this internal function from libssh2 */
+#ifdef USE_BCRYPT_STUB
+int
+bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
+             size_t saltlen,
+             uint8_t *key, size_t keylen, unsigned int rounds);
+
 int
 bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
              size_t saltlen,


### PR DESCRIPTION
- cmake: extend workaround for linking a test with shared libssh2.

  One of the tests uses internal libssh2 functions, and with CMake it
  compiles `src/misc.c` directly for this. `misc.c` references bcrypt /
  blowfish code. This needs a workaround for build configs where libssh2
  doesn't export these.

  Before this patch, we enabled this workaround for MSVC.

  In the patch we extend this to all Windows. There is no CI test for
  this, but gcc and llvm/clang + mingw64 builds also need it. This may
  well apply to other configurations (it should, as shared libs are not
  supposed to export internal functions), so also make it easy to enable
  it at a single point.

  [ autotools builds force-link this one test against static libssh2. ]

- make `misc.c` not depend on bcrypt.

  By moving out our `bcrypt_pbkdf()` wrapper into `bcrypt_pbkdf.c`
  itself.

  This allows to compile `misc.c` into tests without pulling in bcrypt /
  blowfish functions, and simplify the above workaround.

  Source code uses `HAVE_BCRYPT_PBKDF`, a leftover from original bcrypt
  source. We never define this inside libssh2. Defining it breaks the
  build, and this patch doesn't change that.

- make `bcrypt_pbkdf()` static.

  While here, make the low-level `bcrypt_pbkdf()` function static to
  avoid namespace pollution.

Closes #855
