### PR TITLE
wincng: fix memory leak in `_libssh2_dh_secret()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2651,6 +2651,9 @@ out:
         if(agreement) {
             BCryptDestroySecret(agreement);
         }
+
+        free(blob);
+
         if(status == STATUS_NOT_SUPPORTED &&
            _libssh2_wincng.hasAlgDHwithKDF == -1) {
             goto fb; /* fallback to RSA-based implementation */


### PR DESCRIPTION
Patch-by: iruis on github
Assisted-by: Marc Hörsken
Bug #846, commit e3487092ef9553af67633c6747cb9ab2f86465e0.
Fixes #856
