### PR TITLE
mansyntax: make it work on macOS, check reqs locally

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,16 +152,9 @@ add_target_to_copy_dependencies(
   DEPENDENCIES ${RUNTIME_DEPENDENCIES}
   BEFORE_TARGETS ${TEST_TARGETS})
 
-
-# TODO convert mansyntax.sh into CMake script.
-# XXX Just because we can find all three programs, doesn't mean sh can
-# find man and grep
 find_program(SH_EXECUTABLE sh)
-find_program(MAN_EXECUTABLE man)
-find_program(GREP_EXECUTABLE grep)
-mark_as_advanced(SH_EXECUTABLE MAN_EXECUTABLE GREP_EXECUTABLE)
-if(SH_EXECUTABLE AND MAN_EXECUTABLE AND GREP_EXECUTABLE)
-  set(cmd "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
-  set(cmd "${cmd} ${CMAKE_CURRENT_SOURCE_DIR}/mansyntax.sh")
-  add_test(mansyntax ${SH_EXECUTABLE} -c "${cmd}")
+mark_as_advanced(SH_EXECUTABLE)
+if(SH_EXECUTABLE)
+  add_test(mansyntax ${SH_EXECUTABLE} -c
+    "srcdir=${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/mansyntax.sh")
 endif()

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -5,6 +5,10 @@ set -e
 #
 # Run syntax checks for all manpages in the documentation tree.
 #
+# Requirement on macOS: brew install man-db
+#
+
+command -v gman >/dev/null 2>&1 && man() { gman "$@"; }
 
 srcdir="${srcdir:-$PWD}"
 dstdir="${builddir:-$PWD}"
@@ -15,7 +19,8 @@ ec=0
 #
 # Only test if suitable man is available
 #
-if man --help | grep -q warnings; then
+if command -v grep >/dev/null 2>&1 && \
+   man --help | grep -q warnings; then
 
   trap 'rm -f "$dstdir/man3"' EXIT
 
@@ -24,14 +29,14 @@ if man --help | grep -q warnings; then
   for manpage in "$mandir"/libssh2_*.*; do
     echo "$manpage"
     warnings=$(LANG=en_US.UTF-8 MANWIDTH=80 man -M "$dstdir" --warnings \
-      -E UTF-8 -l "$manpage" 2>&1 >/dev/null)
+      -E UTF-8 -l "$manpage" >/dev/null 2>&1)
     if [ -n "$warnings" ]; then
       echo "$warnings"
       ec=1
     fi
   done
 else
-  echo "man version not suitable, skipping tests"
+  echo 'Required tool not found, skipping mansyntax tests.'
 fi
 
 exit "$ec"

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -36,7 +36,7 @@ if command -v grep >/dev/null 2>&1 && \
     fi
   done
 else
-  echo 'Required tool not found, skipping mansyntax tests.'
+  echo 'mansyntax: Required tool not found, skipping tests.'
 fi
 
 exit "$ec"


### PR DESCRIPTION
- use `gman` alias if present. This makes it work when the correct `man` command is provided via `brew` on macOS.

- move CMake attempts to detect tools necessary to run `mansyntax.sh` into the script itself.

- delete CMake TODO to move more test logic into CMake. This would make it CMake-specific and require maintaining it separately for each build tool. Just use our external script when a POSIX shell is available.

Closes #982