### PR TITLE
build: make `windows.h` more lean

### DIFF
--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -55,6 +55,12 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#ifndef NOGDI
+#define NOGDI
+#endif
+#ifndef NONLS
+#define NONLS
+#endif
 
 #ifdef __MINGW32__
 # ifdef __MINGW64_VERSION_MAJOR


### PR DESCRIPTION
Disable GDI and NLS features in `windows.h`. libssh2 doesn't use these.

Closes #940