### PR TITLE
cmake: add and test "unity" builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         shell: msys2 {0}
         run: |
           if [[ "${{ matrix.env }}" = 'clang'* ]]; then
-            options='-DCMAKE_C_COMPILER=clang'
+            options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
@@ -197,13 +197,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - { arch: x64  , plat: windows, crypto: WinCNG , log: 'OFF', shared: 'OFF', zlib: 'OFF' }
-          - { arch: x64  , plat: windows, crypto: WinCNG , log: 'ON' , shared: 'ON' , zlib: 'OFF' }
-          - { arch: x64  , plat: windows, crypto: OpenSSL, log: 'OFF', shared: 'ON' , zlib: 'OFF' }
-          - { arch: x64  , plat: uwp    , crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF' }
-          - { arch: arm64, plat: windows, crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF' }
-          - { arch: arm64, plat: uwp    , crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF' }
-          - { arch: x86  , plat: windows, crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF' }
+          - { arch: x64  , plat: windows, crypto: WinCNG , log: 'OFF', shared: 'OFF', zlib: 'OFF', unity: 'OFF' }
+          - { arch: x64  , plat: windows, crypto: WinCNG , log: 'ON' , shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
+          - { arch: x64  , plat: windows, crypto: OpenSSL, log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
+          - { arch: x64  , plat: uwp    , crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
+          - { arch: arm64, plat: windows, crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
+          - { arch: arm64, plat: uwp    , crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
+          - { arch: x86  , plat: windows, crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -217,6 +217,7 @@ jobs:
           else
             system='Windows'
           fi
+          [ "${{ matrix.unity }}" = 'ON' ] && options="${options} -DCMAKE_UNITY_BUILD=ON"
           cmake . -B bld ${options} \
             -DCMAKE_SYSTEM_NAME=${system} \
             -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake \
@@ -298,6 +299,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: |
           cmake . -B bld ${{ matrix.crypto.cmake }} \
+            -DCMAKE_UNITY_BUILD=ON \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
             -DENABLE_ZLIB_COMPRESSION=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 project(libssh2 C)
 
+set(CMAKE_UNITY_BUILD_BATCH_SIZE 32)
+
 option(BUILD_STATIC_LIBS "Build Static Libraries" ON)
 add_feature_info("Static library" BUILD_STATIC_LIBS
   "creating libssh2 static library")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,20 +82,21 @@ environment:
       CRYPTO_BACKEND: "OpenSSL"
       SKIP_CTEST: "yes"
 
-    - job_name: "VS2010, WinCNG, x64, Build-only"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
-      GENERATOR: "Visual Studio 10 2010"
-      PLATFORM: "x64"
-      BUILD_SHARED_LIBS: "ON"
-      CRYPTO_BACKEND: "WinCNG"
-      SKIP_CTEST: "yes"
-
     - job_name: "VS2008, WinCNG, x86, Build-only"
       APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
       GENERATOR: "Visual Studio 9 2008"
       PLATFORM: "x86"
       BUILD_SHARED_LIBS: "ON"
       CRYPTO_BACKEND: "WinCNG"
+      SKIP_CTEST: "yes"
+
+    - job_name: "VS2010, WinCNG, x64, Build-only"
+      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      GENERATOR: "Visual Studio 10 2010"
+      PLATFORM: "x64"
+      BUILD_SHARED_LIBS: "ON"
+      CRYPTO_BACKEND: "WinCNG"
+      UNITY: "ON"
       SKIP_CTEST: "yes"
 
     - job_name: "VS2022, WinCNG, x64, Server 2019, Logging"
@@ -166,6 +167,9 @@ build_script:
       }
       if($env:UWP -eq "ON") {
         $env:CMAKE_ARG += " -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
+      }
+      if($env:UNITY -eq "ON") {
+        $env:CMAKE_ARG += " -DCMAKE_UNITY_BUILD=ON"
       }
       $env:CMAKE_ARG += " -DCMAKE_VS_GLOBALS=TrackFileAccess=false"
   # FIXME: First sshd test sometimes timeouts, subsequent ones almost always fail:

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -48,6 +48,7 @@ foreach(example ${EXAMPLES})
   # to find generated header
   target_include_directories(${example} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../src ../src)
   target_link_libraries(${example} ${LIB_SELECTED} ${LIBRARIES})
+  set_target_properties(${example} PROPERTIES UNITY_BUILD false)
 endforeach()
 
 add_target_to_copy_dependencies(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ foreach(test ${DOCKER_TESTS} ${STANDALONE_TESTS} ${SSHD_TESTS})
     add_executable(${test} ${test}.c)
     target_compile_definitions(${test} PRIVATE "${CRYPTO_BACKEND_DEFINE}")
     target_include_directories(${test} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/../src" ../src ../include "${CRYPTO_BACKEND_INCLUDE_DIR}")
+    set_target_properties(${test} PROPERTIES UNITY_BUILD false)
 
     # build a single test with gcov
     if(GCOV_PATH AND test STREQUAL test_auth_keyboard_info_request)


### PR DESCRIPTION
"Unity" (aka "jumbo", aka "amalgamation" builds concatenate source files
before compiling. It has these benefits for example: faster builds,
improved code optimization, cleaner code. Let's support and test this.

- enable unity builds for some existing CI builds to test this build
  scenario.
- tune `UNITY_BUILD_BATCH_SIZE` size.
- disable unity build for example and test programs (they use one source
  each already).

You can enable it by passing `-DCMAKE_UNITY_BUILD=ON` to cmake.
Supported by CMake 3.16 and newer.

Ref: https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html

Closes #1034
