### PR TITLE
Transport: Fix incorrect byte offset in debug message

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -1059,7 +1059,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
                 }
             _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
                            "crypting bytes %d-%d", i,
-                           i + session->local.crypt->blocksize - 1));
+                           i + bsize - 1));
             if(session->local.crypt->crypt(session, ptr,
                                            bsize,
                                            &session->local.crypt_abstract,


### PR DESCRIPTION
The debug message for encrypting data is incorrect if the data is not a multiple of the blocksize. For example, when the blocksize is 16 and the data to be encrypted is 36 bytes long, the following debug messages are produced:

> [libssh2] 0.438857 Socket: crypting bytes 0-15
> [libssh2] 0.438857 Socket: crypting bytes 16-31
> [libssh2] 0.438857 Socket: crypting bytes 32-47

The final iteration of the encryption loop would only be encrypting bytes 33 through 36, (offsets 32-35), so the correct message would be:

> [libssh2] 2.801589 Socket: crypting bytes 32-35

This pull request updates the log message to use the computed length of the data chunk being encrypted, rather than the fixed block size.