### PR TITLE
openssl: use automatic initialization with LibreSSL 2.7.0+

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -619,18 +619,15 @@ void _libssh2_openssl_crypto_init(void)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(LIBRESSL_VERSION_NUMBER)
-#ifndef OPENSSL_NO_ENGINE
-    ENGINE_load_builtin_engines();
-    ENGINE_register_all_complete();
-#endif
 #else
     OpenSSL_add_all_algorithms();
     OpenSSL_add_all_ciphers();
     OpenSSL_add_all_digests();
+#endif
+
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_load_builtin_engines();
     ENGINE_register_all_complete();
-#endif
 #endif
 }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -618,7 +618,7 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
 void _libssh2_openssl_crypto_init(void)
 {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || \
-    defined(LIBRESSL_VERSION_NUMBER)
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
     OpenSSL_add_all_algorithms();
     OpenSSL_add_all_ciphers();
     OpenSSL_add_all_digests();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -617,9 +617,8 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
 
 void _libssh2_openssl_crypto_init(void)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-    !defined(LIBRESSL_VERSION_NUMBER)
-#else
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    defined(LIBRESSL_VERSION_NUMBER)
     OpenSSL_add_all_algorithms();
     OpenSSL_add_all_ciphers();
     OpenSSL_add_all_digests();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -622,11 +622,10 @@ void _libssh2_openssl_crypto_init(void)
     OpenSSL_add_all_algorithms();
     OpenSSL_add_all_ciphers();
     OpenSSL_add_all_digests();
-#endif
-
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_load_builtin_engines();
     ENGINE_register_all_complete();
+#endif
 #endif
 }
 


### PR DESCRIPTION
Stop calling `OpenSSL_add_all_*()` for LibreSSL 2.7.0 and later.

LibreSSL 2.7.0 (2018-03-21) introduced automatic initialization and
deprecated these functions. Stop calling these functions manually for
LibreSSL version that no longer need them.

Ref: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.7.0-relnotes.txt
Ref: https://github.com/libressl/openbsd/commit/46f29f11977800547519ee65e2d1850f2483720b
Ref: https://github.com/libssh2/libssh2/issues/302

Also stop calling `ENGINE_*()` functions when initialization is
automatic with LibreSSL 2.7.0+ and OpenSSL 1.1.0+. Engines are also
initializated automatically with these.

Closes #1146
