### PR TITLE
ci: use static+shared builds to cut number of cmake jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,27 +26,23 @@ jobs:
         compiler: [gcc, clang]
         address_size: [64]
         crypto_backend: [OpenSSL, Libgcrypt, mbedTLS]
-        build_shared_libs: [OFF, ON]
         enable_zlib_compression: [OFF, ON]
         b: [cmake]
         include:
           - compiler: gcc
             address_size: 64
             crypto_backend: OpenSSL
-            build_shared_libs: OFF
             enable_zlib_compression: OFF
             b: configure
           - compiler: clang
             address_size: 64
             crypto_backend: OpenSSL
-            build_shared_libs: OFF
             enable_zlib_compression: OFF
             b: configure
     env:
       CC: ${{ matrix.compiler }}
       CC_FOR_BUILD: ${{ matrix.compiler }}
       CRYPTO_BACKEND: ${{ matrix.crypto_backend }}
-      BUILD_SHARED_LIBS: ${{ matrix.build_shared_libs }}
       ENABLE_ZLIB_COMPRESSION: ${{ matrix.enable_zlib_compression }}
     steps:
       - uses: actions/checkout@v3
@@ -89,7 +85,7 @@ jobs:
         run: |
           mkdir bin
           cd bin
-          cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
+          cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=ON -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
           cmake --build .
           export OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:../tests/openssh_server)
           ctest -VV --output-on-failure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,22 +28,22 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - job_name: "VS2015, OpenSSL, Shared"
+    - job_name: "VS2015, OpenSSL"
       GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: "ON"
       CRYPTO_BACKEND: "OpenSSL"
 
-    - job_name: "VS2013, OpenSSL, Shared"
+    - job_name: "VS2013, OpenSSL"
       GENERATOR: "Visual Studio 12 2013"
       BUILD_SHARED_LIBS: "ON"
       CRYPTO_BACKEND: "OpenSSL"
 
-    - job_name: "VS2015, WinCNG, Shared"
+    - job_name: "VS2015, WinCNG"
       GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: "ON"
       CRYPTO_BACKEND: "WinCNG"
 
-    - job_name: "VS2013, WinCNG, Shared"
+    - job_name: "VS2013, WinCNG"
       GENERATOR: "Visual Studio 12 2013"
       BUILD_SHARED_LIBS: "ON"
       CRYPTO_BACKEND: "WinCNG"
@@ -52,21 +52,6 @@ environment:
       GENERATOR: "Visual Studio 14 2015"
       BUILD_SHARED_LIBS: "OFF"
       CRYPTO_BACKEND: "OpenSSL"
-
-    - job_name: "VS2013, OpenSSL, Static"
-      GENERATOR: "Visual Studio 12 2013"
-      BUILD_SHARED_LIBS: "OFF"
-      CRYPTO_BACKEND: "OpenSSL"
-
-    - job_name: "VS2015, WinCNG, Static"
-      GENERATOR: "Visual Studio 14 2015"
-      BUILD_SHARED_LIBS: "OFF"
-      CRYPTO_BACKEND: "WinCNG"
-
-    - job_name: "VS2013, WinCNG, Static"
-      GENERATOR: "Visual Studio 12 2013"
-      BUILD_SHARED_LIBS: "OFF"
-      CRYPTO_BACKEND: "WinCNG"
 
 platform:
   - x64


### PR DESCRIPTION
With CMake builds supporting static-shared libssh2 builds in a single pass, we no longer need to run static and shared jobs separately. For the same effect it's enough to run builds with both shared and static builds enabled. Halving CI jobs.

We add an extra run to test the CMake config-path without shared builds enabled.

This allows to add useful jobs, e.g. MSVS 2022 or ZLIB-enabled builds for Windows, valgrind builds or other useful stuff, without stretching CI run times further.

Ref: #863
Closes #865