### PR TITLE
cmake: do not check for `poll()` on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR
   # not having reliable timeout support
   # inconsistent return of POLLHUP where other implementations give POLLIN
   message("poll use is disabled on this platform")
-else()
+elseif(NOT WIN32)
   check_function_exists(poll HAVE_POLL)
 endif()
 


### PR DESCRIPTION
While it seems to exist on mingw in theory, it's not detected as of this
writing. It also has issues, and not ready for production use:
https://stackoverflow.com/questions/1671827/poll-c-function-on-windows

On MSVC it's even less supported.

Skip checking this to save CMake detection time.

Closes #1027
