### PR TITLE
sftp: Set correct write offset in append mode

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1352,8 +1352,8 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
         fp->u.file.offset_sent = 0;
 
         if(mode & LIBSSH2_FXF_APPEND) {
-            int ret = sftp_stat(fp->sftp, filename, (uint32_t)filename_len,
-                                    LIBSSH2_SFTP_STAT, &attrs);
+            int ret = sftp_stat(fp->sftp, filename, (unsigned int)filename_len,
+                                LIBSSH2_SFTP_STAT, &attrs);
 
             if(ret) {
                 LIBSSH2_FREE(session, fp);

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -99,6 +99,7 @@ struct _LIBSSH2_SFTP_HANDLE
         struct _libssh2_sftp_handle_file_data
         {
             libssh2_uint64_t offset;
+            libssh2_uint64_t offset_remote;
             libssh2_uint64_t offset_sent;
             size_t acked; /* container for acked data that hasn't been
                              returned to caller yet, used for sftp_write */


### PR DESCRIPTION
Currently the file offset starts with zero in all modes. In append mode, this causes SSH_FXP_WRITE commands with wrong offsets.

When appending N bytes to a X bytes long file on the remote side SSH_FXP_WRITE will have an offset parameter of N instead of N+X.

If the remote SFTP server is OpenSSH based, this is no problem since OpenSSH's SFTP server applies the offset only if SSH_FXF_APPEND was not present at open time.
It is also no problem if the remote operating system follows POSIX O_APPEND semantics (ignoring lseek()).

But there are others.
I've been facing problem with Core FTP Server on Microsoft Windows, this server seems to apply the offset blindly.
SFTP append using libssh worked, but not with libssh2.

So, let's stay on the safe side and do it like libssh, learn the remote file length at open time and apply the remote length always to the offset.

That way a SFTP implementation can correctly implement append mode by just looking at the offsets without relying on O_APPEND semantics.