### PR TITLE
src: include `limits.h` for `*_MAX` macros

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -86,6 +86,7 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <limits.h>
 
 /* The following CPP block should really only be in session.c and packet.c.
    However, AIX have #define's for 'events' and 'revents' and we are using


### PR DESCRIPTION
Follow-up to 5a96f494ee0b00282afb2db2e091246fc5e1774a

Reported-by: OldWorldOrdr on github
Fixes #928
Closes #930