### PR TITLE
vms: fix to include `sys/socket.h`

### DIFF
--- a/vms/libssh2_config.h
+++ b/vms/libssh2_config.h
@@ -19,7 +19,7 @@ typedef unsigned int socklen_t; /* missing in headers on VMS */
 #define HAVE_SELECT
 #define HAVE_UIO
 
-#define HAVE_SYS_SOCKET.H
+#define HAVE_SYS_SOCKET_H
 #define HAVE_NETINET_IN_H
 #define HAVE_ARPA_INET_H
 


### PR DESCRIPTION
Due to a typo in the `HAVE_*` macro, this header was never included.

A comment suggests that `socklen_t` is not defined on VMS and defines it
manually. This symbol is usually in `sys/socket.h`, so the typo may have
been the reason for it to be missing.

Closes #1007
