### PR TITLE
src: bump `hash_len` to `size_t` in `LIBSSH2_HOSTKEY_METHOD`

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -947,7 +947,7 @@ struct _LIBSSH2_KEX_METHOD
 struct _LIBSSH2_HOSTKEY_METHOD
 {
     const char *name;
-    unsigned long hash_len;
+    size_t hash_len;
 
     int (*init) (LIBSSH2_SESSION * session, const unsigned char *hostkey_data,
                  size_t hostkey_data_len, void **abstract);


### PR DESCRIPTION
Follow-up to 7b8e02257f01a6dac5f65305b18bb74a157fb5c4
Closes #1076
