### PR TITLE
hostkey: do not advertise ssh-rsa when SHA1 is disabled

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1453,7 +1453,11 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 #if LIBSSH2_RSA_SHA2
     if(key_method_len == 7 &&
        memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
-        return "rsa-sha2-512,rsa-sha2-256,ssh-rsa";
+        return "rsa-sha2-512,rsa-sha2-256"
+#if LIBSSH2_RSA_SHA1
+            ",ssh-rsa"
+#endif
+            ;
     }
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4074,7 +4074,11 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 #if LIBSSH2_RSA_SHA2
     if(key_method_len == 7 &&
        memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
-        return "rsa-sha2-512,rsa-sha2-256,ssh-rsa";
+        return "rsa-sha2-512,rsa-sha2-256"
+#if LIBSSH2_RSA_SHA1
+            ",ssh-rsa"
+#endif
+            ;
     }
 #endif
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2431,7 +2431,11 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 
     if(key_method_len == 7 &&
        memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
-        return "rsa-sha2-512,rsa-sha2-256,ssh-rsa";
+        return "rsa-sha2-512,rsa-sha2-256"
+#if LIBSSH2_RSA_SHA1
+            ",ssh-rsa"
+#endif
+            ;
     }
 
     return NULL;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2731,7 +2731,11 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
 #if LIBSSH2_RSA_SHA2
     if(key_method_len == 7 &&
         memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
-        return "rsa-sha2-512,rsa-sha2-256,ssh-rsa";
+        return "rsa-sha2-512,rsa-sha2-256"
+#if LIBSSH2_RSA_SHA1
+            ",ssh-rsa"
+#endif
+            ;
     }
 #else
     (void)key_method;


### PR DESCRIPTION
Before this patch OpenSSL and mbedTLS advertised both SHA2 and SHA1 host key algos, even when SHA1 was not supported by the crypto backend or forcefully disabled via `LIBSSH2_NO_RSA_SHA1`.

Reported-by: João M. S. Silva
Fixes #1092
Closes #1093