### PR TITLE
tests: cast to avoid `-Wchar-subscripts` with Cygwin

### DIFF
--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -133,7 +133,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
         /* command output may contain a trailing newline, so we trim
          * whitespace here */
         size_t end = strlen(buf);
-        while(end > 0 && isspace(buf[end - 1])) {
+        while(end > 0 && isspace((int)buf[end - 1])) {
             buf[end - 1] = '\0';
         }
 


### PR DESCRIPTION
```
In file included from $HOME/src/cygwin/libssh2/libssh2-1.11.0-1.x86_64/src/libssh2-1.11.0/tests/openssh_fixture.c:57:
$HOME/src/cygwin/libssh2/libssh2-1.11.0-1.x86_64/src/libssh2-1.11.0/tests/openssh_fixture.c: In function 'run_command_varg':
$HOME/src/cygwin/libssh2/libssh2-1.11.0-1.x86_64/src/libssh2-1.11.0/tests/openssh_fixture.c:136:37: warning: array subscript has type 'char' [-Wchar-subscripts]
  136 |         while(end > 0 && isspace(buf[end - 1])) {
      |                                  ~~~^~~~~~~~~
```
Ref: https://github.com/libssh2/libssh2/files/11644340/cygwin-x86_64-libssh2-1.11.0-1-check.log

Reported-by: Brian Inglis
Fixes #1080
Closes #1081
