### PR TITLE
cmake: tidy-ups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+cmake_minimum_required(VERSION 3.1)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
+
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckIncludeFiles)
@@ -43,13 +47,8 @@ include(CheckSymbolExists)
 include(CMakePushCheckState)
 include(FeatureSummary)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 include(CheckFunctionExistsMayNeedLibrary)
 include(CheckNonblockingSocketSupport)
-
-cmake_minimum_required(VERSION 3.1)
-
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 project(libssh2 C)
 
@@ -65,7 +64,7 @@ add_feature_info("Shared library" BUILD_SHARED_LIBS
 
 # Parse version
 
-file(READ ${CMAKE_CURRENT_SOURCE_DIR}/include/libssh2.h _HEADER_CONTENTS)
+file(READ ${PROJECT_SOURCE_DIR}/include/libssh2.h _HEADER_CONTENTS)
 string(
   REGEX REPLACE ".*#define LIBSSH2_VERSION[ \t]+\"([^\"]+)\".*" "\\1"
   LIBSSH2_VERSION "${_HEADER_CONTENTS}")
@@ -86,7 +85,7 @@ if(NOT LIBSSH2_VERSION OR
   message(
     FATAL_ERROR
     "Unable to parse version from"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/libssh2.h")
+    "${PROJECT_SOURCE_DIR}/include/libssh2.h")
 endif()
 
 include(GNUInstallDirs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -181,6 +181,7 @@ install(
 
 ## Export a .pc file for client projects not using CMaek
 if(PC_REQUIRES_PRIVATE)
+  list(REMOVE_DUPLICATES PC_REQUIRES_PRIVATE)
   string(REPLACE ";" "," PC_REQUIRES_PRIVATE "${PC_REQUIRES_PRIVATE}")
 endif()
 if(PC_LIBS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,9 +50,9 @@ list(APPEND STANDALONE_TESTS ${STANDALONE_TESTS_STATIC})
 if(CMAKE_COMPILER_IS_GNUCC)
   find_program(GCOV_PATH gcov)
   if(GCOV_PATH)
-    set(GCOV_OPTIONS -g --coverage)
+    set(GCOV_CFLAGS -g --coverage)
     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
-      set(GCOV_OPTIONS "${GCOV_OPTIONS} -fprofile-abs-path")
+      set(GCOV_CFLAGS "${GCOV_CFLAGS} -fprofile-abs-path")
     endif()
   endif()
 endif()
@@ -94,7 +94,7 @@ foreach(test ${DOCKER_TESTS} ${STANDALONE_TESTS} ${SSHD_TESTS})
 
     # build a single test with gcov
     if(GCOV_PATH AND test STREQUAL test_auth_keyboard_info_request AND TARGET ${LIB_STATIC})
-      target_compile_options(${test} BEFORE PRIVATE ${GCOV_OPTIONS})
+      target_compile_options(${test} BEFORE PRIVATE ${GCOV_CFLAGS})
       target_link_libraries(${test} runner ${LIB_FOR_TESTS} ${LIBRARIES} gcov)
     else()
       target_link_libraries(${test} runner ${LIB_FOR_TESTS} ${LIBRARIES})
@@ -154,9 +154,9 @@ if(RUN_DOCKER_TESTS)
 endif()
 
 add_custom_target(coverage
-  COMMAND gcovr -r "${CMAKE_SOURCE_DIR}" --exclude tests/*
+  COMMAND gcovr --root "${CMAKE_SOURCE_DIR}" --exclude tests/*
   COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/coverage/"
-  COMMAND gcovr -r "${CMAKE_SOURCE_DIR}" --exclude tests/* --html-details --output "${CMAKE_CURRENT_BINARY_DIR}/coverage/index.html")
+  COMMAND gcovr --root "${CMAKE_SOURCE_DIR}" --exclude tests/* --html-details --output "${CMAKE_CURRENT_BINARY_DIR}/coverage/index.html")
 
 add_custom_target(clean-coverage
   COMMAND rm -rf "${CMAKE_CURRENT_BINARY_DIR}/coverage/")


### PR DESCRIPTION
- dedupe `Requires.private` in `libssh2.pc`.
  `zlib` could appear on the list twice:
  ```
  Requires.private: libssl,libcrypto,zlib,zlib
  ```
  According to CMake docs `list(REMOVE_DUPLICATES ...)`, is supported by our minimum required CMake version (and by   earlier ones even): https://cmake.org/cmake/help/v3.1/command/list.html#remove-duplicates

- move `cmake_minimum_required()` to the top.

- move `set(CMAKE_MODULE_PATH)` to the top.

- delete duplicate `set(CMAKE_MODULE_PATH)`.

- replace `CMAKE_CURRENT_SOURCE_DIR` with
  `PROJECT_SOURCE_DIR` in root `CMakeLists.txt`
   for robustness.

- replace `gcovr` option with long-form for readability/consistency.

- rename `GCOV_OPTIONS` to `GCOV_CFLAGS`.

Closes #1122
