### PR TITLE
GNUmakefile: minor fix for DYN mode [ci skip]

### DIFF
--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -55,14 +55,12 @@ LIBSSH2_LDFLAGS_BIN += -L$(PROOT)/win32
 LIBS_BIN := -lssh2 -lws2_32
 
 ifdef DYN
-  libssh2_DEPENDENCIES += $(PROOT)/win32/libssh2.dll.a
+  libssh2_DEPENDENCIES := $(PROOT)/win32/libssh2.dll.a
   LIBSSH2_LDFLAGS_BIN += -shared
 else
   libssh2_DEPENDENCIES := $(PROOT)/win32/libssh2.a
   LIBSSH2_LDFLAGS_BIN += -static
 endif
-
-libssh2_DEPENDENCIES := $(PROOT)/win32/libssh2.a
 
 ### Optional features
 


### PR DESCRIPTION
Follow-up to b8762c1003d97e109efa587bdc760ff9873949eb