### PR TITLE
tidy-up: C header use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,6 @@ check_include_files(inttypes.h HAVE_INTTYPES_H)
 if(NOT MSVC)
   check_include_files(unistd.h HAVE_UNISTD_H)
   check_include_files(sys/time.h HAVE_SYS_TIME_H)
-  check_include_files(sys/param.h HAVE_SYS_PARAM_H)
 endif()
 if(NOT WIN32)
   check_include_files(sys/select.h HAVE_SYS_SELECT_H)
@@ -149,6 +148,7 @@ if(NOT WIN32)
   check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
   check_include_files(sys/ioctl.h HAVE_SYS_IOCTL_H)
   check_include_files(sys/un.h HAVE_SYS_UN_H)
+  check_include_files(sys/param.h HAVE_SYS_PARAM_H)  # tests
   check_include_files(arpa/inet.h HAVE_ARPA_INET_H)  # example and tests
   check_include_files(netinet/in.h HAVE_NETINET_IN_H)  # example and tests
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ check_include_files(inttypes.h HAVE_INTTYPES_H)
 if(NOT MSVC)
   check_include_files(unistd.h HAVE_UNISTD_H)
   check_include_files(sys/time.h HAVE_SYS_TIME_H)
+  check_include_files(sys/param.h HAVE_SYS_PARAM_H)  # tests
 endif()
 if(NOT WIN32)
   check_include_files(sys/select.h HAVE_SYS_SELECT_H)
@@ -148,7 +149,6 @@ if(NOT WIN32)
   check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
   check_include_files(sys/ioctl.h HAVE_SYS_IOCTL_H)
   check_include_files(sys/un.h HAVE_SYS_UN_H)
-  check_include_files(sys/param.h HAVE_SYS_PARAM_H)  # tests
   check_include_files(arpa/inet.h HAVE_ARPA_INET_H)  # example and tests
   check_include_files(netinet/in.h HAVE_NETINET_IN_H)  # example and tests
 endif()

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -20,7 +20,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifndef INADDR_NONE
 #define INADDR_NONE (in_addr_t)~0

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -24,7 +24,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -25,7 +25,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -10,9 +10,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/scp.c
+++ b/example/scp.c
@@ -24,7 +24,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/scp.c
+++ b/example/scp.c
@@ -25,7 +25,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp.c
+++ b/example/scp.c
@@ -22,7 +22,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/scp.c
+++ b/example/scp.c
@@ -23,7 +23,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -35,7 +35,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -36,7 +36,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -34,7 +34,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -30,7 +30,6 @@
 #include <sys/time.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -17,9 +17,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -18,7 +18,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -21,7 +21,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -20,7 +20,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -19,7 +19,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 #include <time.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -23,7 +23,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <time.h>

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -8,9 +8,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -20,7 +20,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
-#include <time.h>
+#include <time.h>  /* for time() */
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -18,7 +18,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <time.h>  /* for time() */
 

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -22,7 +22,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <time.h>
 

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -30,6 +30,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <string.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -29,7 +29,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -30,7 +30,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -28,7 +28,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -31,7 +31,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -25,7 +25,6 @@
 #include <netinet/in.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -18,9 +18,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -29,7 +29,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -30,7 +30,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -31,7 +31,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -26,7 +26,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -25,7 +25,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -26,7 +26,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -25,7 +25,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -26,7 +26,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -25,7 +25,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -31,7 +31,6 @@
 #include <sys/time.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -18,9 +18,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -36,7 +36,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -35,7 +35,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -37,7 +37,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -26,7 +26,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -25,7 +25,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -28,7 +28,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <time.h>
 

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -29,7 +29,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <time.h>

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -30,7 +30,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 #include <time.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <time.h>  /* for time() */
 

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -14,9 +14,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -26,7 +26,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
-#include <time.h>
+#include <time.h>  /* for time() */
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <time.h>  /* for time() */
+#include <string.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -28,7 +28,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <time.h>
 

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -29,7 +29,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <time.h>

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -30,7 +30,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 #include <time.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -14,9 +14,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <time.h>  /* for time() */
 #include <string.h>

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -26,7 +26,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
-#include <time.h>
+#include <time.h>  /* for time() */
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -26,7 +26,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -26,6 +26,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <string.h>
 
 #if defined(_MSC_VER)
 #define __FILESIZE "I64u"

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 #if defined(_MSC_VER)
 #define __FILESIZE "I64u"

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -25,7 +25,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 #if defined(_MSC_VER)

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 
 #if defined(_MSC_VER)

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -26,7 +26,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <ctype.h>
 
 #if defined(_MSC_VER)
 #define __FILESIZE "I64u"

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -25,7 +25,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 
 #if defined(_MSC_VER)

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -32,7 +32,6 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -29,7 +29,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -28,7 +28,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -30,7 +30,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -26,7 +26,6 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 
 static const char *username = "username";
 

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -24,7 +24,6 @@
 
 #include <sys/types.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 static const char *username = "username";
 

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -22,7 +22,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -24,7 +24,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -24,6 +24,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <string.h>
 
 static const char *username = "username";
 

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -23,7 +23,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -34,7 +34,6 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 
 static const char *hostname = "127.0.0.1";
 static const char *commandline = "uptime";

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -31,7 +31,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -27,7 +27,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -32,7 +32,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -17,9 +17,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 static const char *hostname = "127.0.0.1";
 static const char *commandline = "cat";

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -12,9 +12,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -27,7 +27,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -29,7 +29,6 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 
 static const char *hostname = "127.0.0.1";
 static const char *commandline = "cat";

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -26,7 +26,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -22,7 +22,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -31,7 +31,6 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 
 static const char *hostname = "127.0.0.1";
 static const char *commandline = "uptime";

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -28,7 +28,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -29,7 +29,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -14,9 +14,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 static const char *hostname = "127.0.0.1";
 static const char *commandline = "uptime";

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -24,7 +24,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -16,7 +16,6 @@
 
 #include <sys/types.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #ifndef INADDR_NONE

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -15,7 +15,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -16,7 +16,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -14,7 +14,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -20,7 +20,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifndef INADDR_NONE
 #define INADDR_NONE (in_addr_t)~0

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -24,7 +24,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -25,7 +25,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -10,9 +10,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/example/x11.c
+++ b/example/x11.c
@@ -36,7 +36,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdlib.h>
-#include <ctype.h>
 #include <string.h>
 
 #include <termios.h>

--- a/example/x11.c
+++ b/example/x11.c
@@ -34,7 +34,6 @@
 #endif
 
 #include <sys/types.h>
-#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -30,7 +30,6 @@
 #include <sys/un.h>
 #endif
 
-#include <sys/types.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -35,7 +35,6 @@
 
 #include <sys/types.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>

--- a/example/x11.c
+++ b/example/x11.c
@@ -20,9 +20,6 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -185,8 +185,6 @@ typedef int libssh2_socket_t;
 
 #ifdef LIBSSH2_USE_WIN32_LARGE_FILES
 #  include <io.h>
-#  include <sys/types.h>
-#  include <sys/stat.h>
 #  define LIBSSH2_STRUCT_STAT_SIZE_FORMAT    "%I64d"
 typedef struct _stati64 libssh2_struct_stat;
 typedef __int64 libssh2_struct_stat_size;
@@ -197,8 +195,6 @@ typedef __int64 libssh2_struct_stat_size;
  */
 
 #ifdef LIBSSH2_USE_WIN32_SMALL_FILES
-#  include <sys/types.h>
-#  include <sys/stat.h>
 #  ifndef _WIN32_WCE
 #    define LIBSSH2_STRUCT_STAT_SIZE_FORMAT    "%d"
 typedef struct _stat libssh2_struct_stat;

--- a/src/agent.c
+++ b/src/agent.c
@@ -41,6 +41,7 @@
 #include "agent.h"
 
 #include <errno.h>
+#include <stdlib.h>  /* for getenv() */
 
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>

--- a/src/agent.c
+++ b/src/agent.c
@@ -39,7 +39,9 @@
 
 #include "libssh2_priv.h"
 #include "agent.h"
+
 #include <errno.h>
+
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #else
@@ -48,6 +50,7 @@
    support them. */
 #undef PF_UNIX
 #endif
+
 #include "userauth.h"
 #include "session.h"
 

--- a/src/agent_win.c
+++ b/src/agent_win.c
@@ -39,7 +39,6 @@
 
 #include "libssh2_priv.h"
 #include "agent.h"
-#include <errno.h>
 
 #if defined(WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
 

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -20,7 +20,6 @@
 #ifndef HAVE_BCRYPT_PBKDF
 
 #include <stdlib.h>
-#include <sys/types.h>
 
 #define LIBSSH2_BCRYPT_PBKDF_C
 #include "blowfish.c"

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -21,9 +21,6 @@
 
 #include <stdlib.h>
 #include <sys/types.h>
-#ifdef HAVE_SYS_PARAM_H
-#include <sys/param.h>
-#endif
 
 #define LIBSSH2_BCRYPT_PBKDF_C
 #include "blowfish.c"

--- a/src/channel.c
+++ b/src/channel.c
@@ -39,13 +39,14 @@
  */
 
 #include "libssh2_priv.h"
+
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#include <fcntl.h>
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif
+
 #include <assert.h>
 
 #include "channel.h"

--- a/src/comp.c
+++ b/src/comp.c
@@ -37,6 +37,7 @@
  */
 
 #include "libssh2_priv.h"
+
 #ifdef LIBSSH2_HAVE_ZLIB
 #include <zlib.h>
 #undef compress /* dodge name clash with ZLIB macro */

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -38,8 +38,6 @@
 
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 
-#include <string.h>
-
 #if LIBSSH2_RSA
 int
 _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -47,6 +47,7 @@
 #include "libssh2_setup.h"
 
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 #include <limits.h>
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -909,14 +909,6 @@ struct _LIBSSH2_SESSION
     long packet_read_timeout;
 };
 
-#if defined(HAVE_STRTOLL)
-#define scpsize_strtol strtoll
-#elif defined(HAVE_STRTOI64)
-#define scpsize_strtol _strtoi64
-#else
-#define scpsize_strtol strtol
-#endif
-
 /* session.state bits */
 #define LIBSSH2_STATE_EXCHANGING_KEYS   0x00000001
 #define LIBSSH2_STATE_NEWKEYS           0x00000002

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -60,14 +60,8 @@
 */
 #ifdef HAVE_POLL
 # include <poll.h>
-#else
-# if defined(HAVE_SELECT) && !defined(WIN32)
-# ifdef HAVE_SYS_SELECT_H
-#  include <sys/select.h>
-# else
-#  include <sys/types.h>
-# endif
-# endif
+#elif defined(HAVE_SELECT) && defined(HAVE_SYS_SELECT_H)
+# include <sys/select.h>
 #endif
 
 /* Needed for struct iovec on some platforms */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -37,6 +37,8 @@
 
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 
+#include <stdlib.h>
+
 #if MBEDTLS_VERSION_NUMBER < 0x03000000
 #define mbedtls_cipher_info_get_key_bitlen(c) (c->key_bitlen)
 #define mbedtls_cipher_info_get_iv_size(c)    (c->iv_size)

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -40,7 +40,6 @@
 #define LIBSSH2_CRYPTO_ENGINE libssh2_mbedtls
 
 #include <stdlib.h>
-#include <string.h>
 
 #include <mbedtls/platform.h>
 #include <mbedtls/md.h>

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -39,8 +39,6 @@
 
 #define LIBSSH2_CRYPTO_ENGINE libssh2_mbedtls
 
-#include <stdlib.h>
-
 #include <mbedtls/platform.h>
 #include <mbedtls/md.h>
 #include <mbedtls/rsa.h>
@@ -160,6 +158,7 @@
     _libssh2_mbedtls_hash_final(&ctx, hash)
 #define libssh2_sha1(data, datalen, hash) \
     _libssh2_mbedtls_hash(data, datalen, MBEDTLS_MD_SHA1, hash)
+
 
 /*******************************************************************/
 /*

--- a/src/misc.c
+++ b/src/misc.c
@@ -40,20 +40,17 @@
 #include "libssh2_priv.h"
 #include "misc.h"
 
-#include <stdlib.h>
-
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+
+#include <errno.h>
 
 #ifdef WIN32
 /* Force parameter type. */
 #define recv(s, b, l, f)  recv((s), (b), (int)(l), (f))
 #define send(s, b, l, f)  send((s), (b), (int)(l), (f))
 #endif
-
-#include <stdio.h>
-#include <errno.h>
 
 /* snprintf not in Visual Studio CRT and _snprintf dangerously incompatible.
    We provide a safe wrapper if snprintf not found */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -41,7 +41,6 @@
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 
 #include <assert.h>
-#include <string.h>
 
 #ifndef EVP_MAX_BLOCK_LENGTH
 #define EVP_MAX_BLOCK_LENGTH 32

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -40,6 +40,7 @@
 
 #ifdef LIBSSH2_CRYPTO_C /* Compile this via crypto.c */
 
+#include <stdlib.h>
 #include <assert.h>
 
 #ifndef EVP_MAX_BLOCK_LENGTH

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -41,7 +41,6 @@
 
 #include <stdlib.h>
 
-#include <stdio.h>
 #include <stdarg.h>
 #include <alloca.h>
 #include <sys/uio.h>

--- a/src/packet.c
+++ b/src/packet.c
@@ -51,8 +51,6 @@
 #include <sys/uio.h>
 #endif
 
-#include <sys/types.h>
-
 #include "transport.h"
 #include "channel.h"
 #include "packet.h"

--- a/src/packet.c
+++ b/src/packet.c
@@ -39,17 +39,13 @@
  */
 
 #include "libssh2_priv.h"
-#include <errno.h>
-#include <fcntl.h>
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif
-
 /* Needed for struct iovec on some platforms */
 #ifdef HAVE_SYS_UIO_H
 #include <sys/uio.h>

--- a/src/scp.c
+++ b/src/scp.c
@@ -37,12 +37,11 @@
  */
 
 #include "libssh2_priv.h"
-#include <errno.h>
-#include <stdlib.h>
+
+#include <stdlib.h>  /* strtol(), strtoll(), _strtoi64() */
 
 #include "channel.h"
 #include "session.h"
-
 
 /* Max. length of a quoted string after libssh2_shell_quotearg() processing */
 #define _libssh2_shell_quotedsize(s)     (3 * strlen(s) + 2)

--- a/src/scp.c
+++ b/src/scp.c
@@ -38,10 +38,18 @@
 
 #include "libssh2_priv.h"
 
-#include <stdlib.h>  /* strtol(), strtoll(), _strtoi64() */
-
 #include "channel.h"
 #include "session.h"
+
+#include <stdlib.h>  /* strtoll(), _strtoi64(), strtol() */
+
+#if defined(HAVE_STRTOLL)
+#define scpsize_strtol strtoll
+#elif defined(HAVE_STRTOI64)
+#define scpsize_strtol _strtoi64
+#else
+#define scpsize_strtol strtol
+#endif
 
 /* Max. length of a quoted string after libssh2_shell_quotearg() processing */
 #define _libssh2_shell_quotedsize(s)     (3 * strlen(s) + 2)

--- a/src/session.c
+++ b/src/session.c
@@ -42,17 +42,16 @@
 #ifdef WIN32
 #include <ws2tcpip.h>  /* for socklen_t */
 #endif
-
-#include <errno.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#include <stdlib.h>
-#include <fcntl.h>
-
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #endif
+
+#include <errno.h>
+#include <stdlib.h>
+#include <fcntl.h>
 
 #include "transport.h"
 #include "session.h"

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -37,13 +37,14 @@
  * OF SUCH DAMAGE.
  */
 
-#include <assert.h>
-
 #include "libssh2_priv.h"
 #include "libssh2_sftp.h"
+
 #include "channel.h"
 #include "session.h"
 #include "sftp.h"
+
+#include <assert.h>
 
 /* This release of libssh2 implements Version 5 with automatic downgrade
  * based on server's declaration

--- a/src/transport.c
+++ b/src/transport.c
@@ -39,13 +39,9 @@
  */
 
 #include "libssh2_priv.h"
-#include <errno.h>
-#include <fcntl.h>
-#include <ctype.h>
-#ifdef LIBSSH2DEBUG
-#include <stdio.h>
-#endif
 
+#include <errno.h>
+#include <ctype.h>
 #include <assert.h>
 
 #include "transport.h"

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -40,9 +40,6 @@
 #include "libssh2_priv.h"
 
 #include <ctype.h>
-#include <stdio.h>
-
-#include <assert.h>
 
 /* Needed for struct iovec on some platforms */
 #ifdef HAVE_SYS_UIO_H

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -41,14 +41,14 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 
 #include <stdio.h>

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -50,10 +50,11 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#include <ctype.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <ctype.h>
 
 #if defined(WIN32) && defined(_WIN64)
 #define LIBSSH2_SOCKET_MASK "%lld"

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -38,24 +38,24 @@
 #include "session_fixture.h"
 #include "openssh_fixture.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
 
 #ifdef _MSC_VER
 #include <direct.h>
 #define chdir _chdir
 #endif
-
-#ifdef HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
-#ifdef HAVE_SYS_PARAM_H
-#include <sys/param.h>
-#endif
-#include <assert.h>
 
 static LIBSSH2_SESSION *connected_session = NULL;
 static libssh2_socket_t connected_socket = LIBSSH2_INVALID_SOCKET;

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -17,7 +17,7 @@
 #endif
 
 #include <stdio.h>
-#include <stdlib.h>
+#include <stdlib.h>  /* for getenv() */
 
 static const char *hostname = "127.0.0.1";
 static const unsigned short port_number = 4711;


### PR DESCRIPTION
- drop unused or duplicate C headers.
- add missing ones (that worked by chance).
  (`string.h`, `stdlib.h`)
- mention the functions that need certain headers.
- move some headers from crypto header to crypto C source.
- reorder headers in some places.
- simplify the #if tree for `sys/select.h` in `libssh2_priv.h`.
- move scp-specific macros next to their header to `scp.c`
  Follow-up to 5db836b2a829c6fff1e8c7acaa4b21b246ae1757

Closes #999
