### PR TITLE
ci: add MSVS 2008/2010 build tests and fix warnings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,14 +66,32 @@ environment:
       CRYPTO_BACKEND: "OpenSSL"
       CONFIGURATION: "Release"
 
-    - job_name: "VS2013, OpenSSL, x64, Static-only"
+    - job_name: "VS2013, OpenSSL, x64, Static-only, Build-only"
       APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
       GENERATOR: "Visual Studio 12 2013"
       PLATFORM: "x64"
       BUILD_SHARED_LIBS: "OFF"
       CRYPTO_BACKEND: "OpenSSL"
-      SKIP_CTEST: "yes"
       CONFIGURATION: "Release"
+      SKIP_CTEST: "yes"
+
+    - job_name: "VS2010, WinCNG, x64, Build-only"
+      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      GENERATOR: "Visual Studio 10 2010"
+      PLATFORM: "x64"
+      BUILD_SHARED_LIBS: "ON"
+      CRYPTO_BACKEND: "WinCNG"
+      CONFIGURATION: "Release"
+      SKIP_CTEST: "yes"
+
+    - job_name: "VS2008, WinCNG, x86, Build-only"
+      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      GENERATOR: "Visual Studio 9 2008"
+      PLATFORM: "x86"
+      BUILD_SHARED_LIBS: "ON"
+      CRYPTO_BACKEND: "WinCNG"
+      CONFIGURATION: "Release"
+      SKIP_CTEST: "yes"
 
     - job_name: "VS2022, WinCNG, x64, Logging"
       APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
@@ -83,7 +101,7 @@ environment:
       CRYPTO_BACKEND: "WinCNG"
       CONFIGURATION: "Debug"
 
-    - job_name: "VS2022, WinCNG, ARM64"
+    - job_name: "VS2022, WinCNG, ARM64, Build-only"
       APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: "ARM64"
@@ -174,7 +192,7 @@ on_finish:
       Start-Sleep -Seconds 3
       Get-Process -Name "sshd" -ErrorAction SilentlyContinue | Stop-Process
 
-# whitelist branches to avoid testing feature branches twice (as branch and as pull request)
+# Limit branches to avoid testing feature branches twice (as branch and as pull request)
 branches:
   only:
     - master

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -36,6 +36,10 @@
 #define INADDR_NONE (in_addr_t)-1
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
 const char *keyfile2 = "/home/username/.ssh/id_rsa";
 const char *username = "username";

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -45,6 +45,10 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 #ifdef HAVE_GETTIMEOFDAY
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -40,6 +40,10 @@
 #include <ctype.h>
 #include <time.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -46,6 +46,10 @@
 #include <ctype.h>
 #include <time.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -46,6 +46,10 @@
 #include <ctype.h>
 #include <time.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -51,6 +51,10 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -45,6 +45,10 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -47,6 +47,10 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -36,6 +36,10 @@
 #define INADDR_NONE (in_addr_t)-1
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
 const char *keyfile2 = "/home/username/.ssh/id_rsa";
 const char *username = "username";

--- a/example/x11.c
+++ b/example/x11.c
@@ -42,6 +42,10 @@
 
 #include <termios.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#pragma warning(disable:4127)
+#endif
+
 #define _PATH_UNIX_X "/tmp/.X11-unix/X%d"
 
 /*

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -223,6 +223,16 @@
 #define PKCS_RSA_PRIVATE_KEY (LPCSTR)43
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1700
+/* Workaround for warning C4306:
+   'type cast' : conversion from 'int' to 'LPCSTR' of greater size */
+#undef X509_SEQUENCE_OF_ANY
+#undef X509_MULTI_BYTE_UINT
+#undef PKCS_RSA_PRIVATE_KEY
+#define X509_SEQUENCE_OF_ANY ((LPCSTR)(size_t)34)
+#define X509_MULTI_BYTE_UINT ((LPCSTR)(size_t)38)
+#define PKCS_RSA_PRIVATE_KEY ((LPCSTR)(size_t)43)
+#endif
 
 /*******************************************************************/
 /*


### PR DESCRIPTION
Also:

- fix newly surfaced (bogus) warnings in examples with MSVS 2010:

  ```
  ..\..\example\direct_tcpip.c(262): warning C4127: conditional expression is constant
  ```
  Happens for every `FD_SET()` macro reference.

  Ref: https://ci.appveyor.com/project/libssh2org/libssh2/builds/46677835/job/ni4hs97bh18c14ap

- silence MSVS 2010 predefined Windows macro warnings:

  ```
  ..\..\src\wincng.c(867): warning C4306: 'type cast' : conversion from 'int' to 'LPCSTR' of greater size
  ..\..\src\wincng.c(897): warning C4306: 'type cast' : conversion from 'int' to 'LPCSTR' of greater size
  ..\..\src\wincng.c(1132): warning C4306: 'type cast' : conversion from 'int' to 'LPCSTR' of greater size
  ```

  Ref: https://ci.appveyor.com/project/libssh2org/libssh2/builds/46678071/job/08t5ktvkcgdghp7r

Closes #925
