### PR TITLE
ci: add non-static autotools i386 build, ignore GHA updates on AppVeyor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
             crypto: mbedTLS
             build: cmake
             zlib: 'ON'
+          - compiler: clang
+            arch: i386
+            crypto: Libgcrypt
+            build: autotools
+            zlib: 'ON'
+            options: --disable-static
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -93,7 +99,7 @@ jobs:
         run: autoreconf -fi
       - name: 'autotools configure'
         if: ${{ matrix.build == 'autotools' }}
-        run: mkdir bld && cd bld && ../configure --enable-werror --enable-debug
+        run: mkdir bld && cd bld && ../configure --enable-werror --enable-debug ${{ matrix.options }}
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' && !matrix.target }}
         run: make -C bld -j3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,14 @@ jobs:
         run: autoreconf -fi
       - name: 'autotools configure'
         if: ${{ matrix.build == 'autotools' }}
-        run: mkdir bld && cd bld && ../configure --enable-werror --enable-debug ${{ matrix.options }}
+        run: |
+          if [ '${{ matrix.arch }}' = 'i386' ]; then
+            crossoptions='--host=i686-pc-linux-gnu'
+            export CFLAGS=-m32
+          fi
+          mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
+            ${crossoptions} ${{ matrix.options }}
+
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' && !matrix.target }}
         run: make -C bld -j3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -209,6 +209,10 @@ on_finish:
       Start-Sleep -Seconds 3
       Get-Process -Name "sshd" -ErrorAction SilentlyContinue | Stop-Process
 
+skip_commits:
+  files:
+    - '.github/**/*'
+
 # Limit branches to avoid testing feature branches twice (as branch and as pull request)
 branches:
   only:


### PR DESCRIPTION
Add a non-static autotools build to GitHub Actions. Make this build
target i386 and libgcrypt, to test a new build combination if we're at it.

Also:
- add necessary generic bits to GHA to run autotools tests for i386.
- teach AppVeyor CI to ignore commits updating the GitHub Actions configuration.

Follow-up to 572c57c9d8d4e89cfce19dde40125d55481256d1 #1072
Closes #1074
