### PR TITLE
Fix private keys encrypted with aes-gcm methods

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -624,6 +624,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 			if (!_libssh2_check_length(&decoded, 16)) {
 				ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
 									 "GCM auth tag missing");
+				method->dtor(session, &abstract);
 				goto out;
 			}
 			if(method->crypt(session, decoded.dataptr, 16, &abstract, LAST_BLOCK)) {

--- a/src/pem.c
+++ b/src/pem.c
@@ -628,7 +628,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 			}
 			if(method->crypt(session, decoded.dataptr, 16, &abstract, LAST_BLOCK)) {
 				ret = _libssh2_error(session, LIBSSH2_ERROR_DECRYPT,
-									 "GCM auth tag invalid");;
+									 "GCM auth tag invalid");
 				method->dtor(session, &abstract);
 				goto out;
 			}

--- a/src/pem.c
+++ b/src/pem.c
@@ -623,19 +623,19 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 
         /* for the AES GCM methods, the 16 byte authentication tag is
          * appended to the encrypted key */
-        if (strcmp(method->name, "aes256-gcm@openssh.com") == 0 ||
+        if(strcmp(method->name, "aes256-gcm@openssh.com") == 0 ||
         strcmp(method->name, "aes128-gcm@openssh.com") == 0) {
-            if (!_libssh2_check_length(&decoded, 16)) {
+            if(!_libssh2_check_length(&decoded, 16)) {
                 ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
-                "GCM auth tag missing");
+                                     "GCM auth tag missing");
                 method->dtor(session, &abstract);
                 goto out;
             }
-            if(method->crypt(session, decoded.dataptr, 16, &abstract, 
+            if(method->crypt(session, decoded.dataptr, 16, &abstract,
                              LAST_BLOCK
                              )) {
                 ret = _libssh2_error(session, LIBSSH2_ERROR_DECRYPT,
-                "GCM auth tag invalid");
+                                     "GCM auth tag invalid");
                 method->dtor(session, &abstract);
                 goto out;
             }

--- a/src/pem.c
+++ b/src/pem.c
@@ -599,12 +599,14 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         }
 
         while((size_t)len_decrypted <= decrypted.len - blocksize) {
+			/* We always pass MIDDLE_BLOCK here because OpenSSH Key Files do not use AAD to MAC the length (so no special FIRST_BLOCK handling)
+			 * Furthermore, the authentication tag is appended after the encrypted key, and the length of the authentication tag is not included in the key length
+			 * So we need to check it afterwards
+			 */
             if(method->crypt(session, decrypted.data + len_decrypted,
                              blocksize,
                              &abstract,
-                             len_decrypted == 0 ? FIRST_BLOCK : (
-                         ((size_t)len_decrypted == decrypted.len - blocksize) ?
-                               LAST_BLOCK : MIDDLE_BLOCK)
+							 MIDDLE_BLOCK
                              )) {
                 ret = LIBSSH2_ERROR_DECRYPT;
                 method->dtor(session, &abstract);
@@ -615,6 +617,23 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         }
 
         /* No padding */
+
+		/* for the AES GCM methods, the 16 byte authentication tag is appended to the encrypted key */
+		if (strcmp(method->name, "aes256-gcm@openssh.com") == 0 ||
+			strcmp(method->name, "aes128-gcm@openssh.com") == 0) {
+			if (!_libssh2_check_length(&decoded, 16)) {
+				ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+									 "GCM auth tag missing");
+				goto out;
+			}
+			if(method->crypt(session, decoded.dataptr, 16, &abstract, LAST_BLOCK)) {
+				ret = _libssh2_error(session, LIBSSH2_ERROR_DECRYPT,
+									 "GCM auth tag invalid");;
+				method->dtor(session, &abstract);
+				goto out;
+			}
+			decoded.dataptr += 16;
+		}
 
         method->dtor(session, &abstract);
     }

--- a/src/pem.c
+++ b/src/pem.c
@@ -599,14 +599,17 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         }
 
         while((size_t)len_decrypted <= decrypted.len - blocksize) {
-			/* We always pass MIDDLE_BLOCK here because OpenSSH Key Files do not use AAD to MAC the length (so no special FIRST_BLOCK handling)
-			 * Furthermore, the authentication tag is appended after the encrypted key, and the length of the authentication tag is not included in the key length
-			 * So we need to check it afterwards
-			 */
+            /* We always pass MIDDLE_BLOCK here because OpenSSH Key Files
+             * do not use AAD to authenticate the length.
+             * Furthermore, the authentication tag is appended after the
+             * encrypted key, and the length of the authentication tag is
+             * not included in the key length, so we check it after the
+             * loop.
+             */
             if(method->crypt(session, decrypted.data + len_decrypted,
                              blocksize,
                              &abstract,
-							 MIDDLE_BLOCK
+                             MIDDLE_BLOCK
                              )) {
                 ret = LIBSSH2_ERROR_DECRYPT;
                 method->dtor(session, &abstract);
@@ -618,23 +621,26 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
 
         /* No padding */
 
-		/* for the AES GCM methods, the 16 byte authentication tag is appended to the encrypted key */
-		if (strcmp(method->name, "aes256-gcm@openssh.com") == 0 ||
-			strcmp(method->name, "aes128-gcm@openssh.com") == 0) {
-			if (!_libssh2_check_length(&decoded, 16)) {
-				ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
-									 "GCM auth tag missing");
-				method->dtor(session, &abstract);
-				goto out;
-			}
-			if(method->crypt(session, decoded.dataptr, 16, &abstract, LAST_BLOCK)) {
-				ret = _libssh2_error(session, LIBSSH2_ERROR_DECRYPT,
-									 "GCM auth tag invalid");
-				method->dtor(session, &abstract);
-				goto out;
-			}
-			decoded.dataptr += 16;
-		}
+        /* for the AES GCM methods, the 16 byte authentication tag is
+         * appended to the encrypted key */
+        if (strcmp(method->name, "aes256-gcm@openssh.com") == 0 ||
+        strcmp(method->name, "aes128-gcm@openssh.com") == 0) {
+            if (!_libssh2_check_length(&decoded, 16)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                "GCM auth tag missing");
+                method->dtor(session, &abstract);
+                goto out;
+            }
+            if(method->crypt(session, decoded.dataptr, 16, &abstract, 
+                             LAST_BLOCK
+                             )) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_DECRYPT,
+                "GCM auth tag invalid");
+                method->dtor(session, &abstract);
+                goto out;
+            }
+            decoded.dataptr += 16;
+        }
 
         method->dtor(session, &abstract);
     }

--- a/src/pem.c
+++ b/src/pem.c
@@ -624,7 +624,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         /* for the AES GCM methods, the 16 byte authentication tag is
          * appended to the encrypted key */
         if(strcmp(method->name, "aes256-gcm@openssh.com") == 0 ||
-        strcmp(method->name, "aes128-gcm@openssh.com") == 0) {
+           strcmp(method->name, "aes128-gcm@openssh.com") == 0) {
             if(!_libssh2_check_length(&decoded, 16)) {
                 ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                      "GCM auth tag missing");
@@ -632,8 +632,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
                 goto out;
             }
             if(method->crypt(session, decoded.dataptr, 16, &abstract,
-                             LAST_BLOCK
-                             )) {
+                             LAST_BLOCK)) {
                 ret = _libssh2_error(session, LIBSSH2_ERROR_DECRYPT,
                                      "GCM auth tag invalid");
                 method->dtor(session, &abstract);

--- a/src/pem.c
+++ b/src/pem.c
@@ -609,8 +609,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
             if(method->crypt(session, decrypted.data + len_decrypted,
                              blocksize,
                              &abstract,
-                             MIDDLE_BLOCK
-                             )) {
+                             MIDDLE_BLOCK)) {
                 ret = LIBSSH2_ERROR_DECRYPT;
                 method->dtor(session, &abstract);
                 goto out;


### PR DESCRIPTION
libssh2 1.11.0 fails to decrypt private keys encrypted with aes128-gcm@openssh.com and aes256-gcm@openssh.com ciphers.

To reproduce the issue, you can create a test key with a command like the following:

```bash
ssh-keygen -Z aes256-gcm@openssh.com -f id_aes256-gcm
```

If you attempt to use this key for authentication, libssh2 will return the not-so-helpful error message "Wrong passphrase or invalid/unrecognized private key file format".

The problem is that OpenSSH encrypts keys differently than packets. It does not include the length as AAD, and the 16 byte authentication tag is appended after the encrypted key. The length of the authentication tag is not included in the encrypted key length.

I have not found any documentation for this behaviour -- I discovered it by looking at the OpenSSH source. See the `private2_decrypt` function in [sshkey.c](https://github.com/openssh/openssh-portable/blob/master/sshkey.c).

This PR fixes the code for reading OpenSSH private keys encrypted with AES-GCM methods.