### PR TITLE
example: fix regression in `ssh2_exec.c`

### DIFF
--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -260,7 +260,7 @@ int main(int argc, char *argv[])
 
         /* this is due to blocking that would occur otherwise so we loop on
            this condition */
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(nread == LIBSSH2_ERROR_EAGAIN) {
             waitsocket(sock, session);
         }
         else


### PR DESCRIPTION
Regression from b13936bd6a89993cd3bf4a18317ca5bd84bb08d7 #861 #846.
Update a variable name missed above.

Reported-by: PewPewPew
Fixes #1105
Closes #1106