### PR TITLE
build: fix 'unused' compiler warnings with all `NO` options set

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -82,6 +82,11 @@
 #define LIBSSH2_ECDSA 0
 #endif
 
+#ifdef LIBSSH2_NO_ED25519
+#undef LIBSSH2_ED25519
+#define LIBSSH2_ED25519 0
+#endif
+
 #ifdef LIBSSH2_NO_AES_CTR
 #undef LIBSSH2_AES_CTR
 #define LIBSSH2_AES_CTR 0

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1430,6 +1430,7 @@ _libssh2_mbedtls_ecdsa_free(libssh2_ecdsa_ctx *ctx)
     mbedtls_ecdsa_free(ctx);
     mbedtls_free(ctx);
 }
+#endif /* LIBSSH2_ECDSA */
 
 
 /* _libssh2_supported_key_sign_algorithms
@@ -1455,5 +1456,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
     return NULL;
 }
 
-#endif /* LIBSSH2_ECDSA */
 #endif /* LIBSSH2_CRYPTO_C */

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -536,6 +536,19 @@ _libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION *session,
                                size_t hash_len,
                                unsigned char **signature,
                                size_t *signature_len);
+int
+_libssh2_mbedtls_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+                                 size_t hash_len,
+                                 const unsigned char *sig,
+                                 unsigned long sig_len,
+                                 const unsigned char *m, unsigned long m_len);
+int
+_libssh2_mbedtls_rsa_sha2_sign(LIBSSH2_SESSION *session,
+                               libssh2_rsa_ctx *rsa,
+                               const unsigned char *hash,
+                               size_t hash_len,
+                               unsigned char **signature,
+                               size_t *signature_len);
 void
 _libssh2_mbedtls_rsa_free(libssh2_rsa_ctx *rsa);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -643,6 +643,7 @@ void _libssh2_openssl_crypto_exit(void)
 {
 }
 
+#if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA || LIBSSH2_ED25519
 /* TODO: Optionally call a passphrase callback specified by the
  * calling program
  */
@@ -684,13 +685,14 @@ read_private_key_from_memory(void **key_ctx,
     if(!bp) {
         return -1;
     }
+
     *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
                                 (void *) passphrase);
 
     BIO_free(bp);
     return (*key_ctx) ? 0 : -1;
 }
-
+#endif
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
 static int
@@ -3437,6 +3439,12 @@ _libssh2_pub_priv_openssh_keyfile(LIBSSH2_SESSION *session,
 
     rc = -1;
 
+    /* Avoid unused variable warnings when all branches below are disabled */
+    (void)method;
+    (void)method_len;
+    (void)pubkeydata;
+    (void)pubkeydata_len;
+
 #if LIBSSH2_ED25519
     if(strcmp("ssh-ed25519", (const char *)buf) == 0) {
         rc = gen_publickey_from_ed25519_openssh_priv_data(session, decrypted,
@@ -3638,11 +3646,6 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
     (void)method_len;
     (void)pubkeydata;
     (void)pubkeydata_len;
-    (void)algorithm;
-    (void)flags;
-    (void)application;
-    (void)key_handle;
-    (void)handle_len;
 
 #if LIBSSH2_ED25519
     if(strcmp("ssh-ed25519", (const char *)buf) == 0) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3712,6 +3712,17 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
     }
 }
 #endif
+#if !LIBSSH2_ED25519 && !LIBSSH2_ECDSA && !LIBSSH2_RSA && !LIBSSH2_DSA
+    (void)method;
+    (void)method_len;
+    (void)pubkeydata;
+    (void)pubkeydata_len;
+    (void)algorithm;
+    (void)flags;
+    (void)application;
+    (void)key_handle;
+    (void)handle_len;
+#endif
 
     if(rc == LIBSSH2_ERROR_FILE)
         rc = _libssh2_error(session, LIBSSH2_ERROR_FILE,
@@ -3795,7 +3806,6 @@ _libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
     }
 #endif
 #if LIBSSH2_ECDSA
-{
     if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ECDSA_256;
         rc = gen_publickey_from_sk_ecdsa_openssh_priv_data(session, decrypted,
@@ -3808,7 +3818,17 @@ _libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
                                                            handle_len,
                                                  (libssh2_ecdsa_ctx**)key_ctx);
     }
-}
+#endif
+#if !LIBSSH2_ED25519 && !LIBSSH2_ECDSA
+    (void)method;
+    (void)method_len;
+    (void)pubkeydata;
+    (void)pubkeydata_len;
+    (void)algorithm;
+    (void)flags;
+    (void)application;
+    (void)key_handle;
+    (void)handle_len;
 #endif
 
     if(rc == LIBSSH2_ERROR_FILE)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3633,6 +3633,17 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
 
     rc = LIBSSH2_ERROR_FILE;
 
+    /* Avoid unused variable warnings when all branches below are disabled */
+    (void)method;
+    (void)method_len;
+    (void)pubkeydata;
+    (void)pubkeydata_len;
+    (void)algorithm;
+    (void)flags;
+    (void)application;
+    (void)key_handle;
+    (void)handle_len;
+
 #if LIBSSH2_ED25519
     if(strcmp("ssh-ed25519", (const char *)buf) == 0) {
         if(!key_type || strcmp("ssh-ed25519", key_type) == 0) {
@@ -3713,17 +3724,6 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
 }
 #endif
 
-    /* Avoid unused variable warnings when all branches above are disabled */
-    (void)method;
-    (void)method_len;
-    (void)pubkeydata;
-    (void)pubkeydata_len;
-    (void)algorithm;
-    (void)flags;
-    (void)application;
-    (void)key_handle;
-    (void)handle_len;
-
     if(rc == LIBSSH2_ERROR_FILE)
         rc = _libssh2_error(session, LIBSSH2_ERROR_FILE,
                          "Unable to extract public key from private key file: "
@@ -3786,6 +3786,17 @@ _libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
 
     rc = LIBSSH2_ERROR_FILE;
 
+    /* Avoid unused variable warnings when all branches below are disabled */
+    (void)method;
+    (void)method_len;
+    (void)pubkeydata;
+    (void)pubkeydata_len;
+    (void)algorithm;
+    (void)flags;
+    (void)application;
+    (void)key_handle;
+    (void)handle_len;
+
 #if LIBSSH2_ED25519
     if(strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) == 0) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ED25519;
@@ -3819,17 +3830,6 @@ _libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
                                                  (libssh2_ecdsa_ctx**)key_ctx);
     }
 #endif
-
-    /* Avoid unused variable warnings when all branches above are disabled */
-    (void)method;
-    (void)method_len;
-    (void)pubkeydata;
-    (void)pubkeydata_len;
-    (void)algorithm;
-    (void)flags;
-    (void)application;
-    (void)key_handle;
-    (void)handle_len;
 
     if(rc == LIBSSH2_ERROR_FILE)
         rc = _libssh2_error(session, LIBSSH2_ERROR_FILE,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3712,7 +3712,8 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
     }
 }
 #endif
-#if !LIBSSH2_ED25519 && !LIBSSH2_ECDSA && !LIBSSH2_RSA && !LIBSSH2_DSA
+
+    /* Avoid unused variable warnings when all branches above are disabled */
     (void)method;
     (void)method_len;
     (void)pubkeydata;
@@ -3722,7 +3723,6 @@ _libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
     (void)application;
     (void)key_handle;
     (void)handle_len;
-#endif
 
     if(rc == LIBSSH2_ERROR_FILE)
         rc = _libssh2_error(session, LIBSSH2_ERROR_FILE,
@@ -3819,7 +3819,8 @@ _libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
                                                  (libssh2_ecdsa_ctx**)key_ctx);
     }
 #endif
-#if !LIBSSH2_ED25519 && !LIBSSH2_ECDSA
+
+    /* Avoid unused variable warnings when all branches above are disabled */
     (void)method;
     (void)method_len;
     (void)pubkeydata;
@@ -3829,7 +3830,6 @@ _libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
     (void)application;
     (void)key_handle;
     (void)handle_len;
-#endif
 
     if(rc == LIBSSH2_ERROR_FILE)
         rc = _libssh2_error(session, LIBSSH2_ERROR_FILE,


### PR DESCRIPTION
- add `LIBSSH2_NO_ED25519` build-time option to force-disable ED25519 support.
  Useful to replicate crypto-backends builds without ED25519, such as wolfSSL.

- openssl: fix unused variable and function warnings with all supported `LIBSSH2_NO_*` options enabled.

- mbedtls: fix misplaced `#endif` leaving out the required internal public function `libssh2_supported_key_sign_algorithms()`.

- mbedtls: add missing prototype for two internal public functions.

- delete a redundant block.

All `NO` options:
```shell
CPPFLAGS='
-DLIBSSH2_NO_MD5 -DLIBSSH2_NO_HMAC_RIPEMD -DLIBSSH2_NO_DSA
-DLIBSSH2_NO_RSA -DLIBSSH2_NO_RSA_SHA1
-DLIBSSH2_NO_ECDSA -DLIBSSH2_NO_ED25519 -DLIBSSH2_NO_AES_CTR
-DLIBSSH2_NO_BLOWFISH -DLIBSSH2_NO_RC4 -DLIBSSH2_NO_CAST -DLIBSSH2_NO_3DES'
```

Closes #1044
