### PR TITLE
include: silence warnings with casts in public `libssh2_sftp.h`

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -192,9 +192,7 @@ typedef int libssh2_socket_t;
 #  include <io.h>
 #  include <sys/types.h>
 #  include <sys/stat.h>
-#  if defined(__BORLANDC__) || defined(_MSC_VER) || defined(__MINGW32__)
-#    define LIBSSH2_STRUCT_STAT_SIZE_FORMAT    "%I64d"
-#  endif
+#  define LIBSSH2_STRUCT_STAT_SIZE_FORMAT    "%I64d"
 typedef struct _stati64 libssh2_struct_stat;
 typedef __int64 libssh2_struct_stat_size;
 #endif
@@ -223,7 +221,7 @@ typedef off_t libssh2_struct_stat_size;
 #      define LIBSSH2_STRUCT_STAT_SIZE_FORMAT      "%d"
 #    endif
 #  else
-#    define LIBSSH2_STRUCT_STAT_SIZE_FORMAT      "%lld"
+#    define LIBSSH2_STRUCT_STAT_SIZE_FORMAT      "%zd"
 #  endif
 typedef struct stat libssh2_struct_stat;
 typedef off_t libssh2_struct_stat_size;

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -192,7 +192,9 @@ typedef int libssh2_socket_t;
 #  include <io.h>
 #  include <sys/types.h>
 #  include <sys/stat.h>
-#  define LIBSSH2_STRUCT_STAT_SIZE_FORMAT    "%I64d"
+#  if defined(__BORLANDC__) || defined(_MSC_VER) || defined(__MINGW32__)
+#    define LIBSSH2_STRUCT_STAT_SIZE_FORMAT    "%I64d"
+#  endif
 typedef struct _stati64 libssh2_struct_stat;
 typedef __int64 libssh2_struct_stat_size;
 #endif
@@ -221,7 +223,7 @@ typedef off_t libssh2_struct_stat_size;
 #      define LIBSSH2_STRUCT_STAT_SIZE_FORMAT      "%d"
 #    endif
 #  else
-#    define LIBSSH2_STRUCT_STAT_SIZE_FORMAT      "%zd"
+#    define LIBSSH2_STRUCT_STAT_SIZE_FORMAT      "%lld"
 #  endif
 typedef struct stat libssh2_struct_stat;
 typedef off_t libssh2_struct_stat_size;

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -231,10 +231,11 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
                      unsigned long flags,
                      long mode, int open_type);
 #define libssh2_sftp_open(sftp, filename, flags, mode)                  \
-    libssh2_sftp_open_ex((sftp), (filename), strlen(filename), (flags), \
-                         (mode), LIBSSH2_SFTP_OPENFILE)
+    libssh2_sftp_open_ex((sftp), \
+                         (filename), (unsigned int)strlen(filename), \
+                         (flags), (mode), LIBSSH2_SFTP_OPENFILE)
 #define libssh2_sftp_opendir(sftp, path) \
-    libssh2_sftp_open_ex((sftp), (path), strlen(path), 0, 0, \
+    libssh2_sftp_open_ex((sftp), (path), (unsigned int)strlen(path), 0, 0, \
                          LIBSSH2_SFTP_OPENDIR)
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
@@ -281,8 +282,9 @@ LIBSSH2_API int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
                                        unsigned int dest_filename_len,
                                        long flags);
 #define libssh2_sftp_rename(sftp, sourcefile, destfile) \
-    libssh2_sftp_rename_ex((sftp), (sourcefile), strlen(sourcefile), \
-                           (destfile), strlen(destfile),                \
+    libssh2_sftp_rename_ex((sftp), \
+                           (sourcefile), (unsigned int)strlen(sourcefile), \
+                           (destfile), (unsigned int)strlen(destfile), \
                            LIBSSH2_SFTP_RENAME_OVERWRITE | \
                            LIBSSH2_SFTP_RENAME_ATOMIC | \
                            LIBSSH2_SFTP_RENAME_NATIVE)
@@ -305,13 +307,13 @@ LIBSSH2_API int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path,
                                       unsigned int path_len, long mode);
 #define libssh2_sftp_mkdir(sftp, path, mode) \
-    libssh2_sftp_mkdir_ex((sftp), (path), strlen(path), (mode))
+    libssh2_sftp_mkdir_ex((sftp), (path), (unsigned int)strlen(path), (mode))
 
 LIBSSH2_API int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path,
                                       unsigned int path_len);
 #define libssh2_sftp_rmdir(sftp, path) \
-    libssh2_sftp_rmdir_ex((sftp), (path), strlen(path))
+    libssh2_sftp_rmdir_ex((sftp), (path), (unsigned int)strlen(path))
 
 LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                                      const char *path,
@@ -319,14 +321,14 @@ LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                                      int stat_type,
                                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_stat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), strlen(path), LIBSSH2_SFTP_STAT, \
-                         (attrs))
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_STAT, (attrs))
 #define libssh2_sftp_lstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), strlen(path), LIBSSH2_SFTP_LSTAT, \
-                         (attrs))
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_LSTAT, (attrs))
 #define libssh2_sftp_setstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), strlen(path), LIBSSH2_SFTP_SETSTAT, \
-                         (attrs))
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_SETSTAT, (attrs))
 
 LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         const char *path,
@@ -335,13 +337,19 @@ LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         unsigned int target_len,
                                         int link_type);
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \
-    libssh2_sftp_symlink_ex((sftp), (orig), strlen(orig), (linkpath), \
-                            strlen(linkpath), LIBSSH2_SFTP_SYMLINK)
+    libssh2_sftp_symlink_ex((sftp), \
+                            (orig), (unsigned int)strlen(orig), \
+                            (linkpath), (unsigned int)strlen(linkpath), \
+                            LIBSSH2_SFTP_SYMLINK)
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), (path), strlen(path), (target), (maxlen), \
-    LIBSSH2_SFTP_READLINK)
+    libssh2_sftp_symlink_ex((sftp), \
+                            (path), (unsigned int)strlen(path), \
+                            (target), (maxlen), \
+                            LIBSSH2_SFTP_READLINK)
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), (path), strlen(path), (target), (maxlen), \
+    libssh2_sftp_symlink_ex((sftp), \
+                            (path), (unsigned int)strlen(path), \
+                            (target), (maxlen), \
                             LIBSSH2_SFTP_REALPATH)
 
 #ifdef __cplusplus


### PR DESCRIPTION
Avoid triggering warnings in code using libssh2 macros from its
public headers.

Cherry-picked from: #846
Closes #862
