### PR TITLE
cmake: assume `bcrypt.h` with WinCNG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,21 +363,12 @@ endif()
 # Detect platform-specific crypto-backends last:
 
 if(CRYPTO_BACKEND STREQUAL "WinCNG" OR NOT CRYPTO_BACKEND)
+  set(CRYPTO_BACKEND "WinCNG")
+  set(CRYPTO_BACKEND_DEFINE "LIBSSH2_WINCNG")
+  set(CRYPTO_BACKEND_INCLUDE_DIR "")
 
-  # The check actually compiles the header.  This requires windows.h.
-  # Check necessary for old-MinGW
-  check_include_files("windows.h;bcrypt.h" HAVE_BCRYPT_H)
-
-  if(HAVE_BCRYPT_H)
-    set(CRYPTO_BACKEND "WinCNG")
-    set(CRYPTO_BACKEND_DEFINE "LIBSSH2_WINCNG")
-    set(CRYPTO_BACKEND_INCLUDE_DIR "")
-
-    list(APPEND LIBRARIES crypt32 bcrypt)
-    list(APPEND PC_LIBS -lcrypt32 -lbcrypt)
-  elseif(${SPECIFIC_CRYPTO_REQUIREMENT} STREQUAL ${REQUIRED})
-    message(FATAL_ERROR "WinCNG not available")
-  endif()
+  list(APPEND LIBRARIES crypt32 bcrypt)
+  list(APPEND PC_LIBS -lcrypt32 -lbcrypt)
 endif()
 
 # Global functions


### PR DESCRIPTION
autotools already didn't check for `bcrypt.h`, and such check is only
required for old/legacy mingw without obsolete/incomplete Windows
headers.

curl deprecated old-mingw support just recently and will delete support
in September 2023.

This patch saves some complexity and detection time by dropping this
check for CMake. Meaning that mingw-w64 is now required to compile
libssh2 when using the WinCNG backend for 32-bit builds. Other backends
and CPU platforms are not affected.

Ref: https://github.com/curl/curl/commit/e4d5685cb5d6eb07e1b43156fd7e3ba3563afba5

Closes #1026
