### PR TITLE
cmake: dedupe setting `-DHAVE_CONFIG_H`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,13 @@ set(CMAKE_REQUIRED_LIBRARIES ${SOCKET_LIBRARIES})
 check_nonblocking_socket_support()
 cmake_pop_check_state()
 
+# Config file
+
+add_definitions(-DHAVE_CONFIG_H)
+
+configure_file(src/libssh2_config_cmake.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/src/libssh2_config.h)
+
 ## Cryptography backend choice
 
 set(CRYPTO_BACKEND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,24 @@ endif()
 set(LIB_STATIC "libssh2_static")
 set(LIB_SHARED "libssh2_shared")  # Must match libssh2_shared_EXPORTS macro in include/libssh2.h
 
+# Symbol hiding
+
+option(HIDE_SYMBOLS "Set to ON to hide all libssh2 symbols that aren't officially external" ON)
+mark_as_advanced(HIDE_SYMBOLS)
+if(HIDE_SYMBOLS)
+  set(LIB_SHARED_DEFINITIONS LIBSSH2_EXPORTS)
+  if(WIN32)
+  elseif((CMAKE_C_COMPILER_ID MATCHES "Clang") OR
+         (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.0) OR
+         (CMAKE_C_COMPILER_ID MATCHES "Intel" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
+    set(LIB_SHARED_C_FLAGS -fvisibility=hidden)
+    set(LIBSSH2_API "__attribute__ ((__visibility__ (\"default\")))")
+  elseif(CMAKE_C_COMPILER_ID MATCHES "SunPro" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.0)
+    set(LIB_SHARED_C_FLAGS -xldscope=hidden)
+    set(LIBSSH2_API "__global")
+  endif()
+endif()
+
 # Auto-detection
 
 ## Platform checks

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -37,8 +37,6 @@ include(CopyRuntimeDependencies)
 
 list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
 
-add_definitions(-DHAVE_CONFIG_H)
-
 transform_makefile_inc("Makefile.am" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.am.cmake")
 # Get 'noinst_PROGRAMS' variable
 include(${CMAKE_CURRENT_BINARY_DIR}/Makefile.am.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,13 +163,6 @@ if(BUILD_SHARED_LIBS)
   endif()
 endif()
 
-# Config file
-
-add_definitions(-DHAVE_CONFIG_H)
-
-configure_file(libssh2_config_cmake.h.in
-  ${CMAKE_CURRENT_BINARY_DIR}/libssh2_config.h)
-
 ## Installation
 
 install(FILES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,7 +126,8 @@ if(BUILD_SHARED_LIBS)
   if(WIN32)
     set_property(TARGET ${LIB_SHARED} APPEND PROPERTY SOURCES libssh2.rc)
   endif()
-  target_compile_definitions(${LIB_SHARED} PRIVATE ${PRIVATE_COMPILE_DEFINITIONS} ${libssh2_DEFINITIONS})
+  target_compile_definitions(${LIB_SHARED} PRIVATE ${PRIVATE_COMPILE_DEFINITIONS} ${libssh2_DEFINITIONS} ${LIB_SHARED_DEFINITIONS})
+  target_compile_options(${LIB_SHARED} PRIVATE ${LIB_SHARED_C_FLAGS})
   target_link_libraries(${LIB_SHARED} PRIVATE ${LIBRARIES})
   set_target_properties(${LIB_SHARED} PROPERTIES PREFIX "" IMPORT_PREFIX "" OUTPUT_NAME "libssh2")
   if(WIN32 AND BUILD_STATIC_LIBS AND NOT STATIC_LIB_SUFFIX AND
@@ -142,25 +143,6 @@ if(BUILD_SHARED_LIBS)
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
       $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
-
-  # Symbol hiding
-
-  option(HIDE_SYMBOLS "Set to ON to hide all libssh2 symbols that aren't officially external." ON)
-  mark_as_advanced(HIDE_SYMBOLS)
-
-  if(HIDE_SYMBOLS)
-    target_compile_definitions(${LIB_SHARED} PRIVATE LIBSSH2_EXPORTS)
-    if(WIN32)
-    elseif((CMAKE_C_COMPILER_ID MATCHES "Clang") OR
-           (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.0) OR
-           (CMAKE_C_COMPILER_ID MATCHES "Intel" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
-      target_compile_options(${LIB_SHARED} PRIVATE -fvisibility=hidden)
-      set(LIBSSH2_API "__attribute__ ((__visibility__ (\"default\")))")
-    elseif(CMAKE_C_COMPILER_ID MATCHES "SunPro" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.0)
-      target_compile_options(${LIB_SHARED} PRIVATE -xldscope=hidden)
-      set(LIBSSH2_API "__global")
-    endif()
-  endif()
 endif()
 
 ## Installation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,8 +37,6 @@ include(CopyRuntimeDependencies)
 
 list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
 
-add_definitions(-DHAVE_CONFIG_H)
-
 if(CMAKE_COMPILER_IS_GNUCC)
   find_program(GCOV_PATH gcov)
   if(GCOV_PATH)


### PR DESCRIPTION
Move `libssh2_config.h` generation and setting `-DHAVE_CONFIG_H` to
the root `CMakeFile.txt`.

Also move symbol hiding setup there. It needs to be done before
generating the config file for `LIBSSH2_API` value to be set in it.

After this change the `HIDE_SYMBOLS` setting is accepted without 
an annoying CMake warning when not actually building a shared libssh2 lib.

Closes #981
