### PR TITLE
build: support `libssh2.rc` with autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,8 @@ AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL
 AC_C_BIGENDIAN
 
+LT_LANG([Windows Resource])
+
 dnl check for how to do large files
 AC_SYS_LARGEFILE
 
@@ -288,7 +290,7 @@ case $host in
     # These are POSIX-like systems using BSD-like sockets API.
     ;;
   *)
-    AC_CHECK_HEADERS([windows.h])
+    AC_CHECK_HEADERS([windows.h], [have_windows_h=yes], [have_windows_h=no])
     ;;
 esac
 
@@ -357,6 +359,9 @@ fi
 if test $missing_required_deps = 1; then
   AC_MSG_ERROR([Required dependencies are missing!])
 fi
+
+AM_CONDITIONAL([HAVE_WINDRES],
+  [test "x$have_windows_h" = "xyes" && test "x${enable_shared}" = "xyes" && test -n "${RC}"])
 
 # Configure parameters
 LIBSSH2_CHECK_OPTION_WERROR

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,9 @@ endif
 include ../Makefile.inc
 
 libssh2_la_SOURCES = $(CSOURCES) $(HHEADERS)
+if HAVE_WINDRES
+libssh2_la_SOURCES += libssh2.rc
+endif
 
 EXTRA_DIST = libssh2_config.h.in libssh2_config_cmake.h.in
 EXTRA_DIST += CMakeLists.txt
@@ -66,3 +69,8 @@ VERSION=-version-info 1:1:0
 libssh2_la_LDFLAGS = $(VERSION) -no-undefined \
   -export-symbols-regex '^libssh2_.*' \
   $(CRYPTO_LTLIBS) $(LTLIBZ)
+
+if HAVE_WINDRES
+.rc.lo:
+	$(LIBTOOL) --tag=RC --mode=compile $(RC) -I$(top_srcdir)/include $(RCFLAGS) -i $< -o $@
+endif


### PR DESCRIPTION
Caveat: When building `--enable-static` and `--enable-shared` at the same time, the compiled Windows resource is also included in the static library. This appears to be an autotools limitation, with no way to have different input lists (or different custom options) for shared and static libraries, even though it builds them separately.

The workaround is to build static libraries in a separate `./configure` + `make` pass.

Closes #944
