### PR TITLE
crypto: add/fix algo guards and extend `NO` options

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -67,6 +67,46 @@
 #define LIBSSH2_DSA 0
 #endif
 
+#ifdef LIBSSH2_NO_RSA
+#undef LIBSSH2_RSA
+#define LIBSSH2_RSA 0
+#endif
+
+#ifdef LIBSSH2_NO_RSA_SHA1
+#undef LIBSSH2_RSA_SHA1
+#define LIBSSH2_RSA_SHA1 0
+#endif
+
+#ifdef LIBSSH2_NO_ECDSA
+#undef LIBSSH2_ECDSA
+#define LIBSSH2_ECDSA 0
+#endif
+
+#ifdef LIBSSH2_NO_AES_CTR
+#undef LIBSSH2_AES_CTR
+#define LIBSSH2_AES_CTR 0
+#endif
+
+#ifdef LIBSSH2_NO_BLOWFISH
+#undef LIBSSH2_BLOWFISH
+#define LIBSSH2_BLOWFISH 0
+#endif
+
+#ifdef LIBSSH2_NO_RC4
+#undef LIBSSH2_RC4
+#define LIBSSH2_RC4 0
+#endif
+
+#ifdef LIBSSH2_NO_CAST
+#undef LIBSSH2_CAST
+#define LIBSSH2_CAST 0
+#endif
+
+#ifdef LIBSSH2_NO_3DES
+#undef LIBSSH2_3DES
+#define LIBSSH2_3DES 0
+#endif
+
 #define LIBSSH2_ED25519_KEY_LEN 32
 #define LIBSSH2_ED25519_PRIVATE_KEY_LEN 64
 #define LIBSSH2_ED25519_SIG_LEN 64

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -92,6 +92,7 @@ int _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
                              LIBSSH2_SESSION * session,
                              const char *filename,
                              unsigned const char *passphrase);
+#if LIBSSH2_RSA_SHA1
 int _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
                              const unsigned char *sig,
                              size_t sig_len,
@@ -102,6 +103,7 @@ int _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
                            size_t hash_len,
                            unsigned char **signature,
                            size_t *signature_len);
+#endif
 #if LIBSSH2_RSA_SHA2
 int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
                            libssh2_rsa_ctx * rsactx,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -87,18 +87,22 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
     }
 
     /* we accept one of 3 header types */
+#if LIBSSH2_RSA_SHA1
     if(type_len == 7 && strncmp("ssh-rsa", (char *)type, 7) == 0) {
         /* ssh-rsa */
     }
+    else
+#endif
 #if LIBSSH2_RSA_SHA2
-    else if(type_len == 12 && strncmp("rsa-sha2-256", (char *)type, 12) == 0) {
+    if(type_len == 12 && strncmp("rsa-sha2-256", (char *)type, 12) == 0) {
         /* rsa-sha2-256 */
     }
     else if(type_len == 12 && strncmp("rsa-sha2-512", (char *)type, 12) == 0) {
         /* rsa-sha2-512 */
     }
+    else
 #endif
-    else {
+    {
         _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
                        "unexpected rsa type: %.*s", type_len, type));
         return -1;
@@ -187,6 +191,7 @@ hostkey_method_ssh_rsa_initPEMFromMemory(LIBSSH2_SESSION * session,
     return 0;
 }
 
+#if LIBSSH2_RSA_SHA1
 /*
  * hostkey_method_ssh_rsa_sign
  *
@@ -250,6 +255,7 @@ hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION * session,
     return 0;
 #endif
 }
+#endif
 
 /*
  * hostkey_method_ssh_rsa_sha2_256_sig_verify
@@ -413,6 +419,8 @@ hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION * session, void **abstract)
     return 0;
 }
 
+#if LIBSSH2_RSA_SHA1
+
 static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa = {
     "ssh-rsa",
     SHA_DIGEST_LENGTH,
@@ -424,6 +432,8 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa = {
     NULL,                       /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
+
+#endif /* LIBSSH2_RSA_SHA1 */
 
 #if LIBSSH2_RSA_SHA2
 
@@ -453,6 +463,8 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_512 = {
 
 #endif /* LIBSSH2_RSA_SHA2 */
 
+#if LIBSSH2_RSA_SHA1
+
 static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_cert = {
     "ssh-rsa-cert-v01@openssh.com",
     SHA_DIGEST_LENGTH,
@@ -464,6 +476,8 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_cert = {
     NULL,                       /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
+
+#endif /* LIBSSH2_RSA_SHA1 */
 
 #endif /* LIBSSH2_RSA */
 
@@ -1263,8 +1277,10 @@ static const LIBSSH2_HOSTKEY_METHOD *hostkey_methods[] = {
     &hostkey_method_ssh_rsa_sha2_512,
     &hostkey_method_ssh_rsa_sha2_256,
 #endif /* LIBSSH2_RSA_SHA2 */
+#if LIBSSH2_RSA_SHA1
     &hostkey_method_ssh_rsa,
     &hostkey_method_ssh_rsa_cert,
+#endif /* LIBSSH2_RSA_SHA1 */
 #endif /* LIBSSH2_RSA */
 #if LIBSSH2_DSA
     &hostkey_method_ssh_dss,

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -40,6 +40,7 @@
 
 #include <string.h>
 
+#if LIBSSH2_RSA
 int
 _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
                  const unsigned char *edata,
@@ -83,6 +84,7 @@ _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
     return 0;
 }
 
+#if LIBSSH2_RSA_SHA1
 int
 _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
                          const unsigned char *sig,
@@ -114,7 +116,10 @@ _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
 
     return (rc == 0) ? 0 : -1;
 }
+#endif
+#endif
 
+#if LIBSSH2_DSA
 int
 _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
                  const unsigned char *p,
@@ -147,7 +152,9 @@ _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
 
     return 0;
 }
+#endif
 
+#if LIBSSH2_RSA
 int
 _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
                                     LIBSSH2_SESSION * session,
@@ -265,7 +272,9 @@ _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
     LIBSSH2_FREE(session, save_data);
     return ret;
 }
+#endif
 
+#if LIBSSH2_DSA
 int
 _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
                                     LIBSSH2_SESSION * session,
@@ -369,7 +378,10 @@ _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
     LIBSSH2_FREE(session, save_data);
     return ret;
 }
+#endif
 
+#if LIBSSH2_RSA
+#if LIBSSH2_RSA_SHA1
 int
 _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
                        libssh2_rsa_ctx * rsactx,
@@ -429,7 +441,10 @@ _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
 
     return rc;
 }
+#endif
+#endif
 
+#if LIBSSH2_DSA
 int
 _libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
                        const unsigned char *hash,
@@ -549,6 +564,7 @@ _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
 
     return (rc == 0) ? 0 : -1;
 }
+#endif
 
 int
 _libssh2_cipher_init(_libssh2_cipher_ctx * h,

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -57,6 +57,7 @@
 #define LIBSSH2_3DES 1
 
 #define LIBSSH2_RSA 1
+#define LIBSSH2_RSA_SHA1 1
 #define LIBSSH2_RSA_SHA2 0
 #define LIBSSH2_DSA 1
 #define LIBSSH2_ECDSA 0

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -81,6 +81,7 @@
 #define LIBSSH2_3DES            1
 
 #define LIBSSH2_RSA             1
+#define LIBSSH2_RSA_SHA1        1
 #define LIBSSH2_RSA_SHA2        1
 #define LIBSSH2_DSA             0
 #ifdef MBEDTLS_ECDSA_C

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -105,9 +105,11 @@
 
 #ifdef OPENSSL_NO_RSA
 # define LIBSSH2_RSA 0
+# define LIBSSH2_RSA_SHA1 0
 # define LIBSSH2_RSA_SHA2 0
 #else
 # define LIBSSH2_RSA 1
+# define LIBSSH2_RSA_SHA1 1
 # define LIBSSH2_RSA_SHA2 1
 #endif
 
@@ -353,13 +355,17 @@ extern void _libssh2_openssl_crypto_exit(void);
 #define libssh2_crypto_init() _libssh2_openssl_crypto_init()
 #define libssh2_crypto_exit() _libssh2_openssl_crypto_exit()
 
+#if LIBSSH2_RSA
 #define libssh2_rsa_ctx RSA
 
 #define _libssh2_rsa_free(rsactx) RSA_free(rsactx)
+#endif
 
+#if LIBSSH2_DSA
 #define libssh2_dsa_ctx DSA
 
 #define _libssh2_dsa_free(dsactx) DSA_free(dsactx)
+#endif
 
 #if LIBSSH2_ECDSA
 #define libssh2_ecdsa_ctx EC_KEY

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -177,6 +177,7 @@
 #define LIBSSH2_3DES            1
 
 #define LIBSSH2_RSA             1
+#define LIBSSH2_RSA_SHA1        1
 #define LIBSSH2_RSA_SHA2        1
 #define LIBSSH2_DSA             0
 #define LIBSSH2_ECDSA           0

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -953,6 +953,7 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
 }
 #endif /* HAVE_LIBCRYPT32 */
 
+#if LIBSSH2_RSA || LIBSSH2_DSA
 static unsigned long
 _libssh2_wincng_bn_size(const unsigned char *bignum,
                         unsigned long length)
@@ -972,8 +973,10 @@ _libssh2_wincng_bn_size(const unsigned char *bignum,
 
     return length - offset;
 }
+#endif
 
 
+#if LIBSSH2_RSA
 /*******************************************************************/
 /*
  * Windows CNG backend: RSA functions
@@ -1238,6 +1241,7 @@ _libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
 #endif /* HAVE_LIBCRYPT32 */
 }
 
+#if LIBSSH2_RSA_SHA1
 int
 _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                                 const unsigned char *sig,
@@ -1250,7 +1254,9 @@ _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
                                           m, (unsigned long)m_len,
                                           BCRYPT_PAD_PKCS1);
 }
+#endif
 
+#if LIBSSH2_RSA_SHA2
 int
 _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx* rsa,
                                 size_t hash_len,
@@ -1264,6 +1270,7 @@ _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx* rsa,
                                           m, (unsigned long)m_len,
                                           BCRYPT_PAD_PKCS1);
 }
+#endif
 
 int
 _libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
@@ -1338,7 +1345,7 @@ _libssh2_wincng_rsa_free(libssh2_rsa_ctx *rsa)
     _libssh2_wincng_safe_free(rsa->pbKeyObject, rsa->cbKeyObject);
     _libssh2_wincng_safe_free(rsa, sizeof(libssh2_rsa_ctx));
 }
-
+#endif
 
 /*******************************************************************/
 /*
@@ -1665,11 +1672,11 @@ _libssh2_wincng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
                                        unsigned char *pbEncoded,
                                        size_t cbEncoded)
 {
-    unsigned char **rpbDecoded;
-    unsigned long *rcbDecoded;
+    unsigned char **rpbDecoded = NULL;
+    unsigned long *rcbDecoded = NULL;
     unsigned char *key = NULL, *mth = NULL;
     unsigned long keylen = 0, mthlen = 0;
-    unsigned long index, offset, length;
+    unsigned long index, offset, length = 0;
     int ret;
 
     ret = _libssh2_wincng_asn_decode_bns(pbEncoded, cbEncoded,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -65,6 +65,7 @@
 #define LIBSSH2_3DES 1
 
 #define LIBSSH2_RSA 1
+#define LIBSSH2_RSA_SHA1 1
 #define LIBSSH2_RSA_SHA2 1
 #define LIBSSH2_DSA 1
 #define LIBSSH2_ECDSA 0

--- a/tests/test_auth_pubkey_ok_rsa.c
+++ b/tests/test_auth_pubkey_ok_rsa.c
@@ -2,10 +2,15 @@
 
 int test(LIBSSH2_SESSION *session)
 {
+#if LIBSSH2_RSA_SHA1
     /* set in Dockerfile */
     return test_auth_pubkey(session, 0,
                             "libssh2",
                             NULL,
                             "key_rsa.pub",
                             "key_rsa");
+#else
+    (void)session;
+    return 0;
+#endif
 }

--- a/tests/test_auth_pubkey_ok_rsa_encrypted.c
+++ b/tests/test_auth_pubkey_ok_rsa_encrypted.c
@@ -2,10 +2,15 @@
 
 int test(LIBSSH2_SESSION *session)
 {
+#if LIBSSH2_RSA_SHA1
     /* set in Dockerfile */
     return test_auth_pubkey(session, 0,
                             "libssh2",
                             "libssh2",
                             "key_rsa_encrypted.pub",
                             "key_rsa_encrypted");
+#else
+    (void)session;
+    return 0;
+#endif
 }

--- a/tests/test_auth_pubkey_ok_rsa_openssh.c
+++ b/tests/test_auth_pubkey_ok_rsa_openssh.c
@@ -2,7 +2,8 @@
 
 int test(LIBSSH2_SESSION *session)
 {
-#if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
+#if LIBSSH2_RSA_SHA1 && \
+    (defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL))
     /* set in Dockerfile */
     return test_auth_pubkey(session, 0,
                             "libssh2",

--- a/tests/test_auth_pubkey_ok_rsa_signed.c
+++ b/tests/test_auth_pubkey_ok_rsa_signed.c
@@ -2,7 +2,8 @@
 
 int test(LIBSSH2_SESSION *session)
 {
-#if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
+#if LIBSSH2_RSA_SHA1 && \
+    (defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL))
     /* set in Dockerfile */
     return test_auth_pubkey(session, 0,
                             "libssh2",


### PR DESCRIPTION
Add new guard `LIBSSH2_RSA_SHA1`. Add missing guards for `LIBSSH2_RSA`,
`LIBSSH2_DSA`.

Fix warnings when all options are disabled.

This is still not complete and it's possible to break a build with
certain crypto backends (e.g. mbedTLS) and/or combination of options.
It's not guaranteed that all bits everywhere get disabled by these
settings. Consider this a "best effort".

Add these new options to disable certain crypto elements:
- `LIBSSH2_NO_3DES`
- `LIBSSH2_NO_AES_CTR`
- `LIBSSH2_NO_BLOWFISH`
- `LIBSSH2_NO_CAST`
- `LIBSSH2_NO_ECDSA`
- `LIBSSH2_NO_RC4`
- `LIBSSH2_NO_RSA_SHA1`
- `LIBSSH2_NO_RSA`

The goal is to offer a way to disable legacy/obsolete/insecure ones.

See also: 146a25a06dd2365a4330dad34fefcdcee1a206aa `LIBSSH2_NO_HMAC_RIPEMD`
See also: 38015f4e46d8dbeea522dc7ee664522d4f47fc75 `LIBSSH2_NO_DSA`
See also: be31457f3071686b555a0f0b19e5dcf63d67fc27 `LIBSSH2_NO_MD5`

Closes #986
