### PR TITLE
ci: drop cmake --parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           mkdir bin
           cd bin
           cmake $TOOLCHAIN_OPTION -DENABLE_WERROR=ON -DCRYPTO_BACKEND=$CRYPTO_BACKEND -DBUILD_SHARED_LIBS=ON -DENABLE_ZLIB_COMPRESSION=$ENABLE_ZLIB_COMPRESSION ..
-          cmake --build . --parallel 2
+          cmake --build .
           export OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:../tests/openssh_server)
           ctest -VV --output-on-failure
           cmake --build . --target package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ build_script:
         }
       }
   - cmake . -B _builds "-G%GENERATOR%" %CMAKE_ARG% -DENABLE_WERROR=ON -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS% -DCRYPTO_BACKEND=%CRYPTO_BACKEND%
-  - cmake --build _builds --config "%CONFIGURATION%" --parallel 2
+  - cmake --build _builds --config "%CONFIGURATION%"
 
 before_test:
   - appveyor-retry choco install -y --no-progress --limit-output --timeout 180 docker-cli


### PR DESCRIPTION
`--parallel 2` did not seem to make builds faster. Neither did 4 or 6.

Delete this option from both GHA and AppVeyor jobs.

On AppVeyor, with VS, it uses MSBuild under the hood where apparently
`--parallel` doesn't help [1]. The suggested MSBuild-specific option
`/p:CL_MPcount=2` did not improve build times either.

CMake spends significant time (comparable to building the project
itself) on feature detection, it'd be nice to execute those in parallel,
but I found not such CMake option.

[1] https://discourse.cmake.org/t/parallel-does-not-really-enable-parallel-compiles-with-msbuild/964

Partial revert of 7a039d9a7a2945c10b4622f38eeed21ba6b4ec55
