### PR TITLE
autotools: improve libz position

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -389,6 +389,8 @@ elif test "$found_crypto" = "mbedtls"; then
   LIBS="${LIBS} ${LTLIBMBEDCRYPTO}"
 fi
 
+LIBS="${LIBS} ${LTLIBZ}"
+
 AC_CONFIG_FILES([Makefile
                  src/Makefile
                  tests/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,8 +48,7 @@ VERSION=-version-info 1:1:0
 #
 
 libssh2_la_LDFLAGS = $(VERSION) -no-undefined \
-  -export-symbols-regex '^libssh2_.*' \
-  $(LTLIBZ)
+  -export-symbols-regex '^libssh2_.*'
 
 if HAVE_WINDRES
 .rc.lo:


### PR DESCRIPTION
We repositioned crypto libs in 4f0f4bff5a92dce6a6cd7a5600a8ee5660402c3f via #941 and subsequently in d4f58f03438e326b8696edd31acadd6f3e028763 from d93ccf4901ef26443707d341553994715414e207 via #1013.

This patch moves libz accordingly, to unbreak certain build scenarios.

Reported-by: Kenneth Davidson
Regression from 4f0f4bff5a92dce6a6cd7a5600a8ee5660402c3f #941
Fixes #1075
Closes #1077