### PR TITLE
build: fix autoreconf warnings

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -554,12 +554,12 @@ AC_DEFUN([CURL_CHECK_NONBLOCKING_SOCKET],
 [
   AC_MSG_CHECKING([non-blocking sockets style])
 
-  AC_TRY_COMPILE([
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 /* headers for O_NONBLOCK test */
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>
-],[
+]], [[
 /* try to compile O_NONBLOCK */
 
 #if defined(sun) || defined(__sun__) || defined(__SUNPRO_C) || defined(__SUNPRO_CC)
@@ -578,22 +578,22 @@ AC_DEFUN([CURL_CHECK_NONBLOCKING_SOCKET],
 #endif
   int socket;
   int flags = fcntl(socket, F_SETFL, flags | O_NONBLOCK);
-],[
+]])],[
 dnl the O_NONBLOCK test was fine
 nonblock="O_NONBLOCK"
 AC_DEFINE(HAVE_O_NONBLOCK, 1, [use O_NONBLOCK for non-blocking sockets])
 ],[
 dnl the code was bad, try a different program now, test 2
 
-  AC_TRY_COMPILE([
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 /* headers for FIONBIO test */
 #include <unistd.h>
 #include <stropts.h>
-],[
+]], [[
 /* FIONBIO source test (old-style unix) */
  int socket;
  int flags = ioctl(socket, FIONBIO, &flags);
-],[
+]])],[
 dnl FIONBIO test was good
 nonblock="FIONBIO"
 AC_DEFINE(HAVE_FIONBIO, 1, [use FIONBIO for non-blocking sockets])
@@ -601,28 +601,28 @@ AC_DEFINE(HAVE_FIONBIO, 1, [use FIONBIO for non-blocking sockets])
 dnl FIONBIO test was also bad
 dnl the code was bad, try a different program now, test 3
 
-  AC_TRY_LINK([
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 /* headers for IoctlSocket test (Amiga?) */
 #include <sys/ioctl.h>
-],[
+]], [[
 /* IoctlSocket source code */
  int socket;
  int flags = IoctlSocket(socket, FIONBIO, (long)1);
-],[
+]])],[
 dnl ioctlsocket test was good
 nonblock="IoctlSocket"
 AC_DEFINE(HAVE_IOCTLSOCKET_CASE, 1, [use Ioctlsocket() for non-blocking sockets])
 ],[
 dnl Ioctlsocket did not compile, do test 4!
-  AC_TRY_COMPILE([
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 /* headers for SO_NONBLOCK test (BeOS) */
 #include <socket.h>
-],[
+]], [[
 /* SO_NONBLOCK source code */
  long b = 1;
  int socket;
  int flags = setsockopt(socket, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
-],[
+]])],[
 dnl the SO_NONBLOCK test was good
 nonblock="SO_NONBLOCK"
 AC_DEFINE(HAVE_SO_NONBLOCK, 1, [use SO_NONBLOCK for non-blocking sockets])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -844,8 +844,8 @@ AC_DEFUN([LIBSSH2_CHECK_OPTION_WERROR], [
   AC_MSG_CHECKING([whether to enable compiler warnings as errors])
   OPT_COMPILER_WERROR="default"
   AC_ARG_ENABLE(werror,
-AC_HELP_STRING([--enable-werror],[Enable compiler warnings as errors])
-AC_HELP_STRING([--disable-werror],[Disable compiler warnings as errors]),
+AS_HELP_STRING([--enable-werror],[Enable compiler warnings as errors])
+AS_HELP_STRING([--disable-werror],[Disable compiler warnings as errors]),
   OPT_COMPILER_WERROR=$enableval)
   case "$OPT_COMPILER_WERROR" in
     no)

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# AC_PREREQ(2.57)
+# AC_PREREQ(2.59)
 AC_INIT(libssh2, [-], libssh2-devel@lists.haxx.se)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src])
@@ -89,7 +89,7 @@ m4_set_add([crypto_backends], [wincng])
 m4_set_add([crypto_backends], [wolfssl])
 
 AC_ARG_WITH([crypto],
-  AC_HELP_STRING([--with-crypto=auto|]m4_set_contents([crypto_backends], [|]),
+  AS_HELP_STRING([--with-crypto=auto|]m4_set_contents([crypto_backends], [|]),
     [Select crypto backend (default: auto)]),
   use_crypto=$withval,
   use_crypto=auto
@@ -120,7 +120,7 @@ fi
 # libz
 
 AC_ARG_WITH([libz],
-  AC_HELP_STRING([--with-libz],[Use libz for compression]),
+  AS_HELP_STRING([--with-libz],[Use libz for compression]),
   use_libz=$withval,
   use_libz=auto)
 
@@ -151,7 +151,7 @@ AC_SUBST(LIBSREQUIRED)
 # Optional Settings
 #
 AC_ARG_ENABLE(clear-memory,
-  AC_HELP_STRING([--disable-clear-memory],[Disable clearing of memory before being freed]),
+  AS_HELP_STRING([--disable-clear-memory],[Disable clearing of memory before being freed]),
   [CLEAR_MEMORY=$enableval])
 if test "$CLEAR_MEMORY" = "no"; then
   AC_DEFINE(LIBSSH2_NO_CLEAR_MEMORY, 1, [Disable clearing of memory before being freed])
@@ -165,8 +165,8 @@ dnl option to switch on compiler debug options
 dnl
 AC_MSG_CHECKING([whether to enable pedantic and debug compiler options])
 AC_ARG_ENABLE(debug,
-AC_HELP_STRING([--enable-debug],[Enable pedantic and debug options])
-AC_HELP_STRING([--disable-debug],[Disable debug options]),
+AS_HELP_STRING([--enable-debug],[Enable pedantic and debug options])
+AS_HELP_STRING([--disable-debug],[Disable debug options]),
 [ case "$enable_debug" in
   no)
        AC_MSG_RESULT(no)
@@ -194,8 +194,8 @@ dnl on gcc >= 4.0 and SunPro C.
 dnl
 AC_MSG_CHECKING([whether to enable hidden symbols in the library])
 AC_ARG_ENABLE(hidden-symbols,
-AC_HELP_STRING([--enable-hidden-symbols],[Hide internal symbols in library])
-AC_HELP_STRING([--disable-hidden-symbols],[Leave all symbols with default visibility in library]),
+AS_HELP_STRING([--enable-hidden-symbols],[Hide internal symbols in library])
+AS_HELP_STRING([--disable-hidden-symbols],[Leave all symbols with default visibility in library]),
 [ case "$enableval" in
   no)
        AC_MSG_RESULT(no)
@@ -241,8 +241,8 @@ AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = xyes])
 # Build example applications?
 AC_MSG_CHECKING([whether to build example applications])
 AC_ARG_ENABLE([examples-build],
-AC_HELP_STRING([--enable-examples-build], [Build example applications (this is the default)])
-AC_HELP_STRING([--disable-examples-build], [Do not build example applications]),
+AS_HELP_STRING([--enable-examples-build], [Build example applications (this is the default)])
+AS_HELP_STRING([--disable-examples-build], [Do not build example applications]),
 [case "$enableval" in
   no | false)
     build_examples='no'

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # AC_PREREQ(2.59)
-AC_INIT(libssh2, [-], libssh2-devel@lists.haxx.se)
+AC_INIT([libssh2],[-],[libssh2-devel@lists.haxx.se])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_HEADERS([src/libssh2_config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -270,7 +270,6 @@ AM_CONDITIONAL([USE_OSSFUZZ_STATIC], [test -f "$LIB_FUZZING_ENGINE"])
 
 
 # Checks for header files.
-# AC_HEADER_STDC
 AC_CHECK_HEADERS([errno.h fcntl.h stdio.h unistd.h sys/param.h sys/uio.h])
 AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/ioctl.h sys/time.h])
 AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])

--- a/configure.ac
+++ b/configure.ac
@@ -307,16 +307,16 @@ AC_CHECK_FUNCS(gettimeofday select strtoll explicit_bzero explicit_memset memset
 dnl Check for select() into ws2_32 for Msys/Mingw
 if test "$ac_cv_func_select" != "yes"; then
   AC_MSG_CHECKING([for select in ws2_32])
-  AC_TRY_LINK([
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #ifdef HAVE_WINDOWS_H
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
 #endif
-    ],[
+    ]], [[
       select(0,(fd_set *)NULL,(fd_set *)NULL,(fd_set *)NULL,(struct timeval *)NULL);
-    ],[
+    ]])],[
       AC_MSG_RESULT([yes])
       HAVE_SELECT="1"
       AC_DEFINE_UNQUOTED(HAVE_SELECT, 1,

--- a/configure.ac
+++ b/configure.ac
@@ -67,8 +67,13 @@ AC_PATH_PROGS(SSHD, [sshd], [],
      [$PATH$PATH_SEPARATOR/usr/libexec$PATH_SEPARATOR]dnl
      [/usr/sbin$PATH_SEPARATOR/usr/etc$PATH_SEPARATOR/etc])
 AM_CONDITIONAL(SSHD, test -n "$SSHD")
+m4_ifdef([LT_INIT],
+[dnl
+LT_INIT([win32-dll])
+],[dnl
 AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL
+])
 AC_C_BIGENDIAN
 
 LT_LANG([Windows Resource])

--- a/m4/lib-link.m4
+++ b/m4/lib-link.m4
@@ -6,7 +6,7 @@ dnl with or without modifications, as long as this notice is preserved.
 
 dnl From Bruno Haible.
 
-AC_PREREQ(2.54)
+AC_PREREQ([2.54])
 
 dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
 dnl the libraries corresponding to explicit and implicit dependencies.

--- a/m4/lib-link.m4
+++ b/m4/lib-link.m4
@@ -74,7 +74,7 @@ AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
   AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
     ac_save_LIBS="$LIBS"
     LIBS="$LIBS $LIB[]NAME"
-    AC_TRY_LINK([$3], [$4], [ac_cv_lib[]Name=yes], [ac_cv_lib[]Name=no])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[$3]], [[$4]])],[ac_cv_lib[]Name=yes],[ac_cv_lib[]Name=no])
     LIBS="$ac_save_LIBS"
   ])
   if test "$ac_cv_lib[]Name" = yes; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign nostdinc
 
-# Get the CSOURCES, HHEADERS and EXTRA_DIST_SOURCES defines
+# Get the CSOURCES, HHEADERS and EXTRA_DIST defines
 include Makefile.inc
 
 libssh2_la_SOURCES = $(CSOURCES) $(HHEADERS)
@@ -8,8 +8,7 @@ if HAVE_WINDRES
 libssh2_la_SOURCES += libssh2.rc
 endif
 
-EXTRA_DIST = $(EXTRA_DIST_SOURCES) \
-  libssh2_config.h.in libssh2_config_cmake.h.in CMakeLists.txt
+EXTRA_DIST += libssh2_config.h.in libssh2_config_cmake.h.in CMakeLists.txt
 
 lib_LTLIBRARIES = libssh2.la
 

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -45,7 +45,7 @@ HHEADERS =              \
   userauth_kbd_packet.h \
   wincng.h
 
-EXTRA_DIST_SOURCES =    \
+EXTRA_DIST =            \
   blowfish.c            \
   libgcrypt.c           \
   mbedtls.c             \


### PR DESCRIPTION
- update `AC_HELP_STRING' to 'AS_HELP_STRING`:
  ```
  configure.ac:[...]: warning: The macro `AC_HELP_STRING' is obsolete.
  ```
  "AC_HELP_STRING is deprecated in 2.70+ and I believe AS_HELP_STRING works
  already since 2.59 so bump the minimum required version to that."

  Ref: https://github.com/curl/curl/commit/a59f04611629f0db9ad8e768b9def73b9b4d9423

- simplify to avoid:
  ```
  src/Makefile.inc:48: warning: variable 'EXTRA_DIST_SOURCES' is defined but no program or
  src/Makefile.inc:48: library has 'DIST' as canonical name (possible typo)
  ```
  Regression from 2c18b6fc8df060c770fa7e5da704c32cf40a5757

- `AC_TRY_LINK`/`AC_TRY_COMPILE`:
  ```
  configure.ac:335: warning: The macro `AC_TRY_COMPILE' is obsolete.
  configure.ac:335: warning: The macro `AC_TRY_LINK' is obsolete.
  ```

- `libtool`-related ones:
  ```
  configure.ac:70: warning: The macro `AC_LIBTOOL_WIN32_DLL' is obsolete.
  configure.ac:70: warning: AC_LIBTOOL_WIN32_DLL: Remove this warning and the call to _LT_SET_OPTION when you
  configure.ac:70: put the 'win32-dll' option into LT_INIT's first parameter.
  configure.ac:71: warning: The macro `AC_PROG_LIBTOOL' is obsolete.
  ```
  Using code copied from curl:
  https://github.com/curl/curl/blob/9ce7eee07042605045dcfd02a6f5b38ad5c8a05d/m4/xc-lt-iface.m4#L157-L163

- delete commented and obsolete `AC_HEADER_STDC`.

- formatting.

Most cherry picked from `autoupdate` updates.

Cherry-picked from #1017
Closes #1021
