### PR TITLE
Make OS/400 implementation work again

### DIFF
--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -406,6 +406,21 @@ TripleDES-CBC algorithm identifier initializer.
 
 5) Diffie-Hellman support.
 
+LIBSSH2_DH_GEX_MINGROUP
+The minimum Diffie-Hellman group length in bits supported by the backend.
+Usually defined as 2048.
+
+LIBSSH2_DH_GEX_OPTGROUP
+The preferred Diffie-Hellman group length in bits. Usually defined as 4096.
+
+LIBSSH2_DH_GEX_MAXGROUP
+The maximum Diffie-Hellman group length in bits supported by the backend.
+Usually defined as 8192.
+ 
+LIBSSH2_DH_MAX_MODULUS_BITS
+The maximum Diffie-Hellman modulus bit count accepted from the server. This
+value must be supported by the backend.  Usually 16384.
+
 5.1) Diffie-Hellman context.
 _libssh2_dh_ctx
 Type of a Diffie-Hellman computation context.

--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -673,7 +673,28 @@ the allocated signature at (signature, signature_len).
 Signature buffer must be allocated from the given session.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
-Note: this procedure is not used if macro _libssh2_rsa_sha1_signv() is defined.
+Note: this procedure is not used if both macros _libssh2_rsa_sha2_256_signv()
+and _libssh2_rsa_sha2_512_signv are defined.
+
+int _libssh2_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
+                                unsigned char **sig, size_t *siglen,
+                                int count, const struct iovec vector[],
+                                libssh2_rsa_ctx *ctx);
+RSA signs the SHA-256 hash computed over the count data chunks in vector.
+Signature is stored at (sig, siglen).
+Signature buffer must be allocated from the given session.
+Returns 0 if OK, else -1.
+Note: this procedure is optional: if provided, it MUST be defined as a macro.
+
+int _libssh2_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
+                                unsigned char **sig, size_t *siglen,
+                                int count, const struct iovec vector[],
+                                libssh2_rsa_ctx *ctx);
+RSA signs the SHA-512 hash computed over the count data chunks in vector.
+Signature is stored at (sig, siglen).
+Signature buffer must be allocated from the given session.
+Returns 0 if OK, else -1.
+Note: this procedure is optional: if provided, it MUST be defined as a macro.
 
 int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsa,
                              size_t hash_len,

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -228,14 +228,6 @@ typedef off_t libssh2_struct_stat_size;
 #define LIBSSH2_SSH_DEFAULT_BANNER            LIBSSH2_SSH_BANNER
 #define LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF  LIBSSH2_SSH_DEFAULT_BANNER "\r\n"
 
-/* Default generate and safe prime sizes for
-   diffie-hellman-group-exchange-sha1 */
-#define LIBSSH2_DH_GEX_MINGROUP     2048
-#define LIBSSH2_DH_GEX_OPTGROUP     4096
-#define LIBSSH2_DH_GEX_MAXGROUP     8192
-
-#define LIBSSH2_DH_MAX_MODULUS_BITS 16384
-
 /* Defaults for pty requests */
 #define LIBSSH2_TERM_WIDTH      80
 #define LIBSSH2_TERM_HEIGHT     24

--- a/os400/README400
+++ b/os400/README400
@@ -38,7 +38,8 @@ familiar with.
 
 _ As a prerequisite, QADRT development environment must be installed.
 _ Install the libssh2 sources directory in IFS.
-_ Enter shell (QSH)
+_ Enter shell (QSH). You may need to change the LANG environment variable
+  to be in phase with the libssh2 source files CCSID.
 _ Change current directory to the libssh2 sources installation directory
 _ Change current directory to os400
 _ Edit file iniscript.sh. You may want to change tunable configuration

--- a/os400/include/assert.h
+++ b/os400/include/assert.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Patrick Monnerat <patrick@monnerat.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above
+ *   copyright notice, this list of conditions and the
+ *   following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ *   Neither the name of the copyright holder nor the names
+ *   of any other contributors may be used to endorse or
+ *   promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#ifndef LIBSSH2_ASSERT_H
+#define LIBSSH2_ASSERT_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Ascii assert() macro. */
+
+#ifndef NDEBUG
+#pragma convert(819)
+
+#define assert(expr)    ((expr)? ((void) 0): (fprintf(stderr,           \
+                "Assertion failed: %s in file %s line %u. Aborting\n",  \
+                #expr, __FILE__, __LINE__), abort()))
+#else
+#define assert(expr)    ((void) 0)
+#endif
+#endif
+
+/* vim: set expandtab ts=4 sw=4: */

--- a/os400/initscript.sh
+++ b/os400/initscript.sh
@@ -49,8 +49,9 @@ setenv TGTCCSID         '500'                   # Target CCSID of objects.
 setenv DEBUG            '*ALL'                  # Debug level.
 setenv OPTIMIZE         '10'                    # Optimisation level
 setenv OUTPUT           '*NONE'                 # Compilation output option.
-setenv TGTRLS           'V6R1M0'                # Target OS release.
+setenv TGTRLS           'V7R3M0'                # Target OS release.
 setenv IFSDIR           '/libssh2'              # Installation IFS directory.
+setenv QADRTDIR         '/QIBM/ProdData/qadrt'  # QADRT IFS directory.
 
 #       Define ZLIB availability and locations.
 
@@ -182,7 +183,7 @@ make_module()
         CMD="${CMD} SYSIFCOPT(*IFS64IO) OPTION(*INCDIRFIRST)"
         CMD="${CMD} LOCALETYPE(*LOCALE) FLAG(10)"
         CMD="${CMD} INCDIR('${TOPDIR}/os400/include'"
-        CMD="${CMD} '/QIBM/ProdData/qadrt/include' '${TOPDIR}/include'"
+        CMD="${CMD} '${QADRTDIR}/include' '${TOPDIR}/include'"
         CMD="${CMD} '${TOPDIR}/os400' '${SRCDIR}'"
 
         if [ "${WITH_ZLIB}" != "0" ]

--- a/src/kex.c
+++ b/src/kex.c
@@ -264,8 +264,11 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 
         rc = libssh2_dh_key_pair(&exchange_state->x, exchange_state->e, g, p,
                                  group_order, exchange_state->ctx);
-        if(rc)
+        if(rc) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_KEX_FAILURE,
+                                 "dh key pair generation failed");
             goto clean_exit;
+        }
 
         /* Send KEX init */
         /* packet_type(1) + String Length(4) + leading 0(1) */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -220,6 +220,14 @@
 #define _libssh2_bn_bits(bn) gcry_mpi_get_nbits (bn)
 #define _libssh2_bn_free(bn) gcry_mpi_release(bn)
 
+/* Default generate and safe prime sizes for
+   diffie-hellman-group-exchange-sha1 */
+#define LIBSSH2_DH_GEX_MINGROUP     2048
+#define LIBSSH2_DH_GEX_OPTGROUP     4096
+#define LIBSSH2_DH_GEX_MAXGROUP     8192
+
+#define LIBSSH2_DH_MAX_MODULUS_BITS 16384
+
 #define _libssh2_dh_ctx struct gcry_mpi *
 #define libssh2_dh_init(dhctx) _libssh2_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -427,6 +427,14 @@ typedef enum {
  * mbedTLS backend: Diffie-Hellman support.
  */
 
+/* Default generate and safe prime sizes for
+   diffie-hellman-group-exchange-sha1 */
+#define LIBSSH2_DH_GEX_MINGROUP     2048
+#define LIBSSH2_DH_GEX_OPTGROUP     4096
+#define LIBSSH2_DH_GEX_MAXGROUP     8192
+
+#define LIBSSH2_DH_MAX_MODULUS_BITS 16384
+
 #define _libssh2_dh_ctx mbedtls_mpi *
 #define libssh2_dh_init(dhctx) _libssh2_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -417,6 +417,14 @@ libssh2_curve_type;
 #define _libssh2_bn_bits(bn) BN_num_bits(bn)
 #define _libssh2_bn_free(bn) BN_clear_free(bn)
 
+/* Default generate and safe prime sizes for
+   diffie-hellman-group-exchange-sha1 */
+#define LIBSSH2_DH_GEX_MINGROUP     2048
+#define LIBSSH2_DH_GEX_OPTGROUP     4096
+#define LIBSSH2_DH_GEX_MAXGROUP     8192
+
+#define LIBSSH2_DH_MAX_MODULUS_BITS 16384
+
 #define _libssh2_dh_ctx BIGNUM *
 #define libssh2_dh_init(dhctx) _libssh2_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -2,7 +2,7 @@
 #define __LIBSSH2_OS400QC3_H
 /*
  * Copyright (C) 2015-2016 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
- * Copyright (C) 2020 Patrick Monnerat <patrick@monnerat.net>.
+ * Copyright (C) 2020-2023 Patrick Monnerat <patrick@monnerat.net>.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
@@ -314,19 +314,19 @@ typedef struct {        /* Diffie-Hellman context. */
 #define _libssh2_cipher_type(name)  _libssh2_os400qc3_cipher_t name
 #define _libssh2_cipher_aes128 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \
                                 Qc3_CBC, 16}
-#define _libssh2_cipher_aes192 {Qc3_Alg_Block_Cipher, Qc3_AES, 24,          \
+#define _libssh2_cipher_aes192 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \
                                 Qc3_CBC, 24}
-#define _libssh2_cipher_aes256 {Qc3_Alg_Block_Cipher, Qc3_AES, 32,          \
+#define _libssh2_cipher_aes256 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \
                                 Qc3_CBC, 32}
 #define _libssh2_cipher_aes128ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
                                    Qc3_CTR, 16}
-#define _libssh2_cipher_aes192ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 24,       \
+#define _libssh2_cipher_aes192ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
                                    Qc3_CTR, 24}
-#define _libssh2_cipher_aes256ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 32,       \
+#define _libssh2_cipher_aes256ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
                                    Qc3_CTR, 32}
-#define _libssh2_cipher_3des {Qc3_Alg_Block_Cipher, Qc3_TDES, 0,            \
+#define _libssh2_cipher_3des {Qc3_Alg_Block_Cipher, Qc3_TDES, 8,            \
                               Qc3_CBC, 24}
-#define _libssh2_cipher_arcfour {Qc3_Alg_Stream_Cipher, Qc3_RC4, 0, 0, 16}
+#define _libssh2_cipher_arcfour {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
 
 #define _libssh2_cipher_dtor(ctx) _libssh2_os400qc3_crypto_dtor(ctx)
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -339,6 +339,14 @@ typedef struct {        /* Diffie-Hellman context. */
             _libssh2_os400qc3_rsa_sha1_signv(session, sig, siglen,          \
                                              count, vector, ctx)
 
+/* Default generate and safe prime sizes for diffie-hellman-group-exchange-sha1
+   Qc3 is limited to a maximum 2048-bit modulus/key size. */
+#define LIBSSH2_DH_GEX_MINGROUP     1024
+#define LIBSSH2_DH_GEX_OPTGROUP     1536
+#define LIBSSH2_DH_GEX_MAXGROUP     2048
+
+#define LIBSSH2_DH_MAX_MODULUS_BITS 2048
+
 #define _libssh2_dh_ctx         _libssh2_os400qc3_dh_ctx
 #define libssh2_dh_init(dhctx)  _libssh2_os400qc3_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx)        \

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -175,7 +175,7 @@
 #define LIBSSH2_3DES            1
 
 #define LIBSSH2_RSA             1
-#define LIBSSH2_RSA_SHA2        0
+#define LIBSSH2_RSA_SHA2        1
 #define LIBSSH2_DSA             0
 #define LIBSSH2_ECDSA           0
 #define LIBSSH2_ED25519         0
@@ -336,8 +336,14 @@ typedef struct {        /* Diffie-Hellman context. */
 #define libssh2_prepare_iovec(vec, len) memset((char *) (vec), 0,           \
                                                (len) * sizeof(struct iovec))
 #define _libssh2_rsa_sha1_signv(session, sig, siglen, count, vector, ctx)   \
-            _libssh2_os400qc3_rsa_sha1_signv(session, sig, siglen,          \
+            _libssh2_os400qc3_rsa_signv(session, Qc3_SHA1, sig, siglen,     \
                                              count, vector, ctx)
+#define _libssh2_rsa_sha2_256_signv(session, sig, siglen, cnt, vector, ctx) \
+            _libssh2_os400qc3_rsa_signv(session, Qc3_SHA256, sig, siglen,   \
+                                             cnt, vector, ctx)
+#define _libssh2_rsa_sha2_512_signv(session, sig, siglen, cnt, vector, ctx) \
+            _libssh2_os400qc3_rsa_signv(session, Qc3_SHA512, sig, siglen,   \
+                                             cnt, vector, ctx)
 
 /* Default generate and safe prime sizes for diffie-hellman-group-exchange-sha1
    Qc3 is limited to a maximum 2048-bit modulus/key size. */
@@ -389,12 +395,12 @@ extern void     libssh2_os400qc3_hmac_update(_libssh2_os400qc3_crypto_ctx *ctx,
                                              int len);
 extern void     libssh2_os400qc3_hmac_final(_libssh2_os400qc3_crypto_ctx *ctx,
                                             unsigned char *out);
-extern int      _libssh2_os400qc3_rsa_sha1_signv(LIBSSH2_SESSION *session,
-                                                 unsigned char **signature,
-                                                 size_t *signature_len,
-                                                 int veccount,
-                                                 const struct iovec vector[],
-                                                 libssh2_rsa_ctx *ctx);
+extern int      _libssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
+                                            unsigned char **signature,
+                                            size_t *signature_len,
+                                            int veccount,
+                                            const struct iovec vector[],
+                                            libssh2_rsa_ctx *ctx);
 extern void     _libssh2_os400qc3_dh_init(_libssh2_dh_ctx *dhctx);
 extern int      _libssh2_os400qc3_dh_key_pair(_libssh2_dh_ctx *dhctx,
                                               _libssh2_bn *public,

--- a/src/userauth_kbd_packet.c
+++ b/src/userauth_kbd_packet.c
@@ -44,6 +44,7 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
     size_t language_tag_len;
     unsigned int i;
     unsigned char packet_type;
+    uint32_t tmp_u32;
 
     struct string_buf decoded;
 
@@ -95,7 +96,8 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
     }
 
     /* int       num-prompts */
-    if(_libssh2_get_u32(&decoded, &session->userauth_kybd_num_prompts) == -1) {
+    if(_libssh2_get_u32(&decoded, &tmp_u32) == -1 ||
+       (session->userauth_kybd_num_prompts = tmp_u32) != tmp_u32) {
         _libssh2_error(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                        "Unable to decode "
                        "keyboard-interactive number of keyboard prompts");

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -421,6 +421,14 @@ _libssh2_bn *_libssh2_wincng_bignum_init(void);
  * Windows CNG backend: Diffie-Hellman support
  */
 
+/* Default generate and safe prime sizes for
+   diffie-hellman-group-exchange-sha1 */
+#define LIBSSH2_DH_GEX_MINGROUP     2048
+#define LIBSSH2_DH_GEX_OPTGROUP     4096
+#define LIBSSH2_DH_GEX_MAXGROUP     8192
+
+#define LIBSSH2_DH_MAX_MODULUS_BITS 16384
+
 typedef struct {
     /* holds our private and public key components */
     BCRYPT_KEY_HANDLE dh_handle;


### PR DESCRIPTION
After more than 6 years without an IBM i, I have been able to do some work on libssh2 for it thanks to pub400.com.
During this time, some "injuries" were done to this implementation. The commits in this PR contribute all together to fix them:

- Min target version is now V7R3M0. The build script now features ASCII C runtime development files in a non-standard path.
- A code style cleanup introduced a bug in big numbers: fixed.
- A pointer target type function parameter was incompatible: fixed.
- Block length in os400qc3 cipher definitions were wrong: fixed.
- Increase of Diffie-Hellman requested modulus size caused an error (QC3 is limited to 2048 bits). Fixed by reducing these for os400qc3.
- Failing Diffie-Hellman key pair generation now effectively returns an error.
- Implement an ASCII-compatible assert.h header file.
- Implement RSA2 in os400qc3 backend.

Thanks for considering this.



