### PR TITLE
autotools: use comma separator in `Requires.private` of `libssh2.pc`

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -778,7 +778,7 @@ m4_case([$1],
 [openssl], [
   LIBSSH2_LIB_HAVE_LINKFLAGS([ssl], [crypto], [#include <openssl/ssl.h>], [
     AC_DEFINE(LIBSSH2_OPENSSL, 1, [Use $1])
-    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }libssl libcrypto"
+    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+,}libssl,libcrypto"
     found_crypto="$1"
     found_crypto_str="OpenSSL"
   ])
@@ -792,7 +792,7 @@ m4_case([$1],
   fi
   LIBSSH2_LIB_HAVE_LINKFLAGS([wolfssl], [], [#include <wolfssl/options.h>], [
     AC_DEFINE(LIBSSH2_WOLFSSL, 1, [Use $1])
-    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }wolfssl"
+    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+,}wolfssl"
     found_crypto="$1"
   ])
 ],
@@ -800,7 +800,7 @@ m4_case([$1],
 [libgcrypt], [
   LIBSSH2_LIB_HAVE_LINKFLAGS([gcrypt], [], [#include <gcrypt.h>], [
     AC_DEFINE(LIBSSH2_LIBGCRYPT, 1, [Use $1])
-    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }libgcrypt"
+    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+,}libgcrypt"
     found_crypto="$1"
   ])
 ],

--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ Try --with-libz-prefix=PATH if you know that you have it."
     fi
   else
     AC_DEFINE(LIBSSH2_HAVE_ZLIB, 1, [Compile in zlib support])
-    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }zlib"
+    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+,}zlib"
     found_libz="yes"
   fi
 fi


### PR DESCRIPTION
In `Requires*:`, the documented name separator is comma. We already used
it in the CMake-generated `libssh2.pc`. Adjust the autotools-generated
one to use it too, instead of spaces.

Ref: https://linux.die.net/man/1/pkg-config
Ref: https://gitlab.freedesktop.org/pkg-config/pkg-config/-/blob/d97db4fae4c1cd099b506970b285dc2afd818ea2/pkg-config.1

Closes #1124