### PR TITLE
src: silence compiler warnings 3 (change types)

### DIFF
--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -152,7 +152,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 
 int libssh2_sha256(const unsigned char *message,
-                   unsigned long len,
+                   size_t len,
                    unsigned char output[SHA256_DIGEST_LENGTH]);
 Computes the SHA-256 signature over the given message of length len and
 store the result into the output buffer.
@@ -197,7 +197,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 
 int libssh2_sha384(const unsigned char *message,
-                   unsigned long len,
+                   size_t len,
                    unsigned char output[SHA384_DIGEST_LENGTH]);
 Computes the SHA-384 signature over the given message of length len and
 store the result into the output buffer.
@@ -231,7 +231,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 
 int libssh2_sha512(const unsigned char *message,
-                   unsigned long len,
+                   size_t len,
                    unsigned char output[SHA512_DIGEST_LENGTH]);
 Computes the SHA-512 signature over the given message of length len and
 store the result into the output buffer.
@@ -599,7 +599,7 @@ This procedure is already prototyped in crypto.h.
 int _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
                                         LIBSSH2_SESSION *session,
                                         const char *data,
-          size_t data_len,
+                                        size_t data_len,
                                         unsigned const char *passphrase);
 Gets an RSA private key from data into a new RSA context.
 Must call _libssh2_init_if_needed().
@@ -608,8 +608,8 @@ This procedure is already prototyped in crypto.h.
 
 int _libssh2_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                              const unsigned char *sig,
-                             unsigned long sig_len,
-                             const unsigned char *m, unsigned long m_len);
+                             size_t sig_len,
+                             const unsigned char *m, size_t m_len);
 Verify (sig, sig_len) signature of (m, m_len) using an SHA-1 hash and the
 RSA context.
 Return 0 if OK, else -1.
@@ -661,8 +661,8 @@ Note: this procedure is not used if macro _libssh2_rsa_sha1_signv() is defined.
 int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsa,
                              size_t hash_len,
                              const unsigned char *sig,
-                             unsigned long sig_len,
-                             const unsigned char *m, unsigned long m_len);
+                             size_t sig_len,
+                             const unsigned char *m, size_t m_len);
 Verify (sig, sig_len) signature of (m, m_len) using an SHA-2 hash based on
 hash length and the RSA context.
 Return 0 if OK, else -1.
@@ -717,7 +717,7 @@ This procedure is already prototyped in crypto.h.
 
 int _libssh2_dsa_sha1_verify(libssh2_dsa_ctx *dsactx,
                              const unsigned char *sig,
-                             const unsigned char *m, unsigned long m_len);
+                             const unsigned char *m, size_t m_len);
 Verify (sig, siglen) signature of (m, m_len) using an SHA-1 hash and the
 DSA context.
 Returns 0 if OK, else -1.
@@ -725,7 +725,7 @@ This procedure is already prototyped in crypto.h.
 
 int _libssh2_dsa_sha1_sign(libssh2_dsa_ctx *dsactx,
                            const unsigned char *hash,
-                           unsigned long hash_len, unsigned char *sig);
+                           size_t hash_len, unsigned char *sig);
 DSA signs the (hash, hash_len) data using SHA-1 and store the signature at sig.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
@@ -874,7 +874,7 @@ This procedure is already prototyped in crypto.h.
 int _libssh2_ed25519_new_public(libssh2_ed25519_ctx **ed_ctx,
                                 LIBSSH2_SESSION *session,
                                 const unsigned char *raw_pub_key,
-                                const uint8_t key_len);
+                                const size_t key_len);
 Stores at ed_ctx a new ED25519 key context for raw public key (raw_pub_key,
 key_len).
 Return 0 if OK, else -1.
@@ -927,7 +927,7 @@ In example, this is needed to preset unused structure slacks on platforms
 requiring it.
 If this is not needed, it should be defined as an empty macro.
 
-int _libssh2_random(unsigned char *buf, int len);
+int _libssh2_random(unsigned char *buf, size_t len);
 Store len random bytes at buf.
 Returns 0 if OK, else -1.
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -2160,7 +2160,7 @@ LIBSSH2_API ssize_t
 libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id, char *buf,
                         size_t buflen)
 {
-    int rc;
+    ssize_t rc;
     unsigned long recv_window;
 
     if(!channel)

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -130,7 +130,7 @@ int _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
                              unsigned const char *passphrase);
 int _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
                              const unsigned char *sig,
-                             const unsigned char *m, unsigned long m_len);
+                             const unsigned char *m, size_t m_len);
 int _libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
                            const unsigned char *hash,
                            unsigned long hash_len, unsigned char *sig);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -246,7 +246,7 @@ int
 _libssh2_ed25519_new_public(libssh2_ed25519_ctx **ed_ctx,
                             LIBSSH2_SESSION *session,
                             const unsigned char *raw_pub_key,
-                            const uint8_t key_len);
+                            const size_t key_len);
 
 int
 _libssh2_ed25519_sign(libssh2_ed25519_ctx *ctx, LIBSSH2_SESSION *session,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -85,8 +85,8 @@ int _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
                              unsigned const char *passphrase);
 int _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
                              const unsigned char *sig,
-                             unsigned long sig_len,
-                             const unsigned char *m, unsigned long m_len);
+                             size_t sig_len,
+                             const unsigned char *m, size_t m_len);
 int _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
                            libssh2_rsa_ctx * rsactx,
                            const unsigned char *hash,
@@ -103,8 +103,8 @@ int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
 int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsa,
                              size_t hash_len,
                              const unsigned char *sig,
-                             unsigned long sig_len,
-                             const unsigned char *m, unsigned long m_len);
+                             size_t sig_len,
+                             const unsigned char *m, size_t m_len);
 #endif
 int _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
                                         LIBSSH2_SESSION * session,

--- a/src/kex.c
+++ b/src/kex.c
@@ -3106,8 +3106,8 @@ kex_method_strlen(LIBSSH2_COMMON_METHOD ** method)
 /* kex_method_list
  * Generate formatted preference list in buf
  */
-static size_t
-kex_method_list(unsigned char *buf, size_t list_strlen,
+static uint32_t
+kex_method_list(unsigned char *buf, uint32_t list_strlen,
                 LIBSSH2_COMMON_METHOD ** method)
 {
     _libssh2_htonu32(buf, list_strlen);
@@ -3118,7 +3118,7 @@ kex_method_list(unsigned char *buf, size_t list_strlen,
     }
 
     while(*method && (*method)->name) {
-        int mlen = strlen((*method)->name);
+        uint32_t mlen = (uint32_t)strlen((*method)->name);
         memcpy(buf, (*method)->name, mlen);
         buf += mlen;
         *(buf++) = ',';
@@ -3131,7 +3131,7 @@ kex_method_list(unsigned char *buf, size_t list_strlen,
 
 
 #define LIBSSH2_METHOD_PREFS_LEN(prefvar, defaultvar)           \
-    ((prefvar) ? strlen(prefvar) :                              \
+    (uint32_t)((prefvar) ? strlen(prefvar) :                    \
      kex_method_strlen((LIBSSH2_COMMON_METHOD**)(defaultvar)))
 
 #define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)  \
@@ -3154,15 +3154,16 @@ static int kexinit(LIBSSH2_SESSION * session)
     /* 62 = packet_type(1) + cookie(16) + first_packet_follows(1) +
        reserved(4) + length longs(40) */
     size_t data_len = 62;
-    size_t kex_len, hostkey_len = 0;
-    size_t crypt_cs_len, crypt_sc_len;
-    size_t comp_cs_len, comp_sc_len;
-    size_t mac_cs_len, mac_sc_len;
-    size_t lang_cs_len, lang_sc_len;
     unsigned char *data, *s;
     int rc;
 
     if(session->kexinit_state == libssh2_NB_state_idle) {
+        uint32_t kex_len, hostkey_len;
+        uint32_t crypt_cs_len, crypt_sc_len;
+        uint32_t comp_cs_len, comp_sc_len;
+        uint32_t mac_cs_len, mac_sc_len;
+        uint32_t lang_cs_len, lang_sc_len;
+
         kex_len =
             LIBSSH2_METHOD_PREFS_LEN(session->kex_prefs, libssh2_kex_methods);
         hostkey_len =

--- a/src/kex.c
+++ b/src/kex.c
@@ -3324,12 +3324,12 @@ static int kexinit(LIBSSH2_SESSION * session)
  * Needle must be precede by BOL or ',', and followed by ',' or EOL
  */
 static unsigned char *
-kex_agree_instr(unsigned char *haystack, unsigned long haystack_len,
-                const unsigned char *needle, unsigned long needle_len)
+kex_agree_instr(unsigned char *haystack, size_t haystack_len,
+                const unsigned char *needle, size_t needle_len)
 {
     unsigned char *s;
     unsigned char *end_haystack;
-    unsigned long left;
+    size_t left;
 
     if(haystack == NULL || needle == NULL) {
         return NULL;

--- a/src/kex.c
+++ b/src/kex.c
@@ -71,13 +71,13 @@
                                           reqlen, version)                  \
 {                                                                           \
     libssh2_sha##digest_type##_ctx hash;                                    \
-    unsigned long len = 0;                                                  \
+    size_t len = 0;                                                         \
     if(!(value)) {                                                          \
         value = LIBSSH2_ALLOC(session,                                      \
                               reqlen + SHA##digest_type##_DIGEST_LENGTH);   \
     }                                                                       \
     if(value)                                                               \
-        while(len < (unsigned long)reqlen) {                                \
+        while(len < (size_t)reqlen) {                                       \
             (void)libssh2_sha##digest_type##_init(&hash);                   \
             libssh2_sha##digest_type##_update(hash,                         \
                                               exchange_state->k_value,      \
@@ -217,7 +217,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                    unsigned char packet_type_init,
                                    unsigned char packet_type_reply,
                                    unsigned char *midhash,
-                                   unsigned long midhash_len,
+                                   size_t midhash_len,
                                    kmdhgGPshakex_state_t *exchange_state)
 {
     int ret = 0;
@@ -285,7 +285,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
         exchange_state->e_packet[0] = packet_type_init;
         _libssh2_htonu32(exchange_state->e_packet + 1,
-                         exchange_state->e_packet_len - 5);
+                         (uint32_t)(exchange_state->e_packet_len - 5));
         if(_libssh2_bn_bits(exchange_state->e) % 8) {
             _libssh2_bn_to_bin(exchange_state->e,
                                exchange_state->e_packet + 5);
@@ -517,7 +517,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
         _libssh2_htonu32(exchange_state->k_value,
-                         exchange_state->k_value_len - 4);
+                         (uint32_t)(exchange_state->k_value_len - 4));
         if(_libssh2_bn_bits(exchange_state->k) % 8) {
             _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 4);
         }
@@ -610,7 +610,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                      exchange_state->e_packet_len - 1);
 
         _libssh2_htonu32(exchange_state->h_sig_comp,
-                         exchange_state->f_value_len);
+                         (uint32_t)exchange_state->f_value_len);
         _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
                                      exchange_state->h_sig_comp, 4);
         _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
@@ -992,7 +992,7 @@ typedef int (*diffie_hellman_hash_func_t)(LIBSSH2_SESSION *,
                                           unsigned char,
                                           unsigned char,
                                           unsigned char *,
-                                          unsigned long,
+                                          size_t,
                                           kmdhgGPshakex_state_t *);
 static int
 kex_method_diffie_hellman_group14_key_exchange(LIBSSH2_SESSION *session,
@@ -3397,8 +3397,8 @@ kex_get_method_by_name(const char *name, size_t name_len,
  * Agree on a Hostkey which works with this kex
  */
 static int kex_agree_hostkey(LIBSSH2_SESSION * session,
-                             unsigned long kex_flags,
-                             unsigned char *hostkey, unsigned long hostkey_len)
+                             size_t kex_flags,
+                             unsigned char *hostkey, size_t hostkey_len)
 {
     const LIBSSH2_HOSTKEY_METHOD **hostkeyp = libssh2_hostkey_methods();
     unsigned char *s;
@@ -3474,8 +3474,8 @@ static int kex_agree_hostkey(LIBSSH2_SESSION * session,
  * Agree on a Key Exchange method and a hostkey encoding type
  */
 static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
-                                 unsigned long kex_len, unsigned char *hostkey,
-                                 unsigned long hostkey_len)
+                                 size_t kex_len, unsigned char *hostkey,
+                                 size_t hostkey_len)
 {
     const LIBSSH2_KEX_METHOD **kexp = libssh2_kex_methods;
     unsigned char *s;
@@ -3552,7 +3552,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
 static int kex_agree_crypt(LIBSSH2_SESSION * session,
                            libssh2_endpoint_data *endpoint,
                            unsigned char *crypt,
-                           unsigned long crypt_len)
+                           size_t crypt_len)
 {
     const LIBSSH2_CRYPT_METHOD **cryptp = libssh2_crypt_methods();
     unsigned char *s;
@@ -3608,7 +3608,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION * session,
  */
 static int kex_agree_mac(LIBSSH2_SESSION * session,
                          libssh2_endpoint_data * endpoint, unsigned char *mac,
-                         unsigned long mac_len)
+                         size_t mac_len)
 {
     const LIBSSH2_MAC_METHOD **macp = _libssh2_mac_methods();
     unsigned char *s;
@@ -3661,7 +3661,7 @@ static int kex_agree_mac(LIBSSH2_SESSION * session,
  */
 static int kex_agree_comp(LIBSSH2_SESSION *session,
                           libssh2_endpoint_data *endpoint, unsigned char *comp,
-                          unsigned long comp_len)
+                          size_t comp_len)
 {
     const LIBSSH2_COMP_METHOD **compp = _libssh2_comp_methods(session);
     unsigned char *s;

--- a/src/kex.c
+++ b/src/kex.c
@@ -3717,7 +3717,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
  * Decide which specific method to use of the methods offered by each party
  */
 static int kex_agree_methods(LIBSSH2_SESSION * session, unsigned char *data,
-                             unsigned data_len)
+                             size_t data_len)
 {
     unsigned char *kex, *hostkey, *crypt_cs, *crypt_sc, *comp_cs, *comp_sc,
         *mac_cs, *mac_sc;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -560,7 +560,7 @@ _libssh2_cipher_init(_libssh2_cipher_ctx * h,
     int ret;
     int cipher = _libssh2_gcry_cipher(algo);
     int mode = _libssh2_gcry_mode(algo);
-    int keylen = gcry_cipher_get_algo_keylen(cipher);
+    size_t keylen = gcry_cipher_get_algo_keylen(cipher);
 
     (void) encrypt;
 
@@ -576,7 +576,7 @@ _libssh2_cipher_init(_libssh2_cipher_ctx * h,
     }
 
     if(mode != GCRY_CIPHER_MODE_STREAM) {
-        int blklen = gcry_cipher_get_algo_blklen(cipher);
+        size_t blklen = gcry_cipher_get_algo_blklen(cipher);
         if(mode == GCRY_CIPHER_MODE_CTR)
             ret = gcry_cipher_setctr(*h, iv, blklen);
         else

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -525,7 +525,7 @@ _libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
 int
 _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
                          const unsigned char *sig,
-                         const unsigned char *m, unsigned long m_len)
+                         const unsigned char *m, size_t m_len)
 {
     unsigned char hash[SHA_DIGEST_LENGTH + 1];
     gcry_sexp_t s_sig, s_hash;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -88,8 +88,8 @@ _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
 int
 _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
                          const unsigned char *sig,
-                         unsigned long sig_len,
-                         const unsigned char *m, unsigned long m_len)
+                         size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     unsigned char hash[SHA_DIGEST_LENGTH];
     gcry_sexp_t s_sig, s_hash;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -410,7 +410,7 @@ struct _LIBSSH2_CHANNEL
     /* Amount of bytes to be refunded to receive window (but not yet sent) */
     uint32_t adjust_queue;
     /* Data immediately available for reading */
-    uint32_t read_avail;
+    size_t read_avail;
 
     LIBSSH2_SESSION *session;
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -850,8 +850,8 @@ struct _LIBSSH2_SESSION
     LIBSSH2_CHANNEL *sftpInit_channel;
     unsigned char sftpInit_buffer[9];   /* sftp_header(5){excludes request_id}
                                            + version_id(4) */
-    int sftpInit_sent; /* number of bytes from the buffer that have been
-                          sent */
+    size_t sftpInit_sent; /* number of bytes from the buffer that have been
+                             sent */
 
     /* State variables used in libssh2_scp_recv() / libssh_scp_recv2() */
     libssh2_nonblocking_states scpRecv_state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -567,7 +567,7 @@ struct transportpacket
     /* ------------- for outgoing data --------------- */
     unsigned char outbuf[MAX_SSH_PACKET_LEN]; /* area for the outgoing data */
 
-    int ototal_num;         /* size of outbuf in number of bytes */
+    ssize_t ototal_num;     /* size of outbuf in number of bytes */
     const unsigned char *odata; /* original pointer to the data */
     size_t olen;            /* original size of the data we stored in
                                outbuf */

--- a/src/mac.c
+++ b/src/mac.c
@@ -45,8 +45,8 @@
 static int
 mac_none_MAC(LIBSSH2_SESSION * session, unsigned char *buf,
              uint32_t seqno, const unsigned char *packet,
-             uint32_t packet_len, const unsigned char *addtl,
-             uint32_t addtl_len, void **abstract)
+             size_t packet_len, const unsigned char *addtl,
+             size_t addtl_len, void **abstract)
 {
     return 0;
 }
@@ -104,9 +104,9 @@ static int
 mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION * session,
                           unsigned char *buf, uint32_t seqno,
                           const unsigned char *packet,
-                          uint32_t packet_len,
+                          size_t packet_len,
                           const unsigned char *addtl,
-                          uint32_t addtl_len, void **abstract)
+                          size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -149,9 +149,9 @@ static int
 mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION * session,
                           unsigned char *buf, uint32_t seqno,
                           const unsigned char *packet,
-                          uint32_t packet_len,
+                          size_t packet_len,
                           const unsigned char *addtl,
-                          uint32_t addtl_len, void **abstract)
+                          size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -194,9 +194,9 @@ static int
 mac_method_hmac_sha1_hash(LIBSSH2_SESSION * session,
                           unsigned char *buf, uint32_t seqno,
                           const unsigned char *packet,
-                          uint32_t packet_len,
+                          size_t packet_len,
                           const unsigned char *addtl,
-                          uint32_t addtl_len, void **abstract)
+                          size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -235,9 +235,9 @@ static int
 mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION * session,
                              unsigned char *buf, uint32_t seqno,
                              const unsigned char *packet,
-                             uint32_t packet_len,
+                             size_t packet_len,
                              const unsigned char *addtl,
-                             uint32_t addtl_len, void **abstract)
+                             size_t addtl_len, void **abstract)
 {
     unsigned char temp[SHA_DIGEST_LENGTH];
 
@@ -267,9 +267,9 @@ static int
 mac_method_hmac_md5_hash(LIBSSH2_SESSION * session, unsigned char *buf,
                          uint32_t seqno,
                          const unsigned char *packet,
-                         uint32_t packet_len,
+                         size_t packet_len,
                          const unsigned char *addtl,
-                         uint32_t addtl_len, void **abstract)
+                         size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -308,9 +308,9 @@ static int
 mac_method_hmac_md5_96_hash(LIBSSH2_SESSION * session,
                             unsigned char *buf, uint32_t seqno,
                             const unsigned char *packet,
-                            uint32_t packet_len,
+                            size_t packet_len,
                             const unsigned char *addtl,
-                            uint32_t addtl_len, void **abstract)
+                            size_t addtl_len, void **abstract)
 {
     unsigned char temp[MD5_DIGEST_LENGTH];
     mac_method_hmac_md5_hash(session, temp, seqno, packet, packet_len,
@@ -339,9 +339,9 @@ static int
 mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION * session,
                                unsigned char *buf, uint32_t seqno,
                                const unsigned char *packet,
-                               uint32_t packet_len,
+                               size_t packet_len,
                                const unsigned char *addtl,
-                               uint32_t addtl_len,
+                               size_t addtl_len,
                                void **abstract)
 {
     libssh2_hmac_ctx ctx;

--- a/src/mac.h
+++ b/src/mac.h
@@ -54,8 +54,8 @@ struct _LIBSSH2_MAC_METHOD
                  void **abstract);
     int (*hash) (LIBSSH2_SESSION * session, unsigned char *buf,
                  uint32_t seqno, const unsigned char *packet,
-                 uint32_t packet_len, const unsigned char *addtl,
-                 uint32_t addtl_len, void **abstract);
+                 size_t packet_len, const unsigned char *addtl,
+                 size_t addtl_len, void **abstract);
     int (*dtor) (LIBSSH2_SESSION * session, void **abstract);
 };
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -83,7 +83,7 @@ _libssh2_mbedtls_free(void)
 }
 
 int
-_libssh2_mbedtls_random(unsigned char *buf, int len)
+_libssh2_mbedtls_random(unsigned char *buf, size_t len)
 {
     int ret;
     ret = mbedtls_ctr_drbg_random(&_libssh2_mbedtls_ctr_drbg, buf, len);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -91,7 +91,7 @@ _libssh2_mbedtls_random(unsigned char *buf, int len)
 }
 
 static void
-_libssh2_mbedtls_safe_free(void *buf, int len)
+_libssh2_mbedtls_safe_free(void *buf, size_t len)
 {
     if(!buf)
         return;

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -448,7 +448,7 @@ void
 _libssh2_mbedtls_free(void);
 
 int
-_libssh2_mbedtls_random(unsigned char *buf, int len);
+_libssh2_mbedtls_random(unsigned char *buf, size_t len);
 
 int
 _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,

--- a/src/misc.c
+++ b/src/misc.c
@@ -215,13 +215,13 @@ _libssh2_send(libssh2_socket_t sock, const void *buffer, size_t length,
 
 /* libssh2_ntohu32
  */
-unsigned int
+uint32_t
 _libssh2_ntohu32(const unsigned char *buf)
 {
-    return (((unsigned int)buf[0] << 24)
-           | ((unsigned int)buf[1] << 16)
-           | ((unsigned int)buf[2] << 8)
-           | ((unsigned int)buf[3]));
+    return ((uint32_t)buf[0] << 24)
+         | ((uint32_t)buf[1] << 16)
+         | ((uint32_t)buf[2] << 8)
+         | ((uint32_t)buf[3]);
 }
 
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -97,7 +97,7 @@ void _libssh2_list_remove(struct list_node *entry);
 size_t _libssh2_base64_encode(LIBSSH2_SESSION *session,
                               const char *inp, size_t insize, char **outptr);
 
-unsigned int _libssh2_ntohu32(const unsigned char *buf);
+uint32_t _libssh2_ntohu32(const unsigned char *buf);
 libssh2_uint64_t _libssh2_ntohu64(const unsigned char *buf);
 void _libssh2_htonu32(unsigned char *buf, uint32_t val);
 void _libssh2_store_u32(unsigned char **buf, uint32_t value);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -287,7 +287,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
 int
 _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
                          const unsigned char *sig,
-                         const unsigned char *m, unsigned long m_len)
+                         const unsigned char *m, size_t m_len)
 {
     unsigned char hash[SHA_DIGEST_LENGTH];
     DSA_SIG * dsasig;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -174,8 +174,8 @@ int
 _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
                          size_t hash_len,
                          const unsigned char *sig,
-                         unsigned long sig_len,
-                         const unsigned char *m, unsigned long m_len)
+                         size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     int ret;
     int nid_type;
@@ -222,8 +222,8 @@ _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
 int
 _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
                          const unsigned char *sig,
-                         unsigned long sig_len,
-                         const unsigned char *m, unsigned long m_len)
+                         size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     return _libssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH, sig, sig_len, m,
                                     m_len);
@@ -2196,7 +2196,7 @@ _libssh2_sha1_init(libssh2_sha1_ctx *ctx)
 }
 
 int
-_libssh2_sha1(const unsigned char *message, unsigned long len,
+_libssh2_sha1(const unsigned char *message, size_t len,
               unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -2248,7 +2248,7 @@ _libssh2_sha256_init(libssh2_sha256_ctx *ctx)
 }
 
 int
-_libssh2_sha256(const unsigned char *message, unsigned long len,
+_libssh2_sha256(const unsigned char *message, size_t len,
                 unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -2300,8 +2300,8 @@ _libssh2_sha384_init(libssh2_sha384_ctx *ctx)
 }
 
 int
-_libssh2_sha384(const unsigned char *message, unsigned long len,
-    unsigned char *out)
+_libssh2_sha384(const unsigned char *message, size_t len,
+                unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     EVP_MD_CTX * ctx = EVP_MD_CTX_new();
@@ -2352,8 +2352,8 @@ _libssh2_sha512_init(libssh2_sha512_ctx *ctx)
 }
 
 int
-_libssh2_sha512(const unsigned char *message, unsigned long len,
-    unsigned char *out)
+_libssh2_sha512(const unsigned char *message, size_t len,
+                unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
     EVP_MD_CTX * ctx = EVP_MD_CTX_new();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -92,6 +92,16 @@ write_bn(unsigned char *buf, const BIGNUM *bn, int bn_bytes)
 }
 
 int
+_libssh2_openssl_random(void *buf, size_t len)
+{
+    if(len > INT_MAX) {
+        return -1;
+    }
+
+    return RAND_bytes(buf, (int)len) == 1 ? 0 : -1;
+}
+
+int
 _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
                  const unsigned char *edata,
                  unsigned long elen,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1985,7 +1985,7 @@ int
 _libssh2_ed25519_new_public(libssh2_ed25519_ctx ** ed_ctx,
                             LIBSSH2_SESSION * session,
                             const unsigned char *raw_pub_key,
-                            const uint8_t key_len)
+                            const size_t key_len)
 {
     libssh2_ed25519_ctx *ctx = NULL;
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -204,7 +204,7 @@ int _libssh2_sha1_init(libssh2_sha1_ctx *ctx);
 #define libssh2_sha1_update(ctx, data, len) EVP_DigestUpdate(&(ctx), data, len)
 #define libssh2_sha1_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
 #endif
-int _libssh2_sha1(const unsigned char *message, unsigned long len,
+int _libssh2_sha1(const unsigned char *message, size_t len,
                   unsigned char *out);
 #define libssh2_sha1(x,y,z) _libssh2_sha1(x,y,z)
 
@@ -228,8 +228,8 @@ int _libssh2_sha256_init(libssh2_sha256_ctx *ctx);
     EVP_DigestUpdate(&(ctx), data, len)
 #define libssh2_sha256_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
 #endif
-int _libssh2_sha256(const unsigned char *message, unsigned long len,
-                  unsigned char *out);
+int _libssh2_sha256(const unsigned char *message, size_t len,
+                    unsigned char *out);
 #define libssh2_sha256(x,y,z) _libssh2_sha256(x,y,z)
 
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -252,7 +252,7 @@ int _libssh2_sha384_init(libssh2_sha384_ctx *ctx);
     EVP_DigestUpdate(&(ctx), data, len)
 #define libssh2_sha384_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
 #endif
-int _libssh2_sha384(const unsigned char *message, unsigned long len,
+int _libssh2_sha384(const unsigned char *message, size_t len,
                     unsigned char *out);
 #define libssh2_sha384(x,y,z) _libssh2_sha384(x,y,z)
 
@@ -276,7 +276,7 @@ int _libssh2_sha512_init(libssh2_sha512_ctx *ctx);
     EVP_DigestUpdate(&(ctx), data, len)
 #define libssh2_sha512_final(ctx, out) EVP_DigestFinal(&(ctx), out, NULL)
 #endif
-int _libssh2_sha512(const unsigned char *message, unsigned long len,
+int _libssh2_sha512(const unsigned char *message, size_t len,
                     unsigned char *out);
 #define libssh2_sha512(x,y,z) _libssh2_sha512(x,y,z)
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -181,7 +181,8 @@
 
 #define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
-#define _libssh2_random(buf, len) (RAND_bytes((buf), (len)) == 1 ? 0 : -1)
+#define _libssh2_random(buf, len) \
+  _libssh2_openssl_random((buf), (len))
 
 #define libssh2_prepare_iovec(vec, len)  /* Empty. */
 
@@ -426,6 +427,8 @@ extern int _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                               _libssh2_bn *f, _libssh2_bn *p,
                               _libssh2_bn_ctx *bnctx);
 extern void _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
+
+extern int _libssh2_openssl_random(void *buf, size_t len);
 
 const EVP_CIPHER *_libssh2_EVP_aes_128_ctr(void);
 const EVP_CIPHER *_libssh2_EVP_aes_192_ctr(void);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -883,7 +883,7 @@ _libssh2_bn_from_bn(_libssh2_bn *to, _libssh2_bn *from)
 }
 
 int
-_libssh2_random(unsigned char *buf, int len)
+_libssh2_random(unsigned char *buf, size_t len)
 {
     Qc3GenPRNs(buf, len,
         Qc3PRN_TYPE_NORMAL, Qc3PRN_NO_PARITY, (char *) &ecnull);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2379,12 +2379,12 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 
 int
 _libssh2_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
-                         const unsigned char *sig, unsigned long sig_len,
-                         const unsigned char *m, unsigned long m_len)
+                         const unsigned char *sig, size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     Qus_EC_t errcode;
-    int slen = sig_len;
-    int mlen = m_len;
+    int slen = (int)sig_len;
+    int mlen = (int)m_len;
 
     set_EC_length(errcode, sizeof errcode);
     Qc3VerifySignature((char *) sig, &slen, (char *) m, &mlen, Qc3_Data,

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -361,7 +361,7 @@ extern int      _libssh2_bn_from_bin(_libssh2_bn *bn, int len,
                                      const unsigned char *v);
 extern int      _libssh2_bn_set_word(_libssh2_bn *bn, unsigned long val);
 extern int      _libssh2_bn_to_bin(_libssh2_bn *bn, unsigned char *val);
-extern int      _libssh2_random(unsigned char *buf, int len);
+extern int      _libssh2_random(unsigned char *buf, size_t len);
 extern void     _libssh2_os400qc3_crypto_dtor(_libssh2_os400qc3_crypto_ctx *x);
 extern int      libssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x,
                                            unsigned int algo);

--- a/src/packet.c
+++ b/src/packet.c
@@ -72,21 +72,21 @@
  */
 static inline int
 packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
-                      unsigned long datalen,
+                      size_t datalen,
                       packet_queue_listener_state_t *listen_state)
 {
     /*
      * Look for a matching listener
      */
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */
-    unsigned long packet_len = 17 + (sizeof(FwdNotReq) - 1);
+    size_t packet_len = 17 + (sizeof(FwdNotReq) - 1);
     unsigned char *p;
     LIBSSH2_LISTENER *listn = _libssh2_list_first(&session->listeners);
     char failure_code = SSH_OPEN_ADMINISTRATIVELY_PROHIBITED;
     int rc;
 
     if(listen_state->state == libssh2_NB_state_idle) {
-        unsigned long offset = (sizeof("forwarded-tcpip") - 1) + 5;
+        size_t offset = (sizeof("forwarded-tcpip") - 1) + 5;
         size_t temp_len = 0;
         struct string_buf buf;
         buf.data = data;
@@ -285,19 +285,19 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
  */
 static inline int
 packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
-                unsigned long datalen,
+                size_t datalen,
                 packet_x11_open_state_t *x11open_state)
 {
     int failure_code = SSH_OPEN_CONNECT_FAILED;
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */
-    unsigned long packet_len = 17 + (sizeof(X11FwdUnAvil) - 1);
+    size_t packet_len = 17 + (sizeof(X11FwdUnAvil) - 1);
     unsigned char *p;
     LIBSSH2_CHANNEL *channel = x11open_state->channel;
     int rc;
 
     if(x11open_state->state == libssh2_NB_state_idle) {
 
-        unsigned long offset = (sizeof("x11") - 1) + 5;
+        size_t offset = (sizeof("x11") - 1) + 5;
         size_t temp_len = 0;
         struct string_buf buf;
         buf.data = data;
@@ -798,7 +798,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 session->packAdd_state = libssh2_NB_state_jump1;
                 rc = _libssh2_channel_receive_window_adjust(session->
                                                             packAdd_channelp,
-                                                            datalen - 13,
+                                                    (uint32_t)(datalen - 13),
                                                             1, NULL);
                 if(rc == LIBSSH2_ERROR_EAGAIN)
                     return rc;

--- a/src/packet.c
+++ b/src/packet.c
@@ -1208,7 +1208,7 @@ _libssh2_packet_askv(LIBSSH2_SESSION * session,
                      const unsigned char *match_buf,
                      size_t match_len)
 {
-    int i, packet_types_len = strlen((char *) packet_types);
+    size_t i, packet_types_len = strlen((const char *) packet_types);
 
     for(i = 0; i < packet_types_len; i++) {
         if(0 == _libssh2_packet_ask(session, packet_types[i], data,

--- a/src/pem.c
+++ b/src/pem.c
@@ -172,9 +172,9 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
     do {
         if(*line) {
             char *tmp;
-            size_t linelen;
+            unsigned int linelen;
 
-            linelen = strlen(line);
+            linelen = (unsigned int)strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
                 _libssh2_error(session, LIBSSH2_ERROR_ALLOC,

--- a/src/pem.c
+++ b/src/pem.c
@@ -114,7 +114,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
     char line[LINE_SIZE];
     unsigned char iv[LINE_SIZE];
     char *b64data = NULL;
-    unsigned int b64datalen = 0;
+    size_t b64datalen = 0;
     int ret;
     const LIBSSH2_CRYPT_METHOD *method = NULL;
 
@@ -172,9 +172,9 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
     do {
         if(*line) {
             char *tmp;
-            unsigned int linelen;
+            size_t linelen;
 
-            linelen = (unsigned int)strlen(line);
+            linelen = strlen(line);
             tmp = LIBSSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
                 _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -200,7 +200,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
     }
 
     if(libssh2_base64_decode(session, (char **) data, datalen,
-                              b64data, b64datalen)) {
+                             b64data, (unsigned int)b64datalen)) {
         ret = -1;
         goto out;
     }
@@ -299,7 +299,7 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION * session,
 {
     char line[LINE_SIZE];
     char *b64data = NULL;
-    unsigned int b64datalen = 0;
+    size_t b64datalen = 0;
     size_t off = 0;
     int ret;
 
@@ -345,7 +345,7 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION * session,
     }
 
     if(libssh2_base64_decode(session, (char **) data, datalen,
-                              b64data, b64datalen)) {
+                             b64data, (unsigned int)b64datalen)) {
         ret = -1;
         goto out;
     }
@@ -669,7 +669,7 @@ _libssh2_openssh_pem_parse(LIBSSH2_SESSION * session,
 {
     char line[LINE_SIZE];
     char *b64data = NULL;
-    unsigned int b64datalen = 0;
+    size_t b64datalen = 0;
     int ret = 0;
 
     /* read file */
@@ -720,7 +720,7 @@ _libssh2_openssh_pem_parse(LIBSSH2_SESSION * session,
     ret = _libssh2_openssh_pem_parse_data(session,
                                           passphrase,
                                           (const char *)b64data,
-                                          (size_t)b64datalen,
+                                          b64datalen,
                                           decrypted_buf);
 
     if(b64data) {
@@ -741,7 +741,7 @@ _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
 {
     char line[LINE_SIZE];
     char *b64data = NULL;
-    unsigned int b64datalen = 0;
+    size_t b64datalen = 0;
     size_t off = 0;
     int ret;
 

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -105,7 +105,7 @@ static const LIBSSH2_PUBLICKEY_CODE_LIST publickey_status_codes[] = {
  */
 static void
 publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
-                       LIBSSH2_SESSION *session, int status)
+                       LIBSSH2_SESSION *session, unsigned long status)
 {
     const char *msg;
 
@@ -114,7 +114,7 @@ publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
         status = 7;
     }
 
-    if(status < 0 || status > LIBSSH2_PUBLICKEY_STATUS_CODE_MAX) {
+    if(status > LIBSSH2_PUBLICKEY_STATUS_CODE_MAX) {
         msg = "unknown";
     }
     else {
@@ -136,14 +136,14 @@ publickey_packet_receive(LIBSSH2_PUBLICKEY * pkey,
     LIBSSH2_CHANNEL *channel = pkey->channel;
     LIBSSH2_SESSION *session = channel->session;
     unsigned char buffer[4];
-    int rc;
+    ssize_t rc;
     *data = NULL; /* default to nothing returned */
     *data_len = 0;
 
     if(pkey->receive_state == libssh2_NB_state_idle) {
         rc = _libssh2_channel_read(channel, 0, (char *) buffer, 4);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+            return (int)rc;
         }
         else if(rc != 4) {
             return _libssh2_error(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
@@ -166,9 +166,9 @@ publickey_packet_receive(LIBSSH2_PUBLICKEY * pkey,
         rc = _libssh2_channel_read(channel, 0, (char *) pkey->receive_packet,
                                    pkey->receive_packet_len);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+            return (int)rc;
         }
-        else if(rc != (int)pkey->receive_packet_len) {
+        else if(rc != (ssize_t)pkey->receive_packet_len) {
             LIBSSH2_FREE(session, pkey->receive_packet);
             pkey->receive_packet = NULL;
             pkey->receive_state = libssh2_NB_state_idle;
@@ -234,7 +234,7 @@ publickey_response_success(LIBSSH2_PUBLICKEY * pkey)
     size_t data_len;
     int response;
 
-    while(1) {
+    for(;;) {
         int rc = publickey_packet_receive(pkey, &data, &data_len);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             return rc;
@@ -395,20 +395,21 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
     }
 
     if(session->pkeyInit_state == libssh2_NB_state_sent2) {
-        rc = _libssh2_channel_write(session->pkeyInit_channel, 0,
-                                    session->pkeyInit_buffer,
-                                    19 - session->pkeyInit_buffer_sent);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(session->pkeyInit_channel, 0,
+                                          session->pkeyInit_buffer,
+                                          19 - session->pkeyInit_buffer_sent);
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
             _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
                            "Would block sending publickey version packet");
             return NULL;
         }
-        else if(rc < 0) {
-            _libssh2_error(session, rc,
+        else if(nwritten < 0) {
+            _libssh2_error(session, (int)nwritten,
                            "Unable to send publickey version packet");
             goto err_exit;
         }
-        session->pkeyInit_buffer_sent += rc;
+        session->pkeyInit_buffer_sent += nwritten;
         if(session->pkeyInit_buffer_sent < 19) {
             _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
                            "Need to be called again to complete this");
@@ -419,7 +420,7 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
     }
 
     if(session->pkeyInit_state == libssh2_NB_state_sent3) {
-        while(1) {
+        for(;;) {
             unsigned char *s;
             rc = publickey_packet_receive(session->pkeyInit_pkey,
                                           &session->pkeyInit_data,
@@ -698,12 +699,13 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
     }
 
     if(pkey->add_state == libssh2_NB_state_created) {
-        rc = _libssh2_channel_write(channel, 0, pkey->add_packet,
-                                    (pkey->add_s - pkey->add_packet));
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(channel, 0, pkey->add_packet,
+                                          (pkey->add_s - pkey->add_packet));
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+            return (int)nwritten;
         }
-        else if((pkey->add_s - pkey->add_packet) != rc) {
+        else if((pkey->add_s - pkey->add_packet) != nwritten) {
             LIBSSH2_FREE(session, pkey->add_packet);
             pkey->add_packet = NULL;
             return _libssh2_error(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -782,12 +784,13 @@ libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY * pkey,
     }
 
     if(pkey->remove_state == libssh2_NB_state_created) {
-        rc = _libssh2_channel_write(channel, 0, pkey->remove_packet,
-                                    (pkey->remove_s - pkey->remove_packet));
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(channel, 0, pkey->remove_packet,
+                                       (pkey->remove_s - pkey->remove_packet));
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+            return (int)nwritten;
         }
-        else if((pkey->remove_s - pkey->remove_packet) != rc) {
+        else if((pkey->remove_s - pkey->remove_packet) != nwritten) {
             LIBSSH2_FREE(session, pkey->remove_packet);
             pkey->remove_packet = NULL;
             pkey->remove_state = libssh2_NB_state_idle;
@@ -849,14 +852,15 @@ libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY * pkey, unsigned long *num_keys,
     }
 
     if(pkey->listFetch_state == libssh2_NB_state_created) {
-        rc = _libssh2_channel_write(channel, 0,
-                                    pkey->listFetch_buffer,
-                                    (pkey->listFetch_s -
-                                     pkey->listFetch_buffer));
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(channel, 0,
+                                          pkey->listFetch_buffer,
+                                          (pkey->listFetch_s -
+                                           pkey->listFetch_buffer));
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+            return (int)nwritten;
         }
-        else if((pkey->listFetch_s - pkey->listFetch_buffer) != rc) {
+        else if((pkey->listFetch_s - pkey->listFetch_buffer) != nwritten) {
             pkey->listFetch_state = libssh2_NB_state_idle;
             return _libssh2_error(session, LIBSSH2_ERROR_SOCKET_SEND,
                                   "Unable to send publickey list packet");
@@ -865,7 +869,7 @@ libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY * pkey, unsigned long *num_keys,
         pkey->listFetch_state = libssh2_NB_state_sent;
     }
 
-    while(1) {
+    for(;;) {
         rc = publickey_packet_receive(pkey, &pkey->listFetch_data,
                                       &pkey->listFetch_data_len);
         if(rc == LIBSSH2_ERROR_EAGAIN) {

--- a/src/session.c
+++ b/src/session.c
@@ -95,7 +95,7 @@ LIBSSH2_REALLOC_FUNC(libssh2_default_realloc)
 static int
 banner_receive(LIBSSH2_SESSION * session)
 {
-    int ret;
+    ssize_t ret;
     size_t banner_len;
 
     if(session->banner_TxRx_state == libssh2_NB_state_idle) {
@@ -121,11 +121,11 @@ banner_receive(LIBSSH2_SESSION * session)
             if(session->api_block_mode || (ret != -EAGAIN))
                 /* ignore EAGAIN when non-blocking */
                 _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                               "Error recving %d bytes: %d", 1, -ret));
+                               "Error recving %d bytes: %d", 1, (int)-ret));
         }
         else
             _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                           "Recved %d bytes banner", ret));
+                           "Recved %d bytes banner", (int)ret));
 
         if(ret < 0) {
             if(ret == -EAGAIN) {

--- a/src/session.c
+++ b/src/session.c
@@ -96,7 +96,7 @@ static int
 banner_receive(LIBSSH2_SESSION * session)
 {
     int ret;
-    int banner_len;
+    size_t banner_len;
 
     if(session->banner_TxRx_state == libssh2_NB_state_idle) {
         banner_len = 0;
@@ -107,7 +107,7 @@ banner_receive(LIBSSH2_SESSION * session)
         banner_len = session->banner_TxRx_total_send;
     }
 
-    while((banner_len < (int) sizeof(session->banner_TxRx_banner)) &&
+    while((banner_len < sizeof(session->banner_TxRx_banner)) &&
            ((banner_len == 0)
             || (session->banner_TxRx_banner[banner_len - 1] != '\n'))) {
         char c = '\0';
@@ -202,7 +202,7 @@ static int
 banner_send(LIBSSH2_SESSION * session)
 {
     char *banner = (char *) LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
-    int banner_len = sizeof(LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF) - 1;
+    size_t banner_len = sizeof(LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF) - 1;
     ssize_t ret;
 #ifdef LIBSSH2DEBUG
     char banner_dup[256];
@@ -249,7 +249,7 @@ banner_send(LIBSSH2_SESSION * session)
                        banner_len - session->banner_TxRx_total_send,
                        banner, session->banner_TxRx_total_send));
 
-    if(ret != (banner_len - session->banner_TxRx_total_send)) {
+    if(ret != (ssize_t)(banner_len - session->banner_TxRx_total_send)) {
         if(ret >= 0 || ret == -EAGAIN) {
             /* the whole packet could not be sent, save the what was */
             session->socket_block_directions =
@@ -750,7 +750,7 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
             else if(rc)
                 return _libssh2_error(session, rc,
                                       "Failed getting banner");
-        } while(strncmp("SSH-", (char *)session->remote.banner, 4));
+        } while(strncmp("SSH-", (const char *)session->remote.banner, 4));
 
         session->startup_state = libssh2_NB_state_sent1;
     }
@@ -814,7 +814,8 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 
 
         if((session->startup_service_length != (sizeof("ssh-userauth") - 1))
-            || strncmp("ssh-userauth", (char *) session->startup_data + 5,
+            || strncmp("ssh-userauth",
+                       (const char *) session->startup_data + 5,
                        session->startup_service_length)) {
             LIBSSH2_FREE(session, session->startup_data);
             session->startup_data = NULL;
@@ -1153,7 +1154,7 @@ session_disconnect(LIBSSH2_SESSION *session, int reason,
                    const char *lang)
 {
     unsigned char *s;
-    unsigned long descr_len = 0, lang_len = 0;
+    size_t descr_len = 0, lang_len = 0;
     int rc;
 
     if(session->disconnect_state == libssh2_NB_state_idle) {
@@ -1170,6 +1171,10 @@ session_disconnect(LIBSSH2_SESSION *session, int reason,
             return _libssh2_error(session, LIBSSH2_ERROR_INVAL,
                                   "too long description");
 
+        if(lang_len > 256)
+            return _libssh2_error(session, LIBSSH2_ERROR_INVAL,
+                                  "too long language string");
+
         /* 13 = packet_type(1) + reason code(4) + descr_len(4) + lang_len(4) */
         session->disconnect_data_len = descr_len + lang_len + 13;
 
@@ -1179,14 +1184,14 @@ session_disconnect(LIBSSH2_SESSION *session, int reason,
         _libssh2_store_u32(&s, reason);
         _libssh2_store_str(&s, description, descr_len);
         /* store length only, lang is sent separately */
-        _libssh2_store_u32(&s, lang_len);
+        _libssh2_store_u32(&s, (uint32_t)lang_len);
 
         session->disconnect_state = libssh2_NB_state_created;
     }
 
     rc = _libssh2_transport_send(session, session->disconnect_data,
                                  session->disconnect_data_len,
-                                 (unsigned char *)lang, lang_len);
+                                 (const unsigned char *)lang, lang_len);
     if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
 
@@ -1335,7 +1340,7 @@ libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
     }
 
     if(errmsg_len) {
-        *errmsg_len = msglen;
+        *errmsg_len = (int)msglen;
     }
 
     return session->err_code;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1923,14 +1923,15 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
     }
 
     if(data[0] == SSH_FXP_STATUS) {
-        retcode = _libssh2_ntohu32(data + 5);
+        unsigned int rerrno;
+        rerrno = _libssh2_ntohu32(data + 5);
         LIBSSH2_FREE(session, data);
-        if(retcode == LIBSSH2_FX_EOF) {
+        if(rerrno == LIBSSH2_FX_EOF) {
             sftp->readdir_state = libssh2_NB_state_idle;
             return 0;
         }
         else {
-            sftp->last_errno = retcode;
+            sftp->last_errno = rerrno;
             sftp->readdir_state = libssh2_NB_state_idle;
             return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                   "SFTP Protocol Error");

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -333,9 +333,9 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
                                            sftp->partial_size_len],
                                        4 - sftp->partial_size_len);
             if(rc == LIBSSH2_ERROR_EAGAIN)
-                return rc;
+                return (int)rc;
             else if(rc < 0)
-                return _libssh2_error(session, rc, "channel read");
+                return _libssh2_error(session, (int)rc, "channel read");
 
             sftp->partial_size_len += rc;
 
@@ -387,7 +387,7 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
                     libssh2_NB_state_idle;
 
                 if(rc == LIBSSH2_ERROR_EAGAIN)
-                    return rc;
+                    return (int)rc;
             }
         }
 
@@ -405,12 +405,12 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
                  * knows how to continue on the next invoke.
                  */
                 sftp->packet_state = libssh2_NB_state_sent1;
-                return rc;
+                return (int)rc;
             }
             else if(rc < 0) {
                 LIBSSH2_FREE(session, packet);
                 sftp->partial_packet = NULL;
-                return _libssh2_error(session, rc,
+                return _libssh2_error(session, (int)rc,
                                       "Error waiting for SFTP packet");
             }
             sftp->partial_received += rc;
@@ -424,7 +424,7 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
         rc = sftp_packet_add(sftp, packet, sftp->partial_len);
         if(rc) {
             LIBSSH2_FREE(session, packet);
-            return rc;
+            return (int)rc;
         }
         else {
             return packet_type;
@@ -912,7 +912,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         goto sftp_init_error;
     }
     else if(rc) {
-        _libssh2_error(session, rc,
+        _libssh2_error(session, (int)rc,
                        "Timeout waiting for response from SFTP subsystem");
         goto sftp_init_error;
     }
@@ -1165,7 +1165,7 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
             return NULL;
         }
         else if(rc < 0) {
-            _libssh2_error(session, rc, "Unable to send FXP_OPEN*");
+            _libssh2_error(session, (int)rc, "Unable to send FXP_OPEN*");
             LIBSSH2_FREE(session, sftp->open_packet);
             sftp->open_packet = NULL;
             sftp->open_state = libssh2_NB_state_idle;
@@ -1207,7 +1207,8 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
         }
         sftp->open_state = libssh2_NB_state_idle;
         if(rc) {
-            _libssh2_error(session, rc, "Timeout waiting for status message");
+            _libssh2_error(session, (int)rc,
+                           "Timeout waiting for status message");
             return NULL;
         }
 
@@ -1324,8 +1325,8 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
         return NULL;
 
     BLOCK_ADJUST_ERRNO(hnd, sftp->channel->session,
-                       sftp_open(sftp, filename, filename_len, flags, mode,
-                                 open_type));
+                       sftp_open(sftp, filename, filename_len, (uint32_t)flags,
+                                 mode, open_type));
     return hnd;
 }
 
@@ -1718,7 +1719,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
         break;
 
     default:
-        assert(!"State machine error; unrecognised read state");
+        assert(0);  /* State machine error; unrecognised read state */
     }
 
     /* we should never reach this point */
@@ -1917,7 +1918,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
     }
     else if(retcode) {
         sftp->readdir_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, retcode,
+        return _libssh2_error(session, (int)retcode,
                               "Timeout waiting for status message");
     }
 
@@ -1965,13 +1966,13 @@ libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *hnd, char *buffer,
                         size_t longentry_maxlen,
                         LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
-    int rc;
+    ssize_t rc;
     if(!hnd)
         return LIBSSH2_ERROR_BAD_USE;
     BLOCK_ADJUST(rc, hnd->sftp->channel->session,
                  sftp_readdir(hnd, buffer, buffer_maxlen, longentry,
                               longentry_maxlen, attrs));
-    return rc;
+    return (int)rc;  /* FIXME: -> ssize_t */
 }
 
 /*
@@ -2296,7 +2297,7 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
                              sftp->fsync_request_id, &data, &data_len, 9);
     if(rc == LIBSSH2_ERROR_EAGAIN) {
-        return rc;
+        return (int)rc;
     }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
         if(data_len > 0) {
@@ -2307,7 +2308,7 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
     }
     else if(rc) {
         sftp->fsync_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, rc,
+        return _libssh2_error(session, (int)rc,
                               "Error waiting for FXP EXTENDED REPLY");
     }
 
@@ -2387,7 +2388,7 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
         rc = _libssh2_channel_write(channel, 0, sftp->fstat_packet,
                                     packet_len);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+            return (int)rc;
         }
         else if((ssize_t)packet_len != rc) {
             LIBSSH2_FREE(session, sftp->fstat_packet);
@@ -2407,7 +2408,7 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
                               sftp->fstat_request_id, &data,
                               &data_len, 9);
     if(rc == LIBSSH2_ERROR_EAGAIN)
-        return rc;
+        return (int)rc;
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
         if(data_len > 0) {
             LIBSSH2_FREE(session, data);
@@ -2417,7 +2418,7 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
     }
     else if(rc) {
         sftp->fstat_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, rc,
+        return _libssh2_error(session, (int)rc,
                               "Timeout waiting for status message");
     }
 
@@ -2603,12 +2604,13 @@ sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
     }
 
     if(handle->close_state == libssh2_NB_state_created) {
-        rc = _libssh2_channel_write(channel, 0, handle->close_packet,
-                                    packet_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(channel, 0, handle->close_packet,
+                                          packet_len);
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+            return (int)nwritten;
         }
-        else if((ssize_t)packet_len != rc) {
+        else if((ssize_t)packet_len != nwritten) {
             handle->close_state = libssh2_NB_state_idle;
             rc = _libssh2_error(session, LIBSSH2_ERROR_SOCKET_SEND,
                                 "Unable to send FXP_CLOSE command");
@@ -2732,12 +2734,13 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename,
     }
 
     if(sftp->unlink_state == libssh2_NB_state_created) {
-        rc = _libssh2_channel_write(channel, 0, sftp->unlink_packet,
-                                    packet_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(channel, 0, sftp->unlink_packet,
+                                          packet_len);
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+            return (int)nwritten;
         }
-        else if((ssize_t)packet_len != rc) {
+        else if((ssize_t)packet_len != nwritten) {
             LIBSSH2_FREE(session, sftp->unlink_packet);
             sftp->unlink_packet = NULL;
             sftp->unlink_state = libssh2_NB_state_idle;
@@ -2855,7 +2858,7 @@ static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
         rc = _libssh2_channel_write(channel, 0, sftp->rename_packet,
                                     sftp->rename_s - sftp->rename_packet);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+            return (int)rc;
         }
         else if((ssize_t)packet_len != rc) {
             LIBSSH2_FREE(session, sftp->rename_packet);
@@ -2874,7 +2877,7 @@ static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
                              sftp->rename_request_id, &data,
                              &data_len, 9);
     if(rc == LIBSSH2_ERROR_EAGAIN) {
-        return rc;
+        return (int)rc;
     }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
         if(data_len > 0) {
@@ -2885,7 +2888,7 @@ static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
     }
     else if(rc) {
         sftp->rename_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, rc,
+        return _libssh2_error(session, (int)rc,
                               "Error waiting for FXP STATUS");
     }
 
@@ -3008,7 +3011,7 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
                               &data, &data_len, 9);
 
     if(rc == LIBSSH2_ERROR_EAGAIN) {
-        return rc;
+        return (int)rc;
     }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
         if(data_len > 0) {
@@ -3019,7 +3022,7 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
     }
     else if(rc) {
         sftp->fstatvfs_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, rc,
+        return _libssh2_error(session, (int)rc,
                               "Error waiting for FXP EXTENDED REPLY");
     }
 
@@ -3143,7 +3146,7 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
     rc = sftp_packet_requirev(sftp, 2, responses, sftp->statvfs_request_id,
                               &data, &data_len, 9);
     if(rc == LIBSSH2_ERROR_EAGAIN) {
-        return rc;
+        return (int)rc;
     }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
         if(data_len > 0) {
@@ -3154,7 +3157,7 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
     }
     else if(rc) {
         sftp->statvfs_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, rc,
+        return _libssh2_error(session, (int)rc,
                               "Error waiting for FXP EXTENDED REPLY");
     }
 
@@ -3208,8 +3211,8 @@ libssh2_sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
     int rc;
     if(!sftp || !st)
         return LIBSSH2_ERROR_BAD_USE;
-    BLOCK_ADJUST(rc, sftp->channel->session, sftp_statvfs(sftp, path, path_len,
-                                                          st));
+    BLOCK_ADJUST(rc, sftp->channel->session,
+                 sftp_statvfs(sftp, path, (unsigned int)path_len, st));
     return rc;
 }
 
@@ -3267,12 +3270,13 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
     }
 
     if(sftp->mkdir_state == libssh2_NB_state_created) {
-        rc = _libssh2_channel_write(channel, 0, packet, packet_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(channel, 0, packet, packet_len);
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
             sftp->mkdir_packet = packet;
-            return rc;
+            return (int)nwritten;
         }
-        if(packet_len != rc) {
+        if(packet_len != nwritten) {
             LIBSSH2_FREE(session, packet);
             sftp->mkdir_state = libssh2_NB_state_idle;
             return _libssh2_error(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -3369,12 +3373,13 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
     }
 
     if(sftp->rmdir_state == libssh2_NB_state_created) {
-        rc = _libssh2_channel_write(channel, 0, sftp->rmdir_packet,
-                                    packet_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(channel, 0, sftp->rmdir_packet,
+                                          packet_len);
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+            return (int)nwritten;
         }
-        else if(packet_len != rc) {
+        else if(packet_len != nwritten) {
             LIBSSH2_FREE(session, sftp->rmdir_packet);
             sftp->rmdir_packet = NULL;
             sftp->rmdir_state = libssh2_NB_state_idle;
@@ -3493,11 +3498,13 @@ static int sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
     }
 
     if(sftp->stat_state == libssh2_NB_state_created) {
-        rc = _libssh2_channel_write(channel, 0, sftp->stat_packet, packet_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return rc;
+        ssize_t nwritten;
+        nwritten = _libssh2_channel_write(channel, 0,
+                                          sftp->stat_packet, packet_len);
+        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+            return (int)nwritten;
         }
-        else if(packet_len != rc) {
+        else if(packet_len != nwritten) {
             LIBSSH2_FREE(session, sftp->stat_packet);
             sftp->stat_packet = NULL;
             sftp->stat_state = libssh2_NB_state_idle;
@@ -3641,7 +3648,7 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
         ssize_t rc = _libssh2_channel_write(channel, 0, sftp->symlink_packet,
                                             packet_len);
         if(rc == LIBSSH2_ERROR_EAGAIN)
-            return rc;
+            return (int)rc;
         else if(packet_len != rc) {
             LIBSSH2_FREE(session, sftp->symlink_packet);
             sftp->symlink_packet = NULL;
@@ -3669,7 +3676,7 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
     }
     else if(retcode) {
         sftp->symlink_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, retcode,
+        return _libssh2_error(session, (int)retcode,
                               "Error waiting for status message");
     }
 

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -674,7 +674,7 @@ sftp_attr2bin(unsigned char *p, const LIBSSH2_SFTP_ATTRIBUTES * attrs)
 
 /* sftp_bin2attr
  */
-static int
+static ssize_t
 sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs, const unsigned char *p,
               size_t data_len)
 {
@@ -1774,7 +1774,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
             size_t filename_len;
             size_t longentry_len;
             size_t names_packet_len = handle->u.dir.names_packet_len;
-            int attr_len = 0;
+            ssize_t attr_len = 0;
 
             if(names_packet_len >= 4) {
                 s = (unsigned char *) handle->u.dir.next_name;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -2653,7 +2653,7 @@ sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
 
     }
     else {
-        int retcode = _libssh2_ntohu32(data + 5);
+        uint32_t retcode = _libssh2_ntohu32(data + 5);
         LIBSSH2_FREE(session, data);
 
         if(retcode != LIBSSH2_FX_OK) {
@@ -2710,7 +2710,7 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename,
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
     size_t data_len = 0;
-    int retcode;
+    uint32_t retcode;
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) */
     uint32_t packet_len = (uint32_t)(filename_len + 13);
     unsigned char *s, *data = NULL;
@@ -3028,7 +3028,7 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
     }
 
     if(data[0] == SSH_FXP_STATUS) {
-        int retcode = _libssh2_ntohu32(data + 5);
+        uint32_t retcode = _libssh2_ntohu32(data + 5);
         sftp->fstatvfs_state = libssh2_NB_state_idle;
         LIBSSH2_FREE(session, data);
         sftp->last_errno = retcode;
@@ -3163,7 +3163,7 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
     }
 
     if(data[0] == SSH_FXP_STATUS) {
-        int retcode = _libssh2_ntohu32(data + 5);
+        uint32_t retcode = _libssh2_ntohu32(data + 5);
         sftp->statvfs_state = libssh2_NB_state_idle;
         LIBSSH2_FREE(session, data);
         sftp->last_errno = retcode;
@@ -3232,7 +3232,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
         0, 0, 0, 0, 0, 0, 0
     };
     size_t data_len = 0;
-    int retcode;
+    uint32_t retcode;
     ssize_t packet_len;
     unsigned char *packet, *s, *data = NULL;
     int rc;
@@ -3348,7 +3348,7 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
     size_t data_len = 0;
-    int retcode;
+    uint32_t retcode;
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
     ssize_t packet_len = path_len + 13;
     unsigned char *s, *data = NULL;
@@ -3538,7 +3538,7 @@ static int sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
     sftp->stat_state = libssh2_NB_state_idle;
 
     if(data[0] == SSH_FXP_STATUS) {
-        int retcode;
+        uint32_t retcode;
 
         retcode = _libssh2_ntohu32(data + 5);
         LIBSSH2_FREE(session, data);
@@ -3677,7 +3677,7 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
     }
     else if(retcode) {
         sftp->symlink_state = libssh2_NB_state_idle;
-        return _libssh2_error(session, (int)retcode,
+        return _libssh2_error(session, retcode,
                               "Error waiting for status message");
     }
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -720,7 +720,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
     int blocksize =
         (session->state & LIBSSH2_STATE_NEWKEYS) ?
         session->local.crypt->blocksize : 8;
-    int padding_length;
+    ssize_t padding_length;
     size_t packet_length;
     ssize_t total_length;
 #ifdef RANDOM_PADDING

--- a/src/transport.c
+++ b/src/transport.c
@@ -130,7 +130,7 @@ debugdump(LIBSSH2_SESSION * session,
 
 static int
 decrypt(LIBSSH2_SESSION * session, unsigned char *source,
-        unsigned char *dest, int len)
+        unsigned char *dest, ssize_t len)
 {
     struct transportpacket *p = &session->packet;
     int blocksize = session->remote.crypt->blocksize;
@@ -275,13 +275,14 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
 {
     int rc;
     struct transportpacket *p = &session->packet;
-    int remainpack; /* how much there is left to add to the current payload
-                       package */
-    int remainbuf;  /* how much data there is remaining in the buffer to deal
-                       with before we should read more from the network */
-    int numbytes;   /* how much data to deal with from the buffer on this
-                       iteration through the loop */
-    int numdecrypt; /* number of bytes to decrypt this iteration */
+    ssize_t remainpack; /* how much there is left to add to the current payload
+                           package */
+    ssize_t remainbuf;  /* how much data there is remaining in the buffer to
+                           deal with before we should read more from the
+                           network */
+    ssize_t numbytes;   /* how much data to deal with from the buffer on this
+                           iteration through the loop */
+    ssize_t numdecrypt; /* number of bytes to decrypt this iteration */
     unsigned char block[MAX_BLOCKSIZE]; /* working block buffer */
     int blocksize;  /* minimum number of bytes we need before we can
                        use them */
@@ -533,7 +534,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
                 numdecrypt = (p->total_num - skip) - p->data_num;
             }
             else {
-                int frac;
+                ssize_t frac;
                 numdecrypt = numbytes;
                 frac = numdecrypt % blocksize;
                 if(frac) {
@@ -575,7 +576,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
            copy them as-is to the target buffer */
         if(numbytes > 0) {
 
-            if(numbytes <= (int)(p->total_num - (p->wptr - p->payload))) {
+            if((size_t)numbytes <= (p->total_num - (p->wptr - p->payload))) {
                 memcpy(p->wptr, &p->buf[p->readidx], numbytes);
             }
             else {
@@ -721,7 +722,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
         session->local.crypt->blocksize : 8;
     int padding_length;
     size_t packet_length;
-    int total_length;
+    ssize_t total_length;
 #ifdef RANDOM_PADDING
     int rand_max;
     int seed = data[0];         /* FIXME: make this random */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1415,7 +1415,7 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                             const char *username,
                             unsigned int username_len,
                             const unsigned char *pubkeydata,
-                            unsigned long pubkeydata_len,
+                            size_t pubkeydata_len,
                             LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC
                             ((*sign_callback)),
                             void *abstract)

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -739,7 +739,7 @@ static int
 memory_read_privatekey(LIBSSH2_SESSION * session,
                        const LIBSSH2_HOSTKEY_METHOD ** hostkey_method,
                        void **hostkey_abstract,
-                       const unsigned char *method, int method_len,
+                       const unsigned char *method, size_t method_len,
                        const char *privkeyfiledata, size_t privkeyfiledata_len,
                        const char *passphrase)
 {
@@ -780,7 +780,7 @@ static int
 file_read_privatekey(LIBSSH2_SESSION * session,
                      const LIBSSH2_HOSTKEY_METHOD ** hostkey_method,
                      void **hostkey_abstract,
-                     const unsigned char *method, int method_len,
+                     const unsigned char *method, size_t method_len,
                      const char *privkeyfile, const char *passphrase)
 {
     const LIBSSH2_HOSTKEY_METHOD **hostkey_methods_avail =
@@ -1249,7 +1249,7 @@ libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
     return rc;
 }
 
-static int plain_method_len(const char *method, size_t method_len)
+static size_t plain_method_len(const char *method, size_t method_len)
 {
     if(!strncmp("ssh-rsa-cert-v01@openssh.com",
                 method,
@@ -1294,10 +1294,10 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
     const char *p = NULL;
     const char *f = NULL;
     char *i = NULL;
-    int p_len = 0;
-    int f_len = 0;
+    size_t p_len = 0;
+    size_t f_len = 0;
     int rc = 0;
-    int match_len = 0;
+    size_t match_len = 0;
     char *filtered_algs = NULL;
 
     const char *supported_algs =
@@ -1325,12 +1325,12 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
 
     while(s && *s) {
         p = strchr(s, ',');
-        p_len = p ? (p - s) : (int) strlen(s);
+        p_len = (p ? (size_t)(p - s) : strlen(s));
         a = supported_algs;
 
         while(a && *a) {
             f = strchr(a, ',');
-            f_len = f ? (f - a) : (int) strlen(a);
+            f_len = (f ? (size_t)(f - a) : strlen(a));
 
             if(f_len == p_len && memcmp(a, s, p_len) == 0) {
 
@@ -1363,12 +1363,12 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
 
     while(s && *s && !match) {
         p = strchr(s, ',');
-        p_len = p ? (p - s) : (int) strlen(s);
+        p_len = (p ? (size_t)(p - s) : strlen(s));
         a = filtered_algs;
 
         while(a && *a && !match) {
             f = strchr(a, ',');
-            f_len = f ? (f - a) : (int) strlen(a);
+            f_len = (f ? (size_t)(f - a) : strlen(a));
 
             if(f_len == p_len && memcmp(a, s, p_len) == 0) {
                 /* found a match, upgrade key method */
@@ -1413,7 +1413,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
 int
 _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                             const char *username,
-                            unsigned int username_len,
+                            size_t username_len,
                             const unsigned char *pubkeydata,
                             size_t pubkeydata_len,
                             LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC
@@ -2137,10 +2137,10 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
             }
 
             response_callback((const char *)session->userauth_kybd_auth_name,
-                              session->userauth_kybd_auth_name_len,
+                              (int)session->userauth_kybd_auth_name_len,
                               (const char *)
                               session->userauth_kybd_auth_instruction,
-                              session->userauth_kybd_auth_instruction_len,
+                              (int)session->userauth_kybd_auth_instruction_len,
                               session->userauth_kybd_num_prompts,
                               session->userauth_kybd_prompts,
                               session->userauth_kybd_responses,

--- a/src/userauth.h
+++ b/src/userauth.h
@@ -43,7 +43,7 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                             const char *username,
                             unsigned int username_len,
                             const unsigned char *pubkeydata,
-                            unsigned long pubkeydata_len,
+                            size_t pubkeydata_len,
                             LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC
                             ((*sign_callback)),
                             void *abstract);

--- a/src/userauth.h
+++ b/src/userauth.h
@@ -41,7 +41,7 @@
 int
 _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                             const char *username,
-                            unsigned int username_len,
+                            size_t username_len,
                             const unsigned char *pubkeydata,
                             size_t pubkeydata_len,
                             LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1539,10 +1539,10 @@ int
 _libssh2_wincng_dsa_sha1_verify(libssh2_dsa_ctx *dsa,
                                 const unsigned char *sig_fixed,
                                 const unsigned char *m,
-                                unsigned long m_len)
+                                size_t m_len)
 {
     return _libssh2_wincng_key_sha_verify(dsa, SHA_DIGEST_LENGTH, sig_fixed,
-                                          40, m, m_len, 0);
+                                          40, m, (unsigned long)m_len, 0);
 }
 
 int

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -419,11 +419,15 @@ _libssh2_wincng_free(void)
 }
 
 int
-_libssh2_wincng_random(void *buf, int len)
+_libssh2_wincng_random(void *buf, size_t len)
 {
     int ret;
 
-    ret = BCryptGenRandom(_libssh2_wincng.hAlgRNG, buf, len, 0);
+    if(len > ULONG_MAX) {
+        return -1;
+    }
+
+    ret = BCryptGenRandom(_libssh2_wincng.hAlgRNG, buf, (ULONG)len, 0);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -589,7 +589,7 @@ _libssh2_wincng_hmac_cleanup(_libssh2_wincng_hash_ctx *ctx)
 
 int
 _libssh2_wincng_key_sha_verify(_libssh2_wincng_key_ctx *ctx,
-                                size_t hashlen,
+                                unsigned long hashlen,
                                 const unsigned char *sig,
                                 unsigned long sig_len,
                                 const unsigned char *m,
@@ -662,7 +662,7 @@ _libssh2_wincng_key_sha_verify(_libssh2_wincng_key_ctx *ctx,
     memcpy(data, sig, datalen);
 
     ret = BCryptVerifySignature(ctx->hKey, pPaddingInfo,
-                                hash, (ULONG)hashlen, data, datalen, flags);
+                                hash, hashlen, data, datalen, flags);
 
     _libssh2_wincng_safe_free(hash, hashlen);
     _libssh2_wincng_safe_free(data, datalen);
@@ -1219,8 +1219,10 @@ _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                                 const unsigned char *m,
                                 size_t m_len)
 {
-    return _libssh2_wincng_key_sha_verify(rsa, SHA_DIGEST_LENGTH, sig, sig_len,
-                                          m, m_len, BCRYPT_PAD_PKCS1);
+    return _libssh2_wincng_key_sha_verify(rsa, SHA_DIGEST_LENGTH,
+                                          sig, (unsigned long)sig_len,
+                                          m, (unsigned long)m_len,
+                                          BCRYPT_PAD_PKCS1);
 }
 
 int
@@ -1231,8 +1233,10 @@ _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx* rsa,
                                 const unsigned char *m,
                                 size_t m_len)
 {
-    return _libssh2_wincng_key_sha_verify(rsa, hash_len, sig, sig_len, m,
-                                          m_len, BCRYPT_PAD_PKCS1);
+    return _libssh2_wincng_key_sha_verify(rsa, (unsigned long)hash_len,
+                                          sig, (unsigned long)sig_len,
+                                          m, (unsigned long)m_len,
+                                          BCRYPT_PAD_PKCS1);
 }
 
 int

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -429,7 +429,7 @@ _libssh2_wincng_random(void *buf, int len)
 }
 
 static void
-_libssh2_wincng_safe_free(void *buf, int len)
+_libssh2_wincng_safe_free(void *buf, size_t len)
 {
     if(!buf)
         return;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1215,9 +1215,9 @@ _libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
 int
 _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                                 const unsigned char *sig,
-                                unsigned long sig_len,
+                                size_t sig_len,
                                 const unsigned char *m,
-                                unsigned long m_len)
+                                size_t m_len)
 {
     return _libssh2_wincng_key_sha_verify(rsa, SHA_DIGEST_LENGTH, sig, sig_len,
                                           m, m_len, BCRYPT_PAD_PKCS1);
@@ -1227,9 +1227,9 @@ int
 _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx* rsa,
                                 size_t hash_len,
                                 const unsigned char *sig,
-                                unsigned long sig_len,
+                                size_t sig_len,
                                 const unsigned char *m,
-                                unsigned long m_len)
+                                size_t m_len)
 {
     return _libssh2_wincng_key_sha_verify(rsa, hash_len, sig, sig_len, m,
                                           m_len, BCRYPT_PAD_PKCS1);

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -509,9 +509,9 @@ _libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
 int
 _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                                 const unsigned char *sig,
-                                unsigned long sig_len,
+                                size_t sig_len,
                                 const unsigned char *m,
-                                unsigned long m_len);
+                                size_t m_len);
 int
 _libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
                               libssh2_rsa_ctx *rsa,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -445,7 +445,7 @@ typedef struct {
  */
 void _libssh2_wincng_init(void);
 void _libssh2_wincng_free(void);
-int _libssh2_wincng_random(void *buf, int len);
+int _libssh2_wincng_random(void *buf, size_t len);
 
 int
 _libssh2_wincng_hash_init(_libssh2_wincng_hash_ctx *ctx,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -550,7 +550,7 @@ int
 _libssh2_wincng_dsa_sha1_verify(libssh2_dsa_ctx *dsa,
                                 const unsigned char *sig_fixed,
                                 const unsigned char *m,
-                                unsigned long m_len);
+                                size_t m_len);
 int
 _libssh2_wincng_dsa_sha1_sign(libssh2_dsa_ctx *dsa,
                               const unsigned char *hash,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -470,7 +470,7 @@ _libssh2_wincng_hmac_cleanup(_libssh2_wincng_hash_ctx *ctx);
 
 int
 _libssh2_wincng_key_sha_verify(_libssh2_wincng_key_ctx *ctx,
-                                size_t hashlen,
+                                unsigned long hashlen,
                                 const unsigned char *sig,
                                 unsigned long sig_len,
                                 const unsigned char *m,


### PR DESCRIPTION
Apply type changes to avoid casts and warnings. In most cases this
means changing to a larger type, usually `size_t` or `ssize_t`.

Change signedness in a few places.

Also introduce new variables to avoid reusing them for multiple
purposes, to avoid casts and warnings.

- add FIXME for public `libssh2_sftp_readdir_ex()` return type.

- fix `_libssh2_mbedtls_rsa_sha2_verify()` to verify if `sig_len`
  is large enough.

- fix `_libssh2_dh_key_pair()` in `wincng.c` to return error if
  `group_order` input is negative.

  Maybe we should also reject zero?

- bump `_libssh2_random()` size type `int` -> `size_t`. Add checks
  for WinCNG and OpenSSL to return error if requested more than they
  support (`ULONG_MAX`, `INT_MAX` respectively).

- change `_libssh2_ntohu32()` return value `unsigned int` -> `uint32_t`.

- fix `_libssh2_mbedtls_bignum_random()` to check for a negative `top`
  input.

- size down `_libssh2_wincng_key_sha_verify()` `hashlen` to match
  Windows'.

- fix `session_disconnect()` to limit length of `lang_len`
  (to 256 bytes).

- fix bad syntax in an `assert()`.

- add a few `const` to casts.

- `while(1)` -> `for(;;)`.

- add casts that didn't fit into #876.

- update `docs/HACKING-CRYPTO` with new sizes.

May need review for OS400QC3: /cc @monnerat @jonrumsey

See warning details in the PR's individual commits.

Cherry-picked from #846
Closes #879

---

TODO:
- [x] Rebase on master after merging #876.

Partial list of warnings fixed:

```
src/kex.c:3110:..: warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
src/kex.c:3110:20: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
src/kex.c:3110:20: warning: conversion from 'size_t' {aka 'long unsigned int'} to 'int' may change value [-Wconversion]
src/kex.c:3110:20: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int' [-Wshorten-64-to-32]
src/kex.c:3110:20: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
src/kex.c:3128:33: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'uint32_t' {aka 'unsigned int'} may change value [-Wconversion]
src/kex.c:3128:33: warning: conversion from 'size_t' {aka 'long unsigned int'} to 'uint32_t' {aka 'unsigned int'} may change value [-Wconversion]
src/kex.c:3205:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3205:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3206:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3207:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3207:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3208:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3209:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3209:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3210:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3211:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3211:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3212:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3213:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3213:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3214:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3215:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3215:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3216:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3217:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3217:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3218:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3219:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3219:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3220:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3221:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3221:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3222:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
src/kex.c:3223:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3223:37: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
src/kex.c:3224:..: warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
```

```
src/libgcrypt.c:553:18: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
src/libgcrypt.c:569:22: warning: conversion from 'size_t' {aka 'long unsigned int'} to 'int' may change value [-Wconversion]
src/libgcrypt.c:569:22: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
```

```
C:\projects\libssh2\src\wincng.c(2370): warning C4018: '>': signed/unsigned mismatch [C:\projects\libssh2\_builds\src\libssh2.vcxproj]
C:\projects\libssh2\src\wincng.c(2370): warning C4018: '>' : signed/unsigned mismatch [C:\projects\libssh2\_builds\src\libssh2.vcxproj]
```

```
./src/wincng.c:2369:34: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        DWORD key_length_bytes = max(round_down(group_order, 8),
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/opt/mingw-w64/toolchain-x86_64/x86_64-w64-mingw32/include/minwindef.h:173:25: note: expanded from macro 'max'
                     ~  ^  ~
```

```
src/kex.c:3917:..: warning C4267: 'function': conversion from 'size_t' to 'unsigned int', possible loss of data
```

```
src/sftp.c:728:..: warning C4244: 'return': conversion from '__int64' to 'int', possible loss of data
```

```
src/sftp.c:889:..: warning C4244: '+=': conversion from 'ssize_t' to 'int', possible loss of data
```

```
src/openssl.h:188:54: warning: conversion from 'ssize_t' {aka 'long int'} to 'int' may change value [-Wconversion]
src/transport.c:873:50: warning: conversion from 'ssize_t' {aka 'long int'} to 'int' may change value [-Wconversion]
src/transport.c:873:50: warning: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
```
