### PR TITLE
cmake: fix `ENABLE_WERROR=ON` breaking auto-detections

### DIFF
--- a/cmake/CheckNonblockingSocketSupport.cmake
+++ b/cmake/CheckNonblockingSocketSupport.cmake
@@ -47,10 +47,10 @@ macro(check_nonblocking_socket_support)
 #error \"O_NONBLOCK does not work on this platform\"
 #endif
 
-int main()
+int main(void)
 {
-    int socket;
-    int flags = fcntl(socket, F_SETFL, flags | O_NONBLOCK);
+    int socket = 0;
+    (void)fcntl(socket, F_SETFL, O_NONBLOCK);
 }"
   HAVE_O_NONBLOCK)
 
@@ -59,10 +59,11 @@ int main()
 #include <unistd.h>
 #include <stropts.h>
 
-int main()
+int main(void)
 {
-    int socket;
-    int flags = ioctl(socket, FIONBIO, &flags);
+    int socket = 0;
+    int flags = 0;
+    (void)ioctl(socket, FIONBIO, &flags);
 }"
     HAVE_FIONBIO)
 
@@ -76,12 +77,11 @@ int main()
 #include <windows.h>
 #include <winsock2.h>
 
-int main()
+int main(void)
 {
-    SOCKET sd;
+    SOCKET sd = socket(0, 0, 0);
     unsigned long flags = 0;
-    sd = socket(0, 0, 0);
-    ioctlsocket(sd, FIONBIO, &flags);
+    (void)ioctlsocket(sd, FIONBIO, &flags);
 }"
       HAVE_IOCTLSOCKET)
 
@@ -89,10 +89,10 @@ int main()
         check_c_source_compiles("/* IoctlSocket test (Amiga?) */
 #include <sys/ioctl.h>
 
-int main()
+int main(void)
 {
-    int socket;
-    int flags = IoctlSocket(socket, FIONBIO, (long)1);
+    int socket = 0;
+    (void)IoctlSocket(socket, FIONBIO, (long)1);
 }"
         HAVE_IOCTLSOCKET_CASE)
 
@@ -100,11 +100,11 @@ int main()
           check_c_source_compiles("/* SO_NONBLOCK test (BeOS) */
 #include <socket.h>
 
-int main()
+int main(void)
 {
     long b = 1;
-    int socket;
-    int flags = setsockopt(socket, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
+    int socket = 0;
+    (void)setsockopt(socket, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 }"
           HAVE_SO_NONBLOCK)
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -90,9 +90,6 @@ check_include_files(winsock2.h HAVE_WINSOCK2_H)
 check_symbol_exists(strcasecmp strings.h HAVE_STRCASECMP)
 check_symbol_exists(_stricmp string.h HAVE__STRICMP)
 
-check_symbol_exists(__func__ "" HAVE___FUNC__)
-check_symbol_exists(__FUNCTION__ "" HAVE___FUNCTION__)
-
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/libssh2_config_cmake.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/libssh2_config.h)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -34,7 +34,6 @@
 # OF SUCH DAMAGE.
 
 include(CheckIncludeFiles)
-include(CheckSymbolExists)
 include(CopyRuntimeDependencies)
 
 set(EXAMPLES
@@ -86,9 +85,6 @@ check_include_files(sys/time.h HAVE_SYS_TIME_H)
 check_include_files(arpa/inet.h HAVE_ARPA_INET_H)
 check_include_files(netinet/in.h HAVE_NETINET_IN_H)
 check_include_files(winsock2.h HAVE_WINSOCK2_H)
-
-check_symbol_exists(strcasecmp strings.h HAVE_STRCASECMP)
-check_symbol_exists(_stricmp string.h HAVE__STRICMP)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/libssh2_config_cmake.h.in

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -170,9 +170,9 @@ int main(int argc, char *argv[])
 
     /* check for options */
     if(argc > 8) {
-        if((auth & AUTH_PASSWORD) && !strcasecmp(argv[8], "-p"))
+        if((auth & AUTH_PASSWORD) && !strcmp(argv[8], "-p"))
             auth = AUTH_PASSWORD;
-        if((auth & AUTH_PUBLICKEY) && !strcasecmp(argv[8], "-k"))
+        if((auth & AUTH_PUBLICKEY) && !strcmp(argv[8], "-k"))
             auth = AUTH_PUBLICKEY;
     }
 

--- a/example/libssh2_config_cmake.h.in
+++ b/example/libssh2_config_cmake.h.in
@@ -56,15 +56,3 @@
 # define HAVE_STRCASECMP
 # endif
 #endif
-
-/* Symbols */
-#cmakedefine HAVE___FUNC__
-#cmakedefine HAVE___FUNCTION__
-
-/* Workaround for platforms without C90 __func__ */
-#ifndef HAVE___FUNC__
-# ifdef HAVE___FUNCTION__
-# define __func__ __FUNCTION__
-# define HAVE___FUNC__
-# endif
-#endif

--- a/example/libssh2_config_cmake.h.in
+++ b/example/libssh2_config_cmake.h.in
@@ -44,15 +44,3 @@
 #cmakedefine HAVE_ARPA_INET_H
 #cmakedefine HAVE_NETINET_IN_H
 #cmakedefine HAVE_WINSOCK2_H
-
-/* Functions */
-#cmakedefine HAVE_STRCASECMP
-#cmakedefine HAVE__STRICMP
-
-/* Workaround for platforms without POSIX strcasecmp (e.g. Windows) */
-#ifndef HAVE_STRCASECMP
-# ifdef HAVE__STRICMP
-# define strcasecmp _stricmp
-# define HAVE_STRCASECMP
-# endif
-#endif

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -209,13 +209,13 @@ int main(int argc, char *argv[])
 
     /* if we got an 4. argument we set this option if supported */
     if(argc > 5) {
-        if((auth_pw & 1) && !strcasecmp(argv[5], "-p")) {
+        if((auth_pw & 1) && !strcmp(argv[5], "-p")) {
             auth_pw = 1;
         }
-        if((auth_pw & 2) && !strcasecmp(argv[5], "-i")) {
+        if((auth_pw & 2) && !strcmp(argv[5], "-i")) {
             auth_pw = 2;
         }
-        if((auth_pw & 4) && !strcasecmp(argv[5], "-k")) {
+        if((auth_pw & 4) && !strcmp(argv[5], "-k")) {
             auth_pw = 4;
         }
     }

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -180,13 +180,13 @@ int main(int argc, char *argv[])
 
     /* if we got an 5. argument we set this option if supported */
     if(argc > 5) {
-        if((auth_pw & 1) && !strcasecmp(argv[5], "-p")) {
+        if((auth_pw & 1) && !strcmp(argv[5], "-p")) {
             auth_pw = 1;
         }
-        if((auth_pw & 2) && !strcasecmp(argv[5], "-i")) {
+        if((auth_pw & 2) && !strcmp(argv[5], "-i")) {
             auth_pw = 2;
         }
-        if((auth_pw & 4) && !strcasecmp(argv[5], "-k")) {
+        if((auth_pw & 4) && !strcmp(argv[5], "-k")) {
             auth_pw = 4;
         }
     }

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -185,13 +185,13 @@ int main(int argc, char *argv[])
 
     /* if we got an 4. argument we set this option if supported */
     if(argc > 4) {
-        if((auth_pw & 1) && !strcasecmp(argv[4], "-p")) {
+        if((auth_pw & 1) && !strcmp(argv[4], "-p")) {
             auth_pw = 1;
         }
-        if((auth_pw & 2) && !strcasecmp(argv[4], "-i")) {
+        if((auth_pw & 2) && !strcmp(argv[4], "-i")) {
             auth_pw = 2;
         }
-        if((auth_pw & 4) && !strcasecmp(argv[4], "-k")) {
+        if((auth_pw & 4) && !strcmp(argv[4], "-k")) {
             auth_pw = 4;
         }
     }

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -102,8 +102,8 @@ static int netconf_read_until(LIBSSH2_CHANNEL *channel, const char *endtag,
     } while(!specialsequence && rd < buflen);
 
     if(!specialsequence) {
-        fprintf(stderr, "%s: ]]>]]> not found! read buffer too small?\n",
-                __func__);
+        fprintf(stderr, "netconf_read_until(): ]]>]]> not found!"
+                        " read buffer too small?\n");
         return -1;
     }
 

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -211,9 +211,9 @@ int main(int argc, char *argv[])
 
     /* check for options */
     if(argc > 4) {
-        if((auth & AUTH_PASSWORD) && !strcasecmp(argv[4], "-p"))
+        if((auth & AUTH_PASSWORD) && !strcmp(argv[4], "-p"))
             auth = AUTH_PASSWORD;
-        if((auth & AUTH_PUBLICKEY) && !strcasecmp(argv[4], "-k"))
+        if((auth & AUTH_PUBLICKEY) && !strcmp(argv[4], "-k"))
             auth = AUTH_PUBLICKEY;
     }
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -166,9 +166,9 @@ int main(int argc, char *argv[])
 
     /* check for options */
     if(argc > 8) {
-        if((auth & AUTH_PASSWORD) && !strcasecmp(argv[8], "-p"))
+        if((auth & AUTH_PASSWORD) && !strcmp(argv[8], "-p"))
             auth = AUTH_PASSWORD;
-        if((auth & AUTH_PUBLICKEY) && !strcasecmp(argv[8], "-k"))
+        if((auth & AUTH_PUBLICKEY) && !strcmp(argv[8], "-k"))
             auth = AUTH_PUBLICKEY;
     }
 

--- a/nw/GNUmakefile
+++ b/nw/GNUmakefile
@@ -392,11 +392,8 @@ libssh2_config.h: GNUmakefile
 ifeq ($(LIBARCH),CLIB)
 	@echo $(DL)#define OS "i586-pc-clib-NetWare"$(DL) >> $@
 	@echo $(DL)#define NETDB_USE_INTERNET 1$(DL) >> $@
-	@echo $(DL)#define HAVE_STRICMP 1$(DL) >> $@
 	@echo $(DL)#define socklen_t int$(DL) >> $@
 	@echo $(DL)#define sleep(s) delay(1000 * s)$(DL) >> $@
-	@echo $(DL)#define strcasecmp stricmp$(DL) >> $@
-	@echo $(DL)#define strncasecmp strnicmp$(DL) >> $@
 else
 	@echo $(DL)#define OS "i586-pc-libc-NetWare"$(DL) >> $@
 	@echo $(DL)#define HAVE_DLFCN_H 1$(DL) >> $@
@@ -408,7 +405,6 @@ else
 	@echo $(DL)#define HAVE_LIMITS_H 1$(DL) >> $@
 	@echo $(DL)#define HAVE_LONGLONG 1$(DL) >> $@
 	@echo $(DL)#define HAVE_STDINT_H 1$(DL) >> $@
-	@echo $(DL)#define HAVE_STRCASECMP 1$(DL) >> $@
 	@echo $(DL)#define HAVE_STRLCAT 1$(DL) >> $@
 	@echo $(DL)#define HAVE_STRLCPY 1$(DL) >> $@
 	@echo $(DL)#define HAVE_STRTOLL 1$(DL) >> $@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ include(CheckIncludeFiles)
 include(CheckTypeSize)
 include(CheckSymbolExists)
 include(CheckNonblockingSocketSupport)
+include(CMakePushCheckState)
 
 ## Cryptography backend choice
 
@@ -102,14 +103,14 @@ if(CRYPTO_BACKEND STREQUAL "OpenSSL" OR NOT CRYPTO_BACKEND)
     endif()
 
     # Not all OpenSSL have AES-CTR functions.
-    set(SAVE_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+    cmake_push_check_state()
     set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES})
     if(WIN32)
       # For OpenSSL and LibreSSL
       set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}" "ws2_32" "bcrypt")
     endif()
     check_function_exists(EVP_aes_128_ctr HAVE_EVP_AES_128_CTR)
-    set(CMAKE_REQUIRED_LIBRARIES ${SAVE_CMAKE_REQUIRED_LIBRARIES})
+    cmake_pop_check_state()
   endif()
 endif()
 
@@ -383,10 +384,10 @@ endif()
 # Non-blocking socket support tests. Use a separate, yet unset variable
 # for the socket libraries to not link against the other configured
 # dependencies which might not have been built yet.
-set(SAVE_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+cmake_push_check_state()
 set(CMAKE_REQUIRED_LIBRARIES ${SOCKET_LIBRARIES})
 check_nonblocking_socket_support()
-set(CMAKE_REQUIRED_LIBRARIES ${SAVE_CMAKE_REQUIRED_LIBRARIES})
+cmake_pop_check_state()
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/libssh2_config_cmake.h.in

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -326,6 +326,14 @@ check_include_files(winsock2.h HAVE_WINSOCK2_H)
 
 check_type_size("long long" LONGLONG)
 
+# CMake uses C syntax in check_symbol_exists() that generates a warning with
+# MSVC. To not break detection with ENABLE_WERRROR, we disable it for the
+# duration of these tests.
+if(MSVC AND ENABLE_WERROR)
+  set(SAVE_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+  string(REGEX REPLACE "/WX" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+endif()
+
 if(HAVE_SYS_TIME_H)
   check_symbol_exists(gettimeofday sys/time.h HAVE_GETTIMEOFDAY)
 else()
@@ -342,6 +350,10 @@ if (NOT HAVE_STRTOLL)
 endif()
 check_symbol_exists(snprintf stdio.h HAVE_SNPRINTF)
 check_symbol_exists(memset_s string.h HAVE_MEMSET_S)
+
+if(MSVC AND ENABLE_WERROR)
+  set(CMAKE_C_FLAGS ${SAVE_CMAKE_C_FLAGS})
+endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR
    ${CMAKE_SYSTEM_NAME} STREQUAL "Interix")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -331,8 +331,8 @@ check_type_size("long long" LONGLONG)
 # MSVC. To not break detection with ENABLE_WERRROR, we disable it for the
 # duration of these tests.
 if(MSVC AND ENABLE_WERROR)
-  set(SAVE_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
-  string(REGEX REPLACE "/WX" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_FLAGS "/WX-")
 endif()
 
 if(HAVE_SYS_TIME_H)
@@ -353,7 +353,7 @@ check_symbol_exists(snprintf stdio.h HAVE_SNPRINTF)
 check_symbol_exists(memset_s string.h HAVE_MEMSET_S)
 
 if(MSVC AND ENABLE_WERROR)
-  set(CMAKE_C_FLAGS ${SAVE_CMAKE_C_FLAGS})
+  cmake_pop_check_state()
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR

--- a/win32/libssh2_config.h
+++ b/win32/libssh2_config.h
@@ -31,12 +31,7 @@
 #   define vsnprintf _vsnprintf
 #  endif
 #  define strdup _strdup
-#  define strncasecmp _strnicmp
-#  define strcasecmp _stricmp
 # endif
-#else
-# define strncasecmp strnicmp
-# define strcasecmp stricmp
 #endif
 
 /* Enable newer diffie-hellman-group-exchange-sha1 syntax */


### PR DESCRIPTION
- cmake: fix compiler warnings in `CheckNonblockingSocketSupport`.
  detection functions.

  Without this, these detections fail when `ENABLE_WERROR=ON`.

- cmake: disable ENABLE_WERROR for MSVC during symbol checks in `src`.

  CMake's built-in symbol check function `check_symbol_exists()`
  generate warnings with MSVC. With warnings considered errors, these
  detection fail permanently. Our workaround is to disable
  warnings-as-errors while running these checks.

  Ref: https://ci.appveyor.com/project/libssh2org/libssh2/builds/46537222/job/4vg4yg333mu2lg9b

- example: replace `strcasecmp()` with C89 `strcmp()`.

  To avoid using CMake symbol checks in `example`.

  Another option is to duplicate the `check_symbol_exists()` workaround
  from `src`, but I figure it's not worth the complexity. We use
  `strcasecmp()` solely to check optional command-line options for
  example programs, and those are fine as lower-case.

  Without this, these detections fail when `ENABLE_WERROR=ON`.

- also delete `__function__` detection/use in `example`.

  To avoid the complexity for the sake of using it at a single place in
  of the example's error branch. Replace that use with a literal name of
  the function.

- cmake: also use `CMakePushCheckState` functions instead of manual
  save/restore.

Closes #857
