### PR TITLE
cmake: add missing #cmakedefines to src

### DIFF
--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -61,6 +61,9 @@
 #cmakedefine HAVE_STRTOLL
 #cmakedefine HAVE_STRTOI64
 #cmakedefine HAVE_SNPRINTF
+#cmakedefine HAVE_EXPLICIT_BZERO
+#cmakedefine HAVE_EXPLICIT_MEMSET
+#cmakedefine HAVE_MEMSET_S
 
 /* Socket non-blocking support */
 #cmakedefine HAVE_O_NONBLOCK


### PR DESCRIPTION
- `HAVE_MEMSET_S` missing since 03092292597ac601c3f9f0c267ecb145dda75e4e (2018-08-02)

- `HAVE_EXPLICIT_BZERO` and `HAVE_EXPLICIT_MEMSET` missing since 00005682f7b9a1aa42be50e269056ea873637047 (2023-03-28)