### PR TITLE
hostkey: fix `hash_len` field constants

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -413,13 +413,9 @@ hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION * session, void **abstract)
     return 0;
 }
 
-#ifdef OPENSSL_NO_MD5
-#define MD5_DIGEST_LENGTH 16
-#endif
-
 static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa = {
     "ssh-rsa",
-    MD5_DIGEST_LENGTH,
+    SHA_DIGEST_LENGTH,
     hostkey_method_ssh_rsa_init,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -459,7 +455,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_512 = {
 
 static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_cert = {
     "ssh-rsa-cert-v01@openssh.com",
-    MD5_DIGEST_LENGTH,
+    SHA_DIGEST_LENGTH,
     NULL,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -688,7 +684,7 @@ hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION * session, void **abstract)
 
 static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_dss = {
     "ssh-dss",
-    MD5_DIGEST_LENGTH,
+    SHA_DIGEST_LENGTH,
     hostkey_method_ssh_dss_init,
     hostkey_method_ssh_dss_initPEM,
     hostkey_method_ssh_dss_initPEMFromMemory,


### PR DESCRIPTION
Replace incorrect `MD5_DIGEST_LENGTH` with `SHA_DIGEST_LENGTH` for these hostkey algos:

- `ssh-rsa` and `ssh-dss`

  Ref: 7a5ffc8cee259bbde82ab92515cd8fea2166854b (2004-12-07 Initial)

- `ssh-rsa-cert-v01@openssh.com`

  Ref: 4b21e49d9d2db74579b18804ed1f5eeb16578b2f (2022-07-28)
  Ref: #710

Reported-by: Markus-Schmidt on github
Fixes #919
Closes #926