### PR TITLE
tidy-up: `gettimeofday()` fallback and use

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -22,9 +22,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -20,9 +20,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -27,9 +27,6 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -26,9 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -26,9 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -29,9 +29,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -24,9 +24,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -26,9 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -22,9 +22,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 
 #include <sys/types.h>
 #include <fcntl.h>

--- a/example/x11.c
+++ b/example/x11.c
@@ -29,9 +29,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -64,7 +64,6 @@
 # ifdef HAVE_SYS_SELECT_H
 #  include <sys/select.h>
 # else
-#  include <sys/time.h>
 #  include <sys/types.h>
 # endif
 # endif
@@ -112,10 +111,20 @@
 
 /* Use local implementation when not available */
 #if !defined(HAVE_SNPRINTF)
-#define LIBSSH2_SNPRINTF
 #undef snprintf
 #define snprintf _libssh2_snprintf
+#define LIBSSH2_SNPRINTF
 int _libssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...);
+#endif
+
+#if !defined(HAVE_GETTIMEOFDAY)
+#define HAVE_GETTIMEOFDAY
+#undef gettimeofday
+#define gettimeofday _libssh2_gettimeofday
+#define LIBSSH2_GETTIMEOFDAY
+int _libssh2_gettimeofday(struct timeval *tp, void *tzp);
+#elif defined(HAVE_SYS_TIME_H)
+#include <sys/time.h>
 #endif
 
 /* "inline" keyword is valid only with C++ engine! */

--- a/src/misc.c
+++ b/src/misc.c
@@ -701,7 +701,7 @@ int _libssh2_gettimeofday(struct timeval *tp, void *tzp)
         #define _WIN32_FT_OFFSET (116444736000000000)
 
         union {
-            unsigned __int64 ns100; /* time since 1 Jan 1601 in 100ns units */
+            libssh2_uint64_t ns100; /* time since 1 Jan 1601 in 100ns units */
             FILETIME ft;
         } _now;
         GetSystemTimeAsFileTime(&_now.ft);

--- a/src/misc.c
+++ b/src/misc.c
@@ -46,10 +46,6 @@
 #include <unistd.h>
 #endif
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-
 #ifdef WIN32
 /* Force parameter type. */
 #define recv(s, b, l, f)  recv((s), (b), (int)(l), (f))
@@ -533,7 +529,7 @@ _libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
         }
     }
 
-    _libssh2_gettimeofday(&now, NULL);
+    gettimeofday(&now, NULL);
     if(!firstsec) {
         firstsec = now.tv_sec;
     }
@@ -672,8 +668,8 @@ void _libssh2_list_insert(struct list_node *after, /* insert before this */
 
 #endif
 
-/* this define is defined in misc.h for the correct platforms */
-#ifdef LIBSSH2_GETTIMEOFDAY_WIN32
+/* Defined in libssh2_priv.h for the correct platforms */
+#ifdef LIBSSH2_GETTIMEOFDAY
 /*
  * _libssh2_gettimeofday
  * Implementation according to:
@@ -696,27 +692,31 @@ void _libssh2_list_insert(struct list_node *after, /* insert before this */
  *  Danny Smith <dannysmith@users.sourceforge.net>
  */
 
-/* Offset between 1/1/1601 and 1/1/1970 in 100 nanosec units */
-#define _W32_FT_OFFSET (116444736000000000)
-
-int __cdecl _libssh2_gettimeofday(struct timeval *tp, void *tzp)
+int _libssh2_gettimeofday(struct timeval *tp, void *tzp)
 {
-    union {
-        unsigned __int64 ns100; /* time since 1 Jan 1601 in 100ns units */
-        FILETIME ft;
-    } _now;
     (void)tzp;
     if(tp) {
+#ifdef WIN32
+        /* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
+        #define _WIN32_FT_OFFSET (116444736000000000)
+
+        union {
+            unsigned __int64 ns100; /* time since 1 Jan 1601 in 100ns units */
+            FILETIME ft;
+        } _now;
         GetSystemTimeAsFileTime(&_now.ft);
         tp->tv_usec = (long)((_now.ns100 / 10) % 1000000);
-        tp->tv_sec = (long)((_now.ns100 - _W32_FT_OFFSET) / 10000000);
+        tp->tv_sec = (long)((_now.ns100 - _WIN32_FT_OFFSET) / 10000000);
+#else
+        /* Platforms without a native implementation or local replacement */
+        tp->tv_usec = 0;
+        tp->tv_sec = 0;
+#endif
     }
     /* Always return 0 as per Open Group Base Specifications Issue 6.
        Do not set errno on error.  */
     return 0;
 }
-
-
 #endif
 
 void *_libssh2_calloc(LIBSSH2_SESSION* session, size_t size)

--- a/src/misc.c
+++ b/src/misc.c
@@ -707,10 +707,12 @@ int _libssh2_gettimeofday(struct timeval *tp, void *tzp)
         GetSystemTimeAsFileTime(&_now.ft);
         tp->tv_usec = (long)((_now.ns100 / 10) % 1000000);
         tp->tv_sec = (long)((_now.ns100 - _WIN32_FT_OFFSET) / 10000000);
+        #error "gettimeofday win32 fallback"
 #else
         /* Platforms without a native implementation or local replacement */
         tp->tv_usec = 0;
         tp->tv_sec = 0;
+        #error "gettimeofday no-op fallback"
 #endif
     }
     /* Always return 0 as per Open Group Base Specifications Issue 6.

--- a/src/misc.c
+++ b/src/misc.c
@@ -707,7 +707,6 @@ int _libssh2_gettimeofday(struct timeval *tp, void *tzp)
         GetSystemTimeAsFileTime(&_now.ft);
         tp->tv_usec = (long)((_now.ns100 / 10) % 1000000);
         tp->tv_sec = (long)((_now.ns100 - _WIN32_FT_OFFSET) / 10000000);
-        #error "gettimeofday win32 fallback"
 #else
         /* Platforms without a native implementation or local replacement */
         tp->tv_usec = 0;

--- a/src/misc.h
+++ b/src/misc.h
@@ -131,19 +131,6 @@ int _libssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf,
 int _libssh2_check_length(struct string_buf *buf, size_t requested_len);
 int _libssh2_eob(struct string_buf *buf);
 
-#if defined(WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN__)
-/* provide a private one */
-#undef HAVE_GETTIMEOFDAY
-int __cdecl _libssh2_gettimeofday(struct timeval *tp, void *tzp);
-#define HAVE_LIBSSH2_GETTIMEOFDAY
-#define LIBSSH2_GETTIMEOFDAY_WIN32 /* enable the win32 implementation */
-#else
-#ifdef HAVE_GETTIMEOFDAY
-#define _libssh2_gettimeofday(x,y) gettimeofday(x,y)
-#define HAVE_LIBSSH2_GETTIMEOFDAY
-#endif
-#endif
-
 void _libssh2_xor_data(unsigned char *output,
                        const unsigned char *input1,
                        const unsigned char *input2,

--- a/src/packet.c
+++ b/src/packet.c
@@ -46,10 +46,6 @@
 #include <unistd.h>
 #endif
 
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif


### PR DESCRIPTION
Simplify the way we handle `gettimeofday()` fallback for platforms
without native support or without any support. Make it similar to
how we handle `snprintf()`.

In case of no native `gettimeofday()` support and a non-Windows
platform, our local fallback returns zero in `tv_usec` and `tv_sec`,
ending up with a zero `timeout_remaining` in `session.c`, same as
before this patch.

Also:
- drop unused `sys/time.h` headers.
- fix our fallback code to compile with any Windows compilers
  (not just MSVC)
- delete unnecessary casts.

Closes #1001

---

- [x] test run to see via #error if MSVC still compiles the expected fallback code.
  It does: https://ci.appveyor.com/project/libssh2org/libssh2/builds/46884850/job/loix9k3t0trrvdc8#L141
- [x] test run to see via #error if any CI jobs end up compiling the no-op fallback code.
