### PR TITLE
delete legacy SSH2_MSG_KEX_DH_GEX_REQUEST_OLD build option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,13 +165,6 @@ AC_ARG_ENABLE(mac-none,
   AC_HELP_STRING([--enable-mac-none],[Permit "none" MAC -- NOT RECOMMENDED]),
   [AC_DEFINE(LIBSSH2_MAC_NONE, 1, [Enable "none" MAC -- NOT RECOMMENDED])])
 
-AC_ARG_ENABLE(gex-new,
-  AC_HELP_STRING([--disable-gex-new],[Disable "new" diffie-hellman-group-exchange-sha1 method]),
-  [GEX_NEW=$enableval])
-if test "$GEX_NEW" != "no"; then
-  AC_DEFINE(LIBSSH2_DH_GEX_NEW, 1, [Enable newer diffie-hellman-group-exchange-sha1 syntax])
-fi
-
 AC_ARG_ENABLE(clear-memory,
   AC_HELP_STRING([--disable-clear-memory],[Disable clearing of memory before being freed]),
   [CLEAR_MEMORY=$enableval])

--- a/docs/INSTALL_AUTOTOOLS
+++ b/docs/INSTALL_AUTOTOOLS
@@ -280,20 +280,6 @@ Some ./configure options deserve additional comments:
 	method be advertized by the remote end and that no
 	more-preferable methods are available.
 
- * --disable-gex-new
-
-	The diffie-hellman-group-exchange-sha1 (dh-gex) key
-	exchange method originally defined an exchange
-	negotiation using packet type 30 to request a
-	generation pair based on a single target value.  Later
-	refinement of dh-gex provided for range and target
-	values.  By default libssh2 will use the newer range
-	method.
-
-	If you experience trouble connecting to an old SSH
-	server using dh-gex, try this option to fallback on
-	the older more reliable method.
-
  * --with-libgcrypt
  * --without-libgcrypt
  * --with-libgcrypt-prefix=DIR

--- a/docs/INSTALL_CMAKE.md
+++ b/docs/INSTALL_CMAKE.md
@@ -96,18 +96,6 @@ The following options are available:
     however it still requires that the method be advertized by the
     remote end and that no more-preferable methods are available.
 
- * `ENABLE_GEX_NEW=ON`
-
-    The diffie-hellman-group-exchange-sha1 (dh-gex) key exchange
-    method originally defined an exchange negotiation using packet
-    type 30 to request a generation pair based on a single target
-    value.  Later refinement of dh-gex provided for range and target
-    values.  By default libssh2 will use the newer range method.
-
-    If you experience trouble connecting to an old SSH server using
-    dh-gex, try this option to fallback on the older more reliable
-    method.
-
  * `ENABLE_DEBUG_LOGGING=ON` in Debug, `=OFF` in Release
 
     Will enable the libssh2_trace() function for showing debug traces.

--- a/nw/GNUmakefile
+++ b/nw/GNUmakefile
@@ -424,7 +424,6 @@ endif
 ifdef OLD_NOVELLSDK
 	@echo $(DL)#define socklen_t int$(DL) >> $@
 endif
-	@echo $(DL)#define LIBSSH2_DH_GEX_NEW 1$(DL) >> $@
 ifeq ($(DB),DEBUG)
 	@echo $(DL)#define LIBSSH2_DEBUG_CONNECTION 1$(DL) >> $@
 	@echo $(DL)#define LIBSSH2_DEBUG_ERRORS 1$(DL) >> $@

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -146,9 +146,6 @@
 /* Enable "none" cipher -- NOT RECOMMENDED */
 #undef LIBSSH2_CRYPT_NONE
 
-/* Enable newer diffie-hellman-group-exchange-sha1 syntax */
-#define LIBSSH2_DH_GEX_NEW 1
-
 /* Compile in zlib support */
 /* #undef LIBSSH2_HAVE_ZLIB */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -222,14 +222,6 @@ if(ENABLE_MAC_NONE)
   list(APPEND libssh2_DEFINITIONS LIBSSH2_MAC_NONE=1)
 endif()
 
-option(ENABLE_GEX_NEW
-  "Enable diffie-hellman-group-exchange-sha1 method" ON)
-add_feature_info("diffie-hellman-group-exchange-sha1" ENABLE_GEX_NEW
-  "\"new\" diffie-hellman-group-exchange-sha1 method")
-if(ENABLE_GEX_NEW)
-  list(APPEND libssh2_DEFINITIONS LIBSSH2_DH_GEX_NEW=1)
-endif()
-
 # Enable debugging logging by default if the user configured a debug build
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(DEBUG_LOGGING_DEFAULT ON)

--- a/src/kex.c
+++ b/src/kex.c
@@ -583,7 +583,6 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 
         if(packet_type_init == SSH_MSG_KEX_DH_GEX_INIT) {
             /* diffie-hellman-group-exchange hashes additional fields */
-#ifdef LIBSSH2_DH_GEX_NEW
             _libssh2_htonu32(exchange_state->h_sig_comp,
                              LIBSSH2_DH_GEX_MINGROUP);
             _libssh2_htonu32(exchange_state->h_sig_comp + 4,
@@ -592,12 +591,6 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                              LIBSSH2_DH_GEX_MAXGROUP);
             _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
                                          exchange_state->h_sig_comp, 12);
-#else
-            _libssh2_htonu32(exchange_state->h_sig_comp,
-                             LIBSSH2_DH_GEX_OPTGROUP);
-            _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                         exchange_state->h_sig_comp, 4);
-#endif
         }
 
         if(midhash) {
@@ -1342,23 +1335,13 @@ kex_method_diffie_hellman_group_exchange_sha1_key_exchange
         key_state->p = _libssh2_bn_init_from_bin();
         key_state->g = _libssh2_bn_init_from_bin();
         /* Ask for a P and G pair */
-#ifdef LIBSSH2_DH_GEX_NEW
         key_state->request[0] = SSH_MSG_KEX_DH_GEX_REQUEST;
         _libssh2_htonu32(key_state->request + 1, LIBSSH2_DH_GEX_MINGROUP);
         _libssh2_htonu32(key_state->request + 5, LIBSSH2_DH_GEX_OPTGROUP);
         _libssh2_htonu32(key_state->request + 9, LIBSSH2_DH_GEX_MAXGROUP);
         key_state->request_len = 13;
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group-Exchange "
-                       "(New Method)"));
-#else
-        key_state->request[0] = SSH_MSG_KEX_DH_GEX_REQUEST_OLD;
-        _libssh2_htonu32(key_state->request + 1, LIBSSH2_DH_GEX_OPTGROUP);
-        key_state->request_len = 5;
-        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group-Exchange "
-                       "(Old Method)"));
-#endif
+                       "Initiating Diffie-Hellman Group-Exchange SHA1"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1469,23 +1452,13 @@ kex_method_diffie_hellman_group_exchange_sha256_key_exchange
         key_state->p = _libssh2_bn_init();
         key_state->g = _libssh2_bn_init();
         /* Ask for a P and G pair */
-#ifdef LIBSSH2_DH_GEX_NEW
         key_state->request[0] = SSH_MSG_KEX_DH_GEX_REQUEST;
         _libssh2_htonu32(key_state->request + 1, LIBSSH2_DH_GEX_MINGROUP);
         _libssh2_htonu32(key_state->request + 5, LIBSSH2_DH_GEX_OPTGROUP);
         _libssh2_htonu32(key_state->request + 9, LIBSSH2_DH_GEX_MAXGROUP);
         key_state->request_len = 13;
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group-Exchange "
-                       "(New Method SHA256)"));
-#else
-        key_state->request[0] = SSH_MSG_KEX_DH_GEX_REQUEST_OLD;
-        _libssh2_htonu32(key_state->request + 1, LIBSSH2_DH_GEX_OPTGROUP);
-        key_state->request_len = 5;
-        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group-Exchange "
-                       "(Old Method SHA256)"));
-#endif
+                       "Initiating Diffie-Hellman Group-Exchange SHA256"));
 
         key_state->state = libssh2_NB_state_created;
     }

--- a/vms/libssh2_config.h
+++ b/vms/libssh2_config.h
@@ -81,9 +81,5 @@ typedef unsigned int socklen_t; /* missing in headers on VMS */
 
 #define LIBSSH2_HAVE_ZLIB
 
-/* Enable newer diffie-hellman-group-exchange-sha1 syntax */
-
-#define LIBSSH2_DH_GEX_NEW 1
-
 #endif /* __VMS */
 #endif /* LIBSSH2_CONFIG_H */                             

--- a/win32/libssh2_config.h
+++ b/win32/libssh2_config.h
@@ -34,7 +34,4 @@
 # endif
 #endif
 
-/* Enable newer diffie-hellman-group-exchange-sha1 syntax */
-#define LIBSSH2_DH_GEX_NEW 1
-
 #endif /* LIBSSH2_CONFIG_H */


### PR DESCRIPTION
libssh2 supports an "old" style KEX message
`SSH2_MSG_KEX_DH_GEX_REQUEST_OLD`, as an off-by-default build option.

OpenSSH deprecated/disabled this feature in v6.9 (2015-07-01):
https://www.openssh.com/releasenotes.html#6.9

This patch deletes this obsolete feature from libssh2, with no option
to enable it.

Added to libssh2 in: cf8ca63ea0c9388c8ae9079961d7e6a91b72b5c8 (2004-12-31)
RFC: https://datatracker.ietf.org/doc/html/rfc4419 (2006-03)

Closes #872