### PR TITLE
delete redundant `HAVE_WINSOCK2_H`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
 check_include_files(sys/ioctl.h HAVE_SYS_IOCTL_H)
 check_include_files(sys/time.h HAVE_SYS_TIME_H)
 check_include_files(sys/un.h HAVE_SYS_UN_H)
-check_include_files(winsock2.h HAVE_WINSOCK2_H)
 
 # for example and tests
 check_include_files(sys/param.h HAVE_SYS_PARAM_H)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -218,13 +218,7 @@ dnl the code was bad, try a different program now, test 3
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-#ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
-#endif
 #endif
 ],[
 /* ioctlsocket source code */

--- a/configure.ac
+++ b/configure.ac
@@ -289,7 +289,7 @@ case $host in
     # These are POSIX-like systems using BSD-like sockets API.
     ;;
   *)
-    AC_CHECK_HEADERS([windows.h winsock2.h])
+    AC_CHECK_HEADERS([windows.h])
     ;;
 esac
 
@@ -317,7 +317,7 @@ dnl Check for select() into ws2_32 for Msys/Mingw
 if test "$ac_cv_func_select" != "yes"; then
   AC_MSG_CHECKING([for select in ws2_32])
   AC_TRY_LINK([
-#ifdef HAVE_WINSOCK2_H
+#ifdef HAVE_WINDOWS_H
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/example/scp.c
+++ b/example/scp.c
@@ -11,8 +11,9 @@
 #include "libssh2_config.h"
 #include <libssh2.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
+# define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
@@ -35,10 +36,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
-
-#ifdef WIN32
-#define write(f, b, c)  write((f), (b), (unsigned int)(c))
-#endif
 
 int main(int argc, char *argv[])
 {

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -16,8 +16,9 @@
 #include "libssh2_config.h"
 #include <libssh2.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
+# define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
@@ -43,10 +44,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
-
-#ifdef WIN32
-#define write(f, b, c)  write((f), (b), (unsigned int)(c))
-#endif
 
 #ifdef HAVE_GETTIMEOFDAY
 /* diff in ms */

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -11,7 +11,7 @@
 #include "libssh2_config.h"
 #include <libssh2.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -11,7 +11,7 @@
 #include "libssh2_config.h"
 #include <libssh2.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -17,8 +17,9 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
+# define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
@@ -44,10 +45,6 @@
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #pragma warning(disable:4127)
-#endif
-
-#ifdef WIN32
-#define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 
 const char *keyfile1 = "~/.ssh/id_rsa.pub";

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -11,8 +11,9 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
+# define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
@@ -41,10 +42,6 @@
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #pragma warning(disable:4127)
-#endif
-
-#ifdef WIN32
-#define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 
 #define STORAGE "/tmp/sftp-storage" /* this is the local file name this

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -17,7 +17,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -17,7 +17,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -17,7 +17,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -17,8 +17,9 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
+# define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
@@ -47,10 +48,6 @@
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #pragma warning(disable:4127)
-#endif
-
-#ifdef WIN32
-#define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 
 #ifdef HAVE_GETTIMEOFDAY

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -17,7 +17,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -17,7 +17,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -17,7 +17,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -17,7 +17,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -17,7 +17,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -23,8 +23,6 @@
 
 #ifdef WIN32
 # include <windows.h>
-#endif
-#ifdef HAVE_WINSOCK2_H
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -18,8 +18,6 @@
 
 #ifdef WIN32
 # include <windows.h>
-#endif
-#ifdef HAVE_WINSOCK2_H
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -22,7 +22,7 @@
 #include "libssh2_config.h"
 #include <libssh2.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -17,7 +17,7 @@
 #include "libssh2_config.h"
 #include <libssh2.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -19,7 +19,7 @@
 #include "libssh2_config.h"
 #include <libssh2.h>
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -134,9 +134,6 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1
 
-/* Define to 1 if you have the <winsock2.h> header file. */
-#undef HAVE_WINSOCK2_H
-
 /* to make a symbol visible */
 #undef LIBSSH2_API
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -45,7 +45,6 @@
 #cmakedefine HAVE_SYS_IOCTL_H
 #cmakedefine HAVE_SYS_TIME_H
 #cmakedefine HAVE_SYS_UN_H
-#cmakedefine HAVE_WINSOCK2_H
 
 /* for example and tests */
 #cmakedefine HAVE_SYS_PARAM_H

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -76,9 +76,7 @@
 #    define LIBSSH2_WINDOWS_APP
 #  endif
 # endif
-#endif /* WIN32 */
 
-#ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
 #include <ws2tcpip.h>
 /* Force parameter type. */

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -45,7 +45,7 @@
 #include "openssh_fixture.h"
 #include "libssh2_config.h"
 
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
 #include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H
@@ -429,7 +429,7 @@ static char *running_container_id = NULL;
 int start_openssh_fixture(void)
 {
     int ret;
-#ifdef HAVE_WINSOCK2_H
+#ifdef WIN32
     WSADATA wsadata;
 
     ret = WSAStartup(MAKEWORD(2, 0), &wsadata);

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -47,15 +47,14 @@
 
 #ifdef WIN32
 #include <windows.h>
+#include <winsock2.h>
 #ifdef _MSC_VER
 #include <direct.h>
 #define getcwd _getcwd
 #define chdir _chdir
 #endif
 #endif
-#ifdef HAVE_WINSOCK2_H
-#include <winsock2.h>
-#endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -6,8 +6,6 @@
 
 #ifdef WIN32
 # include <windows.h>
-#endif
-#ifdef HAVE_WINSOCK2_H
 # include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H

--- a/win32/libssh2_config.h
+++ b/win32/libssh2_config.h
@@ -10,7 +10,6 @@
 #endif
 
 #define HAVE_LIBCRYPT32
-#define HAVE_WINSOCK2_H
 #define HAVE_STDLIB_H
 #define HAVE_IOCTLSOCKET
 #define HAVE_SELECT


### PR DESCRIPTION
`libssh2.h` required `winsock2.h` for `_WIN32` since 81d53de4dc5ee39bd6215958c7dce3b12731195e (2011-06-04).

Apply that to the whole codebase. This makes it unnecessary to detect `HAVE_WINSOCK2_H` and allows to drop all its uses.

Completes TODO from b66d7317ca6c882afbe52fe426f68c119c40d348

TODO: Straighten out the use a mixture of `HAVE_WINDOWS_H`, `WIN32`, `_WIN32` to detect Windows.