### PR TITLE
libssh2_priv.h: assume `HAVE_LONGLONG`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckIncludeFiles)
-include(CheckTypeSize)
 include(CheckSymbolExists)
 include(CMakePushCheckState)
 
@@ -153,8 +152,6 @@ if(NOT WIN32)
   check_include_files(arpa/inet.h HAVE_ARPA_INET_H)  # example and tests
   check_include_files(netinet/in.h HAVE_NETINET_IN_H)  # example and tests
 endif()
-
-check_type_size("long long" LONGLONG)
 
 # CMake uses C syntax in check_symbol_exists() that generates a warning with
 # MSVC. To not break detection with ENABLE_WERRROR, we disable it for the

--- a/configure.ac
+++ b/configure.ac
@@ -47,12 +47,6 @@ case "$host" in
     ;;
 esac
 
-AC_CHECK_TYPE(long long,
-   [AC_DEFINE(HAVE_LONGLONG, 1,
-      [Define to 1 if the compiler supports the 'long long' data type.])]
-   longlong="yes"
-)
-
 dnl Our configure and build reentrant settings
 CURL_CONFIGURE_REENTRANT
 

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -74,9 +74,6 @@
 /* Define if you have the gcrypt library. */
 #undef HAVE_LIBGCRYPT
 
-/* Define to 1 if the compiler supports the 'long long' data type. */
-#define HAVE_LONGLONG 1
-
 /* Define to 1 if you have the <netinet/in.h> header file. */
 #define HAVE_NETINET_IN_H 1
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -50,9 +50,6 @@
 #cmakedefine HAVE_ARPA_INET_H
 #cmakedefine HAVE_NETINET_IN_H
 
-/* Types */
-#cmakedefine HAVE_LONGLONG
-
 /* Functions */
 #cmakedefine HAVE_GETTIMEOFDAY
 #cmakedefine HAVE_STRTOLL

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -891,11 +891,7 @@ struct _LIBSSH2_SESSION
     unsigned char scpRecv_response[LIBSSH2_SCP_RESPONSE_BUFLEN];
     size_t scpRecv_response_len;
     long scpRecv_mode;
-#if defined(HAVE_LONGLONG)
     libssh2_int64_t scpRecv_size;
-#else
-    long scpRecv_size;
-#endif
     long scpRecv_mtime;
     long scpRecv_atime;
     LIBSSH2_CHANNEL *scpRecv_channel;
@@ -917,12 +913,12 @@ struct _LIBSSH2_SESSION
     long packet_read_timeout;
 };
 
-#if !defined(HAVE_LONGLONG)
-#define scpsize_strtol strtol
-#elif defined(HAVE_STRTOLL)
+#if defined(HAVE_STRTOLL)
 #define scpsize_strtol strtoll
 #elif defined(HAVE_STRTOI64)
 #define scpsize_strtol _strtoi64
+#else
+#define scpsize_strtol strtol
 #endif
 
 /* session.state bits */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -891,16 +891,10 @@ struct _LIBSSH2_SESSION
     unsigned char scpRecv_response[LIBSSH2_SCP_RESPONSE_BUFLEN];
     size_t scpRecv_response_len;
     long scpRecv_mode;
-#if defined(HAVE_LONGLONG) && defined(HAVE_STRTOLL)
-    /* we have the type and we can parse such numbers */
-    long long scpRecv_size;
-#define scpsize_strtol strtoll
-#elif defined(HAVE_STRTOI64)
-    __int64 scpRecv_size;
-#define scpsize_strtol _strtoi64
+#if defined(HAVE_LONGLONG)
+    libssh2_int64_t scpRecv_size;
 #else
     long scpRecv_size;
-#define scpsize_strtol strtol
 #endif
     long scpRecv_mtime;
     long scpRecv_atime;
@@ -922,6 +916,14 @@ struct _LIBSSH2_SESSION
     /* Configurable timeout for packets. Replaces LIBSSH2_READ_TIMEOUT */
     long packet_read_timeout;
 };
+
+#if !defined(HAVE_LONGLONG)
+#define scpsize_strtol strtol
+#elif defined(HAVE_STRTOLL)
+#define scpsize_strtol strtoll
+#elif defined(HAVE_STRTOI64)
+#define scpsize_strtol _strtoi64
+#endif
 
 /* session.state bits */
 #define LIBSSH2_STATE_EXCHANGING_KEYS   0x00000001

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -39,6 +39,8 @@
 # endif
 # if _MSC_VER >= 1800
 #  define HAVE_STRTOLL
+# elif _MSC_VER >= 1310
+#  define HAVE_STRTOI64
 # endif
 # if _MSC_VER < 1900
 #  undef HAVE_SNPRINTF

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -31,15 +31,11 @@
 # define HAVE_SYS_TIME_H
 # define HAVE_SYS_PARAM_H
 # define HAVE_GETTIMEOFDAY
-# define HAVE_LONGLONG
 # define HAVE_STRTOLL
 #elif defined(_MSC_VER)
-# if _MSC_VER >= 1310
-#  define HAVE_LONGLONG
-# endif
 # if _MSC_VER >= 1800
 #  define HAVE_STRTOLL
-# elif _MSC_VER >= 1310
+# else
 #  define HAVE_STRTOI64
 # endif
 # if _MSC_VER < 1900


### PR DESCRIPTION
Unless I'm missing something, it looks like `libssh2.h` has been using
`libssh2_int64_t` unconditionally since at least 2010-04-17 when
`libssh2_scp_send64()` landed via commit
be9ee7095e2d5021985f57d88f5f889d3c2b9d8f.

This makes it redundant to detect `HAVE_LONGLONG` to fallback to a
32-bit `scpRecv_size` in `libssh2_priv.h`. Then deal with possible
combinations of this flag and `strtoll()` options, which was
error-prone.

Instead, assume in `libssh2_priv.h` that we have `libssh2_int64_t`, and
use it always.

For MSVC, this means `_MSC_VER` `1310` (from year 2003) is now
required. Based on the above, this was already so before this patch.

If there happens to be no 64-bit `strtoll()` detected, fall back to the
32-bit `strtol()` (this should never happen with MSVC, and probably
neither with any other reasonably modern toolchain.)

Also make sure to set `HAVE_STRTOI64` for older, non-CMake, MSVC builds
(e.g. `Makefile.mk` or `NMakefile` ones).

Closes #1002
