### PR TITLE
build: MSVS warning suppression option tidy-up

### DIFF
--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -28,8 +28,7 @@ if(MSVC)
     endif()
   endif()
 
-  # Disable broken warnings
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -39,6 +39,11 @@ list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
 
 add_definitions(-DHAVE_CONFIG_H)
 
+if(MSVC)
+  add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+  add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
+endif()
+
 set(EXAMPLES
   direct_tcpip
   scp

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -1,9 +1,3 @@
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/scp.c
+++ b/example/scp.c
@@ -2,12 +2,6 @@
  * Sample showing how to do a simple SCP transfer.
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -7,12 +7,6 @@
  * "scp_nonblock 192.168.0.1 user password /tmp/secrets"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -2,12 +2,6 @@
  * Sample showing how to do an SCP upload.
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -2,12 +2,6 @@
  * Sample showing how to do an SCP non-blocking upload transfer.
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -7,12 +7,6 @@
  * "sftp 192.168.0.1 user password /tmp/secrets -p|-i|-k"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -7,12 +7,6 @@
  * sftp_append 192.168.0.1 user password localfile /tmp/remotefile
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -7,12 +7,6 @@
  * "sftp 192.168.0.1 user password /tmp/sftp_mkdir"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -7,12 +7,6 @@
  * "sftp 192.168.0.1 user password /tmp/sftp_write_nonblock.c"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -7,12 +7,6 @@
  * "sftp_nonblock 192.168.0.1 user password /tmp/secrets"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -7,12 +7,6 @@
  * "sftp 192.168.0.1 user password sftp_write.c /tmp/secrets"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -7,12 +7,6 @@
  * "sftp 192.168.0.1 user password thisfile /tmp/storehere"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -7,12 +7,6 @@
  * "sftp 192.168.0.1 user password file /tmp/storehere"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -7,12 +7,6 @@
  * "sftpdir 192.168.0.1 user password /tmp/secretdir"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -7,12 +7,6 @@
  * "sftpdir 192.168.0.1 user password /tmp/secretdir"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -11,12 +11,6 @@
  *  command executes on the remote machine
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -6,12 +6,6 @@
  * "ssh2_agent host user"
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 #include <libssh2_sftp.h>

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -13,12 +13,6 @@
  *
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -8,12 +8,6 @@
  *
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -10,12 +10,6 @@
  *
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -1,9 +1,3 @@
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -1,9 +1,3 @@
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "libssh2_config.h"
 #include <libssh2.h>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,11 @@ list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
 
 add_definitions(-DHAVE_CONFIG_H)
 
+if(MSVC)
+  add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+  add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
+endif()
+
 set(TESTS
   warmup
   hostkey

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -35,12 +35,6 @@
  * OF SUCH DAMAGE.
  */
 
-#ifdef WIN32
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#endif
-#endif
-
 #include "session_fixture.h"
 #include "openssh_fixture.h"
 #include "libssh2_config.h"

--- a/win32/libssh2_config.h
+++ b/win32/libssh2_config.h
@@ -5,10 +5,6 @@
 #define WIN32
 #endif
 
-#ifndef _CRT_SECURE_NO_DEPRECATE
-#define _CRT_SECURE_NO_DEPRECATE 1
-#endif
-
 #define HAVE_IOCTLSOCKET
 #define HAVE_SELECT
 #define HAVE_SNPRINTF
@@ -21,6 +17,9 @@
 # define HAVE_LONGLONG
 # define HAVE_STRTOLL
 #elif defined(_MSC_VER)
+# ifndef _CRT_SECURE_NO_WARNINGS
+# define _CRT_SECURE_NO_WARNINGS
+# endif
 # if _MSC_VER >= 1310
 #  define HAVE_LONGLONG
 # endif


### PR DESCRIPTION
- in `win32/libssh2_config.h` replace `_CRT_SECURE_NO_DEPRECATE` with
  `_CRT_SECURE_NO_WARNINGS`, to use the official macro for this, like
  in CMake.

  Also, it's now safe to move it back under `_MSC_VER`.

  Suppressing:

  `warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead.`
  `warning C4996: 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead.`

- move `_CRT_NONSTDC_NO_DEPRECATE` to `example` and `tests`.
  Not needed for `src`.

  Suppressing:

  `warning C4996: 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup.`
  `warning C4996: 'write': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _write.`

- move `_WINSOCK_DEPRECATED_NO_WARNINGS` from source files to
  CMake files, in `example` and `tests`. Also limit this to MSVC.

  Suppressing:

  `warning C4996: 'inet_addr': Use inet_pton() or InetPton() instead`

TODO: try fixing these instead of suppressing.

Closes #929
