### PR TITLE
openssl: fix missing check for `LIBRESSL_VERSION_NUMBER` before use

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -99,7 +99,8 @@
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(LIBRESSL_VERSION_NUMBER)) || defined(LIBSSH2_WOLFSSL) || \
-    LIBRESSL_VERSION_NUMBER >= 0x3050000fL
+    (defined(LIBRESSL_VERSION_NUMBER) && \
+    LIBRESSL_VERSION_NUMBER >= 0x3050000fL)
 /* For wolfSSL, whether the structs are truly opaque or not, it's best to not
  * rely on their internal data members being exposed publicly. */
 # define HAVE_OPAQUE_STRUCTS 1


### PR DESCRIPTION
Fixes:
```
openssl.h:101:5: warning: "LIBRESSL_VERSION_NUMBER" is not defined [-Wundef]
     LIBRESSL_VERSION_NUMBER >= 0x3050000fL
     ^
```

Ref: https://github.com/libssh2/libssh2/issues/1115#issuecomment-1631845640
Closes #1117
