### PR TITLE
cmake: introduce variables for lib target names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ if(NOT BUILD_STATIC_LIBS AND (NOT BUILD_SHARED_LIBS OR BUILD_EXAMPLES OR BUILD_T
   set(BUILD_STATIC_LIBS ON)
 endif()
 
+set(LIB_STATIC "libssh2_static")
+set(LIB_SHARED "libssh2_shared")  # Must match libssh2_shared_EXPORTS macro in include/libssh2.h
+
 add_subdirectory(src)
 
 if(BUILD_EXAMPLES)
@@ -123,9 +126,9 @@ if(LINT)
     ./ci/checksrc.sh
     WORKING_DIRECTORY ${libssh2_SOURCE_DIR})
   if(BUILD_STATIC_LIBS)
-    add_dependencies(libssh2_static lint)
+    add_dependencies(${LIB_STATIC} lint)
   else()
-    add_dependencies(libssh2_shared lint)
+    add_dependencies(${LIB_SHARED} lint)
   endif()
 endif()
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -68,7 +68,7 @@ foreach(example ${EXAMPLES})
   list(APPEND EXAMPLE_TARGETS example-${example})
   # to find generated header
   target_include_directories(example-${example} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-  target_link_libraries(example-${example} libssh2_static ${LIBRARIES})
+  target_link_libraries(example-${example} ${LIB_STATIC} ${LIBRARIES})
 endforeach()
 add_target_to_copy_dependencies(
   TARGET copy_example_dependencies

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -359,36 +359,36 @@ set(SOURCES
 
 # we want it to be called libssh2 on all platforms
 if(BUILD_STATIC_LIBS)
-  list(APPEND libssh2_export libssh2_static)
-  add_library(libssh2_static STATIC ${SOURCES})
-  target_compile_definitions(libssh2_static PRIVATE ${PRIVATE_COMPILE_DEFINITIONS} ${libssh2_DEFINITIONS})
-  target_link_libraries(libssh2_static PRIVATE ${LIBRARIES})
-  set_target_properties(libssh2_static PROPERTIES PREFIX "" OUTPUT_NAME "libssh2${STATIC_LIB_SUFFIX}")
+  list(APPEND libssh2_export ${LIB_STATIC})
+  add_library(${LIB_STATIC} STATIC ${SOURCES})
+  target_compile_definitions(${LIB_STATIC} PRIVATE ${PRIVATE_COMPILE_DEFINITIONS} ${libssh2_DEFINITIONS})
+  target_link_libraries(${LIB_STATIC} PRIVATE ${LIBRARIES})
+  set_target_properties(${LIB_STATIC} PROPERTIES PREFIX "" OUTPUT_NAME "libssh2${STATIC_LIB_SUFFIX}")
 
-  target_include_directories(libssh2_static
+  target_include_directories(${LIB_STATIC}
     PRIVATE "${PROJECT_SOURCE_DIR}/include/" ${libssh2_INCLUDE_DIRS} ${PRIVATE_INCLUDE_DIRECTORIES}
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
       $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
 endif()
 if(BUILD_SHARED_LIBS)
-  list(APPEND libssh2_export libssh2_shared)
-  add_library(libssh2_shared SHARED ${SOURCES})
+  list(APPEND libssh2_export ${LIB_SHARED})
+  add_library(${LIB_SHARED} SHARED ${SOURCES})
   if(WIN32)
-    set_property(TARGET libssh2_shared APPEND PROPERTY SOURCES ${PROJECT_SOURCE_DIR}/win32/libssh2.rc)
+    set_property(TARGET ${LIB_SHARED} APPEND PROPERTY SOURCES ${PROJECT_SOURCE_DIR}/win32/libssh2.rc)
   endif()
-  target_compile_definitions(libssh2_shared PRIVATE ${PRIVATE_COMPILE_DEFINITIONS} ${libssh2_DEFINITIONS})
-  target_link_libraries(libssh2_shared PRIVATE ${LIBRARIES})
-  set_target_properties(libssh2_shared PROPERTIES PREFIX "" IMPORT_PREFIX "" OUTPUT_NAME "libssh2")
+  target_compile_definitions(${LIB_SHARED} PRIVATE ${PRIVATE_COMPILE_DEFINITIONS} ${libssh2_DEFINITIONS})
+  target_link_libraries(${LIB_SHARED} PRIVATE ${LIBRARIES})
+  set_target_properties(${LIB_SHARED} PROPERTIES PREFIX "" IMPORT_PREFIX "" OUTPUT_NAME "libssh2")
   if(WIN32 AND BUILD_STATIC_LIBS AND NOT STATIC_LIB_SUFFIX AND
      CMAKE_IMPORT_LIBRARY_SUFFIX STREQUAL CMAKE_STATIC_LIBRARY_SUFFIX)
     # Extra suffix to avoid filename conflict with the static lib.
-    set_target_properties(libssh2_shared PROPERTIES IMPORT_SUFFIX "_imp${CMAKE_IMPORT_LIBRARY_SUFFIX}")
+    set_target_properties(${LIB_SHARED} PROPERTIES IMPORT_SUFFIX "_imp${CMAKE_IMPORT_LIBRARY_SUFFIX}")
   endif()
 
-  set_target_properties(libssh2_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(${LIB_SHARED} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-  target_include_directories(libssh2_shared
+  target_include_directories(${LIB_SHARED}
     PRIVATE "${PROJECT_SOURCE_DIR}/include/" ${libssh2_INCLUDE_DIRS} ${PRIVATE_INCLUDE_DIRECTORIES}
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -404,20 +404,20 @@ install(FILES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(BUILD_STATIC_LIBS)
-  install(TARGETS libssh2_static
+  install(TARGETS ${LIB_STATIC}
     EXPORT Libssh2Config
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 if(BUILD_SHARED_LIBS)
-  install(TARGETS libssh2_shared
+  install(TARGETS ${LIB_SHARED}
     EXPORT Libssh2Config
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-  list(APPEND _RUNTIME_DEPENDENCIES $<TARGET_FILE:libssh2_shared>)
+  list(APPEND _RUNTIME_DEPENDENCIES $<TARGET_FILE:${LIB_SHARED}>)
 endif()
 
 set(RUNTIME_DEPENDENCIES ${_RUNTIME_DEPENDENCIES} CACHE INTERNAL
@@ -452,12 +452,12 @@ install(
 set(LIBSSH2_SOVERSION 1)
 set(LIBSSH2_VERSION 1.0.1)
 if(BUILD_STATIC_LIBS)
-  set_target_properties(libssh2_static PROPERTIES
+  set_target_properties(${LIB_STATIC} PROPERTIES
     SOVERSION ${LIBSSH2_SOVERSION}
     VERSION ${LIBSSH2_VERSION})
 endif()
 if(BUILD_SHARED_LIBS)
-  set_target_properties(libssh2_shared PROPERTIES
+  set_target_properties(${LIB_SHARED} PROPERTIES
     SOVERSION ${LIBSSH2_SOVERSION}
     VERSION ${LIBSSH2_VERSION})
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,14 +178,14 @@ if(BUILD_SHARED_LIBS)
   set(test warmup)  # any test will do
   add_executable(test_${test}_shared test_${test}.c)
   target_include_directories(test_${test}_shared PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
-  target_link_libraries(test_${test}_shared runner libssh2_shared ${LIBRARIES})
+  target_link_libraries(test_${test}_shared runner ${LIB_SHARED} ${LIBRARIES})
 endif()
 
 foreach(test ${TESTS})
   add_executable(test_${test} test_${test}.c)
   list(APPEND TEST_TARGETS test_${test})
   target_include_directories(test_${test} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
-  target_link_libraries(test_${test} runner libssh2_static ${LIBRARIES})
+  target_link_libraries(test_${test} runner ${LIB_STATIC} ${LIBRARIES})
 
   add_test(
     NAME test_${test} COMMAND $<TARGET_FILE:test_${test}>
@@ -239,9 +239,9 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCC AND GCOV_PATH)
   target_compile_options(test_keyboard_interactive_auth_info_request BEFORE PRIVATE
     ${TGT_OPTIONS})
-  target_link_libraries(test_keyboard_interactive_auth_info_request ${LIBRARIES} libssh2_static gcov)
+  target_link_libraries(test_keyboard_interactive_auth_info_request ${LIBRARIES} ${LIB_STATIC} gcov)
 else()
-  target_link_libraries(test_keyboard_interactive_auth_info_request ${LIBRARIES} libssh2_static)
+  target_link_libraries(test_keyboard_interactive_auth_info_request ${LIBRARIES} ${LIB_STATIC})
 endif()
 add_test(
   NAME test_keyboard_interactive_auth_info_request COMMAND $<TARGET_FILE:test_keyboard_interactive_auth_info_request>


### PR DESCRIPTION
Make the CMake config more self-documenting by introducing variables for the shared and static lib target names. Without this, it might be non-trivial to find out which line is referring to a target name vs libname, export name or other occurrences of `libssh2`.

This allows to rename back the shared lib target name to the value used before 4e2580628dd1f8dc51ac65ac747ebcf0e93fa3d1:
`libssh2_shared` -> `libssh2`, if necessary for compatibility. Notice: before that patch, `libssh2` name referred to either the static or shared lib, depending on build settings.