### PR TITLE
man: fixups

### DIFF
--- a/docs/libssh2_agent_connect.3
+++ b/docs/libssh2_agent_connect.3
@@ -5,9 +5,12 @@
 .SH NAME
 libssh2_agent_connect - connect to an ssh-agent
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_agent_connect(LIBSSH2_AGENT *agent);
+int
+libssh2_agent_connect(LIBSSH2_AGENT *agent);
+.fi
 .SH DESCRIPTION
 Connect to an ssh-agent running on the system.
 

--- a/docs/libssh2_agent_disconnect.3
+++ b/docs/libssh2_agent_disconnect.3
@@ -5,9 +5,12 @@
 .SH NAME
 libssh2_agent_disconnect - close a connection to an ssh-agent
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_agent_disconnect(LIBSSH2_AGENT *agent);
+int
+libssh2_agent_disconnect(LIBSSH2_AGENT *agent);
+.fi
 .SH DESCRIPTION
 Close a connection to an ssh-agent.
 

--- a/docs/libssh2_agent_free.3
+++ b/docs/libssh2_agent_free.3
@@ -5,9 +5,12 @@
 .SH NAME
 libssh2_agent_free - free an ssh-agent handle
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-void libssh2_agent_free(LIBSSH2_AGENT *agent);
+void
+libssh2_agent_free(LIBSSH2_AGENT *agent);
+.fi
 .SH DESCRIPTION
 Free an ssh-agent handle.  This function also frees the internal
 collection of public keys.

--- a/docs/libssh2_agent_get_identity.3
+++ b/docs/libssh2_agent_get_identity.3
@@ -5,11 +5,14 @@
 .SH NAME
 libssh2_agent_get_identity - get a public key off the collection of public keys managed by ssh-agent
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_agent_get_identity(LIBSSH2_AGENT *agent,
-                               struct libssh2_agent_publickey **store,
-                               struct libssh2_agent_publickey *prev);
+int
+libssh2_agent_get_identity(LIBSSH2_AGENT *agent,
+                           struct libssh2_agent_publickey **store,
+                           struct libssh2_agent_publickey *prev);
+.fi
 .SH DESCRIPTION
 \fIlibssh2_agent_get_identity(3)\fP allows an application to iterate
 over all public keys in the collection managed by ssh-agent.

--- a/docs/libssh2_agent_get_identity_path.3
+++ b/docs/libssh2_agent_get_identity_path.3
@@ -5,10 +5,12 @@
 .SH NAME
 libssh2_agent_get_identity_path - gets the custom ssh-agent socket path
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 const char *
 libssh2_agent_get_identity_path(LIBSSH2_AGENT *agent);
+.fi
 .SH DESCRIPTION
 Returns the custom agent identity socket path if set using libssh2_agent_set_identity_path()
 

--- a/docs/libssh2_agent_init.3
+++ b/docs/libssh2_agent_init.3
@@ -5,9 +5,12 @@
 .SH NAME
 libssh2_agent_init - init an ssh-agent handle
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session);
+LIBSSH2_AGENT *
+libssh2_agent_init(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 Init an ssh-agent handle. Returns the handle to an internal
 representation of an ssh-agent connection.  After the successful

--- a/docs/libssh2_agent_list_identities.3
+++ b/docs/libssh2_agent_list_identities.3
@@ -5,9 +5,12 @@
 .SH NAME
 libssh2_agent_list_identities - request an ssh-agent to list of public keys.
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_agent_list_identities(LIBSSH2_AGENT *agent);
+int
+libssh2_agent_list_identities(LIBSSH2_AGENT *agent);
+.fi
 .SH DESCRIPTION
 Request an ssh-agent to list of public keys, and stores them in the
 internal collection of the handle.  Call

--- a/docs/libssh2_agent_set_identity_path.3
+++ b/docs/libssh2_agent_set_identity_path.3
@@ -5,10 +5,12 @@
 .SH NAME
 libssh2_agent_set_identity_path - set an ssh-agent socket path on disk
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 void
 libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path);
+.fi
 .SH DESCRIPTION
 Allows a custom agent identity socket path instead of the default SSH_AUTH_SOCK env value
 

--- a/docs/libssh2_agent_userauth.3
+++ b/docs/libssh2_agent_userauth.3
@@ -5,11 +5,14 @@
 .SH NAME
 libssh2_agent_userauth - authenticate a session with a public key, with the help of ssh-agent
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_agent_userauth(LIBSSH2_AGENT *agent,
-                           const char *username,
-                           struct libssh2_agent_publickey *identity);
+int
+libssh2_agent_userauth(LIBSSH2_AGENT *agent,
+                       const char *username,
+                       struct libssh2_agent_publickey *identity);
+.fi
 .SH DESCRIPTION
 \fIagent\fP - ssh-agent handle as returned by
 .BR libssh2_agent_init(3)

--- a/docs/libssh2_banner_set.3
+++ b/docs/libssh2_banner_set.3
@@ -6,7 +6,6 @@ libssh2_banner_set - set the SSH protocol banner for the local client
 
 int
 libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner);
-
 .SH DESCRIPTION
 This function is \fBDEPRECATED\fP. Use \fIlibssh2_session_banner_set(3)\fP
 instead!

--- a/docs/libssh2_banner_set.3
+++ b/docs/libssh2_banner_set.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_banner_set - set the SSH protocol banner for the local client
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner);
+.fi
 .SH DESCRIPTION
 This function is \fBDEPRECATED\fP. Use \fIlibssh2_session_banner_set(3)\fP
 instead!

--- a/docs/libssh2_base64_decode.3
+++ b/docs/libssh2_base64_decode.3
@@ -2,11 +2,14 @@
 .SH NAME
 libssh2_base64_decode - decode a base64 encoded string
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_base64_decode(LIBSSH2_SESSION *session, char **dest,
-                          unsigned int *dest_len, const char *src,
-                          unsigned int src_len);
+int
+libssh2_base64_decode(LIBSSH2_SESSION *session, char **dest,
+                      unsigned int *dest_len, const char *src,
+                      unsigned int src_len);
+.fi
 .SH DESCRIPTION
 This function is deemed DEPRECATED and will be removed from libssh2 in a
 future version. Don't use it!

--- a/docs/libssh2_channel_close.3
+++ b/docs/libssh2_channel_close.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_close - close a channel
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_close(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - active channel stream to set closed status on.
 

--- a/docs/libssh2_channel_close.3
+++ b/docs/libssh2_channel_close.3
@@ -6,7 +6,6 @@ libssh2_channel_close - close a channel
 
 int
 libssh2_channel_close(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 \fIchannel\fP - active channel stream to set closed status on.
 

--- a/docs/libssh2_channel_direct_streamlocal_ex.3
+++ b/docs/libssh2_channel_direct_streamlocal_ex.3
@@ -2,10 +2,14 @@
 .SH NAME
 libssh2_channel_direct_streamlocal_ex - Tunnel a UNIX socket connection through an SSH session
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
-libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION *session, const char *socket_path, const char *shost, int sport);
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION *session,
+                                      const char *socket_path,
+                                      const char *shost, int sport);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_channel_direct_streamlocal_ex.3
+++ b/docs/libssh2_channel_direct_streamlocal_ex.3
@@ -6,10 +6,6 @@ libssh2_channel_direct_streamlocal_ex - Tunnel a UNIX socket connection through 
 
 LIBSSH2_CHANNEL *
 libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION *session, const char *socket_path, const char *shost, int sport);
-
-LIBSSH2_CHANNEL *
-libssh2_channel_direct_streamlocal(LIBSSH2_SESSION *session, const char *socket_path, const char *shost, int sport);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_channel_direct_tcpip.3
+++ b/docs/libssh2_channel_direct_tcpip.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_channel_direct_tcpip - convenience macro for \fIlibssh2_channel_direct_tcpip_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
-libssh2_channel_direct_tcpip(LIBSSH2_SESSION *session, const char *host, int port);
+libssh2_channel_direct_tcpip(LIBSSH2_SESSION *session,
+                             const char *host, int port);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_direct_tcpip_ex(3)\fP.

--- a/docs/libssh2_channel_direct_tcpip.3
+++ b/docs/libssh2_channel_direct_tcpip.3
@@ -6,7 +6,6 @@ libssh2_channel_direct_tcpip - convenience macro for \fIlibssh2_channel_direct_t
 
 LIBSSH2_CHANNEL *
 libssh2_channel_direct_tcpip(LIBSSH2_SESSION *session, const char *host, int port);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_direct_tcpip_ex(3)\fP.

--- a/docs/libssh2_channel_direct_tcpip_ex.3
+++ b/docs/libssh2_channel_direct_tcpip_ex.3
@@ -2,13 +2,18 @@
 .SH NAME
 libssh2_channel_direct_tcpip_ex - Tunnel a TCP connection through an SSH session
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
-libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host, int port, const char *shost, int sport);
+libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session,
+                                const char *host, int port,
+                                const char *shost, int sport);
 
 LIBSSH2_CHANNEL *
-libssh2_channel_direct_tcpip(LIBSSH2_SESSION *session, const char *host, int port);
+libssh2_channel_direct_tcpip(LIBSSH2_SESSION *session,
+                             const char *host, int port);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_channel_direct_tcpip_ex.3
+++ b/docs/libssh2_channel_direct_tcpip_ex.3
@@ -9,7 +9,6 @@ libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host, int 
 
 LIBSSH2_CHANNEL *
 libssh2_channel_direct_tcpip(LIBSSH2_SESSION *session, const char *host, int port);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_channel_eof.3
+++ b/docs/libssh2_channel_eof.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_eof - check a channel's EOF status
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_eof(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - active channel stream to set closed status on.
 

--- a/docs/libssh2_channel_exec.3
+++ b/docs/libssh2_channel_exec.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_exec - convenience macro for \fIlibssh2_channel_process_startup(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_exec(LIBSSH2_CHANNEL *channel, const char *command);
+int
+libssh2_channel_exec(LIBSSH2_CHANNEL *channel, const char *command);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_process_startup(3)\fP.

--- a/docs/libssh2_channel_exec.3
+++ b/docs/libssh2_channel_exec.3
@@ -5,7 +5,6 @@ libssh2_channel_exec - convenience macro for \fIlibssh2_channel_process_startup(
 #include <libssh2.h>
 
 int libssh2_channel_exec(LIBSSH2_CHANNEL *channel, const char *command);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_process_startup(3)\fP.

--- a/docs/libssh2_channel_flush.3
+++ b/docs/libssh2_channel_flush.3
@@ -5,7 +5,6 @@ libssh2_channel_flush - convenience macro for \fIlibssh2_channel_flush_ex(3)\fP 
 #include <libssh2.h>
 
 int libssh2_channel_flush(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_flush_ex(3)\fP.

--- a/docs/libssh2_channel_flush.3
+++ b/docs/libssh2_channel_flush.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_flush - convenience macro for \fIlibssh2_channel_flush_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_flush(LIBSSH2_CHANNEL *channel);
+int
+libssh2_channel_flush(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_flush_ex(3)\fP.

--- a/docs/libssh2_channel_flush_ex.3
+++ b/docs/libssh2_channel_flush_ex.3
@@ -12,7 +12,6 @@ libssh2_channel_flush(LIBSSH2_CHANNEL *channel);
 
 int
 libssh2_channel_flush_stderr(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 \fIchannel\fP - Active channel stream to flush.
 

--- a/docs/libssh2_channel_flush_ex.3
+++ b/docs/libssh2_channel_flush_ex.3
@@ -2,6 +2,7 @@
 .SH NAME
 libssh2_channel_flush_ex - flush a channel
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
@@ -12,6 +13,7 @@ libssh2_channel_flush(LIBSSH2_CHANNEL *channel);
 
 int
 libssh2_channel_flush_stderr(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Active channel stream to flush.
 

--- a/docs/libssh2_channel_flush_stderr.3
+++ b/docs/libssh2_channel_flush_stderr.3
@@ -5,7 +5,6 @@ libssh2_channel_flush_stderr - convenience macro for \fIlibssh2_channel_flush_ex
 #include <libssh2.h>
 
 int libssh2_channel_flush_stderr(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_flush_ex(3)\fP.

--- a/docs/libssh2_channel_flush_stderr.3
+++ b/docs/libssh2_channel_flush_stderr.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_flush_stderr - convenience macro for \fIlibssh2_channel_flush_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_flush_stderr(LIBSSH2_CHANNEL *channel);
+int
+libssh2_channel_flush_stderr(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_flush_ex(3)\fP.

--- a/docs/libssh2_channel_forward_accept.3
+++ b/docs/libssh2_channel_forward_accept.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_forward_accept - accept a queued connection
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
 libssh2_channel_forward_accept(LIBSSH2_LISTENER *listener);
+.fi
 .SH DESCRIPTION
 \fIlistener\fP is a forwarding listener instance as returned by
 \fBlibssh2_channel_forward_listen_ex(3)\fP.

--- a/docs/libssh2_channel_forward_accept.3
+++ b/docs/libssh2_channel_forward_accept.3
@@ -6,7 +6,6 @@ libssh2_channel_forward_accept - accept a queued connection
 
 LIBSSH2_CHANNEL *
 libssh2_channel_forward_accept(LIBSSH2_LISTENER *listener);
-
 .SH DESCRIPTION
 \fIlistener\fP is a forwarding listener instance as returned by
 \fBlibssh2_channel_forward_listen_ex(3)\fP.

--- a/docs/libssh2_channel_forward_cancel.3
+++ b/docs/libssh2_channel_forward_cancel.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_forward_cancel - cancel a forwarded TCP port
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener);
+.fi
 .SH DESCRIPTION
 \fIlistener\fP - Forwarding listener instance as returned by
 .BR libssh2_channel_forward_listen_ex(3)

--- a/docs/libssh2_channel_forward_cancel.3
+++ b/docs/libssh2_channel_forward_cancel.3
@@ -6,7 +6,6 @@ libssh2_channel_forward_cancel - cancel a forwarded TCP port
 
 int
 libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener);
-
 .SH DESCRIPTION
 \fIlistener\fP - Forwarding listener instance as returned by
 .BR libssh2_channel_forward_listen_ex(3)

--- a/docs/libssh2_channel_forward_listen.3
+++ b/docs/libssh2_channel_forward_listen.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_forward_listen - convenience macro for \fIlibssh2_channel_forward_listen_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_forward_listen(LIBSSH2_SESSION *session, int port);
+int
+libssh2_channel_forward_listen(LIBSSH2_SESSION *session, int port);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_forward_listen_ex(3)\fP.

--- a/docs/libssh2_channel_forward_listen.3
+++ b/docs/libssh2_channel_forward_listen.3
@@ -5,7 +5,6 @@ libssh2_channel_forward_listen - convenience macro for \fIlibssh2_channel_forwar
 #include <libssh2.h>
 
 int libssh2_channel_forward_listen(LIBSSH2_SESSION *session, int port);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_forward_listen_ex(3)\fP.

--- a/docs/libssh2_channel_forward_listen_ex.3
+++ b/docs/libssh2_channel_forward_listen_ex.3
@@ -2,13 +2,17 @@
 .SH NAME
 libssh2_channel_forward_listen_ex - listen to inbound connections
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_LISTENER *
-libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session, char *host, int port, int *bound_port, int queue_maxsize);
+libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session,
+                                  char *host, int port,
+                                  int *bound_port, int queue_maxsize);
 
 LIBSSH2_LISTENER *
 libssh2_channel_forward_listen(LIBSSH2_SESSION *session, int port);
+.fi
 .SH DESCRIPTION
 Instruct the remote SSH server to begin listening for inbound TCP/IP
 connections. New connections will be queued by the library until accepted by

--- a/docs/libssh2_channel_forward_listen_ex.3
+++ b/docs/libssh2_channel_forward_listen_ex.3
@@ -9,7 +9,6 @@ libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session, char *host, int port
 
 LIBSSH2_LISTENER *
 libssh2_channel_forward_listen(LIBSSH2_SESSION *session, int port);
-
 .SH DESCRIPTION
 Instruct the remote SSH server to begin listening for inbound TCP/IP
 connections. New connections will be queued by the library until accepted by

--- a/docs/libssh2_channel_free.3
+++ b/docs/libssh2_channel_free.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_free - free all resources associated with a channel
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_free(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Channel stream to free.
 

--- a/docs/libssh2_channel_free.3
+++ b/docs/libssh2_channel_free.3
@@ -6,7 +6,6 @@ libssh2_channel_free - free all resources associated with a channel
 
 int
 libssh2_channel_free(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 \fIchannel\fP - Channel stream to free.
 

--- a/docs/libssh2_channel_get_exit_signal.3
+++ b/docs/libssh2_channel_get_exit_signal.3
@@ -2,6 +2,7 @@
 .SH NAME
 libssh2_channel_get_exit_signal - get the remote exit signal
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
@@ -9,6 +10,7 @@ libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
                                 char **exitsignal, size_t *exitsignal_len,
                                 char **errmsg, size_t *errmsg_len,
                                 char **langtag, size_t *langtag_len);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Closed channel stream to retrieve exit signal from.
 

--- a/docs/libssh2_channel_get_exit_signal.3
+++ b/docs/libssh2_channel_get_exit_signal.3
@@ -5,8 +5,10 @@ libssh2_channel_get_exit_signal - get the remote exit signal
 #include <libssh2.h>
 
 int
-libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel, char **exitsignal, size_t *exitsignal_len, char **errmsg, size_t *errmsg_len, char **langtag, size_t *langtag_len);
-
+libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
+                                char **exitsignal, size_t *exitsignal_len,
+                                char **errmsg, size_t *errmsg_len,
+                                char **langtag, size_t *langtag_len);
 .SH DESCRIPTION
 \fIchannel\fP - Closed channel stream to retrieve exit signal from.
 

--- a/docs/libssh2_channel_get_exit_status.3
+++ b/docs/libssh2_channel_get_exit_status.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_get_exit_status - get the remote exit code
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_get_exit_status(LIBSSH2_CHANNEL* channel)
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Closed channel stream to retrieve exit status from.
 

--- a/docs/libssh2_channel_get_exit_status.3
+++ b/docs/libssh2_channel_get_exit_status.3
@@ -6,7 +6,6 @@ libssh2_channel_get_exit_status - get the remote exit code
 
 int
 libssh2_channel_get_exit_status(LIBSSH2_CHANNEL* channel)
-
 .SH DESCRIPTION
 \fIchannel\fP - Closed channel stream to retrieve exit status from.
 

--- a/docs/libssh2_channel_handle_extended_data.3
+++ b/docs/libssh2_channel_handle_extended_data.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_channel_handle_extended_data - set extended data handling mode
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 void
-libssh2_channel_handle_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode);
+libssh2_channel_handle_extended_data(LIBSSH2_CHANNEL *channel,
+                                     int ignore_mode);
+.fi
 .SH DESCRIPTION
 This function is deprecated. Use the
 \fIlibssh2_channel_handle_extended_data2(3)\fP function instead!

--- a/docs/libssh2_channel_handle_extended_data.3
+++ b/docs/libssh2_channel_handle_extended_data.3
@@ -6,7 +6,6 @@ libssh2_channel_handle_extended_data - set extended data handling mode
 
 void
 libssh2_channel_handle_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode);
-
 .SH DESCRIPTION
 This function is deprecated. Use the
 \fIlibssh2_channel_handle_extended_data2(3)\fP function instead!

--- a/docs/libssh2_channel_handle_extended_data2.3
+++ b/docs/libssh2_channel_handle_extended_data2.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_channel_handle_extended_data2 - set extended data handling mode
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel, int ignore_mode);
+libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
+                                      int ignore_mode);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Active channel stream to change extended data handling on.
 

--- a/docs/libssh2_channel_handle_extended_data2.3
+++ b/docs/libssh2_channel_handle_extended_data2.3
@@ -6,7 +6,6 @@ libssh2_channel_handle_extended_data2 - set extended data handling mode
 
 int
 libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel, int ignore_mode);
-
 .SH DESCRIPTION
 \fIchannel\fP - Active channel stream to change extended data handling on.
 

--- a/docs/libssh2_channel_ignore_extended_data.3
+++ b/docs/libssh2_channel_ignore_extended_data.3
@@ -2,9 +2,13 @@
 .SH NAME
 libssh2_channel_ignore_extended_data - convenience macro for \fIlibssh2_channel_handle_extended_data(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-libssh2_channel_ignore_extended_data(arguments)
+void
+libssh2_channel_ignore_extended_data(LIBSSH2_CHANNEL *channel,
+                                     int ignore_mode);
+.fi
 .SH DESCRIPTION
 This function is deprecated. Use the
 \fIlibssh2_channel_handle_extended_data2(3)\fP function instead!

--- a/docs/libssh2_channel_ignore_extended_data.3
+++ b/docs/libssh2_channel_ignore_extended_data.3
@@ -5,7 +5,6 @@ libssh2_channel_ignore_extended_data - convenience macro for \fIlibssh2_channel_
 #include <libssh2.h>
 
 libssh2_channel_ignore_extended_data(arguments)
-
 .SH DESCRIPTION
 This function is deprecated. Use the
 \fIlibssh2_channel_handle_extended_data2(3)\fP function instead!

--- a/docs/libssh2_channel_open_ex.3
+++ b/docs/libssh2_channel_open_ex.3
@@ -9,7 +9,6 @@ libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *channel_type, unsi
 
 LIBSSH2_CHANNEL *
 libssh2_channel_open_session(session);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_channel_open_ex.3
+++ b/docs/libssh2_channel_open_ex.3
@@ -2,13 +2,19 @@
 .SH NAME
 libssh2_channel_open_ex - establish a generic session channel
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
-libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *channel_type, unsigned int channel_type_len, unsigned int window_size, unsigned int packet_size, const char *message, unsigned int message_len);
+libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *channel_type,
+                        unsigned int channel_type_len,
+                        unsigned int window_size,
+                        unsigned int packet_size,
+                        const char *message, unsigned int message_len);
 
 LIBSSH2_CHANNEL *
 libssh2_channel_open_session(session);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_channel_open_session.3
+++ b/docs/libssh2_channel_open_session.3
@@ -6,7 +6,6 @@ libssh2_channel_open_session - convenience macro for \fIlibssh2_channel_open_ex(
 
 LIBSSH2_CHANNEL *
 libssh2_channel_open_session(LIBSSH2_SESSION *session);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_open_ex(3)\fP.

--- a/docs/libssh2_channel_open_session.3
+++ b/docs/libssh2_channel_open_session.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_open_session - convenience macro for \fIlibssh2_channel_open_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
 libssh2_channel_open_session(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_open_ex(3)\fP.

--- a/docs/libssh2_channel_process_startup.3
+++ b/docs/libssh2_channel_process_startup.3
@@ -10,6 +10,7 @@ int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                     unsigned int request_len,
                                     const char *message,
                                     unsigned int message_len);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Active session channel instance.
 

--- a/docs/libssh2_channel_process_startup.3
+++ b/docs/libssh2_channel_process_startup.3
@@ -5,11 +5,12 @@ libssh2_channel_process_startup - request a shell on a channel
 .nf
 #include <libssh2.h>
 
-int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
-                                    const char *request,
-                                    unsigned int request_len,
-                                    const char *message,
-                                    unsigned int message_len);
+int
+libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
+                                const char *request,
+                                unsigned int request_len,
+                                const char *message,
+                                unsigned int message_len);
 .fi
 .SH DESCRIPTION
 \fIchannel\fP - Active session channel instance.

--- a/docs/libssh2_channel_read.3
+++ b/docs/libssh2_channel_read.3
@@ -2,9 +2,13 @@
 .SH NAME
 libssh2_channel_read - convenience macro for \fIlibssh2_channel_read_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-ssize_t libssh2_channel_read(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
+ssize_t
+libssh2_channel_read(LIBSSH2_CHANNEL *channel,
+                     char *buf, size_t buflen);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_read_ex(3)\fP.

--- a/docs/libssh2_channel_read.3
+++ b/docs/libssh2_channel_read.3
@@ -5,7 +5,6 @@ libssh2_channel_read - convenience macro for \fIlibssh2_channel_read_ex(3)\fP ca
 #include <libssh2.h>
 
 ssize_t libssh2_channel_read(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_read_ex(3)\fP.

--- a/docs/libssh2_channel_read_ex.3
+++ b/docs/libssh2_channel_read_ex.3
@@ -2,16 +2,21 @@
 .SH NAME
 libssh2_channel_read_ex - read data from a channel stream
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 ssize_t
-libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id, char *buf, size_t buflen);
+libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id,
+                        char *buf, size_t buflen);
 
 ssize_t
-libssh2_channel_read(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
+libssh2_channel_read(LIBSSH2_CHANNEL *channel,
+                     char *buf, size_t buflen);
 
 ssize_t
-libssh2_channel_read_stderr(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
+libssh2_channel_read_stderr(LIBSSH2_CHANNEL *channel,
+                            char *buf, size_t buflen);
+.fi
 .SH DESCRIPTION
 Attempt to read data from an active channel stream. All channel streams have
 one standard I/O substream (stream_id == 0), and may have up to 2^32 extended

--- a/docs/libssh2_channel_read_ex.3
+++ b/docs/libssh2_channel_read_ex.3
@@ -12,7 +12,6 @@ libssh2_channel_read(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
 
 ssize_t
 libssh2_channel_read_stderr(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
-
 .SH DESCRIPTION
 Attempt to read data from an active channel stream. All channel streams have
 one standard I/O substream (stream_id == 0), and may have up to 2^32 extended

--- a/docs/libssh2_channel_read_stderr.3
+++ b/docs/libssh2_channel_read_stderr.3
@@ -5,7 +5,9 @@ libssh2_channel_read_stderr - convenience macro for \fIlibssh2_channel_read_ex(3
 .nf
 #include <libssh2.h>
 
-ssize_t libssh2_channel_read_stderr(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
+ssize_t
+libssh2_channel_read_stderr(LIBSSH2_CHANNEL *channel,
+                            char *buf, size_t buflen);
 .fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the

--- a/docs/libssh2_channel_read_stderr.3
+++ b/docs/libssh2_channel_read_stderr.3
@@ -2,10 +2,11 @@
 .SH NAME
 libssh2_channel_read_stderr - convenience macro for \fIlibssh2_channel_read_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 ssize_t libssh2_channel_read_stderr(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
-
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_read_ex(3)\fP.

--- a/docs/libssh2_channel_receive_window_adjust.3
+++ b/docs/libssh2_channel_receive_window_adjust.3
@@ -8,7 +8,6 @@ unsigned long
 libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL * channel,
                                       unsigned long adjustment,
                                       unsigned char force);
-
 .SH DESCRIPTION
 This function is deprecated in 1.1. Use
 \fIlibssh2_channel_receive_window_adjust2(3)\fP!

--- a/docs/libssh2_channel_receive_window_adjust.3
+++ b/docs/libssh2_channel_receive_window_adjust.3
@@ -2,12 +2,14 @@
 .SH NAME
 libssh2_channel_receive_window_adjust - adjust the channel window
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 unsigned long
 libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL * channel,
                                       unsigned long adjustment,
                                       unsigned char force);
+.fi
 .SH DESCRIPTION
 This function is deprecated in 1.1. Use
 \fIlibssh2_channel_receive_window_adjust2(3)\fP!

--- a/docs/libssh2_channel_receive_window_adjust2.3
+++ b/docs/libssh2_channel_receive_window_adjust2.3
@@ -2,6 +2,7 @@
 .SH NAME
 libssh2_channel_receive_window_adjust2 - adjust the channel window
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
@@ -9,6 +10,7 @@ libssh2_channel_receive_window_adjust2(LIBSSH2_CHANNEL * channel,
                                        unsigned long adjustment,
                                        unsigned char force,
                                        unsigned int *window);
+.fi
 .SH DESCRIPTION
 Adjust the receive window for a channel by adjustment bytes. If the amount to
 be adjusted is less than LIBSSH2_CHANNEL_MINADJUST and force is 0 the

--- a/docs/libssh2_channel_receive_window_adjust2.3
+++ b/docs/libssh2_channel_receive_window_adjust2.3
@@ -9,7 +9,6 @@ libssh2_channel_receive_window_adjust2(LIBSSH2_CHANNEL * channel,
                                        unsigned long adjustment,
                                        unsigned char force,
                                        unsigned int *window);
-
 .SH DESCRIPTION
 Adjust the receive window for a channel by adjustment bytes. If the amount to
 be adjusted is less than LIBSSH2_CHANNEL_MINADJUST and force is 0 the

--- a/docs/libssh2_channel_request_auth_agent.3
+++ b/docs/libssh2_channel_request_auth_agent.3
@@ -6,7 +6,6 @@ libssh2_channel_request_auth_agent - request agent forwarding for a session
 
 int
 libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 Request that agent forwarding be enabled for this SSH session. This sends the
 request over this specific channel, which causes the agent listener to be

--- a/docs/libssh2_channel_request_auth_agent.3
+++ b/docs/libssh2_channel_request_auth_agent.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_request_auth_agent - request agent forwarding for a session
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 Request that agent forwarding be enabled for this SSH session. This sends the
 request over this specific channel, which causes the agent listener to be

--- a/docs/libssh2_channel_request_pty.3
+++ b/docs/libssh2_channel_request_pty.3
@@ -5,7 +5,6 @@ libssh2_channel_request_pty - convenience macro for \fIlibssh2_channel_request_p
 #include <libssh2.h>
 
 int libssh2_channel_request_pty(LIBSSH2_SESSION *session, const char *term);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_request_pty_ex(3)\fP.

--- a/docs/libssh2_channel_request_pty.3
+++ b/docs/libssh2_channel_request_pty.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_request_pty - convenience macro for \fIlibssh2_channel_request_pty_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_request_pty(LIBSSH2_SESSION *session, const char *term);
+int
+libssh2_channel_request_pty(LIBSSH2_SESSION *session, const char *term);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_request_pty_ex(3)\fP.

--- a/docs/libssh2_channel_request_pty_ex.3
+++ b/docs/libssh2_channel_request_pty_ex.3
@@ -9,7 +9,6 @@ libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel, const char *term, unsig
 
 int
 libssh2_channel_request_pty(LIBSSH2_CHANNEL *channel, char *term);
-
 .SH DESCRIPTION
 \fIchannel\fP - Previously opened channel instance such as returned by
 .BR libssh2_channel_open_ex(3)

--- a/docs/libssh2_channel_request_pty_ex.3
+++ b/docs/libssh2_channel_request_pty_ex.3
@@ -2,13 +2,19 @@
 .SH NAME
 libssh2_channel_request_pty_ex - short function description
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel, const char *term, unsigned int term_len, const char *modes, unsigned int modes_len, int width, int height, int width_px, int height_px);
+libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel, const char *term,
+                               unsigned int term_len,
+                               const char *modes, unsigned int modes_len,
+                               int width, int height,
+                               int width_px, int height_px);
 
 int
-libssh2_channel_request_pty(LIBSSH2_CHANNEL *channel, char *term);
+libssh2_channel_request_pty(LIBSSH2_CHANNEL *channel, const char *term);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Previously opened channel instance such as returned by
 .BR libssh2_channel_open_ex(3)

--- a/docs/libssh2_channel_request_pty_size.3
+++ b/docs/libssh2_channel_request_pty_size.3
@@ -2,9 +2,13 @@
 .SH NAME
 libssh2_channel_request_pty_size - convenience macro for \fIlibssh2_channel_request_pty_size_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_request_pty_size(LIBSSH2_CHANNEL *channel, int width, int height);
+int
+libssh2_channel_request_pty_size(LIBSSH2_CHANNEL *channel,
+                                 int width, int height);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_request_pty_size_ex(3)\fP.

--- a/docs/libssh2_channel_request_pty_size.3
+++ b/docs/libssh2_channel_request_pty_size.3
@@ -5,7 +5,6 @@ libssh2_channel_request_pty_size - convenience macro for \fIlibssh2_channel_requ
 #include <libssh2.h>
 
 int libssh2_channel_request_pty_size(LIBSSH2_CHANNEL *channel, int width, int height);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_request_pty_size_ex(3)\fP.

--- a/docs/libssh2_channel_request_pty_size_ex.3
+++ b/docs/libssh2_channel_request_pty_size_ex.3
@@ -2,7 +2,8 @@
 .SH NAME
 libssh2_channel_request_pty_size_ex - TODO
 .SH SYNOPSIS
-
+.nf
+.fi
 .SH DESCRIPTION
 
 .SH RETURN VALUE

--- a/docs/libssh2_channel_send_eof.3
+++ b/docs/libssh2_channel_send_eof.3
@@ -6,7 +6,6 @@ libssh2_channel_send_eof - send EOF to remote server
 
 int
 libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 Tell the remote host that no further data will be sent on the specified
 channel. Processes typically interpret this as a closed stdin descriptor.

--- a/docs/libssh2_channel_send_eof.3
+++ b/docs/libssh2_channel_send_eof.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_send_eof - send EOF to remote server
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 Tell the remote host that no further data will be sent on the specified
 channel. Processes typically interpret this as a closed stdin descriptor.

--- a/docs/libssh2_channel_set_blocking.3
+++ b/docs/libssh2_channel_set_blocking.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_set_blocking - set or clear blocking mode on channel
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 void
 libssh2_channel_set_blocking(LIBSSH2_CHANNEL *channel, int blocking);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - channel stream to set or clean blocking status on.
 

--- a/docs/libssh2_channel_setenv.3
+++ b/docs/libssh2_channel_setenv.3
@@ -5,7 +5,6 @@ libssh2_channel_setenv - convenience macro for \fIlibssh2_channel_setenv_ex(3)\f
 #include <libssh2.h>
 
 int libssh2_channel_setenv(LIBSSH2_CHANNEL *channel, const char *varname, const char *value);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_setenv_ex(3)\fP.

--- a/docs/libssh2_channel_setenv.3
+++ b/docs/libssh2_channel_setenv.3
@@ -2,9 +2,13 @@
 .SH NAME
 libssh2_channel_setenv - convenience macro for \fIlibssh2_channel_setenv_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_setenv(LIBSSH2_CHANNEL *channel, const char *varname, const char *value);
+int
+libssh2_channel_setenv(LIBSSH2_CHANNEL *channel,
+                       const char *varname, const char *value);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_setenv_ex(3)\fP.

--- a/docs/libssh2_channel_setenv_ex.3
+++ b/docs/libssh2_channel_setenv_ex.3
@@ -2,13 +2,18 @@
 .SH NAME
 libssh2_channel_setenv_ex - set an environment variable on the channel
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel, char *varname, unsigned int varname_len, const char *value, unsigned int value_len);
+libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
+                          char *varname, unsigned int varname_len,
+                          const char *value, unsigned int value_len);
 
 int
-libssh2_channel_setenv(LIBSSH2_CHANNEL *channel, char *varname, const char *value);
+libssh2_channel_setenv(LIBSSH2_CHANNEL *channel,
+                       char *varname, const char *value);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Previously opened channel instance such as returned by
 .BR libssh2_channel_open_ex(3)

--- a/docs/libssh2_channel_setenv_ex.3
+++ b/docs/libssh2_channel_setenv_ex.3
@@ -9,7 +9,6 @@ libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel, char *varname, unsigned int 
 
 int
 libssh2_channel_setenv(LIBSSH2_CHANNEL *channel, char *varname, const char *value);
-
 .SH DESCRIPTION
 \fIchannel\fP - Previously opened channel instance such as returned by
 .BR libssh2_channel_open_ex(3)

--- a/docs/libssh2_channel_shell.3
+++ b/docs/libssh2_channel_shell.3
@@ -5,7 +5,6 @@ libssh2_channel_shell - convenience macro for \fIlibssh2_channel_process_startup
 #include <libssh2.h>
 
 int libssh2_channel_shell(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_process_startup(3)\fP.

--- a/docs/libssh2_channel_shell.3
+++ b/docs/libssh2_channel_shell.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_shell - convenience macro for \fIlibssh2_channel_process_startup(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_shell(LIBSSH2_CHANNEL *channel);
+int
+libssh2_channel_shell(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_process_startup(3)\fP.

--- a/docs/libssh2_channel_subsystem.3
+++ b/docs/libssh2_channel_subsystem.3
@@ -5,7 +5,6 @@ libssh2_channel_subsystem - convenience macro for \fIlibssh2_channel_process_sta
 #include <libssh2.h>
 
 int libssh2_channel_subsystem(LIBSSH2_CHANNEL *channel, const char *subsystem);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_process_startup(3)\fP.

--- a/docs/libssh2_channel_subsystem.3
+++ b/docs/libssh2_channel_subsystem.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_subsystem - convenience macro for \fIlibssh2_channel_process_startup(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_subsystem(LIBSSH2_CHANNEL *channel, const char *subsystem);
+int
+libssh2_channel_subsystem(LIBSSH2_CHANNEL *channel, const char *subsystem);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_process_startup(3)\fP.

--- a/docs/libssh2_channel_wait_closed.3
+++ b/docs/libssh2_channel_wait_closed.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_wait_closed - wait for the remote to close the channel
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_wait_closed(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 Enter a temporary blocking state until the remote host closes the named
 channel. Typically sent after \fIlibssh2_channel_close(3)\fP in order to

--- a/docs/libssh2_channel_wait_closed.3
+++ b/docs/libssh2_channel_wait_closed.3
@@ -6,7 +6,6 @@ libssh2_channel_wait_closed - wait for the remote to close the channel
 
 int
 libssh2_channel_wait_closed(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 Enter a temporary blocking state until the remote host closes the named
 channel. Typically sent after \fIlibssh2_channel_close(3)\fP in order to

--- a/docs/libssh2_channel_wait_eof.3
+++ b/docs/libssh2_channel_wait_eof.3
@@ -6,7 +6,6 @@ libssh2_channel_wait_eof - wait for the remote to reply to an EOF request
 
 int
 libssh2_channel_wait_eof(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 Wait for the remote end to send EOF.
 

--- a/docs/libssh2_channel_wait_eof.3
+++ b/docs/libssh2_channel_wait_eof.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_channel_wait_eof - wait for the remote to reply to an EOF request
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_channel_wait_eof(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 Wait for the remote end to send EOF.
 

--- a/docs/libssh2_channel_window_read.3
+++ b/docs/libssh2_channel_window_read.3
@@ -5,7 +5,6 @@ libssh2_channel_window_read - convenience macro for \fIlibssh2_channel_window_re
 #include <libssh2.h>
 
 unsigned long libssh2_channel_window_read(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_window_read_ex(3)\fP.

--- a/docs/libssh2_channel_window_read.3
+++ b/docs/libssh2_channel_window_read.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_window_read - convenience macro for \fIlibssh2_channel_window_read_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-unsigned long libssh2_channel_window_read(LIBSSH2_CHANNEL *channel);
+unsigned long
+libssh2_channel_window_read(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_window_read_ex(3)\fP.

--- a/docs/libssh2_channel_window_read_ex.3
+++ b/docs/libssh2_channel_window_read_ex.3
@@ -2,12 +2,14 @@
 .SH NAME
 libssh2_channel_window_read_ex - Check the status of the read window
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 unsigned long
 libssh2_channel_window_read_ex(LIBSSH2_CHANNEL *channel,
                                unsigned long *read_avail,
                                unsigned long *window_size_initial)
+.fi
 .SH DESCRIPTION
 Check the status of the read window. Returns the number of bytes which the
 remote end may send without overflowing the window limit read_avail (if

--- a/docs/libssh2_channel_window_write.3
+++ b/docs/libssh2_channel_window_write.3
@@ -5,7 +5,6 @@ libssh2_channel_window_write - convenience macro for \fIlibssh2_channel_window_w
 #include <libssh2.h>
 
 unsigned long libssh2_channel_window_write(LIBSSH2_CHANNEL *channel);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_window_write_ex(3)\fP.

--- a/docs/libssh2_channel_window_write.3
+++ b/docs/libssh2_channel_window_write.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_window_write - convenience macro for \fIlibssh2_channel_window_write_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-unsigned long libssh2_channel_window_write(LIBSSH2_CHANNEL *channel);
+unsigned long
+libssh2_channel_window_write(LIBSSH2_CHANNEL *channel);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_window_write_ex(3)\fP.

--- a/docs/libssh2_channel_window_write_ex.3
+++ b/docs/libssh2_channel_window_write_ex.3
@@ -2,11 +2,13 @@
 .SH NAME
 libssh2_channel_window_write_ex - Check the status of the write window
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 unsigned long
 libssh2_channel_window_write_ex(LIBSSH2_CHANNEL *channel,
                                 unsigned long *window_size_initial)
+.fi
 .SH DESCRIPTION
 Check the status of the write window Returns the number of bytes which may be
 safely written on the channel without blocking. 'window_size_initial' (if

--- a/docs/libssh2_channel_write.3
+++ b/docs/libssh2_channel_write.3
@@ -6,7 +6,7 @@ libssh2_channel_write - convenience macro for \fIlibssh2_channel_write_ex(3)\fP
 #include <libssh2.h>
 
 ssize_t libssh2_channel_write(LIBSSH2_CHANNEL *channel, const char *buf, size_t buflen);
-
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_write_ex(3)\fP.

--- a/docs/libssh2_channel_write.3
+++ b/docs/libssh2_channel_write.3
@@ -5,7 +5,9 @@ libssh2_channel_write - convenience macro for \fIlibssh2_channel_write_ex(3)\fP
 .nf
 #include <libssh2.h>
 
-ssize_t libssh2_channel_write(LIBSSH2_CHANNEL *channel, const char *buf, size_t buflen);
+ssize_t
+libssh2_channel_write(LIBSSH2_CHANNEL *channel,
+                      const char *buf, size_t buflen);
 .fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the

--- a/docs/libssh2_channel_write_ex.3
+++ b/docs/libssh2_channel_write_ex.3
@@ -8,6 +8,7 @@ libssh2_channel_write_ex - write data to a channel stream blocking
 ssize_t libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel,
                                  int stream_id, char *buf,
                                  size_t buflen);
+.fi
 .SH DESCRIPTION
 Write data to a channel stream. All channel streams have one standard I/O
 substream (stream_id == 0), and may have up to 2^32 extended data streams as

--- a/docs/libssh2_channel_write_ex.3
+++ b/docs/libssh2_channel_write_ex.3
@@ -5,9 +5,10 @@ libssh2_channel_write_ex - write data to a channel stream blocking
 .nf
 #include <libssh2.h>
 
-ssize_t libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel,
-                                 int stream_id, char *buf,
-                                 size_t buflen);
+ssize_t
+libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel,
+                         int stream_id, char *buf,
+                         size_t buflen);
 .fi
 .SH DESCRIPTION
 Write data to a channel stream. All channel streams have one standard I/O

--- a/docs/libssh2_channel_write_stderr.3
+++ b/docs/libssh2_channel_write_stderr.3
@@ -6,7 +6,7 @@ libssh2_channel_write_stderr - convenience macro for \fIlibssh2_channel_write_ex
 #include <libssh2.h>
 
 ssize_t libssh2_channel_write_stderr(LIBSSH2_CHANNEL *channel, const char *buf, size_t buflen);
-
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_write_ex(3)\fP.

--- a/docs/libssh2_channel_write_stderr.3
+++ b/docs/libssh2_channel_write_stderr.3
@@ -5,7 +5,9 @@ libssh2_channel_write_stderr - convenience macro for \fIlibssh2_channel_write_ex
 .nf
 #include <libssh2.h>
 
-ssize_t libssh2_channel_write_stderr(LIBSSH2_CHANNEL *channel, const char *buf, size_t buflen);
+ssize_t
+libssh2_channel_write_stderr(LIBSSH2_CHANNEL *channel,
+                             const char *buf, size_t buflen);
 .fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the

--- a/docs/libssh2_channel_x11_req.3
+++ b/docs/libssh2_channel_x11_req.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_channel_x11_req - convenience macro for \fIlibssh2_channel_x11_req_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_channel_x11_req(LIBSSH2_CHANNEL *channel, int screen_number);
+int
+libssh2_channel_x11_req(LIBSSH2_CHANNEL *channel, int screen_number);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_x11_req_ex(3)\fP.

--- a/docs/libssh2_channel_x11_req.3
+++ b/docs/libssh2_channel_x11_req.3
@@ -5,7 +5,6 @@ libssh2_channel_x11_req - convenience macro for \fIlibssh2_channel_x11_req_ex(3)
 #include <libssh2.h>
 
 int libssh2_channel_x11_req(LIBSSH2_CHANNEL *channel, int screen_number);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_channel_x11_req_ex(3)\fP.

--- a/docs/libssh2_channel_x11_req_ex.3
+++ b/docs/libssh2_channel_x11_req_ex.3
@@ -2,13 +2,18 @@
 .SH NAME
 libssh2_channel_x11_req_ex - request an X11 forwarding channel
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel, int single_connection, const char *auth_proto, const char *auth_cookie, int screen_number);
+libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel, int single_connection,
+                           const char *auth_proto, const char *auth_cookie,
+                           int screen_number);
 
 int
-libssh2_channel_x11_req(LIBSSH2_CHANNEL *channel, int screen_number);
+libssh2_channel_x11_req(LIBSSH2_CHANNEL *channel,
+                        int screen_number);
+.fi
 .SH DESCRIPTION
 \fIchannel\fP - Previously opened channel instance such as returned by
 .BR libssh2_channel_open_ex(3)

--- a/docs/libssh2_channel_x11_req_ex.3
+++ b/docs/libssh2_channel_x11_req_ex.3
@@ -9,7 +9,6 @@ libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel, int single_connection, cons
 
 int
 libssh2_channel_x11_req(LIBSSH2_CHANNEL *channel, int screen_number);
-
 .SH DESCRIPTION
 \fIchannel\fP - Previously opened channel instance such as returned by
 .BR libssh2_channel_open_ex(3)

--- a/docs/libssh2_crypto_engine.3
+++ b/docs/libssh2_crypto_engine.3
@@ -1,11 +1,13 @@
 .TH libssh2_crypto_engine 3 "22 Nov 2021" "libssh2 1.11" "libssh2 manual"
 .SH NAME
- - retrieve used crypto engine
+libssh2_crypto_engine - retrieve used crypto engine
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 libssh2_crypto_engine_t
 libssh2_crypto_engine();
+.fi
 .SH DESCRIPTION
 Returns currently used crypto engine, as en enum value.
 .SH AVAILABILITY

--- a/docs/libssh2_crypto_engine.3
+++ b/docs/libssh2_crypto_engine.3
@@ -6,7 +6,7 @@ libssh2_crypto_engine - retrieve used crypto engine
 #include <libssh2.h>
 
 libssh2_crypto_engine_t
-libssh2_crypto_engine();
+libssh2_crypto_engine(void);
 .fi
 .SH DESCRIPTION
 Returns currently used crypto engine, as en enum value.

--- a/docs/libssh2_exit.3
+++ b/docs/libssh2_exit.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_exit - global library deinitialization
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 void
 libssh2_exit(void);
+.fi
 .SH DESCRIPTION
 Exit the libssh2 functions and free's all memory used internal.
 .SH AVAILABILITY

--- a/docs/libssh2_free.3
+++ b/docs/libssh2_free.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_free - deallocate libssh2 memory
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 void
 libssh2_free(LIBSSH2_SESSION *session, void *ptr);
+.fi
 .SH DESCRIPTION
 Deallocate memory allocated by earlier call to libssh2 functions.  It
 uses the memory allocation callbacks provided by the application, if

--- a/docs/libssh2_free.3
+++ b/docs/libssh2_free.3
@@ -1,4 +1,4 @@
-.TH libssh2_exit 3 "13 Oct 2010" "libssh2 1.2.8" "libssh2 manual"
+.TH libssh2_free 3 "13 Oct 2010" "libssh2 1.2.8" "libssh2 manual"
 .SH NAME
 libssh2_free - deallocate libssh2 memory
 .SH SYNOPSIS

--- a/docs/libssh2_hostkey_hash.3
+++ b/docs/libssh2_hostkey_hash.3
@@ -6,7 +6,6 @@ libssh2_hostkey_hash - return a hash of the remote host's key
 
 const char *
 libssh2_hostkey_hash(LIBSSH2_SESSION *session, int hash_type);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_hostkey_hash.3
+++ b/docs/libssh2_hostkey_hash.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_hostkey_hash - return a hash of the remote host's key
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 const char *
 libssh2_hostkey_hash(LIBSSH2_SESSION *session, int hash_type);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_init.3
+++ b/docs/libssh2_init.3
@@ -2,12 +2,14 @@
 .SH NAME
 libssh2_init - global library initialization
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 #define LIBSSH2_INIT_NO_CRYPTO 0x0001
 
 int
 libssh2_init(int flags);
+.fi
 .SH DESCRIPTION
 Initialize the libssh2 functions.  This typically initialize the
 crypto library.  It uses a global state, and is not thread safe -- you

--- a/docs/libssh2_keepalive_config.3
+++ b/docs/libssh2_keepalive_config.3
@@ -2,8 +2,8 @@
 .SH NAME
 libssh2_keepalive_config - short function description
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
+#include <libssh2.h>
 
 void libssh2_keepalive_config(LIBSSH2_SESSION *session,
                               int want_reply,

--- a/docs/libssh2_keepalive_config.3
+++ b/docs/libssh2_keepalive_config.3
@@ -5,9 +5,10 @@ libssh2_keepalive_config - short function description
 .nf
 #include <libssh2.h>
 
-void libssh2_keepalive_config(LIBSSH2_SESSION *session,
-                              int want_reply,
-                              unsigned interval);
+void
+libssh2_keepalive_config(LIBSSH2_SESSION *session,
+                         int want_reply,
+                         unsigned interval);
 .fi
 .SH DESCRIPTION
 Set how often keepalive messages should be sent. \fBwant_reply\fP indicates

--- a/docs/libssh2_keepalive_send.3
+++ b/docs/libssh2_keepalive_send.3
@@ -5,8 +5,9 @@ libssh2_keepalive_send - short function description
 .nf
 #include <libssh2.h>
 
-int libssh2_keepalive_send(LIBSSH2_SESSION *session,
-                           int *seconds_to_next);
+int
+libssh2_keepalive_send(LIBSSH2_SESSION *session,
+                       int *seconds_to_next);
 .fi
 .SH DESCRIPTION
 Send a keepalive message if needed.  \fBseconds_to_next\fP indicates how many

--- a/docs/libssh2_keepalive_send.3
+++ b/docs/libssh2_keepalive_send.3
@@ -2,11 +2,12 @@
 .SH NAME
 libssh2_keepalive_send - short function description
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
+#include <libssh2.h>
 
 int libssh2_keepalive_send(LIBSSH2_SESSION *session,
                            int *seconds_to_next);
+.fi
 .SH DESCRIPTION
 Send a keepalive message if needed.  \fBseconds_to_next\fP indicates how many
 seconds you can sleep after this call before you need to call it again.

--- a/docs/libssh2_knownhost_add.3
+++ b/docs/libssh2_knownhost_add.3
@@ -1,4 +1,4 @@
-
+.\"
 .\" Copyright (c) 2009, 2010 by Daniel Stenberg
 .\"
 .TH libssh2_knownhost_add 3 "28 May 2009" "libssh2 1.2" "libssh2 manual"
@@ -13,6 +13,7 @@ int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
                           char *key, size_t keylen,
                           int typemask,
                           struct libssh2_knownhost **store);
+.fi
 .SH DESCRIPTION
 We discourage use of this function as of libssh2 1.2.5. Instead we strongly
 urge users to use \fIlibssh2_knownhost_addc(3)\fP instead, which as a more

--- a/docs/libssh2_knownhost_add.3
+++ b/docs/libssh2_knownhost_add.3
@@ -8,11 +8,12 @@ libssh2_knownhost_add - add a known host
 .nf
 #include <libssh2.h>
 
-int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
-                          char *host, char *salt,
-                          char *key, size_t keylen,
-                          int typemask,
-                          struct libssh2_knownhost **store);
+int
+libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
+                      char *host, char *salt,
+                      char *key, size_t keylen,
+                      int typemask,
+                      struct libssh2_knownhost **store);
 .fi
 .SH DESCRIPTION
 We discourage use of this function as of libssh2 1.2.5. Instead we strongly

--- a/docs/libssh2_knownhost_addc.3
+++ b/docs/libssh2_knownhost_addc.3
@@ -5,14 +5,17 @@
 .SH NAME
 libssh2_knownhost_add - add a known host
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
-                           char *host, char *salt,
-                           char *key, size_t keylen,
-                           const char *comment, size_t commentlen,
-                           int typemask,
-                           struct libssh2_knownhost **store);
+int
+libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
+                       char *host, char *salt,
+                       char *key, size_t keylen,
+                       const char *comment, size_t commentlen,
+                       int typemask,
+                       struct libssh2_knownhost **store);
+.fi
 .SH DESCRIPTION
 Adds a known host to the collection of known hosts identified by the 'hosts'
 handle.

--- a/docs/libssh2_knownhost_addc.3
+++ b/docs/libssh2_knownhost_addc.3
@@ -1,9 +1,9 @@
 .\"
 .\" Copyright (c) 2009, 2010 by Daniel Stenberg
 .\"
-.TH libssh2_knownhost_add 3 "28 May 2009" "libssh2 1.2" "libssh2 manual"
+.TH libssh2_knownhost_addc 3 "28 May 2009" "libssh2 1.2" "libssh2 manual"
 .SH NAME
-libssh2_knownhost_add - add a known host
+libssh2_knownhost_addc - add a known host
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>

--- a/docs/libssh2_knownhost_addc.3
+++ b/docs/libssh2_knownhost_addc.3
@@ -1,4 +1,4 @@
-
+.\"
 .\" Copyright (c) 2009, 2010 by Daniel Stenberg
 .\"
 .TH libssh2_knownhost_add 3 "28 May 2009" "libssh2 1.2" "libssh2 manual"

--- a/docs/libssh2_knownhost_check.3
+++ b/docs/libssh2_knownhost_check.3
@@ -5,13 +5,16 @@
 .SH NAME
 libssh2_knownhost_check - check a host+key against the list of known hosts
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
-                            const char *host,
-                            const char *key, size_t keylen,
-                            int typemask,
-                            struct libssh2_knownhost **knownhost);
+int
+libssh2_knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
+                        const char *host,
+                        const char *key, size_t keylen,
+                        int typemask,
+                        struct libssh2_knownhost **knownhost);
+.fi
 .SH DESCRIPTION
 Checks a host and its associated key against the collection of known hosts,
 and returns info back about the (partially) matched entry.

--- a/docs/libssh2_knownhost_checkp.3
+++ b/docs/libssh2_knownhost_checkp.3
@@ -5,13 +5,16 @@
 .SH NAME
 libssh2_knownhost_checkp - check a host+key against the list of known hosts
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_knownhost_checkp(LIBSSH2_KNOWNHOSTS *hosts,
-                             const char *host, int port,
-                             const char *key, size_t keylen,
-                             int typemask,
-                             struct libssh2_knownhost **knownhost);
+int
+libssh2_knownhost_checkp(LIBSSH2_KNOWNHOSTS *hosts,
+                         const char *host, int port,
+                         const char *key, size_t keylen,
+                         int typemask,
+                         struct libssh2_knownhost **knownhost);
+.fi
 .SH DESCRIPTION
 Checks a host and its associated key against the collection of known hosts,
 and returns info back about the (partially) matched entry.

--- a/docs/libssh2_knownhost_checkp.3
+++ b/docs/libssh2_knownhost_checkp.3
@@ -1,7 +1,7 @@
 .\"
 .\" Copyright (c) 2009-2010 by Daniel Stenberg
 .\"
-.TH libssh2_knownhost_check 3 "1 May 2010" "libssh2 1.2.6" "libssh2 manual"
+.TH libssh2_knownhost_checkp 3 "1 May 2010" "libssh2 1.2.6" "libssh2 manual"
 .SH NAME
 libssh2_knownhost_checkp - check a host+key against the list of known hosts
 .SH SYNOPSIS

--- a/docs/libssh2_knownhost_del.3
+++ b/docs/libssh2_knownhost_del.3
@@ -5,10 +5,13 @@
 .SH NAME
 libssh2_knownhost_del - delete a known host entry
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
-                          struct libssh2_knownhost *entry);
+int
+libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
+                      struct libssh2_knownhost *entry);
+.fi
 .SH DESCRIPTION
 Delete a known host entry from the collection of known hosts.
 

--- a/docs/libssh2_knownhost_free.3
+++ b/docs/libssh2_knownhost_free.3
@@ -5,9 +5,12 @@
 .SH NAME
 libssh2_knownhost_free - free a collection of known hosts
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-void libssh2_knownhost_free(LIBSSH2_KNOWNHOSTS *hosts);
+void
+libssh2_knownhost_free(LIBSSH2_KNOWNHOSTS *hosts);
+.fi
 .SH DESCRIPTION
 Free a collection of known hosts.
 .SH RETURN VALUE

--- a/docs/libssh2_knownhost_get.3
+++ b/docs/libssh2_knownhost_get.3
@@ -5,11 +5,14 @@
 .SH NAME
 libssh2_knownhost_get - get a known host off the collection of known hosts
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_knownhost_get(LIBSSH2_KNOWNHOSTS *hosts,
-                          struct libssh2_knownhost **store,
-                          struct libssh2_knownhost *prev):
+int
+libssh2_knownhost_get(LIBSSH2_KNOWNHOSTS *hosts,
+                      struct libssh2_knownhost **store,
+                      struct libssh2_knownhost *prev):
+.fi
 .SH DESCRIPTION
 \fIlibssh2_knownhost_get(3)\fP allows an application to iterate over all known
 hosts in the collection.

--- a/docs/libssh2_knownhost_init.3
+++ b/docs/libssh2_knownhost_init.3
@@ -5,9 +5,12 @@
 .SH NAME
 libssh2_knownhost_init - init a collection of known hosts
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-LIBSSH2_KNOWNHOSTS *libssh2_knownhost_init(LIBSSH2_SESSION *session);
+LIBSSH2_KNOWNHOSTS *
+libssh2_knownhost_init(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 Init a collection of known hosts for this session. Returns the handle to an
 internal representation of a known host collection.

--- a/docs/libssh2_knownhost_readfile.3
+++ b/docs/libssh2_knownhost_readfile.3
@@ -5,10 +5,13 @@
 .SH NAME
 libssh2_knownhost_readfile - parse a file of known hosts
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
-                               const char *filename, int type);
+int
+libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
+                           const char *filename, int type);
+.fi
 .SH DESCRIPTION
 Reads a collection of known hosts from a specified file and adds them to the
 collection of known hosts.

--- a/docs/libssh2_knownhost_readline.3
+++ b/docs/libssh2_knownhost_readline.3
@@ -5,10 +5,13 @@
 .SH NAME
 libssh2_knownhost_readline - read a known host line
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
-                               const char *line, size_t len, int type):
+int
+libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
+                           const char *line, size_t len, int type):
+.fi
 .SH DESCRIPTION
 Tell libssh2 to read a buffer as it if is a line from a known hosts file.
 

--- a/docs/libssh2_knownhost_writefile.3
+++ b/docs/libssh2_knownhost_writefile.3
@@ -5,10 +5,13 @@
 .SH NAME
 libssh2_knownhost_writefile - write a collection of known hosts to a file
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
-                                const char *filename, int type);
+int
+libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
+                            const char *filename, int type);
+.fi
 .SH DESCRIPTION
 Writes all the known hosts to the specified file using the specified file
 format.

--- a/docs/libssh2_knownhost_writeline.3
+++ b/docs/libssh2_knownhost_writeline.3
@@ -5,13 +5,16 @@
 .SH NAME
 libssh2_knownhost_writeline - convert a known host to a line for storage
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
+int
 libssh2_knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
                             struct libssh2_knownhost *known,
                             char *buffer, size_t buflen,
                             size_t *outlen,
                             int type);
+.fi
 .SH DESCRIPTION
 Converts a single known host to a single line of output for storage, using
 the 'type' output format.

--- a/docs/libssh2_poll.3
+++ b/docs/libssh2_poll.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_poll - poll for activity on a socket, channel or listener
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout);
+int
+libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout);
+.fi
 .SH DESCRIPTION
 This function is deprecated. Do note use. We encourage users to instead use
 the \fIpoll(3)\fP or \fIselect(3)\fP functions to check for socket activity or

--- a/docs/libssh2_poll_channel_read.3
+++ b/docs/libssh2_poll_channel_read.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_poll_channel_read - check if data is available
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended);
+int
+libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended);
+.fi
 .SH DESCRIPTION
 This function is deprecated. Do note use.
 

--- a/docs/libssh2_publickey_add.3
+++ b/docs/libssh2_publickey_add.3
@@ -8,7 +8,6 @@ int libssh2_publickey_add(LIBSSH2_PUBLICKEY *pkey,
                           const unsigned char *name,
                           const unsigned char *blob, unsigned long blob_len, char overwrite,
                           unsigned long num_attrs, const libssh2_publickey_attribute attrs[]);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_publickey_add_ex(3)\fP.

--- a/docs/libssh2_publickey_add.3
+++ b/docs/libssh2_publickey_add.3
@@ -2,12 +2,16 @@
 .SH NAME
 libssh2_publickey_add - convenience macro for \fIlibssh2_publickey_add_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_publickey_add(LIBSSH2_PUBLICKEY *pkey,
-                          const unsigned char *name,
-                          const unsigned char *blob, unsigned long blob_len, char overwrite,
-                          unsigned long num_attrs, const libssh2_publickey_attribute attrs[]);
+int
+libssh2_publickey_add(LIBSSH2_PUBLICKEY *pkey,
+                      const unsigned char *name,
+                      const unsigned char *blob, unsigned long blob_len,
+                      char overwrite, unsigned long num_attrs,
+                      const libssh2_publickey_attribute attrs[]);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_publickey_add_ex(3)\fP.

--- a/docs/libssh2_publickey_add_ex.3
+++ b/docs/libssh2_publickey_add_ex.3
@@ -2,14 +2,16 @@
 .SH NAME
 libssh2_publickey_add_ex - Add a public key entry
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
-                         unsigned long name_len, const unsigned char *blob,
-                         unsigned long blob_len, char overwrite,
-                         unsigned long num_attrs,
+libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
+                         const unsigned char *name, unsigned long name_len,
+                         const unsigned char *blob, unsigned long blob_len,
+                         char overwrite, unsigned long num_attrs,
                          const libssh2_publickey_attribute attrs[])
+.fi
 .SH DESCRIPTION
 TBD
 .SH RETURN VALUE

--- a/docs/libssh2_publickey_add_ex.3
+++ b/docs/libssh2_publickey_add_ex.3
@@ -10,7 +10,6 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
                          unsigned long blob_len, char overwrite,
                          unsigned long num_attrs,
                          const libssh2_publickey_attribute attrs[])
-
 .SH DESCRIPTION
 TBD
 .SH RETURN VALUE

--- a/docs/libssh2_publickey_init.3
+++ b/docs/libssh2_publickey_init.3
@@ -2,7 +2,8 @@
 .SH NAME
 libssh2_publickey_init - TODO
 .SH SYNOPSIS
-
+.nf
+.fi
 .SH DESCRIPTION
 
 .SH RETURN VALUE

--- a/docs/libssh2_publickey_list_fetch.3
+++ b/docs/libssh2_publickey_list_fetch.3
@@ -2,7 +2,8 @@
 .SH NAME
 libssh2_publickey_list_fetch - TODO
 .SH SYNOPSIS
-
+.nf
+.fi
 .SH DESCRIPTION
 
 .SH RETURN VALUE

--- a/docs/libssh2_publickey_list_free.3
+++ b/docs/libssh2_publickey_list_free.3
@@ -2,7 +2,8 @@
 .SH NAME
 libssh2_publickey_list_free - TODO
 .SH SYNOPSIS
-
+.nf
+.fi
 .SH DESCRIPTION
 
 .SH RETURN VALUE

--- a/docs/libssh2_publickey_remove.3
+++ b/docs/libssh2_publickey_remove.3
@@ -7,7 +7,6 @@ libssh2_publickey_remove - convenience macro for \fIlibssh2_publickey_remove_ex(
 int libssh2_publickey_remove(LIBSSH2_PUBLICKEY *pkey,
                              const unsigned char *name, unsigned long name_len,
                              const unsigned char *blob, unsigned long blob_len);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_publickey_remove_ex(3)\fP.

--- a/docs/libssh2_publickey_remove.3
+++ b/docs/libssh2_publickey_remove.3
@@ -2,11 +2,14 @@
 .SH NAME
 libssh2_publickey_remove - convenience macro for \fIlibssh2_publickey_remove_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_publickey_remove(LIBSSH2_PUBLICKEY *pkey,
-                             const unsigned char *name, unsigned long name_len,
-                             const unsigned char *blob, unsigned long blob_len);
+int
+libssh2_publickey_remove(LIBSSH2_PUBLICKEY *pkey,
+                         const unsigned char *name, unsigned long name_len,
+                         const unsigned char *blob, unsigned long blob_len);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_publickey_remove_ex(3)\fP.

--- a/docs/libssh2_publickey_remove_ex.3
+++ b/docs/libssh2_publickey_remove_ex.3
@@ -2,7 +2,8 @@
 .SH NAME
 libssh2_publickey_list_remove_ex - TODO
 .SH SYNOPSIS
-
+.nf
+.fi
 .SH DESCRIPTION
 
 .SH RETURN VALUE

--- a/docs/libssh2_publickey_shutdown.3
+++ b/docs/libssh2_publickey_shutdown.3
@@ -2,7 +2,8 @@
 .SH NAME
 libssh2_publickey_shutdown - TODO
 .SH SYNOPSIS
-
+.nf
+.fi
 .SH DESCRIPTION
 
 .SH RETURN VALUE

--- a/docs/libssh2_scp_recv.3
+++ b/docs/libssh2_scp_recv.3
@@ -6,7 +6,6 @@ libssh2_scp_recv - request a remote file via SCP
 
 LIBSSH2_CHANNEL *
 libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path, struct stat *sb);
-
 .SH DESCRIPTION
 This function is \fBDEPRECATED\fP. Use \fIlibssh2_scp_recv2(3)\fP
 instead!

--- a/docs/libssh2_scp_recv.3
+++ b/docs/libssh2_scp_recv.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_scp_recv - request a remote file via SCP
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
 libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path, struct stat *sb);
+.fi
 .SH DESCRIPTION
 This function is \fBDEPRECATED\fP. Use \fIlibssh2_scp_recv2(3)\fP
 instead!

--- a/docs/libssh2_scp_recv2.3
+++ b/docs/libssh2_scp_recv2.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_scp_recv2 - request a remote file via SCP
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
 libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path, struct_stat *sb);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_scp_recv2.3
+++ b/docs/libssh2_scp_recv2.3
@@ -6,7 +6,6 @@ libssh2_scp_recv2 - request a remote file via SCP
 
 LIBSSH2_CHANNEL *
 libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path, struct_stat *sb);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_scp_send.3
+++ b/docs/libssh2_scp_send.3
@@ -6,7 +6,6 @@ libssh2_scp_send - convenience macro for \fIlibssh2_scp_send_ex(3)\fP calls
 
 LIBSSH2_CHANNEL *
 libssh2_scp_send(LIBSSH2_SESSION *session, const char *path, int mode, size_t size);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_scp_send_ex(3)\fP.

--- a/docs/libssh2_scp_send.3
+++ b/docs/libssh2_scp_send.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_scp_send - convenience macro for \fIlibssh2_scp_send_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *
-libssh2_scp_send(LIBSSH2_SESSION *session, const char *path, int mode, size_t size);
+libssh2_scp_send(LIBSSH2_SESSION *session, const char *path,
+                 int mode, size_t size);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_scp_send_ex(3)\fP.

--- a/docs/libssh2_scp_send64.3
+++ b/docs/libssh2_scp_send64.3
@@ -8,6 +8,7 @@ libssh2_scp_send64 - Send a file via SCP
 LIBSSH2_CHANNEL *
 libssh2_scp_send64(LIBSSH2_SESSION *session, const char *path, int mode,
                    libssh2_uint64_t size, time_t mtime, time_t atime);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_scp_send_ex.3
+++ b/docs/libssh2_scp_send_ex.3
@@ -8,6 +8,7 @@ libssh2_scp_send_ex - Send a file via SCP
 LIBSSH2_CHANNEL *
 libssh2_scp_send_ex(LIBSSH2_SESSION *session, const char *path, int mode,
                     size_t size, long mtime, long atime);
+.fi
 .SH DESCRIPTION
 This function has been deemed deprecated since libssh2 1.2.6. See
 \fIlibssh2_scp_send64(3)\fP.

--- a/docs/libssh2_session_abstract.3
+++ b/docs/libssh2_session_abstract.3
@@ -6,7 +6,6 @@ libssh2_session_abstract - return a pointer to a session's abstract pointer
 
 void **
 libssh2_session_abstract(LIBSSH2_SESSION *session);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_abstract.3
+++ b/docs/libssh2_session_abstract.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_abstract - return a pointer to a session's abstract pointer
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 void **
 libssh2_session_abstract(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_banner_get.3
+++ b/docs/libssh2_session_banner_get.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_session_banner_get - get the remote banner
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-const char *libssh2_session_banner_get(oLIBSSH2_SESSION *session);
+const char *
+libssh2_session_banner_get(oLIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 Once the session has been setup and \fIlibssh2_session_handshake(3)\fP has
 completed successfully, this function can be used to get the server id from

--- a/docs/libssh2_session_banner_set.3
+++ b/docs/libssh2_session_banner_set.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_banner_set - set the SSH protocol banner for the local client
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_banner_set.3
+++ b/docs/libssh2_session_banner_set.3
@@ -6,7 +6,6 @@ libssh2_session_banner_set - set the SSH protocol banner for the local client
 
 int
 libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_block_directions.3
+++ b/docs/libssh2_session_block_directions.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_block_directions - get directions to wait for
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_session_block_directions(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by \fBlibssh2_session_init_ex(3)\fP
 

--- a/docs/libssh2_session_callback_set.3
+++ b/docs/libssh2_session_callback_set.3
@@ -7,6 +7,7 @@ libssh2_session_callback_set - set a callback function
 
 void *libssh2_session_callback_set(LIBSSH2_SESSION *session,
                                    int cbtype, void *callback);
+.fi
 .SH DESCRIPTION
 Sets a custom callback handler for a previously initialized session
 object. Callbacks are triggered by the receipt of special packets at the

--- a/docs/libssh2_session_callback_set.3
+++ b/docs/libssh2_session_callback_set.3
@@ -5,8 +5,9 @@ libssh2_session_callback_set - set a callback function
 .nf
 #include <libssh2.h>
 
-void *libssh2_session_callback_set(LIBSSH2_SESSION *session,
-                                   int cbtype, void *callback);
+void *
+libssh2_session_callback_set(LIBSSH2_SESSION *session,
+                             int cbtype, void *callback);
 .fi
 .SH DESCRIPTION
 Sets a custom callback handler for a previously initialized session

--- a/docs/libssh2_session_disconnect.3
+++ b/docs/libssh2_session_disconnect.3
@@ -5,7 +5,6 @@ libssh2_session_disconnect - convenience macro for \fIlibssh2_session_disconnect
 #include <libssh2.h>
 
 int libssh2_session_disconnect(LIBSSH2_SESSION *session, const char *description);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_session_disconnect_ex(3)\fP.

--- a/docs/libssh2_session_disconnect.3
+++ b/docs/libssh2_session_disconnect.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_session_disconnect - convenience macro for \fIlibssh2_session_disconnect_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_session_disconnect(LIBSSH2_SESSION *session, const char *description);
+int
+libssh2_session_disconnect(LIBSSH2_SESSION *session, const char *description);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_session_disconnect_ex(3)\fP.

--- a/docs/libssh2_session_disconnect_ex.3
+++ b/docs/libssh2_session_disconnect_ex.3
@@ -2,13 +2,18 @@
 .SH NAME
 libssh2_session_disconnect_ex - terminate transport layer
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason, const char *description, const char *lang);
+libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
+                              const char *description,
+                              const char *lang);
 
 int
-libssh2_session_disconnect(LIBSSH2_SESSION *session, const char *description);
+libssh2_session_disconnect(LIBSSH2_SESSION *session,
+                           const char *description);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_disconnect_ex.3
+++ b/docs/libssh2_session_disconnect_ex.3
@@ -9,7 +9,6 @@ libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason, const char *
 
 int
 libssh2_session_disconnect(LIBSSH2_SESSION *session, const char *description);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_flag.3
+++ b/docs/libssh2_session_flag.3
@@ -2,8 +2,12 @@
 .SH NAME
 libssh2_session_flag - TODO
 .SH SYNOPSIS
+.nf
+#include <libssh2.h>
+
 int
 libssh2_session_flag(LIBSSH2_SESSION *session, int flag, int value);
+.fi
 .SH DESCRIPTION
 Set options for the created session. \fIflag\fP is the option to set, while
 \fIvalue\fP is typically set to 1 or 0 to enable or disable the option.

--- a/docs/libssh2_session_free.3
+++ b/docs/libssh2_session_free.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_free - frees resources associated with a session instance
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_session_free(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 Frees all resources associated with a session instance. Typically called after
 .BR libssh2_session_disconnect_ex(3)

--- a/docs/libssh2_session_get_blocking.3
+++ b/docs/libssh2_session_get_blocking.3
@@ -2,7 +2,12 @@
 .SH NAME
 libssh2_session_get_blocking - TODO
 .SH SYNOPSIS
-int libssh2_session_get_blocking(LIBSSH2_SESSION *session);
+.nf
+#include <libssh2.h>
+
+int
+libssh2_session_get_blocking(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 Returns 0 if the state of the session has previously be set to non-blocking
 and it returns 1 if the state was set to blocking.

--- a/docs/libssh2_session_get_read_timeout.3
+++ b/docs/libssh2_session_get_read_timeout.3
@@ -5,7 +5,8 @@ libssh2_session_get_read_timeout - get the timeout for packet read functions
 .nf
 #include <libssh2.h>
 
-long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session);
+long
+libssh2_session_get_read_timeout(LIBSSH2_SESSION *session);
 .fi
 .SH DESCRIPTION
 Returns the \fBtimeout\fP (in seconds) for how long the ssh2 packet receive

--- a/docs/libssh2_session_get_read_timeout.3
+++ b/docs/libssh2_session_get_read_timeout.3
@@ -2,9 +2,11 @@
 .SH NAME
 libssh2_session_get_read_timeout - get the timeout for packet read functions
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
+#include <libssh2.h>
+
 long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 Returns the \fBtimeout\fP (in seconds) for how long the ssh2 packet receive
 function calls may wait until they consider the situation an error and

--- a/docs/libssh2_session_get_timeout.3
+++ b/docs/libssh2_session_get_timeout.3
@@ -5,7 +5,8 @@ libssh2_session_get_timeout - get the timeout for blocking functions
 .nf
 #include <libssh2.h>
 
-long libssh2_session_get_timeout(LIBSSH2_SESSION *session);
+long
+libssh2_session_get_timeout(LIBSSH2_SESSION *session);
 .fi
 .SH DESCRIPTION
 Returns the \fBtimeout\fP (in milliseconds) for how long a blocking the

--- a/docs/libssh2_session_get_timeout.3
+++ b/docs/libssh2_session_get_timeout.3
@@ -2,9 +2,11 @@
 .SH NAME
 libssh2_session_get_timeout - get the timeout for blocking functions
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
+#include <libssh2.h>
+
 long libssh2_session_get_timeout(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 Returns the \fBtimeout\fP (in milliseconds) for how long a blocking the
 libssh2 function calls may wait until they consider the situation an error and

--- a/docs/libssh2_session_handshake.3
+++ b/docs/libssh2_session_handshake.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_handshake - perform the SSH handshake
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_session_handshake(LIBSSH2_SESSION *session, libssh2_socket_t socket);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_hostkey.3
+++ b/docs/libssh2_session_hostkey.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_session_hostkey - get the remote key
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-const char *libssh2_session_hostkey(LIBSSH2_SESSION *session,
-                                    size_t *len, int *type);
+const char *
+libssh2_session_hostkey(LIBSSH2_SESSION *session,
+                        size_t *len, int *type);
+.fi
 .SH DESCRIPTION
 Returns a pointer to the current host key, the value \fIlen\fP points to will
 get the length of the key.

--- a/docs/libssh2_session_init.3
+++ b/docs/libssh2_session_init.3
@@ -6,7 +6,6 @@ libssh2_session_init - convenience macro for \fIlibssh2_session_init_ex(3)\fP ca
 
 LIBSSH2_SESSION *
 libssh2_session_init(void);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_session_init_ex(3)\fP.

--- a/docs/libssh2_session_init.3
+++ b/docs/libssh2_session_init.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_init - convenience macro for \fIlibssh2_session_init_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_SESSION *
 libssh2_session_init(void);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_session_init_ex(3)\fP.

--- a/docs/libssh2_session_init_ex.3
+++ b/docs/libssh2_session_init_ex.3
@@ -2,6 +2,7 @@
 .SH NAME
 libssh2_session_init_ex - initializes an SSH session object
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 LIBSSH2_SESSION *
@@ -12,6 +13,7 @@ libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC((*myalloc)),
 
 LIBSSH2_SESSION *
 libssh2_session_init(void);
+.fi
 .SH DESCRIPTION
 \fImyalloc\fP - Custom allocator function. Refer to the section on Callbacks
 for implementing an allocator callback. Pass a value of NULL to use the

--- a/docs/libssh2_session_init_ex.3
+++ b/docs/libssh2_session_init_ex.3
@@ -5,11 +5,13 @@ libssh2_session_init_ex - initializes an SSH session object
 #include <libssh2.h>
 
 LIBSSH2_SESSION *
-libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC((*myalloc)), LIBSSH2_FREE_FUNC((*myfree)), LIBSSH2_REALLOC_FUNC((*myrealloc)), void *abstract);
+libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC((*myalloc)),
+                        LIBSSH2_FREE_FUNC((*myfree)),
+                        LIBSSH2_REALLOC_FUNC((*myrealloc)),
+                        void *abstract);
 
 LIBSSH2_SESSION *
 libssh2_session_init(void);
-
 .SH DESCRIPTION
 \fImyalloc\fP - Custom allocator function. Refer to the section on Callbacks
 for implementing an allocator callback. Pass a value of NULL to use the

--- a/docs/libssh2_session_last_errno.3
+++ b/docs/libssh2_session_last_errno.3
@@ -6,7 +6,6 @@ libssh2_session_last_errno - get the most recent error number
 
 int
 libssh2_session_last_errno(LIBSSH2_SESSION *session);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_last_errno.3
+++ b/docs/libssh2_session_last_errno.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_last_errno - get the most recent error number
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_session_last_errno(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_last_error.3
+++ b/docs/libssh2_session_last_error.3
@@ -6,7 +6,6 @@ libssh2_session_last_error - get the most recent error
 
 int
 libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg, int *errmsg_len, int want_buf);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_last_error.3
+++ b/docs/libssh2_session_last_error.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_session_last_error - get the most recent error
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg, int *errmsg_len, int want_buf);
+libssh2_session_last_error(LIBSSH2_SESSION *session,
+                           char **errmsg, int *errmsg_len, int want_buf);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_method_pref.3
+++ b/docs/libssh2_session_method_pref.3
@@ -6,7 +6,6 @@ libssh2_session_method_pref - set preferred key exchange method
 
 int
 libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type, const char *prefs);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_method_pref.3
+++ b/docs/libssh2_session_method_pref.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_session_method_pref - set preferred key exchange method
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type, const char *prefs);
+libssh2_session_method_pref(LIBSSH2_SESSION *session,
+                            int method_type, const char *prefs);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_methods.3
+++ b/docs/libssh2_session_methods.3
@@ -6,7 +6,6 @@ libssh2_session_methods - return the currently active algorithms
 
 const char *
 libssh2_session_methods(LIBSSH2_SESSION *session, int method_type);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_methods.3
+++ b/docs/libssh2_session_methods.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_methods - return the currently active algorithms
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 const char *
 libssh2_session_methods(LIBSSH2_SESSION *session, int method_type);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_set_blocking.3
+++ b/docs/libssh2_session_set_blocking.3
@@ -6,7 +6,6 @@ libssh2_session_set_blocking - set or clear blocking mode on session
 
 void
 libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking);
-
 .SH DESCRIPTION
 \fIsession\fP - session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_set_blocking.3
+++ b/docs/libssh2_session_set_blocking.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_set_blocking - set or clear blocking mode on session
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 void
 libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_set_last_error.3
+++ b/docs/libssh2_session_set_last_error.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_session_set_last_error - sets the internal error state
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
-libssh2_session_set_last_error(LIBSSH2_SESSION *session, int errcode, const char *errmsg)
+libssh2_session_set_last_error(LIBSSH2_SESSION *session,
+                               int errcode, const char *errmsg)
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_set_last_error.3
+++ b/docs/libssh2_session_set_last_error.3
@@ -6,7 +6,6 @@ libssh2_session_set_last_error - sets the internal error state
 
 int
 libssh2_session_set_last_error(LIBSSH2_SESSION *session, int errcode, const char *errmsg)
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_session_set_read_timeout.3
+++ b/docs/libssh2_session_set_read_timeout.3
@@ -2,9 +2,11 @@
 .SH NAME
 libssh2_session_set_read_timeout - set timeout for packet read functions
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
+#include <libssh2.h>
+
 void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout);
+.fi
 .SH DESCRIPTION
 Set the \fBtimeout\fP in seconds for how long libssh2 packet read
 function calls may wait until they consider the situation an error and return

--- a/docs/libssh2_session_set_read_timeout.3
+++ b/docs/libssh2_session_set_read_timeout.3
@@ -5,7 +5,8 @@ libssh2_session_set_read_timeout - set timeout for packet read functions
 .nf
 #include <libssh2.h>
 
-void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout);
+void
+libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout);
 .fi
 .SH DESCRIPTION
 Set the \fBtimeout\fP in seconds for how long libssh2 packet read

--- a/docs/libssh2_session_set_timeout.3
+++ b/docs/libssh2_session_set_timeout.3
@@ -5,7 +5,8 @@ libssh2_session_set_timeout - set timeout for blocking functions
 .nf
 #include <libssh2.h>
 
-void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout);
+void
+libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout);
 .fi
 .SH DESCRIPTION
 Set the \fBtimeout\fP in milliseconds for how long a blocking the libssh2

--- a/docs/libssh2_session_set_timeout.3
+++ b/docs/libssh2_session_set_timeout.3
@@ -2,9 +2,11 @@
 .SH NAME
 libssh2_session_set_timeout - set timeout for blocking functions
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
+#include <libssh2.h>
+
 void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout);
+.fi
 .SH DESCRIPTION
 Set the \fBtimeout\fP in milliseconds for how long a blocking the libssh2
 function calls may wait until they consider the situation an error and return

--- a/docs/libssh2_session_startup.3
+++ b/docs/libssh2_session_startup.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_session_startup - begin transport layer
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_session_startup(LIBSSH2_SESSION *session, int socket);
+.fi
 .SH DESCRIPTION
 Starting in libssh2 version 1.2.8 this function is considered deprecated. Use
 \fIlibssh2_session_handshake(3)\fP instead.

--- a/docs/libssh2_session_supported_algs.3
+++ b/docs/libssh2_session_supported_algs.3
@@ -5,9 +5,10 @@ libssh2_session_supported_algs - get list of supported algorithms
 .nf
 #include <libssh2.h>
 
-int libssh2_session_supported_algs(LIBSSH2_SESSION* session,
-                                   int method_type,
-                                   const char*** algs);
+int
+libssh2_session_supported_algs(LIBSSH2_SESSION* session,
+                               int method_type,
+                               const char*** algs);
 .fi
 .SH DESCRIPTION
 \fIsession\fP - An instance of initialized LIBSSH2_SESSION (the function will
@@ -42,11 +43,11 @@ session = libssh2_session_init();
 rc = libssh2_session_supported_algs(session,
                                     LIBSSH2_METHOD_CRYPT_CS,
                                     &algorithms);
-if (rc>0) {
+if(rc > 0) {
     /* the call succeeded, do sth. with the list of algorithms
        (e.g. list them)... */
     printf("Supported symmetric algorithms:\\n");
-    for ( i=0; i<rc; i++ )
+    for(i = 0; i < rc; i++)
         printf("\\t%s\\n", algorithms[i]);
 
     /* ... and free the allocated memory when not needed anymore */
@@ -55,6 +56,7 @@ if (rc>0) {
 else {
     /* call failed, error handling */
 }
+.fi
 .SH RETURN VALUE
 On success, a number of returned algorithms (i.e a positive number will be
 returned).  In case of a failure, an error code (a negative number, see below)

--- a/docs/libssh2_session_supported_algs.3
+++ b/docs/libssh2_session_supported_algs.3
@@ -8,6 +8,7 @@ libssh2_session_supported_algs - get list of supported algorithms
 int libssh2_session_supported_algs(LIBSSH2_SESSION* session,
                                    int method_type,
                                    const char*** algs);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - An instance of initialized LIBSSH2_SESSION (the function will
 use its pointer to the memory allocation function).  \fImethod_type\fP -

--- a/docs/libssh2_sftp_close.3
+++ b/docs/libssh2_sftp_close.3
@@ -5,7 +5,6 @@ libssh2_sftp_close - convenience macro for \fIlibssh2_sftp_close_handle(3)\fP ca
 #include <libssh2.h>
 
 int libssh2_sftp_close(LIBSSH2_SFTP_HANDLE *handle);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_close_handle(3)\fP.

--- a/docs/libssh2_sftp_close.3
+++ b/docs/libssh2_sftp_close.3
@@ -2,9 +2,13 @@
 .SH NAME
 libssh2_sftp_close - convenience macro for \fIlibssh2_sftp_close_handle(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_close(LIBSSH2_SFTP_HANDLE *handle);
+int
+libssh2_sftp_close(LIBSSH2_SFTP_HANDLE *handle);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_close_handle(3)\fP.

--- a/docs/libssh2_sftp_close_handle.3
+++ b/docs/libssh2_sftp_close_handle.3
@@ -2,6 +2,7 @@
 .SH NAME
 libssh2_sftp_close_handle - close filehandle
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
@@ -13,6 +14,7 @@ libssh2_sftp_close(LIBSSH2_SFTP_HANDLE *handle);
 
 int
 libssh2_sftp_closedir(LIBSSH2_SFTP_HANDLE *handle);
+.fi
 .SH DESCRIPTION
 \fIhandle\fP - SFTP File Handle as returned by \fBlibssh2_sftp_open_ex(3)\fP
 or \fBlibssh2_sftp_opendir(3)\fP (which is a macro).

--- a/docs/libssh2_sftp_close_handle.3
+++ b/docs/libssh2_sftp_close_handle.3
@@ -13,7 +13,6 @@ libssh2_sftp_close(LIBSSH2_SFTP_HANDLE *handle);
 
 int
 libssh2_sftp_closedir(LIBSSH2_SFTP_HANDLE *handle);
-
 .SH DESCRIPTION
 \fIhandle\fP - SFTP File Handle as returned by \fBlibssh2_sftp_open_ex(3)\fP
 or \fBlibssh2_sftp_opendir(3)\fP (which is a macro).

--- a/docs/libssh2_sftp_closedir.3
+++ b/docs/libssh2_sftp_closedir.3
@@ -2,9 +2,13 @@
 .SH NAME
 libssh2_sftp_closedir - convenience macro for \fIlibssh2_sftp_close_handle(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_closedir(LIBSSH2_SFTP_HANDLE *handle)
+int
+libssh2_sftp_closedir(LIBSSH2_SFTP_HANDLE *handle)
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_close_handle(3)\fP.

--- a/docs/libssh2_sftp_closedir.3
+++ b/docs/libssh2_sftp_closedir.3
@@ -5,7 +5,6 @@ libssh2_sftp_closedir - convenience macro for \fIlibssh2_sftp_close_handle(3)\fP
 #include <libssh2.h>
 
 int libssh2_sftp_closedir(LIBSSH2_SFTP_HANDLE *handle)
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_close_handle(3)\fP.

--- a/docs/libssh2_sftp_fsetstat.3
+++ b/docs/libssh2_sftp_fsetstat.3
@@ -5,7 +5,6 @@ libssh2_sftp_fsetstat - convenience macro for \fIlibssh2_sftp_fstat_ex(3)\fP cal
 #include <libssh2.h>
 
 int libssh2_sftp_fsetstat(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_ATTRIBUTES *attrs);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_fstat_ex(3)\fP.

--- a/docs/libssh2_sftp_fsetstat.3
+++ b/docs/libssh2_sftp_fsetstat.3
@@ -2,9 +2,14 @@
 .SH NAME
 libssh2_sftp_fsetstat - convenience macro for \fIlibssh2_sftp_fstat_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_fsetstat(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_ATTRIBUTES *attrs);
+int
+libssh2_sftp_fsetstat(LIBSSH2_SFTP_HANDLE *handle,
+                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_fstat_ex(3)\fP.

--- a/docs/libssh2_sftp_fstat.3
+++ b/docs/libssh2_sftp_fstat.3
@@ -2,9 +2,14 @@
 .SH NAME
 libssh2_sftp_fstat - convenience macro for \fIlibssh2_sftp_fstat_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_fstat(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_ATTRIBUTES *attrs);
+int
+libssh2_sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
+                   LIBSSH2_SFTP_ATTRIBUTES *attrs);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_fstat_ex(3)\fP.

--- a/docs/libssh2_sftp_fstat.3
+++ b/docs/libssh2_sftp_fstat.3
@@ -5,7 +5,6 @@ libssh2_sftp_fstat - convenience macro for \fIlibssh2_sftp_fstat_ex(3)\fP calls
 #include <libssh2.h>
 
 int libssh2_sftp_fstat(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_ATTRIBUTES *attrs);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_fstat_ex(3)\fP.

--- a/docs/libssh2_sftp_get_channel.3
+++ b/docs/libssh2_sftp_get_channel.3
@@ -6,8 +6,8 @@ libssh2_sftp_get_channel - return the channel of sftp
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-.fi
 LIBSSH2_CHANNEL *libssh2_sftp_get_channel(LIBSSH2_SFTP *sftp);
+.fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_get_channel.3
+++ b/docs/libssh2_sftp_get_channel.3
@@ -6,7 +6,8 @@ libssh2_sftp_get_channel - return the channel of sftp
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-LIBSSH2_CHANNEL *libssh2_sftp_get_channel(LIBSSH2_SFTP *sftp);
+LIBSSH2_CHANNEL *
+libssh2_sftp_get_channel(LIBSSH2_SFTP *sftp);
 .fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by

--- a/docs/libssh2_sftp_init.3
+++ b/docs/libssh2_sftp_init.3
@@ -2,11 +2,13 @@
 .SH NAME
 libssh2_sftp_init - open SFTP channel for the given SSH session.
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
 LIBSSH2_SFTP *
 libssh2_sftp_init(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_sftp_init.3
+++ b/docs/libssh2_sftp_init.3
@@ -7,7 +7,6 @@ libssh2_sftp_init - open SFTP channel for the given SSH session.
 
 LIBSSH2_SFTP *
 libssh2_sftp_init(LIBSSH2_SESSION *session);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_sftp_last_error.3
+++ b/docs/libssh2_sftp_last_error.3
@@ -7,7 +7,6 @@ libssh2_sftp_last_error - return the last SFTP-specific error code
 
 unsigned long
 libssh2_sftp_last_error(LIBSSH2_SFTP *sftp);
-
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_last_error.3
+++ b/docs/libssh2_sftp_last_error.3
@@ -2,11 +2,13 @@
 .SH NAME
 libssh2_sftp_last_error - return the last SFTP-specific error code
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
 unsigned long
 libssh2_sftp_last_error(LIBSSH2_SFTP *sftp);
+.fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_lstat.3
+++ b/docs/libssh2_sftp_lstat.3
@@ -2,9 +2,14 @@
 .SH NAME
 libssh2_sftp_lstat - convenience macro for \fIlibssh2_sftp_stat_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_lstat(LIBSSH2_SFTP *sftp, const char *path, LIBSSH2_SFTP_ATTRIBUTES *attrs);
+int
+libssh2_sftp_lstat(LIBSSH2_SFTP *sftp, const char *path,
+                   LIBSSH2_SFTP_ATTRIBUTES *attrs);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_stat_ex(3)\fP.

--- a/docs/libssh2_sftp_lstat.3
+++ b/docs/libssh2_sftp_lstat.3
@@ -5,7 +5,6 @@ libssh2_sftp_lstat - convenience macro for \fIlibssh2_sftp_stat_ex(3)\fP calls
 #include <libssh2.h>
 
 int libssh2_sftp_lstat(LIBSSH2_SFTP *sftp, const char *path, LIBSSH2_SFTP_ATTRIBUTES *attrs);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_stat_ex(3)\fP.

--- a/docs/libssh2_sftp_mkdir.3
+++ b/docs/libssh2_sftp_mkdir.3
@@ -5,7 +5,6 @@ libssh2_sftp_mkdir - convenience macro for \fIlibssh2_sftp_mkdir_ex(3)\fP calls
 #include <libssh2.h>
 
 int libssh2_sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path, long mode);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_mkdir_ex(3)\fP.

--- a/docs/libssh2_sftp_mkdir.3
+++ b/docs/libssh2_sftp_mkdir.3
@@ -2,9 +2,14 @@
 .SH NAME
 libssh2_sftp_mkdir - convenience macro for \fIlibssh2_sftp_mkdir_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path, long mode);
+int
+libssh2_sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
+                   long mode);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_mkdir_ex(3)\fP.

--- a/docs/libssh2_sftp_mkdir_ex.3
+++ b/docs/libssh2_sftp_mkdir_ex.3
@@ -2,14 +2,20 @@
 .SH NAME
 libssh2_sftp_mkdir_ex - create a directory on the remote file system
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
 int
-libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp, const char *path, unsigned int path_len, long mode);
+libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
+                      const char *path, unsigned int path_len,
+                      long mode);
 
 int
-libssh2_sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path, long mode);
+libssh2_sftp_mkdir(LIBSSH2_SFTP *sftp,
+                   const char *path,
+                   long mode);
+.fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_open.3
+++ b/docs/libssh2_sftp_open.3
@@ -2,12 +2,15 @@
 .SH NAME
 libssh2_sftp_open - convenience macro for \fIlibssh2_sftp_open_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
 LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
                   unsigned long flags,
                   long mode);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_open_ex(3)\fP.

--- a/docs/libssh2_sftp_open.3
+++ b/docs/libssh2_sftp_open.3
@@ -5,8 +5,9 @@ libssh2_sftp_open - convenience macro for \fIlibssh2_sftp_open_ex(3)\fP calls
 #include <libssh2.h>
 
 LIBSSH2_SFTP_HANDLE *
-libssh2_sftp_open(LIBSSH2_SFTP *sftp, const char *path, unsigned long flags, long mode);
-
+libssh2_sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
+                  unsigned long flags,
+                  long mode);
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_open_ex(3)\fP.

--- a/docs/libssh2_sftp_open_ex.3
+++ b/docs/libssh2_sftp_open_ex.3
@@ -1,6 +1,6 @@
 .TH libssh2_sftp_open_ex 3 "1 Jun 2007" "libssh2 0.15" "libssh2 manual"
 .SH NAME
-libssh2_sftp_open - open filehandle for file on SFTP.
+libssh2_sftp_open_ex - open filehandle for file on SFTP.
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>
@@ -8,8 +8,11 @@ libssh2_sftp_open - open filehandle for file on SFTP.
 
 LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
-                     unsigned int filename_len, unsigned long flags,
-                     long mode, int open_type);
+                     unsigned int filename_len,
+                     unsigned long flags,
+                     long mode,
+                     int open_type);
+.fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by \fIlibssh2_sftp_init(3)\fP
 

--- a/docs/libssh2_sftp_opendir.3
+++ b/docs/libssh2_sftp_opendir.3
@@ -6,7 +6,6 @@ libssh2_sftp_opendir - convenience macro for \fIlibssh2_sftp_open_ex(3)\fP calls
 
 LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_opendir(LIBSSH2_SFTP *sftp, const char *path);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_open_ex(3)\fP.

--- a/docs/libssh2_sftp_opendir.3
+++ b/docs/libssh2_sftp_opendir.3
@@ -2,10 +2,13 @@
 .SH NAME
 libssh2_sftp_opendir - convenience macro for \fIlibssh2_sftp_open_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
 LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_opendir(LIBSSH2_SFTP *sftp, const char *path);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_open_ex(3)\fP.

--- a/docs/libssh2_sftp_read.3
+++ b/docs/libssh2_sftp_read.3
@@ -2,11 +2,14 @@
 .SH NAME
 libssh2_sftp_read - read data from an SFTP handle
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
 ssize_t
-libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle, char *buffer, size_t buffer_maxlen);
+libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
+                  char *buffer, size_t buffer_maxlen);
+.fi
 .SH DESCRIPTION
 \fIhandle\fP is the SFTP File Handle as returned by
 .BR libssh2_sftp_open_ex(3)

--- a/docs/libssh2_sftp_read.3
+++ b/docs/libssh2_sftp_read.3
@@ -7,7 +7,6 @@ libssh2_sftp_read - read data from an SFTP handle
 
 ssize_t
 libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle, char *buffer, size_t buffer_maxlen);
-
 .SH DESCRIPTION
 \fIhandle\fP is the SFTP File Handle as returned by
 .BR libssh2_sftp_open_ex(3)

--- a/docs/libssh2_sftp_readdir.3
+++ b/docs/libssh2_sftp_readdir.3
@@ -5,7 +5,6 @@ libssh2_sftp_readdir - convenience macro for \fIlibssh2_sftp_readdir_ex(3)\fP ca
 #include <libssh2.h>
 
 int libssh2_sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer, size_t buffer_maxlen, LIBSSH2_SFTP_ATTRIBUTES *attrs);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_readdir_ex(3)\fP.

--- a/docs/libssh2_sftp_readdir.3
+++ b/docs/libssh2_sftp_readdir.3
@@ -2,9 +2,15 @@
 .SH NAME
 libssh2_sftp_readdir - convenience macro for \fIlibssh2_sftp_readdir_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer, size_t buffer_maxlen, LIBSSH2_SFTP_ATTRIBUTES *attrs);
+int
+libssh2_sftp_readdir(LIBSSH2_SFTP_HANDLE *handle,
+                     char *buffer, size_t buffer_maxlen,
+                     LIBSSH2_SFTP_ATTRIBUTES *attrs);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_readdir_ex(3)\fP.

--- a/docs/libssh2_sftp_readdir_ex.3
+++ b/docs/libssh2_sftp_readdir_ex.3
@@ -11,6 +11,7 @@ libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle,
                         char *buffer, size_t buffer_maxlen,
                         char *longentry, size_t longentry_maxlen,
                         LIBSSH2_SFTP_ATTRIBUTES *attrs);
+.fi
 .SH DESCRIPTION
 Reads a block of data from a LIBSSH2_SFTP_HANDLE and returns file entry
 information for the next entry, if any.

--- a/docs/libssh2_sftp_readlink.3
+++ b/docs/libssh2_sftp_readlink.3
@@ -4,10 +4,12 @@ libssh2_sftp_readlink - convenience macro for \fIlibssh2_sftp_symlink_ex(3)\fP
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \\
-    libssh2_sftp_symlink_ex((sftp), (path), strlen(path), (target), (maxlen), \\
-    LIBSSH2_SFTP_READLINK)
+    libssh2_sftp_symlink_ex((sftp), (path), strlen(path), \\
+                            (target), (maxlen), \\
+                            LIBSSH2_SFTP_READLINK)
 .fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the

--- a/docs/libssh2_sftp_readlink.3
+++ b/docs/libssh2_sftp_readlink.3
@@ -8,6 +8,7 @@ libssh2_sftp_readlink - convenience macro for \fIlibssh2_sftp_symlink_ex(3)\fP
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \\
     libssh2_sftp_symlink_ex((sftp), (path), strlen(path), (target), (maxlen), \\
     LIBSSH2_SFTP_READLINK)
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_symlink_ex(3)\fP.

--- a/docs/libssh2_sftp_realpath.3
+++ b/docs/libssh2_sftp_realpath.3
@@ -4,6 +4,7 @@ libssh2_sftp_realpath - convenience macro for \fIlibssh2_sftp_symlink_ex(3)\fP
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \\
     libssh2_sftp_symlink_ex((sftp), \\

--- a/docs/libssh2_sftp_realpath.3
+++ b/docs/libssh2_sftp_realpath.3
@@ -6,8 +6,11 @@ libssh2_sftp_realpath - convenience macro for \fIlibssh2_sftp_symlink_ex(3)\fP
 #include <libssh2.h>
 
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \\
-  libssh2_sftp_symlink_ex((sftp), (path), strlen(path), (target), (maxlen), \\
-                          LIBSSH2_SFTP_REALPATH)
+    libssh2_sftp_symlink_ex((sftp), \\
+                            (path), strlen(path), \\
+                            (target), (maxlen), \\
+                            LIBSSH2_SFTP_REALPATH)
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_symlink_ex(3)\fP.

--- a/docs/libssh2_sftp_rename.3
+++ b/docs/libssh2_sftp_rename.3
@@ -2,9 +2,15 @@
 .SH NAME
 libssh2_sftp_rename - convenience macro for \fIlibssh2_sftp_rename_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename, const char *destination_filename);
+int
+libssh2_sftp_rename(LIBSSH2_SFTP *sftp,
+                    const char *source_filename,
+                    const char *destination_filename);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_rename_ex(3)\fP.

--- a/docs/libssh2_sftp_rename.3
+++ b/docs/libssh2_sftp_rename.3
@@ -5,7 +5,6 @@ libssh2_sftp_rename - convenience macro for \fIlibssh2_sftp_rename_ex(3)\fP call
 #include <libssh2.h>
 
 int libssh2_sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename, const char *destination_filename);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_rename_ex(3)\fP.

--- a/docs/libssh2_sftp_rename_ex.3
+++ b/docs/libssh2_sftp_rename_ex.3
@@ -2,14 +2,23 @@
 .SH NAME
 libssh2_sftp_rename_ex - rename an SFTP file
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
 int
-libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp, const char *source_filename, unsigned int source_filename_len, const char *dest_filename, unsigned int dest_filename_len, long flags);
+libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
+                       const char *source_filename,
+                       unsigned int source_filename_len,
+                       const char *dest_filename,
+                       unsigned int dest_filename_len,
+                       long flags);
 
 int
-libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp, const char *source_filename, const char *dest_filename);
+libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
+                       const char *source_filename,
+                       const char *dest_filename);
+.fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_rename_ex.3
+++ b/docs/libssh2_sftp_rename_ex.3
@@ -10,7 +10,6 @@ libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp, const char *source_filename, unsigned
 
 int
 libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp, const char *source_filename, const char *dest_filename);
-
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_rewind.3
+++ b/docs/libssh2_sftp_rewind.3
@@ -2,9 +2,13 @@
 .SH NAME
 libssh2_sftp_rewind - convenience macro for \fIlibssh2_sftp_seek64(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_rewind(LIBSSH2_SFTP_HANDLE *handle);
+int
+libssh2_sftp_rewind(LIBSSH2_SFTP_HANDLE *handle);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_seek64(3)\fP.

--- a/docs/libssh2_sftp_rewind.3
+++ b/docs/libssh2_sftp_rewind.3
@@ -5,7 +5,6 @@ libssh2_sftp_rewind - convenience macro for \fIlibssh2_sftp_seek64(3)\fP calls
 #include <libssh2.h>
 
 int libssh2_sftp_rewind(LIBSSH2_SFTP_HANDLE *handle);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_seek64(3)\fP.

--- a/docs/libssh2_sftp_rmdir.3
+++ b/docs/libssh2_sftp_rmdir.3
@@ -7,6 +7,7 @@ libssh2_sftp_rmdir - convenience macro for \fIlibssh2_sftp_rmdir_ex(3)\fP
 
 #define libssh2_sftp_rmdir(sftp, path) \\
     libssh2_sftp_rmdir_ex((sftp), (path), strlen(path))
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_rmdir_ex(3)\fP.

--- a/docs/libssh2_sftp_rmdir.3
+++ b/docs/libssh2_sftp_rmdir.3
@@ -4,6 +4,7 @@ libssh2_sftp_rmdir - convenience macro for \fIlibssh2_sftp_rmdir_ex(3)\fP
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
 #define libssh2_sftp_rmdir(sftp, path) \\
     libssh2_sftp_rmdir_ex((sftp), (path), strlen(path))

--- a/docs/libssh2_sftp_rmdir_ex.3
+++ b/docs/libssh2_sftp_rmdir_ex.3
@@ -6,8 +6,9 @@ libssh2_sftp_rmdir_ex - remove an SFTP directory
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp, const char *path,
-                          unsigned int path_len);
+int
+libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp, const char *path,
+                      unsigned int path_len);
 .fi
 .SH DESCRIPTION
 Remove a directory from the remote file system.

--- a/docs/libssh2_sftp_rmdir_ex.3
+++ b/docs/libssh2_sftp_rmdir_ex.3
@@ -8,6 +8,7 @@ libssh2_sftp_rmdir_ex - remove an SFTP directory
 
 int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp, const char *path,
                           unsigned int path_len);
+.fi
 .SH DESCRIPTION
 Remove a directory from the remote file system.
 

--- a/docs/libssh2_sftp_seek.3
+++ b/docs/libssh2_sftp_seek.3
@@ -7,6 +7,7 @@ libssh2_sftp_seek - set the read/write position indicator within a file
 #include <libssh2_sftp.h>
 
 void libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset);
+.fi
 .SH DESCRIPTION
 Deprecated function. Use \fIlibssh2_sftp_seek64(3)\fP instead!
 

--- a/docs/libssh2_sftp_seek.3
+++ b/docs/libssh2_sftp_seek.3
@@ -6,7 +6,9 @@ libssh2_sftp_seek - set the read/write position indicator within a file
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-void libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset);
+void
+libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle,
+                  size_t offset);
 .fi
 .SH DESCRIPTION
 Deprecated function. Use \fIlibssh2_sftp_seek64(3)\fP instead!

--- a/docs/libssh2_sftp_seek64.3
+++ b/docs/libssh2_sftp_seek64.3
@@ -6,8 +6,9 @@ libssh2_sftp_seek64 - set the read/write position within a file
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle,
-                         libssh2_uint64_t offset);
+void
+libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle,
+                    libssh2_uint64_t offset);
 .fi
 .SH DESCRIPTION
 \fIhandle\fP - SFTP File Handle as returned by

--- a/docs/libssh2_sftp_seek64.3
+++ b/docs/libssh2_sftp_seek64.3
@@ -8,6 +8,7 @@ libssh2_sftp_seek64 - set the read/write position within a file
 
 void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle,
                          libssh2_uint64_t offset);
+.fi
 .SH DESCRIPTION
 \fIhandle\fP - SFTP File Handle as returned by
 .BR libssh2_sftp_open_ex(3)

--- a/docs/libssh2_sftp_setstat.3
+++ b/docs/libssh2_sftp_setstat.3
@@ -2,9 +2,14 @@
 .SH NAME
 libssh2_sftp_setstat - convenience macro for \fIlibssh2_sftp_stat_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_setstat(LIBSSH2_SFTP *sftp, const char *path, LIBSSH2_SFTP_ATTRIBUTES *attr);
+int
+libssh2_sftp_setstat(LIBSSH2_SFTP *sftp, const char *path,
+                     LIBSSH2_SFTP_ATTRIBUTES *attr);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_stat_ex(3)\fP.

--- a/docs/libssh2_sftp_setstat.3
+++ b/docs/libssh2_sftp_setstat.3
@@ -5,7 +5,6 @@ libssh2_sftp_setstat - convenience macro for \fIlibssh2_sftp_stat_ex(3)\fP calls
 #include <libssh2.h>
 
 int libssh2_sftp_setstat(LIBSSH2_SFTP *sftp, const char *path, LIBSSH2_SFTP_ATTRIBUTES *attr);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_stat_ex(3)\fP.

--- a/docs/libssh2_sftp_shutdown.3
+++ b/docs/libssh2_sftp_shutdown.3
@@ -7,7 +7,6 @@ libssh2_sftp_shutdown - shut down an SFTP session
 
 int
 libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp);
-
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_shutdown.3
+++ b/docs/libssh2_sftp_shutdown.3
@@ -2,11 +2,13 @@
 .SH NAME
 libssh2_sftp_shutdown - shut down an SFTP session
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
 int
 libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp);
+.fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_stat.3
+++ b/docs/libssh2_sftp_stat.3
@@ -2,9 +2,14 @@
 .SH NAME
 libssh2_sftp_stat - convenience macro for \fIlibssh2_sftp_fstat_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_stat(LIBSSH2_SFTP *sftp, const char *path, LIBSSH2_SFTP_ATTRIBUTES *attrs);
+int
+libssh2_sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
+                  LIBSSH2_SFTP_ATTRIBUTES *attrs);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_fstat_ex(3)\fP.

--- a/docs/libssh2_sftp_stat.3
+++ b/docs/libssh2_sftp_stat.3
@@ -5,7 +5,6 @@ libssh2_sftp_stat - convenience macro for \fIlibssh2_sftp_fstat_ex(3)\fP calls
 #include <libssh2.h>
 
 int libssh2_sftp_stat(LIBSSH2_SFTP *sftp, const char *path, LIBSSH2_SFTP_ATTRIBUTES *attrs);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_fstat_ex(3)\fP.

--- a/docs/libssh2_sftp_stat_ex.3
+++ b/docs/libssh2_sftp_stat_ex.3
@@ -6,9 +6,10 @@ libssh2_sftp_stat_ex - get status about an SFTP file
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp, const char *path,
-                         unsigned int path_len, int stat_type,
-                         LIBSSH2_SFTP_ATTRIBUTES *attrs);
+int
+libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp, const char *path,
+                     unsigned int path_len, int stat_type,
+                     LIBSSH2_SFTP_ATTRIBUTES *attrs);
 .fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by

--- a/docs/libssh2_sftp_stat_ex.3
+++ b/docs/libssh2_sftp_stat_ex.3
@@ -9,6 +9,7 @@ libssh2_sftp_stat_ex - get status about an SFTP file
 int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp, const char *path,
                          unsigned int path_len, int stat_type,
                          LIBSSH2_SFTP_ATTRIBUTES *attrs);
+.fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_symlink.3
+++ b/docs/libssh2_sftp_symlink.3
@@ -4,6 +4,7 @@ libssh2_sftp_symlink - convenience macro for \fIlibssh2_sftp_symlink_ex(3)\fP
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \\
     libssh2_sftp_symlink_ex((sftp), (orig), strlen(orig), (linkpath), \\

--- a/docs/libssh2_sftp_symlink.3
+++ b/docs/libssh2_sftp_symlink.3
@@ -8,6 +8,7 @@ libssh2_sftp_symlink - convenience macro for \fIlibssh2_sftp_symlink_ex(3)\fP
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \\
     libssh2_sftp_symlink_ex((sftp), (orig), strlen(orig), (linkpath), \\
                             strlen(linkpath), LIBSSH2_SFTP_SYMLINK)
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_symlink_ex(3)\fP.

--- a/docs/libssh2_sftp_symlink_ex.3
+++ b/docs/libssh2_sftp_symlink_ex.3
@@ -10,6 +10,7 @@ int
 libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp, const char *path,
                         unsigned int path_len, char *target,
                         unsigned int target_len, int link_type);
+.fi
 .SH DESCRIPTION
 Create a symlink or read out symlink information from the remote side.
 

--- a/docs/libssh2_sftp_tell.3
+++ b/docs/libssh2_sftp_tell.3
@@ -7,7 +7,6 @@ libssh2_sftp_tell - get the current read/write position indicator for a file
 
 size_t
 libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle);
-
 .SH DESCRIPTION
 \fIhandle\fP - SFTP File Handle as returned by \fBlibssh2_sftp_open_ex(3)\fP.
 

--- a/docs/libssh2_sftp_tell.3
+++ b/docs/libssh2_sftp_tell.3
@@ -2,11 +2,13 @@
 .SH NAME
 libssh2_sftp_tell - get the current read/write position indicator for a file
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
 size_t
 libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle);
+.fi
 .SH DESCRIPTION
 \fIhandle\fP - SFTP File Handle as returned by \fBlibssh2_sftp_open_ex(3)\fP.
 

--- a/docs/libssh2_sftp_tell64.3
+++ b/docs/libssh2_sftp_tell64.3
@@ -2,11 +2,13 @@
 .SH NAME
 libssh2_sftp_tell64 - get the current read/write position indicator for a file
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
 libssh2_uint64_t
 libssh2_sftp_tell64(LIBSSH2_SFTP_HANDLE *handle);
+.fi
 .SH DESCRIPTION
 \fIhandle\fP - SFTP File Handle as returned by \fBlibssh2_sftp_open_ex(3)\fP
 

--- a/docs/libssh2_sftp_tell64.3
+++ b/docs/libssh2_sftp_tell64.3
@@ -7,7 +7,6 @@ libssh2_sftp_tell64 - get the current read/write position indicator for a file
 
 libssh2_uint64_t
 libssh2_sftp_tell64(LIBSSH2_SFTP_HANDLE *handle);
-
 .SH DESCRIPTION
 \fIhandle\fP - SFTP File Handle as returned by \fBlibssh2_sftp_open_ex(3)\fP
 

--- a/docs/libssh2_sftp_unlink.3
+++ b/docs/libssh2_sftp_unlink.3
@@ -2,9 +2,13 @@
 .SH NAME
 libssh2_sftp_unlink - convenience macro for \fIlibssh2_sftp_unlink_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
+#include <libssh2_sftp.h>
 
-int libssh2_sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename);
+int
+libssh2_sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_unlink_ex(3)\fP.

--- a/docs/libssh2_sftp_unlink.3
+++ b/docs/libssh2_sftp_unlink.3
@@ -5,7 +5,6 @@ libssh2_sftp_unlink - convenience macro for \fIlibssh2_sftp_unlink_ex(3)\fP call
 #include <libssh2.h>
 
 int libssh2_sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename);
-
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_sftp_unlink_ex(3)\fP.

--- a/docs/libssh2_sftp_unlink_ex.3
+++ b/docs/libssh2_sftp_unlink_ex.3
@@ -2,6 +2,7 @@
 .SH NAME
 libssh2_sftp_unlink_ex - unlink an SFTP file
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
@@ -10,6 +11,7 @@ libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp, const char *filename, unsigned int fi
 
 int
 libssh2_sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename);
+.fi
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_unlink_ex.3
+++ b/docs/libssh2_sftp_unlink_ex.3
@@ -10,7 +10,6 @@ libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp, const char *filename, unsigned int fi
 
 int
 libssh2_sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename);
-
 .SH DESCRIPTION
 \fIsftp\fP - SFTP instance as returned by
 .BR libssh2_sftp_init(3)

--- a/docs/libssh2_sftp_write.3
+++ b/docs/libssh2_sftp_write.3
@@ -6,9 +6,10 @@ libssh2_sftp_write - write SFTP data
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-ssize_t libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle,
-                           const char *buffer,
-                           size_t count);
+ssize_t
+libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle,
+                   const char *buffer,
+                   size_t count);
 .fi
 .SH DESCRIPTION
 \fBlibssh2_sftp_write(3)\fP writes a block of data to the SFTP server. This

--- a/docs/libssh2_sftp_write.3
+++ b/docs/libssh2_sftp_write.3
@@ -9,6 +9,7 @@ libssh2_sftp_write - write SFTP data
 ssize_t libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle,
                            const char *buffer,
                            size_t count);
+.fi
 .SH DESCRIPTION
 \fBlibssh2_sftp_write(3)\fP writes a block of data to the SFTP server. This
 method is modeled after the POSIX write() function and uses the same calling

--- a/docs/libssh2_sign_sk.3
+++ b/docs/libssh2_sign_sk.3
@@ -2,8 +2,9 @@
 .SH NAME
 libssh2_sign_sk - Create a signature from a FIDO2 authenticator.
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
+#include <libssh2.h>
+
 int
 libssh2_sign_sk(LIBSSH2_SESSION *session,
                 unsigned char **sig,

--- a/docs/libssh2_sign_sk.3
+++ b/docs/libssh2_sign_sk.3
@@ -4,12 +4,13 @@ libssh2_sign_sk - Create a signature from a FIDO2 authenticator.
 .SH SYNOPSIS
 #include <libssh2.h>
 .nf
-int libssh2_sign_sk(LIBSSH2_SESSION *session,
-                    unsigned char **sig,
-                    size_t *sig_len,
-                    const unsigned char *data,
-                    size_t data_len,
-                    void **abstract);
+int
+libssh2_sign_sk(LIBSSH2_SESSION *session,
+                unsigned char **sig,
+                size_t *sig_len,
+                const unsigned char *data,
+                size_t data_len,
+                void **abstract);
 
 typedef struct _LIBSSH2_PRIVKEY_SK {
     int algorithm;

--- a/docs/libssh2_sign_sk.3
+++ b/docs/libssh2_sign_sk.3
@@ -20,7 +20,7 @@ typedef struct _LIBSSH2_PRIVKEY_SK {
     LIBSSH2_USERAUTH_SK_SIGN_FUNC((*sign_callback));
     void **orig_abstract;
 } LIBSSH2_PRIVKEY_SK;
-
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_trace.3
+++ b/docs/libssh2_trace.3
@@ -2,9 +2,12 @@
 .SH NAME
 libssh2_trace - enable debug info from inside libssh2
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-void libssh2_trace(LIBSSH2_SESSION *session, int bitmask);
+void
+libssh2_trace(LIBSSH2_SESSION *session, int bitmask);
+.fi
 .SH DESCRIPTION
 This is a function present in the library that can be used to get debug info
 from within libssh2 when it is running. Helpful when trying to trace or debug

--- a/docs/libssh2_trace.3
+++ b/docs/libssh2_trace.3
@@ -5,7 +5,6 @@ libssh2_trace - enable debug info from inside libssh2
 #include <libssh2.h>
 
 void libssh2_trace(LIBSSH2_SESSION *session, int bitmask);
-
 .SH DESCRIPTION
 This is a function present in the library that can be used to get debug info
 from within libssh2 when it is running. Helpful when trying to trace or debug

--- a/docs/libssh2_trace_sethandler.3
+++ b/docs/libssh2_trace_sethandler.3
@@ -10,9 +10,10 @@ typedef void (*libssh2_trace_handler_func)(LIBSSH2_SESSION *session,
                                            const char *data,
                                            size_t length);
 
-int libssh2_trace_sethandler(LIBSSH2_SESSION *session,
-                             void* context,
-                             libssh2_trace_handler_func callback);
+int
+libssh2_trace_sethandler(LIBSSH2_SESSION *session,
+                         void* context,
+                         libssh2_trace_handler_func callback);
 .fi
 .SH DESCRIPTION
 libssh2_trace_sethandler installs a trace output handler for your application.

--- a/docs/libssh2_trace_sethandler.3
+++ b/docs/libssh2_trace_sethandler.3
@@ -13,6 +13,7 @@ typedef void (*libssh2_trace_handler_func)(LIBSSH2_SESSION *session,
 int libssh2_trace_sethandler(LIBSSH2_SESSION *session,
                              void* context,
                              libssh2_trace_handler_func callback);
+.fi
 .SH DESCRIPTION
 libssh2_trace_sethandler installs a trace output handler for your application.
 By default, when tracing has been switched on via a call to libssh2_trace(),

--- a/docs/libssh2_userauth_authenticated.3
+++ b/docs/libssh2_userauth_authenticated.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_userauth_authenticated - return authentication status
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
 libssh2_userauth_authenticated(LIBSSH2_SESSION *session);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_userauth_authenticated.3
+++ b/docs/libssh2_userauth_authenticated.3
@@ -6,7 +6,6 @@ libssh2_userauth_authenticated - return authentication status
 
 int
 libssh2_userauth_authenticated(LIBSSH2_SESSION *session);
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_userauth_banner.3
+++ b/docs/libssh2_userauth_banner.3
@@ -7,6 +7,7 @@ libssh2_userauth_banner - get the server's userauth banner message
 
 int
 libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_userauth_hostbased_fromfile.3
+++ b/docs/libssh2_userauth_hostbased_fromfile.3
@@ -4,8 +4,12 @@ libssh2_userauth_hostbased_fromfile - convenience macro for \fIlibssh2_userauth_
 .SH SYNOPSIS
 #include <libssh2.h>
 
-int libssh2_userauth_hostbased_fromfile(LIBSSH2_SESSION *session, const char *username, const char *publickey, const char *privatekey, const char *passphrase, const char *hostname);
-
+int libssh2_userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
+                                        const char *username,
+                                        const char *publickey,
+                                        const char *privatekey,
+                                        const char *passphrase,
+                                        const char *hostname);
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_userauth_hostbased_fromfile_ex(3)\fP.

--- a/docs/libssh2_userauth_hostbased_fromfile.3
+++ b/docs/libssh2_userauth_hostbased_fromfile.3
@@ -2,14 +2,17 @@
 .SH NAME
 libssh2_userauth_hostbased_fromfile - convenience macro for \fIlibssh2_userauth_hostbased_fromfile_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-int libssh2_userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
-                                        const char *username,
-                                        const char *publickey,
-                                        const char *privatekey,
-                                        const char *passphrase,
-                                        const char *hostname);
+int
+libssh2_userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
+                                    const char *username,
+                                    const char *publickey,
+                                    const char *privatekey,
+                                    const char *passphrase,
+                                    const char *hostname);
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_userauth_hostbased_fromfile_ex(3)\fP.

--- a/docs/libssh2_userauth_hostbased_fromfile_ex.3
+++ b/docs/libssh2_userauth_hostbased_fromfile_ex.3
@@ -2,7 +2,8 @@
 .SH NAME
 libssh2_userauth_hostbased_fromfile_ex - TODO
 .SH SYNOPSIS
-
+.nf
+.fi
 .SH DESCRIPTION
 
 .SH RETURN VALUE

--- a/docs/libssh2_userauth_keyboard_interactive.3
+++ b/docs/libssh2_userauth_keyboard_interactive.3
@@ -4,11 +4,11 @@ libssh2_userauth_keyboard_interactive - convenience macro for \fIlibssh2_useraut
 .SH SYNOPSIS
 #include <libssh2.h>
 .nf
-
 int
 libssh2_userauth_keyboard_interactive(LIBSSH2_SESSION* session,
                                       const char *username,
            LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC((*response_callback)));
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_userauth_keyboard_interactive_ex(3)\fP.

--- a/docs/libssh2_userauth_keyboard_interactive.3
+++ b/docs/libssh2_userauth_keyboard_interactive.3
@@ -2,12 +2,13 @@
 .SH NAME
 libssh2_userauth_keyboard_interactive - convenience macro for \fIlibssh2_userauth_keyboard_interactive_ex(3)\fP calls
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
+#include <libssh2.h>
+
 int
 libssh2_userauth_keyboard_interactive(LIBSSH2_SESSION* session,
                                       const char *username,
-           LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC((*response_callback)));
+                 LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC((*response_callback)));
 .fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the

--- a/docs/libssh2_userauth_keyboard_interactive_ex.3
+++ b/docs/libssh2_userauth_keyboard_interactive_ex.3
@@ -10,7 +10,7 @@ int
 libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION *session,
                                          const char *username,
                                          unsigned int username_len,
-            LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback));
+                   LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback));
 .fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
@@ -29,13 +29,13 @@ control. Responses will be sent to the host. String values will be free(3)ed
 by the library. The callback prototype must match this:
 
 .nf
- void response(const char *name,
-               int name_len, const char *instruction,
-               int instruction_len,
-               int num_prompts,
-               const LIBSSH2_USERAUTH_KBDINT_PROMPT *prompts,
-               LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses,
-               void **abstract);
+void response(const char *name,
+              int name_len, const char *instruction,
+              int instruction_len,
+              int num_prompts,
+              const LIBSSH2_USERAUTH_KBDINT_PROMPT *prompts,
+              LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses,
+              void **abstract);
 .fi
 
 Attempts keyboard-interactive (challenge/response) authentication.

--- a/docs/libssh2_userauth_keyboard_interactive_ex.3
+++ b/docs/libssh2_userauth_keyboard_interactive_ex.3
@@ -11,6 +11,7 @@ libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION *session,
                                          const char *username,
                                          unsigned int username_len,
             LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback));
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 \fIlibssh2_session_init_ex(3)\fP.

--- a/docs/libssh2_userauth_list.3
+++ b/docs/libssh2_userauth_list.3
@@ -8,6 +8,7 @@ libssh2_userauth_list - list supported authentication methods
 char *
 libssh2_userauth_list(LIBSSH2_SESSION *session, const char *username,
                       unsigned int username_len);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_userauth_list.3
+++ b/docs/libssh2_userauth_list.3
@@ -6,7 +6,8 @@ libssh2_userauth_list - list supported authentication methods
 #include <libssh2.h>
 
 char *
-libssh2_userauth_list(LIBSSH2_SESSION *session, const char *username,
+libssh2_userauth_list(LIBSSH2_SESSION *session,
+                      const char *username,
                       unsigned int username_len);
 .fi
 .SH DESCRIPTION

--- a/docs/libssh2_userauth_password.3
+++ b/docs/libssh2_userauth_password.3
@@ -2,12 +2,13 @@
 .SH NAME
 libssh2_userauth_password - convenience macro for \fIlibssh2_userauth_password_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int libssh2_userauth_password(LIBSSH2_SESSION *session,
                               const char *username,
                               const char *password);
-
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_userauth_password_ex(3)\fP.

--- a/docs/libssh2_userauth_password.3
+++ b/docs/libssh2_userauth_password.3
@@ -5,9 +5,10 @@ libssh2_userauth_password - convenience macro for \fIlibssh2_userauth_password_e
 .nf
 #include <libssh2.h>
 
-int libssh2_userauth_password(LIBSSH2_SESSION *session,
-                              const char *username,
-                              const char *password);
+int
+libssh2_userauth_password(LIBSSH2_SESSION *session,
+                          const char *username,
+                          const char *password);
 .fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the

--- a/docs/libssh2_userauth_password_ex.3
+++ b/docs/libssh2_userauth_password_ex.3
@@ -5,16 +5,17 @@ libssh2_userauth_password_ex - authenticate a session with username and password
 #include <libssh2.h>
 .nf
 int libssh2_userauth_password_ex(LIBSSH2_SESSION *session,
-                    const char *username,
-                    unsigned int username_len,
-                    const char *password,
-                    unsigned int password_len,
-                    LIBSSH2_PASSWD_CHANGEREQ_FUNC((*passwd_change_cb)));
+                                 const char *username,
+                                 unsigned int username_len,
+                                 const char *password,
+                                 unsigned int password_len,
+                 LIBSSH2_PASSWD_CHANGEREQ_FUNC((*passwd_change_cb)));
 
 #define libssh2_userauth_password(session, username, password) \\
  libssh2_userauth_password_ex((session), (username), \\
                               strlen(username), \\
                               (password), strlen(password), NULL)
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_userauth_password_ex.3
+++ b/docs/libssh2_userauth_password_ex.3
@@ -2,19 +2,21 @@
 .SH NAME
 libssh2_userauth_password_ex - authenticate a session with username and password
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
-int libssh2_userauth_password_ex(LIBSSH2_SESSION *session,
-                                 const char *username,
-                                 unsigned int username_len,
-                                 const char *password,
-                                 unsigned int password_len,
-                 LIBSSH2_PASSWD_CHANGEREQ_FUNC((*passwd_change_cb)));
+#include <libssh2.h>
+
+int
+libssh2_userauth_password_ex(LIBSSH2_SESSION *session,
+                             const char *username,
+                             unsigned int username_len,
+                             const char *password,
+                             unsigned int password_len,
+                           LIBSSH2_PASSWD_CHANGEREQ_FUNC((*passwd_change_cb)));
 
 #define libssh2_userauth_password(session, username, password) \\
- libssh2_userauth_password_ex((session), (username), \\
-                              strlen(username), \\
-                              (password), strlen(password), NULL)
+     libssh2_userauth_password_ex((session), (username), \\
+                                  strlen(username), \\
+                                  (password), strlen(password), NULL)
 .fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by

--- a/docs/libssh2_userauth_publickey.3
+++ b/docs/libssh2_userauth_publickey.3
@@ -5,12 +5,13 @@ libssh2_userauth_publickey - authenticate using a callback function
 .nf
 #include <libssh2.h>
 
-int libssh2_userauth_publickey(LIBSSH2_SESSION *session,
-                               const char *user,
-                               const unsigned char *pubkeydata,
-                               size_t pubkeydata_len,
-                               sign_callback,
-                               void **abstract);
+int
+libssh2_userauth_publickey(LIBSSH2_SESSION *session,
+                           const char *user,
+                           const unsigned char *pubkeydata,
+                           size_t pubkeydata_len,
+                           sign_callback,
+                           void **abstract);
 .fi
 .SH DESCRIPTION
 Authenticate with the \fIsign_callback\fP callback that matches the prototype

--- a/docs/libssh2_userauth_publickey.3
+++ b/docs/libssh2_userauth_publickey.3
@@ -2,15 +2,16 @@
 .SH NAME
 libssh2_userauth_publickey - authenticate using a callback function
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-.nf
 int libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                                const char *user,
                                const unsigned char *pubkeydata,
                                size_t pubkeydata_len,
                                sign_callback,
                                void **abstract);
+.fi
 .SH DESCRIPTION
 Authenticate with the \fIsign_callback\fP callback that matches the prototype
 below

--- a/docs/libssh2_userauth_publickey_fromfile.3
+++ b/docs/libssh2_userauth_publickey_fromfile.3
@@ -2,6 +2,7 @@
 .SH NAME
 libssh2_userauth_publickey_fromfile - convenience macro for \fIlibssh2_userauth_publickey_fromfile_ex(3)\fP calls
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 int
@@ -10,7 +11,7 @@ libssh2_userauth_publickey_fromfile(LIBSSH2_SESSION *session,
                                     const char *publickey,
                                     const char *privatekey,
                                     const char *passphrase);
-
+.fi
 .SH DESCRIPTION
 This is a macro defined in a public libssh2 header file that is using the
 underlying function \fIlibssh2_userauth_publickey_fromfile_ex(3)\fP.

--- a/docs/libssh2_userauth_publickey_fromfile_ex.3
+++ b/docs/libssh2_userauth_publickey_fromfile_ex.3
@@ -1,6 +1,6 @@
-.TH libssh2_userauth_publickey_fromfile 3 "1 Jun 2007" "libssh2 0.15" "libssh2 manual"
+.TH libssh2_userauth_publickey_fromfile_ex 3 "1 Jun 2007" "libssh2 0.15" "libssh2 manual"
 .SH NAME
-libssh2_userauth_publickey_fromfile - authenticate a session with a public key, read from a file
+libssh2_userauth_publickey_fromfile_ex - authenticate a session with a public key, read from a file
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>

--- a/docs/libssh2_userauth_publickey_fromfile_ex.3
+++ b/docs/libssh2_userauth_publickey_fromfile_ex.3
@@ -5,12 +5,13 @@ libssh2_userauth_publickey_fromfile - authenticate a session with a public key, 
 .nf
 #include <libssh2.h>
 
-int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
-                                           const char *username,
-                                           unsigned int ousername_len,
-                                           const char *publickey,
-                                           const char *privatekey,
-                                           const char *passphrase);
+int
+libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
+                                       const char *username,
+                                       unsigned int ousername_len,
+                                       const char *publickey,
+                                       const char *privatekey,
+                                       const char *passphrase);
 .fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by

--- a/docs/libssh2_userauth_publickey_fromfile_ex.3
+++ b/docs/libssh2_userauth_publickey_fromfile_ex.3
@@ -2,15 +2,16 @@
 .SH NAME
 libssh2_userauth_publickey_fromfile - authenticate a session with a public key, read from a file
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-.nf
 int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
                                            const char *username,
                                            unsigned int ousername_len,
                                            const char *publickey,
                                            const char *privatekey,
                                            const char *passphrase);
+.fi
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 \fBlibssh2_session_init_ex(3)\fP

--- a/docs/libssh2_userauth_publickey_frommemory.3
+++ b/docs/libssh2_userauth_publickey_frommemory.3
@@ -2,17 +2,18 @@
 .SH NAME
 libssh2_userauth_publickey_frommemory - authenticate a session with a public key, read from memory
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
-.nf
 int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
-                                           const char *username,
-                                           size_t username_len,
-                                           const char *publickeydata,
-                                           size_t publickeydata_len,
-                                           const char *privatekeydata,
-                                           size_t privatekeydata_len,
-                                           const char *passphrase);
+                                          const char *username,
+                                          size_t username_len,
+                                          const char *publickeydata,
+                                          size_t publickeydata_len,
+                                          const char *privatekeydata,
+                                          size_t privatekeydata_len,
+                                          const char *passphrase);
+.fi
 .SH DESCRIPTION
 This function allows to authenticate a session with a public key read from memory.
 It's only supported when libssh2 is backed by OpenSSL.

--- a/docs/libssh2_userauth_publickey_frommemory.3
+++ b/docs/libssh2_userauth_publickey_frommemory.3
@@ -5,14 +5,15 @@ libssh2_userauth_publickey_frommemory - authenticate a session with a public key
 .nf
 #include <libssh2.h>
 
-int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
-                                          const char *username,
-                                          size_t username_len,
-                                          const char *publickeydata,
-                                          size_t publickeydata_len,
-                                          const char *privatekeydata,
-                                          size_t privatekeydata_len,
-                                          const char *passphrase);
+int
+libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
+                                      const char *username,
+                                      size_t username_len,
+                                      const char *publickeydata,
+                                      size_t publickeydata_len,
+                                      const char *privatekeydata,
+                                      size_t privatekeydata_len,
+                                      const char *passphrase);
 .fi
 .SH DESCRIPTION
 This function allows to authenticate a session with a public key read from memory.

--- a/docs/libssh2_userauth_publickey_sk.3
+++ b/docs/libssh2_userauth_publickey_sk.3
@@ -2,17 +2,19 @@
 .SH NAME
 libssh2_userauth_publickey_sk - authenticate a session with a FIDO2 authenticator
 .SH SYNOPSIS
-#include <libssh2.h>
 .nf
-int libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
-                                  const char *username,
-                                  size_t username_len,
-                                  const char *privatekeydata,
-                                  size_t privatekeydata_len,
-                                  const char *passphrase,
-                  LIBSSH2_USERAUTH_SK_SIGN_FUNC((*sign_callback)),
-                                  void **abstract);
+#include <libssh2.h>
 
+int
+libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+                              const char *username,
+                              size_t username_len,
+                              const char *privatekeydata,
+                              size_t privatekeydata_len,
+                              const char *passphrase,
+                              LIBSSH2_USERAUTH_SK_SIGN_FUNC((*sign_callback)),
+                              void **abstract);
+.fi
 .SH CALLBACK
 .nf
 #define LIBSSH2_SK_PRESENCE_REQUIRED     0x01

--- a/docs/libssh2_userauth_publickey_sk.3
+++ b/docs/libssh2_userauth_publickey_sk.3
@@ -10,8 +10,7 @@ int libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
                                   const char *privatekeydata,
                                   size_t privatekeydata_len,
                                   const char *passphrase,
-                                  LIBSSH2_USERAUTH_SK_SIGN_FUNC
-                                  ((*sign_callback)),
+                  LIBSSH2_USERAUTH_SK_SIGN_FUNC((*sign_callback)),
                                   void **abstract);
 
 .SH CALLBACK
@@ -34,7 +33,6 @@ int name(LIBSSH2_SESSION *session, LIBSSH2_SK_SIG_INFO *sig_info,
          const unsigned char *key_handle, size_t handle_len,
          void **abstract);
 .fi
-
 .SH DESCRIPTION
 \fIsession\fP - Session instance as returned by
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_version.3
+++ b/docs/libssh2_version.3
@@ -2,10 +2,12 @@
 .SH NAME
 libssh2_version - return the libssh2 version number
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 const char *
 libssh2_version(int required_version);
+.fi
 .SH DESCRIPTION
 If \fIrequired_version\fP is lower than or equal to the version number of the
 libssh2 in use, the version number of libssh2 is returned as a pointer to a

--- a/docs/template.3
+++ b/docs/template.3
@@ -1,12 +1,13 @@
-.TH libssh2_template 3 "1 Jun 2007" "libssh2 0.15" "libssh2 manual"
+.TH libssh2_template 3 "1 Jun 2022" "libssh2 1.10.0" "libssh2 manual"
 .SH NAME
 libssh2_template - short function description
 .SH SYNOPSIS
+.nf
 #include <libssh2.h>
 
 void
 libssh2_template(void);
-
+.fi
 .SH DESCRIPTION
 Long text describing the function and its input arguments.
 


### PR DESCRIPTION
- add missing `.fi` tags.
- fix misplaced `.nf` tags.
- add `.nf`/`.fi` tags `SYNOPSIS` where missing.
- fix missing/wrong function name from `SH NAME`.
- fix wrong function name in `TH`.
- keep return values in a separate line.
- indent.
- fold long lines.
- deleted `libssh2_channel_direct_streamlocal()`, there is no such function.
- add missing types.
- add missing headers.
