### PR TITLE
src: more tolerant snprintf() local override

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -135,6 +135,7 @@
 /* Use local implementation when not available */
 #if !defined(HAVE_SNPRINTF)
 #define LIBSSH2_SNPRINTF
+#undef snprintf
 #define snprintf _libssh2_snprintf
 int _libssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...);
 #endif


### PR DESCRIPTION
`#undef snprintf` before redefining it, when `HAVE_SNPRINTF` is not defined, even though `snprintf` is available and it should have been. Possibly with 3rd party builds.

Downside is that cases of missing `HAVE_SNPRINTF` are less trivially detected at compile-time.

Closes #881
