### PR TITLE
tests: switch Dockerfile to debian:testing-slim

### DIFF
--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -33,7 +33,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 # OF SUCH DAMAGE.
 
-FROM debian:bullseye
+FROM debian:testing-slim
 
 RUN apt-get update \
  && apt-get install -y openssh-server \


### PR DESCRIPTION
From debian:bullseye

- doesn't need manual bumps.
- is ahead of stable and should be stable enough for our purpose.
- slim is saving resources.

Closes #971
