### PR TITLE
autotools: delete unused conditional `HAVE_SYS_UN_H`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -281,8 +281,7 @@ AM_CONDITIONAL([USE_OSSFUZZ_STATIC], [test -f "$LIB_FUZZING_ENGINE"])
 AC_CHECK_HEADERS([errno.h fcntl.h stdio.h unistd.h sys/param.h sys/uio.h])
 AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/ioctl.h sys/time.h])
 AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
-AC_CHECK_HEADERS([sys/un.h], [have_sys_un_h=yes], [have_sys_un_h=no])
-AM_CONDITIONAL([HAVE_SYS_UN_H], test "x$have_sys_un_h" = xyes)
+AC_CHECK_HEADERS([sys/un.h])
 
 case $host in
   *-*-cygwin* | *-*-cegcc*)


### PR DESCRIPTION
No longer necessary after moving the disabling/enabling logic from build tool to `example/x11.c`.

Reverts 4774d500e724bc4e548f743a0cb644ab05599474
Follow-up to d245c66cc0029e480674394c23e8be1c9410f7ad