### PR TITLE
delete redundant `HAVE_WS2TCPIP_H`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
 check_include_files(sys/ioctl.h HAVE_SYS_IOCTL_H)
 check_include_files(sys/time.h HAVE_SYS_TIME_H)
 check_include_files(sys/un.h HAVE_SYS_UN_H)
-check_include_files(ws2tcpip.h HAVE_WS2TCPIP_H)
 check_include_files(winsock2.h HAVE_WINSOCK2_H)
 
 # for example and tests

--- a/configure.ac
+++ b/configure.ac
@@ -289,7 +289,7 @@ case $host in
     # These are POSIX-like systems using BSD-like sockets API.
     ;;
   *)
-    AC_CHECK_HEADERS([windows.h winsock2.h ws2tcpip.h])
+    AC_CHECK_HEADERS([windows.h winsock2.h])
     ;;
 esac
 

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -137,9 +137,6 @@
 /* Define to 1 if you have the <winsock2.h> header file. */
 #undef HAVE_WINSOCK2_H
 
-/* Define to 1 if you have the <ws2tcpip.h> header file. */
-#undef HAVE_WS2TCPIP_H
-
 /* to make a symbol visible */
 #undef LIBSSH2_API
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -45,7 +45,6 @@
 #cmakedefine HAVE_SYS_IOCTL_H
 #cmakedefine HAVE_SYS_TIME_H
 #cmakedefine HAVE_SYS_UN_H
-#cmakedefine HAVE_WS2TCPIP_H
 #cmakedefine HAVE_WINSOCK2_H
 
 /* for example and tests */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -78,8 +78,12 @@
 # endif
 #endif /* WIN32 */
 
-#ifdef HAVE_WS2TCPIP_H
+#ifdef HAVE_WINSOCK2_H
+#include <winsock2.h>
 #include <ws2tcpip.h>
+/* Force parameter type. */
+#define recv(s, b, l, f)  recv((s), (b), (int)(l), (f))
+#define send(s, b, l, f)  send((s), (b), (int)(l), (f))
 #endif
 
 #include <stdio.h>
@@ -163,14 +167,6 @@ struct iovec {
 #endif
 
 #include "crypto.h"
-
-#ifdef HAVE_WINSOCK2_H
-#include <winsock2.h>
-#include <ws2tcpip.h>
-/* Force parameter type. */
-#define recv(s, b, l, f)  recv((s), (b), (int)(l), (f))
-#define send(s, b, l, f)  send((s), (b), (int)(l), (f))
-#endif
 
 #ifndef SIZE_MAX
 #if _WIN64


### PR DESCRIPTION
It was used once in `src/libssh2_priv.h`, but without any effect. The header included `ws2tcpip.h` twice, once guarded by `HAVE_WS2TCPIP_H` and another time by `HAVE_WINSOCK2_H`.

Dedupe these to not use `HAVE_WS2TCPIP_H`. Then delete detection of this feature from all build methods.

TODO: Replace `HAVE_WINSOCK2_H` with `_WIN32`/`WIN32`.
