### PR TITLE
example: make `x11` exclusion build-tool-agnostic

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -62,7 +62,8 @@ set(EXAMPLES
   ssh2_echo
   ssh2_exec
   subsystem_netconf
-  tcpip-forward)
+  tcpip-forward
+  x11)
 
 foreach(example ${EXAMPLES})
   add_executable(example-${example} ${example}.c)

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -26,11 +26,8 @@ noinst_PROGRAMS = \
   ssh2_echo \
   ssh2_exec \
   subsystem_netconf \
-  tcpip-forward
-
-if HAVE_SYS_UN_H
-noinst_PROGRAMS += x11
-endif
+  tcpip-forward \
+  x11
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/example -I../src
 LDADD = $(top_builddir)/src/libssh2.la

--- a/example/x11.c
+++ b/example/x11.c
@@ -13,18 +13,35 @@
 #ifdef HAVE_SYS_UN_H
 
 #include <string.h>
+#ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
+#endif
+#ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
+#endif
+#ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
+#endif
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <sys/types.h>
+#ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
+#endif
 #include <fcntl.h>
 #include <errno.h>
 #include <ctype.h>
+#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
+#endif
+
 #include <termios.h>
 
 #define _PATH_UNIX_X "/tmp/.X11-unix/X%d"

--- a/example/x11.c
+++ b/example/x11.c
@@ -5,6 +5,13 @@
  * "ssh2 host user password [DEBUG]"
  */
 
+#include <libssh2.h>
+#include "libssh2_config.h"
+
+#include <stdio.h>
+
+#ifdef HAVE_SYS_UN_H
+
 #include <string.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>
@@ -16,12 +23,9 @@
 #include <sys/un.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <termios.h>
-
-#include <libssh2.h>
 
 #define _PATH_UNIX_X "/tmp/.X11-unix/X%d"
 
@@ -474,3 +478,14 @@ main (int argc, char *argv[])
 
     return 0;
 }
+
+#else
+
+int
+main (void)
+{
+    printf("Sorry, this platform is not supported.");
+    return 1;
+}
+
+#endif /* HAVE_SYS_UN_H */

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -52,7 +52,7 @@ RCFLAGS  += -I$(PROOT)/include
 # examples, tests
 
 LIBSSH2_LDFLAGS_BIN += -L$(PROOT)/win32
-LIBS_BIN := -lssh2 -lws2_32
+LIBS_BIN := -lssh2
 
 ifdef DYN
   libssh2_DEPENDENCIES := $(PROOT)/win32/libssh2.dll.a
@@ -164,7 +164,7 @@ libssh2_dll_LIBRARY := $(TARGET)$(LIBSSH2_DLL_SUFFIX).dll
 libssh2_dll_a_LIBRARY := $(TARGET).dll.a
 
 EXAMPLES := $(PROOT)/example
-TARGETS_EXAMPLES := $(filter-out $(EXAMPLES)/x11.exe,$(patsubst %.c,%.exe,$(strip $(wildcard $(EXAMPLES)/*.c))))
+TARGETS_EXAMPLES := $(patsubst %.c,%.exe,$(strip $(wildcard $(EXAMPLES)/*.c)))
 
 all: lib dll
 


### PR DESCRIPTION
Whether to build the `x11` example or not was decided by each build
tool. CMake didn't build it even on supported platforms. GNUMakefile
used a specific blocklist for it, while autotools enabled it based on
feature-detection.

Migrate the enabler logic to an #ifdef in source and build `x11`
unconditionally with all build tools.

On unsupported platforms (=Windows) this program now displays a short
message stating that fact.

Also:

- fix `x11.c` warnings uncovered after CMake started building it.

- use `libssh2_socket_t` type for portability in `x11.c` too.

- use detected header guards in `x11.c`.

- delete a duplicate reference to `-lws2_32` from `win32/GNUmakefile`
  while there.

Closes #909
