### PR TITLE
Add NULL pointer check for outlen before use

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -901,7 +901,8 @@ int _libssh2_copy_string(LIBSSH2_SESSION *session, struct string_buf *buf,
         }
     }
     else {
-        *outlen = 0;
+        if(outlen)
+            *outlen = 0;
         *outbuf = NULL;
     }
 


### PR DESCRIPTION
Before assigning a value to the outlen, we need to check whether it is NULL.
Fixes https://github.com/libssh2/libssh2/issues/1108