### PR TITLE
ci: enable shared libs in msys2/macOS cmake builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           cmake . -B bld ${options} \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
+            -DBUILD_SHARED_LIBS=ON \
             -DCRYPTO_BACKEND=OpenSSL \
             -DENABLE_ZLIB_COMPRESSION=ON \
             -DRUN_DOCKER_TESTS=OFF \
@@ -302,6 +303,7 @@ jobs:
             -DCMAKE_UNITY_BUILD=ON \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
+            -DBUILD_SHARED_LIBS=ON \
             -DENABLE_ZLIB_COMPRESSION=ON \
             -DRUN_DOCKER_TESTS=OFF \
             -DRUN_SSHD_TESTS=OFF


### PR DESCRIPTION
Shared libs improve example/tests build times. For "unity"
builds the overhead of building shared lib is negligible, so
this even reduced the overall build-time.

Follow-up to 3d64a3f5100f7f4cf52202396eb4f1c3f3567771
Follow-up to d93ccf4901ef26443707d341553994715414e207

Tests:
https://github.com/libssh2/libssh2/actions/runs/4906586658: unity builds enabled
https://github.com/libssh2/libssh2/actions/runs/4906925743: unity builds enabled + parallel msys2 builds
https://github.com/libssh2/libssh2/actions/runs/4906777629: unity + shared lib (this commit)
https://github.com/libssh2/libssh2/actions/runs/4906927190: unity + shared lib (this commit) + parallel msys2 builds

Consider making shared libs enabled by default also in CMake, to sync it with autotools?

Closes #1035
