### PR TITLE
cmake: add `HIDE_SYMBOLS` option & do symbol hiding on *nix

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -105,8 +105,7 @@ extern "C" {
 /* Allow alternate API prefix from CFLAGS or calling app */
 #ifndef LIBSSH2_API
 # ifdef _LIBSSH2_WIN32
-#  if defined(LIBSSH2_EXPORTS) || defined(DLL_EXPORT) || \
-      defined(_WINDLL) || defined(libssh2_shared_EXPORTS)
+#  if defined(LIBSSH2_EXPORTS) || defined(DLL_EXPORT) || defined(_WINDLL)
 #   ifdef LIBSSH2_LIBRARY
 #    define LIBSSH2_API __declspec(dllexport)
 #   else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,11 +88,6 @@ if(WIN32)
   list(APPEND PC_LIBS -lws2_32)
 endif()
 
-add_definitions(-DHAVE_CONFIG_H)
-
-configure_file(libssh2_config_cmake.h.in
-  ${CMAKE_CURRENT_BINARY_DIR}/libssh2_config.h)
-
 # to find generated header
 list(APPEND libssh2_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -179,7 +174,33 @@ if(BUILD_SHARED_LIBS)
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
       $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
+
+  # Symbol hiding
+
+  option(HIDE_SYMBOLS "Set to ON to hide all libssh2 symbols that aren't officially external." ON)
+  mark_as_advanced(HIDE_SYMBOLS)
+
+  if(HIDE_SYMBOLS)
+    target_compile_definitions(${LIB_SHARED} PRIVATE LIBSSH2_EXPORTS)
+    if(WIN32)
+    elseif((CMAKE_C_COMPILER_ID MATCHES "Clang") OR
+           (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.0) OR
+           (CMAKE_C_COMPILER_ID MATCHES "Intel" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
+      target_compile_options(${LIB_SHARED} PRIVATE -fvisibility=hidden)
+      set(LIBSSH2_API "__attribute__ ((__visibility__ (\"default\")))")
+    elseif(CMAKE_C_COMPILER_ID MATCHES "SunPro" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.0)
+      target_compile_options(${LIB_SHARED} PRIVATE -xldscope=hidden)
+      set(LIBSSH2_API "__global")
+    endif()
+  endif()
 endif()
+
+# Config file
+
+add_definitions(-DHAVE_CONFIG_H)
+
+configure_file(libssh2_config_cmake.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libssh2_config.h)
 
 ## Installation
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -72,3 +72,8 @@
 #cmakedefine HAVE_IOCTLSOCKET_CASE
 #cmakedefine HAVE_SO_NONBLOCK
 #cmakedefine HAVE_DISABLED_NONBLOCKING
+
+/* attribute to export symbol */
+#if defined(LIBSSH2_EXPORTS) && defined(LIBSSH2_LIBRARY)
+#cmakedefine LIBSSH2_API ${LIBSSH2_API}
+#endif


### PR DESCRIPTION
- implement symbol hiding on non-Windows platforms.

  The essence of the detection logic was copied from: https://github.com/curl/curl/blob/dfabe8bca218d2524af052bd551aa87e13b8a10b/CMake/CurlSymbolHiding.cmake

  Then simplified and shortened. This method doesn't require a recent CMake version, nor an external, auto-generated C header.

  Move `configure_file()` after `set(LIBSSH2_API ...)`, for the config file to pick up `LIBSSH2_API`s value.

  Closes #602

- add CMake option `HIDE_SYMBOLS`.

  This setting means to hide non-public functions from the libssh2 dynamic library when set to `ON`. The default.

  When set to `OFF`, make all non-static/internal functions visible in the dynamic library.

  This setting requires `BUILD_SHARED_LIBS=ON`.

- honor this setting on Windows.

  By setting the `LIBSSH2_EXPORTS` manual macro again, and stop recognizing the automatic CMake macro for this purpose: `libssh2_shared_EXPORT`.

Closes #939
