### PR TITLE
Don't put `@LIBS@` in pc file

### DIFF
--- a/libssh2.pc.in
+++ b/libssh2.pc.in
@@ -15,6 +15,6 @@ URL: https://www.libssh2.org/
 Description: Library for SSH-based communication
 Version: @LIBSSH2VER@
 Requires.private: @LIBSREQUIRED@
-Libs: -L${libdir} -lssh2 @LIBS@
+Libs: -L${libdir} -lssh2
 Libs.private: @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Not an autotools expert, but `LIBS` contains `libssh2`'s own dependencies, so when doing shared linking, it makes no sense to put them under `Libs: ...` in the pkg-config file. `Libs.private` is what you want to use for that, since during static linking you do have to provide transitive deps.

What's not fixed in this PR: adding the `-L` search dirs when doing static linking. Apparently when openssl has its libraries in `<prefix>/lib64`, no `-L<prefix>/lib64` is added. But when it's in `<prefix>/lib`, it is? I guess this is a matter of custom logic in libssh2's autotools stuff, where `LIBS = -L... -lssl` is used for the `lib` check (custom?), while `LDFLAGS = -L...` and `LIBS = -lssl` is used for the `lib64` check (autotools internals?)