### PR TITLE
revert: build: respect autotools `DLL_EXPORT` in `libssh2.h`

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -107,7 +107,7 @@ extern "C" {
 /* Allow alternate API prefix from CFLAGS or calling app */
 #ifndef LIBSSH2_API
 # ifdef LIBSSH2_WIN32
-#  if defined(LIBSSH2_EXPORTS) || defined(DLL_EXPORT) || defined(_WINDLL)
+#  if defined(LIBSSH2_EXPORTS) || defined(_WINDLL)
 #   ifdef LIBSSH2_LIBRARY
 #    define LIBSSH2_API __declspec(dllexport)
 #   else


### PR DESCRIPTION
Revert fb1195cf88268a11e2709b9912ab9dca8c23739c #917

On a second look this change did not improve anything with autotools
builds. autotools seems to handle the dll export matter without it.

This patch also broke (e.g.) curl-for-win autotools builds, where the
curl build defines `DLL_EXPORT` while building libcurl DLL. `libssh2.h`
picks it up, resulting in unresolved symbols while trying to link a
static libssh2 on Windows. The best fix seems to be to revert this,
instead of adding extra tweaks to dependents.

Fixes:
https://ci.appveyor.com/project/curlorg/curl-for-win/builds/47667412#L11035
```
ld.lld-15: error: undefined symbol: __declspec(dllimport) libssh2_session_block_directions
>>> referenced by vssh/.libs/libcurl_la-libssh2.o:(ssh_do)
>>> referenced by vssh/.libs/libcurl_la-libssh2.o:(ssh_connect)
>>> referenced by vssh/.libs/libcurl_la-libssh2.o:(ssh_multi_statemach)
>>> referenced 8 more times

ld.lld-15: error: undefined symbol: __declspec(dllimport) libssh2_session_init_ex
>>> referenced by vssh/.libs/libcurl_la-libssh2.o:(ssh_connect)

ld.lld-15: error: undefined symbol: __declspec(dllimport) libssh2_session_set_read_timeout
[...]
```

Closes #1141