### PR TITLE
cmake: CMAKE_SOURCE_DIR -> PROJECT_SOURCE_DIR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,7 +174,7 @@ export(TARGETS ${libssh2_export} NAMESPACE libssh2:: FILE libssh2-targets.cmake)
 export(PACKAGE libssh2)  # register it
 
 # Generate libssh2-config.cmake into build tree and install it
-configure_file(${CMAKE_SOURCE_DIR}/cmake/libssh2-config.cmake.in libssh2-config.cmake @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/libssh2-config.cmake.in libssh2-config.cmake @ONLY)
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/libssh2-config.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libssh2)
@@ -193,7 +193,7 @@ set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "\${prefix}")
 set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
 set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-configure_file(${CMAKE_SOURCE_DIR}/libssh2.pc.in libssh2.pc @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/libssh2.pc.in libssh2.pc @ONLY)
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/libssh2.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,9 +154,9 @@ if(RUN_DOCKER_TESTS)
 endif()
 
 add_custom_target(coverage
-  COMMAND gcovr -r "${CMAKE_SOURCE_DIR}" --exclude tests/*
+  COMMAND gcovr -r "${PROJECT_SOURCE_DIR}" --exclude tests/*
   COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/coverage/"
-  COMMAND gcovr -r "${CMAKE_SOURCE_DIR}" --exclude tests/* --html-details --output "${CMAKE_CURRENT_BINARY_DIR}/coverage/index.html")
+  COMMAND gcovr -r "${PROJECT_SOURCE_DIR}" --exclude tests/* --html-details --output "${CMAKE_CURRENT_BINARY_DIR}/coverage/index.html")
 
 add_custom_target(clean-coverage
   COMMAND rm -rf "${CMAKE_CURRENT_BINARY_DIR}/coverage/")


### PR DESCRIPTION
Fixes compiling as dependency with FetchContent