### PR TITLE
build: be friendly with 3rd-party build tools

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1010,7 +1010,8 @@ typedef enum {
     libssh2_openssl,
     libssh2_gcrypt,
     libssh2_mbedtls,
-    libssh2_wincng
+    libssh2_wincng,
+    libssh2_os400qc3
 } libssh2_crypto_engine_t;
 
 LIBSSH2_API

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -25,6 +25,7 @@
 #include <sys/param.h>
 #endif
 
+#define LIBSSH2_BCRYPT_PBKDF_C
 #include "blowfish.c"
 
 #define MINIMUM(a,b) (((a) < (b)) ? (a) : (b))

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -37,6 +37,8 @@
  * Bruce Schneier.
  */
 
+#if defined(LIBSSH2_BCRYPT_PBKDF_C) || defined(_DEBUG_BLOWFISH)
+
 #if !defined(HAVE_BCRYPT_PBKDF) && (!defined(HAVE_BLOWFISH_INITSTATE) || \
                                     !defined(HAVE_BLOWFISH_EXPAND0STATE) || \
                                     !defined(HAVE_BLF_ENC))
@@ -743,3 +745,5 @@ main(void)
           (!defined(HAVE_BLOWFISH_INITSTATE) ||   \
           !defined(HAVE_BLOWFISH_EXPAND0STATE) || \
           '!defined(HAVE_BLF_ENC)) */
+
+#endif /* defined(LIBSSH2_BCRYPT_PBKDF_C) || defined(_DEBUG_BLOWFISH) */

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1,3 +1,5 @@
+#define LIBSSH2_CRYPTO_C
+
 #include "libssh2_priv.h"
 
 #if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -40,22 +40,16 @@
 
 #if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
 #include "openssl.h"
-#endif
-
-#ifdef LIBSSH2_LIBGCRYPT
+#elif defined(LIBSSH2_LIBGCRYPT)
 #include "libgcrypt.h"
-#endif
-
-#ifdef LIBSSH2_WINCNG
-#include "wincng.h"
-#endif
-
-#ifdef LIBSSH2_OS400QC3
-#include "os400qc3.h"
-#endif
-
-#ifdef LIBSSH2_MBEDTLS
+#elif defined(LIBSSH2_MBEDTLS)
 #include "mbedtls.h"
+#elif defined(LIBSSH2_OS400QC3)
+#include "os400qc3.h"
+#elif defined(LIBSSH2_WINCNG)
+#include "wincng.h"
+#else
+#error "no cryptography backend selected"
 #endif
 
 #ifdef LIBSSH2_NO_MD5

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -36,8 +36,7 @@
  * OF SUCH DAMAGE.
  */
 
-#include "libssh2_priv.h"
-
+#ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 #ifdef LIBSSH2_LIBGCRYPT /* compile only if we build with libgcrypt */
 
 #include <string.h>
@@ -742,3 +741,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 }
 
 #endif /* LIBSSH2_LIBGCRYPT */
+#endif /* LIBSSH2_CRYPTO_C */

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -37,7 +37,6 @@
  */
 
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
-#ifdef LIBSSH2_LIBGCRYPT /* compile only if we build with libgcrypt */
 
 #include <string.h>
 
@@ -740,5 +739,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
     return NULL;
 }
 
-#endif /* LIBSSH2_LIBGCRYPT */
 #endif /* LIBSSH2_CRYPTO_C */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -39,6 +39,8 @@
  * OF SUCH DAMAGE.
  */
 
+#define LIBSSH2_CRYPTO_ENGINE libssh2_gcrypt
+
 #include <gcrypt.h>
 
 #define LIBSSH2_MD5 1

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -35,8 +35,7 @@
  * OF SUCH DAMAGE.
  */
 
-#include "libssh2_priv.h"
-
+#ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 #ifdef LIBSSH2_MBEDTLS /* compile only if we build with mbedtls */
 
 #if MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -1457,3 +1456,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 
 #endif /* LIBSSH2_ECDSA */
 #endif /* LIBSSH2_MBEDTLS */
+#endif /* LIBSSH2_CRYPTO_C */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -36,7 +36,6 @@
  */
 
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
-#ifdef LIBSSH2_MBEDTLS /* compile only if we build with mbedtls */
 
 #if MBEDTLS_VERSION_NUMBER < 0x03000000
 #define mbedtls_cipher_info_get_key_bitlen(c) (c->key_bitlen)
@@ -1455,5 +1454,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 }
 
 #endif /* LIBSSH2_ECDSA */
-#endif /* LIBSSH2_MBEDTLS */
 #endif /* LIBSSH2_CRYPTO_C */

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -37,6 +37,8 @@
  * OF SUCH DAMAGE.
  */
 
+#define LIBSSH2_CRYPTO_ENGINE libssh2_mbedtls
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -39,8 +39,6 @@
  */
 
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
-/* compile only if we build with openssl or wolfSSL */
-#if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
 
 #include <string.h>
 
@@ -3917,5 +3915,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
     return NULL;
 }
 
-#endif /* LIBSSH2_OPENSSL */
 #endif /* LIBSSH2_CRYPTO_C */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -38,8 +38,7 @@
  * OF SUCH DAMAGE.
  */
 
-#include "libssh2_priv.h"
-
+#ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 /* compile only if we build with openssl or wolfSSL */
 #if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
 
@@ -3919,3 +3918,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 }
 
 #endif /* LIBSSH2_OPENSSL */
+#endif /* LIBSSH2_CRYPTO_C */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -39,6 +39,8 @@
  * OF SUCH DAMAGE.
  */
 
+#define LIBSSH2_CRYPTO_ENGINE libssh2_openssl
+
 /* disable deprecated warnings in OpenSSL 3 */
 #define OPENSSL_SUPPRESS_DEPRECATED
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -37,8 +37,7 @@
  * OF SUCH DAMAGE.
  */
 
-#include "libssh2_priv.h"
-
+#ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 #ifdef LIBSSH2_OS400QC3 /* compile only if we build with OS/400 QC3 library */
 
 #include <stdlib.h>
@@ -2443,5 +2442,6 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 }
 
 #endif /* LIBSSH2_OS400QC3 */
+#endif /* LIBSSH2_CRYPTO_C */
 
 /* vim: set expandtab ts=4 sw=4: */

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -38,7 +38,6 @@
  */
 
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
-#ifdef LIBSSH2_OS400QC3 /* compile only if we build with OS/400 QC3 library */
 
 #include <stdlib.h>
 
@@ -2441,7 +2440,6 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
     return NULL;
 }
 
-#endif /* LIBSSH2_OS400QC3 */
 #endif /* LIBSSH2_CRYPTO_C */
 
 /* vim: set expandtab ts=4 sw=4: */

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -39,6 +39,8 @@
  * OF SUCH DAMAGE.
  */
 
+#define LIBSSH2_CRYPTO_ENGINE libssh2_os400qc3
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/version.c
+++ b/src/version.c
@@ -56,15 +56,5 @@ const char *libssh2_version(int req_version_num)
 LIBSSH2_API
 libssh2_crypto_engine_t libssh2_crypto_engine(void)
 {
-#if defined LIBSSH2_OPENSSL
-    return libssh2_openssl;
-#elif defined LIBSSH2_LIBGCRYPT
-    return libssh2_gcrypt;
-#elif defined LIBSSH2_MBEDTLS
-    return libssh2_mbedtls;
-#elif defined LIBSSH2_WINCNG
-    return libssh2_wincng;
-#else
-    return libssh2_no_crypto;
-#endif
+    return LIBSSH2_CRYPTO_ENGINE;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -36,8 +36,7 @@
  * OF SUCH DAMAGE.
  */
 
-#include "libssh2_priv.h"
-
+#ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 #ifdef LIBSSH2_WINCNG /* compile only if we build with wincng */
 
 /* required for cross-compilation against the w64 mingw-runtime package */
@@ -2731,3 +2730,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 }
 
 #endif /* LIBSSH2_WINCNG */
+#endif /* LIBSSH2_CRYPTO_C */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -37,7 +37,6 @@
  */
 
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
-#ifdef LIBSSH2_WINCNG /* compile only if we build with wincng */
 
 /* required for cross-compilation against the w64 mingw-runtime package */
 #if defined(_WIN32_WINNT) && (_WIN32_WINNT < 0x0600)
@@ -2729,5 +2728,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
     return NULL;
 }
 
-#endif /* LIBSSH2_WINCNG */
 #endif /* LIBSSH2_CRYPTO_C */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -38,6 +38,8 @@
  * OF SUCH DAMAGE.
  */
 
+#define LIBSSH2_CRYPTO_ENGINE libssh2_wincng
+
 /* required for cross-compilation against the w64 mingw-runtime package */
 #if defined(_WIN32_WINNT) && (_WIN32_WINNT < 0x0600)
 #undef _WIN32_WINNT


### PR DESCRIPTION
After recent build changes, 3rd party build that took the list of
C source to compile them as-is, stopped working as expected, due to
`blowfish.c` and crypto-backend C sources no longer expected to compile
separately but via `bcrypt_pbkdf.c` and `crypto.c`, respectively.

This patch ensures that compiling these files directly result in an
empty object instead of redundant code and duplicated symbols.

Also:
- add a compile-time error if none of the supported crypto backends
  are enabled.
- fix `libssh2_crypto_engine()` for wolfSSL and os400qc3.
  Rearrange code to avoid a hard-to-find copy of crypto-backend
  selection guards.

Follow-up to 4f0f4bff5a92dce6a6cd7a5600a8ee5660402c3f
Follow-up to ff3c774e03585252b70a9ee0fcf254de7b14a767

Closes #951
