### PR TITLE
cmake: bump minimum CMake version to v3.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.7)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 


### PR DESCRIPTION
Fixes the warning below, which appeared in CMake v3.27.0:
```
CMake Deprecation Warning at CMakeLists.txt:39 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Bump straight up to v3.7.0 to sync up with the curl project: https://github.com/curl/curl/blob/2900c29218d2d24ab519853589da84caa850e8c7/CMakeLists.txt#L64

CMake release dates:
v3.7.0 2016-11-11
v3.5.0 2016-03-08
v3.1.0 2014-12-17

Closes #1126