### PR TITLE
build: respect autotools `DLL_EXPORT` in `libssh2.h`

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -100,7 +100,7 @@ extern "C" {
 /* Allow alternate API prefix from CFLAGS or calling app */
 #ifndef LIBSSH2_API
 # ifdef WIN32
-#  if defined(LIBSSH2_EXPORTS) || \
+#  if defined(LIBSSH2_EXPORTS) || defined(DLL_EXPORT) || \
       defined(_WINDLL) || defined(libssh2_shared_EXPORTS)
 #   ifdef LIBSSH2_LIBRARY
 #    define LIBSSH2_API __declspec(dllexport)


### PR DESCRIPTION
The `DLL_EXPORT` macro is automatically set by autotools when building the libssh2 DLL. Certain toolchains might require this to correctly export symbols, so make sure to respect it in `libssh2.h` to enable `declspec(dllexport)`.

With this patch we have a manual macro for that (`LIBSSH2_EXPORT`), this autotools one, the CMake one, and `_WINDLL` (added in c355d31ff94a1622526c4988b9d09074f7f7605d), possibly defined by Visual Studio.