### PR TITLE
ci: cmake `ENABLE_WERROR` -> `ON`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           mkdir bin
           cd bin
-          cmake $TOOLCHAIN_OPTION -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=ON -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
+          cmake $TOOLCHAIN_OPTION -DENABLE_WERROR=ON -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=ON -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
           cmake --build . --parallel 2
           export OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:../tests/openssh_server)
           ctest -VV --output-on-failure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,7 @@ build_script:
           $env:CMAKE_ARG = "-DOPENSSL_ROOT_DIR=C:/OpenSSL-v111-Win32"
         }
       }
-  - cmake . -B _builds "-G%GENERATOR%" %CMAKE_ARG% -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS% -DCRYPTO_BACKEND=%CRYPTO_BACKEND%
+  - cmake . -B _builds "-G%GENERATOR%" %CMAKE_ARG% -DENABLE_WERROR=ON -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS% -DCRYPTO_BACKEND=%CRYPTO_BACKEND%
   - cmake --build _builds --config "%CONFIGURATION%" --parallel 2
 
 before_test:


### PR DESCRIPTION
Consider warnings as errors for CMake jobs in CI.

Cherry-picked from #846
Closes #877

---

TODO:

- [x] rebase on master, once all #846 had been merged.
