### PR TITLE
cmake: use shared libs again in example and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,12 +114,19 @@ endif()
 option(BUILD_EXAMPLES "Build libssh2 examples" ON)
 option(BUILD_TESTING "Build libssh2 test suite" ON)
 
-if(NOT BUILD_STATIC_LIBS AND (NOT BUILD_SHARED_LIBS OR BUILD_EXAMPLES OR BUILD_TESTING))
+if(NOT BUILD_STATIC_LIBS AND (NOT BUILD_SHARED_LIBS OR BUILD_TESTING))
   set(BUILD_STATIC_LIBS ON)
 endif()
 
 set(LIB_STATIC "libssh2_static")
 set(LIB_SHARED "libssh2_shared")
+
+# lib flavour selected for example and test programs.
+if(BUILD_SHARED_LIBS)
+  set(LIB_SELECTED ${LIB_SHARED})
+else()
+  set(LIB_SELECTED ${LIB_STATIC})
+endif()
 
 # Symbol hiding
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -47,7 +47,7 @@ foreach(example ${EXAMPLES})
   list(APPEND EXAMPLE_TARGETS ${example})
   # to find generated header
   target_include_directories(${example} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../src ../src)
-  target_link_libraries(${example} ${LIB_STATIC} ${LIBRARIES})
+  target_link_libraries(${example} ${LIB_SELECTED} ${LIBRARIES})
 endforeach()
 
 add_target_to_copy_dependencies(

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -32,10 +32,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
-
 static const char *pubkey = ".ssh/id_rsa.pub";
 static const char *privkey = ".ssh/id_rsa";
 static const char *username = "username";

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -21,10 +21,6 @@
 #define INADDR_NONE (in_addr_t)~0
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
-
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";
 static const char *username = "username";

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -78,6 +78,13 @@
 #  ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
 #  define _WINSOCK_DEPRECATED_NO_WARNINGS  /* for inet_addr() */
 #  endif
+   /* we cannot access our internal snprintf() implementation in examples and
+      tests when linking to a shared libssh2. */
+#  if _MSC_VER < 1900
+#   undef HAVE_SNPRINTF
+#   define HAVE_SNPRINTF
+#   define snprintf _snprintf
+#  endif
 # endif
 # if _MSC_VER < 1500
 #  define vsnprintf _vsnprintf

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,15 +65,6 @@ target_compile_definitions(runner PRIVATE "${CRYPTO_BACKEND_DEFINE}")
 target_include_directories(runner PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../src" ../src ../include "${CRYPTO_BACKEND_INCLUDE_DIR}")
 target_compile_definitions(runner PRIVATE FIXTURE_WORKDIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
-# test building against shared libssh2 lib
-if(BUILD_SHARED_LIBS)
-  foreach(test test_ssh2)
-    add_executable(${test}_shared ${test}.c)
-    target_include_directories(${test}_shared PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../src" ../src)
-    target_link_libraries(${test}_shared ${LIB_SHARED} ${LIBRARIES})
-  endforeach()
-endif()
-
 foreach(test ${DOCKER_TESTS} ${STANDALONE_TESTS} ${SSHD_TESTS})
   # We support the same target as both Docker and SSHD test. Build those just once.
   if(NOT TARGET ${test})
@@ -85,8 +76,11 @@ foreach(test ${DOCKER_TESTS} ${STANDALONE_TESTS} ${SSHD_TESTS})
     if(GCOV_PATH AND test STREQUAL test_auth_keyboard_info_request)
       target_compile_options(${test} BEFORE PRIVATE ${GCOV_OPTIONS})
       target_link_libraries(${test} runner ${LIB_STATIC} ${LIBRARIES} gcov)
-    else()
+    # always build these against the static lib
+    elseif(test MATCHES "^(test_auth_keyboard_info_request|test_hostkey|test_simple)$")
       target_link_libraries(${test} runner ${LIB_STATIC} ${LIBRARIES})
+    else()
+      target_link_libraries(${test} runner ${LIB_SELECTED} ${LIBRARIES})
     endif()
 
     list(APPEND TEST_TARGETS ${test})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,14 @@ target_compile_definitions(runner PRIVATE "${CRYPTO_BACKEND_DEFINE}")
 target_include_directories(runner PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../src" ../src ../include "${CRYPTO_BACKEND_INCLUDE_DIR}")
 target_compile_definitions(runner PRIVATE FIXTURE_WORKDIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
+# These programs use internal libssh2 functions so they need to be statically
+# linked against libssh2
+set(TESTS_WITH_LIB_STATIC
+  test_auth_keyboard_info_request
+  test_hostkey
+  test_simple
+)
+
 foreach(test ${DOCKER_TESTS} ${STANDALONE_TESTS} ${SSHD_TESTS})
   # We support the same target as both Docker and SSHD test. Build those just once.
   if(NOT TARGET ${test})
@@ -76,8 +84,7 @@ foreach(test ${DOCKER_TESTS} ${STANDALONE_TESTS} ${SSHD_TESTS})
     if(GCOV_PATH AND test STREQUAL test_auth_keyboard_info_request)
       target_compile_options(${test} BEFORE PRIVATE ${GCOV_OPTIONS})
       target_link_libraries(${test} runner ${LIB_STATIC} ${LIBRARIES} gcov)
-    # always build these against the static lib
-    elseif(test MATCHES "^(test_auth_keyboard_info_request|test_hostkey|test_simple)$")
+    elseif(";${TESTS_WITH_LIB_STATIC};" MATCHES ";${test};")
       target_link_libraries(${test} runner ${LIB_STATIC} ${LIBRARIES})
     else()
       target_link_libraries(${test} runner ${LIB_SELECTED} ${LIBRARIES})


### PR DESCRIPTION
Re-sync with autotools and v1.10.0 behavior.

This improves build times. It also allows to stop building our special
shared test target to test shared builds.

Follow-up to 4e2580628dd1f8dc51ac65ac747ebcf0e93fa3d1

Cherry-picked from #1017
Closes #1022
