### PR TITLE
crypto: fix `LIBSSH2_NO_MD5` compiler warnings

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -60,6 +60,7 @@
 
 #ifdef LIBSSH2_NO_MD5
 #undef LIBSSH2_MD5
+#define LIBSSH2_MD5 0
 #endif
 
 #define LIBSSH2_ED25519_KEY_LEN 32


### PR DESCRIPTION
Follow-up to be31457f3071686b555a0f0b19e5dcf63d67fc27
