### PR TITLE
wolfssl: add workaround for HMAC_Update() len arg difference

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -315,8 +315,14 @@ int _libssh2_md5_init(libssh2_md5_ctx *ctx);
 #define libssh2_hmac_sha512_init(ctx, key, keylen) \
   HMAC_Init_ex(*(ctx), key, (int)keylen, EVP_sha512(), NULL)
 
+#ifdef LIBSSH2_WOLFSSL
+/* FIXME: upstream bug as of v5.6.0: datalen is int instead of size_t */
+#define libssh2_hmac_update(ctx, data, datalen) \
+  HMAC_Update(ctx, data, (int)datalen)
+#else
 #define libssh2_hmac_update(ctx, data, datalen) \
   HMAC_Update(ctx, data, datalen)
+#endif /* LIBSSH2_WOLFSSL */
 #define libssh2_hmac_final(ctx, data) HMAC_Final(ctx, data, NULL)
 #define libssh2_hmac_cleanup(ctx) HMAC_CTX_free(*(ctx))
 #else


### PR DESCRIPTION
It's `int` in wolfSSL. `size_t` in OpenSSL/quictls/LibreSSL/BoringSSL.

Ref: https://github.com/wolfSSL/wolfssl/blob/ba47562d182e10e59813da012e0ab8ef20892231/wolfssl/openssl/hmac.h#L60-L61

/cc @wolfSSL

---

```
../src/mac.c -o release/mac.o
In file included from ../src/crypto.h:42,
                 from ../src/libssh2_priv.h:165,
                 from ../src/mac.c:38:
../src/mac.c: In function 'mac_method_hmac_sha2_512_hash':
../src/mac.c:120:38: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  120 |     libssh2_hmac_update(ctx, packet, packet_len);
      |                                      ^~~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
../src/mac.c:122:41: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  122 |         libssh2_hmac_update(ctx, addtl, addtl_len);
      |                                         ^~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
../src/mac.c: In function 'mac_method_hmac_sha2_256_hash':
../src/mac.c:165:38: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  165 |     libssh2_hmac_update(ctx, packet, packet_len);
      |                                      ^~~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
../src/mac.c:167:41: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  167 |         libssh2_hmac_update(ctx, addtl, addtl_len);
      |                                         ^~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
../src/mac.c: In function 'mac_method_hmac_sha1_hash':
../src/mac.c:210:38: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  210 |     libssh2_hmac_update(ctx, packet, packet_len);
      |                                      ^~~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
../src/mac.c:212:41: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  212 |         libssh2_hmac_update(ctx, addtl, addtl_len);
      |                                         ^~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
../src/mac.c: In function 'mac_method_hmac_md5_hash':
../src/mac.c:283:38: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  283 |     libssh2_hmac_update(ctx, packet, packet_len);
      |                                      ^~~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
../src/mac.c:285:41: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  285 |         libssh2_hmac_update(ctx, addtl, addtl_len);
      |                                         ^~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
../src/knownhost.c -o release/knownhost.o
In file included from ../src/crypto.h:42,
                 from ../src/libssh2_priv.h:165,
                 from ../src/knownhost.c:39:
../src/knownhost.c: In function 'knownhost_check':
../src/knownhost.c:432:41: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'int' may change value [-Wconversion]
  432 |                                         strlen(host));
      |                                         ^~~~~~~~~~~~
../src/openssl.h:319:26: note: in definition of macro 'libssh2_hmac_update'
  319 |   HMAC_Update(ctx, data, datalen)
      |                          ^~~~~~~
```
