### PR TITLE
scp: fix missing cast for targets without large file support

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -762,7 +762,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
 
         sb->st_mtime = session->scpRecv_mtime;
         sb->st_atime = session->scpRecv_atime;
-        sb->st_size = session->scpRecv_size;
+        sb->st_size = (libssh2_struct_stat_size)session->scpRecv_size;
         sb->st_mode = (unsigned short)session->scpRecv_mode;
     }
 


### PR DESCRIPTION
E.g. on 32-bit Linux. Issue revealed after adding i386 Linux CI build
in abdf40c741c575f94bdea1c67a9d1182ff813ccb #1057.

```
/home/runner/work/libssh2/libssh2/src/scp.c: In function 'scp_recv':
/home/runner/work/libssh2/libssh2/src/scp.c:765:23: error: conversion from 'libssh2_int64_t' {aka 'long long int'} to '__off_t' {aka 'long int'} may change value [-Werror=conversion]
  765 |         sb->st_size = session->scpRecv_size;
      |                       ^~~~~~~
```
Ref: https://github.com/libssh2/libssh2/actions/runs/5126803482/jobs/9221746299?pr=1054#step:12:51

Regression from 5db836b2a829c6fff1e8c7acaa4b21b246ae1757 #1002
Closes #1060
