### PR TITLE
test_sshd.test: set a safe PID directory

### DIFF
--- a/tests/test_sshd.test
+++ b/tests/test_sshd.test
@@ -76,6 +76,7 @@ chmod go-rwx \
   -h "${d}/openssh_server/ssh_host_rsa_key" \
   -h "${d}/openssh_server/ssh_host_ecdsa_key" \
   -h "${d}/openssh_server/ssh_host_ed25519_key" \
+  -o "PidFile sshd.pid" \
   -o "AuthorizedKeysFile ${PUBKEY} ${d}/openssh_server/authorized_keys" \
   -o "TrustedUserCAKeys ${cakeys}" \
   -o 'PermitRootLogin yes' \

--- a/tests/test_sshd.test
+++ b/tests/test_sshd.test
@@ -76,7 +76,7 @@ chmod go-rwx \
   -h "${d}/openssh_server/ssh_host_rsa_key" \
   -h "${d}/openssh_server/ssh_host_ecdsa_key" \
   -h "${d}/openssh_server/ssh_host_ed25519_key" \
-  -o "PidFile sshd.pid" \
+  -o 'PidFile sshd.pid' \
   -o "AuthorizedKeysFile ${PUBKEY} ${d}/openssh_server/authorized_keys" \
   -o "TrustedUserCAKeys ${cakeys}" \
   -o 'PermitRootLogin yes' \


### PR DESCRIPTION
The compiled in default to sshd can be a non-writable location since it
expects to be run as root.