### PR TITLE
Couple of small fixes

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1165,7 +1165,7 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             _libssh2_error(session, rc,
                            "Would block sending auth-agent request");
-	    return rc;
+            return rc;
         }
         else if(rc) {
             channel->req_auth_agent_state = libssh2_NB_state_idle;

--- a/src/channel.c
+++ b/src/channel.c
@@ -1165,6 +1165,7 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             _libssh2_error(session, rc,
                            "Would block sending auth-agent request");
+	    return rc;
         }
         else if(rc) {
             channel->req_auth_agent_state = libssh2_NB_state_idle;

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -89,6 +89,7 @@
 #ifndef OPENSSL_NO_MD5
 #include <openssl/md5.h>
 #endif
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/bn.h>

--- a/src/packet.c
+++ b/src/packet.c
@@ -1212,6 +1212,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                        sizeof(session->packAdd_authagent_state));
 
               libssh2_packet_add_jump_authagent:
+                session->packAdd_state = libssh2_NB_state_jumpauthagent;
                 rc = packet_authagent_open(session, data, datalen,
                                            &session->packAdd_authagent_state);
             }


### PR DESCRIPTION
The first merely makes sure that we include the proper header file, otherwise this fails to compile with recent versions of Xcode.

The second patch fixes an issue that would corrupt the data stream when attempting to initialize the agent in non-blocking mode, as it is necessary to propagate the EAGAIN signal upstream when the transport returns EAGAIN.