### PR TITLE
src: silence compiler warnings 4 (alignment in WinCNG)

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -885,23 +885,23 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
                                unsigned long *pcbCount)
 {
     PCRYPT_DER_BLOB pBlob;
-    unsigned char *pbDecoded, **rpbDecoded;
+    unsigned char **rpbDecoded;
+    PCRYPT_DATA_BLOB pbDecoded;
     unsigned long cbDecoded, *rcbDecoded, index, length;
     int ret;
 
     ret = _libssh2_wincng_asn_decode(pbEncoded, cbEncoded,
                                      X509_SEQUENCE_OF_ANY,
-                                     &pbDecoded, &cbDecoded);
+                                     (void *)&pbDecoded, &cbDecoded);
     if(!ret) {
-        length = ((PCRYPT_DATA_BLOB)pbDecoded)->cbData;
+        length = pbDecoded->cbData;
 
         rpbDecoded = malloc(sizeof(PBYTE) * length);
         if(rpbDecoded) {
             rcbDecoded = malloc(sizeof(DWORD) * length);
             if(rcbDecoded) {
                 for(index = 0; index < length; index++) {
-                    pBlob = &((PCRYPT_DER_BLOB)
-                              ((PCRYPT_DATA_BLOB)pbDecoded)->pbData)[index];
+                    pBlob = &((PCRYPT_DER_BLOB)(pbDecoded)->pbData)[index];
                     ret = _libssh2_wincng_asn_decode_bn(pBlob->pbData,
                                                         pBlob->cbData,
                                                         &rpbDecoded[index],

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1925,7 +1925,8 @@ _libssh2_wincng_cipher_init(_libssh2_cipher_ctx *ctx,
     }
 
 
-    keylen = sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) + type.dwKeyLength;
+    keylen = (unsigned long)sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) +
+             type.dwKeyLength;
     header = (BCRYPT_KEY_DATA_BLOB_HEADER *)malloc(keylen);
     if(!header) {
         free(pbKeyObject);
@@ -2406,7 +2407,8 @@ _libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
             return -1;
         }
 
-        dh_params_len = sizeof(*dh_params) + 2 * key_length_bytes;
+        dh_params_len = (unsigned long)sizeof(*dh_params) +
+                        2 * key_length_bytes;
         dh_params = (BCRYPT_DH_PARAMETER_HEADER *)malloc(dh_params_len);
         if(!dh_params) {
             return -1;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -855,16 +855,17 @@ _libssh2_wincng_asn_decode_bn(unsigned char *pbEncoded,
                               unsigned char **ppbDecoded,
                               unsigned long *pcbDecoded)
 {
-    unsigned char *pbDecoded = NULL, *pbInteger;
+    unsigned char *pbDecoded = NULL;
+    PCRYPT_DATA_BLOB pbInteger;
     unsigned long cbDecoded = 0, cbInteger;
     int ret;
 
     ret = _libssh2_wincng_asn_decode(pbEncoded, cbEncoded,
                                      X509_MULTI_BYTE_UINT,
-                                     &pbInteger, &cbInteger);
+                                     (void *)&pbInteger, &cbInteger);
     if(!ret) {
-        ret = _libssh2_wincng_bn_ltob(((PCRYPT_DATA_BLOB)pbInteger)->pbData,
-                                      ((PCRYPT_DATA_BLOB)pbInteger)->cbData,
+        ret = _libssh2_wincng_bn_ltob(pbInteger->pbData,
+                                      pbInteger->cbData,
                                       &pbDecoded, &cbDecoded);
         if(!ret) {
             *ppbDecoded = pbDecoded;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -886,7 +886,7 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
 {
     PCRYPT_DER_BLOB pBlob;
     unsigned char **rpbDecoded;
-    PCRYPT_DATA_BLOB pbDecoded;
+    PCRYPT_SEQUENCE_OF_ANY pbDecoded;
     unsigned long cbDecoded, *rcbDecoded, index, length;
     int ret;
 
@@ -894,14 +894,14 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
                                      X509_SEQUENCE_OF_ANY,
                                      (void *)&pbDecoded, &cbDecoded);
     if(!ret) {
-        length = pbDecoded->cbData;
+        length = pbDecoded->cValue;
 
         rpbDecoded = malloc(sizeof(PBYTE) * length);
         if(rpbDecoded) {
             rcbDecoded = malloc(sizeof(DWORD) * length);
             if(rcbDecoded) {
                 for(index = 0; index < length; index++) {
-                    pBlob = &((PCRYPT_DER_BLOB)(pbDecoded)->pbData)[index];
+                    pBlob = &pbDecoded->rgValue[index];
                     ret = _libssh2_wincng_asn_decode_bn(pBlob->pbData,
                                                         pBlob->cbData,
                                                         &rpbDecoded[index],

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -251,7 +251,7 @@ typedef struct __libssh2_wincng_hash_ctx {
 
 typedef struct __libssh2_wincng_key_ctx {
     BCRYPT_KEY_HANDLE hKey;
-    unsigned char *pbKeyObject;
+    void *pbKeyObject;
     unsigned long cbKeyObject;
 } _libssh2_wincng_key_ctx;
 


### PR DESCRIPTION
Silence alignment warnings in WinCNG, by reworking the code.

Also add two unrelated casts to avoid gcc compiler warnings
in surrounding code.

`increases required alignment from 1 to 4 [-Wcast-align]`
`increases required alignment from 1 to 8 [-Wcast-align]`

See warning details in the PR's individual commits.

Reviewed-by: Marc Hörsken in <https://github.com/libssh2/libssh2/pull/846#pullrequestreview-1350253621>
Cherry-picked from #846
Closes #880

---

TODO:
- [ ] Rebase on master after merging #879.

Partial list of warnings fixed:

```
src/wincng.c:2403:21: warning: cast from 'unsigned char *' to 'BCRYPT_DH_PARAMETER_HEADER *' (aka 'struct _BCRYPT_DH_PARAMETER_HEADER *') increases required alignment from 1 to 4 [-Wcast-align]
        dh_params = (BCRYPT_DH_PARAMETER_HEADER*)blob;
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/wincng.c:2484:23: warning: cast from 'unsigned char *' to 'BCRYPT_DH_KEY_BLOB *' (aka 'struct _BCRYPT_DH_KEY_BLOB *') increases required alignment from 1 to 4 [-Wcast-align]
        dh_key_blob = (BCRYPT_DH_KEY_BLOB*)blob;
                      ^~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/wincng.c:2580:27: warning: cast from 'unsigned char *' to 'BCRYPT_DH_KEY_BLOB *' (aka 'struct _BCRYPT_DH_KEY_BLOB *') increases required alignment from 1 to 4 [-Wcast-align]
            public_blob = (BCRYPT_DH_KEY_BLOB*)blob;
                          ^~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/wincng.c:2164:14: warning: cast from 'unsigned char *' to 'BCRYPT_RSAKEY_BLOB *' (aka 'struct _BCRYPT_RSAKEY_BLOB *') increases required alignment from 1 to 4 [-Wcast-align]
    rsakey = (BCRYPT_RSAKEY_BLOB *)key;
             ^~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/wincng.c:1921:14: warning: cast from 'unsigned char *' to 'BCRYPT_KEY_DATA_BLOB_HEADER *' (aka 'struct _BCRYPT_KEY_DATA_BLOB_HEADER *') increases required alignment from 1 to 4 [-Wcast-align]
    header = (BCRYPT_KEY_DATA_BLOB_HEADER *)key;
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/wincng.c:1364:14: warning: cast from 'unsigned char *' to 'BCRYPT_DSA_KEY_BLOB *' (aka 'struct _BCRYPT_DSA_KEY_BLOB *') increases required alignment from 1 to 4 [-Wcast-align]
    dsakey = (BCRYPT_DSA_KEY_BLOB *)key;
             ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/wincng.c:1017:14: warning: cast from 'unsigned char *' to 'BCRYPT_RSAKEY_BLOB *' (aka 'struct _BCRYPT_RSAKEY_BLOB *') increases required alignment from 1 to 4 [-Wcast-align]
    rsakey = (BCRYPT_RSAKEY_BLOB *)key;
             ^~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/wincng.c:866:40: warning: cast from 'unsigned char *' to 'PCRYPT_DATA_BLOB' (aka 'struct _CRYPTOAPI_BLOB *') increases required alignment from 1 to 8 [-Wcast-align]
        ret = _libssh2_wincng_bn_ltob(((PCRYPT_DATA_BLOB)pbInteger)->pbData,
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/wincng.c:867:40: warning: cast from 'unsigned char *' to 'PCRYPT_DATA_BLOB' (aka 'struct _CRYPTOAPI_BLOB *') increases required alignment from 1 to 8 [-Wcast-align]
                                      ((PCRYPT_DATA_BLOB)pbInteger)->cbData,
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/wincng.c:895:19: warning: cast from 'unsigned char *' to 'PCRYPT_DATA_BLOB' (aka 'struct _CRYPTOAPI_BLOB *') increases required alignment from 1 to 8 [-Wcast-align]
        length = ((PCRYPT_DATA_BLOB)pbDecoded)->cbData;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/wincng.c:903:32: warning: cast from 'unsigned char *' to 'PCRYPT_DATA_BLOB' (aka 'struct _CRYPTOAPI_BLOB *') increases required alignment from 1 to 8 [-Wcast-align]
                              ((PCRYPT_DATA_BLOB)pbDecoded)->pbData)[index];
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/wincng.c:902:31: warning: cast from 'BYTE *' (aka 'unsigned char *') to 'PCRYPT_DER_BLOB' (aka 'struct _CRYPTOAPI_BLOB *') increases required alignment from 1 to 8 [-Wcast-align]
                    pBlob = &((PCRYPT_DER_BLOB)
                              ^~~~~~~~~~~~~~~~~
```
