### PR TITLE
tidy-up: example, tests

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -44,10 +44,10 @@ static const char *password = "";
 static const char *server_ip = "127.0.0.1";
 
 static const char *local_listenip = "127.0.0.1";
-unsigned int local_listenport = 2222;
+static unsigned int local_listenport = 2222;
 
 static const char *remote_desthost = "localhost"; /* resolved by the server */
-unsigned int remote_destport = 22;
+static unsigned int remote_destport = 22;
 
 enum {
     AUTH_NONE = 0,

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -10,6 +10,12 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
@@ -20,33 +26,27 @@
 #include <sys/time.h>
 #endif
 
+#include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#include <sys/types.h>
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 
 #ifndef INADDR_NONE
-#define INADDR_NONE (in_addr_t)-1
+#define INADDR_NONE (in_addr_t)~0
 #endif
 
-const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
-const char *keyfile2 = "/home/username/.ssh/id_rsa";
-const char *username = "username";
-const char *password = "";
+static const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
+static const char *keyfile2 = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "";
 
-const char *server_ip = "127.0.0.1";
+static const char *server_ip = "127.0.0.1";
 
-const char *local_listenip = "127.0.0.1";
+static const char *local_listenip = "127.0.0.1";
 unsigned int local_listenport = 2222;
 
-const char *remote_desthost = "localhost"; /* resolved by the server */
+static const char *remote_desthost = "localhost"; /* resolved by the server */
 unsigned int remote_destport = 22;
 
 enum {
@@ -112,24 +112,19 @@ int main(int argc, char *argv[])
     /* Connect to SSH server */
     sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if(sock == LIBSSH2_INVALID_SOCKET) {
-#ifdef WIN32
         fprintf(stderr, "failed to open socket!\n");
-#else
-        perror("socket");
-#endif
         return -1;
     }
 
     sin.sin_family = AF_INET;
     sin.sin_addr.s_addr = inet_addr(server_ip);
     if(INADDR_NONE == sin.sin_addr.s_addr) {
-        perror("inet_addr");
+        fprintf(stderr, "inet_addr: Invalid IP address \"%s\"\n", server_ip);
         return -1;
     }
     sin.sin_port = htons(22);
-    if(connect(sock, (struct sockaddr*)(&sin),
-               sizeof(struct sockaddr_in)) != 0) {
-        fprintf(stderr, "failed to connect!\n");
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
+        fprintf(stderr, "Failed to connect to %s!\n", inet_ntoa(sin.sin_addr));
         return -1;
     }
 
@@ -198,11 +193,7 @@ int main(int argc, char *argv[])
 
     listensock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if(listensock == LIBSSH2_INVALID_SOCKET) {
-#ifdef WIN32
         fprintf(stderr, "failed to open listen socket!\n");
-#else
-        perror("socket");
-#endif
         return -1;
     }
 
@@ -231,11 +222,7 @@ int main(int argc, char *argv[])
 
     forwardsock = accept(listensock, (struct sockaddr *)&sin, &sinlen);
     if(forwardsock == LIBSSH2_INVALID_SOCKET) {
-#ifdef WIN32
         fprintf(stderr, "failed to accept forward socket!\n");
-#else
-        perror("accept");
-#endif
         goto shutdown;
     }
 

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -36,8 +36,8 @@
 #define INADDR_NONE (in_addr_t)~0
 #endif
 
-static const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
-static const char *keyfile2 = "/home/username/.ssh/id_rsa";
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "";
 
@@ -179,8 +179,9 @@ int main(int argc, char *argv[])
         }
     }
     else if(auth & AUTH_PUBLICKEY) {
-        if(libssh2_userauth_publickey_fromfile(session, username, keyfile1,
-                                               keyfile2, password)) {
+        if(libssh2_userauth_publickey_fromfile(session, username,
+                                               pubkey, privkey,
+                                               password)) {
             fprintf(stderr, "\tAuthentication by public key failed!\n");
             goto shutdown;
         }

--- a/example/scp.c
+++ b/example/scp.c
@@ -6,16 +6,17 @@
 #include <libssh2.h>
 
 #ifdef WIN32
-# define write(f, b, c)  write((f), (b), (unsigned int)(c))
+#define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -88,8 +89,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-               sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -174,10 +174,9 @@ int main(int argc, char *argv[])
     libssh2_channel_free(channel);
     channel = NULL;
 
- shutdown:
+shutdown:
 
-    libssh2_session_disconnect(session,
-                               "Normal Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/scp.c
+++ b/example/scp.c
@@ -40,6 +40,8 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *scppath = "/tmp/TEST";
@@ -130,10 +132,8 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-#define HOME_DIR "/home/username/"
         if(libssh2_userauth_publickey_fromfile(session, username,
-                                               HOME_DIR ".ssh/id_rsa.pub",
-                                               HOME_DIR ".ssh/id_rsa",
+                                               pubkey, privkey,
                                                password)) {
             fprintf(stderr, "\tAuthentication by public key failed\n");
             goto shutdown;

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -87,6 +87,8 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *scppath = "/tmp/TEST";
@@ -194,10 +196,7 @@ int main(int argc, char *argv[])
     else {
         /* Or by public key */
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
-                                                        "/home/username/"
-                                                        ".ssh/id_rsa.pub",
-                                                        "/home/username/"
-                                                        ".ssh/id_rsa",
+                                                        pubkey, privkey,
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -43,8 +43,8 @@
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
-  return (newer.tv_sec-older.tv_sec)*1000+
-      (newer.tv_usec-older.tv_usec)/1000;
+    return (newer.tv_sec-older.tv_sec)*1000+
+        (newer.tv_usec-older.tv_usec)/1000;
 }
 #endif
 

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -11,19 +11,20 @@
 #include <libssh2.h>
 
 #ifdef WIN32
-# define write(f, b, c)  write((f), (b), (unsigned int)(c))
+#define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -277,8 +278,7 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session,
-                               "Normal Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -36,6 +36,8 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *loclfile = "scp_write.c";
@@ -145,10 +147,8 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-#define HOME "/home/username/"
         if(libssh2_userauth_publickey_fromfile(session, username,
-                                               HOME ".ssh/id_rsa.pub",
-                                               HOME ".ssh/id_rsa",
+                                               pubkey, privkey,
                                                password)) {
             fprintf(stderr, "\tAuthentication by public key failed\n");
             goto shutdown;

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -8,11 +8,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -104,8 +104,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-               sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -206,7 +205,7 @@ int main(int argc, char *argv[])
     libssh2_channel_free(channel);
     channel = NULL;
 
- shutdown:
+shutdown:
 
     if(session) {
         libssh2_session_disconnect(session, "Normal Shutdown");

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -70,6 +70,8 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *loclfile = "scp_write.c";
@@ -185,10 +187,8 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-#define HOME "/home/username/"
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
-                                                        HOME ".ssh/id_rsa.pub",
-                                                        HOME ".ssh/id_rsa",
+                                                        pubkey, privkey,
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -8,14 +8,14 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -138,8 +138,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-               sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -265,11 +264,10 @@ int main(int argc, char *argv[])
     libssh2_channel_free(channel);
     channel = NULL;
 
- shutdown:
+shutdown:
 
-    while(libssh2_session_disconnect(session,
-                                     "Normal Shutdown,") ==
-          LIBSSH2_ERROR_EAGAIN);
+    while(libssh2_session_disconnect(session, "Normal Shutdown")
+          == LIBSSH2_ERROR_EAGAIN);
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -12,16 +12,17 @@
 #include <libssh2_sftp.h>
 
 #ifdef WIN32
-# define write(f, b, c)  write((f), (b), (unsigned int)(c))
+#define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -36,11 +37,11 @@
 #include <stdio.h>
 #include <ctype.h>
 
-const char *keyfile1 = "~/.ssh/id_rsa.pub";
-const char *keyfile2 = "~/.ssh/id_rsa";
-const char *username = "username";
-const char *password = "password";
-const char *sftppath = "/tmp/TEST";
+static const char *keyfile1 = "~/.ssh/id_rsa.pub";
+static const char *keyfile2 = "~/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *sftppath = "/tmp/TEST";
 
 
 static void kbd_callback(const char *name, int name_len,
@@ -122,7 +123,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -148,8 +148,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-               sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -284,7 +283,7 @@ int main(int argc, char *argv[])
     libssh2_sftp_close(sftp_handle);
     libssh2_sftp_shutdown(sftp_session);
 
-  shutdown:
+shutdown:
 
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -37,8 +37,8 @@
 #include <stdio.h>
 #include <ctype.h>
 
-static const char *keyfile1 = "~/.ssh/id_rsa.pub";
-static const char *keyfile2 = "~/.ssh/id_rsa";
+static const char *pubkey = "~/.ssh/id_rsa.pub";
+static const char *privkey = "~/.ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "password";
 static const char *sftppath = "/tmp/TEST";
@@ -232,8 +232,9 @@ int main(int argc, char *argv[])
     }
     else if(auth_pw & 4) {
         /* Or by public key */
-        if(libssh2_userauth_publickey_fromfile(session, username, keyfile1,
-                                               keyfile2, password)) {
+        if(libssh2_userauth_publickey_fromfile(session, username,
+                                               pubkey, privkey,
+                                               password)) {
             fprintf(stderr, "\tAuthentication by public key failed!\n");
             goto shutdown;
         }

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -37,12 +37,11 @@
 #include <stdio.h>
 #include <ctype.h>
 
-static const char *pubkey = "~/.ssh/id_rsa.pub";
-static const char *privkey = "~/.ssh/id_rsa";
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "password";
 static const char *sftppath = "/tmp/TEST";
-
 
 static void kbd_callback(const char *name, int name_len,
                          const char *instruction, int instruction_len,
@@ -91,7 +90,6 @@ static void kbd_callback(const char *name, int name_len,
     fprintf(stderr,
         "Done. Sending keyboard-interactive responses to server now.\n");
 }
-
 
 int main(int argc, char *argv[])
 {

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -12,19 +12,20 @@
 #include <libssh2_sftp.h>
 
 #ifdef WIN32
-# define write(f, b, c)  write((f), (b), (unsigned int)(c))
+#define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -119,8 +120,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = htonl(0x7F000001);
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -341,7 +341,7 @@ int main(int argc, char *argv[])
 
     libssh2_sftp_shutdown(sftp_session);
 
-  shutdown:
+shutdown:
 
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -81,6 +81,8 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *sftppath = "/tmp/TEST"; /* source path */
@@ -186,10 +188,7 @@ int main(int argc, char *argv[])
         /* Or by public key */
         while((rc =
                libssh2_userauth_publickey_fromfile(session, username,
-                                                   "/home/username/"
-                                                   ".ssh/id_rsa.pub",
-                                                   "/home/username/"
-                                                   ".ssh/id_rsa",
+                                                   pubkey, privkey,
                                                    password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -38,6 +38,8 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *loclfile = "sftp_write.c";
@@ -147,10 +149,8 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-#define HOME "/home/username/"
         if(libssh2_userauth_publickey_fromfile(session, username,
-                                               HOME ".ssh/id_rsa.pub",
-                                               HOME ".ssh/id_rsa",
+                                               pubkey, privkey,
                                                password)) {
             fprintf(stderr, "\tAuthentication by public key failed\n");
             goto shutdown;

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -14,11 +14,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -69,7 +69,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -104,8 +103,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-               sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -218,8 +216,7 @@ int main(int argc, char *argv[])
     libssh2_sftp_shutdown(sftp_session);
 
 shutdown:
-    libssh2_session_disconnect(session,
-                               "Normal Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -14,11 +14,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -61,7 +61,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -87,8 +86,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-            sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -159,7 +157,7 @@ int main(int argc, char *argv[])
 
     libssh2_sftp_shutdown(sftp_session);
 
- shutdown:
+shutdown:
 
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -38,6 +38,8 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *sftppath = "/tmp/sftp_mkdir";
@@ -128,9 +130,8 @@ int main(int argc, char *argv[])
     else {
         /* Or by public key */
         if(libssh2_userauth_publickey_fromfile(session, username,
-                            "/home/username/.ssh/id_rsa.pub",
-                            "/home/username/.ssh/id_rsa",
-                            password)) {
+                                               pubkey, privkey,
+                                               password)) {
             fprintf(stderr, "\tAuthentication by public key failed\n");
             goto shutdown;
         }

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -38,6 +38,8 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *sftppath = "/tmp/sftp_mkdir_nonblock";
@@ -128,9 +130,8 @@ int main(int argc, char *argv[])
     else {
         /* Or by public key */
         if(libssh2_userauth_publickey_fromfile(session, username,
-                            "/home/username/.ssh/id_rsa.pub",
-                            "/home/username/.ssh/id_rsa",
-                            password)) {
+                                               pubkey, privkey,
+                                               password)) {
             fprintf(stderr, "\tAuthentication by public key failed\n");
             goto shutdown;
         }

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -14,11 +14,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -61,7 +61,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -87,8 +86,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-            sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -159,7 +157,7 @@ int main(int argc, char *argv[])
 
     libssh2_sftp_shutdown(sftp_session);
 
- shutdown:
+shutdown:
 
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -87,6 +87,8 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *sftppath = "/tmp/TEST";
@@ -195,10 +197,7 @@ int main(int argc, char *argv[])
         /* Or by public key */
         while((rc =
                libssh2_userauth_publickey_fromfile(session, username,
-                                                   "/home/username/"
-                                                   ".ssh/id_rsa.pub",
-                                                   "/home/username/"
-                                                   ".ssh/id_rsa",
+                                                   pubkey, privkey,
                                                    password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -12,19 +12,20 @@
 #include <libssh2_sftp.h>
 
 #ifdef WIN32
-# define write(f, b, c)  write((f), (b), (unsigned int)(c))
+#define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -117,7 +118,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -143,8 +143,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -281,9 +280,8 @@ int main(int argc, char *argv[])
 shutdown:
 
     fprintf(stderr, "libssh2_session_disconnect\n");
-    while(libssh2_session_disconnect(session,
-                                      "Normal Shutdown, Thank you") ==
-           LIBSSH2_ERROR_EAGAIN);
+    while(libssh2_session_disconnect(session, "Normal Shutdown")
+          == LIBSSH2_ERROR_EAGAIN);
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -14,11 +14,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -68,7 +68,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -103,8 +102,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-            sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -202,8 +200,7 @@ int main(int argc, char *argv[])
     libssh2_sftp_shutdown(sftp_session);
 
 shutdown:
-    libssh2_session_disconnect(session,
-                               "Normal Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -38,6 +38,8 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *loclfile = "sftp_write.c";
@@ -146,8 +148,6 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-        const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-        const char *privkey = "/home/username/.ssh/id_rsa.pub";
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -75,6 +75,8 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *loclfile = "sftp_write_nonblock.c";
@@ -189,8 +191,6 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-        const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-        const char *privkey = "/home/username/.ssh/id_rsa";
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
                                                         pubkey, privkey,
                                                         password)) ==

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -14,14 +14,14 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -108,7 +108,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -143,8 +142,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -270,7 +268,7 @@ int main(int argc, char *argv[])
 shutdown:
 
     while(libssh2_session_disconnect(session, "Normal Shutdown")
-           == LIBSSH2_ERROR_EAGAIN);
+          == LIBSSH2_ERROR_EAGAIN);
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -75,6 +75,8 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *loclfile = "sftp_write_nonblock.c";
@@ -189,8 +191,6 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-        const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-        const char *privkey = "/home/username/.ssh/id_rsa";
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
                                                         pubkey, privkey,
                                                         password)) ==

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -14,14 +14,14 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -108,7 +108,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -143,14 +142,13 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
 
     /* Create a session instance
-        */
+     */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -168,10 +166,10 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* At this point we have not yet authenticated.  The first thing to do is
-     * check the hostkey's fingerprint against our known hosts Your app may
-     * have it hard coded, may go to a file, may present it to the user,
-     * that's your call
+    /* At this point we have not yet authenticated.  The first thing to do
+     * is check the hostkey's fingerprint against our known hosts Your app
+     * may have it hard coded, may go to a file, may present it to the
+     * user, that's your call
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
@@ -191,10 +189,10 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-#define PUBKEY "/home/username/.ssh/id_rsa.pub"
-#define PRIVKEY "/home/username/.ssh/id_rsa"
+        const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+        const char *privkey = "/home/username/.ssh/id_rsa";
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
-                                                        PUBKEY, PRIVKEY,
+                                                        pubkey, privkey,
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
@@ -223,7 +221,6 @@ int main(int argc, char *argv[])
                               LIBSSH2_FXF_TRUNC,
                               LIBSSH2_SFTP_S_IRUSR|LIBSSH2_SFTP_S_IWUSR|
                               LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
-
         if(!sftp_handle &&
            (libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN)) {
             fprintf(stderr, "Unable to open file with SFTP\n");

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -39,8 +39,8 @@
 #define __FILESIZE "llu"
 #endif
 
-static const char *keyfile1 = "~/.ssh/id_rsa.pub";
-static const char *keyfile2 = "~/.ssh/id_rsa";
+static const char *pubkey = "~/.ssh/id_rsa.pub";
+static const char *privkey = "~/.ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "password";
 
@@ -202,8 +202,9 @@ int main(int argc, char *argv[])
     }
     else if(auth_pw & 4) {
         /* Or by public key */
-        if(libssh2_userauth_publickey_fromfile(session, username, keyfile1,
-                                               keyfile2, password)) {
+        if(libssh2_userauth_publickey_fromfile(session, username,
+                                               pubkey, privkey,
+                                               password)) {
             fprintf(stderr, "\tAuthentication by public key failed!\n");
             goto shutdown;
         }

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -39,8 +39,8 @@
 #define __FILESIZE "llu"
 #endif
 
-static const char *pubkey = "~/.ssh/id_rsa.pub";
-static const char *privkey = "~/.ssh/id_rsa";
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "password";
 

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -14,11 +14,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -39,10 +39,10 @@
 #define __FILESIZE "llu"
 #endif
 
-const char *keyfile1 = "~/.ssh/id_rsa.pub";
-const char *keyfile2 = "~/.ssh/id_rsa";
-const char *username = "username";
-const char *password = "password";
+static const char *keyfile1 = "~/.ssh/id_rsa.pub";
+static const char *keyfile2 = "~/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
 
 static void kbd_callback(const char *name, int name_len,
                          const char *instruction, int instruction_len,
@@ -93,7 +93,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -119,8 +118,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-               sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -277,15 +275,16 @@ int main(int argc, char *argv[])
                 printf("%s\n", mem);
             }
         }
-        else
+        else {
             break;
+        }
 
     } while(1);
 
     libssh2_sftp_closedir(sftp_handle);
     libssh2_sftp_shutdown(sftp_session);
 
- shutdown:
+shutdown:
 
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -47,11 +47,11 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
     const char *username = "username";
     const char *password = "password";
     const char *sftppath = "/tmp/secretdir";
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
     int rc;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -14,11 +14,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -73,7 +73,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -99,8 +98,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-               sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -229,7 +227,7 @@ int main(int argc, char *argv[])
     libssh2_sftp_closedir(sftp_handle);
     libssh2_sftp_shutdown(sftp_session);
 
-  shutdown:
+shutdown:
 
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -18,31 +18,31 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
 
-#include <stdlib.h>
 #include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
 
-const char *keyfile1 = ".ssh/id_rsa.pub";
-const char *keyfile2 = ".ssh/id_rsa";
-const char *username = "username";
-const char *password = "password";
+static const char *keyfile1 = ".ssh/id_rsa.pub";
+static const char *keyfile2 = ".ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
 
 
 static void kbd_callback(const char *name, int name_len,
@@ -92,7 +92,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -118,8 +117,7 @@ int main(int argc, char *argv[])
     fprintf(stderr, "Connecting to %s:%d as user %s\n",
             inet_ntoa(sin.sin_addr), ntohs(sin.sin_port), username);
 
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -146,10 +144,10 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* At this point we have not authenticated. The first thing to do is check
-     * the hostkey's fingerprint against our known hosts Your app may have it
-     * hard coded, may go to a file, may present it to the user, that's your
-     * call
+    /* At this point we have not yet authenticated.  The first thing to do
+     * is check the hostkey's fingerprint against our known hosts Your app
+     * may have it hard coded, may go to a file, may present it to the
+     * user, that's your call
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
@@ -284,18 +282,19 @@ int main(int argc, char *argv[])
           }
           #endif
 
-/* At this point the shell can be interacted with using
- * libssh2_channel_read()
- * libssh2_channel_read_stderr()
- * libssh2_channel_write()
- * libssh2_channel_write_stderr()
- *
- * Blocking mode may be (en|dis)abled with: libssh2_channel_set_blocking()
- * If the server send EOF, libssh2_channel_eof() will return non-0
- * To send EOF to the server use: libssh2_channel_send_eof()
- * A channel can be closed with: libssh2_channel_close()
- * A channel can be freed with: libssh2_channel_free()
- */
+        /* At this point the shell can be interacted with using
+         * libssh2_channel_read()
+         * libssh2_channel_read_stderr()
+         * libssh2_channel_write()
+         * libssh2_channel_write_stderr()
+         *
+         * Blocking mode may be (en|dis)abled with:
+         *    libssh2_channel_set_blocking()
+         * If the server send EOF, libssh2_channel_eof() will return non-0
+         * To send EOF to the server use: libssh2_channel_send_eof()
+         * A channel can be closed with: libssh2_channel_close()
+         * A channel can be freed with: libssh2_channel_free()
+         */
 
         /* Read and display all the data received on stdout (ignoring stderr)
          * until the channel closes. This will eventually block if the command
@@ -331,10 +330,9 @@ int main(int argc, char *argv[])
      * libssh2_channel_direct_tcpip()
      */
 
-  shutdown:
+shutdown:
 
-    libssh2_session_disconnect(session,
-                               "Normal Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 
 #ifdef WIN32
@@ -342,7 +340,7 @@ int main(int argc, char *argv[])
 #else
     close(sock);
 #endif
-    fprintf(stderr, "all done!\n");
+    fprintf(stderr, "all done\n");
 
     libssh2_exit();
 

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -39,8 +39,8 @@
 #define snprintf _snprintf
 #endif
 
-static const char *keyfile1 = ".ssh/id_rsa.pub";
-static const char *keyfile2 = ".ssh/id_rsa";
+static const char *pubkey = ".ssh/id_rsa.pub";
+static const char *privkey = ".ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "password";
 
@@ -213,8 +213,8 @@ int main(int argc, char *argv[])
         char const *h = getenv("HOME");
         if(!h || !*h)
             h = ".";
-        fn1sz = strlen(h) + strlen(keyfile1) + 2;
-        fn2sz = strlen(h) + strlen(keyfile2) + 2;
+        fn1sz = strlen(h) + strlen(pubkey) + 2;
+        fn2sz = strlen(h) + strlen(privkey) + 2;
         fn1 = malloc(fn1sz);
         fn2 = malloc(fn2sz);
         if(!fn1 || !fn2) {
@@ -224,11 +224,12 @@ int main(int argc, char *argv[])
             goto shutdown;
         }
         /* Using asprintf() here would be much cleaner, but less portable */
-        snprintf(fn1, fn1sz, "%s/%s", h, keyfile1);
-        snprintf(fn2, fn2sz, "%s/%s", h, keyfile2);
+        snprintf(fn1, fn1sz, "%s/%s", h, pubkey);
+        snprintf(fn2, fn2sz, "%s/%s", h, privkey);
 
-        if(libssh2_userauth_publickey_fromfile(session, username, fn1,
-                                               fn2, password)) {
+        if(libssh2_userauth_publickey_fromfile(session, username,
+                                               fn1, fn2,
+                                               password)) {
             fprintf(stderr, "\tAuthentication by public key failed!\n");
             free(fn2);
             free(fn1);

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -44,7 +44,6 @@ static const char *privkey = ".ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "password";
 
-
 static void kbd_callback(const char *name, int name_len,
                          const char *instruction, int instruction_len,
                          int num_prompts,
@@ -62,8 +61,7 @@ static void kbd_callback(const char *name, int name_len,
     }
     (void)prompts;
     (void)abstract;
-} /* kbd_callback */
-
+}
 
 int main(int argc, char *argv[])
 {

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -13,11 +13,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -27,10 +27,10 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
-#include <ctype.h>
 #include <stdlib.h>
+#include <ctype.h>
 
-const char *username = "username";
+static const char *username = "username";
 
 int main(int argc, char *argv[])
 {
@@ -86,8 +86,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         goto shutdown;
     }
@@ -101,10 +100,10 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    /* At this point we have not authenticated. The first thing to do is check
-     * the hostkey's fingerprint against our known hosts Your app may have it
-     * hard coded, may go to a file, may present it to the user, that's your
-     * call
+    /* At this point we have not yet authenticated.  The first thing to do
+     * is check the hostkey's fingerprint against our known hosts Your app
+     * may have it hard coded, may go to a file, may present it to the
+     * user, that's your call
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
@@ -208,7 +207,7 @@ int main(int argc, char *argv[])
      * A channel can be freed with: libssh2_channel_free()
      */
 
-  skip_shell:
+skip_shell:
     if(channel) {
         libssh2_channel_free(channel);
         channel = NULL;
@@ -220,7 +219,7 @@ int main(int argc, char *argv[])
      * libssh2_channel_direct_tcpip()
      */
 
-  shutdown:
+shutdown:
 
     if(agent) {
         libssh2_agent_disconnect(agent);
@@ -228,8 +227,7 @@ int main(int argc, char *argv[])
     }
 
     if(session) {
-        libssh2_session_disconnect(session,
-                                   "Normal Shutdown, Thank you for playing");
+        libssh2_session_disconnect(session, "Normal Shutdown");
         libssh2_session_free(session);
     }
 
@@ -241,7 +239,7 @@ int main(int argc, char *argv[])
 #endif
     }
 
-    fprintf(stderr, "all done!\n");
+    fprintf(stderr, "all done\n");
 
     libssh2_exit();
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -19,27 +19,27 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
+
 #include <sys/types.h>
-#include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
@@ -122,8 +122,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -273,8 +272,7 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session,
-                               "Normal Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -14,14 +14,14 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -29,11 +29,12 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
+
 #include <sys/types.h>
-#include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
@@ -98,10 +99,9 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1)
-        /* must be ip address only */
-        hostname = argv[1];
-
+    if(argc > 1) {
+        hostname = argv[1];  /* must be ip address only */
+    }
     if(argc > 2) {
         username = argv[2];
     }
@@ -126,8 +126,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -144,7 +143,7 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-           LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         return -1;
@@ -233,7 +232,7 @@ int main(int argc, char *argv[])
         for(i = 0; i < BUFSIZE; i++)
             buffer[i] = 'A';
 
-        fds = malloc(sizeof (LIBSSH2_POLLFD));
+        fds = malloc(sizeof(LIBSSH2_POLLFD));
         if(!fds) {
             fprintf(stderr, "malloc failed\n");
             exit(1);
@@ -349,8 +348,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    libssh2_session_disconnect(session,
-                               "Normal Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -16,14 +16,14 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -31,11 +31,12 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
+
 #include <sys/types.h>
-#include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
@@ -99,10 +100,9 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1)
-        /* must be ip address only */
-        hostname = argv[1];
-
+    if(argc > 1) {
+        hostname = argv[1];  /* must be ip address only */
+    }
     if(argc > 2) {
         username = argv[2];
     }
@@ -130,8 +130,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return -1;
     }
@@ -148,7 +147,7 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-           LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         return -1;
@@ -240,11 +239,11 @@ int main(int argc, char *argv[])
         exit(1);
     }
     while((rc = libssh2_channel_exec(channel, commandline)) ==
-           LIBSSH2_ERROR_EAGAIN) {
+          LIBSSH2_ERROR_EAGAIN) {
         waitsocket(sock, session);
     }
     if(rc != 0) {
-        fprintf(stderr, "Error\n");
+        fprintf(stderr, "exec error\n");
         exit(1);
     }
     for(;;) {
@@ -299,8 +298,7 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session,
-                               "Normal Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -73,8 +73,10 @@ int main(int argc, char *argv[])
 {
     const char *hostname = "127.0.0.1";
     const char *commandline = "uptime";
-    const char *username    = "user";
-    const char *password    = "password";
+    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+    const char *privkey = "/home/username/.ssh/id_rsa";
+    const char *username = "user";
+    const char *password = "password";
     uint32_t hostaddr;
     libssh2_socket_t sock;
     struct sockaddr_in sin;
@@ -212,11 +214,8 @@ int main(int argc, char *argv[])
     else {
         /* Or by public key */
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
-                                                         "/home/user/"
-                                                         ".ssh/id_rsa.pub",
-                                                         "/home/user/"
-                                                         ".ssh/id_rsa",
-                                                         password)) ==
+                                                        pubkey, privkey,
+                                                        password)) ==
                LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "\tAuthentication by public key failed\n");

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -35,8 +35,8 @@
 #define snprintf _snprintf
 #endif
 
-static const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
-static const char *keyfile2 = "/home/username/.ssh/id_rsa";
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "";
 
@@ -214,8 +214,9 @@ int main(int argc, char *argv[])
         }
     }
     else if(auth & AUTH_PUBLICKEY) {
-        if(libssh2_userauth_publickey_fromfile(session, username, keyfile1,
-                                               keyfile2, password)) {
+        if(libssh2_userauth_publickey_fromfile(session, username,
+                                               pubkey, privkey,
+                                               password)) {
             fprintf(stderr, "\tAuthentication by public key failed!\n");
             goto shutdown;
         }

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -4,6 +4,12 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
@@ -14,18 +20,12 @@
 #include <sys/time.h>
 #endif
 
+#include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#include <sys/types.h>
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
+#include <string.h>
 
 #ifndef INADDR_NONE
 #define INADDR_NONE (in_addr_t)~0
@@ -35,12 +35,12 @@
 #define snprintf _snprintf
 #endif
 
-const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
-const char *keyfile2 = "/home/username/.ssh/id_rsa";
-const char *username = "username";
-const char *password = "";
+static const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
+static const char *keyfile2 = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "";
 
-const char *server_ip = "127.0.0.1";
+static const char *server_ip = "127.0.0.1";
 
 enum {
     AUTH_NONE = 0,
@@ -147,11 +147,7 @@ int main(int argc, char *argv[])
     /* Connect to SSH server */
     sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if(sock == LIBSSH2_INVALID_SOCKET) {
-#ifdef WIN32
         fprintf(stderr, "failed to open socket!\n");
-#else
-        perror("socket");
-#endif
         return -1;
     }
 
@@ -162,8 +158,7 @@ int main(int argc, char *argv[])
         return -1;
     }
     sin.sin_port = htons(830);
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "Failed to connect to %s!\n", inet_ntoa(sin.sin_addr));
         return -1;
     }
@@ -220,11 +215,11 @@ int main(int argc, char *argv[])
     }
     else if(auth & AUTH_PUBLICKEY) {
         if(libssh2_userauth_publickey_fromfile(session, username, keyfile1,
-                                                keyfile2, password)) {
-            fprintf(stderr, "Authentication by public key failed!\n");
+                                               keyfile2, password)) {
+            fprintf(stderr, "\tAuthentication by public key failed!\n");
             goto shutdown;
         }
-        fprintf(stderr, "Authentication by public key succeeded.\n");
+        fprintf(stderr, "\tAuthentication by public key succeeded.\n");
     }
     else {
         fprintf(stderr, "No supported authentication methods found!\n");

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -36,8 +36,8 @@
 #define INADDR_NONE (in_addr_t)~0
 #endif
 
-static const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
-static const char *keyfile2 = "/home/username/.ssh/id_rsa";
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "";
 
@@ -177,8 +177,9 @@ int main(int argc, char *argv[])
         }
     }
     else if(auth & AUTH_PUBLICKEY) {
-        if(libssh2_userauth_publickey_fromfile(session, username, keyfile1,
-                                               keyfile2, password)) {
+        if(libssh2_userauth_publickey_fromfile(session, username,
+                                               pubkey, privkey,
+                                               password)) {
             fprintf(stderr, "\tAuthentication by public key failed!\n");
             goto shutdown;
         }

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -10,6 +10,12 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
@@ -20,34 +26,30 @@
 #include <sys/time.h>
 #endif
 
+#include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#include <sys/types.h>
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 
 #ifndef INADDR_NONE
-#define INADDR_NONE (in_addr_t)-1
+#define INADDR_NONE (in_addr_t)~0
 #endif
 
-const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
-const char *keyfile2 = "/home/username/.ssh/id_rsa";
-const char *username = "username";
-const char *password = "";
+static const char *keyfile1 = "/home/username/.ssh/id_rsa.pub";
+static const char *keyfile2 = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "";
 
-const char *server_ip = "127.0.0.1";
+static const char *server_ip = "127.0.0.1";
 
-const char *remote_listenhost = "localhost"; /* resolved by the server */
+/* resolved by the server */
+static const char *remote_listenhost = "localhost";
+
 int remote_wantport = 2222;
 int remote_listenport;
 
-const char *local_destip = "127.0.0.1";
+static const char *local_destip = "127.0.0.1";
 int local_destport = 22;
 
 enum {
@@ -108,24 +110,19 @@ int main(int argc, char *argv[])
     /* Connect to SSH server */
     sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if(sock == LIBSSH2_INVALID_SOCKET) {
-#ifdef WIN32
         fprintf(stderr, "failed to open socket!\n");
-#else
-        perror("socket");
-#endif
         return -1;
     }
 
     sin.sin_family = AF_INET;
     sin.sin_addr.s_addr = inet_addr(server_ip);
     if(INADDR_NONE == sin.sin_addr.s_addr) {
-        perror("inet_addr");
+        fprintf(stderr, "inet_addr: Invalid IP address \"%s\"\n", server_ip);
         return -1;
     }
     sin.sin_port = htons(22);
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
-        fprintf(stderr, "failed to connect!\n");
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
+        fprintf(stderr, "Failed to connect to %s!\n", inet_ntoa(sin.sin_addr));
         return -1;
     }
 
@@ -221,11 +218,7 @@ int main(int argc, char *argv[])
         local_destip, local_destport);
     forwardsock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
     if(forwardsock == LIBSSH2_INVALID_SOCKET) {
-#ifdef WIN32
         fprintf(stderr, "failed to open forward socket!\n");
-#else
-        perror("socket");
-#endif
         goto shutdown;
     }
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -211,7 +211,6 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, int sock)
     timeval_out.tv_sec = 0;
     timeval_out.tv_usec = 0;
 
-
     FD_ZERO(&set);
     FD_SET(sock, &set);
 
@@ -295,7 +294,6 @@ main(int argc, char *argv[])
     timeval_out.tv_sec = 0;
     timeval_out.tv_usec = 10;
 
-
     if(argc > 3) {
         hostaddr = inet_addr(argv[1]);
         username = argv[2];
@@ -368,7 +366,6 @@ main(int argc, char *argv[])
         close(sock);
         return -1;
     }
-
 
     /* Request a PTY */
     rc = libssh2_channel_request_pty(channel, "xterm");

--- a/example/x11.c
+++ b/example/x11.c
@@ -12,7 +12,6 @@
 
 #ifdef HAVE_SYS_UN_H
 
-#include <string.h>
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -25,20 +24,22 @@
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
-#ifdef HAVE_ARPA_INET_H
-#include <arpa/inet.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#include <sys/types.h>
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif
+
+#include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <ctype.h>
 #include <stdlib.h>
+#include <ctype.h>
+#include <string.h>
 
 #include <termios.h>
 
@@ -85,8 +86,7 @@ static void remove_node(struct chan_X11_list *elem)
 
 static void session_shutdown(LIBSSH2_SESSION *session)
 {
-    libssh2_session_disconnect(session,
-                               "Session Shutdown, Thank you for playing");
+    libssh2_session_disconnect(session, "Session Shutdown");
     libssh2_session_free(session);
 }
 
@@ -205,7 +205,7 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, int sock)
     int   bufsize      = 8192;
     int   rc           = 0;
     int   nfds         = 1;
-    LIBSSH2_POLLFD  *fds      = NULL;
+    LIBSSH2_POLLFD *fds = NULL;
     fd_set set;
     struct timeval timeval_out;
     timeval_out.tv_sec = 0;
@@ -219,7 +219,7 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, int sock)
     if(!buf)
         return 0;
 
-    fds = malloc(sizeof (LIBSSH2_POLLFD));
+    fds = malloc(sizeof(LIBSSH2_POLLFD));
     if(!fds) {
         free(buf);
         return 0;
@@ -266,7 +266,7 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, int sock)
  * Main, more than inspired by ssh2.c by Bagder
  */
 int
-main (int argc, char *argv[])
+main(int argc, char *argv[])
 {
     uint32_t hostaddr = 0;
     int rc = 0;
@@ -328,9 +328,7 @@ main (int argc, char *argv[])
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
 
-    rc = connect(sock, (struct sockaddr *) &sin,
-                 sizeof(struct sockaddr_in));
-    if(rc != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "Failed to established connection!\n");
         return -1;
     }
@@ -430,7 +428,7 @@ main (int argc, char *argv[])
         if(buf == NULL)
             break;
 
-        fds = malloc(sizeof (LIBSSH2_POLLFD));
+        fds = malloc(sizeof(LIBSSH2_POLLFD));
         if(fds == NULL) {
             free(buf);
             break;
@@ -468,7 +466,6 @@ main (int argc, char *argv[])
             current_node = next_node;
         }
 
-
         rc = select((int)(fileno(stdin) + 1), &set, NULL, NULL, &timeval_out);
         if(rc > 0) {
             ssize_t nread;
@@ -482,7 +479,7 @@ main (int argc, char *argv[])
         free(fds);
         free(buf);
 
-        if(libssh2_channel_eof (channel) == 1) {
+        if(libssh2_channel_eof(channel) == 1) {
             break;
         }
     }
@@ -501,7 +498,7 @@ main (int argc, char *argv[])
 #else
 
 int
-main (void)
+main(void)
 {
     printf("Sorry, this platform is not supported.");
     return 1;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -389,8 +389,8 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     sin.sin_addr.s_addr = hostaddr;
 
     for(counter = 0; counter < 3; ++counter) {
-        if(connect(sock, (struct sockaddr *)(&sin),
-                   sizeof(struct sockaddr_in)) != 0) {
+        if(connect(sock, (struct sockaddr*)(&sin),
+                   sizeof(struct sockaddr_in))) {
             fprintf(stderr,
                     "Connection to %s:%s attempt #%d failed: retrying...\n",
                     ip_address, port_string, counter);

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -36,10 +36,10 @@
  * OF SUCH DAMAGE.
  */
 
+#include <libssh2.h>
+
 #include <stdio.h>
 #include <stdlib.h>
-
-#include "libssh2.h"
 
 static int test_libssh2_base64_decode(LIBSSH2_SESSION *session)
 {

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -7,11 +7,11 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
     if(getenv("USER"))
       username = getenv("USER");
 
-    if(getenv ("PRIVKEY"))
+    if(getenv("PRIVKEY"))
       privkeyfile = getenv("PRIVKEY");
 
     if(getenv("PUBKEY"))
@@ -72,8 +72,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(4711);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr*)(&sin),
-                sizeof(struct sockaddr_in)) != 0) {
+    if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
         return 1;
     }
@@ -159,13 +158,13 @@ int main(int argc, char *argv[])
 
     ec = 0;
 
-  skip_shell:
+skip_shell:
     if(channel) {
         libssh2_channel_free(channel);
         channel = NULL;
     }
 
-  shutdown:
+shutdown:
 
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -1,4 +1,4 @@
-/* Self test, based on examples/ssh2.c. */
+/* Self test, based on example/ssh2.c. */
 
 #include "libssh2_setup.h"
 #include <libssh2.h>
@@ -34,8 +34,8 @@ int main(int argc, char *argv[])
     char *userauthlist;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
-    const char *pubkeyfile = "etc/user.pub";
-    const char *privkeyfile = "etc/user";
+    const char *pubkey = "etc/user.pub";
+    const char *privkey = "etc/user";
     const char *username = "username";
     const char *password = "password";
     int ec = 1;
@@ -58,10 +58,10 @@ int main(int argc, char *argv[])
       username = getenv("USER");
 
     if(getenv("PRIVKEY"))
-      privkeyfile = getenv("PRIVKEY");
+      privkey = getenv("PRIVKEY");
 
     if(getenv("PUBKEY"))
-      pubkeyfile = getenv("PUBKEY");
+      pubkey = getenv("PUBKEY");
 
     hostaddr = htonl(0x7F000001);
 
@@ -116,8 +116,9 @@ int main(int argc, char *argv[])
 
     if(auth_pw & 4) {
         /* Authenticate by public key */
-        if(libssh2_userauth_publickey_fromfile(session, username, pubkeyfile,
-                                               privkeyfile, password)) {
+        if(libssh2_userauth_publickey_fromfile(session, username,
+                                               pubkey, privkey,
+                                               password)) {
             printf("\tAuthentication by public key failed!\n");
             goto shutdown;
         }

--- a/tests/test_keyboard_interactive_auth_info_request.c
+++ b/tests/test_keyboard_interactive_auth_info_request.c
@@ -221,7 +221,7 @@ LIBSSH2_ALLOC_FUNC(test_alloc)
 {
     int *threshold_int_ptr = *abstract;
     alloc_count++;
-    if (*abstract != NULL && *threshold_int_ptr == alloc_count) {
+    if(*abstract != NULL && *threshold_int_ptr == alloc_count) {
         return NULL;
     }
 
@@ -233,7 +233,7 @@ LIBSSH2_ALLOC_FUNC(test_alloc)
 static
 LIBSSH2_FREE_FUNC(test_free)
 {
-    (void) abstract;
+    (void)abstract;
     free_count++;
     free(ptr);
 }
@@ -307,10 +307,10 @@ int main(void)
         int tc =  i + TEST_CASES_LEN + 1;
         int malloc_call_num = 5 + i;
         test_case(tc,
-                    failed_malloc_test_cases[i].data,
-                    failed_malloc_test_cases[i].data_len,
-                    &malloc_call_num,
-                    failed_malloc_test_cases[i].expected);
+                  failed_malloc_test_cases[i].data,
+                  failed_malloc_test_cases[i].data_len,
+                  &malloc_call_num,
+                  failed_malloc_test_cases[i].expected);
     }
 
     return 0;


### PR DESCRIPTION
- drop unnecessary `WIN32`-specific branches.

- add `static`.

- sync header inclusion order.

- sync some common code between examples/tests.

- fix formatting/indentation.

- fix some `checksrc` errors not caught by `checksrc`.

Closes #936
