### PR TITLE
mbedtls: include `version.h` for `MBEDTLS_VERSION_NUMBER`

### DIFF
--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -41,6 +41,7 @@
 
 #define LIBSSH2_CRYPTO_ENGINE libssh2_mbedtls
 
+#include <mbedtls/version.h>
 #include <mbedtls/platform.h>
 #include <mbedtls/md.h>
 #include <mbedtls/rsa.h>


### PR DESCRIPTION
Older (2021 or earlier?) mbedTLS releases require this.

Reported-by: rahmanih on Github
Fixes #1094
Closes #1095