### PR TITLE
transport: rename local `RANDOM_PADDING` macro

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -723,7 +723,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
     ssize_t padding_length;
     size_t packet_length;
     ssize_t total_length;
-#ifdef RANDOM_PADDING
+#ifdef LIBSSH2_RANDOM_PADDING
     int rand_max;
     int seed = data[0];         /* FIXME: make this random */
 #endif
@@ -846,7 +846,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
     if(padding_length < 4) {
         padding_length += blocksize;
     }
-#ifdef RANDOM_PADDING
+#ifdef LIBSSH2_RANDOM_PADDING
     /* FIXME: we can add padding here, but that also makes the packets
        bigger etc */
 


### PR DESCRIPTION
Rename `RANDOM_PADDING` macro used internally to enable some code.

Committed in the initial version of `transport.c` in 9d55db6501aa4e21f0858cf36cdc2ddc11b96e83 (2007-02-02). libssh2 code never defined it.

The name happens to collide with a Windows macro in `wincrypt.h`. `transport.c` doesn't include this header, but it includes `winsock2.h`, and it turns out it can also define this macro in some cases, e.g. when `WIN32_LEAN_AND_MEAN` is not set.

To be on the safe side, prefix the name with `LIBSSH2_` to avoid enabling it by accident.

Q: Maybe it'd be best to delete it with the guarded code?

Reported-by: Markus-Schmidt on github
Fixes #921
Closes #924