### PR TITLE
crypto: add `LIBSSH2_NO_HMAC_RIPEMD` option

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -57,6 +57,11 @@
 #define LIBSSH2_MD5 0
 #endif
 
+#ifdef LIBSSH2_NO_HMAC_RIPEMD
+#undef LIBSSH2_HMAC_RIPEMD
+#define LIBSSH2_HMAC_RIPEMD 0
+#endif
+
 #ifdef LIBSSH2_NO_DSA
 #undef LIBSSH2_DSA
 #define LIBSSH2_DSA 0


### PR DESCRIPTION
See also: 38015f4e46d8dbeea522dc7ee664522d4f47fc75
See also: be31457f3071686b555a0f0b19e5dcf63d67fc27

Closes #965
