### PR TITLE
Makefile.mk: move portable GNU Make file to the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,17 @@
 .deps
 .libs
+*.a
 *.lib
 *.pdb
 *.dll
+*.def
 *.exe
 *.obj
 .*.swp
 Debug
 Release
+debug-*
+release-*
 *.exp
 Makefile
 Makefile.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ VMSFILES = vms/libssh2_make_example.dcl vms/libssh2_make_help.dcl \
   vms/libssh2_make_kit.dcl vms/libssh2_make_lib.dcl vms/man2help.c \
   vms/readme.vms vms/libssh2_config.h
 
-WIN32FILES = win32/GNUmakefile NMakefile \
+WIN32FILES = NMakefile \
   win32/libssh2_config.h \
   src/libssh2.rc
 
@@ -40,7 +40,7 @@ OS400FILES = os400/README400 os400/initscript.sh os400/make.sh \
 EXTRA_DIST = $(WIN32FILES) get_ver.awk \
   maketgz RELEASE-NOTES libssh2.pc.in $(VMSFILES) config.rpath \
   CMakeLists.txt cmake git2news.pl libssh2-style.el README.md $(OS400FILES) \
-  buildconf
+  buildconf Makefile.mk
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -1,7 +1,7 @@
 #########################################################################
 #
 # Makefile for building libssh2 with GCC-like toolchains.
-# Use: make -f GNUmakefile [help|all|clean|dist|distclean|dyn|objclean|test|testclean]
+# Use: make -f Makefile.mk [help|all|clean|dist|distclean|dyn|objclean|test|testclean]
 #
 # Hacked by: Guenter Knauf
 #
@@ -9,7 +9,7 @@
 #
 #########################################################################
 
-PROOT := ..
+PROOT := .
 
 ### Common
 
@@ -276,7 +276,7 @@ $(OBJ_DIR):
 $(DISTDIR):
 	@$(call MKDIR, $@)
 
-$(DISTDIR)/readme.txt: GNUmakefile
+$(DISTDIR)/readme.txt: Makefile.mk
 	@echo Creating... $@
 	@echo $(DL)This is a binary distribution for $(TRIPLET).$(DL) > $@
 	@echo $(DL)libssh2 version $(LIBSSH2_VERSION_STR)$(DL) >> $@


### PR DESCRIPTION
Move the GNU Make file formerly known as `win32/GNUmakefile` to the root directory from `win32`. It now supports any platform with a GCC-like toolchain, while also keeping support for win32.

For non-Windows platforms it's necessary to provide a hand-crafted `libssh2_config.h` header for now.

Usage: `make -f Makefile.mk`
