### PR TITLE
Handle EINTR from send/recv/poll/select to try again as the error is not fatal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,8 +212,7 @@ if(NOT WIN32)
   check_include_files("sys/un.h" HAVE_SYS_UN_H)
   check_include_files("arpa/inet.h" HAVE_ARPA_INET_H)  # example and tests
   check_include_files("netinet/in.h" HAVE_NETINET_IN_H)  # example and tests
-  check_include_files(pthread.h HAVE_PTHREAD_H)  # tests
-  check_include_files(signal.h HAVE_SIGNAL_H) # tests
+  check_include_files("pthread.h" HAVE_PTHREAD_H)  # tests
 endif()
 
 # CMake uses C syntax in check_symbol_exists() that generates a warning with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,8 @@ if(NOT WIN32)
   check_include_files("sys/un.h" HAVE_SYS_UN_H)
   check_include_files("arpa/inet.h" HAVE_ARPA_INET_H)  # example and tests
   check_include_files("netinet/in.h" HAVE_NETINET_IN_H)  # example and tests
+  check_include_files(pthread.h HAVE_PTHREAD_H)  # tests
+  check_include_files(signal.h HAVE_SIGNAL_H) # tests
 endif()
 
 # CMake uses C syntax in check_symbol_exists() that generates a warning with

--- a/src/misc.h
+++ b/src/misc.h
@@ -79,7 +79,7 @@ int _libssh2_error_flags(LIBSSH2_SESSION* session, int errcode,
                          const char *errmsg, int errflags);
 int _libssh2_error(LIBSSH2_SESSION* session, int errcode, const char *errmsg);
 
-#ifdef WIN32
+#ifdef _WIN32
 /* Convert Win32 WSAGetLastError to errno equivalent */
 int _libssh2_wsa2errno(void);
 #endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -79,6 +79,11 @@ int _libssh2_error_flags(LIBSSH2_SESSION* session, int errcode,
                          const char *errmsg, int errflags);
 int _libssh2_error(LIBSSH2_SESSION* session, int errcode, const char *errmsg);
 
+#ifdef WIN32
+/* Convert Win32 WSAGetLastError to errno equivalent */
+int _libssh2_wsa2errno(void);
+#endif
+
 void _libssh2_list_init(struct list_head *head);
 
 /* add a node last in the list */

--- a/src/session.c
+++ b/src/session.c
@@ -674,7 +674,7 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
     }
     if(rc < 0) {
         int err;
-#ifdef WIN32
+#ifdef _WIN32
         err = _libssh2_wsa2errno();
 #else
         err = errno;


### PR DESCRIPTION
Fixes #955 

Would it make sense to handle EINTR in the wrapper macros `BLOCK_ADJUST` and `BLOCK_ADJUST_ERRNO` instead?

**macOS**:
`man select`:
> select() returns with an error, including one due to an interrupted call, the descriptor sets will be unmodified and the global variable errno will be set to indicate the error.

`man poll`:
> If poll() returns with an error, including one due to an interrupted call, the fds array will be unmodified and the global variable errno will be set to indicate the error.

`man recv`:
> [EINTR]            The receive was interrupted by delivery of a signal before any data were available.

`man send`:
> [EINTR]            A signal interrupts the system call before any data is transmitted.

**Linux**:
`man select`:
> EINTR The function was interrupted before any of the selected events occurred and before the timeout interval expired.

`man poll`:
> EINTR A signal was caught during poll().
Not super helpful, but the text implies behavior as if no other actions were taken.

`man recv`:
> EINTR The receive was interrupted by delivery of a signal before any data were available
`man send`:
>EINTR A signal interrupted send() before any data was transmitted.

**FreeBSD**:
Does not mention EINTR at all in `send` but for `recv`, `poll`, `select` the text follow as macOS and Linux.
https://man.freebsd.org/cgi/man.cgi?sektion=2&query=send

**Windows**:
It looks like `WSAEINTR` should be handled identically as above, ~however that is NOT implemented in this PR (yet! feedback appreciated!)~ Update: added Windows handling, but did not adapt a test for it.
: https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2