### PR TITLE
cmake: avoid `list(PREPEND)` for compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,9 +371,8 @@ if(CRYPTO_BACKEND STREQUAL "wolfSSL" OR NOT CRYPTO_BACKEND)
     find_package(ZLIB)
 
     if(ZLIB_FOUND)
-      list(PREPEND CRYPTO_BACKEND_INCLUDE_DIR ${ZLIB_INCLUDE_DIR})
-
-      list(APPEND LIBRARIES ${ZLIB_LIBRARIES})  # Public wolfSSL headers require zlib headers
+      list(APPEND CRYPTO_BACKEND_INCLUDE_DIR ${ZLIB_INCLUDE_DIR})  # Public wolfSSL headers require zlib headers
+      list(APPEND LIBRARIES ${ZLIB_LIBRARIES})
       list(APPEND PC_REQUIRES_PRIVATE zlib)
     endif()
   endif()


### PR DESCRIPTION
`list(PREPEND)` requires CMake v3.15, our minimum is v3.1. `APPEND` should work fine for headers anyway.

Also fix a wrongly placed comment.

Ref: https://cmake.org/cmake/help/latest/command/list.html#prepend

Regression from 1e3319a167d2f32d295603167486e9e88af9bb4e

Closes #1043