### PR TITLE
build: speed up and extend picky compiler options

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -325,7 +325,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
            dnl only if the compiler is newer than 2.95 since we got lots of
            dnl "`_POSIX_C_SOURCE' is not defined" in system headers with
            dnl gcc 2.95.4 on FreeBSD 4.9!
-           WARN="$WARN -Wundef -Wno-long-long -Wsign-compare"
+           WARN="$WARN -Wno-long-long -Wno-multichar -Wshadow -Wsign-compare -Wundef -Wunused"
          fi
 
          if test "$gccnum" -ge "296"; then
@@ -360,9 +360,6 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          #
          dnl Only gcc 4.1 or later (possibly earlier)
          if test "$gccnum" -ge "401"; then
-           CURL_ADD_COMPILER_WARNINGS([WARN], [shadow])
-           CURL_ADD_COMPILER_WARNINGS([WARN], [unused])
-           CURL_ADD_COMPILER_WARNINGS([WARN], [no-multichar])
            CURL_ADD_COMPILER_WARNINGS([WARN], [no-system-headers])
          fi
          #

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -255,6 +255,11 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          esac
        fi
        #
+       dnl Only clang 3.4 or later
+       if test "$gccver" -ge "304"; then
+         CURL_ADD_COMPILER_WARNINGS([WARN], [unused-const-variable])
+       fi
+       #
        dnl Only clang 3.6 or later
        if test "$gccver" -ge "306"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [double-promotion])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -373,9 +373,11 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          dnl Only gcc 4.5 or later
          if test "$gccnum" -ge "405"; then
            dnl Only windows targets
-           if test "$curl_cv_have_def__WIN32" = "yes"; then
+           case $host_os in
+           mingw*)
              WARN="$WARN -Wno-pedantic-ms-format"
-           fi
+             ;;
+           esac
          fi
          #
          dnl Only gcc 4.6 or later

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -181,21 +181,6 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
       CURL_DETECT_ICC
     fi
 
-# clang missing:
-# -Wconversion
-# -Wempty-body
-# -Wenum-conversion
-# -Wignored-qualifiers
-# -Wno-sign-conversion
-# -Wtype-limits
-
-# gcc missing:
-# -Wno-multichar
-# -Wno-pedantic-ms-format
-# -Wno-system-headers
-# -Wshadow
-# -Wunused
-
     if test "z$compiler_id" = "zCLANG"; then
 
        CLANG="yes"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -232,8 +232,18 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          CURL_ADD_COMPILER_WARNINGS([WARN], [shift-sign-overflow])
        fi
        #
+       dnl Only clang 3.0 or later (possibly earlier)
+       if test "$gccver" -ge "300"; then
+         CURL_ADD_COMPILER_WARNINGS([WARN], [conversion])
+         CURL_ADD_COMPILER_WARNINGS([WARN], [empty-body])
+         CURL_ADD_COMPILER_WARNINGS([WARN], [ignored-qualifiers])
+         CURL_ADD_COMPILER_WARNINGS([WARN], [type-limits])
+         CURL_ADD_COMPILER_WARNINGS([WARN], [no-sign-conversion])
+       fi
+       #
        dnl Only clang 3.2 or later
        if test "$gccver" -ge "302"; then
+         CURL_ADD_COMPILER_WARNINGS([WARN], [enum-conversion])
          case $host_os in
          cygwin* | mingw*)
            dnl skip missing-variable-declarations warnings for cygwin and

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -373,7 +373,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          if test "$gccnum" -ge "403"; then
            CURL_ADD_COMPILER_WARNINGS([WARN], [type-limits old-style-declaration])
            CURL_ADD_COMPILER_WARNINGS([WARN], [missing-parameter-type empty-body])
-           CURL_ADD_COMPILER_WARNINGS([WARN], [clobbered ignored-qualifiers])
+           CURL_ADD_COMPILER_WARNINGS([WARN], [ignored-qualifiers])
            CURL_ADD_COMPILER_WARNINGS([WARN], [conversion])
            WARN="$WARN -Wno-sign-conversion"
            CURL_ADD_COMPILER_WARNINGS([WARN], [vla])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -239,7 +239,6 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          CURL_ADD_COMPILER_WARNINGS([WARN], [ignored-qualifiers])
          CURL_ADD_COMPILER_WARNINGS([WARN], [type-limits])
          CURL_ADD_COMPILER_WARNINGS([WARN], [no-sign-conversion])
-         WARN="$WARN -Wformat=2"
        fi
        #
        dnl Only clang 3.2 or later

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -400,10 +400,6 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
            CURL_ADD_COMPILER_WARNINGS([WARN], [alloc-zero])
            WARN="$WARN -Wformat-overflow=2"
            WARN="$WARN -Wformat-truncation=2"
-           if test "$gccnum" -lt "1200"; then
-             dnl gcc 12 doesn't acknowledge our comment markups
-             WARN="$WARN -Wimplicit-fallthrough=4"
-           fi
          fi
          #
          dnl Only gcc 10 or later

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -189,105 +189,105 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
 
     if test "$CLANG" = "yes"; then
 
-       fullclangver=`$CC -v 2>&1 | grep version`
-       clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`
-       if test -z "$clangver"; then
-         if echo $fullclangver | grep "Apple LLVM version " >/dev/null; then
-           dnl Starting with Xcode 7 / clang 3.7, Apple clang won't tell its upstream version
-           clangver="3.7"
-         else
-           clangver=`echo $fullclangver | "$SED" 's/.*version \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
-         fi
-       fi
-       clangvhi=`echo $clangver | cut -d . -f1`
-       clangvlo=`echo $clangver | cut -d . -f2`
-       compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
-       AC_MSG_RESULT($compiler_num)
+      fullclangver=`$CC -v 2>&1 | grep version`
+      clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`
+      if test -z "$clangver"; then
+        if echo $fullclangver | grep "Apple LLVM version " >/dev/null; then
+          dnl Starting with Xcode 7 / clang 3.7, Apple clang won't tell its upstream version
+          clangver="3.7"
+        else
+          clangver=`echo $fullclangver | "$SED" 's/.*version \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
+        fi
+      fi
+      clangvhi=`echo $clangver | cut -d . -f1`
+      clangvlo=`echo $clangver | cut -d . -f2`
+      compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
+      AC_MSG_RESULT($compiler_num)
 
-       WARN="-pedantic"
-       CURL_ADD_COMPILER_WARNINGS([WARN], [all extra])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [pointer-arith write-strings])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [shadow])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [inline nested-externs])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [missing-declarations])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [missing-prototypes])
-       WARN="$WARN -Wno-long-long"
-       CURL_ADD_COMPILER_WARNINGS([WARN], [float-equal])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [no-multichar sign-compare])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [undef])
-       WARN="$WARN -Wno-format-nonliteral"
-       CURL_ADD_COMPILER_WARNINGS([WARN], [endif-labels strict-prototypes])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [declaration-after-statement])
-       CURL_ADD_COMPILER_WARNINGS([WARN], [cast-align])
-       WARN="$WARN -Wno-system-headers"
-       CURL_ADD_COMPILER_WARNINGS([WARN], [shorten-64-to-32])
-       #
-       dnl Only clang 1.1 or later
-       if test "$compiler_num" -ge "101"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [unused])
-       fi
-       #
-       dnl Only clang 2.8 or later
-       if test "$compiler_num" -ge "208"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [vla])
-       fi
-       #
-       dnl Only clang 2.9 or later
-       if test "$compiler_num" -ge "209"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [shift-sign-overflow])
-       fi
-       #
-       dnl Only clang 3.0 or later (possibly earlier)
-       if test "$compiler_num" -ge "300"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [conversion])
-         CURL_ADD_COMPILER_WARNINGS([WARN], [empty-body])
-         CURL_ADD_COMPILER_WARNINGS([WARN], [ignored-qualifiers])
-         CURL_ADD_COMPILER_WARNINGS([WARN], [type-limits])
-         CURL_ADD_COMPILER_WARNINGS([WARN], [no-sign-conversion])
-       fi
-       #
-       dnl Only clang 3.2 or later
-       if test "$compiler_num" -ge "302"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [enum-conversion])
-         case $host_os in
-         cygwin* | mingw*)
-           dnl skip missing-variable-declarations warnings for cygwin and
-           dnl mingw because the libtool wrapper executable causes them
-           ;;
-         *)
-           CURL_ADD_COMPILER_WARNINGS([WARN], [missing-variable-declarations])
-           ;;
-         esac
-       fi
-       #
-       dnl Only clang 3.4 or later
-       if test "$compiler_num" -ge "304"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [unused-const-variable])
-       fi
-       #
-       dnl Only clang 3.6 or later
-       if test "$compiler_num" -ge "306"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [double-promotion])
-       fi
-       #
-       dnl Only clang 3.9 or later
-       if test "$compiler_num" -ge "309"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [comma])
-         # avoid the varargs warning, fixed in 4.0
-         # https://bugs.llvm.org/show_bug.cgi?id=29140
-         if test "$compiler_num" -lt "400"; then
-           WARN="$WARN -Wno-varargs"
-         fi
-       fi
-       dnl clang 7 or later
-       if test "$compiler_num" -ge "700"; then
-         CURL_ADD_COMPILER_WARNINGS([WARN], [assign-enum])
-         CURL_ADD_COMPILER_WARNINGS([WARN], [extra-semi-stmt])
-       fi
+      WARN="-pedantic"
+      CURL_ADD_COMPILER_WARNINGS([WARN], [all extra])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [pointer-arith write-strings])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [shadow])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [inline nested-externs])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [missing-declarations])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [missing-prototypes])
+      WARN="$WARN -Wno-long-long"
+      CURL_ADD_COMPILER_WARNINGS([WARN], [float-equal])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [no-multichar sign-compare])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [undef])
+      WARN="$WARN -Wno-format-nonliteral"
+      CURL_ADD_COMPILER_WARNINGS([WARN], [endif-labels strict-prototypes])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [declaration-after-statement])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [cast-align])
+      WARN="$WARN -Wno-system-headers"
+      CURL_ADD_COMPILER_WARNINGS([WARN], [shorten-64-to-32])
+      #
+      dnl Only clang 1.1 or later
+      if test "$compiler_num" -ge "101"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [unused])
+      fi
+      #
+      dnl Only clang 2.8 or later
+      if test "$compiler_num" -ge "208"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [vla])
+      fi
+      #
+      dnl Only clang 2.9 or later
+      if test "$compiler_num" -ge "209"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [shift-sign-overflow])
+      fi
+      #
+      dnl Only clang 3.0 or later (possibly earlier)
+      if test "$compiler_num" -ge "300"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [conversion])
+        CURL_ADD_COMPILER_WARNINGS([WARN], [empty-body])
+        CURL_ADD_COMPILER_WARNINGS([WARN], [ignored-qualifiers])
+        CURL_ADD_COMPILER_WARNINGS([WARN], [type-limits])
+        CURL_ADD_COMPILER_WARNINGS([WARN], [no-sign-conversion])
+      fi
+      #
+      dnl Only clang 3.2 or later
+      if test "$compiler_num" -ge "302"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [enum-conversion])
+        case $host_os in
+        cygwin* | mingw*)
+          dnl skip missing-variable-declarations warnings for cygwin and
+          dnl mingw because the libtool wrapper executable causes them
+          ;;
+        *)
+          CURL_ADD_COMPILER_WARNINGS([WARN], [missing-variable-declarations])
+          ;;
+        esac
+      fi
+      #
+      dnl Only clang 3.4 or later
+      if test "$compiler_num" -ge "304"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [unused-const-variable])
+      fi
+      #
+      dnl Only clang 3.6 or later
+      if test "$compiler_num" -ge "306"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [double-promotion])
+      fi
+      #
+      dnl Only clang 3.9 or later
+      if test "$compiler_num" -ge "309"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [comma])
+        # avoid the varargs warning, fixed in 4.0
+        # https://bugs.llvm.org/show_bug.cgi?id=29140
+        if test "$compiler_num" -lt "400"; then
+          WARN="$WARN -Wno-varargs"
+        fi
+      fi
+      dnl clang 7 or later
+      if test "$compiler_num" -ge "700"; then
+        CURL_ADD_COMPILER_WARNINGS([WARN], [assign-enum])
+        CURL_ADD_COMPILER_WARNINGS([WARN], [extra-semi-stmt])
+      fi
 
-       CFLAGS="$CFLAGS $WARN"
+      CFLAGS="$CFLAGS $WARN"
 
-       AC_MSG_NOTICE([Added this set of compiler options: $WARN])
+      AC_MSG_NOTICE([Added this set of compiler options: $WARN])
 
     elif test "$GCC" = "yes"; then
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -177,13 +177,17 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
 [
     if test "z$CLANG" = "z"; then
       CURL_CHECK_COMPILER_CLANG
-    elif test "z$ICC" = "z"; then
+      if test "z$compiler_id" = "zCLANG"; then
+        CLANG="yes"
+      else
+        CLANG="no"
+      fi
+    fi
+    if test "z$ICC" = "z"; then
       CURL_DETECT_ICC
     fi
 
-    if test "z$compiler_id" = "zCLANG"; then
-
-       CLANG="yes"
+    if test "$CLANG" = "yes"; then
 
        fullclangver=`$CC -v 2>&1 | grep version`
        clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -181,6 +181,21 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
       CURL_DETECT_ICC
     fi
 
+# clang missing:
+# -Wconversion
+# -Wempty-body
+# -Wenum-conversion
+# -Wignored-qualifiers
+# -Wno-sign-conversion
+# -Wtype-limits
+
+# gcc missing:
+# -Wno-multichar
+# -Wno-pedantic-ms-format
+# -Wno-system-headers
+# -Wshadow
+# -Wunused
+
     if test "z$compiler_id" = "zCLANG"; then
 
        CLANG="yes"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -189,6 +189,8 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
 
     if test "$CLANG" = "yes"; then
 
+      dnl figure out clang version!
+      AC_MSG_CHECKING([clang version])
       fullclangver=`$CC -v 2>&1 | grep version`
       clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`
       if test -z "$clangver"; then

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -353,6 +353,14 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
            WARN="$WARN -Wstrict-aliasing=3"
          fi
          #
+         dnl Only gcc 4.1 or later (possibly earlier)
+         if test "$gccnum" -ge "401"; then
+           CURL_ADD_COMPILER_WARNINGS([WARN], [shadow])
+           CURL_ADD_COMPILER_WARNINGS([WARN], [unused])
+           CURL_ADD_COMPILER_WARNINGS([WARN], [no-multichar])
+           CURL_ADD_COMPILER_WARNINGS([WARN], [no-system-headers])
+         fi
+         #
          dnl Only gcc 4.2 or later
          if test "$gccnum" -ge "402"; then
            CURL_ADD_COMPILER_WARNINGS([WARN], [cast-align])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -239,6 +239,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          CURL_ADD_COMPILER_WARNINGS([WARN], [ignored-qualifiers])
          CURL_ADD_COMPILER_WARNINGS([WARN], [type-limits])
          CURL_ADD_COMPILER_WARNINGS([WARN], [no-sign-conversion])
+         WARN="$WARN -Wformat=2"
        fi
        #
        dnl Only clang 3.2 or later

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -201,7 +201,8 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
        fi
        clangvhi=`echo $clangver | cut -d . -f1`
        clangvlo=`echo $clangver | cut -d . -f2`
-       gccver=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
+       compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
+       AC_MSG_RESULT($compiler_num)
 
        WARN="-pedantic"
        CURL_ADD_COMPILER_WARNINGS([WARN], [all extra])
@@ -222,22 +223,22 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
        CURL_ADD_COMPILER_WARNINGS([WARN], [shorten-64-to-32])
        #
        dnl Only clang 1.1 or later
-       if test "$gccver" -ge "101"; then
+       if test "$compiler_num" -ge "101"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [unused])
        fi
        #
        dnl Only clang 2.8 or later
-       if test "$gccver" -ge "208"; then
+       if test "$compiler_num" -ge "208"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [vla])
        fi
        #
        dnl Only clang 2.9 or later
-       if test "$gccver" -ge "209"; then
+       if test "$compiler_num" -ge "209"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [shift-sign-overflow])
        fi
        #
        dnl Only clang 3.0 or later (possibly earlier)
-       if test "$gccver" -ge "300"; then
+       if test "$compiler_num" -ge "300"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [conversion])
          CURL_ADD_COMPILER_WARNINGS([WARN], [empty-body])
          CURL_ADD_COMPILER_WARNINGS([WARN], [ignored-qualifiers])
@@ -246,7 +247,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
        fi
        #
        dnl Only clang 3.2 or later
-       if test "$gccver" -ge "302"; then
+       if test "$compiler_num" -ge "302"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [enum-conversion])
          case $host_os in
          cygwin* | mingw*)
@@ -260,26 +261,26 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
        fi
        #
        dnl Only clang 3.4 or later
-       if test "$gccver" -ge "304"; then
+       if test "$compiler_num" -ge "304"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [unused-const-variable])
        fi
        #
        dnl Only clang 3.6 or later
-       if test "$gccver" -ge "306"; then
+       if test "$compiler_num" -ge "306"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [double-promotion])
        fi
        #
        dnl Only clang 3.9 or later
-       if test "$gccver" -ge "309"; then
+       if test "$compiler_num" -ge "309"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [comma])
          # avoid the varargs warning, fixed in 4.0
          # https://bugs.llvm.org/show_bug.cgi?id=29140
-         if test "$gccver" -lt "400"; then
+         if test "$compiler_num" -lt "400"; then
            WARN="$WARN -Wno-varargs"
          fi
        fi
        dnl clang 7 or later
-       if test "$gccver" -ge "700"; then
+       if test "$compiler_num" -ge "700"; then
          CURL_ADD_COMPILER_WARNINGS([WARN], [assign-enum])
          CURL_ADD_COMPILER_WARNINGS([WARN], [extra-semi-stmt])
        fi

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -332,7 +332,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
            dnl only if the compiler is newer than 2.95 since we got lots of
            dnl "`_POSIX_C_SOURCE' is not defined" in system headers with
            dnl gcc 2.95.4 on FreeBSD 4.9!
-           WARN="$WARN -Wno-long-long -Wno-multichar -Wshadow -Wsign-compare -Wundef -Wunused"
+           WARN="$WARN -Wundef -Wno-long-long -Wno-multichar -Wshadow -Wsign-compare -Wunused"
          fi
 
          if test "$gccnum" -ge "296"; then

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -421,7 +421,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
            CURL_ADD_COMPILER_WARNINGS([WARN], [restrict])
            CURL_ADD_COMPILER_WARNINGS([WARN], [alloc-zero])
            WARN="$WARN -Wformat-overflow=2"
-           WARN="$WARN -Wformat-truncation=2"
+           WARN="$WARN -Wformat-truncation=1"
          fi
          #
          dnl Only gcc 10 or later

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -103,15 +103,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wmissing-variable-declarations    # clang  3.2            appleclang  4.6
       )
     else()  # gcc
-      if(MINGW)
-        list(APPEND WARNOPTS_DETECT
-          -Wno-pedantic-ms-format          #             gcc  4.5 (mingw-only)
-        )
-      endif()
-      list(APPEND WARNOPTS_DETECT
-        -Wformat=2                         # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
-      )
-
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
         list(APPEND WARNOPTS_ENABLE
@@ -119,6 +110,16 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
           -Wstrict-aliasing=3              #             gcc  4.0
+        )
+      endif()
+      if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.5 AND MINGW)
+        list(APPEND WARNOPTS_ENABLE
+          -Wno-pedantic-ms-format          #             gcc  4.5 (mingw-only)
+        )
+      endif()
+      if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
+        list(APPEND WARNOPTS_ENABLE
+          -Wformat=2                       # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -85,13 +85,13 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       )
       # clang-only
       list(APPEND WARNOPTS_ENABLE
+        -Wshift-sign-overflow          # clang  2.9
         -Wshorten-64-to-32             # clang  1.0
       )
       list(APPEND WARNOPTS_TOCHECK
         -Wassign-enum                  # clang  7.0
         -Wcomma                        # clang  3.9
         -Wextra-semi-stmt              # clang  7.0
-        -Wshift-sign-overflow          # clang  2.9
       )
     else()
       if(MINGW)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -56,9 +56,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     # Add new options here, if in doubt:
     # ----------------------------------
     set(WARNOPTS_DETECT
-      -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
-      -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
-      -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
     )
 
     # Assume these options always exist with both clang and gcc.
@@ -95,6 +92,12 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
+    set(WARNOPTS_COMMON
+      -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
+      -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
+      -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
+    )
+
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
       list(APPEND WARNOPTS_ENABLE
         ${WARNOPTS_COMMON_OLD}
@@ -102,6 +105,12 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wshorten-64-to-32                 # clang  1.0
       )
       # Enable based on compiler version
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
+        list(APPEND WARNOPTS_ENABLE
+          ${WARNOPTS_COMMON}
+        )
+      endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.3))
         list(APPEND WARNOPTS_ENABLE
@@ -117,6 +126,9 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         )
       endif()
     else()  # gcc
+      list(APPEND WARNOPTS_DETECT
+        ${WARNOPTS_COMMON}
+      )
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
         list(APPEND WARNOPTS_ENABLE

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -92,7 +92,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wno-format-nonliteral               # clang  1.0  gcc  2.96
       -Wno-long-long                       # clang  1.0  gcc  2.95
       -Wno-multichar                       # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
-      -Wno-pedantic-ms-format              #             gcc  4.5 (mingw-only) --> autotools-gcc
+      -Wno-pedantic-ms-format              #             gcc  4.5 (mingw-only)
       -Wno-sign-conversion                 # clang _3.0  gcc  4.3
       -Wno-system-headers                  # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
       )

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -140,9 +140,9 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
         list(APPEND WARNOPTS_ENABLE
+          -Wduplicated-cond                #             gcc  6.0
           -Wnull-dereference               # clang  3.0  gcc  6.0 (clang default)
             -fdelete-null-pointer-checks
-          -Wduplicated-cond                #             gcc  6.0
           -Wshift-negative-value           # clang  3.7  gcc  6.0 (clang default)
           -Wshift-overflow=2               # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
         )

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -67,6 +67,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wdouble-promotion               # clang  3.6  gcc  4.6
       -Wempty-body                     # clang  3.0  gcc  4.3
       -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
+      -Wformat=2                       # clang  3.0  gcc  4.8
       -Wignored-qualifiers             # clang  3.0  gcc  4.3
       -Wtype-limits                    # clang  3.0  gcc  4.3
       -Wunused-const-variable          # clang  3.4  gcc  6.0
@@ -116,7 +117,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wduplicated-cond              #             gcc  6.0
         -Wformat-overflow=2            #             gcc  7.0
         -Wformat-truncation=1          #             gcc  7.0
-        -Wformat=2                     # clang  3.0  gcc  4.8 (clang part-default)
         -Wmissing-parameter-type       #             gcc  4.3
         -Wold-style-declaration        #             gcc  4.3
         -Wrestrict                     #             gcc  7.0

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -110,7 +110,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wduplicated-branches          #             gcc  7.0
         -Wduplicated-cond              #             gcc  6.0
         -Wformat-overflow=2            #             gcc  7.0
-        -Wformat-truncation=2          #             gcc  7.0
+        -Wformat-truncation=1          #             gcc  7.0
         -Wformat=2                     # clang  3.0  gcc  4.8 [clang some-default]
         -Wmissing-parameter-type       #             gcc  4.3
         -Wno-pedantic-ms-format        #             gcc  4.5 (mingw-only)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -83,6 +83,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
+    # Add new options here if in doubt:
     set(WARNOPTS_DETECT
       -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
       -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -41,7 +41,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
   if(PICKY_COMPILER)
 
-    # Assume these options always exist.
+    # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.96 or later.
     set(WARNOPTS_ENABLE
       -W
@@ -63,6 +63,20 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wwrite-strings                  # clang  1.0  gcc  1.0
     )
 
+    # Skip check with clang, do check with gcc
+    set(WARNOPTS_COMMON
+      -Wcast-align                     # clang  1.0  gcc  4.2
+      -Wdeclaration-after-statement    # clang  1.0  gcc  3.4
+      -Wempty-body                     # clang  3.0  gcc  4.3
+      -Wendif-labels                   # clang  1.0  gcc  3.3
+      -Wignored-qualifiers             # clang  3.0  gcc  4.3
+      -Wno-sign-conversion             # clang  3.0  gcc  4.3
+      -Wno-system-headers              # clang  1.0  gcc  3.0
+      -Wstrict-prototypes              # clang  1.0  gcc  3.3
+      -Wtype-limits                    # clang  3.0  gcc  4.3
+      -Wvla                            # clang  2.8  gcc  4.3
+    )
+
     # Enable if available
     set(WARNOPTS_TOCHECK
       -Wdouble-promotion               # clang  3.6  gcc  4.6
@@ -71,21 +85,8 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      # common with gcc, but skip detection with clang
       list(APPEND WARNOPTS_ENABLE
-        -Wcast-align                   # clang  1.0  gcc  4.2
-        -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
-        -Wempty-body                   # clang  3.0  gcc  4.3
-        -Wendif-labels                 # clang  1.0  gcc  3.3
-        -Wignored-qualifiers           # clang  3.0  gcc  4.3
-        -Wno-sign-conversion           # clang  3.0  gcc  4.3
-        -Wno-system-headers            # clang  1.0  gcc  3.0
-        -Wstrict-prototypes            # clang  1.0  gcc  3.3
-        -Wtype-limits                  # clang  3.0  gcc  4.3
-        -Wvla                          # clang  2.8  gcc  4.3
-      )
-      # clang-only
-      list(APPEND WARNOPTS_ENABLE
+        ${WARNOPTS_COMMON}
         -Wshift-sign-overflow          # clang  2.9
         -Wshorten-64-to-32             # clang  1.0
       )
@@ -100,21 +101,8 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
           -Wno-pedantic-ms-format      #             gcc  4.5 (mingw-only)
         )
       endif()
-      # common with clang
       list(APPEND WARNOPTS_TOCHECK
-        -Wcast-align                   # clang  1.0  gcc  4.2
-        -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
-        -Wempty-body                   # clang  3.0  gcc  4.3
-        -Wendif-labels                 # clang  1.0  gcc  3.3
-        -Wignored-qualifiers           # clang  3.0  gcc  4.3
-        -Wno-sign-conversion           # clang  3.0  gcc  4.3
-        -Wno-system-headers            # clang  1.0  gcc  3.0
-        -Wstrict-prototypes            # clang  1.0  gcc  3.3
-        -Wtype-limits                  # clang  3.0  gcc  4.3
-        -Wvla                          # clang  2.8  gcc  4.3
-      )
-      # gcc-only
-      list(APPEND WARNOPTS_TOCHECK
+        ${WARNOPTS_COMMON}
         -Walloc-zero                   #             gcc  7.0
         -Warith-conversion             #             gcc 10.0
         -Wduplicated-branches          #             gcc  7.0

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -52,87 +52,87 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     # Require clang 3.0 / gcc 2.96 or later.
     list(APPEND WARNOPTS_ENABLE
       -pedantic
-      -Wconversion                       # clang  3.0  gcc  2.95
-      -Wfloat-equal                      # clang  1.0  gcc  2.96
-      -Winline                           # clang  1.0  gcc  1.0
-      -Wmissing-declarations             # clang  1.0  gcc  2.7
-      -Wmissing-prototypes               # clang  1.0  gcc  1.0
-      -Wnested-externs                   # clang  1.0  gcc  1.0
-      -Wno-format-nonliteral             # clang  1.0  gcc  2.96
-      -Wno-long-long                     # clang  1.0  gcc  2.95
-      -Wno-multichar                     # clang  1.0  gcc  2.95
-      -Wpointer-arith                    # clang  1.0  gcc  1.0
-      -Wshadow                           # clang  1.0  gcc  2.95
-      -Wsign-compare                     # clang  1.0  gcc  2.95
-      -Wundef                            # clang  1.0  gcc  2.95
-      -Wunused                           # clang  1.1  gcc  2.95
-      -Wwrite-strings                    # clang  1.0  gcc  1.0
+      -Wconversion                         # clang  3.0  gcc  2.95
+      -Wfloat-equal                        # clang  1.0  gcc  2.96
+      -Winline                             # clang  1.0  gcc  1.0
+      -Wmissing-declarations               # clang  1.0  gcc  2.7
+      -Wmissing-prototypes                 # clang  1.0  gcc  1.0
+      -Wnested-externs                     # clang  1.0  gcc  1.0
+      -Wno-format-nonliteral               # clang  1.0  gcc  2.96
+      -Wno-long-long                       # clang  1.0  gcc  2.95
+      -Wno-multichar                       # clang  1.0  gcc  2.95
+      -Wpointer-arith                      # clang  1.0  gcc  1.0
+      -Wshadow                             # clang  1.0  gcc  2.95
+      -Wsign-compare                       # clang  1.0  gcc  2.95
+      -Wundef                              # clang  1.0  gcc  2.95
+      -Wunused                             # clang  1.1  gcc  2.95
+      -Wwrite-strings                      # clang  1.0  gcc  1.0
     )
 
     # Skip check with clang, do check with gcc
     set(WARNOPTS_COMMON
-      -Wcast-align                       # clang  1.0  gcc  4.2
-      -Wdeclaration-after-statement      # clang  1.0  gcc  3.4
-      -Wempty-body                       # clang  3.0  gcc  4.3
-      -Wendif-labels                     # clang  1.0  gcc  3.3
-      -Wignored-qualifiers               # clang  3.0  gcc  4.3
-      -Wno-sign-conversion               # clang  3.0  gcc  4.3
-      -Wno-system-headers                # clang  1.0  gcc  3.0
-      -Wstrict-prototypes                # clang  1.0  gcc  3.3
-      -Wtype-limits                      # clang  3.0  gcc  4.3
-      -Wvla                              # clang  2.8  gcc  4.3
+      -Wcast-align                         # clang  1.0  gcc  4.2
+      -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
+      -Wempty-body                         # clang  3.0  gcc  4.3
+      -Wendif-labels                       # clang  1.0  gcc  3.3
+      -Wignored-qualifiers                 # clang  3.0  gcc  4.3
+      -Wno-sign-conversion                 # clang  3.0  gcc  4.3
+      -Wno-system-headers                  # clang  1.0  gcc  3.0
+      -Wstrict-prototypes                  # clang  1.0  gcc  3.3
+      -Wtype-limits                        # clang  3.0  gcc  4.3
+      -Wvla                                # clang  2.8  gcc  4.3
     )
 
     # Enable if available
     set(WARNOPTS_TOCHECK
-      -Wdouble-promotion                 # clang  3.6  gcc  4.6  appleclang  6.3
-      -Wenum-conversion                  # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
-      -Wunused-const-variable            # clang  3.4  gcc  6.0  appleclang  5.1
+      -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
+      -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
+      -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
       list(APPEND WARNOPTS_ENABLE
         ${WARNOPTS_COMMON}
-        -Wshift-sign-overflow            # clang  2.9
-        -Wshorten-64-to-32               # clang  1.0
+        -Wshift-sign-overflow              # clang  2.9
+        -Wshorten-64-to-32                 # clang  1.0
       )
       list(APPEND WARNOPTS_TOCHECK
-        -Wassign-enum                    # clang  7.0            appleclang 10.3
-        -Wcomma                          # clang  3.9            appleclang  8.3
-        -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
-        -Wmissing-variable-declarations  # clang  3.2            appleclang  4.6
+        -Wassign-enum                      # clang  7.0            appleclang 10.3
+        -Wcomma                            # clang  3.9            appleclang  8.3
+        -Wextra-semi-stmt                  # clang  7.0            appleclang 10.3
+        -Wmissing-variable-declarations    # clang  3.2            appleclang  4.6
       )
     else()
       if(MINGW)
         list(APPEND WARNOPTS_TOCHECK
-          -Wno-pedantic-ms-format        #             gcc  4.5 (mingw-only)
+          -Wno-pedantic-ms-format          #             gcc  4.5 (mingw-only)
         )
       endif()
       list(APPEND WARNOPTS_TOCHECK
         ${WARNOPTS_COMMON}
-        -Walloc-zero                     #             gcc  7.0
-        -Warith-conversion               #             gcc 10.0
-        -Wduplicated-branches            #             gcc  7.0
-        -Wduplicated-cond                #             gcc  6.0
-        -Wformat-overflow=2              #             gcc  7.0
-        -Wformat-truncation=1            #             gcc  7.0
-        -Wformat=2                       # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
-        -Wmissing-parameter-type         #             gcc  4.3
-        -Wold-style-declaration          #             gcc  4.3
-        -Wrestrict                       #             gcc  7.0
-        -Wshift-negative-value           # clang  3.7  gcc  6.0 (clang default)
-        -Wshift-overflow=2               # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
-        -Wstrict-aliasing=3              #             gcc  4.0
+        -Walloc-zero                       #             gcc  7.0
+        -Warith-conversion                 #             gcc 10.0
+        -Wduplicated-branches              #             gcc  7.0
+        -Wduplicated-cond                  #             gcc  6.0
+        -Wformat-overflow=2                #             gcc  7.0
+        -Wformat-truncation=1              #             gcc  7.0
+        -Wformat=2                         # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
+        -Wmissing-parameter-type           #             gcc  4.3
+        -Wold-style-declaration            #             gcc  4.3
+        -Wrestrict                         #             gcc  7.0
+        -Wshift-negative-value             # clang  3.7  gcc  6.0 (clang default)
+        -Wshift-overflow=2                 # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
+        -Wstrict-aliasing=3                #             gcc  4.0
       )
 
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
         list(APPEND WARNOPTS_ENABLE -Warray-bounds=2 -ftree-vrp)
-                                         # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
+                                           # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
         list(APPEND WARNOPTS_ENABLE -Wnull-dereference -fdelete-null-pointer-checks)
-                                         # clang  3.0  gcc  6.0 (clang default)
+                                           # clang  3.0  gcc  6.0 (clang default)
       endif()
     endif()
 

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -65,14 +65,14 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Warith-conversion                   #             gcc 10.0
       -Wcast-align                         # clang  1.0  gcc  4.2
       -Wclobbered                          #             gcc  4.3/-Wextra
-      -Wconversion                         # clang _3.0  gcc  4.3 (or even 4.1) --> autotools-clang
+      -Wconversion                         # clang _3.0  gcc  4.3 (or even 4.1)
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
       -Wdouble-promotion                   # clang  3.6  gcc  4.6
-      -Wempty-body                         # clang _3.0  gcc  4.3              --> autotools-clang
+      -Wempty-body                         # clang _3.0  gcc  4.3
       -Wendif-labels                       # clang  1.0  gcc  3.3
-      -Wenum-conversion                    # clang  3.2  gcc 10.0 (for C, 11.0 for C++) --> autotools-clang
+      -Wenum-conversion                    # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
       -Wfloat-equal                        # clang  1.0  gcc  2.96
-      -Wignored-qualifiers                 # clang _3.0  gcc  4.3              --> autotools-clang
+      -Wignored-qualifiers                 # clang _3.0  gcc  4.3
       -Winline                             # clang  1.0  gcc  1.0
       -Wmissing-declarations               # clang  1.0  gcc  2.7
       -Wmissing-parameter-type             #             gcc  4.3
@@ -84,7 +84,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wsign-compare                       # clang  1.0  gcc  2.95
       -Wstrict-aliasing=3                  #             gcc  4.0
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
-      -Wtype-limits                        # clang _3.0  gcc  4.3              --> autotools-clang
+      -Wtype-limits                        # clang _3.0  gcc  4.3
       -Wundef                              # clang  1.0  gcc  2.95
       -Wunused                             # clang  1.1  gcc _4.1 (or earlier) --> autotools-gcc
       -Wvla                                # clang  2.8  gcc  4.3
@@ -93,7 +93,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wno-long-long                       # clang  1.0  gcc  2.95
       -Wno-multichar                       # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
       -Wno-pedantic-ms-format              #             gcc  4.5 (mingw-only) --> autotools-gcc
-      -Wno-sign-conversion                 # clang _3.0  gcc  4.3              --> autotools-clang
+      -Wno-sign-conversion                 # clang _3.0  gcc  4.3
       -Wno-system-headers                  # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
       )
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -94,6 +94,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wassign-enum                    # clang  7.0            appleclang 10.3
         -Wcomma                          # clang  3.9            appleclang  8.3
         -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
+        -Wmissing-variable-declarations  # clang  3.2            appleclang  4.6
       )
     else()
       if(MINGW)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -52,9 +52,12 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wnested-externs                 # clang  1.0  gcc  1.0
       -Wno-format-nonliteral           # clang  1.0  gcc  2.96
       -Wno-long-long                   # clang  1.0  gcc  2.95
+      -Wno-multichar                   # clang  1.0  gcc  2.95
       -Wpointer-arith                  # clang  1.0  gcc  1.0
+      -Wshadow                         # clang  1.0  gcc  2.95
       -Wsign-compare                   # clang  1.0  gcc  2.95
       -Wundef                          # clang  1.0  gcc  2.95
+      -Wunused                         # clang  1.1  gcc  2.95
       -Wwrite-strings                  # clang  1.0  gcc  1.0
     )
 
@@ -66,7 +69,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
       -Wignored-qualifiers             # clang _3.0  gcc  4.3
       -Wtype-limits                    # clang _3.0  gcc  4.3
-      -Wunused                         # clang  1.1  gcc _4.1 (or earlier)
       -Wunused-const-variable          # clang  3.4  gcc  6.0
       -Wvla                            # clang  2.8  gcc  4.3
       -Wno-sign-conversion             # clang _3.0  gcc  4.3
@@ -78,9 +80,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wcast-align                   # clang  1.0  gcc  4.2
         -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
         -Wendif-labels                 # clang  1.0  gcc  3.3
-        -Wno-multichar                 # clang  1.0  gcc _4.1 (or earlier)
         -Wno-system-headers            # clang  1.0  gcc _4.1 (or earlier)
-        -Wshadow                       # clang  1.0  gcc _4.1 (or earlier)
         -Wstrict-prototypes            # clang  1.0  gcc  3.3
       )
       # clang-only
@@ -99,9 +99,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wcast-align                   # clang  1.0  gcc  4.2
         -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
         -Wendif-labels                 # clang  1.0  gcc  3.3
-        -Wno-multichar                 # clang  1.0  gcc _4.1 (or earlier)
         -Wno-system-headers            # clang  1.0  gcc _4.1 (or earlier)
-        -Wshadow                       # clang  1.0  gcc _4.1 (or earlier)
         -Wstrict-prototypes            # clang  1.0  gcc  3.3
       )
       # gcc-only

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -80,21 +80,21 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wnested-externs                     # clang  1.0  gcc  1.0
       -Wold-style-declaration              #             gcc  4.3
       -Wpointer-arith                      # clang  1.0  gcc  1.0
-      -Wshadow                             # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
+      -Wshadow                             # clang  1.0  gcc _4.1 (or earlier)
       -Wsign-compare                       # clang  1.0  gcc  2.95
       -Wstrict-aliasing=3                  #             gcc  4.0
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
       -Wtype-limits                        # clang _3.0  gcc  4.3
       -Wundef                              # clang  1.0  gcc  2.95
-      -Wunused                             # clang  1.1  gcc _4.1 (or earlier) --> autotools-gcc
+      -Wunused                             # clang  1.1  gcc _4.1 (or earlier)
       -Wvla                                # clang  2.8  gcc  4.3
       -Wwrite-strings                      # clang  1.0  gcc  1.0
       -Wno-format-nonliteral               # clang  1.0  gcc  2.96
       -Wno-long-long                       # clang  1.0  gcc  2.95
-      -Wno-multichar                       # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
+      -Wno-multichar                       # clang  1.0  gcc _4.1 (or earlier)
       -Wno-pedantic-ms-format              #             gcc  4.5 (mingw-only)
       -Wno-sign-conversion                 # clang _3.0  gcc  4.3
-      -Wno-system-headers                  # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
+      -Wno-system-headers                  # clang  1.0  gcc _4.1 (or earlier)
       )
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -94,6 +94,11 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wshift-sign-overflow          # clang  2.9
       )
     else()
+      if(MINGW)
+        list(APPEND WARNOPTS_TOCHECK
+          -Wno-pedantic-ms-format      #             gcc  4.5 (mingw-only)
+        )
+      endif()
       # common with clang
       list(APPEND WARNOPTS_TOCHECK
         -Wcast-align                   # clang  1.0  gcc  4.2
@@ -113,7 +118,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wformat-truncation=1          #             gcc  7.0
         -Wformat=2                     # clang  3.0  gcc  4.8 [clang some-default]
         -Wmissing-parameter-type       #             gcc  4.3
-        -Wno-pedantic-ms-format        #             gcc  4.5 (mingw-only)
         -Wold-style-declaration        #             gcc  4.3
         -Wrestrict                     #             gcc  7.0
         -Wshift-negative-value         # clang  3.7  gcc  6.0 [clang default]

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -48,6 +48,10 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       set(WARNOPTS_ENABLE "-W")
     endif()
 
+    list(APPEND WARNOPTS_ENABLE
+      -pedantic
+    )
+
     # ----------------------------------
     # Add new options here, if in doubt:
     # ----------------------------------
@@ -60,7 +64,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.95 or later.
     list(APPEND WARNOPTS_ENABLE
-      -pedantic
       -Wconversion                         # clang  3.0  gcc  2.95
       -Winline                             # clang  1.0  gcc  1.0
       -Wmissing-declarations               # clang  1.0  gcc  2.7

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -69,7 +69,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wwrite-strings                      # clang  1.0  gcc  1.0
     )
 
-    # Skip check with clang, use conditions with gcc
+    # Always enable with clang, version dependent with gcc
     set(WARNOPTS_COMMON_OLD
       -Wcast-align                         # clang  1.0  gcc  4.2
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
@@ -83,8 +83,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
-    # Detect
-    set(WARNOPTS_TOCHECK
+    set(WARNOPTS_DETECT
       -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
       -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
       -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
@@ -96,21 +95,19 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
       )
-      # Detect
-      list(APPEND WARNOPTS_TOCHECK
+      list(APPEND WARNOPTS_DETECT
         -Wassign-enum                      # clang  7.0            appleclang 10.3
         -Wcomma                            # clang  3.9            appleclang  8.3
         -Wextra-semi-stmt                  # clang  7.0            appleclang 10.3
         -Wmissing-variable-declarations    # clang  3.2            appleclang  4.6
       )
-    else()
-      # Detect
+    else()  # gcc
       if(MINGW)
-        list(APPEND WARNOPTS_TOCHECK
+        list(APPEND WARNOPTS_DETECT
           -Wno-pedantic-ms-format          #             gcc  4.5 (mingw-only)
         )
       endif()
-      list(APPEND WARNOPTS_TOCHECK
+      list(APPEND WARNOPTS_DETECT
         -Wformat=2                         # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
       )
 
@@ -157,7 +154,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       set(WARNOPTS "${WARNOPTS} ${_CCOPT}")
     endforeach()
 
-    foreach(_CCOPT ${WARNOPTS_TOCHECK})
+    foreach(_CCOPT ${WARNOPTS_DETECT})
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -46,86 +46,86 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     set(WARNOPTS_ENABLE
       -W
       -pedantic
-      -Wconversion                     # clang  3.0  gcc  2.95
-      -Wfloat-equal                    # clang  1.0  gcc  2.96
-      -Winline                         # clang  1.0  gcc  1.0
-      -Wmissing-declarations           # clang  1.0  gcc  2.7
-      -Wmissing-prototypes             # clang  1.0  gcc  1.0
-      -Wnested-externs                 # clang  1.0  gcc  1.0
-      -Wno-format-nonliteral           # clang  1.0  gcc  2.96
-      -Wno-long-long                   # clang  1.0  gcc  2.95
-      -Wno-multichar                   # clang  1.0  gcc  2.95
-      -Wpointer-arith                  # clang  1.0  gcc  1.0
-      -Wshadow                         # clang  1.0  gcc  2.95
-      -Wsign-compare                   # clang  1.0  gcc  2.95
-      -Wundef                          # clang  1.0  gcc  2.95
-      -Wunused                         # clang  1.1  gcc  2.95
-      -Wwrite-strings                  # clang  1.0  gcc  1.0
+      -Wconversion                       # clang  3.0  gcc  2.95
+      -Wfloat-equal                      # clang  1.0  gcc  2.96
+      -Winline                           # clang  1.0  gcc  1.0
+      -Wmissing-declarations             # clang  1.0  gcc  2.7
+      -Wmissing-prototypes               # clang  1.0  gcc  1.0
+      -Wnested-externs                   # clang  1.0  gcc  1.0
+      -Wno-format-nonliteral             # clang  1.0  gcc  2.96
+      -Wno-long-long                     # clang  1.0  gcc  2.95
+      -Wno-multichar                     # clang  1.0  gcc  2.95
+      -Wpointer-arith                    # clang  1.0  gcc  1.0
+      -Wshadow                           # clang  1.0  gcc  2.95
+      -Wsign-compare                     # clang  1.0  gcc  2.95
+      -Wundef                            # clang  1.0  gcc  2.95
+      -Wunused                           # clang  1.1  gcc  2.95
+      -Wwrite-strings                    # clang  1.0  gcc  1.0
     )
 
     # Skip check with clang, do check with gcc
     set(WARNOPTS_COMMON
-      -Wcast-align                     # clang  1.0  gcc  4.2
-      -Wdeclaration-after-statement    # clang  1.0  gcc  3.4
-      -Wempty-body                     # clang  3.0  gcc  4.3
-      -Wendif-labels                   # clang  1.0  gcc  3.3
-      -Wignored-qualifiers             # clang  3.0  gcc  4.3
-      -Wno-sign-conversion             # clang  3.0  gcc  4.3
-      -Wno-system-headers              # clang  1.0  gcc  3.0
-      -Wstrict-prototypes              # clang  1.0  gcc  3.3
-      -Wtype-limits                    # clang  3.0  gcc  4.3
-      -Wvla                            # clang  2.8  gcc  4.3
+      -Wcast-align                       # clang  1.0  gcc  4.2
+      -Wdeclaration-after-statement      # clang  1.0  gcc  3.4
+      -Wempty-body                       # clang  3.0  gcc  4.3
+      -Wendif-labels                     # clang  1.0  gcc  3.3
+      -Wignored-qualifiers               # clang  3.0  gcc  4.3
+      -Wno-sign-conversion               # clang  3.0  gcc  4.3
+      -Wno-system-headers                # clang  1.0  gcc  3.0
+      -Wstrict-prototypes                # clang  1.0  gcc  3.3
+      -Wtype-limits                      # clang  3.0  gcc  4.3
+      -Wvla                              # clang  2.8  gcc  4.3
     )
 
     # Enable if available
     set(WARNOPTS_TOCHECK
-      -Wdouble-promotion               # clang  3.6  gcc  4.6  appleclang  6.3
-      -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
-      -Wunused-const-variable          # clang  3.4  gcc  6.0  appleclang  5.1
+      -Wdouble-promotion                 # clang  3.6  gcc  4.6  appleclang  6.3
+      -Wenum-conversion                  # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
+      -Wunused-const-variable            # clang  3.4  gcc  6.0  appleclang  5.1
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
       list(APPEND WARNOPTS_ENABLE
         ${WARNOPTS_COMMON}
-        -Wshift-sign-overflow          # clang  2.9
-        -Wshorten-64-to-32             # clang  1.0
+        -Wshift-sign-overflow            # clang  2.9
+        -Wshorten-64-to-32               # clang  1.0
       )
       list(APPEND WARNOPTS_TOCHECK
-        -Wassign-enum                  # clang  7.0            appleclang 10.3
-        -Wcomma                        # clang  3.9            appleclang  8.3
-        -Wextra-semi-stmt              # clang  7.0            appleclang 10.3
+        -Wassign-enum                    # clang  7.0            appleclang 10.3
+        -Wcomma                          # clang  3.9            appleclang  8.3
+        -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
       )
     else()
       if(MINGW)
         list(APPEND WARNOPTS_TOCHECK
-          -Wno-pedantic-ms-format      #             gcc  4.5 (mingw-only)
+          -Wno-pedantic-ms-format        #             gcc  4.5 (mingw-only)
         )
       endif()
       list(APPEND WARNOPTS_TOCHECK
         ${WARNOPTS_COMMON}
-        -Walloc-zero                   #             gcc  7.0
-        -Warith-conversion             #             gcc 10.0
-        -Wduplicated-branches          #             gcc  7.0
-        -Wduplicated-cond              #             gcc  6.0
-        -Wformat-overflow=2            #             gcc  7.0
-        -Wformat-truncation=1          #             gcc  7.0
-        -Wformat=2                     # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
-        -Wmissing-parameter-type       #             gcc  4.3
-        -Wold-style-declaration        #             gcc  4.3
-        -Wrestrict                     #             gcc  7.0
-        -Wshift-negative-value         # clang  3.7  gcc  6.0 (clang default)
-        -Wshift-overflow=2             # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
-        -Wstrict-aliasing=3            #             gcc  4.0
+        -Walloc-zero                     #             gcc  7.0
+        -Warith-conversion               #             gcc 10.0
+        -Wduplicated-branches            #             gcc  7.0
+        -Wduplicated-cond                #             gcc  6.0
+        -Wformat-overflow=2              #             gcc  7.0
+        -Wformat-truncation=1            #             gcc  7.0
+        -Wformat=2                       # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
+        -Wmissing-parameter-type         #             gcc  4.3
+        -Wold-style-declaration          #             gcc  4.3
+        -Wrestrict                       #             gcc  7.0
+        -Wshift-negative-value           # clang  3.7  gcc  6.0 (clang default)
+        -Wshift-overflow=2               # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
+        -Wstrict-aliasing=3              #             gcc  4.0
       )
 
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
         list(APPEND WARNOPTS_ENABLE -Warray-bounds=2 -ftree-vrp)
-                                       # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
+                                         # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
         list(APPEND WARNOPTS_ENABLE -Wnull-dereference -fdelete-null-pointer-checks)
-                                       # clang  3.0  gcc  6.0 (clang default)
+                                         # clang  3.0  gcc  6.0 (clang default)
       endif()
     endif()
 

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -60,26 +60,30 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
     # Enable if available
     set(WARNOPTS_TOCHECK
-      -Wcast-align                     # clang  1.0  gcc  4.2
       -Wconversion                     # clang _3.0  gcc  4.3 (or even 4.1)
-      -Wdeclaration-after-statement    # clang  1.0  gcc  3.4
       -Wdouble-promotion               # clang  3.6  gcc  4.6
       -Wempty-body                     # clang _3.0  gcc  4.3
-      -Wendif-labels                   # clang  1.0  gcc  3.3
       -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
       -Wignored-qualifiers             # clang _3.0  gcc  4.3
-      -Wshadow                         # clang  1.0  gcc _4.1 (or earlier)
-      -Wstrict-prototypes              # clang  1.0  gcc  3.3
       -Wtype-limits                    # clang _3.0  gcc  4.3
       -Wunused                         # clang  1.1  gcc _4.1 (or earlier)
       -Wunused-const-variable          # clang  3.4  gcc  6.0
       -Wvla                            # clang  2.8  gcc  4.3
-      -Wno-multichar                   # clang  1.0  gcc _4.1 (or earlier)
       -Wno-sign-conversion             # clang _3.0  gcc  4.3
-      -Wno-system-headers              # clang  1.0  gcc _4.1 (or earlier)
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+      # common with gcc, but save detection with clang
+      list(APPEND WARNOPTS_ENABLE
+        -Wcast-align                   # clang  1.0  gcc  4.2
+        -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
+        -Wendif-labels                 # clang  1.0  gcc  3.3
+        -Wno-multichar                 # clang  1.0  gcc _4.1 (or earlier)
+        -Wno-system-headers            # clang  1.0  gcc _4.1 (or earlier)
+        -Wshadow                       # clang  1.0  gcc _4.1 (or earlier)
+        -Wstrict-prototypes            # clang  1.0  gcc  3.3
+      )
+      # clang-only
       list(APPEND WARNOPTS_ENABLE
         -Wshorten-64-to-32             # clang  1.0
       )
@@ -90,6 +94,17 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wshift-sign-overflow          # clang  2.9
       )
     else()
+      # common with clang
+      list(APPEND WARNOPTS_TOCHECK
+        -Wcast-align                   # clang  1.0  gcc  4.2
+        -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
+        -Wendif-labels                 # clang  1.0  gcc  3.3
+        -Wno-multichar                 # clang  1.0  gcc _4.1 (or earlier)
+        -Wno-system-headers            # clang  1.0  gcc _4.1 (or earlier)
+        -Wshadow                       # clang  1.0  gcc _4.1 (or earlier)
+        -Wstrict-prototypes            # clang  1.0  gcc  3.3
+      )
+      # gcc-only
       list(APPEND WARNOPTS_TOCHECK
         -Walloc-zero                   #             gcc  7.0
         -Warith-conversion             #             gcc 10.0

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -130,7 +130,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     endif()
 
     foreach(_CCOPT ${WARNOPTS_ENABLE})
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CCOPT}")
+      set(WARNOPTS "${WARNOPTS} ${_CCOPT}")
     endforeach()
 
     foreach(_CCOPT ${WARNOPTS_TOCHECK})
@@ -142,8 +142,11 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       string(REPLACE "-Wno-" "-W" _CCOPT_ON "${_CCOPT}")
       check_c_compiler_flag(${_CCOPT_ON} ${_optvarname})
       if(${_optvarname})
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CCOPT}")
+        set(WARNOPTS "${WARNOPTS} ${_CCOPT}")
       endif()
     endforeach()
+
+    message(STATUS "Picky compiler options:${WARNOPTS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNOPTS}")
   endif()
 endif()

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -58,16 +58,14 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     )
 
     # Assume these options always exist with both clang and gcc.
-    # Require clang 3.0 / gcc 2.96 or later.
+    # Require clang 3.0 / gcc 2.95 or later.
     list(APPEND WARNOPTS_ENABLE
       -pedantic
       -Wconversion                         # clang  3.0  gcc  2.95
-      -Wfloat-equal                        # clang  1.0  gcc  2.96
       -Winline                             # clang  1.0  gcc  1.0
       -Wmissing-declarations               # clang  1.0  gcc  2.7
       -Wmissing-prototypes                 # clang  1.0  gcc  1.0
       -Wnested-externs                     # clang  1.0  gcc  1.0
-      -Wno-format-nonliteral               # clang  1.0  gcc  2.96
       -Wno-long-long                       # clang  1.0  gcc  2.95
       -Wno-multichar                       # clang  1.0  gcc  2.95
       -Wpointer-arith                      # clang  1.0  gcc  1.0
@@ -84,7 +82,9 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
       -Wempty-body                         # clang  3.0  gcc  4.3
       -Wendif-labels                       # clang  1.0  gcc  3.3
+      -Wfloat-equal                        # clang  1.0  gcc  2.96 (3.0)
       -Wignored-qualifiers                 # clang  3.0  gcc  4.3
+      -Wno-format-nonliteral               # clang  1.0  gcc  2.96 (3.0)
       -Wno-sign-conversion                 # clang  3.0  gcc  4.3
       -Wno-system-headers                  # clang  1.0  gcc  3.0
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -67,7 +67,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wdouble-promotion               # clang  3.6  gcc  4.6
       -Wempty-body                     # clang  3.0  gcc  4.3
       -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
-      -Wformat=2                       # clang  3.0  gcc  4.8
       -Wignored-qualifiers             # clang  3.0  gcc  4.3
       -Wtype-limits                    # clang  3.0  gcc  4.3
       -Wunused-const-variable          # clang  3.4  gcc  6.0
@@ -116,6 +115,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wduplicated-cond              #             gcc  6.0
         -Wformat-overflow=2            #             gcc  7.0
         -Wformat-truncation=1          #             gcc  7.0
+        -Wformat=2                     # clang  3.0  gcc  4.8 (clang part-default)
         -Wmissing-parameter-type       #             gcc  4.3
         -Wold-style-declaration        #             gcc  4.3
         -Wrestrict                     #             gcc  7.0

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -41,26 +41,29 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
   if(PICKY_COMPILER)
 
+    # WPICKY_ENABLE = Options we want to enable as-is.
+    # WPICKY_DETECT = Options we want to test first and enable if available.
+
     # Prefer the -Wextra alias with clang.
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      set(WARNOPTS_ENABLE "-Wextra")
+      set(WPICKY_ENABLE "-Wextra")
     else()
-      set(WARNOPTS_ENABLE "-W")
+      set(WPICKY_ENABLE "-W")
     endif()
 
-    list(APPEND WARNOPTS_ENABLE
+    list(APPEND WPICKY_ENABLE
       -pedantic
     )
 
     # ----------------------------------
     # Add new options here, if in doubt:
     # ----------------------------------
-    set(WARNOPTS_DETECT
+    set(WPICKY_DETECT
     )
 
     # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.95 or later.
-    list(APPEND WARNOPTS_ENABLE
+    list(APPEND WPICKY_ENABLE
       -Wconversion                         # clang  3.0  gcc  2.95
       -Winline                             # clang  1.0  gcc  1.0
       -Wmissing-declarations               # clang  1.0  gcc  2.7
@@ -77,7 +80,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     )
 
     # Always enable with clang, version dependent with gcc
-    set(WARNOPTS_COMMON_OLD
+    set(WPICKY_COMMON_OLD
       -Wcast-align                         # clang  1.0  gcc  4.2
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
       -Wempty-body                         # clang  3.0  gcc  4.3
@@ -92,69 +95,69 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
-    set(WARNOPTS_COMMON
+    set(WPICKY_COMMON
       -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
       -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
       -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      list(APPEND WARNOPTS_ENABLE
-        ${WARNOPTS_COMMON_OLD}
+      list(APPEND WPICKY_ENABLE
+        ${WPICKY_COMMON_OLD}
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
       )
       # Enable based on compiler version
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
-        list(APPEND WARNOPTS_ENABLE
-          ${WARNOPTS_COMMON}
+        list(APPEND WPICKY_ENABLE
+          ${WPICKY_COMMON}
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.3))
-        list(APPEND WARNOPTS_ENABLE
+        list(APPEND WPICKY_ENABLE
           -Wcomma                          # clang  3.9            appleclang  8.3
           -Wmissing-variable-declarations  # clang  3.2            appleclang  4.6
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.3))
-        list(APPEND WARNOPTS_ENABLE
+        list(APPEND WPICKY_ENABLE
           -Wassign-enum                    # clang  7.0            appleclang 10.3
           -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
         )
       endif()
     else()  # gcc
-      list(APPEND WARNOPTS_DETECT
-        ${WARNOPTS_COMMON}
+      list(APPEND WPICKY_DETECT
+        ${WPICKY_COMMON}
       )
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
-        list(APPEND WARNOPTS_ENABLE
-          ${WARNOPTS_COMMON_OLD}
+        list(APPEND WPICKY_ENABLE
+          ${WPICKY_COMMON_OLD}
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
           -Wstrict-aliasing=3              #             gcc  4.0
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.5 AND MINGW)
-        list(APPEND WARNOPTS_ENABLE
+        list(APPEND WPICKY_ENABLE
           -Wno-pedantic-ms-format          #             gcc  4.5 (mingw-only)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
-        list(APPEND WARNOPTS_ENABLE
+        list(APPEND WPICKY_ENABLE
           -Wformat=2                       # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
-        list(APPEND WARNOPTS_ENABLE
+        list(APPEND WPICKY_ENABLE
           -Warray-bounds=2 -ftree-vrp      # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
-        list(APPEND WARNOPTS_ENABLE
+        list(APPEND WPICKY_ENABLE
           -Wduplicated-cond                #             gcc  6.0
           -Wnull-dereference               # clang  3.0  gcc  6.0 (clang default)
             -fdelete-null-pointer-checks
@@ -163,7 +166,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0)
-        list(APPEND WARNOPTS_ENABLE
+        list(APPEND WPICKY_ENABLE
         -Walloc-zero                       #             gcc  7.0
         -Wduplicated-branches              #             gcc  7.0
         -Wformat-overflow=2                #             gcc  7.0
@@ -172,17 +175,21 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0)
-        list(APPEND WARNOPTS_ENABLE
+        list(APPEND WPICKY_ENABLE
           -Warith-conversion               #             gcc 10.0
         )
       endif()
     endif()
 
-    foreach(_CCOPT ${WARNOPTS_ENABLE})
-      set(WARNOPTS "${WARNOPTS} ${_CCOPT}")
+    #
+
+    unset(WPICKY)
+
+    foreach(_CCOPT ${WPICKY_ENABLE})
+      set(WPICKY "${WPICKY} ${_CCOPT}")
     endforeach()
 
-    foreach(_CCOPT ${WARNOPTS_DETECT})
+    foreach(_CCOPT ${WPICKY_DETECT})
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)
@@ -191,11 +198,11 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       string(REPLACE "-Wno-" "-W" _CCOPT_ON "${_CCOPT}")
       check_c_compiler_flag(${_CCOPT_ON} ${_optvarname})
       if(${_optvarname})
-        set(WARNOPTS "${WARNOPTS} ${_CCOPT}")
+        set(WPICKY "${WPICKY} ${_CCOPT}")
       endif()
     endforeach()
 
-    message(STATUS "Picky compiler options:${WARNOPTS}")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNOPTS}")
+    message(STATUS "Picky compiler options:${WPICKY}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WPICKY}")
   endif()
 endif()

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -41,10 +41,16 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
   if(PICKY_COMPILER)
 
+    # Prefer the -Wextra alias with clang.
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+      set(WARNOPTS_ENABLE "-Wextra")
+    else()
+      set(WARNOPTS_ENABLE "-W")
+    endif()
+
     # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.96 or later.
-    set(WARNOPTS_ENABLE
-      -W
+    list(APPEND WARNOPTS_ENABLE
       -pedantic
       -Wconversion                       # clang  3.0  gcc  2.95
       -Wfloat-equal                      # clang  1.0  gcc  2.96

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -41,10 +41,16 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
   if(PICKY_COMPILER)
 
-    # common gcc and clang warnings
-    set(WARNOPTS
+    # assume these options always exist
+    foreach(_CCOPT
       -W
       -pedantic
+      )
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CCOPT}")
+    endforeach()
+
+    # common gcc and clang warnings
+    set(WARNOPTS
       -Wcast-align                     # clang  1.0  gcc  4.2
       -Wconversion                     # clang _3.0  gcc  4.3 (or even 4.1)
       -Wdeclaration-after-statement    # clang  1.0  gcc  3.4

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -41,7 +41,8 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
   if(PICKY_COMPILER)
 
-    # Assume these options always exist
+    # Assume these options always exist.
+    # Require clang 3.0 / gcc 2.96 or later.
     set(WARNOPTS_ENABLE
       -W
       -pedantic
@@ -65,13 +66,8 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     # Enable if available
     set(WARNOPTS_TOCHECK
       -Wdouble-promotion               # clang  3.6  gcc  4.6
-      -Wempty-body                     # clang  3.0  gcc  4.3
       -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
-      -Wignored-qualifiers             # clang  3.0  gcc  4.3
-      -Wtype-limits                    # clang  3.0  gcc  4.3
       -Wunused-const-variable          # clang  3.4  gcc  6.0
-      -Wvla                            # clang  2.8  gcc  4.3
-      -Wno-sign-conversion             # clang  3.0  gcc  4.3
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -79,9 +75,14 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       list(APPEND WARNOPTS_ENABLE
         -Wcast-align                   # clang  1.0  gcc  4.2
         -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
+        -Wempty-body                   # clang  3.0  gcc  4.3
         -Wendif-labels                 # clang  1.0  gcc  3.3
+        -Wignored-qualifiers           # clang  3.0  gcc  4.3
+        -Wno-sign-conversion           # clang  3.0  gcc  4.3
         -Wno-system-headers            # clang  1.0  gcc  3.0
         -Wstrict-prototypes            # clang  1.0  gcc  3.3
+        -Wtype-limits                  # clang  3.0  gcc  4.3
+        -Wvla                          # clang  2.8  gcc  4.3
       )
       # clang-only
       list(APPEND WARNOPTS_ENABLE
@@ -103,9 +104,14 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       list(APPEND WARNOPTS_TOCHECK
         -Wcast-align                   # clang  1.0  gcc  4.2
         -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
+        -Wempty-body                   # clang  3.0  gcc  4.3
         -Wendif-labels                 # clang  1.0  gcc  3.3
+        -Wignored-qualifiers           # clang  3.0  gcc  4.3
+        -Wno-sign-conversion           # clang  3.0  gcc  4.3
         -Wno-system-headers            # clang  1.0  gcc  3.0
         -Wstrict-prototypes            # clang  1.0  gcc  3.3
+        -Wtype-limits                  # clang  3.0  gcc  4.3
+        -Wvla                          # clang  2.8  gcc  4.3
       )
       # gcc-only
       list(APPEND WARNOPTS_TOCHECK

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -48,6 +48,15 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       set(WARNOPTS_ENABLE "-W")
     endif()
 
+    # ----------------------------------
+    # Add new options here, if in doubt:
+    # ----------------------------------
+    set(WARNOPTS_DETECT
+      -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
+      -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
+      -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
+    )
+
     # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.96 or later.
     list(APPEND WARNOPTS_ENABLE
@@ -81,13 +90,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
       -Wtype-limits                        # clang  3.0  gcc  4.3
       -Wvla                                # clang  2.8  gcc  4.3
-    )
-
-    # Add new options here if in doubt:
-    set(WARNOPTS_DETECT
-      -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
-      -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
-      -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -79,9 +79,9 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
     # Enable if available
     set(WARNOPTS_TOCHECK
-      -Wdouble-promotion               # clang  3.6  gcc  4.6
-      -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
-      -Wunused-const-variable          # clang  3.4  gcc  6.0
+      -Wdouble-promotion               # clang  3.6  gcc  4.6  appleclang  6.3
+      -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
+      -Wunused-const-variable          # clang  3.4  gcc  6.0  appleclang  5.1
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -91,9 +91,9 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wshorten-64-to-32             # clang  1.0
       )
       list(APPEND WARNOPTS_TOCHECK
-        -Wassign-enum                  # clang  7.0
-        -Wcomma                        # clang  3.9
-        -Wextra-semi-stmt              # clang  7.0
+        -Wassign-enum                  # clang  7.0            appleclang 10.3
+        -Wcomma                        # clang  3.9            appleclang  8.3
+        -Wextra-semi-stmt              # clang  7.0            appleclang 10.3
       )
     else()
       if(MINGW)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -63,15 +63,15 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
     # Enable if available
     set(WARNOPTS_TOCHECK
-      -Wconversion                     # clang _3.0  gcc  4.3 (or even 4.1)
+      -Wconversion                     # clang  3.0  gcc  4.3 (or even 4.1)
       -Wdouble-promotion               # clang  3.6  gcc  4.6
-      -Wempty-body                     # clang _3.0  gcc  4.3
+      -Wempty-body                     # clang  3.0  gcc  4.3
       -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
-      -Wignored-qualifiers             # clang _3.0  gcc  4.3
-      -Wtype-limits                    # clang _3.0  gcc  4.3
+      -Wignored-qualifiers             # clang  3.0  gcc  4.3
+      -Wtype-limits                    # clang  3.0  gcc  4.3
       -Wunused-const-variable          # clang  3.4  gcc  6.0
       -Wvla                            # clang  2.8  gcc  4.3
-      -Wno-sign-conversion             # clang _3.0  gcc  4.3
+      -Wno-sign-conversion             # clang  3.0  gcc  4.3
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -80,7 +80,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wcast-align                   # clang  1.0  gcc  4.2
         -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
         -Wendif-labels                 # clang  1.0  gcc  3.3
-        -Wno-system-headers            # clang  1.0  gcc _4.1 (or earlier)
+        -Wno-system-headers            # clang  1.0  gcc  3.0
         -Wstrict-prototypes            # clang  1.0  gcc  3.3
       )
       # clang-only
@@ -99,7 +99,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wcast-align                   # clang  1.0  gcc  4.2
         -Wdeclaration-after-statement  # clang  1.0  gcc  3.4
         -Wendif-labels                 # clang  1.0  gcc  3.3
-        -Wno-system-headers            # clang  1.0  gcc _4.1 (or earlier)
+        -Wno-system-headers            # clang  1.0  gcc  3.0
         -Wstrict-prototypes            # clang  1.0  gcc  3.3
       )
       # gcc-only
@@ -111,24 +111,24 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wduplicated-cond              #             gcc  6.0
         -Wformat-overflow=2            #             gcc  7.0
         -Wformat-truncation=2          #             gcc  7.0
-        -Wformat=2                     # clang _3.0  gcc  4.8 [clang some-default]
+        -Wformat=2                     # clang  3.0  gcc  4.8 [clang some-default]
         -Wmissing-parameter-type       #             gcc  4.3
         -Wno-pedantic-ms-format        #             gcc  4.5 (mingw-only)
         -Wold-style-declaration        #             gcc  4.3
         -Wrestrict                     #             gcc  7.0
         -Wshift-negative-value         # clang  3.7  gcc  6.0 [clang default]
-        -Wshift-overflow=2             # clang _3.0  gcc  6.0 [clang default -Wshift-overflow]
+        -Wshift-overflow=2             # clang  3.0  gcc  6.0 [clang default -Wshift-overflow]
         -Wstrict-aliasing=3            #             gcc  4.0
       )
 
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
         list(APPEND WARNOPTS_ENABLE -Warray-bounds=2 -ftree-vrp)
-                                       # clang _3.0  gcc  5.0 [clang default -Warray-bounds]
+                                       # clang  3.0  gcc  5.0 [clang default -Warray-bounds]
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
         list(APPEND WARNOPTS_ENABLE -Wnull-dereference -fdelete-null-pointer-checks)
-                                       # clang _3.0  gcc  6.0 [clang default]
+                                       # clang  3.0  gcc  6.0 [clang default]
       endif()
     endif()
 

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -39,63 +39,77 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
   endif()
 
-# cmake clang missing:
-# -Wassign-enum                                         # clang  7.0
-# -Wcomma                                               # clang  3.9
-# -Wextra-semi-stmt                                     # clang  7.0
-# -Wshift-sign-overflow                                 # clang  2.9
-# -Wshorten-64-to-32                                    # clang  1.0
-
-# cmake gcc missing:
-# -Walloc-zero                                          #             gcc 7.0
-# -Warray-bounds=2 -ftree-vrp                           # clang _3.0  gcc 5.0 [clang default -Warray-bounds]
-# -Wduplicated-branches                                 #             gcc 7.0
-# -Wduplicated-cond                                     #             gcc 6.0
-# -Wformat-overflow=2                                   #             gcc 7.0
-# -Wformat-truncation=2                                 #             gcc 7.0
-# -Wformat=2                                            # clang _3.0  gcc 4.8 [clang some-default]
-# -Wnull-dereference -fdelete-null-pointer-checks       # clang _3.0  gcc 6.0 [clang default]
-# -Wrestrict                                            #             gcc 7.0
-# -Wshift-negative-value                                # clang  3.7  gcc 6.0 [clang default]
-# -Wshift-overflow=2                                    # clang _3.0  gcc 6.0 [clang default -Wshift-overflow]
-# -Wunused-const-variable                               # clang  3.4  gcc 6.0
-
   if(PICKY_COMPILER)
-    foreach(_CCOPT -pedantic -W
-      -Warith-conversion                   #             gcc 10.0
-      -Wcast-align                         # clang  1.0  gcc  4.2
-      -Wclobbered                          #             gcc  4.3/-Wextra
-      -Wconversion                         # clang _3.0  gcc  4.3 (or even 4.1)
-      -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
-      -Wdouble-promotion                   # clang  3.6  gcc  4.6
-      -Wempty-body                         # clang _3.0  gcc  4.3
-      -Wendif-labels                       # clang  1.0  gcc  3.3
-      -Wenum-conversion                    # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
-      -Wfloat-equal                        # clang  1.0  gcc  2.96
-      -Wignored-qualifiers                 # clang _3.0  gcc  4.3
-      -Winline                             # clang  1.0  gcc  1.0
-      -Wmissing-declarations               # clang  1.0  gcc  2.7
-      -Wmissing-parameter-type             #             gcc  4.3
-      -Wmissing-prototypes                 # clang  1.0  gcc  1.0
-      -Wnested-externs                     # clang  1.0  gcc  1.0
-      -Wold-style-declaration              #             gcc  4.3
-      -Wpointer-arith                      # clang  1.0  gcc  1.0
-      -Wshadow                             # clang  1.0  gcc _4.1 (or earlier)
-      -Wsign-compare                       # clang  1.0  gcc  2.95
-      -Wstrict-aliasing=3                  #             gcc  4.0
-      -Wstrict-prototypes                  # clang  1.0  gcc  3.3
-      -Wtype-limits                        # clang _3.0  gcc  4.3
-      -Wundef                              # clang  1.0  gcc  2.95
-      -Wunused                             # clang  1.1  gcc _4.1 (or earlier)
-      -Wvla                                # clang  2.8  gcc  4.3
-      -Wwrite-strings                      # clang  1.0  gcc  1.0
-      -Wno-format-nonliteral               # clang  1.0  gcc  2.96
-      -Wno-long-long                       # clang  1.0  gcc  2.95
-      -Wno-multichar                       # clang  1.0  gcc _4.1 (or earlier)
-      -Wno-pedantic-ms-format              #             gcc  4.5 (mingw-only)
-      -Wno-sign-conversion                 # clang _3.0  gcc  4.3
-      -Wno-system-headers                  # clang  1.0  gcc _4.1 (or earlier)
+
+    # common gcc and clang warnings
+    set(WARNOPTS
+      -W
+      -pedantic
+      -Wcast-align                     # clang  1.0  gcc  4.2
+      -Wconversion                     # clang _3.0  gcc  4.3 (or even 4.1)
+      -Wdeclaration-after-statement    # clang  1.0  gcc  3.4
+      -Wdouble-promotion               # clang  3.6  gcc  4.6
+      -Wempty-body                     # clang _3.0  gcc  4.3
+      -Wendif-labels                   # clang  1.0  gcc  3.3
+      -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
+      -Wfloat-equal                    # clang  1.0  gcc  2.96
+      -Wignored-qualifiers             # clang _3.0  gcc  4.3
+      -Winline                         # clang  1.0  gcc  1.0
+      -Wmissing-declarations           # clang  1.0  gcc  2.7
+      -Wmissing-prototypes             # clang  1.0  gcc  1.0
+      -Wnested-externs                 # clang  1.0  gcc  1.0
+      -Wpointer-arith                  # clang  1.0  gcc  1.0
+      -Wshadow                         # clang  1.0  gcc _4.1 (or earlier)
+      -Wsign-compare                   # clang  1.0  gcc  2.95
+      -Wstrict-prototypes              # clang  1.0  gcc  3.3
+      -Wtype-limits                    # clang _3.0  gcc  4.3
+      -Wundef                          # clang  1.0  gcc  2.95
+      -Wunused                         # clang  1.1  gcc _4.1 (or earlier)
+      -Wunused-const-variable          # clang  3.4  gcc  6.0
+      -Wvla                            # clang  2.8  gcc  4.3
+      -Wwrite-strings                  # clang  1.0  gcc  1.0
+      -Wno-format-nonliteral           # clang  1.0  gcc  2.96
+      -Wno-long-long                   # clang  1.0  gcc  2.95
+      -Wno-multichar                   # clang  1.0  gcc _4.1 (or earlier)
+      -Wno-sign-conversion             # clang _3.0  gcc  4.3
+      -Wno-system-headers              # clang  1.0  gcc _4.1 (or earlier)
+    )
+
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+      list(APPEND WARNOPTS
+        -Wassign-enum                  # clang  7.0
+        -Wcomma                        # clang  3.9
+        -Wextra-semi-stmt              # clang  7.0
+        -Wshift-sign-overflow          # clang  2.9
+        -Wshorten-64-to-32             # clang  1.0
       )
+    else()
+      list(APPEND WARNOPTS
+        -Walloc-zero                   #             gcc  7.0
+        -Warith-conversion             #             gcc 10.0
+        -Wclobbered                    #             gcc  4.3 (-Wextra default)
+        -Wduplicated-branches          #             gcc  7.0
+        -Wduplicated-cond              #             gcc  6.0
+        -Wformat-overflow=2            #             gcc  7.0
+        -Wformat-truncation=2          #             gcc  7.0
+        -Wformat=2                     # clang _3.0  gcc  4.8 [clang some-default]
+        -Wmissing-parameter-type       #             gcc  4.3
+        -Wno-pedantic-ms-format        #             gcc  4.5 (mingw-only)
+        -Wold-style-declaration        #             gcc  4.3
+        -Wrestrict                     #             gcc  7.0
+        -Wshift-negative-value         # clang  3.7  gcc  6.0 [clang default]
+        -Wshift-overflow=2             # clang _3.0  gcc  6.0 [clang default -Wshift-overflow]
+        -Wstrict-aliasing=3            #             gcc  4.0
+      )
+      if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Warray-bounds=2 -ftree-vrp")  # clang _3.0  gcc  5.0 [clang default -Warray-bounds]
+      endif()
+      if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wnull-dereference -fdelete-null-pointer-checks")  # clang _3.0  gcc  6.0 [clang default]
+      endif()
+    endif()
+
+    foreach(_CCOPT ${WARNOPTS})
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -75,7 +75,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      # common with gcc, but save detection with clang
+      # common with gcc, but skip detection with clang
       list(APPEND WARNOPTS_ENABLE
         -Wcast-align                   # clang  1.0  gcc  4.2
         -Wdeclaration-after-statement  # clang  1.0  gcc  3.4

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -69,8 +69,8 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wwrite-strings                      # clang  1.0  gcc  1.0
     )
 
-    # Skip check with clang, do check with gcc
-    set(WARNOPTS_COMMON
+    # Skip check with clang, use conditions with gcc
+    set(WARNOPTS_COMMON_OLD
       -Wcast-align                         # clang  1.0  gcc  4.2
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
       -Wempty-body                         # clang  3.0  gcc  4.3
@@ -83,7 +83,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
-    # Enable if available
+    # Detect
     set(WARNOPTS_TOCHECK
       -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
       -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
@@ -92,10 +92,11 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
       list(APPEND WARNOPTS_ENABLE
-        ${WARNOPTS_COMMON}
+        ${WARNOPTS_COMMON_OLD}
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
       )
+      # Detect
       list(APPEND WARNOPTS_TOCHECK
         -Wassign-enum                      # clang  7.0            appleclang 10.3
         -Wcomma                            # clang  3.9            appleclang  8.3
@@ -103,36 +104,52 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wmissing-variable-declarations    # clang  3.2            appleclang  4.6
       )
     else()
+      # Detect
       if(MINGW)
         list(APPEND WARNOPTS_TOCHECK
           -Wno-pedantic-ms-format          #             gcc  4.5 (mingw-only)
         )
       endif()
       list(APPEND WARNOPTS_TOCHECK
-        ${WARNOPTS_COMMON}
-        -Walloc-zero                       #             gcc  7.0
-        -Warith-conversion                 #             gcc 10.0
-        -Wduplicated-branches              #             gcc  7.0
-        -Wduplicated-cond                  #             gcc  6.0
-        -Wformat-overflow=2                #             gcc  7.0
-        -Wformat-truncation=1              #             gcc  7.0
         -Wformat=2                         # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
-        -Wmissing-parameter-type           #             gcc  4.3
-        -Wold-style-declaration            #             gcc  4.3
-        -Wrestrict                         #             gcc  7.0
-        -Wshift-negative-value             # clang  3.7  gcc  6.0 (clang default)
-        -Wshift-overflow=2                 # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
-        -Wstrict-aliasing=3                #             gcc  4.0
       )
 
       # Enable based on compiler version
+      if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
+        list(APPEND WARNOPTS_ENABLE
+          ${WARNOPTS_COMMON_OLD}
+          -Wmissing-parameter-type         #             gcc  4.3
+          -Wold-style-declaration          #             gcc  4.3
+          -Wstrict-aliasing=3              #             gcc  4.0
+        )
+      endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
-        list(APPEND WARNOPTS_ENABLE -Warray-bounds=2 -ftree-vrp)
-                                           # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
+        list(APPEND WARNOPTS_ENABLE
+          -Warray-bounds=2 -ftree-vrp      # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
+        )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
-        list(APPEND WARNOPTS_ENABLE -Wnull-dereference -fdelete-null-pointer-checks)
-                                           # clang  3.0  gcc  6.0 (clang default)
+        list(APPEND WARNOPTS_ENABLE
+          -Wnull-dereference               # clang  3.0  gcc  6.0 (clang default)
+            -fdelete-null-pointer-checks
+          -Wduplicated-cond                #             gcc  6.0
+          -Wshift-negative-value           # clang  3.7  gcc  6.0 (clang default)
+          -Wshift-overflow=2               # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
+        )
+      endif()
+      if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0)
+        list(APPEND WARNOPTS_ENABLE
+        -Walloc-zero                       #             gcc  7.0
+        -Wduplicated-branches              #             gcc  7.0
+        -Wformat-overflow=2                #             gcc  7.0
+        -Wformat-truncation=1              #             gcc  7.0
+        -Wrestrict                         #             gcc  7.0
+        )
+      endif()
+      if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0)
+        list(APPEND WARNOPTS_ENABLE
+          -Warith-conversion               #             gcc 10.0
+        )
       endif()
     endif()
 

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -45,6 +45,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     set(WARNOPTS_ENABLE
       -W
       -pedantic
+      -Wconversion                     # clang  3.0  gcc  2.95
       -Wfloat-equal                    # clang  1.0  gcc  2.96
       -Winline                         # clang  1.0  gcc  1.0
       -Wmissing-declarations           # clang  1.0  gcc  2.7
@@ -63,7 +64,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
     # Enable if available
     set(WARNOPTS_TOCHECK
-      -Wconversion                     # clang  3.0  gcc  4.3 (or even 4.1)
       -Wdouble-promotion               # clang  3.6  gcc  4.6
       -Wempty-body                     # clang  3.0  gcc  4.3
       -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -28,6 +28,10 @@ if(MSVC)
     endif()
   endif()
 elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+
+  # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+  # https://clang.llvm.org/docs/DiagnosticsReference.html
+
   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
   endif()
@@ -35,8 +39,58 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
   endif()
 
+# clang missing:
+# -Wassign-enum
+# -Wcomma
+# -Wextra-semi-stmt
+# -Wshift-sign-overflow
+# -Wshorten-64-to-32
+
+# gcc missing:
+# -Walloc-zero
+# -Warray-bounds=2 -ftree-vrp
+# -Wduplicated-branches
+# -Wduplicated-cond
+# -Wformat-overflow=2
+# -Wformat-truncation=2
+# -Wformat=2
+# -Wnull-dereference -fdelete-null-pointer-checks
+# -Wrestrict
+# -Wshift-negative-value
+# -Wshift-overflow=2
+# -Wunused-const-variable
+
   if(PICKY_COMPILER)
-    foreach(_CCOPT -pedantic -W -Wpointer-arith -Wwrite-strings -Wunused -Wshadow -Winline -Wnested-externs -Wmissing-declarations -Wmissing-prototypes -Wfloat-equal -Wsign-compare -Wundef -Wendif-labels -Wstrict-prototypes -Wdeclaration-after-statement -Wstrict-aliasing=3 -Wcast-align -Wtype-limits -Wold-style-declaration -Wmissing-parameter-type -Wempty-body -Wclobbered -Wignored-qualifiers -Wconversion -Wvla -Wdouble-promotion -Wenum-conversion -Warith-conversion)
+    message(STATUS "C compiler version: ${CMAKE_C_COMPILER_VERSION}")
+    foreach(_CCOPT -pedantic -W
+        -Warith-conversion                   # gcc
+        -Wcast-align
+        -Wclobbered                          # gcc, part of -Wextra
+        -Wconversion
+        -Wdeclaration-after-statement
+        -Wdouble-promotion
+        -Wempty-body
+        -Wendif-labels
+        -Wenum-conversion
+        -Wfloat-equal
+        -Wignored-qualifiers
+        -Winline
+        -Wmissing-declarations
+        -Wmissing-parameter-type             # gcc
+        -Wmissing-prototypes
+        -Wnested-externs
+        -Wold-style-declaration              # gcc
+        -Wpointer-arith
+        -Wshadow
+        -Wsign-compare
+        -Wstrict-aliasing=3                  # gcc
+        -Wstrict-prototypes
+        -Wtype-limits
+        -Wundef
+        -Wunused
+        -Wvla
+        -Wwrite-strings
+      )
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)
@@ -45,7 +99,14 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CCOPT}")
       endif()
     endforeach()
-    foreach(_CCOPT long-long multichar format-nonliteral sign-conversion system-headers pedantic-ms-format)
+    foreach(_CCOPT
+        format-nonliteral
+        long-long
+        multichar
+        pedantic-ms-format                   # gcc
+        sign-conversion
+        system-headers
+      )
       # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
       # so test for the positive form instead
       string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -112,7 +112,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       list(APPEND WARNOPTS_TOCHECK
         -Walloc-zero                   #             gcc  7.0
         -Warith-conversion             #             gcc 10.0
-        -Wclobbered                    #             gcc  4.3 (comes with -Wextra)
         -Wduplicated-branches          #             gcc  7.0
         -Wduplicated-cond              #             gcc  6.0
         -Wformat-overflow=2            #             gcc  7.0

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -115,7 +115,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wduplicated-cond              #             gcc  6.0
         -Wformat-overflow=2            #             gcc  7.0
         -Wformat-truncation=1          #             gcc  7.0
-        -Wformat=2                     # clang  3.0  gcc  4.8 (clang part-default)
+        -Wformat=2                     # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
         -Wmissing-parameter-type       #             gcc  4.3
         -Wold-style-declaration        #             gcc  4.3
         -Wrestrict                     #             gcc  7.0

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -39,80 +39,72 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
   endif()
 
-# clang missing:
-# -Wassign-enum
-# -Wcomma
-# -Wextra-semi-stmt
-# -Wshift-sign-overflow
-# -Wshorten-64-to-32
+# cmake clang missing:
+# -Wassign-enum                                         # clang  7.0
+# -Wcomma                                               # clang  3.9
+# -Wextra-semi-stmt                                     # clang  7.0
+# -Wshift-sign-overflow                                 # clang  2.9
+# -Wshorten-64-to-32                                    # clang  1.0
 
-# gcc missing:
-# -Walloc-zero
-# -Warray-bounds=2 -ftree-vrp
-# -Wduplicated-branches
-# -Wduplicated-cond
-# -Wformat-overflow=2
-# -Wformat-truncation=2
-# -Wformat=2
-# -Wnull-dereference -fdelete-null-pointer-checks
-# -Wrestrict
-# -Wshift-negative-value
-# -Wshift-overflow=2
-# -Wunused-const-variable
+# cmake gcc missing:
+# -Walloc-zero                                          #             gcc 7.0
+# -Warray-bounds=2 -ftree-vrp                           # clang _3.0  gcc 5.0 [clang default -Warray-bounds]
+# -Wduplicated-branches                                 #             gcc 7.0
+# -Wduplicated-cond                                     #             gcc 6.0
+# -Wformat-overflow=2                                   #             gcc 7.0
+# -Wformat-truncation=2                                 #             gcc 7.0
+# -Wformat=2                                            # clang _3.0  gcc 4.8 [clang some-default]
+# -Wnull-dereference -fdelete-null-pointer-checks       # clang _3.0  gcc 6.0 [clang default]
+# -Wrestrict                                            #             gcc 7.0
+# -Wshift-negative-value                                # clang  3.7  gcc 6.0 [clang default]
+# -Wshift-overflow=2                                    # clang _3.0  gcc 6.0 [clang default -Wshift-overflow]
+# -Wunused-const-variable                               # clang  3.4  gcc 6.0
 
   if(PICKY_COMPILER)
-    message(STATUS "C compiler version: ${CMAKE_C_COMPILER_VERSION}")
     foreach(_CCOPT -pedantic -W
-        -Warith-conversion                   # gcc
-        -Wcast-align
-        -Wclobbered                          # gcc, part of -Wextra
-        -Wconversion
-        -Wdeclaration-after-statement
-        -Wdouble-promotion
-        -Wempty-body
-        -Wendif-labels
-        -Wenum-conversion
-        -Wfloat-equal
-        -Wignored-qualifiers
-        -Winline
-        -Wmissing-declarations
-        -Wmissing-parameter-type             # gcc
-        -Wmissing-prototypes
-        -Wnested-externs
-        -Wold-style-declaration              # gcc
-        -Wpointer-arith
-        -Wshadow
-        -Wsign-compare
-        -Wstrict-aliasing=3                  # gcc
-        -Wstrict-prototypes
-        -Wtype-limits
-        -Wundef
-        -Wunused
-        -Wvla
-        -Wwrite-strings
+      -Warith-conversion                   #             gcc 10.0
+      -Wcast-align                         # clang  1.0  gcc  4.2
+      -Wclobbered                          #             gcc  4.3/-Wextra
+      -Wconversion                         # clang _3.0  gcc  4.3 (or even 4.1) --> autotools-clang
+      -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
+      -Wdouble-promotion                   # clang  3.6  gcc  4.6
+      -Wempty-body                         # clang _3.0  gcc  4.3              --> autotools-clang
+      -Wendif-labels                       # clang  1.0  gcc  3.3
+      -Wenum-conversion                    # clang  3.2  gcc 10.0 (for C, 11.0 for C++) --> autotools-clang
+      -Wfloat-equal                        # clang  1.0  gcc  2.96
+      -Wignored-qualifiers                 # clang _3.0  gcc  4.3              --> autotools-clang
+      -Winline                             # clang  1.0  gcc  1.0
+      -Wmissing-declarations               # clang  1.0  gcc  2.7
+      -Wmissing-parameter-type             #             gcc  4.3
+      -Wmissing-prototypes                 # clang  1.0  gcc  1.0
+      -Wnested-externs                     # clang  1.0  gcc  1.0
+      -Wold-style-declaration              #             gcc  4.3
+      -Wpointer-arith                      # clang  1.0  gcc  1.0
+      -Wshadow                             # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
+      -Wsign-compare                       # clang  1.0  gcc  2.95
+      -Wstrict-aliasing=3                  #             gcc  4.0
+      -Wstrict-prototypes                  # clang  1.0  gcc  3.3
+      -Wtype-limits                        # clang _3.0  gcc  4.3              --> autotools-clang
+      -Wundef                              # clang  1.0  gcc  2.95
+      -Wunused                             # clang  1.1  gcc _4.1 (or earlier) --> autotools-gcc
+      -Wvla                                # clang  2.8  gcc  4.3
+      -Wwrite-strings                      # clang  1.0  gcc  1.0
+      -Wno-format-nonliteral               # clang  1.0  gcc  2.96
+      -Wno-long-long                       # clang  1.0  gcc  2.95
+      -Wno-multichar                       # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
+      -Wno-pedantic-ms-format              #             gcc  4.5 (mingw-only) --> autotools-gcc
+      -Wno-sign-conversion                 # clang _3.0  gcc  4.3              --> autotools-clang
+      -Wno-system-headers                  # clang  1.0  gcc _4.1 (or earlier) --> autotools-gcc
       )
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)
-      check_c_compiler_flag(${_CCOPT} ${_optvarname})
-      if(${_optvarname})
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CCOPT}")
-      endif()
-    endforeach()
-    foreach(_CCOPT
-        format-nonliteral
-        long-long
-        multichar
-        pedantic-ms-format                   # gcc
-        sign-conversion
-        system-headers
-      )
       # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
       # so test for the positive form instead
-      string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)
-      check_c_compiler_flag("-W${_CCOPT}" ${_optvarname})
+      string(REPLACE "-Wno-" "-W" _CCOPT_ON "${_CCOPT}")
+      check_c_compiler_flag(${_CCOPT_ON} ${_optvarname})
       if(${_optvarname})
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-${_CCOPT}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CCOPT}")
       endif()
     endforeach()
   endif()

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -41,16 +41,25 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
   if(PICKY_COMPILER)
 
-    # assume these options always exist
-    foreach(_CCOPT
+    # Assume these options always exist
+    set(WARNOPTS_ENABLE
       -W
       -pedantic
-      )
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CCOPT}")
-    endforeach()
+      -Wfloat-equal                    # clang  1.0  gcc  2.96
+      -Winline                         # clang  1.0  gcc  1.0
+      -Wmissing-declarations           # clang  1.0  gcc  2.7
+      -Wmissing-prototypes             # clang  1.0  gcc  1.0
+      -Wnested-externs                 # clang  1.0  gcc  1.0
+      -Wno-format-nonliteral           # clang  1.0  gcc  2.96
+      -Wno-long-long                   # clang  1.0  gcc  2.95
+      -Wpointer-arith                  # clang  1.0  gcc  1.0
+      -Wsign-compare                   # clang  1.0  gcc  2.95
+      -Wundef                          # clang  1.0  gcc  2.95
+      -Wwrite-strings                  # clang  1.0  gcc  1.0
+    )
 
-    # common gcc and clang warnings
-    set(WARNOPTS
+    # Enable if available
+    set(WARNOPTS_TOCHECK
       -Wcast-align                     # clang  1.0  gcc  4.2
       -Wconversion                     # clang _3.0  gcc  4.3 (or even 4.1)
       -Wdeclaration-after-statement    # clang  1.0  gcc  3.4
@@ -58,39 +67,30 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wempty-body                     # clang _3.0  gcc  4.3
       -Wendif-labels                   # clang  1.0  gcc  3.3
       -Wenum-conversion                # clang  3.2  gcc 10.0 (for C, 11.0 for C++)
-      -Wfloat-equal                    # clang  1.0  gcc  2.96
       -Wignored-qualifiers             # clang _3.0  gcc  4.3
-      -Winline                         # clang  1.0  gcc  1.0
-      -Wmissing-declarations           # clang  1.0  gcc  2.7
-      -Wmissing-prototypes             # clang  1.0  gcc  1.0
-      -Wnested-externs                 # clang  1.0  gcc  1.0
-      -Wpointer-arith                  # clang  1.0  gcc  1.0
       -Wshadow                         # clang  1.0  gcc _4.1 (or earlier)
-      -Wsign-compare                   # clang  1.0  gcc  2.95
       -Wstrict-prototypes              # clang  1.0  gcc  3.3
       -Wtype-limits                    # clang _3.0  gcc  4.3
-      -Wundef                          # clang  1.0  gcc  2.95
       -Wunused                         # clang  1.1  gcc _4.1 (or earlier)
       -Wunused-const-variable          # clang  3.4  gcc  6.0
       -Wvla                            # clang  2.8  gcc  4.3
-      -Wwrite-strings                  # clang  1.0  gcc  1.0
-      -Wno-format-nonliteral           # clang  1.0  gcc  2.96
-      -Wno-long-long                   # clang  1.0  gcc  2.95
       -Wno-multichar                   # clang  1.0  gcc _4.1 (or earlier)
       -Wno-sign-conversion             # clang _3.0  gcc  4.3
       -Wno-system-headers              # clang  1.0  gcc _4.1 (or earlier)
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      list(APPEND WARNOPTS
+      list(APPEND WARNOPTS_ENABLE
+        -Wshorten-64-to-32             # clang  1.0
+      )
+      list(APPEND WARNOPTS_TOCHECK
         -Wassign-enum                  # clang  7.0
         -Wcomma                        # clang  3.9
         -Wextra-semi-stmt              # clang  7.0
         -Wshift-sign-overflow          # clang  2.9
-        -Wshorten-64-to-32             # clang  1.0
       )
     else()
-      list(APPEND WARNOPTS
+      list(APPEND WARNOPTS_TOCHECK
         -Walloc-zero                   #             gcc  7.0
         -Warith-conversion             #             gcc 10.0
         -Wclobbered                    #             gcc  4.3 (-Wextra default)
@@ -107,15 +107,23 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wshift-overflow=2             # clang _3.0  gcc  6.0 [clang default -Wshift-overflow]
         -Wstrict-aliasing=3            #             gcc  4.0
       )
+
+      # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Warray-bounds=2 -ftree-vrp")  # clang _3.0  gcc  5.0 [clang default -Warray-bounds]
+        list(APPEND WARNOPTS_ENABLE -Warray-bounds=2 -ftree-vrp)
+                                       # clang _3.0  gcc  5.0 [clang default -Warray-bounds]
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wnull-dereference -fdelete-null-pointer-checks")  # clang _3.0  gcc  6.0 [clang default]
+        list(APPEND WARNOPTS_ENABLE -Wnull-dereference -fdelete-null-pointer-checks)
+                                       # clang _3.0  gcc  6.0 [clang default]
       endif()
     endif()
 
-    foreach(_CCOPT ${WARNOPTS})
+    foreach(_CCOPT ${WARNOPTS_ENABLE})
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CCOPT}")
+    endforeach()
+
+    foreach(_CCOPT ${WARNOPTS_TOCHECK})
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -111,28 +111,28 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       list(APPEND WARNOPTS_TOCHECK
         -Walloc-zero                   #             gcc  7.0
         -Warith-conversion             #             gcc 10.0
-        -Wclobbered                    #             gcc  4.3 (-Wextra default)
+        -Wclobbered                    #             gcc  4.3 (comes with -Wextra)
         -Wduplicated-branches          #             gcc  7.0
         -Wduplicated-cond              #             gcc  6.0
         -Wformat-overflow=2            #             gcc  7.0
         -Wformat-truncation=1          #             gcc  7.0
-        -Wformat=2                     # clang  3.0  gcc  4.8 [clang some-default]
+        -Wformat=2                     # clang  3.0  gcc  4.8 (clang part-default)
         -Wmissing-parameter-type       #             gcc  4.3
         -Wold-style-declaration        #             gcc  4.3
         -Wrestrict                     #             gcc  7.0
-        -Wshift-negative-value         # clang  3.7  gcc  6.0 [clang default]
-        -Wshift-overflow=2             # clang  3.0  gcc  6.0 [clang default -Wshift-overflow]
+        -Wshift-negative-value         # clang  3.7  gcc  6.0 (clang default)
+        -Wshift-overflow=2             # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
         -Wstrict-aliasing=3            #             gcc  4.0
       )
 
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
         list(APPEND WARNOPTS_ENABLE -Warray-bounds=2 -ftree-vrp)
-                                       # clang  3.0  gcc  5.0 [clang default -Warray-bounds]
+                                       # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
         list(APPEND WARNOPTS_ENABLE -Wnull-dereference -fdelete-null-pointer-checks)
-                                       # clang  3.0  gcc  6.0 [clang default]
+                                       # clang  3.0  gcc  6.0 (clang default)
       endif()
     endif()
 

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -98,12 +98,21 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
       )
-      list(APPEND WARNOPTS_DETECT
-        -Wassign-enum                      # clang  7.0            appleclang 10.3
-        -Wcomma                            # clang  3.9            appleclang  8.3
-        -Wextra-semi-stmt                  # clang  7.0            appleclang 10.3
-        -Wmissing-variable-declarations    # clang  3.2            appleclang  4.6
-      )
+      # Enable based on compiler version
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.3))
+        list(APPEND WARNOPTS_ENABLE
+          -Wcomma                          # clang  3.9            appleclang  8.3
+          -Wmissing-variable-declarations  # clang  3.2            appleclang  4.6
+        )
+      endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.3))
+        list(APPEND WARNOPTS_ENABLE
+          -Wassign-enum                    # clang  7.0            appleclang 10.3
+          -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
+        )
+      endif()
     else()  # gcc
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -185,9 +185,7 @@ int main(int argc, char *argv[])
 
         /* loop until we fail */
         while((rc = libssh2_sftp_readdir(sftp_handle, mem, sizeof(mem),
-                                         &attrs)) == LIBSSH2_ERROR_EAGAIN) {
-            ;
-        }
+                                         &attrs)) == LIBSSH2_ERROR_EAGAIN);
         if(rc > 0) {
             /* rc is the length of the file name in the mem
                buffer */

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -46,11 +46,11 @@ static const char *server_ip = "127.0.0.1";
 /* resolved by the server */
 static const char *remote_listenhost = "localhost";
 
-int remote_wantport = 2222;
-int remote_listenport;
+static int remote_wantport = 2222;
+static int remote_listenport;
 
 static const char *local_destip = "127.0.0.1";
-int local_destport = 22;
+static int local_destport = 22;
 
 enum {
     AUTH_NONE = 0,

--- a/example/x11.c
+++ b/example/x11.c
@@ -55,8 +55,8 @@ struct chan_X11_list {
     struct chan_X11_list *next;
 };
 
-struct chan_X11_list * gp_x11_chan = NULL;
-struct termios         _saved_tio;
+static struct chan_X11_list * gp_x11_chan = NULL;
+static struct termios         _saved_tio;
 
 /*
  * Utility function to remove a Node of the chained list

--- a/src/agent.c
+++ b/src/agent.c
@@ -128,20 +128,22 @@ agent_connect_unix(LIBSSH2_AGENT *agent)
 }
 
 #define RECV_SEND_ALL(func, socket, buffer, length, flags, abstract) \
-    size_t finished = 0;                                             \
+    do {                                                             \
+        size_t finished = 0;                                         \
                                                                      \
-    while(finished < length) {                                       \
-        ssize_t rc;                                                  \
-        rc = func(socket,                                            \
-                  (char *)buffer + finished, length - finished,      \
-                  flags, abstract);                                  \
-        if(rc < 0)                                                   \
-            return rc;                                               \
+        while(finished < length) {                                   \
+            ssize_t rc;                                              \
+            rc = func(socket,                                        \
+                      (char *)buffer + finished, length - finished,  \
+                      flags, abstract);                              \
+            if(rc < 0)                                               \
+                return rc;                                           \
                                                                      \
-        finished += rc;                                              \
-    }                                                                \
+            finished += rc;                                          \
+        }                                                            \
                                                                      \
-    return finished;
+        return finished;                                             \
+    } while(0)
 
 static ssize_t _send_all(LIBSSH2_SEND_FUNC(func), libssh2_socket_t socket,
                          const void *buffer, size_t length,
@@ -242,7 +244,7 @@ agent_disconnect_unix(LIBSSH2_AGENT *agent)
     return LIBSSH2_ERROR_NONE;
 }
 
-struct agent_ops agent_ops_unix = {
+static struct agent_ops agent_ops_unix = {
     agent_connect_unix,
     agent_transact_unix,
     agent_disconnect_unix
@@ -347,7 +349,7 @@ agent_disconnect_pageant(LIBSSH2_AGENT *agent)
     return 0;
 }
 
-struct agent_ops agent_ops_pageant = {
+static struct agent_ops agent_ops_pageant = {
     agent_connect_pageant,
     agent_transact_pageant,
     agent_disconnect_pageant

--- a/src/agent.h
+++ b/src/agent.h
@@ -75,9 +75,9 @@ struct agent_publickey {
 };
 
 struct agent_ops {
-    agent_connect_func connect;
-    agent_transact_func transact;
-    agent_disconnect_func disconnect;
+    const agent_connect_func connect;
+    const agent_transact_func transact;
+    const agent_disconnect_func disconnect;
 };
 
 struct _LIBSSH2_AGENT

--- a/src/comp.c
+++ b/src/comp.c
@@ -237,7 +237,7 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
     /* If strm is null, then we have not yet been initialized. */
     if(strm == NULL)
         return _libssh2_error(session, LIBSSH2_ERROR_COMPRESS,
-                              "decompression uninitialized");;
+                              "decompression uninitialized");
 
     /* In practice they never come smaller than this */
     if(out_maxlen < 25)

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -894,7 +894,7 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
 
 
 #define LIBSSH2_HOSTKEY_METHOD_EC_SIGNV_HASH(digest_type)               \
-    {                                                                   \
+    do {                                                                \
         unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];           \
         libssh2_sha##digest_type##_ctx ctx;                             \
         int i;                                                          \
@@ -907,7 +907,7 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
         ret = _libssh2_ecdsa_sign(session, ec_ctx, hash,                \
                                   SHA##digest_type##_DIGEST_LENGTH,     \
                                   signature, signature_len);            \
-    }
+    } while(0)
 
 
 /*

--- a/src/kex.c
+++ b/src/kex.c
@@ -54,7 +54,7 @@
    kex_method_diffie_hellman_group1_sha1_key_exchange */
 
 #define LIBSSH2_KEX_METHOD_EC_SHA_VALUE_HASH(value, reqlen, version)        \
-    {                                                                       \
+    do {                                                                    \
         if(type == LIBSSH2_EC_CURVE_NISTP256) {                             \
             LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(256, value, reqlen, version); \
         }                                                                   \
@@ -64,12 +64,11 @@
         else if(type == LIBSSH2_EC_CURVE_NISTP521) {                        \
             LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(512, value, reqlen, version); \
         }                                                                   \
-    }                                                                       \
-
+    } while(0)
 
 #define LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(digest_type, value,               \
                                           reqlen, version)                  \
-{                                                                           \
+do {                                                                        \
     libssh2_sha##digest_type##_ctx hash;                                    \
     size_t len = 0;                                                         \
     if(!(value)) {                                                          \
@@ -96,7 +95,7 @@
             libssh2_sha##digest_type##_final(hash, (value) + len);          \
             len += SHA##digest_type##_DIGEST_LENGTH;                        \
         }                                                                   \
-}
+} while(0)
 
 /*!
  * @note The following are wrapper functions used by diffie_hellman_sha_algo().
@@ -1569,96 +1568,96 @@ kex_method_diffie_hellman_group_exchange_sha256_key_exchange
  *
  */
 
-#define LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(digest_type)       \
-{                                                                       \
-    libssh2_sha##digest_type##_ctx ctx;                                 \
-    exchange_state->exchange_hash = (void *)&ctx;                       \
-    (void)libssh2_sha##digest_type##_init(&ctx);                        \
-    if(session->local.banner) {                                         \
-        _libssh2_htonu32(exchange_state->h_sig_comp,                    \
-            (uint32_t)(strlen((char *) session->local.banner) - 2));    \
-        libssh2_sha##digest_type##_update(ctx,                          \
-                                          exchange_state->h_sig_comp, 4); \
-        libssh2_sha##digest_type##_update(ctx,                          \
-                                          (char *) session->local.banner, \
-                                          strlen((char *)               \
-                                                 session->local.banner) \
-                                          - 2);                         \
-    }                                                                   \
-    else {                                                              \
-        _libssh2_htonu32(exchange_state->h_sig_comp,                    \
-                         sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);       \
-        libssh2_sha##digest_type##_update(ctx,                          \
-                                          exchange_state->h_sig_comp, 4); \
-        libssh2_sha##digest_type##_update(ctx,                          \
-                                          LIBSSH2_SSH_DEFAULT_BANNER,   \
+#define LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(digest_type)            \
+do {                                                                         \
+    libssh2_sha##digest_type##_ctx ctx;                                      \
+    exchange_state->exchange_hash = (void *)&ctx;                            \
+    (void)libssh2_sha##digest_type##_init(&ctx);                             \
+    if(session->local.banner) {                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                         \
+            (uint32_t)(strlen((char *) session->local.banner) - 2));         \
+        libssh2_sha##digest_type##_update(ctx,                               \
+                                          exchange_state->h_sig_comp, 4);    \
+        libssh2_sha##digest_type##_update(ctx,                               \
+                                          (char *) session->local.banner,    \
+                                          strlen((char *)                    \
+                                                 session->local.banner)      \
+                                          - 2);                              \
+    }                                                                        \
+    else {                                                                   \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                         \
+                         sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);            \
+        libssh2_sha##digest_type##_update(ctx,                               \
+                                          exchange_state->h_sig_comp, 4);    \
+        libssh2_sha##digest_type##_update(ctx,                               \
+                                          LIBSSH2_SSH_DEFAULT_BANNER,        \
                                           sizeof(LIBSSH2_SSH_DEFAULT_BANNER) \
-                                          - 1);                         \
-    }                                                                   \
-                                                                        \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                        \
-        (uint32_t)strlen((char *) session->remote.banner));             \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      exchange_state->h_sig_comp, 4);   \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      session->remote.banner,           \
-                                      strlen((char *)                   \
-                                             session->remote.banner));  \
-                                                                        \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                        \
-                     (uint32_t)session->local.kexinit_len);             \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      exchange_state->h_sig_comp, 4);   \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      session->local.kexinit,           \
-                                      session->local.kexinit_len);      \
-                                                                        \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                        \
-                     (uint32_t)session->remote.kexinit_len);            \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      exchange_state->h_sig_comp, 4);   \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      session->remote.kexinit,          \
-                                      session->remote.kexinit_len);     \
-                                                                        \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                        \
-                     session->server_hostkey_len);                      \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      exchange_state->h_sig_comp, 4);   \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      session->server_hostkey,          \
-                                      session->server_hostkey_len);     \
-                                                                        \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                        \
-                     (uint32_t)public_key_len);                         \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      exchange_state->h_sig_comp, 4);   \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      public_key,                       \
-                                      public_key_len);                  \
-                                                                        \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                        \
-                     (uint32_t)server_public_key_len);                  \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      exchange_state->h_sig_comp, 4);   \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      server_public_key,                \
-                                      server_public_key_len);           \
-                                                                        \
-    libssh2_sha##digest_type##_update(ctx,                              \
-                                      exchange_state->k_value,          \
-                                      exchange_state->k_value_len);     \
-                                                                        \
-    libssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp);  \
-                                                                        \
-    if(session->hostkey->                                               \
-       sig_verify(session, exchange_state->h_sig,                       \
-                  exchange_state->h_sig_len, exchange_state->h_sig_comp, \
-                  SHA##digest_type##_DIGEST_LENGTH,                     \
-                  &session->server_hostkey_abstract)) {                 \
-        rc = -1;                                                        \
-    }                                                                   \
-}                                                                       \
+                                          - 1);                              \
+    }                                                                        \
+                                                                             \
+    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
+        (uint32_t)strlen((char *) session->remote.banner));                  \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      exchange_state->h_sig_comp, 4);        \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      session->remote.banner,                \
+                                      strlen((char *)                        \
+                                             session->remote.banner));       \
+                                                                             \
+    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
+                     (uint32_t)session->local.kexinit_len);                  \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      exchange_state->h_sig_comp, 4);        \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      session->local.kexinit,                \
+                                      session->local.kexinit_len);           \
+                                                                             \
+    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
+                     (uint32_t)session->remote.kexinit_len);                 \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      exchange_state->h_sig_comp, 4);        \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      session->remote.kexinit,               \
+                                      session->remote.kexinit_len);          \
+                                                                             \
+    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
+                     session->server_hostkey_len);                           \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      exchange_state->h_sig_comp, 4);        \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      session->server_hostkey,               \
+                                      session->server_hostkey_len);          \
+                                                                             \
+    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
+                     (uint32_t)public_key_len);                              \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      exchange_state->h_sig_comp, 4);        \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      public_key,                            \
+                                      public_key_len);                       \
+                                                                             \
+    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
+                     (uint32_t)server_public_key_len);                       \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      exchange_state->h_sig_comp, 4);        \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      server_public_key,                     \
+                                      server_public_key_len);                \
+                                                                             \
+    libssh2_sha##digest_type##_update(ctx,                                   \
+                                      exchange_state->k_value,               \
+                                      exchange_state->k_value_len);          \
+                                                                             \
+    libssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp);       \
+                                                                             \
+    if(session->hostkey->                                                    \
+       sig_verify(session, exchange_state->h_sig,                            \
+                  exchange_state->h_sig_len, exchange_state->h_sig_comp,     \
+                  SHA##digest_type##_DIGEST_LENGTH,                          \
+                  &session->server_hostkey_abstract)) {                      \
+        rc = -1;                                                             \
+    }                                                                        \
+} while(0)
 
 
 #if LIBSSH2_ECDSA
@@ -3105,17 +3104,19 @@ kex_method_list(unsigned char *buf, uint32_t list_strlen,
     (uint32_t)((prefvar) ? strlen(prefvar) :                    \
      kex_method_strlen((LIBSSH2_COMMON_METHOD**)(defaultvar)))
 
-#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)  \
-    if(prefvar) {                                                       \
-        _libssh2_htonu32((buf), (prefvarlen));                          \
-        buf += 4;                                                       \
-        memcpy((buf), (prefvar), (prefvarlen));                         \
-        buf += (prefvarlen);                                            \
-    }                                                                   \
-    else {                                                              \
-        buf += kex_method_list((buf), (prefvarlen),                     \
-                               (LIBSSH2_COMMON_METHOD**)(defaultvar));  \
-    }
+#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)     \
+    do {                                                                   \
+        if(prefvar) {                                                      \
+            _libssh2_htonu32((buf), (prefvarlen));                         \
+            buf += 4;                                                      \
+            memcpy((buf), (prefvar), (prefvarlen));                        \
+            buf += (prefvarlen);                                           \
+        }                                                                  \
+        else {                                                             \
+            buf += kex_method_list((buf), (prefvarlen),                    \
+                                   (LIBSSH2_COMMON_METHOD**)(defaultvar)); \
+        }                                                                  \
+    } while(0)
 
 /* kexinit
  * Send SSH_MSG_KEXINIT packet

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -155,7 +155,7 @@
 #define libssh2_hmac_final(ctx, data) \
   memcpy(data, gcry_md_read(ctx, 0), \
       gcry_md_get_algo_dlen(gcry_md_get_algo(ctx)))
-#define libssh2_hmac_cleanup(ctx) gcry_md_close (*ctx);
+#define libssh2_hmac_cleanup(ctx) gcry_md_close(*ctx)
 
 #define libssh2_crypto_init() gcry_control (GCRYCTL_DISABLE_SECMEM)
 #define libssh2_crypto_exit()

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1033,17 +1033,16 @@ cleanup:
     return rc;
 }
 
-#define LIBSSH2_MBEDTLS_ECDSA_VERIFY(digest_type)                      \
-{                                                                      \
-    unsigned char hsh[SHA##digest_type##_DIGEST_LENGTH];               \
-                                                                       \
-    if(libssh2_sha##digest_type(m, m_len, hsh) == 0) {                 \
-        rc = mbedtls_ecdsa_verify(&ctx->MBEDTLS_PRIVATE(grp), hsh,     \
-                                  SHA##digest_type##_DIGEST_LENGTH,    \
-                                  &ctx->MBEDTLS_PRIVATE(Q), &pr, &ps); \
-    }                                                                  \
-                                                                       \
-}
+#define LIBSSH2_MBEDTLS_ECDSA_VERIFY(digest_type)                           \
+    do {                                                                    \
+        unsigned char hsh[SHA##digest_type##_DIGEST_LENGTH];                \
+                                                                            \
+        if(libssh2_sha##digest_type(m, m_len, hsh) == 0) {                  \
+            rc = mbedtls_ecdsa_verify(&ctx->MBEDTLS_PRIVATE(grp), hsh,      \
+                                      SHA##digest_type##_DIGEST_LENGTH,     \
+                                      &ctx->MBEDTLS_PRIVATE(Q), &pr, &ps);  \
+        }                                                                   \
+    } while(0)
 
 /* _libssh2_ecdsa_sign
  *

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -410,14 +410,13 @@ _libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx ** ec_ctx,
     return (ret == 1) ? 0 : -1;
 }
 
-#define LIBSSH2_ECDSA_VERIFY(digest_type)                           \
-{                                                                   \
-    unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];           \
-    libssh2_sha##digest_type(m, m_len, hash);                       \
-    ret = ECDSA_do_verify(hash, SHA##digest_type##_DIGEST_LENGTH,   \
-      ecdsa_sig, ec_key);                                           \
-                                                                    \
-}
+#define LIBSSH2_ECDSA_VERIFY(digest_type)                               \
+    do {                                                                \
+        unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];           \
+        libssh2_sha##digest_type(m, m_len, hash);                       \
+        ret = ECDSA_do_verify(hash, SHA##digest_type##_DIGEST_LENGTH,   \
+                              ecdsa_sig, ec_key);                       \
+    } while(0)
 
 int
 _libssh2_ecdsa_verify(libssh2_ecdsa_ctx * ctx,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,8 +83,8 @@ target_compile_definitions(runner PRIVATE FIXTURE_WORKDIR="${CMAKE_CURRENT_SOURC
 
 # test building against shared libssh2 lib
 if(BUILD_SHARED_LIBS)
-  set(test warmup)  # any test will do
-  add_executable(test_${test}_shared test_${test}.c)
+  set(test simple)
+  add_executable(test_${test}_shared ${test}.c)
   target_include_directories(test_${test}_shared PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../src" ../src)
   target_link_libraries(test_${test}_shared runner ${LIB_SHARED} ${LIBRARIES})
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,19 +56,19 @@ set(TESTS
   )
 
 if(CRYPTO_BACKEND STREQUAL "OpenSSL" OR CRYPTO_BACKEND STREQUAL "wolfSSL")
+  list(APPEND TESTS
+    public_key_auth_succeeds_with_correct_rsa_openssh_key
+  )
+  if(OPENSSL_VERSION VERSION_GREATER "1.1.0" OR CRYPTO_BACKEND STREQUAL "wolfSSL")
     list(APPEND TESTS
-      public_key_auth_succeeds_with_correct_rsa_openssh_key
+      public_key_auth_succeeds_with_correct_ed25519_key
+      public_key_auth_succeeds_with_correct_encrypted_ed25519_key
+      public_key_auth_succeeds_with_correct_ed25519_key_from_mem
+      public_key_auth_succeeds_with_correct_ecdsa_key
+      public_key_auth_succeeds_with_correct_signed_ecdsa_key
+      public_key_auth_succeeds_with_correct_signed_rsa_key
     )
-    if(OPENSSL_VERSION VERSION_GREATER "1.1.0" OR CRYPTO_BACKEND STREQUAL "wolfSSL")
-      list(APPEND TESTS
-        public_key_auth_succeeds_with_correct_ed25519_key
-        public_key_auth_succeeds_with_correct_encrypted_ed25519_key
-        public_key_auth_succeeds_with_correct_ed25519_key_from_mem
-        public_key_auth_succeeds_with_correct_ecdsa_key
-        public_key_auth_succeeds_with_correct_signed_ecdsa_key
-        public_key_auth_succeeds_with_correct_signed_rsa_key
-       )
-    endif()
+  endif()
 endif()
 
 if(NOT CRYPTO_BACKEND STREQUAL "mbedTLS")
@@ -143,7 +143,7 @@ target_include_directories(test_keyboard_interactive_auth_info_request PRIVATE "
 find_program(GCOV_PATH gcov)
 set(TGT_OPTIONS -g --coverage -fprofile-abs-path)
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
-        set(TGT_OPTIONS -g --coverage)
+  set(TGT_OPTIONS -g --coverage)
 endif()
 if(CMAKE_COMPILER_IS_GNUCC AND GCOV_PATH)
   target_compile_options(test_keyboard_interactive_auth_info_request BEFORE PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,10 +83,11 @@ target_compile_definitions(runner PRIVATE FIXTURE_WORKDIR="${CMAKE_CURRENT_SOURC
 
 # test building against shared libssh2 lib
 if(BUILD_SHARED_LIBS)
-  set(test simple)
-  add_executable(test_${test}_shared ${test}.c)
-  target_include_directories(test_${test}_shared PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../src" ../src)
-  target_link_libraries(test_${test}_shared runner ${LIB_SHARED} ${LIBRARIES})
+  foreach(test simple ssh2)
+    add_executable(test_${test}_shared ${test}.c)
+    target_include_directories(test_${test}_shared PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../src" ../src)
+    target_link_libraries(test_${test}_shared ${LIB_SHARED} ${LIBRARIES})
+  endforeach()
 endif()
 
 foreach(test ${TESTS})

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -66,8 +66,9 @@ static int have_docker = 0;
 
 static int run_command_varg(char **output, const char *command, va_list args)
 {
+    static const char redirect_stderr[] = "%s 2>&1";
+
     FILE *pipe;
-    const char redirect_stderr[] = "%s 2>&1";
     char command_buf[BUFSIZ];
     char buf[BUFSIZ];
     int ret;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -67,7 +67,7 @@ static int have_docker = 0;
 static int run_command_varg(char **output, const char *command, va_list args)
 {
     FILE *pipe;
-    char redirect_stderr[] = "%s 2>&1";
+    const char redirect_stderr[] = "%s 2>&1";
     char command_buf[BUFSIZ];
     char buf[BUFSIZ];
     int ret;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -58,8 +58,8 @@
 #endif
 #include <assert.h>
 
-LIBSSH2_SESSION *connected_session = NULL;
-libssh2_socket_t connected_socket = LIBSSH2_INVALID_SOCKET;
+static LIBSSH2_SESSION *connected_session = NULL;
+static libssh2_socket_t connected_socket = LIBSSH2_INVALID_SOCKET;
 
 static int connect_to_server(void)
 {

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -46,11 +46,11 @@ static int test_libssh2_base64_decode(LIBSSH2_SESSION *session)
     char *data;
     unsigned int datalen;
     const char *src = "Zm5vcmQ=";
-    unsigned int src_len = strlen(src);
+    size_t src_len = strlen(src);
     int ret;
 
     ret = libssh2_base64_decode(session, &data, &datalen,
-                                src, src_len);
+                                src, (unsigned int)src_len);
     if(ret)
         return ret;
 

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     session = libssh2_session_init();
-    if(libssh2_session_startup(session, sock)) {
+    if(libssh2_session_handshake(session, sock)) {
         fprintf(stderr, "Failure establishing SSH session\n");
         return 1;
     }

--- a/tests/test_agent_forward_succeeds.c
+++ b/tests/test_agent_forward_succeeds.c
@@ -1,8 +1,8 @@
 #include "runner.h"
 
-const char *USERNAME = "libssh2"; /* set in Dockerfile */
-const char *KEY_FILE_PRIVATE = "key_rsa";
-const char *KEY_FILE_PUBLIC = "key_rsa.pub"; /* set in Dockerfile */
+static const char *USERNAME = "libssh2"; /* set in Dockerfile */
+static const char *KEY_FILE_PRIVATE = "key_rsa";
+static const char *KEY_FILE_PUBLIC = "key_rsa.pub"; /* set in Dockerfile */
 
 int test(LIBSSH2_SESSION *session)
 {

--- a/tests/test_keyboard_interactive_auth_info_request.c
+++ b/tests/test_keyboard_interactive_auth_info_request.c
@@ -55,7 +55,8 @@ struct test_case {
 };
 
 #define TEST_CASES_LEN 16
-struct test_case test_cases[TEST_CASES_LEN] = {
+static const struct test_case
+    test_cases[TEST_CASES_LEN] = {
     /* too small */
     {
         NULL, 0,
@@ -191,7 +192,8 @@ struct test_case test_cases[TEST_CASES_LEN] = {
 };
 
 #define FAILED_MALLOC_TEST_CASES_LEN 2
-struct test_case failed_malloc_test_cases[FAILED_MALLOC_TEST_CASES_LEN] = {
+static const struct test_case
+    failed_malloc_test_cases[FAILED_MALLOC_TEST_CASES_LEN] = {
     /* malloc fail */
     {
         "<"
@@ -298,7 +300,8 @@ int main(void)
 
     for(i = 0; i < TEST_CASES_LEN; i++) {
         test_case(i + 1,
-                  test_cases[i].data, test_cases[i].data_len,
+                  test_cases[i].data,
+                  test_cases[i].data_len,
                   NULL,
                   test_cases[i].expected);
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c
@@ -5,7 +5,7 @@
 static const char *USERNAME = "libssh2"; /* set in Dockerfile */
 static const char *KEY_FILE_ED25519_PRIVATE = "key_ed25519";
 
-int read_file(const char *path, char **buf, size_t *len);
+static int read_file(const char *path, char **buf, size_t *len);
 
 int test(LIBSSH2_SESSION *session)
 {
@@ -48,7 +48,7 @@ int test(LIBSSH2_SESSION *session)
     return 0;
 }
 
-int read_file(const char *path, char **out_buffer, size_t *out_len)
+static int read_file(const char *path, char **out_buffer, size_t *out_len)
 {
     FILE *fp = NULL;
     char *buffer = NULL;


### PR DESCRIPTION
Implement picky warnings with clang in autotools. Extend picky gcc
warnings, sync them between build tools and compilers and greatly
speed up detection in CMake.

- autotools: enable clang compiler warnings with `--enable-debug`.

- autotools: enable more gcc compiler warnings with `--enable-debug`.

- autotools/cmake: sync compiler warning options between gcc and clang.

- sync compiler warning options between autotools and cmake.

- cmake: reduce option-checks to speed up the detection phase.
  Bring them down to 3 (from 35). Leaving some checks to keep the
  CMake logic alive and for an easy way to add new options.

  clang 3.0 (2011-11-29) and gcc 2.95 (1999-07-31) now required.

- autotools logic copied from curl, with these differences:

  - delete `-Wimplicit-fallthrough=4` due to a false positive.

  - reduce `-Wformat-truncation=2` to `1` due to a false positive.

  - simplify MinGW detection for `-Wno-pedantic-ms-format`.

- cmake: show enabled picky compiler options (like autotools).

- cmake: do compile `tests/simple.c` and `tests/ssh2.c`.

- fix new compiler warnings.

- `tests/CMakeLists.txt`: fix indentation.

Original source of autotools logic:
- https://github.com/curl/curl/blob/a8fbdb461cecbfe1ac6ecc5d8f6cf181e1507da8/acinclude.m4
- https://github.com/curl/curl/blob/a8fbdb461cecbfe1ac6ecc5d8f6cf181e1507da8/m4/curl-compilers.m4

Notice that the autotools implementation considers Apple clang as
legacy clang 3.7. CMake detection works more accurately, at the same
time more error-prone and difficult to update due to the sparsely
documented nature of Apple clang option evolution.

Closes #952

---

Without whitespace changes: https://github.com/libssh2/libssh2/pull/952/files?w=1
