### PR TITLE
wolfssl: fix detection of AES-GCM feature

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -161,7 +161,8 @@
 #endif
 
 #if (OPENSSL_VERSION_NUMBER >= 0x01010100fL && !defined(OPENSSL_NO_AES)) || \
-    (defined(LIBSSH2_WOLFSSL) && defined(WOLFSSL_AESGCM_STREAM))
+    (defined(LIBSSH2_WOLFSSL) && \
+    defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM))
 # define LIBSSH2_AES_GCM 1
 #else
 # define LIBSSH2_AES_GCM 0

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -161,7 +161,7 @@
 #endif
 
 #if (OPENSSL_VERSION_NUMBER >= 0x01010100fL && !defined(OPENSSL_NO_AES)) || \
-    (defined(LIBSSH2_WOLFSSL) && defined(HAVE_AESGCM))
+    (defined(LIBSSH2_WOLFSSL) && defined(WOLFSSL_AESGCM_STREAM))
 # define LIBSSH2_AES_GCM 1
 #else
 # define LIBSSH2_AES_GCM 0


### PR DESCRIPTION
Follow-up to df513c0128e1a811ad863d153892618e728845f0

Ref: https://github.com/libssh2/libssh2/issues/1020#issuecomment-1562069241

Closes #1045
