### PR TITLE
delete redundant `HAVE_STDLIB_H`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,6 @@ set(LIB_SHARED "libssh2_shared")  # Must match libssh2_shared_EXPORTS macro in i
 ## Platform checks
 check_include_files(unistd.h HAVE_UNISTD_H)
 check_include_files(inttypes.h HAVE_INTTYPES_H)
-check_include_files(stdlib.h HAVE_STDLIB_H)
 check_include_files(sys/select.h HAVE_SYS_SELECT_H)
 
 check_include_files(sys/uio.h HAVE_SYS_UIO_H)
@@ -151,11 +150,7 @@ if(HAVE_SYS_TIME_H)
 else()
   check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
 endif()
-if(HAVE_STDLIB_H)
-  check_symbol_exists(strtoll stdlib.h HAVE_STRTOLL)
-else()
-  check_function_exists(strtoll HAVE_STRTOLL)
-endif()
+check_symbol_exists(strtoll stdlib.h HAVE_STRTOLL)
 if (NOT HAVE_STRTOLL)
   # Try _strtoi64 if strtoll isn't available
   check_symbol_exists(_strtoi64 stdlib.h HAVE_STRTOI64)

--- a/configure.ac
+++ b/configure.ac
@@ -278,7 +278,7 @@ AM_CONDITIONAL([USE_OSSFUZZ_STATIC], [test -f "$LIB_FUZZING_ENGINE"])
 
 # Checks for header files.
 # AC_HEADER_STDC
-AC_CHECK_HEADERS([errno.h fcntl.h stdio.h stdlib.h unistd.h sys/param.h sys/uio.h])
+AC_CHECK_HEADERS([errno.h fcntl.h stdio.h unistd.h sys/param.h sys/uio.h])
 AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/ioctl.h sys/time.h])
 AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
 AC_CHECK_HEADERS([sys/un.h], [have_sys_un_h=yes], [have_sys_un_h=no])

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -23,9 +23,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -39,9 +39,7 @@
 #include <sys/time.h>
 #endif
 #include <sys/types.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -41,9 +41,7 @@
 #include <sys/time.h>
 #endif
 #include <sys/types.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -22,9 +22,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -23,9 +23,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/x11.c
+++ b/example/x11.c
@@ -38,9 +38,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <ctype.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 #include <termios.h>
 

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -107,9 +107,6 @@
 /* Define to 1 if you have the <stdio.h> header file. */
 #define HAVE_STDIO_H 1
 
-/* Define to 1 if you have the <stdlib.h> header file. */
-#define HAVE_STDLIB_H 1
-
 /* Define to 1 if you have the `strtoll' function. */
 #define HAVE_STRTOLL 1
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -38,7 +38,6 @@
 /* Headers */
 #cmakedefine HAVE_UNISTD_H
 #cmakedefine HAVE_INTTYPES_H
-#cmakedefine HAVE_STDLIB_H
 #cmakedefine HAVE_SYS_SELECT_H
 #cmakedefine HAVE_SYS_UIO_H
 #cmakedefine HAVE_SYS_SOCKET_H

--- a/src/misc.c
+++ b/src/misc.c
@@ -40,9 +40,7 @@
 #include "libssh2_priv.h"
 #include "misc.h"
 
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -41,9 +41,7 @@
 
 #ifdef LIBSSH2_OS400QC3 /* compile only if we build with OS/400 QC3 library */
 
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 #include <stdio.h>
 #include <stdarg.h>

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -60,9 +60,8 @@
 #include <bcrypt.h>
 #include <math.h>
 
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
+
 #ifdef HAVE_LIBCRYPT32
 #include <wincrypt.h>
 #endif

--- a/vms/libssh2_config.h
+++ b/vms/libssh2_config.h
@@ -14,7 +14,6 @@ typedef unsigned int socklen_t; /* missing in headers on VMS */
 /* Have's */
 
 #define HAVE_UNISTD_H
-#define HAVE_STDLIB_H
 #define HAVE_INTTYPES_H
 #define HAVE_SYS_TIME_H
 #define HAVE_SELECT

--- a/win32/libssh2_config.h
+++ b/win32/libssh2_config.h
@@ -10,7 +10,6 @@
 #endif
 
 #define HAVE_LIBCRYPT32
-#define HAVE_STDLIB_H
 #define HAVE_IOCTLSOCKET
 #define HAVE_SELECT
 #define HAVE_SNPRINTF


### PR DESCRIPTION
libssh2 used this standard C89 header unconditionally before this patch.

Delete the feature checks and all unnecessary header guards.