### PR TITLE
tidy-up: null-mac/cipher documentation

### DIFF
--- a/docs/INSTALL_AUTOTOOLS
+++ b/docs/INSTALL_AUTOTOOLS
@@ -254,32 +254,6 @@ More configure options
 
 Some ./configure options deserve additional comments:
 
- * --enable-crypt-none
-
-        The SSH2 Transport allows for unencrypted data
-        transmission using the "none" cipher.  Because this is
-        such a huge security hole, it is typically disabled on
-        SSH2 implementations and is disabled in libssh2 by
-        default as well.
-
-        Enabling this option will allow for "none" as a
-        negotiable method, however it still requires that the
-        method be advertised by the remote end and that no
-        more-preferable methods are available.
-
- * --enable-mac-none
-
-        The SSH2 Transport also allows implementations to
-        forego a message authentication code.  While this is
-        less of a security risk than using a "none" cipher, it
-        is still not recommended as disabling MAC hashes
-        removes a layer of security.
-
-        Enabling this option will allow for "none" as a
-        negotiable method, however it still requires that the
-        method be advertised by the remote end and that no
-        more-preferable methods are available.
-
  * --with-libgcrypt
  * --without-libgcrypt
  * --with-libgcrypt-prefix=DIR

--- a/docs/INSTALL_CMAKE.md
+++ b/docs/INSTALL_CMAKE.md
@@ -74,28 +74,6 @@ The following options are available:
     Will use zlib (https://zlib.net/) for payload compression.  Can
     be `ON` or `OFF`.
 
- * `ENABLE_CRYPT_NONE=OFF`
-
-    The SSH2 Transport allows for unencrypted data transmission using
-    the "none" cipher.  Because this is such a huge security hole, it
-    is typically disabled on SSH2 implementations and is disabled in
-    libssh2 by default as well.
-
-    Enabling this option will allow for "none" as a negotiable method,
-    however it still requires that the method be advertised by the
-    remote end and that no more-preferable methods are available.
-
- * `ENABLE_MAC_NONE=OFF`
-
-    The SSH2 Transport also allows implementations to forego a message
-    authentication code.  While this is less of a security risk than
-    using a "none" cipher, it is still not recommended as disabling
-    MAC hashes removes a layer of security.
-
-    Enabling this option will allow for "none" as a negotiable method,
-    however it still requires that the method be advertised by the
-    remote end and that no more-preferable methods are available.
-
  * `ENABLE_DEBUG_LOGGING=ON` in Debug, `=OFF` in Release
 
     Will enable the libssh2_trace() function for showing debug traces.

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -39,9 +39,18 @@
 #include "libssh2_priv.h"
 
 #if defined(LIBSSH2DEBUG) && defined(LIBSSH2_CRYPT_NONE_INSECURE)
-
 /* crypt_none_crypt
  * Minimalist cipher: no encryption. DO NOT USE.
+ *
+ * The SSH2 Transport allows for unencrypted data transmission using
+ * the "none" cipher.  Because this is such a huge security hole, it is
+ * typically disabled on SSH2 implementations and is disabled in libssh2
+ * by default as well.
+ *
+ * Enabling this option will allow for "none" as a negotiable method,
+ * however it still requires that the method be advertised by the remote
+ * end and that no more-preferable methods are available.
+ *
  */
 static int
 crypt_none_crypt(LIBSSH2_SESSION * session, unsigned char *buf,

--- a/src/mac.c
+++ b/src/mac.c
@@ -41,6 +41,16 @@
 #if defined(LIBSSH2DEBUG) && defined(LIBSSH2_MAC_NONE_INSECURE)
 /* mac_none_MAC
  * Minimalist MAC: No MAC. DO NOT USE.
+ *
+ * The SSH2 Transport allows implementations to forego a message
+ * authentication code.  While this is less of a security risk than using
+ * a "none" cipher, it is still not recommended as disabling MAC hashes
+ * removes a layer of security.
+ *
+ * Enabling this option will allow for "none" as a negotiable method,
+ * however it still requires that the method be advertised by the remote
+ * end and that no more-preferable methods are available.
+ *
  */
 static int
 mac_none_MAC(LIBSSH2_SESSION * session, unsigned char *buf,


### PR DESCRIPTION
Move documentation for these deleted build-level options from autotools/cmake docs to the source code itself.

Follow-up to 50c9bf868e833258d23c5f55ed546d1fcd5687d0