### PR TITLE
Support for direct-streamlocal@openssh.com UNIX socket connection

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -14,6 +14,7 @@ dist_man_MANS = \
   libssh2_banner_set.3 \
   libssh2_base64_decode.3 \
   libssh2_channel_close.3 \
+  libssh2_channel_direct_streamlocal_ex.3 \
   libssh2_channel_direct_tcpip.3 \
   libssh2_channel_direct_tcpip_ex.3 \
   libssh2_channel_eof.3 \

--- a/docs/libssh2_channel_direct_streamlocal_ex.3
+++ b/docs/libssh2_channel_direct_streamlocal_ex.3
@@ -1,4 +1,4 @@
-.TH libssh2_channel_direct_streamlocal_ex 3 "1 Jun 2007" "libssh2 0.15" "libssh2 manual"
+.TH libssh2_channel_direct_streamlocal_ex 3 "10 Apr 2023" "libssh2 1.11.0" "libssh2 manual"
 .SH NAME
 libssh2_channel_direct_streamlocal_ex - Tunnel a UNIX socket connection through an SSH session
 .SH SYNOPSIS

--- a/docs/libssh2_channel_direct_streamlocal_ex.3
+++ b/docs/libssh2_channel_direct_streamlocal_ex.3
@@ -1,0 +1,33 @@
+.TH libssh2_channel_direct_streamlocal_ex 3 "1 Jun 2007" "libssh2 0.15" "libssh2 manual"
+.SH NAME
+libssh2_channel_direct_streamlocal_ex - Tunnel a UNIX socket connection through an SSH session
+.SH SYNOPSIS
+#include <libssh2.h>
+
+LIBSSH2_CHANNEL *
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION *session, const char *socket_path, const char *shost, int sport);
+
+LIBSSH2_CHANNEL *
+libssh2_channel_direct_streamlocal(LIBSSH2_SESSION *session, const char *socket_path, const char *shost, int sport);
+
+.SH DESCRIPTION
+\fIsession\fP - Session instance as returned by
+.BR libssh2_session_init_ex(3)
+
+\fIsocket_path\fP - UNIX socket to connect to using the SSH host as a proxy.
+
+\fIshost\fP - Host to tell the SSH server the connection originated on.
+
+\fIsport\fP - Port to tell the SSH server the connection originated from.
+
+Tunnel a UNIX socket connection through the SSH transport via the remote host to
+a third party. Communication from the client to the SSH server remains
+encrypted, communication from the server to the 3rd party host travels
+in cleartext.
+
+.SH RETURN VALUE
+Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
+.SH ERRORS
+\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+.SH SEE ALSO
+.BR libssh2_session_init_ex(3)

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -791,6 +791,11 @@ libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
 #define libssh2_channel_direct_tcpip(session, host, port) \
   libssh2_channel_direct_tcpip_ex((session), (host), (port), "127.0.0.1", 22)
 
+LIBSSH2_API LIBSSH2_CHANNEL *
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
+                                      const char *socket_path,
+                                      const char *shost, int sport);
+
 LIBSSH2_API LIBSSH2_LISTENER *
 libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session, const char *host,
                                   int port, int *bound_port,

--- a/src/channel.c
+++ b/src/channel.c
@@ -453,6 +453,84 @@ libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
 }
 
 /*
+ * libssh2_channel_direct_streamlocal_ex
+ *
+ * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
+ */
+static LIBSSH2_CHANNEL *
+channel_direct_streamlocal(LIBSSH2_SESSION * session, const char *socket_path,
+                           const char *shost, int sport)
+{
+    LIBSSH2_CHANNEL *channel;
+    unsigned char *s;
+
+    if(session->direct_state == libssh2_NB_state_idle) {
+        session->direct_host_len = strlen(socket_path);
+        session->direct_shost_len = strlen(shost);
+        session->direct_message_len =
+            session->direct_host_len + session->direct_shost_len + 12;
+
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN,
+                       "Requesting direct-streamlocal session to %s",
+                       socket_path));
+
+        s = session->direct_message =
+            LIBSSH2_ALLOC(session, session->direct_message_len);
+        if(!session->direct_message) {
+            _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                "Unable to allocate memory for direct-streamlocal connection");
+            return NULL;
+        }
+        _libssh2_store_str(&s, socket_path, session->direct_host_len);
+        _libssh2_store_str(&s, shost, session->direct_shost_len);
+        _libssh2_store_u32(&s, sport);
+    }
+
+    channel =
+        _libssh2_channel_open(session, "direct-streamlocal@openssh.com",
+                              sizeof("direct-streamlocal@openssh.com") - 1,
+                              LIBSSH2_CHANNEL_WINDOW_DEFAULT,
+                              LIBSSH2_CHANNEL_PACKET_DEFAULT,
+                              session->direct_message,
+                              session->direct_message_len);
+
+    if(!channel &&
+        libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
+        /* The error code is still set to LIBSSH2_ERROR_EAGAIN, set our state
+           to created to avoid re-creating the package on next invoke */
+        session->direct_state = libssh2_NB_state_created;
+        return NULL;
+    }
+    /* by default we set (keep?) idle state... */
+    session->direct_state = libssh2_NB_state_idle;
+
+    LIBSSH2_FREE(session, session->direct_message);
+    session->direct_message = NULL;
+
+    return channel;
+}
+
+/*
+ * libssh2_channel_direct_streamlocal_ex
+ *
+ * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
+ */
+LIBSSH2_API LIBSSH2_CHANNEL *
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
+                                      const char *socket_path,
+                                      const char *shost, int sport)
+{
+    LIBSSH2_CHANNEL *ptr;
+
+    if(!session)
+        return NULL;
+
+    BLOCK_ADJUST_ERRNO(ptr, session,
+                       channel_direct_streamlocal(session, socket_path, shost, sport));
+    return ptr;
+}
+
+/*
  * channel_forward_listen
  *
  * Bind a port on the remote host and listen for connections
@@ -2398,6 +2476,9 @@ libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
 
     if(!channel)
         return LIBSSH2_ERROR_BAD_USE;
+
+    if(!channel->session)
+        return LIBSSH2_ERROR_SOCKET_RECV;
 
     BLOCK_ADJUST(rc, channel->session,
                  _libssh2_channel_write(channel, stream_id,

--- a/src/channel.c
+++ b/src/channel.c
@@ -526,7 +526,8 @@ libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
         return NULL;
 
     BLOCK_ADJUST_ERRNO(ptr, session,
-                       channel_direct_streamlocal(session, socket_path, shost, sport));
+                       channel_direct_streamlocal(session,
+                       socket_path, shost, sport));
     return ptr;
 }
 
@@ -2476,9 +2477,6 @@ libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
 
     if(!channel)
         return LIBSSH2_ERROR_BAD_USE;
-
-    if(!channel->session)
-        return LIBSSH2_ERROR_SOCKET_RECV;
 
     BLOCK_ADJUST(rc, channel->session,
                  _libssh2_channel_write(channel, stream_id,


### PR DESCRIPTION
This patch allow to use direct-streamlocal service from OpenSSH 6.7, that allows UNIX socket connections.

Patch-by: @gjalves Gustavo Junior Alves

Closes #216
Closes #632
Closes #945
