### PR TITLE
build: assume non-blocking I/O on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,10 +188,12 @@ endif()
 # Non-blocking socket support tests. Use a separate, yet unset variable
 # for the socket libraries to not link against the other configured
 # dependencies which might not have been built yet.
-cmake_push_check_state()
-set(CMAKE_REQUIRED_LIBRARIES ${SOCKET_LIBRARIES})
-check_nonblocking_socket_support()
-cmake_pop_check_state()
+if(NOT WIN32)
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_LIBRARIES ${SOCKET_LIBRARIES})
+  check_nonblocking_socket_support()
+  cmake_pop_check_state()
+endif()
 
 ## Cryptography backend choice
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -629,7 +629,6 @@ AC_DEFINE(HAVE_SO_NONBLOCK, 1, [use SO_NONBLOCK for non-blocking sockets])
 ],[
 dnl test 4 did not compile!
 nonblock="nada"
-AC_DEFINE(HAVE_DISABLED_NONBLOCKING, 1, [disabled non-blocking sockets])
 ])
 dnl end of forth test
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -601,28 +601,6 @@ AC_DEFINE(HAVE_FIONBIO, 1, [use FIONBIO for non-blocking sockets])
 dnl FIONBIO test was also bad
 dnl the code was bad, try a different program now, test 3
 
-  AC_TRY_COMPILE([
-/* headers for ioctlsocket test (Windows) */
-#undef inline
-#ifdef HAVE_WINDOWS_H
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <winsock2.h>
-#endif
-],[
-/* ioctlsocket source code */
- SOCKET sd;
- unsigned long flags = 0;
- sd = socket(0, 0, 0);
- ioctlsocket(sd, FIONBIO, &flags);
-],[
-dnl ioctlsocket test was good
-nonblock="ioctlsocket"
-AC_DEFINE(HAVE_IOCTLSOCKET, 1, [use ioctlsocket() for non-blocking sockets])
-],[
-dnl ioctlsocket did not compile!, go to test 4
-
   AC_TRY_LINK([
 /* headers for IoctlSocket test (Amiga?) */
 #include <sys/ioctl.h>
@@ -635,7 +613,7 @@ dnl ioctlsocket test was good
 nonblock="IoctlSocket"
 AC_DEFINE(HAVE_IOCTLSOCKET_CASE, 1, [use Ioctlsocket() for non-blocking sockets])
 ],[
-dnl Ioctlsocket did not compile, do test 5!
+dnl Ioctlsocket did not compile, do test 4!
   AC_TRY_COMPILE([
 /* headers for SO_NONBLOCK test (BeOS) */
 #include <socket.h>
@@ -649,12 +627,9 @@ dnl the SO_NONBLOCK test was good
 nonblock="SO_NONBLOCK"
 AC_DEFINE(HAVE_SO_NONBLOCK, 1, [use SO_NONBLOCK for non-blocking sockets])
 ],[
-dnl test 5 did not compile!
+dnl test 4 did not compile!
 nonblock="nada"
 AC_DEFINE(HAVE_DISABLED_NONBLOCKING, 1, [disabled non-blocking sockets])
-])
-dnl end of fifth test
-
 ])
 dnl end of forth test
 

--- a/cmake/CheckNonblockingSocketSupport.cmake
+++ b/cmake/CheckNonblockingSocketSupport.cmake
@@ -13,7 +13,6 @@ include(CheckCSourceCompiles)
 #   HAVE_FIONBIO
 #   HAVE_IOCTLSOCKET_CASE
 #   HAVE_SO_NONBLOCK
-#   HAVE_DISABLED_NONBLOCKING
 #
 # The following variables may be set before calling this macro to
 # modify the way the check is run:
@@ -88,11 +87,6 @@ int main(void)
     (void)setsockopt(socket, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 }"
           HAVE_SO_NONBLOCK)
-
-        if(NOT HAVE_SO_NONBLOCK)
-          # No non-blocking socket method found
-          set(HAVE_DISABLED_NONBLOCKING 1)
-        endif()
       endif()
     endif()
   endif()

--- a/cmake/CheckNonblockingSocketSupport.cmake
+++ b/cmake/CheckNonblockingSocketSupport.cmake
@@ -1,6 +1,6 @@
 include(CheckCSourceCompiles)
 
-# - check_nonblocking_socket_support()
+# check_nonblocking_socket_support()
 #
 # Check for how to set a socket to non-blocking state. There seems to exist
 # four known different ways, with the one used almost everywhere being POSIX
@@ -11,7 +11,6 @@ include(CheckCSourceCompiles)
 # method (if any):
 #   HAVE_O_NONBLOCK
 #   HAVE_FIONBIO
-#   HAVE_IOCTLSOCKET
 #   HAVE_IOCTLSOCKET_CASE
 #   HAVE_SO_NONBLOCK
 #   HAVE_DISABLED_NONBLOCKING
@@ -27,8 +26,7 @@ include(CheckCSourceCompiles)
 macro(check_nonblocking_socket_support)
   # There are two known platforms (AIX 3.x and SunOS 4.1.x) where the
   # O_NONBLOCK define is found but does not work.
-  if(NOT WIN32)
-    check_c_source_compiles("
+  check_c_source_compiles("
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -53,12 +51,10 @@ int main(void)
     int socket = 0;
     (void)fcntl(socket, F_SETFL, O_NONBLOCK);
 }"
-      HAVE_O_NONBLOCK)
-  endif()
+    HAVE_O_NONBLOCK)
 
   if(NOT HAVE_O_NONBLOCK)
-    if(NOT WIN32)
-      check_c_source_compiles("/* FIONBIO test (old-style unix) */
+    check_c_source_compiles("/* FIONBIO test (old-style unix) */
 #include <unistd.h>
 #include <stropts.h>
 
@@ -68,30 +64,10 @@ int main(void)
     int flags = 0;
     (void)ioctl(socket, FIONBIO, &flags);
 }"
-        HAVE_FIONBIO)
-    endif()
+      HAVE_FIONBIO)
 
     if(NOT HAVE_FIONBIO)
-      if(WIN32)
-        check_c_source_compiles("/* ioctlsocket test (Windows) */
-#undef inline
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-
-#include <winsock2.h>
-
-int main(void)
-{
-    SOCKET sd = socket(0, 0, 0);
-    unsigned long flags = 0;
-    (void)ioctlsocket(sd, FIONBIO, &flags);
-}"
-          HAVE_IOCTLSOCKET)
-      endif()
-
-      if(NOT HAVE_IOCTLSOCKET)
-        check_c_source_compiles("/* IoctlSocket test (Amiga?) */
+      check_c_source_compiles("/* IoctlSocket test (Amiga?) */
 #include <sys/ioctl.h>
 
 int main(void)
@@ -99,10 +75,10 @@ int main(void)
     int socket = 0;
     (void)IoctlSocket(socket, FIONBIO, (long)1);
 }"
-          HAVE_IOCTLSOCKET_CASE)
+        HAVE_IOCTLSOCKET_CASE)
 
-        if(NOT HAVE_IOCTLSOCKET_CASE)
-          check_c_source_compiles("/* SO_NONBLOCK test (BeOS) */
+      if(NOT HAVE_IOCTLSOCKET_CASE)
+        check_c_source_compiles("/* SO_NONBLOCK test (BeOS) */
 #include <socket.h>
 
 int main(void)
@@ -111,12 +87,11 @@ int main(void)
     int socket = 0;
     (void)setsockopt(socket, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 }"
-            HAVE_SO_NONBLOCK)
+          HAVE_SO_NONBLOCK)
 
-          if(NOT HAVE_SO_NONBLOCK)
-            # No non-blocking socket method found
-            set(HAVE_DISABLED_NONBLOCKING 1)
-          endif()
+        if(NOT HAVE_SO_NONBLOCK)
+          # No non-blocking socket method found
+          set(HAVE_DISABLED_NONBLOCKING 1)
         endif()
       endif()
     endif()

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -59,9 +59,6 @@
 /* Define to 1 if you have the <arpa/inet.h> header file. */
 #define HAVE_ARPA_INET_H 1
 
-/* disabled non-blocking sockets */
-#undef HAVE_DISABLED_NONBLOCKING
-
 /* use FIONBIO for non-blocking sockets */
 #undef HAVE_FIONBIO
 

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -71,9 +71,6 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
 
-/* use ioctlsocket() for non-blocking sockets */
-#undef HAVE_IOCTLSOCKET
-
 /* use Ioctlsocket() for non-blocking sockets */
 #undef HAVE_IOCTLSOCKET_CASE
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -70,7 +70,6 @@
 #cmakedefine HAVE_FIONBIO
 #cmakedefine HAVE_IOCTLSOCKET_CASE
 #cmakedefine HAVE_SO_NONBLOCK
-#cmakedefine HAVE_DISABLED_NONBLOCKING
 
 /* attribute to export symbol */
 #if defined(LIBSSH2_EXPORTS) && defined(LIBSSH2_LIBRARY)

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -68,7 +68,6 @@
 /* Socket non-blocking support */
 #cmakedefine HAVE_O_NONBLOCK
 #cmakedefine HAVE_FIONBIO
-#cmakedefine HAVE_IOCTLSOCKET
 #cmakedefine HAVE_IOCTLSOCKET_CASE
 #cmakedefine HAVE_SO_NONBLOCK
 #cmakedefine HAVE_DISABLED_NONBLOCKING

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -22,7 +22,6 @@
 /* Hand-crafted configuration for platforms which lack config tool. */
 #elif defined(WIN32)
 
-#define HAVE_IOCTLSOCKET
 #define HAVE_SELECT
 #define HAVE_SNPRINTF
 

--- a/src/session.c
+++ b/src/session.c
@@ -293,11 +293,7 @@ static int
 session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
                  int nonblock /* TRUE or FALSE */ )
 {
-#if defined(HAVE_DISABLED_NONBLOCKING)
-    (void)sockfd;
-    (void)nonblock;
-    return 0;                   /* returns success */
-#elif defined(HAVE_O_NONBLOCK)
+#ifdef HAVE_O_NONBLOCK
     /* most recent unix versions */
     int flags;
 
@@ -325,7 +321,9 @@ session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
 
     return ioctlsocket(sockfd, FIONBIO, &flags);
 #else
-#error "no non-blocking method was found/used/set"
+    (void)sockfd;
+    (void)nonblock;
+    return 0;                   /* returns success */
 #endif
 }
 
@@ -337,10 +335,7 @@ session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
 static int
 get_socket_nonblocking(libssh2_socket_t sockfd)
 {                               /* operate on this */
-#if defined(HAVE_DISABLED_NONBLOCKING)
-    (void)sockfd;
-    return 1;                   /* returns blocking */
-#elif defined(HAVE_O_NONBLOCK)
+#ifdef HAVE_O_NONBLOCK
     /* most recent unix versions */
     int flags = fcntl(sockfd, F_GETFL, 0);
 
@@ -384,7 +379,8 @@ get_socket_nonblocking(libssh2_socket_t sockfd)
     }
     return (int) option_value;
 #else
-#error "no non-blocking method was found/used/get"
+    (void)sockfd;
+    return 1;                   /* returns blocking */
 #endif
 }
 

--- a/src/session.c
+++ b/src/session.c
@@ -317,8 +317,8 @@ session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
     return setsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 #elif defined(WIN32)
     unsigned long flags;
-    flags = nonblock;
 
+    flags = nonblock;
     return ioctlsocket(sockfd, FIONBIO, &flags);
 #else
     (void)sockfd;
@@ -372,8 +372,8 @@ get_socket_nonblocking(libssh2_socket_t sockfd)
     unsigned int option_value;
     socklen_t option_len = sizeof(option_value);
 
-    if(getsockopt
-        (sockfd, SOL_SOCKET, SO_ERROR, (void *) &option_value, &option_len)) {
+    if(getsockopt(sockfd, SOL_SOCKET, SO_ERROR,
+                  (void *) &option_value, &option_len)) {
         /* Assume blocking on error */
         return 1;
     }


### PR DESCRIPTION
Drop checks from Windows builds and enable it based on `WIN32`.

This saves detection time and also makes 3rd party builds simpler.

Also:

- delete `HAVE_DISABLED_NONBLOCKING`, that we used in build tools to
  explicitly disable an explicit `#error` in `session.c`.

- replace existing `WSAEWOULDBLOCK` check for Windows support with
  `WIN32`. Cleaner with the same result.

Follow-up to f1e80d8d8ce9570d81836da96ba02f4d4552a7b3
Follow-up to 5644eea2161b17f7c16e18f3a10465ebb217ca1f

Closes #980

---

Non-whitespace: https://github.com/libssh2/libssh2/pull/980/files?w=1