### PR TITLE
tidy-up: example, tests continued

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -51,8 +51,8 @@ static unsigned int remote_destport = 22;
 
 enum {
     AUTH_NONE = 0,
-    AUTH_PASSWORD,
-    AUTH_PUBLICKEY
+    AUTH_PASSWORD = 1,
+    AUTH_PUBLICKEY = 2
 };
 
 int main(int argc, char *argv[])

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
 
         if(auth & AUTH_PASSWORD) {
             if(libssh2_userauth_password(session, username, password)) {
-                fprintf(stderr, "Authentication by password failed.\n");
+                fprintf(stderr, "Authentication by password failed!\n");
                 goto shutdown;
             }
         }
@@ -311,6 +311,7 @@ int main(int argc, char *argv[])
     }
 
 shutdown:
+
     if(forwardsock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
         closesocket(forwardsock);
@@ -331,7 +332,7 @@ shutdown:
         libssh2_channel_free(channel);
 
     if(session) {
-        libssh2_session_disconnect(session, "Client disconnecting normally");
+        libssh2_session_disconnect(session, "Normal Shutdown");
         libssh2_session_free(session);
     }
 

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -241,8 +241,8 @@ int main(int argc, char *argv[])
         remote_destport, shost, sport);
     if(!channel) {
         fprintf(stderr, "Could not open the direct-tcpip channel!\n"
-                "(Note that this can be a problem at the server!"
-                " Please review the server logs.)\n");
+                        "(Note that this can be a problem at the server!"
+                        " Please review the server logs.)\n");
         goto shutdown;
     }
 

--- a/example/scp.c
+++ b/example/scp.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -93,13 +93,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/scp.c
+++ b/example/scp.c
@@ -21,9 +21,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>
@@ -51,11 +48,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -135,7 +131,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed\n");
             goto shutdown;
         }
     }

--- a/example/scp.c
+++ b/example/scp.c
@@ -28,6 +28,12 @@
 #include <stdio.h>
 #include <ctype.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *scppath = "/tmp/TEST";
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -37,11 +43,6 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *scppath = "/tmp/TEST";
     libssh2_struct_stat fileinfo;
     int rc;
     libssh2_struct_stat_size got = 0;
@@ -78,9 +79,8 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    /* Ultra basic "connect to port 22 on localhost"
-     * Your code is responsible for creating the socket establishing the
-     * connection
+    /* Ultra basic "connect to port 22 on localhost".  Your code is
+     * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/example/scp.c
+++ b/example/scp.c
@@ -179,11 +179,14 @@ shutdown:
         libssh2_session_free(session);
     }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/scp.c
+++ b/example/scp.c
@@ -98,8 +98,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -39,6 +39,12 @@
 #include <stdio.h>
 #include <ctype.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *scppath = "/tmp/TEST";
+
 #ifdef HAVE_GETTIMEOFDAY
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
@@ -87,11 +93,6 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *scppath = "/tmp/TEST";
     libssh2_struct_stat fileinfo;
 #ifdef HAVE_GETTIMEOFDAY
     struct timeval start;
@@ -135,9 +136,8 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    /* Ultra basic "connect to port 22 on localhost"
-     * Your code is responsible for creating the socket establishing the
-     * connection
+    /* Ultra basic "connect to port 22 on localhost".  Your code is
+     * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "scp_nonblock 192.168.0.1 user password /tmp/secrets"
+ * $ ./scp_nonblock 192.168.0.1 user password /tmp/secrets
  */
 
 #include "libssh2_setup.h"

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -105,11 +105,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -200,7 +199,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -49,8 +49,8 @@ static const char *scppath = "/tmp/TEST";
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
-    return (newer.tv_sec-older.tv_sec)*1000+
-        (newer.tv_usec-older.tv_usec)/1000;
+    return (newer.tv_sec - older.tv_sec) * 1000 +
+        (newer.tv_usec - older.tv_usec) / 1000;
 }
 #endif
 
@@ -272,7 +272,7 @@ int main(int argc, char *argv[])
     time_ms = tvdiff(end, start);
     fprintf(stderr, "Got %ld bytes in %ld ms = %.1f bytes/sec spin: %d\n",
             (long)total, time_ms,
-            (double)total/((double)time_ms/1000.0), spin);
+            (double)total / ((double)time_ms / 1000.0), spin);
 #else
     fprintf(stderr, "Got %ld bytes spin: %d\n", (long)total, spin);
 #endif

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -155,8 +155,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -285,11 +285,14 @@ shutdown:
         libssh2_session_free(session);
     }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -150,13 +150,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -230,13 +230,13 @@ int main(int argc, char *argv[])
     fprintf(stderr, "libssh2_scp_recv() is done, now receive data!\n");
 
     while(got < fileinfo.st_size) {
-        char mem[1024*24];
+        char mem[1024 * 24];
         ssize_t nread;
 
         do {
             int amount = sizeof(mem);
 
-            if((fileinfo.st_size -got) < amount) {
+            if((fileinfo.st_size - got) < amount) {
                 amount = (int)(fileinfo.st_size - got);
             }
 
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
             }
         } while(nread > 0);
 
-        if((nread == LIBSSH2_ERROR_EAGAIN) && (got < fileinfo.st_size)) {
+        if(nread == LIBSSH2_ERROR_EAGAIN && got < fileinfo.st_size) {
             /* this is due to blocking that would occur otherwise
             so we loop on this condition */
 

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -208,13 +208,17 @@ shutdown:
         libssh2_session_free(session);
     }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     if(local)
         fclose(local);
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -109,8 +109,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -17,9 +17,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>
@@ -48,14 +45,13 @@ int main(int argc, char *argv[])
     size_t nread;
     char *ptr;
     struct stat fileinfo;
-    int err;
 
 #ifdef WIN32
     WSADATA wsadata;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -150,7 +146,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }
@@ -162,6 +158,7 @@ int main(int argc, char *argv[])
     if(!channel) {
         char *errmsg;
         int errlen;
+        int err;
         err = libssh2_session_last_error(session, &errmsg, &errlen, 0);
         fprintf(stderr, "Unable to open a session: (%d) %s\n", err, errmsg);
         goto shutdown;

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
     local = fopen(loclfile, "rb");
     if(!local) {
         fprintf(stderr, "Can't open local file %s\n", loclfile);
-        return -1;
+        return 1;
     }
 
     stat(loclfile, &fileinfo);
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -104,13 +104,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -24,6 +24,13 @@
 #include <stdio.h>
 #include <ctype.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *loclfile = "scp_write.c";
+static const char *scppath = "/tmp/TEST";
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -33,12 +40,6 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *loclfile = "scp_write.c";
-    const char *scppath = "/tmp/TEST";
     FILE *local;
     int rc;
     char mem[1024];
@@ -89,9 +90,8 @@ int main(int argc, char *argv[])
 
     stat(loclfile, &fileinfo);
 
-    /* Ultra basic "connect to port 22 on localhost"
-     * Your code is responsible for creating the socket establishing the
-     * connection
+    /* Ultra basic "connect to port 22 on localhost".  Your code is
+     * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -38,10 +38,10 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
+    int rc;
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     FILE *local;
-    int rc;
     char mem[1024];
     size_t nread;
     char *ptr;
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -107,8 +107,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -137,7 +136,7 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -146,7 +145,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }
@@ -208,6 +207,7 @@ shutdown:
         libssh2_session_disconnect(session, "Normal Shutdown");
         libssh2_session_free(session);
     }
+
 #ifdef WIN32
     closesocket(sock);
 #else

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -156,8 +156,8 @@ int main(int argc, char *argv[])
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
      */
-    while((rc = libssh2_session_handshake(session, sock))
-          == LIBSSH2_ERROR_EAGAIN);
+    while((rc = libssh2_session_handshake(session, sock)) ==
+          LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         return -1;
@@ -201,8 +201,8 @@ int main(int argc, char *argv[])
         channel = libssh2_scp_send(session, scppath, fileinfo.st_mode & 0777,
                                    (size_t)fileinfo.st_size);
 
-        if((!channel) && (libssh2_session_last_errno(session) !=
-                          LIBSSH2_ERROR_EAGAIN)) {
+        if(!channel &&
+           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             char *err_msg;
 
             libssh2_session_last_error(session, &err_msg, NULL, 0);
@@ -265,8 +265,8 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    while(libssh2_session_disconnect(session, "Normal Shutdown")
-          == LIBSSH2_ERROR_EAGAIN);
+    while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+          LIBSSH2_ERROR_EAGAIN);
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
         } while(nread);
     } while(!nread); /* only continue if nread was drained */
 
-    duration = (int)(time(NULL)-start);
+    duration = (int)(time(NULL) - start);
 
     fprintf(stderr, "%ld bytes in %d seconds makes %.1f bytes/sec\n",
            (long)total, duration, (double)total / duration);

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -31,6 +31,13 @@
 #include <ctype.h>
 #include <time.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *loclfile = "scp_write.c";
+static const char *scppath = "/tmp/TEST";
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;
@@ -70,12 +77,6 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *loclfile = "scp_write.c";
-    const char *scppath = "/tmp/TEST";
     FILE *local;
     int rc;
     char mem[1024*100];
@@ -130,9 +131,8 @@ int main(int argc, char *argv[])
 
     stat(loclfile, &fileinfo);
 
-    /* Ultra basic "connect to port 22 on localhost"
-     * Your code is responsible for creating the socket establishing the
-     * connection
+    /* Ultra basic "connect to port 22 on localhost".  Your code is
+     * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -274,11 +274,14 @@ shutdown:
         libssh2_session_free(session);
     }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -150,8 +150,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -89,11 +89,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -192,7 +191,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
     local = fopen(loclfile, "rb");
     if(!local) {
         fprintf(stderr, "Can't open local file %s\n", loclfile);
-        return -1;
+        return 1;
     }
 
     stat(loclfile, &fileinfo);
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -145,13 +145,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -185,13 +185,13 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "password") != NULL) {
+        if(strstr(userauthlist, "password")) {
             auth_pw |= 1;
         }
-        if(strstr(userauthlist, "keyboard-interactive") != NULL) {
+        if(strstr(userauthlist, "keyboard-interactive")) {
             auth_pw |= 2;
         }
-        if(strstr(userauthlist, "publickey") != NULL) {
+        if(strstr(userauthlist, "publickey")) {
             auth_pw |= 4;
         }
 

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     char *userauthlist;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 
@@ -281,14 +281,19 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -73,7 +73,7 @@ static void kbd_callback(const char *name, int name_len,
         fgets(buf, sizeof(buf), stdin);
         n = strlen(buf);
         while(n > 0 && strchr("\r\n", buf[n - 1]))
-          n--;
+            n--;
         buf[n] = 0;
 
         responses[i].text = strdup(buf);
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -148,13 +148,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -153,8 +153,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);
@@ -195,7 +197,7 @@ int main(int argc, char *argv[])
             auth_pw |= 4;
         }
 
-        /* if we got an 5. argument we set this option if supported */
+        /* check for options */
         if(argc > 5) {
             if((auth_pw & 1) && !strcmp(argv[5], "-p")) {
                 auth_pw = 1;

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp 192.168.0.1 user password /tmp/secrets -p|-i|-k"
+ * $ ./sftp 192.168.0.1 user password /tmp/secrets -p|-i|-k
  */
 
 #include "libssh2_setup.h"

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -258,14 +258,14 @@ int main(int argc, char *argv[])
 
     fprintf(stderr, "libssh2_sftp_open()!\n");
     /* Request a file via SFTP */
-    sftp_handle =
-        libssh2_sftp_open(sftp_session, sftppath, LIBSSH2_FXF_READ, 0);
-
+    sftp_handle = libssh2_sftp_open(sftp_session, sftppath,
+                                    LIBSSH2_FXF_READ, 0);
     if(!sftp_handle) {
         fprintf(stderr, "Unable to open file with SFTP: %ld\n",
                 libssh2_sftp_last_error(sftp_session));
         goto shutdown;
     }
+
     fprintf(stderr, "libssh2_sftp_open() is done, now receive data!\n");
     do {
         char mem[1024];

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -138,6 +138,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -147,8 +147,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
-    LIBSSH2_SESSION *session;
     int rc;
+    LIBSSH2_SESSION *session;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
     FILE *tempstorage;
@@ -101,14 +101,27 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
 
+    if(argc > 1) {
+        username = argv[1];
+    }
+    if(argc > 2) {
+        password = argv[2];
+    }
+    if(argc > 3) {
+        sftppath = argv[3];
+    }
+    if(argc > 4) {
+        dest = argv[4];
+    }
+
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -126,8 +139,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -155,19 +167,6 @@ int main(int argc, char *argv[])
     }
     fprintf(stderr, "\n");
 
-    if(argc > 1) {
-        username = argv[1];
-    }
-    if(argc > 2) {
-        password = argv[2];
-    }
-    if(argc > 3) {
-        sftppath = argv[3];
-    }
-    if(argc > 4) {
-        dest = argv[4];
-    }
-
     tempstorage = fopen(STORAGE, "wb");
     if(!tempstorage) {
         fprintf(stderr, "Can't open temp storage file %s\n", STORAGE);
@@ -179,19 +178,19 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
     else {
         /* Or by public key */
         while((rc =
-               libssh2_userauth_publickey_fromfile(session, username,
-                                                   pubkey, privkey,
-                                                   password)) ==
+              libssh2_userauth_publickey_fromfile(session, username,
+                                                  pubkey, privkey,
+                                                  password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -44,6 +44,13 @@
                                        example uses to store the downloaded
                                        file in */
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *sftppath = "/tmp/TEST"; /* source path */
+static const char *dest = "/tmp/TEST2";    /* destination path */
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;
@@ -81,12 +88,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *sftppath = "/tmp/TEST"; /* source path */
-    const char *dest = "/tmp/TEST2";    /* destination path */
     int rc;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
@@ -98,11 +99,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
                                                    password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed\n");
             goto shutdown;
         }
     }

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -27,9 +27,6 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-#ifdef HAVE_ARPA_INET_H
-#include <arpa/inet.h>
-#endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -130,6 +130,10 @@ int main(int argc, char *argv[])
      * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
-    FILE *tempstorage;
+    FILE *tempstorage = NULL;
     char mem[1000];
     struct timeval timeout;
     fd_set fd;

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -176,8 +176,8 @@ int main(int argc, char *argv[])
 
     if(auth_pw) {
         /* We could authenticate via password */
-        while((rc = libssh2_userauth_password(session, username, password))
-               == LIBSSH2_ERROR_EAGAIN);
+        while((rc = libssh2_userauth_password(session, username, password)) ==
+              LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -200,8 +200,7 @@ int main(int argc, char *argv[])
         sftp_session = libssh2_sftp_init(session);
 
         if(!sftp_session) {
-            if(libssh2_session_last_errno(session) ==
-               LIBSSH2_ERROR_EAGAIN) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
                 fprintf(stderr, "non-blocking init\n");
                 waitsocket(sock, session); /* now we wait */
             }

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -140,13 +140,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = htonl(0x7F000001);
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     libssh2_session_set_blocking(session, 0);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -145,8 +145,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -217,10 +217,10 @@ int main(int argc, char *argv[])
     do {
         sftp_handle = libssh2_sftp_open(sftp_session, sftppath,
                                         LIBSSH2_FXF_READ, 0);
-
         if(!sftp_handle) {
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-                fprintf(stderr, "Unable to open file with SFTP\n");
+                fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                        libssh2_sftp_last_error(sftp_session));
                 goto shutdown;
             }
             else {
@@ -283,11 +283,13 @@ int main(int argc, char *argv[])
 
     /* we're done downloading, now reverse the process and upload the
        temporarily stored data to the destination path */
-    sftp_handle =
-        libssh2_sftp_open(sftp_session, dest,
-                          LIBSSH2_FXF_WRITE|LIBSSH2_FXF_CREAT,
-                          LIBSSH2_SFTP_S_IRUSR|LIBSSH2_SFTP_S_IWUSR|
-                          LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
+    sftp_handle = libssh2_sftp_open(sftp_session, dest,
+                                    LIBSSH2_FXF_WRITE |
+                                    LIBSSH2_FXF_CREAT,
+                                    LIBSSH2_SFTP_S_IRUSR |
+                                    LIBSSH2_SFTP_S_IWUSR |
+                                    LIBSSH2_SFTP_S_IRGRP |
+                                    LIBSSH2_SFTP_S_IROTH);
     if(sftp_handle) {
         size_t nread;
         char *ptr;

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -113,9 +113,8 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    /* Ultra basic "connect to port 22 on localhost"
-     * The application is responsible for creating the socket establishing
-     * the connection
+    /* Ultra basic "connect to port 22 on localhost".  Your code is
+     * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
     FILE *tempstorage;
@@ -339,16 +339,22 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     if(tempstorage)
         fclose(tempstorage);
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -101,6 +101,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -56,11 +56,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -152,7 +151,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     local = fopen(loclfile, "rb");
     if(!local) {
         fprintf(stderr, "Can't open local file %s\n", loclfile);
-        return -1;
+        return 1;
     }
 
     /*
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -111,13 +111,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -172,11 +172,13 @@ int main(int argc, char *argv[])
 
     fprintf(stderr, "libssh2_sftp_open() for READ and WRITE!\n");
     /* Request a file via SFTP */
-    sftp_handle =
-        libssh2_sftp_open(sftp_session, sftppath,
-                          LIBSSH2_FXF_WRITE|LIBSSH2_FXF_READ,
-                          LIBSSH2_SFTP_S_IRUSR|LIBSSH2_SFTP_S_IWUSR|
-                          LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
+    sftp_handle = libssh2_sftp_open(sftp_session, sftppath,
+                                    LIBSSH2_FXF_WRITE |
+                                    LIBSSH2_FXF_READ,
+                                    LIBSSH2_SFTP_S_IRUSR |
+                                    LIBSSH2_SFTP_S_IWUSR |
+                                    LIBSSH2_SFTP_S_IRGRP |
+                                    LIBSSH2_SFTP_S_IROTH);
     if(!sftp_handle) {
         fprintf(stderr, "Unable to open file with SFTP\n");
         goto shutdown;

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * sftp_append 192.168.0.1 user password localfile /tmp/remotefile
+ * "sftp_append 192.168.0.1 user password localfile /tmp/remotefile"
  */
 
 #include "libssh2_setup.h"
@@ -44,13 +44,13 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
-    LIBSSH2_SESSION *session;
     int rc;
-    FILE *local;
+    LIBSSH2_SESSION *session;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
     LIBSSH2_SFTP_ATTRIBUTES attrs;
-    char mem[1024*100];
+    char mem[1024 * 100];
+    FILE *local;
     size_t nread;
     ssize_t nwritten;
     char *ptr;
@@ -110,8 +110,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -143,7 +142,7 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -152,7 +151,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }
@@ -167,7 +166,6 @@ int main(int argc, char *argv[])
 
     fprintf(stderr, "libssh2_sftp_open() for READ and WRITE!\n");
     /* Request a file via SFTP */
-
     sftp_handle =
         libssh2_sftp_open(sftp_session, sftppath,
                           LIBSSH2_FXF_WRITE|LIBSSH2_FXF_READ,
@@ -216,6 +214,7 @@ int main(int argc, char *argv[])
     libssh2_sftp_shutdown(sftp_session);
 
 shutdown:
+
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
     LIBSSH2_SFTP_ATTRIBUTES attrs;
@@ -215,16 +215,22 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     if(local)
         fclose(local);
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp_append 192.168.0.1 user password localfile /tmp/remotefile"
+ * $ ./sftp_append 192.168.0.1 user password localfile /tmp/remotefile
  */
 
 #include "libssh2_setup.h"

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -116,8 +116,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -180,7 +180,8 @@ int main(int argc, char *argv[])
                                     LIBSSH2_SFTP_S_IRGRP |
                                     LIBSSH2_SFTP_S_IROTH);
     if(!sftp_handle) {
-        fprintf(stderr, "Unable to open file with SFTP\n");
+        fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                libssh2_sftp_last_error(sftp_session));
         goto shutdown;
     }
 
@@ -193,11 +194,12 @@ int main(int argc, char *argv[])
     fprintf(stderr, "Did a seek to position %ld\n", (long) attrs.filesize);
 
     fprintf(stderr, "libssh2_sftp_open() a handle for APPEND\n");
-
     if(!sftp_handle) {
-        fprintf(stderr, "Unable to open file with SFTP\n");
+        fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                libssh2_sftp_last_error(sftp_session));
         goto shutdown;
     }
+
     fprintf(stderr, "libssh2_sftp_open() is done, now send data!\n");
     do {
         nread = fread(mem, 1, sizeof(mem), local);

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -30,6 +30,13 @@
 #include <stdio.h>
 #include <ctype.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *loclfile = "sftp_write.c";
+static const char *sftppath = "/tmp/TEST";
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -38,12 +45,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *loclfile = "sftp_write.c";
-    const char *sftppath = "/tmp/TEST";
     int rc;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -99,8 +99,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
 
 #ifdef WIN32
@@ -159,14 +159,19 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp 192.168.0.1 user password /tmp/sftp_mkdir"
+ * $ ./sftp_mkdir 192.168.0.1 user password /tmp/sftp_mkdir
  */
 
 #include "libssh2_setup.h"

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -30,6 +30,12 @@
 #include <stdio.h>
 #include <ctype.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *sftppath = "/tmp/sftp_mkdir";
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -38,11 +44,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *sftppath = "/tmp/sftp_mkdir";
     int rc;
     LIBSSH2_SFTP *sftp_session;
 

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -154,10 +154,11 @@ int main(int argc, char *argv[])
 
     /* Make a directory via SFTP */
     rc = libssh2_sftp_mkdir(sftp_session, sftppath,
-                            LIBSSH2_SFTP_S_IRWXU|
-                            LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IXGRP|
-                            LIBSSH2_SFTP_S_IROTH|LIBSSH2_SFTP_S_IXOTH);
-
+                            LIBSSH2_SFTP_S_IRWXU |
+                            LIBSSH2_SFTP_S_IRGRP |
+                            LIBSSH2_SFTP_S_IXGRP |
+                            LIBSSH2_SFTP_S_IROTH |
+                            LIBSSH2_SFTP_S_IXOTH);
     if(rc)
         fprintf(stderr, "libssh2_sftp_mkdir failed: %d\n", rc);
 

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -48,11 +48,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -132,7 +131,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -94,13 +94,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -84,6 +84,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -43,15 +43,15 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
-    LIBSSH2_SESSION *session;
     int rc;
+    LIBSSH2_SESSION *session;
     LIBSSH2_SFTP *sftp_session;
 
 #ifdef WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -93,8 +93,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -123,7 +122,7 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -132,7 +131,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -99,8 +99,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -94,13 +94,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do
@@ -152,9 +152,9 @@ int main(int argc, char *argv[])
 
     /* Make a directory via SFTP */
     while(libssh2_sftp_mkdir(sftp_session, sftppath,
-                              LIBSSH2_SFTP_S_IRWXU|
-                              LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IXGRP|
-                              LIBSSH2_SFTP_S_IROTH|LIBSSH2_SFTP_S_IXOTH) ==
+                             LIBSSH2_SFTP_S_IRWXU|
+                             LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IXGRP|
+                             LIBSSH2_SFTP_S_IROTH|LIBSSH2_SFTP_S_IXOTH) ==
           LIBSSH2_ERROR_EAGAIN);
 
     libssh2_sftp_shutdown(sftp_session);

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -154,9 +154,11 @@ int main(int argc, char *argv[])
 
     /* Make a directory via SFTP */
     while(libssh2_sftp_mkdir(sftp_session, sftppath,
-                             LIBSSH2_SFTP_S_IRWXU|
-                             LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IXGRP|
-                             LIBSSH2_SFTP_S_IROTH|LIBSSH2_SFTP_S_IXOTH) ==
+                             LIBSSH2_SFTP_S_IRWXU |
+                             LIBSSH2_SFTP_S_IRGRP |
+                             LIBSSH2_SFTP_S_IXGRP |
+                             LIBSSH2_SFTP_S_IROTH |
+                             LIBSSH2_SFTP_S_IXOTH) ==
           LIBSSH2_ERROR_EAGAIN);
 
     libssh2_sftp_shutdown(sftp_session);

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
 
 #ifdef WIN32
@@ -157,14 +157,19 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -30,6 +30,12 @@
 #include <stdio.h>
 #include <ctype.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *sftppath = "/tmp/sftp_mkdir_nonblock";
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -38,11 +44,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *sftppath = "/tmp/sftp_mkdir_nonblock";
     int rc;
     LIBSSH2_SFTP *sftp_session;
 

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -48,11 +48,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -132,7 +131,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp 192.168.0.1 user password /tmp/sftp_write_nonblock.c"
+ * $ ./sftp_mkdir_nonblock 192.168.0.1 user password /tmp/sftp_write_nonblock.c
  */
 
 #include "libssh2_setup.h"

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -153,8 +153,8 @@ int main(int argc, char *argv[])
     while(libssh2_sftp_mkdir(sftp_session, sftppath,
                               LIBSSH2_SFTP_S_IRWXU|
                               LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IXGRP|
-                              LIBSSH2_SFTP_S_IROTH|LIBSSH2_SFTP_S_IXOTH)
-           == LIBSSH2_ERROR_EAGAIN);
+                              LIBSSH2_SFTP_S_IROTH|LIBSSH2_SFTP_S_IXOTH) ==
+          LIBSSH2_ERROR_EAGAIN);
 
     libssh2_sftp_shutdown(sftp_session);
 

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -84,6 +84,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -43,15 +43,15 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
-    LIBSSH2_SESSION *session;
     int rc;
+    LIBSSH2_SESSION *session;
     LIBSSH2_SFTP *sftp_session;
 
 #ifdef WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -93,8 +93,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -123,7 +122,7 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -132,12 +131,11 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }
 
-    fprintf(stderr, "libssh2_sftp_init()!\n");
     sftp_session = libssh2_sftp_init(session);
 
     if(!sftp_session) {
@@ -148,7 +146,6 @@ int main(int argc, char *argv[])
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
 
-    fprintf(stderr, "libssh2_sftp_mkdirnb()!\n");
     /* Make a directory via SFTP */
     while(libssh2_sftp_mkdir(sftp_session, sftppath,
                               LIBSSH2_SFTP_S_IRWXU|

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -235,10 +235,10 @@ int main(int argc, char *argv[])
     do {
         sftp_handle = libssh2_sftp_open(sftp_session, sftppath,
                                         LIBSSH2_FXF_READ, 0);
-
         if(!sftp_handle) {
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-                fprintf(stderr, "Unable to open file with SFTP\n");
+                fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                        libssh2_sftp_last_error(sftp_session));
                 goto shutdown;
             }
             else {

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -156,8 +156,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -141,6 +141,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -40,6 +40,12 @@
 #include <stdio.h>
 #include <ctype.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *sftppath = "/tmp/TEST";
+
 #ifdef HAVE_GETTIMEOFDAY
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
@@ -87,11 +93,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *sftppath = "/tmp/TEST";
 #ifdef HAVE_GETTIMEOFDAY
     struct timeval start;
     struct timeval end;

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-           LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         return -1;
@@ -186,8 +186,8 @@ int main(int argc, char *argv[])
 
     if(auth_pw) {
         /* We could authenticate via password */
-        while((rc = libssh2_userauth_password(session, username, password))
-               == LIBSSH2_ERROR_EAGAIN);
+        while((rc = libssh2_userauth_password(session, username, password)) ==
+              LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -213,8 +213,7 @@ int main(int argc, char *argv[])
         sftp_session = libssh2_sftp_init(session);
 
         if(!sftp_session) {
-            if(libssh2_session_last_errno(session) ==
-               LIBSSH2_ERROR_EAGAIN) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
                 fprintf(stderr, "non-blocking init\n");
                 waitsocket(sock, session); /* now we wait */
             }
@@ -249,8 +248,8 @@ int main(int argc, char *argv[])
         ssize_t nread;
 
         /* loop until we fail */
-        while((nread = libssh2_sftp_read(sftp_handle, mem,
-                              sizeof(mem))) == LIBSSH2_ERROR_EAGAIN) {
+        while((nread = libssh2_sftp_read(sftp_handle, mem, sizeof(mem))) ==
+              LIBSSH2_ERROR_EAGAIN) {
             spin++;
             waitsocket(sock, session); /* now we wait */
         }
@@ -279,8 +278,8 @@ int main(int argc, char *argv[])
 shutdown:
 
     fprintf(stderr, "libssh2_session_disconnect\n");
-    while(libssh2_session_disconnect(session, "Normal Shutdown")
-          == LIBSSH2_ERROR_EAGAIN);
+    while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+          LIBSSH2_ERROR_EAGAIN);
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -50,8 +50,8 @@ static const char *sftppath = "/tmp/TEST";
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
-  return (newer.tv_sec-older.tv_sec)*1000+
-      (newer.tv_usec-older.tv_usec)/1000;
+  return (newer.tv_sec - older.tv_sec) * 1000 +
+      (newer.tv_usec - older.tv_usec) / 1000;
 }
 #endif
 
@@ -273,7 +273,7 @@ int main(int argc, char *argv[])
     time_ms = tvdiff(end, start);
     fprintf(stderr, "Got %ld bytes in %ld ms = %.1f bytes/sec spin: %d\n",
             (long)total, time_ms,
-            (double)total/((double)time_ms/1000.0), spin);
+            (double)total / ((double)time_ms / 1000.0), spin);
 #else
     fprintf(stderr, "Got %ld bytes spin: %d\n", (long)total, spin);
 #endif

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp_nonblock 192.168.0.1 user password /tmp/secrets"
+ * $ ./sftp_nonblock 192.168.0.1 user password /tmp/secrets
  */
 
 #include "libssh2_setup.h"

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -105,11 +105,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -201,7 +200,7 @@ int main(int argc, char *argv[])
                                                    password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 #ifdef HAVE_GETTIMEOFDAY
@@ -277,16 +277,21 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    fprintf(stderr, "libssh2_session_disconnect\n");
-    while(libssh2_session_disconnect(session, "Normal Shutdown") ==
-          LIBSSH2_ERROR_EAGAIN);
-    libssh2_session_free(session);
+    if(session) {
+        fprintf(stderr, "libssh2_session_disconnect\n");
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN);
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -92,23 +92,23 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
+    int rc;
     LIBSSH2_SESSION *session;
+    LIBSSH2_SFTP *sftp_session;
+    LIBSSH2_SFTP_HANDLE *sftp_handle;
 #ifdef HAVE_GETTIMEOFDAY
     struct timeval start;
     struct timeval end;
     long time_ms;
 #endif
-    int rc;
     libssh2_struct_stat_size total = 0;
     int spin = 0;
-    LIBSSH2_SFTP *sftp_session;
-    LIBSSH2_SFTP_HANDLE *sftp_handle;
 
 #ifdef WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
                                                    password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
 
     fprintf(stderr, "libssh2_sftp_open() is done, now receive data!\n");
     do {
-        char mem[1024*24];
+        char mem[1024 * 24];
         ssize_t nread;
 
         /* loop until we fail */

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -151,13 +151,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do
@@ -200,9 +200,9 @@ int main(int argc, char *argv[])
     else {
         /* Or by public key */
         while((rc =
-               libssh2_userauth_publickey_fromfile(session, username,
-                                                   pubkey, privkey,
-                                                   password)) ==
+              libssh2_userauth_publickey_fromfile(session, username,
+                                                  pubkey, privkey,
+                                                  password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed!\n");

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -100,6 +100,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -171,12 +171,14 @@ int main(int argc, char *argv[])
 
     fprintf(stderr, "libssh2_sftp_open()!\n");
     /* Request a file via SFTP */
-    sftp_handle =
-        libssh2_sftp_open(sftp_session, sftppath,
-                      LIBSSH2_FXF_WRITE|LIBSSH2_FXF_CREAT|LIBSSH2_FXF_TRUNC,
-                      LIBSSH2_SFTP_S_IRUSR|LIBSSH2_SFTP_S_IWUSR|
-                      LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
-
+    sftp_handle = libssh2_sftp_open(sftp_session, sftppath,
+                                    LIBSSH2_FXF_WRITE |
+                                    LIBSSH2_FXF_CREAT |
+                                    LIBSSH2_FXF_TRUNC,
+                                    LIBSSH2_SFTP_S_IRUSR |
+                                    LIBSSH2_SFTP_S_IWUSR |
+                                    LIBSSH2_SFTP_S_IRGRP |
+                                    LIBSSH2_SFTP_S_IROTH);
     if(!sftp_handle) {
         fprintf(stderr, "Unable to open file with SFTP\n");
         goto shutdown;

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -115,8 +115,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
     local = fopen(loclfile, "rb");
     if(!local) {
         fprintf(stderr, "Can't open local file %s\n", loclfile);
-        return -1;
+        return 1;
     }
 
     /*
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -110,13 +110,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -46,9 +46,9 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
+    FILE *local;
     char mem[1024 * 100];
     size_t nread;
     ssize_t nwritten;
@@ -180,9 +180,11 @@ int main(int argc, char *argv[])
                                     LIBSSH2_SFTP_S_IRGRP |
                                     LIBSSH2_SFTP_S_IROTH);
     if(!sftp_handle) {
-        fprintf(stderr, "Unable to open file with SFTP\n");
+        fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                libssh2_sftp_last_error(sftp_session));
         goto shutdown;
     }
+
     fprintf(stderr, "libssh2_sftp_open() is done, now send data!\n");
     do {
         nread = fread(mem, 1, sizeof(mem), local);

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp 192.168.0.1 user password sftp_write.c /tmp/secrets"
+ * $ ./sftp_write 192.168.0.1 user password sftp_write.c /tmp/secrets
  */
 
 #include "libssh2_setup.h"

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -44,12 +44,12 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
-    LIBSSH2_SESSION *session;
     int rc;
+    LIBSSH2_SESSION *session;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
-    char mem[1024*100];
+    char mem[1024 * 100];
     size_t nread;
     ssize_t nwritten;
     char *ptr;
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -109,8 +109,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -142,7 +141,7 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -151,7 +150,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }
@@ -193,13 +192,13 @@ int main(int argc, char *argv[])
             ptr += nwritten;
             nread -= nwritten;
         } while(nread);
-
     } while(nwritten > 0);
 
     libssh2_sftp_close(sftp_handle);
     libssh2_sftp_shutdown(sftp_session);
 
 shutdown:
+
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
@@ -199,16 +199,22 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     if(local)
         fclose(local);
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -55,11 +55,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -151,7 +150,7 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -30,6 +30,13 @@
 #include <stdio.h>
 #include <ctype.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *loclfile = "sftp_write.c";
+static const char *sftppath = "/tmp/TEST";
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -38,12 +45,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *loclfile = "sftp_write.c";
-    const char *sftppath = "/tmp/TEST";
     int rc;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -140,6 +140,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -220,12 +220,14 @@ int main(int argc, char *argv[])
     fprintf(stderr, "libssh2_sftp_open()!\n");
     /* Request a file via SFTP */
     do {
-        sftp_handle =
-            libssh2_sftp_open(sftp_session, sftppath,
-                              LIBSSH2_FXF_WRITE|LIBSSH2_FXF_CREAT|
-                              LIBSSH2_FXF_TRUNC,
-                              LIBSSH2_SFTP_S_IRUSR|LIBSSH2_SFTP_S_IWUSR|
-                              LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
+        sftp_handle = libssh2_sftp_open(sftp_session, sftppath,
+                                        LIBSSH2_FXF_WRITE |
+                                        LIBSSH2_FXF_CREAT |
+                                        LIBSSH2_FXF_TRUNC,
+                                        LIBSSH2_SFTP_S_IRUSR |
+                                        LIBSSH2_SFTP_S_IWUSR |
+                                        LIBSSH2_SFTP_S_IRGRP |
+                                        LIBSSH2_SFTP_S_IROTH);
         if(!sftp_handle &&
            libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             fprintf(stderr, "Unable to open file with SFTP\n");

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
@@ -265,15 +265,20 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    while(libssh2_session_disconnect(session, "Normal Shutdown") ==
-          LIBSSH2_ERROR_EAGAIN);
-    libssh2_session_free(session);
+    if(session) {
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN);
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -83,9 +83,9 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
+    FILE *local;
     char mem[1024 * 100];
     size_t nread;
     ssize_t nwritten;
@@ -230,15 +230,14 @@ int main(int argc, char *argv[])
                                         LIBSSH2_SFTP_S_IROTH);
         if(!sftp_handle &&
            libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            fprintf(stderr, "Unable to open file with SFTP\n");
+            fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                    libssh2_sftp_last_error(sftp_session));
             goto shutdown;
         }
     } while(!sftp_handle);
 
     fprintf(stderr, "libssh2_sftp_open() is done, now send data!\n");
-
     start = time(NULL);
-
     do {
         nread = fread(mem, 1, sizeof(mem), local);
         if(nread <= 0) {
@@ -262,7 +261,7 @@ int main(int argc, char *argv[])
         } while(nread);
     } while(nwritten > 0);
 
-    duration = (int)(time(NULL)-start);
+    duration = (int)(time(NULL) - start);
 
     fprintf(stderr, "%ld bytes in %d seconds makes %.1f bytes/sec\n",
             (long)total, duration, (double)total / duration);

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -161,8 +161,8 @@ int main(int argc, char *argv[])
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
      */
-    while((rc = libssh2_session_handshake(session, sock))
-           == LIBSSH2_ERROR_EAGAIN);
+    while((rc = libssh2_session_handshake(session, sock)) ==
+          LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         return -1;
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-               LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
         sftp_session = libssh2_sftp_init(session);
 
         if(!sftp_session &&
-            (libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN)) {
+           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             fprintf(stderr, "Unable to init SFTP session\n");
             goto shutdown;
         }
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
                               LIBSSH2_SFTP_S_IRUSR|LIBSSH2_SFTP_S_IWUSR|
                               LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
         if(!sftp_handle &&
-           (libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN)) {
+           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             fprintf(stderr, "Unable to open file with SFTP\n");
             goto shutdown;
         }
@@ -245,7 +245,7 @@ int main(int argc, char *argv[])
         do {
             /* write data in a loop until we block */
             while((nwritten = libssh2_sftp_write(sftp_handle, ptr, nread)) ==
-                   LIBSSH2_ERROR_EAGAIN) {
+                  LIBSSH2_ERROR_EAGAIN) {
                 waitsocket(sock, session);
             }
             if(nwritten < 0)
@@ -267,8 +267,8 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    while(libssh2_session_disconnect(session, "Normal Shutdown")
-          == LIBSSH2_ERROR_EAGAIN);
+    while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+          LIBSSH2_ERROR_EAGAIN);
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
     local = fopen(loclfile, "rb");
     if(!local) {
         fprintf(stderr, "Can't open local file %s\n", loclfile);
-        return -1;
+        return 1;
     }
 
     /*
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -150,13 +150,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -95,11 +95,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -196,7 +195,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -37,6 +37,13 @@
 #include <ctype.h>
 #include <time.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *loclfile = "sftp_write_nonblock.c";
+static const char *sftppath = "/tmp/sftp_write_nonblock.c";
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;
@@ -75,12 +82,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *loclfile = "sftp_write_nonblock.c";
-    const char *sftppath = "/tmp/sftp_write_nonblock.c";
     int rc;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -155,8 +155,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -81,8 +81,8 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
-    LIBSSH2_SESSION *session;
     int rc;
+    LIBSSH2_SESSION *session;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -149,8 +149,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-        */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -168,10 +167,10 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* At this point we have not yet authenticated.  The first thing to do is
-     * check the hostkey's fingerprint against our known hosts Your app may
-     * have it hard coded, may go to a file, may present it to the user,
-     * that's your call
+    /* At this point we have not yet authenticated.  The first thing to do
+     * is check the hostkey's fingerprint against our known hosts Your app
+     * may have it hard coded, may go to a file, may present it to the
+     * user, that's your call
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
@@ -185,7 +184,7 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -196,7 +195,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }
@@ -252,7 +251,6 @@ int main(int argc, char *argv[])
                 break;
             ptr += nwritten;
             nread -= nwritten;
-
         } while(nread);
     } while(nwritten > 0);
 

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp 192.168.0.1 user password thisfile /tmp/storehere"
+ * $ ./sftp_write_nonblock 192.168.0.1 user password thisfile /tmp/storehere
  */
 
 #include "libssh2_setup.h"

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -140,6 +140,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -220,12 +220,14 @@ int main(int argc, char *argv[])
     fprintf(stderr, "libssh2_sftp_open()!\n");
     /* Request a file via SFTP */
     do {
-        sftp_handle =
-            libssh2_sftp_open(sftp_session, sftppath,
-                              LIBSSH2_FXF_WRITE|LIBSSH2_FXF_CREAT|
-                              LIBSSH2_FXF_TRUNC,
-                              LIBSSH2_SFTP_S_IRUSR|LIBSSH2_SFTP_S_IWUSR|
-                              LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
+        sftp_handle = libssh2_sftp_open(sftp_session, sftppath,
+                                        LIBSSH2_FXF_WRITE |
+                                        LIBSSH2_FXF_CREAT |
+                                        LIBSSH2_FXF_TRUNC,
+                                        LIBSSH2_SFTP_S_IRUSR |
+                                        LIBSSH2_SFTP_S_IWUSR |
+                                        LIBSSH2_SFTP_S_IRGRP |
+                                        LIBSSH2_SFTP_S_IROTH);
         if(!sftp_handle &&
            libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             fprintf(stderr, "Unable to open file with SFTP\n");

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
     local = fopen(loclfile, "rb");
     if(!local) {
         fprintf(stderr, "Can't open local file %s\n", loclfile);
-        return -1;
+        return 1;
     }
 
     /*
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -150,13 +150,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp 192.168.0.1 user password thisfile /tmp/storehere"
+ * $ ./sftp_write_sliding 192.168.0.1 user password thisfile /tmp/storehere
  */
 
 #include "libssh2_setup.h"

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -83,9 +83,9 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
+    FILE *local;
     char mem[1024 * 1000];
     size_t nread;
     ssize_t nwritten;
@@ -230,18 +230,17 @@ int main(int argc, char *argv[])
                                         LIBSSH2_SFTP_S_IROTH);
         if(!sftp_handle &&
            libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            fprintf(stderr, "Unable to open file with SFTP\n");
+            fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                    libssh2_sftp_last_error(sftp_session));
             goto shutdown;
         }
     } while(!sftp_handle);
 
     fprintf(stderr, "libssh2_sftp_open() is done, now send data!\n");
-
     start = time(NULL);
-
-    memuse = 0; /* it starts blank */
+    memuse = 0;  /* it starts blank */
     do {
-        nread = fread(&mem[memuse], 1, sizeof(mem)-memuse, local);
+        nread = fread(&mem[memuse], 1, sizeof(mem) - memuse, local);
         if(nread <= 0) {
             /* end of file */
             if(memuse > 0)
@@ -272,7 +271,7 @@ int main(int argc, char *argv[])
 
     } while(nwritten > 0);
 
-    duration = (int)(time(NULL)-start);
+    duration = (int)(time(NULL) - start);
 
     fprintf(stderr, "%ld bytes in %d seconds makes %.1f bytes/sec\n",
             (long)total, duration, (double)total / duration);

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -95,11 +95,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -196,7 +195,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -37,6 +37,13 @@
 #include <ctype.h>
 #include <time.h>
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *loclfile = "sftp_write_nonblock.c";
+static const char *sftppath = "/tmp/sftp_write_nonblock.c";
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;
@@ -75,12 +82,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *loclfile = "sftp_write_nonblock.c";
-    const char *sftppath = "/tmp/sftp_write_nonblock.c";
     int rc;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -161,8 +161,8 @@ int main(int argc, char *argv[])
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
      */
-    while((rc = libssh2_session_handshake(session, sock))
-           == LIBSSH2_ERROR_EAGAIN);
+    while((rc = libssh2_session_handshake(session, sock)) ==
+          LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         return -1;
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-               LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
         sftp_session = libssh2_sftp_init(session);
 
         if(!sftp_session &&
-            (libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN)) {
+           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             fprintf(stderr, "Unable to init SFTP session\n");
             goto shutdown;
         }
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
                               LIBSSH2_SFTP_S_IRUSR|LIBSSH2_SFTP_S_IWUSR|
                               LIBSSH2_SFTP_S_IRGRP|LIBSSH2_SFTP_S_IROTH);
         if(!sftp_handle &&
-           (libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN)) {
+           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             fprintf(stderr, "Unable to open file with SFTP\n");
             goto shutdown;
         }
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
 
         /* write data in a loop until we block */
         while((nwritten = libssh2_sftp_write(sftp_handle, mem, memuse)) ==
-               LIBSSH2_ERROR_EAGAIN) {
+              LIBSSH2_ERROR_EAGAIN) {
             waitsocket(sock, session);
         }
         if(nwritten < 0)
@@ -276,8 +276,8 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    while(libssh2_session_disconnect(session, "Normal Shutdown")
-          == LIBSSH2_ERROR_EAGAIN);
+    while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+          LIBSSH2_ERROR_EAGAIN);
     libssh2_session_free(session);
 
 #ifdef WIN32

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -155,8 +155,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
@@ -275,15 +275,20 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    while(libssh2_session_disconnect(session, "Normal Shutdown") ==
-          LIBSSH2_ERROR_EAGAIN);
-    libssh2_session_free(session);
+    if(session) {
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN);
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * "sftp 192.168.0.1 user password file /tmp/storehere"
+ * "sftp 192.168.0.1 user password thisfile /tmp/storehere"
  */
 
 #include "libssh2_setup.h"
@@ -81,15 +81,15 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
-    LIBSSH2_SESSION *session;
     int rc;
+    LIBSSH2_SESSION *session;
     FILE *local;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
     char mem[1024 * 1000];
     size_t nread;
-    size_t memuse;
     ssize_t nwritten;
+    size_t memuse;
     time_t start;
     libssh2_struct_stat_size total = 0;
     int duration;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -149,8 +149,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -185,7 +184,7 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -196,7 +195,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -23,9 +23,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>
@@ -43,6 +40,7 @@ static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";
 static const char *username = "username";
 static const char *password = "password";
+static const char *sftppath = "/tmp/secretdir";
 
 static void kbd_callback(const char *name, int name_len,
                          const char *instruction, int instruction_len,
@@ -67,22 +65,21 @@ int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
     libssh2_socket_t sock;
-    int rc, i, auth_pw = 0;
+    int i, auth_pw = 0;
     struct sockaddr_in sin;
     const char *fingerprint;
     char *userauthlist;
+    int rc;
     LIBSSH2_SESSION *session;
-    const char *sftppath = "/tmp/secretdir";
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -153,68 +150,67 @@ int main(int argc, char *argv[])
     /* check what authentication methods are available */
     userauthlist = libssh2_userauth_list(session, username,
                                          (unsigned int)strlen(username));
-    fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-    if(strstr(userauthlist, "password") != NULL) {
-        auth_pw |= 1;
-    }
-    if(strstr(userauthlist, "keyboard-interactive") != NULL) {
-        auth_pw |= 2;
-    }
-    if(strstr(userauthlist, "publickey") != NULL) {
-        auth_pw |= 4;
-    }
+    if(userauthlist) {
+        fprintf(stderr, "Authentication methods: %s\n", userauthlist);
+        if(strstr(userauthlist, "password") != NULL) {
+            auth_pw |= 1;
+        }
+        if(strstr(userauthlist, "keyboard-interactive") != NULL) {
+            auth_pw |= 2;
+        }
+        if(strstr(userauthlist, "publickey") != NULL) {
+            auth_pw |= 4;
+        }
 
-    /* if we got an 5. argument we set this option if supported */
-    if(argc > 5) {
-        if((auth_pw & 1) && !strcmp(argv[5], "-p")) {
-            auth_pw = 1;
+        /* if we got an 5. argument we set this option if supported */
+        if(argc > 5) {
+            if((auth_pw & 1) && !strcmp(argv[5], "-p")) {
+                auth_pw = 1;
+            }
+            if((auth_pw & 2) && !strcmp(argv[5], "-i")) {
+                auth_pw = 2;
+            }
+            if((auth_pw & 4) && !strcmp(argv[5], "-k")) {
+                auth_pw = 4;
+            }
         }
-        if((auth_pw & 2) && !strcmp(argv[5], "-i")) {
-            auth_pw = 2;
-        }
-        if((auth_pw & 4) && !strcmp(argv[5], "-k")) {
-            auth_pw = 4;
-        }
-    }
 
-    if(auth_pw & 1) {
-        /* We could authenticate via password */
-        if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "\tAuthentication by password failed!\n");
-            goto shutdown;
+        if(auth_pw & 1) {
+            /* We could authenticate via password */
+            if(libssh2_userauth_password(session, username, password)) {
+                fprintf(stderr, "Authentication by password failed!\n");
+                goto shutdown;
+            }
+        }
+        else if(auth_pw & 2) {
+            /* Or via keyboard-interactive */
+            if(libssh2_userauth_keyboard_interactive(session, username,
+                                                     &kbd_callback) ) {
+                fprintf(stderr,
+                        "Authentication by keyboard-interactive failed!\n");
+                goto shutdown;
+            }
+            else {
+                fprintf(stderr,
+                        "Authentication by keyboard-interactive succeeded.\n");
+            }
+        }
+        else if(auth_pw & 4) {
+            /* Or by public key */
+            if(libssh2_userauth_publickey_fromfile(session, username,
+                                                   pubkey, privkey,
+                                                   password)) {
+                fprintf(stderr, "Authentication by public key failed!\n");
+                goto shutdown;
+            }
+            else {
+                fprintf(stderr, "Authentication by public key succeeded.\n");
+            }
         }
         else {
-            fprintf(stderr, "\tAuthentication by password succeeded.\n");
-        }
-    }
-    else if(auth_pw & 2) {
-        /* Or via keyboard-interactive */
-        if(libssh2_userauth_keyboard_interactive(session, username,
-                                                 &kbd_callback) ) {
-            fprintf(stderr,
-                    "\tAuthentication by keyboard-interactive failed!\n");
+            fprintf(stderr, "No supported authentication methods found!\n");
             goto shutdown;
         }
-        else {
-            fprintf(stderr,
-                    "\tAuthentication by keyboard-interactive succeeded.\n");
-        }
-    }
-    else if(auth_pw & 4) {
-        /* Or by public key */
-        if(libssh2_userauth_publickey_fromfile(session, username,
-                                               pubkey, privkey,
-                                               password)) {
-            fprintf(stderr, "\tAuthentication by public key failed!\n");
-            goto shutdown;
-        }
-        else {
-            fprintf(stderr, "\tAuthentication by public key succeeded.\n");
-        }
-    }
-    else {
-        fprintf(stderr, "No supported authentication methods found!\n");
-        goto shutdown;
     }
 
     fprintf(stderr, "libssh2_sftp_init()!\n");

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     char *userauthlist;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -120,8 +120,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -283,8 +282,10 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
 #ifdef WIN32
     closesocket(sock);

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password and
  * path, but you can specify them on the command line like:
  *
- * "sftpdir 192.168.0.1 user password /tmp/secretdir"
+ * $ ./sftpdir 192.168.0.1 user password /tmp/secretdir
  */
 
 #include "libssh2_setup.h"

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -155,13 +155,13 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "password") != NULL) {
+        if(strstr(userauthlist, "password")) {
             auth_pw |= 1;
         }
-        if(strstr(userauthlist, "keyboard-interactive") != NULL) {
+        if(strstr(userauthlist, "keyboard-interactive")) {
             auth_pw |= 2;
         }
-        if(strstr(userauthlist, "publickey") != NULL) {
+        if(strstr(userauthlist, "publickey")) {
             auth_pw |= 4;
         }
 

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -126,8 +126,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -165,7 +167,7 @@ int main(int argc, char *argv[])
             auth_pw |= 4;
         }
 
-        /* if we got an 5. argument we set this option if supported */
+        /* check for options */
         if(argc > 5) {
             if((auth_pw & 1) && !strcmp(argv[5], "-p")) {
                 auth_pw = 1;

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -287,11 +287,14 @@ shutdown:
         libssh2_session_free(session);
     }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -121,13 +121,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -232,11 +232,11 @@ int main(int argc, char *argv[])
     fprintf(stderr, "libssh2_sftp_opendir()!\n");
     /* Request a dir listing via SFTP */
     sftp_handle = libssh2_sftp_opendir(sftp_session, sftppath);
-
     if(!sftp_handle) {
         fprintf(stderr, "Unable to open dir with SFTP\n");
         goto shutdown;
     }
+
     fprintf(stderr, "libssh2_sftp_opendir() is done, now receive listing!\n");
     do {
         char mem[512];

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -111,6 +111,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -49,8 +49,8 @@ int main(int argc, char *argv[])
     int i, auth_pw = 1;
     struct sockaddr_in sin;
     const char *fingerprint;
-    LIBSSH2_SESSION *session;
     int rc;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -100,8 +100,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    /* Create a session instance
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
         return -1;
@@ -136,7 +135,7 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -147,7 +146,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }
@@ -224,8 +223,10 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
 #ifdef WIN32
     closesocket(sock);

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -101,13 +101,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -91,6 +91,10 @@ int main(int argc, char *argv[])
      * and establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -4,7 +4,7 @@
  * The sample code has default values for host name, user name, password and
  * path, but you can specify them on the command line like:
  *
- * "sftpdir 192.168.0.1 user password /tmp/secretdir"
+ * $ ./sftpdir_nonblock 192.168.0.1 user password /tmp/secretdir
  */
 
 #include "libssh2_setup.h"

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -23,9 +23,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>
@@ -39,6 +36,12 @@
 #define __FILESIZE "llu"
 #endif
 
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "username";
+static const char *password = "password";
+static const char *sftppath = "/tmp/secretdir";
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -47,22 +50,16 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     LIBSSH2_SESSION *session;
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "username";
-    const char *password = "password";
-    const char *sftppath = "/tmp/secretdir";
     int rc;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -150,7 +147,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -106,8 +106,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -228,11 +228,14 @@ shutdown:
         libssh2_session_free(session);
     }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -156,8 +156,8 @@ int main(int argc, char *argv[])
     do {
         sftp_session = libssh2_sftp_init(session);
 
-        if((!sftp_session) && (libssh2_session_last_errno(session) !=
-                               LIBSSH2_ERROR_EAGAIN)) {
+        if(!sftp_session &&
+           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             fprintf(stderr, "Unable to init SFTP session\n");
             goto shutdown;
         }
@@ -168,8 +168,8 @@ int main(int argc, char *argv[])
     do {
         sftp_handle = libssh2_sftp_opendir(sftp_session, sftppath);
 
-        if((!sftp_handle) && (libssh2_session_last_errno(session) !=
-                              LIBSSH2_ERROR_EAGAIN)) {
+        if(!sftp_handle &&
+           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
             fprintf(stderr, "Unable to open dir with SFTP\n");
             goto shutdown;
         }

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
 
     if(libssh2_session_handshake(session, sock)) {
         fprintf(stderr, "Failure establishing SSH session\n");
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -165,13 +165,13 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "password") != NULL) {
+        if(strstr(userauthlist, "password")) {
             auth_pw |= 1;
         }
-        if(strstr(userauthlist, "keyboard-interactive") != NULL) {
+        if(strstr(userauthlist, "keyboard-interactive")) {
             auth_pw |= 2;
         }
-        if(strstr(userauthlist, "publickey") != NULL) {
+        if(strstr(userauthlist, "publickey")) {
             auth_pw |= 4;
         }
 

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -4,7 +4,8 @@
  * The sample code has default values for host name, user name, password
  * and path to copy, but you can specify them on the command line like:
  *
- * Usage: ssh2 hostip user password [[-p|-i|-k] [command]]
+ * $ ./ssh2 hostip user password [[-p|-i|-k] [command]]
+ *
  *  -p authenticate using password
  *  -i authenticate using keyboard-interactive
  *  -k authenticate using public key (password argument decrypts keyfile)
@@ -13,7 +14,6 @@
 
 #include "libssh2_setup.h"
 #include <libssh2.h>
-#include <libssh2_sftp.h>
 
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
@@ -110,6 +110,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
+        rc = 1;
         goto shutdown;
     }
 
@@ -122,7 +123,7 @@ int main(int argc, char *argv[])
 
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance and start it up. This will trade welcome

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -130,6 +130,10 @@ int main(int argc, char *argv[])
      * banners, exchange keys, and setup crypto, compression, and MAC layers
      */
     session = libssh2_session_init();
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
+        goto shutdown;
+    }
 
     /* Enable all debugging when libssh2 was built with debugging enabled */
     libssh2_trace(session,
@@ -177,7 +181,7 @@ int main(int argc, char *argv[])
             auth_pw |= 4;
         }
 
-        /* if we got an 4. argument we set this option if supported */
+        /* check for options */
         if(argc > 4) {
             if((auth_pw & 1) && !strcmp(argv[4], "-p")) {
                 auth_pw = 1;

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -130,6 +130,7 @@ int main(int argc, char *argv[])
      * banners, exchange keys, and setup crypto, compression, and MAC layers
      */
     session = libssh2_session_init();
+
     /* Enable all debugging when libssh2 was built with debugging enabled */
     libssh2_trace(session,
         LIBSSH2_TRACE_TRANS     |
@@ -143,8 +144,9 @@ int main(int argc, char *argv[])
         LIBSSH2_TRACE_SOCKET
     );
 
-    if(libssh2_session_handshake(session, sock)) {
-        fprintf(stderr, "Failure establishing SSH session\n");
+    rc = libssh2_session_handshake(session, sock);
+    if(rc) {
+        fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
     }
 

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -136,17 +136,7 @@ int main(int argc, char *argv[])
     }
 
     /* Enable all debugging when libssh2 was built with debugging enabled */
-    libssh2_trace(session,
-        LIBSSH2_TRACE_TRANS     |
-        LIBSSH2_TRACE_KEX       |
-        LIBSSH2_TRACE_AUTH      |
-        LIBSSH2_TRACE_CONN      |
-        LIBSSH2_TRACE_SCP       |
-        LIBSSH2_TRACE_SFTP      |
-        LIBSSH2_TRACE_ERROR     |
-        LIBSSH2_TRACE_PUBLICKEY |
-        LIBSSH2_TRACE_SOCKET
-    );
+    libssh2_trace(session, ~0);
 
     rc = libssh2_session_handshake(session, sock);
     if(rc) {

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -35,7 +35,7 @@ static const char *username = "username";
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
-    libssh2_socket_t sock = LIBSSH2_INVALID_SOCKET;
+    libssh2_socket_t sock;
     int i;
     struct sockaddr_in sin;
     const char *fingerprint;

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "publickey") == NULL) {
+        if(!strstr(userauthlist, "publickey")) {
             fprintf(stderr, "\"publickey\" authentication is not supported\n");
             goto shutdown;
         }

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -93,9 +93,11 @@ int main(int argc, char *argv[])
      * banners, exchange keys, and setup crypto, compression, and MAC layers
      */
     session = libssh2_session_init();
-    if(libssh2_session_handshake(session, sock)) {
-        fprintf(stderr, "Failure establishing SSH session\n");
-        return 1;
+
+    rc = libssh2_session_handshake(session, sock);
+    if(rc) {
+        fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -36,10 +36,11 @@ int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
     libssh2_socket_t sock = LIBSSH2_INVALID_SOCKET;
-    int i, rc;
+    int i;
     struct sockaddr_in sin;
     const char *fingerprint;
     char *userauthlist;
+    int rc;
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_AGENT *agent = NULL;

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -89,10 +89,12 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
 
-    /* Create a session instance and start it up. This will trade welcome
-     * banners, exchange keys, and setup crypto, compression, and MAC layers
-     */
+    /* Create a session instance */
     session = libssh2_session_init();
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
+        goto shutdown;
+    }
 
     rc = libssh2_session_handshake(session, sock);
     if(rc) {

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -3,12 +3,11 @@
  *
  * The sample code has default values for host name, user name:
  *
- * "ssh2_agent host user"
+ * $ ./ssh2_agent host user
  */
 
 #include "libssh2_setup.h"
 #include <libssh2.h>
-#include <libssh2_sftp.h>
 
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
@@ -62,7 +61,6 @@ int main(int argc, char *argv[])
     else {
         hostaddr = htonl(0x7F000001);
     }
-
     if(argc > 2) {
         username = argv[2];
     }
@@ -183,7 +181,8 @@ int main(int argc, char *argv[])
     libssh2_channel_setenv(channel, "FOO", "bar");
 
     /* Request a terminal with 'vanilla' terminal emulation
-     * See /etc/termcap for more options
+     * See /etc/termcap for more options. This is useful when opening
+     * an interactive shell.
      */
     if(libssh2_channel_request_pty(channel, "vanilla")) {
         fprintf(stderr, "Failed requesting pty\n");

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -210,6 +210,7 @@ int main(int argc, char *argv[])
      */
 
 skip_shell:
+
     if(channel) {
         libssh2_channel_free(channel);
         channel = NULL;

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -199,12 +199,15 @@ int main(int argc, char *argv[])
     /* Set session to non-blocking */
     libssh2_session_set_blocking(session, 0);
 
-    /* Exec non-blocking on the remove host */
-    while(!(channel = libssh2_channel_open_session(session)) &&
-          libssh2_session_last_error(session, NULL, NULL, 0) ==
-          LIBSSH2_ERROR_EAGAIN) {
+    /* Exec non-blocking on the remote host */
+    do {
+        channel = libssh2_channel_open_session(session);
+        if(channel ||
+           libssh2_session_last_error(session, NULL, NULL, 0) !=
+           LIBSSH2_ERROR_EAGAIN)
+            break;
         waitsocket(sock, session);
-    }
+    } while(1);
     if(!channel) {
         fprintf(stderr, "Error\n");
         exit(1);

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -269,10 +269,11 @@ int main(int argc, char *argv[])
     }
 
     if(exitsignal) {
-        printf("\nGot signal: %s\n", exitsignal);
+        fprintf(stderr, "\nGot signal: %s\n", exitsignal);
     }
     else {
-        printf("\nEXIT: %d bytecount: %d\n", exitcode, (int)bytecount);
+        fprintf(stderr, "\nEXIT: %d bytecount: %d\n",
+                exitcode, (int)bytecount);
     }
 
     libssh2_channel_free(channel);

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -7,8 +7,6 @@
  * The example uses agent authentication to ensure an agent to forward
  * is running.
  *
- * Run it like this:
- *
  * $ ./ssh2_agent_forwarding 127.0.0.1 user "uptime"
  *
  */

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -122,6 +122,10 @@ int main(int argc, char *argv[])
      * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -132,17 +132,17 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     if(libssh2_session_handshake(session, sock) != 0) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* Connect to the ssh-agent */

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -137,8 +137,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     if(libssh2_session_handshake(session, sock) != 0) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -209,7 +209,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN) {
         waitsocket(sock, session);
     }
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Error, couldn't request auth agent, error code %d.\n",
                 rc);
         exit(1);
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN) {
         waitsocket(sock, session);
     }
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Error\n");
         exit(1);
     }

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -42,6 +42,10 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+static const char *hostname = "127.0.0.1";
+static const char *commandline = "uptime";
+static const char *username;
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;
@@ -74,17 +78,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
 int main(int argc, char *argv[])
 {
-    const char *hostname = "127.0.0.1";
-    const char *commandline = "uptime";
-    const char *username    = NULL;
     uint32_t hostaddr;
     libssh2_socket_t sock;
     struct sockaddr_in sin;
+    int rc;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_AGENT *agent = NULL;
     struct libssh2_agent_publickey *identity, *prev_identity = NULL;
-    int rc;
     int exitcode;
     char *exitsignal = (char *)"none";
     ssize_t bytecount = 0;
@@ -119,9 +120,8 @@ int main(int argc, char *argv[])
 
     hostaddr = inet_addr(hostname);
 
-    /* Ultra basic "connect to port 22 on localhost"
-     * Your code is responsible for creating the socket establishing the
-     * connection
+    /* Ultra basic "connect to port 22 on localhost".  Your code is
+     * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     libssh2_socket_t sock;
     struct sockaddr_in sin;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_AGENT *agent = NULL;
     struct libssh2_agent_publickey *identity, *prev_identity = NULL;
@@ -276,14 +276,19 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -198,12 +198,12 @@ int main(int argc, char *argv[])
     libssh2_session_set_blocking(session, 0);
 
     /* Exec non-blocking on the remove host */
-    while((channel = libssh2_channel_open_session(session)) == NULL &&
+    while(!(channel = libssh2_channel_open_session(session)) &&
           libssh2_session_last_error(session, NULL, NULL, 0) ==
           LIBSSH2_ERROR_EAGAIN) {
         waitsocket(sock, session);
     }
-    if(channel == NULL) {
+    if(!channel) {
         fprintf(stderr, "Error\n");
         exit(1);
     }

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -91,8 +91,14 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    WSAStartup(MAKEWORD(2, 0), &wsadata);
+
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
+        return 1;
+    }
 #endif
+
     if(argc < 2) {
         fprintf(stderr, "At least IP and username arguments are required.\n");
         return 1;
@@ -165,14 +171,14 @@ int main(int argc, char *argv[])
             goto shutdown;
         }
         if(libssh2_agent_userauth(agent, username, identity)) {
-            fprintf(stderr, "\tAuthentication with username %s and "
-                   "public key %s failed!\n",
-                   username, identity->comment);
+            fprintf(stderr, "Authentication with username %s and "
+                    "public key %s failed!\n",
+                    username, identity->comment);
         }
         else {
-            fprintf(stderr, "\tAuthentication with username %s and "
-                   "public key %s succeeded!\n",
-                   username, identity->comment);
+            fprintf(stderr, "Authentication with username %s and "
+                    "public key %s succeeded.\n",
+                    username, identity->comment);
             break;
         }
         prev_identity = identity;
@@ -209,7 +215,7 @@ int main(int argc, char *argv[])
         exit(1);
     }
     else {
-        fprintf(stdout, "\tAgent forwarding request succeeded!\n");
+        fprintf(stdout, "Agent forwarding request succeeded!\n");
     }
     while((rc = libssh2_channel_exec(channel, commandline)) ==
           LIBSSH2_ERROR_EAGAIN) {

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -73,8 +73,8 @@ int main(int argc, char *argv[])
 {
     const char *hostname = "127.0.0.1";
     const char *commandline = "cat";
-    const char *username    = "user";
-    const char *password    = "password";
+    const char *username = "user";
+    const char *password = "password";
     uint32_t hostaddr;
     libssh2_socket_t sock;
     struct sockaddr_in sin;
@@ -90,11 +90,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -201,12 +201,12 @@ int main(int argc, char *argv[])
     libssh2_trace(session, LIBSSH2_TRACE_SOCKET);
 
     /* Exec non-blocking on the remove host */
-    while((channel = libssh2_channel_open_session(session)) == NULL &&
+    while(!(channel = libssh2_channel_open_session(session)) &&
           libssh2_session_last_error(session, NULL, NULL, 0) ==
           LIBSSH2_ERROR_EAGAIN) {
         waitsocket(sock, session);
     }
-    if(channel == NULL) {
+    if(!channel) {
         fprintf(stderr, "Error\n");
         exit(1);
     }

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -176,8 +176,8 @@ int main(int argc, char *argv[])
                                              &host);
 
         fprintf(stderr, "Host check: %d, key: %s\n", check,
-                (check <= LIBSSH2_KNOWNHOST_CHECK_MISMATCH)?
-                host->key:"<none>");
+                (check <= LIBSSH2_KNOWNHOST_CHECK_MISMATCH) ?
+                host->key : "<none>");
 
         /*****
          * At this point, we could verify that 'check' tells us the key is
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
 
         do {
             int act = 0;
-            rc = (libssh2_poll(fds, 1, 10));
+            rc = libssh2_poll(fds, 1, 10);
 
             if(rc < 1)
                 continue;

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -129,13 +129,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* tell libssh2 we want it all done non-blocking */
     libssh2_session_set_blocking(session, 0);
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     nh = libssh2_knownhost_init(session);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -1,10 +1,8 @@
 /*
- * Run it like this:
- *
- * $ ./ssh2_echo 127.0.0.1 user password
- *
  * The code sends a 'cat' command, and then writes a lot of data to it only to
  * check that reading the returned data sums up to the same amount.
+ *
+ * $ ./ssh2_echo 127.0.0.1 user password
  *
  */
 
@@ -209,9 +207,9 @@ int main(int argc, char *argv[])
         exit(1);
     }
     while((rc = libssh2_channel_exec(channel, commandline)) ==
-          LIBSSH2_ERROR_EAGAIN)
+          LIBSSH2_ERROR_EAGAIN) {
         waitsocket(sock, session);
-
+    }
     if(rc) {
         fprintf(stderr, "exec error\n");
         exit(1);
@@ -346,6 +344,8 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
+
+shutdown:
 
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -119,6 +119,10 @@ int main(int argc, char *argv[])
      * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -80,9 +80,9 @@ int main(int argc, char *argv[])
     libssh2_socket_t sock;
     struct sockaddr_in sin;
     const char *fingerprint;
+    int rc;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
-    int rc;
     int exitcode = 0;
     char *exitsignal = (char *)"none";
     size_t len;
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             exit(1);
         }
     }
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN)
         waitsocket(sock, session);
 
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "exec error\n");
         exit(1);
     }

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -37,6 +37,11 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+static const char *hostname = "127.0.0.1";
+static const char *commandline = "cat";
+static const char *username = "user";
+static const char *password = "password";
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;
@@ -71,10 +76,6 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
 int main(int argc, char *argv[])
 {
-    const char *hostname = "127.0.0.1";
-    const char *commandline = "cat";
-    const char *username = "user";
-    const char *password = "password";
     uint32_t hostaddr;
     libssh2_socket_t sock;
     struct sockaddr_in sin;
@@ -116,9 +117,8 @@ int main(int argc, char *argv[])
 
     hostaddr = inet_addr(hostname);
 
-    /* Ultra basic "connect to port 22 on localhost"
-     * Your code is responsible for creating the socket establishing the
-     * connection
+    /* Ultra basic "connect to port 22 on localhost".  Your code is
+     * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -134,8 +134,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* tell libssh2 we want it all done non-blocking */
     libssh2_session_set_blocking(session, 0);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -202,12 +202,15 @@ int main(int argc, char *argv[])
 
     libssh2_trace(session, LIBSSH2_TRACE_SOCKET);
 
-    /* Exec non-blocking on the remove host */
-    while(!(channel = libssh2_channel_open_session(session)) &&
-          libssh2_session_last_error(session, NULL, NULL, 0) ==
-          LIBSSH2_ERROR_EAGAIN) {
+    /* Exec non-blocking on the remote host */
+    do {
+        channel = libssh2_channel_open_session(session);
+        if(channel ||
+           libssh2_session_last_error(session, NULL, NULL, 0) !=
+           LIBSSH2_ERROR_EAGAIN)
+            break;
         waitsocket(sock, session);
-    }
+    } while(1);
     if(!channel) {
         fprintf(stderr, "Error\n");
         exit(1);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     int exitcode = 0;
     char *exitsignal = (char *)"none";
@@ -347,14 +347,19 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -220,12 +220,12 @@ int main(int argc, char *argv[])
 #endif
 
     /* Exec non-blocking on the remove host */
-    while((channel = libssh2_channel_open_session(session)) == NULL &&
+    while(!(channel = libssh2_channel_open_session(session)) &&
           libssh2_session_last_error(session, NULL, NULL, 0) ==
           LIBSSH2_ERROR_EAGAIN) {
         waitsocket(sock, session);
     }
-    if(channel == NULL) {
+    if(!channel) {
         fprintf(stderr, "Error\n");
         exit(1);
     }

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -4,8 +4,6 @@
  * The sample code has fixed values for host name, user name, password
  * and command to run.
  *
- * Run it like this:
- *
  * $ ./ssh2_exec 127.0.0.1 user password "uptime"
  *
  */
@@ -176,6 +174,7 @@ int main(int argc, char *argv[])
                                              LIBSSH2_KNOWNHOST_TYPE_PLAIN|
                                              LIBSSH2_KNOWNHOST_KEYENC_RAW,
                                              &host);
+
         fprintf(stderr, "Host check: %d, key: %s\n", check,
                 (check <= LIBSSH2_KNOWNHOST_CHECK_MISMATCH)?
                 host->key:"<none>");

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -39,6 +39,13 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+static const char *hostname = "127.0.0.1";
+static const char *commandline = "uptime";
+static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
+static const char *privkey = "/home/username/.ssh/id_rsa";
+static const char *username = "user";
+static const char *password = "password";
+
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
     struct timeval timeout;
@@ -71,12 +78,6 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
 int main(int argc, char *argv[])
 {
-    const char *hostname = "127.0.0.1";
-    const char *commandline = "uptime";
-    const char *pubkey = "/home/username/.ssh/id_rsa.pub";
-    const char *privkey = "/home/username/.ssh/id_rsa";
-    const char *username = "user";
-    const char *password = "password";
     uint32_t hostaddr;
     libssh2_socket_t sock;
     struct sockaddr_in sin;
@@ -122,9 +123,8 @@ int main(int argc, char *argv[])
 
     hostaddr = inet_addr(hostname);
 
-    /* Ultra basic "connect to port 22 on localhost"
-     * Your code is responsible for creating the socket establishing the
-     * connection
+    /* Ultra basic "connect to port 22 on localhost".  Your code is
+     * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -221,12 +221,15 @@ int main(int argc, char *argv[])
     libssh2_trace(session, ~0);
 #endif
 
-    /* Exec non-blocking on the remove host */
-    while(!(channel = libssh2_channel_open_session(session)) &&
-          libssh2_session_last_error(session, NULL, NULL, 0) ==
-          LIBSSH2_ERROR_EAGAIN) {
+    /* Exec non-blocking on the remote host */
+    do {
+        channel = libssh2_channel_open_session(session);
+        if(channel ||
+           libssh2_session_last_error(session, NULL, NULL, 0) !=
+           LIBSSH2_ERROR_EAGAIN)
+            break;
         waitsocket(sock, session);
-    }
+    } while(1);
     if(!channel) {
         fprintf(stderr, "Error\n");
         exit(1);

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -140,8 +140,10 @@ int main(int argc, char *argv[])
 
     /* Create a session instance */
     session = libssh2_session_init();
-    if(!session)
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
         goto shutdown;
+    }
 
     /* tell libssh2 we want it all done non-blocking */
     libssh2_session_set_blocking(session, 0);

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -93,11 +93,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -208,7 +207,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
                LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "\tAuthentication by public key failed\n");
+            fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
     }

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
     if(strlen(password) != 0) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-               LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
                                                         pubkey, privkey,
                                                         password)) ==
-               LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     const char *fingerprint;
     int rc;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     int exitcode;
     char *exitsignal = (char *)"none";
@@ -285,14 +285,19 @@ int main(int argc, char *argv[])
 
 shutdown:
 
-    libssh2_session_disconnect(session, "Normal Shutdown");
-    libssh2_session_free(session);
+    if(session) {
+        libssh2_session_disconnect(session, "Normal Shutdown");
+        libssh2_session_free(session);
+    }
 
+    if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-    closesocket(sock);
+        closesocket(sock);
 #else
-    close(sock);
+        close(sock);
 #endif
+    }
+
     fprintf(stderr, "all done\n");
 
     libssh2_exit();

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -82,9 +82,9 @@ int main(int argc, char *argv[])
     libssh2_socket_t sock;
     struct sockaddr_in sin;
     const char *fingerprint;
+    int rc;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
-    int rc;
     int exitcode;
     char *exitsignal = (char *)"none";
     ssize_t bytecount = 0;
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
                                                         password)) ==
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
-            fprintf(stderr, "Authentication by public key failed.\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
     }
@@ -230,7 +230,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN) {
         waitsocket(sock, session);
     }
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "exec error\n");
         exit(1);
     }

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -182,8 +182,8 @@ int main(int argc, char *argv[])
                                              &host);
 
         fprintf(stderr, "Host check: %d, key: %s\n", check,
-                (check <= LIBSSH2_KNOWNHOST_CHECK_MISMATCH)?
-                host->key:"<none>");
+                (check <= LIBSSH2_KNOWNHOST_CHECK_MISMATCH) ?
+                host->key : "<none>");
 
         /*****
          * At this point, we could verify that 'check' tells us the key is

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -125,6 +125,10 @@ int main(int argc, char *argv[])
      * responsible for creating the socket establishing the connection
      */
     sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock == LIBSSH2_INVALID_SOCKET) {
+        fprintf(stderr, "failed to create socket!\n");
+        return -1;
+    }
 
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr, "failed to create socket!\n");
-        return -1;
+        goto shutdown;
     }
 
     sin.sin_family = AF_INET;
@@ -135,13 +135,13 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session)
-        return -1;
+        goto shutdown;
 
     /* tell libssh2 we want it all done non-blocking */
     libssh2_session_set_blocking(session, 0);
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
           LIBSSH2_ERROR_EAGAIN);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     nh = libssh2_knownhost_init(session);

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -4,9 +4,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -41,8 +41,8 @@ static const char *server_ip = "127.0.0.1";
 
 enum {
     AUTH_NONE = 0,
-    AUTH_PASSWORD,
-    AUTH_PUBLICKEY
+    AUTH_PASSWORD = 1,
+    AUTH_PUBLICKEY = 2
 };
 
 static int netconf_write(LIBSSH2_CHANNEL *channel, const char *buf, size_t len)

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -152,19 +152,19 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = inet_addr(server_ip);
     if(INADDR_NONE == sin.sin_addr.s_addr) {
         fprintf(stderr, "inet_addr: Invalid IP address \"%s\"\n", server_ip);
-        return -1;
+        goto shutdown;
     }
     sin.sin_port = htons(830);
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "Failed to connect to %s!\n", inet_ntoa(sin.sin_addr));
-        return -1;
+        goto shutdown;
     }
 
     /* Create a session instance */
     session = libssh2_session_init();
     if(!session) {
         fprintf(stderr, "Could not initialize SSH session!\n");
-        return -1;
+        goto shutdown;
     }
 
     /* ... start it up. This will trade welcome banners, exchange keys,
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
     rc = libssh2_session_handshake(session, sock);
     if(rc) {
         fprintf(stderr, "Error when starting up SSH session: %d\n", rc);
-        return -1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
         password = argv[3];
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
 
     if(auth & AUTH_PASSWORD) {
         if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "Authentication by password failed.\n");
+            fprintf(stderr, "Authentication by password failed!\n");
             goto shutdown;
         }
     }
@@ -284,11 +284,12 @@ int main(int argc, char *argv[])
             (int)len, buf);
 
 shutdown:
+
     if(channel)
         libssh2_channel_free(channel);
 
     if(session) {
-        libssh2_session_disconnect(session, "Client disconnecting normally");
+        libssh2_session_disconnect(session, "Normal Shutdown");
         libssh2_session_free(session);
     }
 

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -190,40 +190,42 @@ int main(int argc, char *argv[])
     /* check what authentication methods are available */
     userauthlist = libssh2_userauth_list(session, username,
                                          (unsigned int)strlen(username));
-    fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-    if(strstr(userauthlist, "password"))
-        auth |= AUTH_PASSWORD;
-    if(strstr(userauthlist, "publickey"))
-        auth |= AUTH_PUBLICKEY;
+    if(userauthlist) {
+        fprintf(stderr, "Authentication methods: %s\n", userauthlist);
+        if(strstr(userauthlist, "password"))
+            auth |= AUTH_PASSWORD;
+        if(strstr(userauthlist, "publickey"))
+            auth |= AUTH_PUBLICKEY;
 
-    /* check for options */
-    if(argc > 4) {
-        if((auth & AUTH_PASSWORD) && !strcmp(argv[4], "-p"))
-            auth = AUTH_PASSWORD;
-        if((auth & AUTH_PUBLICKEY) && !strcmp(argv[4], "-k"))
-            auth = AUTH_PUBLICKEY;
-    }
-
-    if(auth & AUTH_PASSWORD) {
-        if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "Authentication by password failed!\n");
-            goto shutdown;
+        /* check for options */
+        if(argc > 4) {
+            if((auth & AUTH_PASSWORD) && !strcmp(argv[4], "-p"))
+                auth = AUTH_PASSWORD;
+            if((auth & AUTH_PUBLICKEY) && !strcmp(argv[4], "-k"))
+                auth = AUTH_PUBLICKEY;
         }
-    }
-    else if(auth & AUTH_PUBLICKEY) {
-        if(libssh2_userauth_publickey_fromfile(session, username,
-                                               pubkey, privkey,
-                                               password)) {
-            fprintf(stderr, "Authentication by public key failed!\n");
-            goto shutdown;
+
+        if(auth & AUTH_PASSWORD) {
+            if(libssh2_userauth_password(session, username, password)) {
+                fprintf(stderr, "Authentication by password failed!\n");
+                goto shutdown;
+            }
+        }
+        else if(auth & AUTH_PUBLICKEY) {
+            if(libssh2_userauth_publickey_fromfile(session, username,
+                                                   pubkey, privkey,
+                                                   password)) {
+                fprintf(stderr, "Authentication by public key failed!\n");
+                goto shutdown;
+            }
+            else {
+                fprintf(stderr, "Authentication by public key succeeded.\n");
+            }
         }
         else {
-            fprintf(stderr, "Authentication by public key succeeded.\n");
+            fprintf(stderr, "No supported authentication methods found!\n");
+            goto shutdown;
         }
-    }
-    else {
-        fprintf(stderr, "No supported authentication methods found!\n");
-        goto shutdown;
     }
 
     /* open a channel */

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -16,9 +16,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>
@@ -110,10 +107,11 @@ static ssize_t netconf_read_until(LIBSSH2_CHANNEL *channel, const char *endtag,
 
 int main(int argc, char *argv[])
 {
-    int rc, i, auth = AUTH_NONE;
+    int i, auth = AUTH_NONE;
     struct sockaddr_in sin;
     const char *fingerprint;
     char *userauthlist;
+    int rc;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel = NULL;
     char buf[1048576]; /* avoid any buffer reallocation for simplicity */
@@ -122,11 +120,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -217,10 +214,12 @@ int main(int argc, char *argv[])
         if(libssh2_userauth_publickey_fromfile(session, username,
                                                pubkey, privkey,
                                                password)) {
-            fprintf(stderr, "\tAuthentication by public key failed!\n");
+            fprintf(stderr, "Authentication by public key failed!\n");
             goto shutdown;
         }
-        fprintf(stderr, "\tAuthentication by public key succeeded.\n");
+        else {
+            fprintf(stderr, "Authentication by public key succeeded.\n");
+        }
     }
     else {
         fprintf(stderr, "No supported authentication methods found!\n");

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -229,16 +229,16 @@ int main(int argc, char *argv[])
     channel = libssh2_channel_open_session(session);
     if(!channel) {
         fprintf(stderr, "Could not open the channel!\n"
-                "(Note that this can be a problem at the server!"
-                " Please review the server logs.)\n");
+                        "(Note that this can be a problem at the server!"
+                       " Please review the server logs.)\n");
         goto shutdown;
     }
 
     /* execute the subsystem on our channel */
     if(libssh2_channel_subsystem(channel, "netconf")) {
         fprintf(stderr, "Could not execute the \"netconf\" subsystem!\n"
-                "(Note that this can be a problem at the server!"
-                " Please review the server logs.)\n");
+                        "(Note that this can be a problem at the server!"
+                        " Please review the server logs.)\n");
         goto shutdown;
     }
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
 
         if(auth & AUTH_PASSWORD) {
             if(libssh2_userauth_password(session, username, password)) {
-                fprintf(stderr, "Authentication by password failed.\n");
+                fprintf(stderr, "Authentication by password failed!\n");
                 goto shutdown;
             }
         }
@@ -306,6 +306,7 @@ int main(int argc, char *argv[])
     }
 
 shutdown:
+
     if(forwardsock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
         closesocket(forwardsock);
@@ -321,7 +322,7 @@ shutdown:
         libssh2_channel_forward_cancel(listener);
 
     if(session) {
-        libssh2_session_disconnect(session, "Client disconnecting normally");
+        libssh2_session_disconnect(session, "Normal Shutdown");
         libssh2_session_free(session);
     }
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -201,8 +201,8 @@ int main(int argc, char *argv[])
         remote_wantport, &remote_listenport, 1);
     if(!listener) {
         fprintf(stderr, "Could not start the tcpip-forward listener!\n"
-                "(Note that this can be a problem at the server!"
-                " Please review the server logs.)\n");
+                        "(Note that this can be a problem at the server!"
+                        " Please review the server logs.)\n");
         goto shutdown;
     }
 
@@ -213,8 +213,8 @@ int main(int argc, char *argv[])
     channel = libssh2_channel_forward_accept(listener);
     if(!channel) {
         fprintf(stderr, "Could not accept connection!\n"
-                "(Note that this can be a problem at the server!"
-                " Please review the server logs.)\n");
+                        "(Note that this can be a problem at the server!"
+                        " Please review the server logs.)\n");
         goto shutdown;
     }
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -54,8 +54,8 @@ static int local_destport = 22;
 
 enum {
     AUTH_NONE = 0,
-    AUTH_PASSWORD,
-    AUTH_PUBLICKEY
+    AUTH_PASSWORD = 1,
+    AUTH_PUBLICKEY = 2
 };
 
 int main(int argc, char *argv[])

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -60,11 +60,12 @@ enum {
 
 int main(int argc, char *argv[])
 {
-    int rc, i, auth = AUTH_NONE;
+    int i, auth = AUTH_NONE;
     struct sockaddr_in sin;
     socklen_t sinlen = sizeof(sin);
     const char *fingerprint;
     char *userauthlist;
+    int rc;
     LIBSSH2_SESSION *session;
     LIBSSH2_LISTENER *listener = NULL;
     LIBSSH2_CHANNEL *channel = NULL;
@@ -77,11 +78,10 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
     WSADATA wsadata;
-    int err;
 
-    err = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(err != 0) {
-        fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+    rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
+    if(rc != 0) {
+        fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
 #endif
@@ -156,38 +156,42 @@ int main(int argc, char *argv[])
     /* check what authentication methods are available */
     userauthlist = libssh2_userauth_list(session, username,
                                          (unsigned int)strlen(username));
-    fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-    if(strstr(userauthlist, "password"))
-        auth |= AUTH_PASSWORD;
-    if(strstr(userauthlist, "publickey"))
-        auth |= AUTH_PUBLICKEY;
+    if(userauthlist) {
+        fprintf(stderr, "Authentication methods: %s\n", userauthlist);
+        if(strstr(userauthlist, "password"))
+            auth |= AUTH_PASSWORD;
+        if(strstr(userauthlist, "publickey"))
+            auth |= AUTH_PUBLICKEY;
 
-    /* check for options */
-    if(argc > 8) {
-        if((auth & AUTH_PASSWORD) && !strcmp(argv[8], "-p"))
-            auth = AUTH_PASSWORD;
-        if((auth & AUTH_PUBLICKEY) && !strcmp(argv[8], "-k"))
-            auth = AUTH_PUBLICKEY;
-    }
+        /* check for options */
+        if(argc > 8) {
+            if((auth & AUTH_PASSWORD) && !strcmp(argv[8], "-p"))
+                auth = AUTH_PASSWORD;
+            if((auth & AUTH_PUBLICKEY) && !strcmp(argv[8], "-k"))
+                auth = AUTH_PUBLICKEY;
+        }
 
-    if(auth & AUTH_PASSWORD) {
-        if(libssh2_userauth_password(session, username, password)) {
-            fprintf(stderr, "Authentication by password failed.\n");
+        if(auth & AUTH_PASSWORD) {
+            if(libssh2_userauth_password(session, username, password)) {
+                fprintf(stderr, "Authentication by password failed.\n");
+                goto shutdown;
+            }
+        }
+        else if(auth & AUTH_PUBLICKEY) {
+            if(libssh2_userauth_publickey_fromfile(session, username,
+                                                   pubkey, privkey,
+                                                   password)) {
+                fprintf(stderr, "Authentication by public key failed!\n");
+                goto shutdown;
+            }
+            else {
+                fprintf(stderr, "Authentication by public key succeeded.\n");
+            }
+        }
+        else {
+            fprintf(stderr, "No supported authentication methods found!\n");
             goto shutdown;
         }
-    }
-    else if(auth & AUTH_PUBLICKEY) {
-        if(libssh2_userauth_publickey_fromfile(session, username,
-                                               pubkey, privkey,
-                                               password)) {
-            fprintf(stderr, "\tAuthentication by public key failed!\n");
-            goto shutdown;
-        }
-        fprintf(stderr, "\tAuthentication by public key succeeded.\n");
-    }
-    else {
-        fprintf(stderr, "No supported authentication methods found!\n");
-        goto shutdown;
     }
 
     fprintf(stderr, "Asking server to listen on remote %s:%d\n",

--- a/example/x11.c
+++ b/example/x11.c
@@ -321,7 +321,7 @@ main(int argc, char *argv[])
 
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
-        perror("socket");
+        fprintf(stderr, "failed to open socket!\n");
         return -1;
     }
 
@@ -362,7 +362,7 @@ main(int argc, char *argv[])
     }
 
     /* Open a channel */
-    channel  = libssh2_channel_open_session(session);
+    channel = libssh2_channel_open_session(session);
     if(channel == NULL) {
         fprintf(stderr, "Failed to open a new channel\n");
         session_shutdown(session);

--- a/example/x11.c
+++ b/example/x11.c
@@ -89,7 +89,7 @@ static void remove_node(struct chan_X11_list *elem)
 
 static void session_shutdown(LIBSSH2_SESSION *session)
 {
-    libssh2_session_disconnect(session, "Session Shutdown");
+    libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
 }
 
@@ -314,7 +314,7 @@ main(int argc, char *argv[])
     }
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -336,7 +336,7 @@ main(int argc, char *argv[])
     /* Open a session */
     session = libssh2_session_init();
     rc      = libssh2_session_handshake(session, sock);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Failed Start the SSH session\n");
         return -1;
     }
@@ -354,7 +354,7 @@ main(int argc, char *argv[])
 
     /* Authenticate via password */
     rc = libssh2_userauth_password(session, username, password);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Failed to authenticate\n");
         session_shutdown(session);
         close(sock);
@@ -372,7 +372,7 @@ main(int argc, char *argv[])
 
     /* Request a PTY */
     rc = libssh2_channel_request_pty(channel, "xterm");
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Failed to request a pty\n");
         session_shutdown(session);
         close(sock);
@@ -381,7 +381,7 @@ main(int argc, char *argv[])
 
     /* Request X11 */
     rc = libssh2_channel_x11_req(channel, 0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Failed to request X11 forwarding\n");
         session_shutdown(session);
         close(sock);
@@ -390,7 +390,7 @@ main(int argc, char *argv[])
 
     /* Request a shell */
     rc = libssh2_channel_shell(channel);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Failed to open a shell\n");
         session_shutdown(session);
         close(sock);
@@ -398,7 +398,7 @@ main(int argc, char *argv[])
     }
 
     rc = _raw_mode();
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Failed to entered in raw mode\n");
         session_shutdown(session);
         close(sock);

--- a/example/x11.c
+++ b/example/x11.c
@@ -149,7 +149,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
             display[0] == ':') {
             /* Connect to the local unix domain */
             ptr = strrchr(display, ':');
-            temp_buff = (char *) calloc(strlen(ptr + 1) + 1, sizeof(char));
+            temp_buff = (char *)calloc(strlen(ptr + 1) + 1, sizeof(char));
             if(!temp_buff) {
                 fprintf(stderr, "failed to calloc()!\n");
                 return;

--- a/example/x11.c
+++ b/example/x11.c
@@ -497,7 +497,7 @@ int main(int argc, char *argv[])
 
 int main(void)
 {
-    printf("Sorry, this platform is not supported.");
+    fprintf(stderr, "Sorry, this platform is not supported.");
     return 1;
 }
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -243,7 +243,7 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, int sock)
     if(rc > 0) {
         ssize_t nread;
 
-        memset((void *)buf, 0, bufsize);
+        memset(buf, 0, bufsize);
 
         /* Data in sock */
         nread = read(sock, buf, bufsize);

--- a/example/x11.c
+++ b/example/x11.c
@@ -266,14 +266,13 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, int sock)
 /*
  * Main, more than inspired by ssh2.c by Bagder
  */
-int
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
     uint32_t hostaddr = 0;
     int rc;
     libssh2_socket_t sock = LIBSSH2_INVALID_SOCKET;
     struct sockaddr_in sin;
-    LIBSSH2_SESSION *session;
+    LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     char *username = NULL;
     char *password = NULL;
@@ -496,8 +495,7 @@ main(int argc, char *argv[])
 
 #else
 
-int
-main(void)
+int main(void)
 {
     printf("Sorry, this platform is not supported.");
     return 1;

--- a/example/x11.c
+++ b/example/x11.c
@@ -75,7 +75,7 @@ static void remove_node(struct chan_X11_list *elem)
         return;
     }
 
-    while(current_node->next != NULL) {
+    while(current_node->next) {
         if(current_node->next == elem) {
             current_node->next = current_node->next->next;
             current_node = current_node->next;
@@ -144,7 +144,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
      * Inspired by x11_connect_display in openssh
      */
     display = getenv("DISPLAY");
-    if(display != NULL) {
+    if(display) {
         if(strncmp(display, "unix:", 5) == 0 ||
             display[0] == ':') {
             /* Connect to the local unix domain */
@@ -169,7 +169,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
 
             if(rc != -1) {
                 /* Connection Successful */
-                if(gp_x11_chan == NULL) {
+                if(!gp_x11_chan) {
                     /* Calloc ensure that gp_X11_chan is full of 0 */
                     gp_x11_chan = (struct chan_X11_list *)
                         calloc(1, sizeof(struct chan_X11_list));
@@ -179,7 +179,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
                 }
                 else {
                     chan_iter = gp_x11_chan;
-                    while(chan_iter->next != NULL)
+                    while(chan_iter->next)
                         chan_iter = chan_iter->next;
                     /* Create the new Node */
                     new = (struct chan_X11_list *)
@@ -361,7 +361,7 @@ int main(int argc, char *argv[])
 
     /* Open a channel */
     channel = libssh2_channel_open_session(session);
-    if(channel == NULL) {
+    if(!channel) {
         fprintf(stderr, "Failed to open a new channel\n");
         session_shutdown(session);
         close(sock);
@@ -423,11 +423,11 @@ int main(int argc, char *argv[])
         }
 
         buf = calloc(bufsiz, sizeof(char));
-        if(buf == NULL)
+        if(!buf)
             break;
 
         fds = malloc(sizeof(LIBSSH2_POLLFD));
-        if(fds == NULL) {
+        if(!fds) {
             free(buf);
             break;
         }
@@ -445,13 +445,13 @@ int main(int argc, char *argv[])
         }
 
         /* Looping on X clients */
-        if(gp_x11_chan != NULL) {
+        if(gp_x11_chan) {
             current_node = gp_x11_chan;
         }
         else
             current_node = NULL;
 
-        while(current_node != NULL) {
+        while(current_node) {
             struct chan_X11_list *next_node;
             rc = x11_send_receive(current_node->chan, current_node->sock);
             next_node = current_node->next;

--- a/example/x11.c
+++ b/example/x11.c
@@ -152,7 +152,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
             ptr = strrchr(display, ':');
             temp_buff = (char *) calloc(strlen(ptr + 1) + 1, sizeof(char));
             if(!temp_buff) {
-                perror("calloc");
+                fprintf(stderr, "failed to calloc()!\n");
                 return;
             }
             memcpy(temp_buff, ptr + 1, strlen(ptr + 1));

--- a/example/x11.c
+++ b/example/x11.c
@@ -1,8 +1,7 @@
 /*
  * Sample showing how to makes SSH2 with X11 Forwarding works.
  *
- * Usage:
- * "ssh2 host user password [DEBUG]"
+ * $ ./x11 host user password [DEBUG]
  */
 
 #include "libssh2_setup.h"

--- a/example/x11.c
+++ b/example/x11.c
@@ -30,6 +30,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif
@@ -124,11 +127,11 @@ static int _normal_mode(void)
 static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
                          char *shost, int sport, void **abstract)
 {
-    const char *display = NULL;
-    char *ptr          = NULL;
-    char *temp_buff    = NULL;
-    int   display_port = 0;
-    int   rc           = 0;
+    const char *display;
+    char *ptr;
+    char *temp_buff;
+    int display_port;
+    int rc;
     libssh2_socket_t sock = LIBSSH2_INVALID_SOCKET;
     struct sockaddr_un addr;
     struct chan_X11_list *new;
@@ -201,10 +204,10 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
  */
 static int x11_send_receive(LIBSSH2_CHANNEL *channel, int sock)
 {
-    char *buf          = NULL;
-    int   bufsize      = 8192;
-    int   rc           = 0;
-    int   nfds         = 1;
+    char *buf;
+    int bufsize = 8192;
+    int rc;
+    int nfds = 1;
     LIBSSH2_POLLFD *fds = NULL;
     fd_set set;
     struct timeval timeval_out;
@@ -268,7 +271,7 @@ int
 main(int argc, char *argv[])
 {
     uint32_t hostaddr = 0;
-    int rc = 0;
+    int rc;
     libssh2_socket_t sock = LIBSSH2_INVALID_SOCKET;
     struct sockaddr_in sin;
     LIBSSH2_SESSION *session;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -119,7 +119,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
 #else
     ret = pclose(pipe);
 #endif
-    if(ret != 0) {
+    if(ret) {
         fprintf(stderr, "Error running command '%s' (exit %d): %s\n",
                 command, ret, buf);
     }
@@ -235,7 +235,7 @@ static int is_running_inside_a_container(void)
     ssize_t read = 0;
     int found = 0;
     f = fopen(cgroup_filename, "r");
-    if(f == NULL) {
+    if(!f) {
         /* Don't go further, we are not in a container */
         return 0;
     }
@@ -337,14 +337,14 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     if(have_docker) {
         int res;
         res = ip_address_from_container(container_id, &ip_address);
-        if(res != 0) {
+        if(res) {
             fprintf(stderr, "Failed to get IP address for container %s\n",
                     container_id);
             goto cleanup;
         }
 
         res = port_from_container(container_id, &port_string);
-        if(res != 0) {
+        if(res) {
             fprintf(stderr, "Failed to get port for container %s\n",
                     container_id);
             goto cleanup;
@@ -424,7 +424,7 @@ int start_openssh_fixture(void)
     WSADATA wsadata;
 
     ret = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(ret != 0) {
+    if(ret) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", ret);
         return 1;
     }
@@ -433,7 +433,7 @@ int start_openssh_fixture(void)
     have_docker = (getenv("OPENSSH_NO_DOCKER") == NULL);
 
     ret = build_openssh_server_docker_image();
-    if(ret == 0) {
+    if(!ret) {
         return start_openssh_server(&running_container_id);
     }
     else {

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -110,7 +110,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
     buf[0] = 0;
     buf_len = 0;
     while(buf_len < (sizeof(buf) - 1) &&
-        fgets(&buf[buf_len], (int)(sizeof(buf) - buf_len), pipe) != NULL) {
+        fgets(&buf[buf_len], (int)(sizeof(buf) - buf_len), pipe)) {
         buf_len = strlen(buf);
     }
 
@@ -159,7 +159,7 @@ static int build_openssh_server_docker_image(void)
     if(have_docker) {
         char buildcmd[1024];
         const char *container_image_name = openssh_server_image();
-        if(container_image_name != NULL) {
+        if(container_image_name) {
             int ret = run_command(NULL, "docker pull --quiet %s",
                                   container_image_name);
             if(ret == 0) {
@@ -191,7 +191,7 @@ static int start_openssh_server(char **container_id_out)
 {
     if(have_docker) {
         const char *container_host_port = openssh_server_port();
-        if(container_host_port != NULL) {
+        if(container_host_port) {
             return run_command(container_id_out,
                                "docker run --rm -d -p %s:22 "
                                "libssh2/openssh_server",
@@ -240,7 +240,7 @@ static int is_running_inside_a_container(void)
         return 0;
     }
     while((read = getline(&line, &len, f)) != -1) {
-        if(strstr(line, "docker") != NULL) {
+        if(strstr(line, "docker")) {
             found = 1;
             break;
         }
@@ -263,7 +263,7 @@ static void portable_sleep(unsigned int seconds)
 static int ip_address_from_container(char *container_id, char **ip_address_out)
 {
     const char *active_docker_machine = docker_machine_name();
-    if(active_docker_machine != NULL) {
+    if(active_docker_machine) {
 
         /* This can be flaky when tests run in parallel (see
            https://github.com/docker/machine/issues/2612), so we retry a few

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -10,12 +10,12 @@
 #include "testinput.h"
 
 #define FUZZ_ASSERT(COND)                                                     \
-        if(!(COND))                                                           \
-        {                                                                     \
-          fprintf(stderr, "Assertion failed: " #COND "\n%s",                  \
-                  strerror(errno));                                           \
-          assert((COND));                                                     \
-        }
+    if(!(COND))                                                               \
+    {                                                                         \
+      fprintf(stderr, "Assertion failed: " #COND "\n%s",                      \
+              strerror(errno));                                               \
+      assert((COND));                                                         \
+    }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
@@ -27,7 +27,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
   rc = libssh2_init(0);
 
-  if(rc != 0) {
+  if(rc) {
     fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
     goto EXIT_LABEL;
   }
@@ -38,7 +38,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
   written = send(socket_fds[1], data, size, 0);
 
-  if (written != size)
+  if(written != size)
   {
     // Handle whatever error case we're in.
     fprintf(stderr, "send() of %zu bytes returned %zu (%d)\n",
@@ -49,7 +49,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   }
 
   rc = shutdown(socket_fds[1], SHUT_WR);
-  if (rc != 0)
+  if(rc)
   {
     fprintf(stderr, "socket shutdown failed (%d)\n", rc);
     goto EXIT_LABEL;
@@ -61,7 +61,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     libssh2_session_set_blocking(session, 1);
   }
   else {
-      goto EXIT_LABEL;
+    goto EXIT_LABEL;
   }
 
   if(libssh2_session_handshake(session, socket_fds[0])) {
@@ -73,9 +73,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
 EXIT_LABEL:
 
-  if (session != NULL)
+  if(session != NULL)
   {
-    if (handshake_completed)
+    if(handshake_completed)
     {
       libssh2_session_disconnect(session,
                                  "Normal Shutdown, Thank you for playing");

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -73,7 +73,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
 EXIT_LABEL:
 
-  if(session != NULL)
+  if(session)
   {
     if(handshake_completed)
     {

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -41,7 +41,7 @@ int main(void)
 {
     int exit_code = 1;
     LIBSSH2_SESSION *session = start_session_fixture();
-    if(session != NULL) {
+    if(session) {
         exit_code = (test(session) == 0) ? 0 : 1;
     }
     stop_session_fixture();

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -120,7 +120,7 @@ LIBSSH2_SESSION *start_session_fixture(void)
     if(getenv("FIXTURE_TRACE_ALL")) {
         libssh2_trace(connected_session, ~0);
     }
-    if(connected_session == NULL) {
+    if(!connected_session) {
         fprintf(stderr, "libssh2_session_init_ex failed\n");
         return NULL;
     }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -70,7 +70,7 @@ static int connect_to_server(void)
     }
 
     rc = libssh2_session_handshake(connected_session, connected_socket);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_session_handshake");
         return -1;
     }
@@ -107,11 +107,11 @@ LIBSSH2_SESSION *start_session_fixture(void)
     setup_fixture_workdir();
 
     rc = start_openssh_fixture();
-    if(rc != 0) {
+    if(rc) {
         return NULL;
     }
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2_init failed (%d)\n", rc);
         return NULL;
     }
@@ -153,7 +153,7 @@ LIBSSH2_SESSION *start_session_fixture(void)
     libssh2_session_set_blocking(connected_session, 1);
 
     rc = connect_to_server();
-    if(rc != 0) {
+    if(rc) {
         return NULL;
     }
 

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     (void)argc;
 
     rc = libssh2_init(LIBSSH2_INIT_NO_CRYPTO);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2_init() failed: %d\n", rc);
         return 1;
     }

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "WSAStartup failed with error: %d\n", rc);
         return 1;
     }
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     hostaddr = htonl(0x7F000001);
 
     rc = libssh2_init(0);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
         return 1;
     }
@@ -174,6 +174,7 @@ int main(int argc, char *argv[])
     rc = 0;
 
 skip_shell:
+
     if(channel) {
         libssh2_channel_free(channel);
         channel = NULL;

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect!\n");
-        return 1;
+        goto shutdown;
     }
 
     /* Create a session instance and start it up. This will trade welcome
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
     session = libssh2_session_init();
     if(libssh2_session_handshake(session, sock)) {
         fprintf(stderr, "Failure establishing SSH session\n");
-        return 1;
+        goto shutdown;
     }
 
     /* At this point we have not yet authenticated.  The first thing to do

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -2,7 +2,6 @@
 
 #include "libssh2_setup.h"
 #include <libssh2.h>
-#include <libssh2_sftp.h>
 
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
@@ -189,10 +188,8 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
 #ifdef WIN32
-        Sleep(1000);
         closesocket(sock);
 #else
-        sleep(1);
         close(sock);
 #endif
     }

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -93,6 +93,10 @@ int main(int argc, char *argv[])
      * banners, exchange keys, and setup crypto, compression, and MAC layers
      */
     session = libssh2_session_init();
+    if(!session) {
+        fprintf(stderr, "Could not initialize SSH session!\n");
+        goto shutdown;
+    }
 
     rc = libssh2_session_handshake(session, sock);
     if(rc) {

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -115,13 +115,13 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "password") != NULL) {
+        if(strstr(userauthlist, "password")) {
             auth_pw |= 1;
         }
-        if(strstr(userauthlist, "keyboard-interactive") != NULL) {
+        if(strstr(userauthlist, "keyboard-interactive")) {
             auth_pw |= 2;
         }
-        if(strstr(userauthlist, "publickey") != NULL) {
+        if(strstr(userauthlist, "publickey")) {
             auth_pw |= 4;
         }
 

--- a/tests/ssh2.c
+++ b/tests/ssh2.c
@@ -93,8 +93,10 @@ int main(int argc, char *argv[])
      * banners, exchange keys, and setup crypto, compression, and MAC layers
      */
     session = libssh2_session_init();
-    if(libssh2_session_handshake(session, sock)) {
-        fprintf(stderr, "Failure establishing SSH session\n");
+
+    rc = libssh2_session_handshake(session, sock);
+    if(rc) {
+        fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
     }
 

--- a/tests/test_agent_forward_succeeds.c
+++ b/tests/test_agent_forward_succeeds.c
@@ -12,12 +12,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_agent_forward_succeeds.c
+++ b/tests/test_agent_forward_succeeds.c
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }
@@ -39,7 +39,7 @@ int test(LIBSSH2_SESSION *session)
     /* } */
 
     rc = libssh2_channel_request_auth_agent(channel);
-    if(rc != 0) {
+    if(rc) {
         fprintf(stderr, "Auth agent request for agent forwarding failed, "
             "error code %d\n", rc);
         return 1;

--- a/tests/test_hostkey.c
+++ b/tests/test_hostkey.c
@@ -21,7 +21,7 @@ int test(LIBSSH2_SESSION *session)
     char *expected_hostkey = NULL;
 
     const char *hostkey = libssh2_session_hostkey(session, &len, &type);
-    if(hostkey == NULL) {
+    if(!hostkey) {
         print_last_session_error("libssh2_session_hostkey");
         return 1;
     }

--- a/tests/test_hostkey.c
+++ b/tests/test_hostkey.c
@@ -41,7 +41,7 @@ int test(LIBSSH2_SESSION *session)
         return 1;
     }
 
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_base64_decode");
         return 1;
     }

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -62,7 +62,7 @@ int test(LIBSSH2_SESSION *session)
     (void)EXPECTED_ECDSA_HOSTKEY;
 
     hostkey = libssh2_session_hostkey(session, &len, &type);
-    if(hostkey == NULL) {
+    if(!hostkey) {
         print_last_session_error("libssh2_session_hostkey");
         return 1;
     }
@@ -70,7 +70,7 @@ int test(LIBSSH2_SESSION *session)
     if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA_256) {
 
         md5_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_MD5);
-        if(md5_hash == NULL) {
+        if(!md5_hash) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_MD5)");
             return 1;
@@ -86,7 +86,7 @@ int test(LIBSSH2_SESSION *session)
         }
 
         sha1_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
-        if(sha1_hash == NULL) {
+        if(!sha1_hash) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA1)");
             return 1;
@@ -103,7 +103,7 @@ int test(LIBSSH2_SESSION *session)
 
         sha256_hash = libssh2_hostkey_hash(session,
                                            LIBSSH2_HOSTKEY_HASH_SHA256);
-        if(sha256_hash == NULL) {
+        if(!sha256_hash) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA256)");
             return 1;
@@ -122,7 +122,7 @@ int test(LIBSSH2_SESSION *session)
     else if(type == LIBSSH2_HOSTKEY_TYPE_RSA) {
 
         md5_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_MD5);
-        if(md5_hash == NULL) {
+        if(!md5_hash) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_MD5)");
             return 1;
@@ -138,7 +138,7 @@ int test(LIBSSH2_SESSION *session)
         }
 
         sha1_hash = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
-        if(sha1_hash == NULL) {
+        if(!sha1_hash) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA1)");
             return 1;
@@ -155,7 +155,7 @@ int test(LIBSSH2_SESSION *session)
 
         sha256_hash = libssh2_hostkey_hash(session,
                                            LIBSSH2_HOSTKEY_HASH_SHA256);
-        if(sha256_hash == NULL) {
+        if(!sha256_hash) {
             print_last_session_error(
                 "libssh2_hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA256)");
             return 1;

--- a/tests/test_keyboard_interactive_auth_fails_with_wrong_response.c
+++ b/tests/test_keyboard_interactive_auth_fails_with_wrong_response.c
@@ -32,12 +32,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "keyboard-interactive") == NULL) {
+    if(!strstr(userauth_list, "keyboard-interactive")) {
         fprintf(stderr,
                 "'keyboard-interactive' was expected in userauth list: %s\n",
                 userauth_list);

--- a/tests/test_keyboard_interactive_auth_info_request.c
+++ b/tests/test_keyboard_interactive_auth_info_request.c
@@ -252,7 +252,7 @@ int test_case(int num,
     alloc_count = 0;
     free_count = 0;
     session = libssh2_session_init_ex(test_alloc, test_free, NULL, abstract);
-    if(session == NULL) {
+    if(!session) {
         fprintf(stderr, "libssh2_session_init_ex failed\n");
         return 1;
     }

--- a/tests/test_keyboard_interactive_auth_info_request.c
+++ b/tests/test_keyboard_interactive_auth_info_request.c
@@ -223,7 +223,7 @@ LIBSSH2_ALLOC_FUNC(test_alloc)
 {
     int *threshold_int_ptr = *abstract;
     alloc_count++;
-    if(*abstract != NULL && *threshold_int_ptr == alloc_count) {
+    if(*abstract && *threshold_int_ptr == alloc_count) {
         return NULL;
     }
 

--- a/tests/test_keyboard_interactive_auth_succeeds_with_correct_response.c
+++ b/tests/test_keyboard_interactive_auth_succeeds_with_correct_response.c
@@ -48,7 +48,7 @@ int test(LIBSSH2_SESSION *session)
 
     rc = libssh2_userauth_keyboard_interactive_ex(
         session, USERNAME, (unsigned int)strlen(USERNAME), kbd_callback);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_keyboard_interactive_ex");
         return 1;
     }

--- a/tests/test_keyboard_interactive_auth_succeeds_with_correct_response.c
+++ b/tests/test_keyboard_interactive_auth_succeeds_with_correct_response.c
@@ -34,12 +34,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "keyboard-interactive") == NULL) {
+    if(!strstr(userauth_list, "keyboard-interactive")) {
         fprintf(stderr,
                 "'keyboard-interactive' was expected in userauth list: %s\n",
                 userauth_list);

--- a/tests/test_password_auth_fails_with_wrong_password.c
+++ b/tests/test_password_auth_fails_with_wrong_password.c
@@ -10,12 +10,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "password") == NULL) {
+    if(!strstr(userauth_list, "password")) {
         fprintf(stderr, "'password' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_password_auth_fails_with_wrong_username.c
+++ b/tests/test_password_auth_fails_with_wrong_username.c
@@ -11,12 +11,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, WRONG_USERNAME,
                               (unsigned int)strlen(WRONG_USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "password") == NULL) {
+    if(!strstr(userauth_list, "password")) {
         fprintf(stderr, "'password' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_password_auth_succeeds_with_correct_credentials.c
+++ b/tests/test_password_auth_succeeds_with_correct_credentials.c
@@ -11,12 +11,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "password") == NULL) {
+    if(!strstr(userauth_list, "password")) {
         fprintf(stderr, "'password' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_password_auth_succeeds_with_correct_credentials.c
+++ b/tests/test_password_auth_succeeds_with_correct_credentials.c
@@ -26,7 +26,7 @@ int test(LIBSSH2_SESSION *session)
                                       (unsigned int)strlen(USERNAME),
                                       PASSWORD,
                                       (unsigned int)strlen(PASSWORD), NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_password_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_fails_with_wrong_key.c
+++ b/tests/test_public_key_auth_fails_with_wrong_key.c
@@ -11,12 +11,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_dsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_dsa_key.c
@@ -26,7 +26,7 @@ int test(LIBSSH2_SESSION *session)
     rc = libssh2_userauth_publickey_fromfile_ex(
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE), NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_dsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_dsa_key.c
@@ -12,12 +12,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_ecdsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_ecdsa_key.c
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_ecdsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_ecdsa_key.c
@@ -12,12 +12,12 @@ int test(LIBSSH2_SESSION *session)
 
     userauth_list = libssh2_userauth_list(session, USERNAME,
                                           (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_ed25519_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_ed25519_key.c
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_ed25519_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_ed25519_key.c
@@ -12,12 +12,12 @@ int test(LIBSSH2_SESSION *session)
 
     userauth_list = libssh2_userauth_list(session, USERNAME,
                                           (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c
@@ -40,7 +40,7 @@ int test(LIBSSH2_SESSION *session)
 
     free(buffer);
 
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_ed25519_key_from_mem.c
@@ -16,12 +16,12 @@ int test(LIBSSH2_SESSION *session)
 
     userauth_list = libssh2_userauth_list(session, USERNAME,
                                           (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;
@@ -54,7 +54,7 @@ static int read_file(const char *path, char **out_buffer, size_t *out_len)
     char *buffer = NULL;
     size_t len = 0;
 
-    if(out_buffer == NULL || out_len == NULL || path == NULL) {
+    if(!out_buffer || !out_len || !path) {
         fprintf(stderr, "invalid params.");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_encrypted_ed25519_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_encrypted_ed25519_key.c
@@ -28,7 +28,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         PASSWORD);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_encrypted_ed25519_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_encrypted_ed25519_key.c
@@ -13,12 +13,12 @@ int test(LIBSSH2_SESSION *session)
 
     userauth_list = libssh2_userauth_list(session, USERNAME,
                                           (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_encrypted_rsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_encrypted_rsa_key.c
@@ -28,7 +28,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
        srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         PASSWORD);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_encrypted_rsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_encrypted_rsa_key.c
@@ -13,12 +13,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_rsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_rsa_key.c
@@ -12,12 +12,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_rsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_rsa_key.c
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_rsa_openssh_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_rsa_openssh_key.c
@@ -12,12 +12,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_rsa_openssh_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_rsa_openssh_key.c
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_signed_ecdsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_signed_ecdsa_key.c
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_public_key_auth_succeeds_with_correct_signed_ecdsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_signed_ecdsa_key.c
@@ -12,12 +12,12 @@ int test(LIBSSH2_SESSION *session)
 
     userauth_list = libssh2_userauth_list(session, USERNAME,
                                           (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_signed_rsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_signed_rsa_key.c
@@ -12,12 +12,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;

--- a/tests/test_public_key_auth_succeeds_with_correct_signed_rsa_key.c
+++ b/tests/test_public_key_auth_succeeds_with_correct_signed_rsa_key.c
@@ -27,7 +27,7 @@ int test(LIBSSH2_SESSION *session)
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE),
         NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -46,7 +46,7 @@ int test(LIBSSH2_SESSION *session)
     rc = libssh2_userauth_publickey_fromfile_ex(
         session, USERNAME, (unsigned int)strlen(USERNAME),
         srcdir_path(KEY_FILE_PUBLIC), srcdir_path(KEY_FILE_PRIVATE), NULL);
-    if(rc != 0) {
+    if(rc) {
         print_last_session_error("libssh2_userauth_publickey_fromfile_ex");
         return 1;
     }

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -32,12 +32,12 @@ int test(LIBSSH2_SESSION *session)
     const char *userauth_list =
         libssh2_userauth_list(session, USERNAME,
                               (unsigned int)strlen(USERNAME));
-    if(userauth_list == NULL) {
+    if(!userauth_list) {
         print_last_session_error("libssh2_userauth_list");
         return 1;
     }
 
-    if(strstr(userauth_list, "publickey") == NULL) {
+    if(!strstr(userauth_list, "publickey")) {
         fprintf(stderr, "'publickey' was expected in userauth list: %s\n",
                 userauth_list);
         return 1;


### PR DESCRIPTION
- fix skip auth if `userauthlist` is NULL.
  Closes #836 (Reported-by: @sudipm-mukherjee on github)
- fix most silenced `checksrc` warnings.
- sync examples/tests code between each other.
  (output messages, error handling, declaration order, comments)
- stop including unnecessary headers.
- always deinitialize in case of error.
- drop some redundant variables.
- add error handling where missing.
- show more error codes.
- switch `perror()` to `fprintf()`.
- fix some `printf()`s to be `fprintf()`.
- formatting.

Closes #960

---

https://github.com/libssh2/libssh2/pull/960/files?w=1
