### PR TITLE
copyright: remove years from copyright headers

### DIFF
--- a/.checksrc
+++ b/.checksrc
@@ -1,4 +1,3 @@
-disable COPYRIGHT
 disable FOPENMODE
 disable SNPRINTF
 disable TYPEDEFSTRUCT

--- a/.github/workflows/appveyor_docker.yml
+++ b/.github/workflows/appveyor_docker.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Marc Hoersken
+# Copyright (C) Marc Hoersken
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/.github/workflows/appveyor_status.yml
+++ b/.github/workflows/appveyor_status.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Marc Hoersken
+# Copyright (C) Marc Hoersken
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Marc Hoersken
+# Copyright (C) Marc Hoersken
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2014, 2015 Alexander Lamaison <alexander.lamaison@gmail.com>
-# Copyright (c) 2023 Viktor Szakats
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Viktor Szakats
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/COPYING
+++ b/COPYING
@@ -1,11 +1,11 @@
-/* Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2005,2006 Mikhail Gusarov <dottedmag@dottedmag.net>
- * Copyright (c) 2006-2007 The Written Word, Inc.
- * Copyright (c) 2007 Eli Fant <elifantu@mail.ru>
- * Copyright (c) 2009-2023 Daniel Stenberg
+/* Copyright (C) 2004-2007 Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) 2005,2006 Mikhail Gusarov <dottedmag@dottedmag.net>
+ * Copyright (C) 2006-2007 The Written Word, Inc.
+ * Copyright (C) 2007 Eli Fant <elifantu@mail.ru>
+ * Copyright (C) 2009-2023 Daniel Stenberg
  * Copyright (C) 2008, 2009 Simon Josefsson
- * Copyright (c) 2000 Markus Friedl
- * Copyright (c) 2015 Microsoft Corp.
+ * Copyright (C) 2000 Markus Friedl
+ * Copyright (C) 2015 Microsoft Corp.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
-# Copyright (c) 2014, Ruslan Baratov
-# Copyright (c) 2014, 2016 Alexander Lamaison
-# Copyright (c) 2020, 2021 Marc Hoersken
-# Copyright (c) 2023 Viktor Szakats
+# Copyright (C) Ruslan Baratov
+# Copyright (C) Alexander Lamaison
+# Copyright (C) Marc Hoersken
+# Copyright (C) Viktor Szakats
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cmake/CheckFunctionExistsMayNeedLibrary.cmake
+++ b/cmake/CheckFunctionExistsMayNeedLibrary.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/cmake/CopyRuntimeDependencies.cmake
+++ b/cmake/CopyRuntimeDependencies.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/cmake/FindLibgcrypt.cmake
+++ b/cmake/FindLibgcrypt.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Viktor Szakats
+# Copyright (C) Viktor Szakats
 
 include(CheckCCompilerFlag)
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2014 Alexander Lamaison <alexander.lamaison@gmail.com>
-# Copyright (c) 2023 Viktor Szakats
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Viktor Szakats
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/docs/libssh2_agent_connect.3
+++ b/docs/libssh2_agent_connect.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daiki Ueno
+.\" Copyright (C) Daiki Ueno
 .\"
 .TH libssh2_agent_connect 3 "23 Dec 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_agent_disconnect.3
+++ b/docs/libssh2_agent_disconnect.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daiki Ueno
+.\" Copyright (C) Daiki Ueno
 .\"
 .TH libssh2_agent_disconnect 3 "23 Dec 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_agent_free.3
+++ b/docs/libssh2_agent_free.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daiki Ueno
+.\" Copyright (C) Daiki Ueno
 .\"
 .TH libssh2_agent_free 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_agent_get_identity.3
+++ b/docs/libssh2_agent_get_identity.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daiki Ueno
+.\" Copyright (C) Daiki Ueno
 .\"
 .TH libssh2_agent_get_identity 3 "23 Dec 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_agent_get_identity_path.3
+++ b/docs/libssh2_agent_get_identity_path.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2019 by Will Cosgrove
+.\" Copyright (C) Will Cosgrove
 .\"
 .TH libssh2_agent_get_identity_path 3 "6 Mar 2019" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_agent_init.3
+++ b/docs/libssh2_agent_init.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daiki Ueno
+.\" Copyright (C) Daiki Ueno
 .\"
 .TH libssh2_agent_init 3 "23 Dec 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_agent_list_identities.3
+++ b/docs/libssh2_agent_list_identities.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daiki Ueno
+.\" Copyright (C) Daiki Ueno
 .\"
 .TH libssh2_agent_list_identities 3 "23 Dec 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_agent_set_identity_path.3
+++ b/docs/libssh2_agent_set_identity_path.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2019 by Will Cosgrove
+.\" Copyright (C) Will Cosgrove
 .\"
 .TH libssh2_agent_set_identity_path 3 "6 Mar 2019" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_agent_userauth.3
+++ b/docs/libssh2_agent_userauth.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daiki Ueno
+.\" Copyright (C) Daiki Ueno
 .\"
 .TH libssh2_agent_userauth 3 "23 Dec 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_add.3
+++ b/docs/libssh2_knownhost_add.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009, 2010 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_add 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_addc.3
+++ b/docs/libssh2_knownhost_addc.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009, 2010 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_addc 3 "28 May 2009" "libssh2 1.2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_check.3
+++ b/docs/libssh2_knownhost_check.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_check 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_checkp.3
+++ b/docs/libssh2_knownhost_checkp.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009-2010 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_checkp 3 "1 May 2010" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_del.3
+++ b/docs/libssh2_knownhost_del.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_del 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_free.3
+++ b/docs/libssh2_knownhost_free.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_free 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_get.3
+++ b/docs/libssh2_knownhost_get.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_get 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_init.3
+++ b/docs/libssh2_knownhost_init.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_init 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_readfile.3
+++ b/docs/libssh2_knownhost_readfile.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009-2011 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_readfile 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_readline.3
+++ b/docs/libssh2_knownhost_readline.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_readline 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_writefile.3
+++ b/docs/libssh2_knownhost_writefile.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_writefile 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/docs/libssh2_knownhost_writeline.3
+++ b/docs/libssh2_knownhost_writeline.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2009 by Daniel Stenberg
+.\" Copyright (C) Daniel Stenberg
 .\"
 .TH libssh2_knownhost_writeline 3 "28 May 2009" "libssh2" "libssh2"
 .SH NAME

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2014, 2015 Alexander Lamaison <alexander.lamaison@gmail.com>
-# Copyright (c) 2023 Viktor Szakats
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Viktor Szakats
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "libssh2_setup.h"
 #include <libssh2.h>
 

--- a/example/scp.c
+++ b/example/scp.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do a simple SCP transfer.
  */
 

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SCP transfers in a non-blocking manner.
  *
  * The sample code has default values for host name, user name, password

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do an SCP upload.
  */
 

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do an SCP non-blocking upload transfer.
  */
 

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP transfers.
  *
  * The sample code has default values for host name, user name, password

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP transfers in a non-blocking manner.
  *
  * It will first download a given source file, store it locally and then

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP append of a local file onto a remote one.
  *
  * The sample code has default values for host name, user name, password

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP mkdir
  *
  * The sample code has default values for host name, user name, password

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP non-blocking mkdir.
  *
  * The sample code has default values for host name, user name, password

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP non-blocking transfers.
  *
  * The sample code has default values for host name, user name, password

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP write transfers.
  *
  * The sample code has default values for host name, user name, password

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP non-blocking write transfers.
  *
  * The sample code has default values for host name, user name, password

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SFTP non-blocking write transfers.
  *
  * The sample code has default values for host name, user name, password

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample doing an SFTP directory listing.
  *
  * The sample code has default values for host name, user name, password and

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample doing an SFTP directory listing.
  *
  * The sample code has default values for host name, user name, password and

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SSH2 connect.
  *
  * The sample code has default values for host name, user name, password

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to do SSH2 connect using ssh-agent.
  *
  * The sample code has default values for host name, user name:

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to use libssh2 to request agent forwarding
  * on the remote host. The command executed will run with agent forwarded
  * so you should be able to do things like clone out protected git

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * The code sends a 'cat' command, and then writes a lot of data to it only to
  * check that reading the returned data sums up to the same amount.
  *

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to use libssh2 to execute a command remotely.
  *
  * The sample code has fixed values for host name, user name, password

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "libssh2_setup.h"
 #include <libssh2.h>
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "libssh2_setup.h"
 #include <libssh2.h>
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -1,4 +1,5 @@
-/*
+/* Copyright (C) The libssh2 project and its contributors.
+ *
  * Sample showing how to makes SSH2 with X11 Forwarding works.
  *
  * $ ./x11 host user password [DEBUG]

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2004-2009, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2009-2021 Daniel Stenberg
- * Copyright (c) 2010 Simon Josefsson <simon@josefsson.org>
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg
+ * Copyright (C) Simon Josefsson <simon@josefsson.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
@@ -40,7 +40,7 @@
 #ifndef LIBSSH2_H
 #define LIBSSH2_H 1
 
-#define LIBSSH2_COPYRIGHT "2004-2023 The libssh2 project and its contributors."
+#define LIBSSH2_COPYRIGHT "The libssh2 project and its contributors."
 
 /* We use underscore instead of dash when appending DEV in dev versions just
    to make the BANNER define (used by src/session.c) be a valid SSH

--- a/include/libssh2_publickey.h
+++ b/include/libssh2_publickey.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2004-2006, Sara Golemon <sarag@libssh2.org>
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2004-2008, Sara Golemon <sarag@libssh2.org>
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/m4/autobuild.m4
+++ b/m4/autobuild.m4
@@ -1,5 +1,5 @@
 # autobuild.m4 serial 3
-# Copyright (C) 2004, 2006 Simon Josefsson
+# Copyright (C) Simon Josefsson
 #
 # This file is free software, distributed under the terms of the GNU
 # General Public License.  As a special exception to the GNU General

--- a/os400/ccsid.c
+++ b/os400/ccsid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/os400/include/alloca.h
+++ b/os400/include/alloca.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/os400/include/assert.h
+++ b/os400/include/assert.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Patrick Monnerat <patrick@monnerat.net>
+ * Copyright (C) Patrick Monnerat <patrick@monnerat.net>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/os400/include/stdio.h
+++ b/os400/include/stdio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/os400/include/sys/socket.h
+++ b/os400/include/sys/socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/os400/libssh2_ccsid.h
+++ b/os400/libssh2_ccsid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/os400/libssh2rpg/libssh2.rpgle.in
+++ b/os400/libssh2rpg/libssh2.rpgle.in
@@ -1,4 +1,4 @@
-      * Copyright (c) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+      * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
       * All rights reserved.
       *
       * Redistribution and use in source and binary forms,
@@ -38,7 +38,7 @@
       /define LIBSSH2_H_
 
      d LIBSSH2_COPYRIGHT...
-     d                 c                   '2004-2015 The libssh2 project and +
+     d                 c                   'The libssh2 project and +
      d                                     its contributors.'
 
       * We use underscore instead of dash when appending DEV in dev versions

--- a/os400/libssh2rpg/libssh2_ccsid.rpgle.in
+++ b/os400/libssh2rpg/libssh2_ccsid.rpgle.in
@@ -1,4 +1,4 @@
-      * Copyright (c) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+      * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
       * All rights reserved.
       *
       * Redistribution and use in source and binary forms,

--- a/os400/libssh2rpg/libssh2_publickey.rpgle
+++ b/os400/libssh2rpg/libssh2_publickey.rpgle
@@ -1,4 +1,4 @@
-      * Copyright (c) 2015, Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+      * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
       * All rights reserved.
       *
       * Redistribution and use in source and binary forms,

--- a/os400/libssh2rpg/libssh2_sftp.rpgle
+++ b/os400/libssh2rpg/libssh2_sftp.rpgle
@@ -1,4 +1,4 @@
-      * Copyright (c) 2015, Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+      * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
       * All rights reserved.
       *
       * Redistribution and use in source and binary forms,

--- a/os400/macros.h
+++ b/os400/macros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/os400/os400sys.c
+++ b/os400/os400sys.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2014 Alexander Lamaison <alexander.lamaison@gmail.com>
-# Copyright (c) 2023 Viktor Szakats
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Viktor Szakats
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/src/agent.c
+++ b/src/agent.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2009 by Daiki Ueno
- * Copyright (C) 2010-2021 by Daniel Stenberg
+ * Copyright (C) Daiki Ueno
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/agent_win.c
+++ b/src/agent_win.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2009 by Daiki Ueno
- * Copyright (C) 2010-2014 by Daniel Stenberg
+ * Copyright (C) Daiki Ueno
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
@@ -59,7 +59,7 @@
  *     - fileio_close replacing close
  *
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
- * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+ * Copyright (C) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
  *                    All rights reserved
  * Functions for connecting the local authentication agent.
  *
@@ -70,7 +70,7 @@
  * called by a name other than "ssh" or "Secure Shell".
  *
  * SSH2 implementation,
- * Copyright (c) 2000 Markus Friedl.  All rights reserved.
+ * Copyright (C) 2000 Markus Friedl.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -92,7 +92,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Copyright (c) 2015 Microsoft Corp.
+ * Copyright (C) 2015 Microsoft Corp.
  * All rights reserved
  *
  * Microsoft openssh win32 port

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -1,6 +1,6 @@
 /* $OpenBSD: bcrypt_pbkdf.c,v 1.4 2013/07/29 00:55:53 tedu Exp $ */
 /*
- * Copyright (c) 2013 Ted Unangst <tedu@openbsd.org>
+ * Copyright (C) Ted Unangst <tedu@openbsd.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -2,7 +2,7 @@
 /*
  * Blowfish for OpenBSD - a fast block cipher designed by Bruce Schneier
  *
- * Copyright 1997 Niels Provos <provos@physnet.uni-hamburg.de>
+ * Copyright (C) Niels Provos <provos@physnet.uni-hamburg.de>
  * All rights reserved.
  *
  * Implementation advice by David Mazieres <dm@lcs.mit.edu>.

--- a/src/channel.c
+++ b/src/channel.c
@@ -1,7 +1,6 @@
-/* Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2005 Mikhail Gusarov <dottedmag@dottedmag.net>
- * Copyright (c) 2008-2019 by Daniel Stenberg
- *
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Mikhail Gusarov <dottedmag@dottedmag.net>
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/channel.h
+++ b/src/channel.h
@@ -1,6 +1,6 @@
 #ifndef __LIBSSH2_CHANNEL_H
 #define __LIBSSH2_CHANNEL_H
-/* Copyright (c) 2008-2010 by Daniel Stenberg
+/* Copyright (C) Daniel Stenberg
  *
  * All rights reserved.
  *

--- a/src/comp.c
+++ b/src/comp.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2004-2007, 2019, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2010-2014, Daniel Stenberg <daniel@haxx.se>
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg <daniel@haxx.se>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/comp.h
+++ b/src/comp.h
@@ -1,6 +1,6 @@
 #ifndef __LIBSSH2_COMP_H
 #define __LIBSSH2_COMP_H
-/* Copyright (C) 2009-2010 by Daniel Stenberg
+/* Copyright (C) Daniel Stenberg
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2009, 2010 Simon Josefsson <simon@josefsson.org>
- * Copyright (c) 2004-2007, Sara Golemon <sarag@libssh2.org>
+/* Copyright (C) Simon Josefsson <simon@josefsson.org>
+ * Copyright (C) Sara Golemon <sarag@libssh2.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1,3 +1,5 @@
+/* Copyright (C) Viktor Szakats */
+
 #define LIBSSH2_CRYPTO_C
 #include "libssh2_priv.h"
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -1,8 +1,9 @@
 #ifndef __LIBSSH2_CRYPTO_H
 #define __LIBSSH2_CRYPTO_H
-/* Copyright (C) 2009, 2010 Simon Josefsson
- * Copyright (C) 2006, 2007 The Written Word, Inc.  All rights reserved.
- * Copyright (C) 2010-2019 Daniel Stenberg
+/* Copyright (C) Simon Josefsson
+ * Copyright (C) The Written Word, Inc.
+ * Copyright (C) Daniel Stenberg
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/global.c
+++ b/src/global.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2010 Lars Nordin <Lars.Nordin@SDlabs.se>
- * Copyright (C) 2010 Simon Josefsson <simon@josefsson.org>
+/* Copyright (C) Lars Nordin <Lars.Nordin@SDlabs.se>
+ * Copyright (C) Simon Josefsson <simon@josefsson.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2004-2006, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2009-2019 by Daniel Stenberg
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2010  Simon Josefsson
- * Author: Simon Josefsson
+/* Copyright (C) Simon Josefsson
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/kex.c
+++ b/src/kex.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2004-2007, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2010-2019, Daniel Stenberg <daniel@haxx.se>
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg <daniel@haxx.se>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 by Daniel Stenberg
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2008, 2009, Simon Josefsson
- * Copyright (C) 2006, 2007, The Written Word, Inc.
+/* Copyright (C) Simon Josefsson
+ * Copyright (C) The Written Word, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -1,8 +1,8 @@
 #ifndef __LIBSSH2_LIBGCRYPT_H
 #define __LIBSSH2_LIBGCRYPT_H
 /*
- * Copyright (C) 2008, 2009, 2010 Simon Josefsson
- * Copyright (C) 2006, 2007, The Written Word, Inc.
+ * Copyright (C) Simon Josefsson
+ * Copyright (C) The Written Word, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -1,5 +1,6 @@
-/* Copyright (c) 2014 Alexander Lamaison <alexander.lamaison@gmail.com>
- * Copyright (c) 1999-2011 Douglas Gilbert. All rights reserved.
+/* Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
+ * Copyright (C) Douglas Gilbert
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1,8 +1,8 @@
 #ifndef __LIBSSH2_PRIV_H
 #define __LIBSSH2_PRIV_H
-/* Copyright (c) 2004-2008, 2010, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2009-2014 by Daniel Stenberg
- * Copyright (c) 2010 Simon Josefsson
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg
+ * Copyright (C) Simon Josefsson
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023 Viktor Szakats */
+/* Copyright (C) Viktor Szakats */
 
 #ifndef LIBSSH2_SETUP_H
 #define LIBSSH2_SETUP_H

--- a/src/mac.c
+++ b/src/mac.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2004-2007, Sara Golemon <sarag@libssh2.org>
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/mac.h
+++ b/src/mac.h
@@ -1,6 +1,7 @@
 #ifndef __LIBSSH2_MAC_H
 #define __LIBSSH2_MAC_H
-/* Copyright (C) 2009-2010 by Daniel Stenberg
+/* Copyright (C) Daniel Stenberg
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016, Art <https://github.com/wildart>
+/* Copyright (C) Art <https://github.com/wildart>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -1,6 +1,6 @@
 #ifndef __LIBSSH2_MBEDTLS_H
 #define __LIBSSH2_MBEDTLS_H
-/* Copyright (c) 2016, Art <https://github.com/wildart>
+/* Copyright (C) Art <https://github.com/wildart>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/misc.c
+++ b/src/misc.c
@@ -1,6 +1,6 @@
-/* Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2009-2019 by Daniel Stenberg
- * Copyright (c) 2010  Simon Josefsson
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg
+ * Copyright (C) Simon Josefsson
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/misc.h
+++ b/src/misc.h
@@ -1,7 +1,6 @@
 #ifndef __LIBSSH2_MISC_H
 #define __LIBSSH2_MISC_H
-/* Copyright (c) 2009-2019 by Daniel Stenberg
- *
+/* Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1,8 +1,7 @@
-/* Copyright (C) 2009, 2010 Simon Josefsson
- * Copyright (C) 2006, 2007 The Written Word, Inc.  All rights reserved.
- * Copyright (c) 2004-2006, Sara Golemon <sarag@libssh2.org>
- *
- * Author: Simon Josefsson
+/* Copyright (C) Simon Josefsson
+ * Copyright (C) The Written Word, Inc.
+ * Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -1,9 +1,8 @@
 #ifndef __LIBSSH2_OPENSSL_H
 #define __LIBSSH2_OPENSSL_H
-/* Copyright (C) 2009, 2010 Simon Josefsson
- * Copyright (C) 2006, 2007 The Written Word, Inc.  All rights reserved.
- *
- * Author: Simon Josefsson
+/* Copyright (C) Simon Josefsson
+ * Copyright (C) The Written Word, Inc.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2015-2016 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
- * Copyright (C) 2020-2023 Patrick Monnerat <patrick@monnerat.net>.
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat <patrick@monnerat.net>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -1,8 +1,8 @@
 #ifndef __LIBSSH2_OS400QC3_H
 #define __LIBSSH2_OS400QC3_H
 /*
- * Copyright (C) 2015-2016 Patrick Monnerat, D+H <patrick.monnerat@dh.com>
- * Copyright (C) 2020-2023 Patrick Monnerat <patrick@monnerat.net>.
+ * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
+ * Copyright (C) Patrick Monnerat <patrick@monnerat.net>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/packet.c
+++ b/src/packet.c
@@ -1,7 +1,7 @@
-/* Copyright (c) 2004-2007, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2005,2006 Mikhail Gusarov
- * Copyright (c) 2009-2014 by Daniel Stenberg
- * Copyright (c) 2010 Simon Josefsson
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Mikhail Gusarov
+ * Copyright (C) Daniel Stenberg
+ * Copyright (C) Simon Josefsson
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/packet.h
+++ b/src/packet.h
@@ -1,8 +1,8 @@
 #ifndef __LIBSSH2_PACKET_H
 #define __LIBSSH2_PACKET_H
 /*
- * Copyright (C) 2010 by Daniel Stenberg
- * Author: Daniel Stenberg <daniel@haxx.se>
+ * Copyright (C) Daniel Stenberg
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/pem.c
+++ b/src/pem.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2007 The Written Word, Inc.
- * Copyright (C) 2008, Simon Josefsson
+/* Copyright (C) The Written Word, Inc.
+ * Copyright (C) Simon Josefsson
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2004-2007, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2010-2014 by Daniel Stenberg
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/scp.c
+++ b/src/scp.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2009-2019 by Daniel Stenberg
- * Copyright (c) 2004-2008, Sara Golemon <sarag@libssh2.org>
+/* Copyright (C) Daniel Stenberg
+ * Copyright (C) Sara Golemon <sarag@libssh2.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/session.c
+++ b/src/session.c
@@ -1,6 +1,6 @@
-/* Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2009-2015 by Daniel Stenberg
- * Copyright (c) 2010 Simon Josefsson <simon@josefsson.org>
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg
+ * Copyright (C) Simon Josefsson <simon@josefsson.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/session.h
+++ b/src/session.h
@@ -1,8 +1,8 @@
 #ifndef __LIBSSH2_SESSION_H
 #define __LIBSSH2_SESSION_H
-/* Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2009-2010 by Daniel Stenberg
- * Copyright (c) 2010 Simon Josefsson <simon@josefsson.org>
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg
+ * Copyright (C) Simon Josefsson <simon@josefsson.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1,6 +1,6 @@
-/* Copyright (c) 2004-2008, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2007 Eli Fant <elifantu@mail.ru>
- * Copyright (c) 2009-2019 by Daniel Stenberg
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Eli Fant <elifantu@mail.ru>
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -1,8 +1,8 @@
 #ifndef __LIBSSH2_SFTP_H
 #define __LIBSSH2_SFTP_H
 /*
- * Copyright (C) 2010 - 2012 by Daniel Stenberg
- * Author: Daniel Stenberg <daniel@haxx.se>
+ * Copyright (C) Daniel Stenberg
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/transport.c
+++ b/src/transport.c
@@ -1,6 +1,6 @@
-/* Copyright (C) 2007 The Written Word, Inc.  All rights reserved.
- * Copyright (C) 2009-2010 by Daniel Stenberg
- * Author: Daniel Stenberg <daniel@haxx.se>
+/* Copyright (C) The Written Word, Inc.
+ * Copyright (C) Daniel Stenberg
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/transport.h
+++ b/src/transport.h
@@ -1,8 +1,8 @@
 #ifndef __LIBSSH2_TRANSPORT_H
 #define __LIBSSH2_TRANSPORT_H
-/* Copyright (C) 2007 The Written Word, Inc.  All rights reserved.
- * Copyright (C) 2009-2010 by Daniel Stenberg
- * Author: Daniel Stenberg <daniel@haxx.se>
+/* Copyright (C) The Written Word, Inc.
+ * Copyright (C) Daniel Stenberg
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1,6 +1,6 @@
-/* Copyright (c) 2004-2007, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2005 Mikhail Gusarov <dottedmag@dottedmag.net>
- * Copyright (c) 2009-2014 by Daniel Stenberg
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Mikhail Gusarov <dottedmag@dottedmag.net>
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/userauth.h
+++ b/src/userauth.h
@@ -1,7 +1,7 @@
 #ifndef __LIBSSH2_USERAUTH_H
 #define __LIBSSH2_USERAUTH_H
-/* Copyright (c) 2004-2007, Sara Golemon <sarag@libssh2.org>
- * Copyright (c) 2009-2010 by Daniel Stenberg
+/* Copyright (C) Sara Golemon <sarag@libssh2.org>
+ * Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/userauth_kbd_packet.c
+++ b/src/userauth_kbd_packet.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, Xaver Loppenstedt <xaver@loppenstedt.de>
+/* Copyright (C) Xaver Loppenstedt <xaver@loppenstedt.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/userauth_kbd_packet.h
+++ b/src/userauth_kbd_packet.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, Xaver Loppenstedt <xaver@loppenstedt.de>
+/* Copyright (C) Xaver Loppenstedt <xaver@loppenstedt.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/version.c
+++ b/src/version.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2009 Daniel Stenberg.  All rights reserved.
+/* Copyright (C) Daniel Stenberg
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted provided

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Marc Hoersken <info@marc-hoersken.de>
+ * Copyright (C) Marc Hoersken <info@marc-hoersken.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -1,7 +1,7 @@
 #ifndef __LIBSSH2_WINCNG_H
 #define __LIBSSH2_WINCNG_H
 /*
- * Copyright (C) 2013-2020 Marc Hoersken <info@marc-hoersken.de>
+ * Copyright (C) Marc Hoersken <info@marc-hoersken.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2014-2016 Alexander Lamaison <alexander.lamaison@gmail.com>
-# Copyright (c) 2023 Viktor Szakats
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Viktor Szakats
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/tests/gen_keys.sh
+++ b/tests/gen_keys.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) Viktor Szakats
+# Copyright (C) Viktor Szakats
 
 set -e
 set -u

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016 Alexander Lamaison
+/* Copyright (C) Alexander Lamaison
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/openssh_fixture.h
+++ b/tests/openssh_fixture.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016 Alexander Lamaison
+/* Copyright (C) Alexander Lamaison
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 #
 # Redistribution and use in source and binary forms,
 # with or without modification, are permitted provided

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016 Alexander Lamaison
+/* Copyright (C) Alexander Lamaison
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/runner.h
+++ b/tests/runner.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016 Alexander Lamaison
+/* Copyright (C) Alexander Lamaison
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016 Alexander Lamaison
+/* Copyright (C) Alexander Lamaison
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/session_fixture.h
+++ b/tests/session_fixture.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016 Alexander Lamaison
+/* Copyright (C) Alexander Lamaison
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/test_aa_warmup.c
+++ b/tests/test_aa_warmup.c
@@ -1,3 +1,5 @@
+/* Copyright (C) Viktor Szakats */
+
 /* Warm-up test. Always return success.
    Workaround for CI/docker/etc flakiness on the first run. */
 

--- a/tests/test_agent_forward_ok.c
+++ b/tests/test_agent_forward_ok.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 static const char *username = "libssh2"; /* set in Dockerfile */

--- a/tests/test_auth_keyboard_fail.c
+++ b/tests/test_auth_keyboard_fail.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_keyboard_info_request.c
+++ b/tests/test_auth_keyboard_info_request.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Xaver Loppenstedt
+/* Copyright (C) Xaver Loppenstedt
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/test_auth_keyboard_ok.c
+++ b/tests/test_auth_keyboard_ok.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_password_fail_password.c
+++ b/tests/test_auth_password_fail_password.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_password_fail_username.c
+++ b/tests/test_auth_password_fail_username.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_password_ok.c
+++ b/tests/test_auth_password_ok.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_fail.c
+++ b/tests/test_auth_pubkey_fail.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_dsa.c
+++ b/tests/test_auth_pubkey_ok_dsa.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_ecdsa.c
+++ b/tests/test_auth_pubkey_ok_ecdsa.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_ecdsa_signed.c
+++ b/tests/test_auth_pubkey_ok_ecdsa_signed.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_ed25519.c
+++ b/tests/test_auth_pubkey_ok_ed25519.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_ed25519_encrypted.c
+++ b/tests/test_auth_pubkey_ok_ed25519_encrypted.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_ed25519_mem.c
+++ b/tests/test_auth_pubkey_ok_ed25519_mem.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_rsa.c
+++ b/tests/test_auth_pubkey_ok_rsa.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_rsa_encrypted.c
+++ b/tests/test_auth_pubkey_ok_rsa_encrypted.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_rsa_openssh.c
+++ b/tests/test_auth_pubkey_ok_rsa_openssh.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_auth_pubkey_ok_rsa_signed.c
+++ b/tests/test_auth_pubkey_ok_rsa_signed.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_hostkey.c
+++ b/tests/test_hostkey.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 static const char *EXPECTED_RSA_HOSTKEY =

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 #include "runner.h"
 
 static const char *EXPECTED_RSA_HOSTKEY =

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -1,4 +1,7 @@
-/* libssh2 test receiving large amounts of data through a channel */
+/* Copyright (C) The libssh2 project and its contributors.
+ *
+ * libssh2 test receiving large amounts of data through a channel
+ */
 
 #include "runner.h"
 

--- a/tests/test_read_algos.test
+++ b/tests/test_read_algos.test
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) Viktor Szakats
+# Copyright (C) Viktor Szakats
 
 set -e
 set -u

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2007 The Written Word, Inc.
- * Copyright (C) 2008, 2010 Simon Josefsson
+/* Copyright (C) The Written Word, Inc.
+ * Copyright (C) Simon Josefsson
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms,

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -1,3 +1,5 @@
+/* Copyright (C) The libssh2 project and its contributors. */
+
 /* Self test, based on example/ssh2.c. */
 
 #include "libssh2_setup.h"


### PR DESCRIPTION
Also:
- uppercase `(C)`.
- add missing 'All rights reserved.' lines.
- drop duplicate 'Author' lines.
- add copyright headers where missing.
- enable copyright header check in checksrc.

Reasons for deleting years (copied as-is from curl):
- they are mostly pointless in all major jurisdictions
- many big corporations and projects already don't use them
- saves us from pointless churn
- git keeps history for us
- the year range is kept in COPYING

Closes #1082
