### PR TITLE
base64: do not use `snprintf()` on encoding

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -443,22 +443,22 @@ size_t _libssh2_base64_encode(LIBSSH2_SESSION *session,
 
         switch(inputparts) {
         case 1: /* only one byte read */
-            snprintf(output, 5, "%c%c==",
-                     table64[obuf[0]],
-                     table64[obuf[1]]);
+            output[0] = table64[obuf[0]];
+            output[1] = table64[obuf[1]];
+            output[2] = '=';
+            output[3] = '=';
             break;
         case 2: /* two bytes read */
-            snprintf(output, 5, "%c%c%c=",
-                     table64[obuf[0]],
-                     table64[obuf[1]],
-                     table64[obuf[2]]);
+            output[0] = table64[obuf[0]];
+            output[1] = table64[obuf[1]];
+            output[2] = table64[obuf[2]];
+            output[3] = '=';
             break;
         default:
-            snprintf(output, 5, "%c%c%c%c",
-                     table64[obuf[0]],
-                     table64[obuf[1]],
-                     table64[obuf[2]],
-                     table64[obuf[3]]);
+            output[0] = table64[obuf[0]];
+            output[1] = table64[obuf[1]];
+            output[2] = table64[obuf[2]];
+            output[3] = table64[obuf[3]];
             break;
         }
         output += 4;


### PR DESCRIPTION
This also significantly (by 7-8x in my limited tests with a short string)
speeds up this function. The impact is still minor as this function is only
used in `knownhost.c` in release builds.

Closes #985
