### PR TITLE
rework how to enable insecure null-cipher/null-MAC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,14 +157,6 @@ AC_SUBST(LIBSREQUIRED)
 #
 # Optional Settings
 #
-AC_ARG_ENABLE(crypt-none,
-  AC_HELP_STRING([--enable-crypt-none],[Permit "none" cipher -- NOT RECOMMENDED]),
-  [AC_DEFINE(LIBSSH2_CRYPT_NONE, 1, [Enable "none" cipher -- NOT RECOMMENDED])])
-
-AC_ARG_ENABLE(mac-none,
-  AC_HELP_STRING([--enable-mac-none],[Permit "none" MAC -- NOT RECOMMENDED]),
-  [AC_DEFINE(LIBSSH2_MAC_NONE, 1, [Enable "none" MAC -- NOT RECOMMENDED])])
-
 AC_ARG_ENABLE(clear-memory,
   AC_HELP_STRING([--disable-clear-memory],[Disable clearing of memory before being freed]),
   [CLEAR_MEMORY=$enableval])

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -143,17 +143,11 @@
 /* to make a symbol visible */
 #undef LIBSSH2_API
 
-/* Enable "none" cipher -- NOT RECOMMENDED */
-#undef LIBSSH2_CRYPT_NONE
-
 /* Compile in zlib support */
 /* #undef LIBSSH2_HAVE_ZLIB */
 
 /* Use libgcrypt */
 #undef LIBSSH2_LIBGCRYPT
-
-/* Enable "none" MAC -- NOT RECOMMENDED */
-#undef LIBSSH2_MAC_NONE
 
 /* Use OpenSSL */
 #undef LIBSSH2_OPENSSL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -210,18 +210,6 @@ if(ENABLE_ZLIB_COMPRESSION)
   endif()
 endif()
 
-option(ENABLE_CRYPT_NONE "Permit \"none\" cipher -- NOT RECOMMENDED")
-add_feature_info("\"none\" cipher" ENABLE_CRYPT_NONE "")
-if(ENABLE_CRYPT_NONE)
-  list(APPEND libssh2_DEFINITIONS LIBSSH2_CRYPT_NONE=1)
-endif()
-
-option(ENABLE_MAC_NONE "Permit \"none\" MAC -- NOT RECOMMMENDED")
-add_feature_info("\"none\" MAC" ENABLE_MAC_NONE "")
-if(ENABLE_MAC_NONE)
-  list(APPEND libssh2_DEFINITIONS LIBSSH2_MAC_NONE=1)
-endif()
-
 # Enable debugging logging by default if the user configured a debug build
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(DEBUG_LOGGING_DEFAULT ON)

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -38,10 +38,10 @@
 
 #include "libssh2_priv.h"
 
-#ifdef LIBSSH2_CRYPT_NONE
+#if defined(LIBSSH2DEBUG) && defined(LIBSSH2_CRYPT_NONE_INSECURE)
 
 /* crypt_none_crypt
- * Minimalist cipher: VERY secure *wink*
+ * Minimalist cipher: no encryption. DO NOT USE.
  */
 static int
 crypt_none_crypt(LIBSSH2_SESSION * session, unsigned char *buf,
@@ -62,7 +62,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_none = {
     crypt_none_crypt,
     NULL
 };
-#endif /* LIBSSH2_CRYPT_NONE */
+#endif /* defined(LIBSSH2DEBUG) && defined(LIBSSH2_CRYPT_NONE_INSECURE) */
 
 struct crypt_ctx
 {
@@ -337,7 +337,7 @@ static const LIBSSH2_CRYPT_METHOD *_libssh2_crypt_methods[] = {
 #if LIBSSH2_3DES
     &libssh2_crypt_method_3des_cbc,
 #endif /*  LIBSSH2_DES */
-#ifdef LIBSSH2_CRYPT_NONE
+#if defined(LIBSSH2DEBUG) && defined(LIBSSH2_CRYPT_NONE_INSECURE)
     &libssh2_crypt_method_none,
 #endif
     NULL

--- a/src/mac.c
+++ b/src/mac.c
@@ -38,9 +38,9 @@
 #include "libssh2_priv.h"
 #include "mac.h"
 
-#ifdef LIBSSH2_MAC_NONE
+#if defined(LIBSSH2DEBUG) && defined(LIBSSH2_MAC_NONE_INSECURE)
 /* mac_none_MAC
- * Minimalist MAC: No MAC
+ * Minimalist MAC: No MAC. DO NOT USE.
  */
 static int
 mac_none_MAC(LIBSSH2_SESSION * session, unsigned char *buf,
@@ -62,7 +62,7 @@ static LIBSSH2_MAC_METHOD mac_method_none = {
     mac_none_MAC,
     NULL
 };
-#endif /* LIBSSH2_MAC_NONE */
+#endif /* defined(LIBSSH2DEBUG) && defined(LIBSSH2_MAC_NONE_INSECURE) */
 
 /* mac_method_common_init
  * Initialize simple mac methods
@@ -401,9 +401,9 @@ static const LIBSSH2_MAC_METHOD *mac_methods[] = {
     &mac_method_hmac_ripemd160,
     &mac_method_hmac_ripemd160_openssh_com,
 #endif /* LIBSSH2_HMAC_RIPEMD */
-#ifdef LIBSSH2_MAC_NONE
+#if defined(LIBSSH2DEBUG) && defined(LIBSSH2_MAC_NONE_INSECURE)
     &mac_method_none,
-#endif /* LIBSSH2_MAC_NONE */
+#endif
     NULL
 };
 


### PR DESCRIPTION
Null-cipher and null-MAC are security footguns we want to avoid.

Existing option names to toggle these were ambiguous and gave room for
misinterpretation. Some projects may have had these options enabled by
accident.

This patch aims to make it more difficult to enable them, and making
sure that existing methods require an update to stay enabled.

- delete CMake/autotools settings to enable the "none" cipher and MAC.

- rename existing C macros that can enable them.

  To use them, pass them as custom `CPPFLAGS` to the build.

- enable them only if `LIBSSH2DEBUG` is also enabled.

Best would be to delete them, though they may have some use while
developing libssh2 itself, or debugging.

Closes #873
