### PR TITLE
test_warmup: re-implement as `test()`

### DIFF
--- a/tests/test_warmup.c
+++ b/tests/test_warmup.c
@@ -1,4 +1,4 @@
-/* Warm-up test. Always return 0.
+/* Warm-up test. Always return success.
    Workaround for CI/docker/etc flakiness on the first run. */
 
 #include "session_fixture.h"
@@ -8,20 +8,17 @@
 
 #include <stdio.h>
 
-int main(void)
+int test(LIBSSH2_SESSION *session)
 {
-    LIBSSH2_SESSION *session = start_session_fixture();
-    if(session != NULL) {
-        size_t len = 0;
-        int type = 0;
-        const char *hostkey = libssh2_session_hostkey(session, &len, &type);
+    size_t len = 0;
+    int type = 0;
+    const char *hostkey = libssh2_session_hostkey(session, &len, &type);
 
-        (void)hostkey;
+    (void)hostkey;
 
-        fprintf(stdout,
-                "libssh2_session_hostkey returned len, type: %d, %d\n",
-                (int)len, type);
-    }
-    stop_session_fixture();
-    return 0;
+    fprintf(stdout,
+            "libssh2_session_hostkey returned len, type: %d, %d\n",
+            (int)len, type);
+
+    return 0;  /* always return success */
 }


### PR DESCRIPTION
Instead of overriding `main()`. To align with the other tests.
    
Overriding `main()` can cause duplicate symbols without using a lib for
the `runner` code.

Follow-up to 40ac6b230a309d35c57aa65a8f6d7ab6654aa3d8

Closes #934
