### PR TITLE
ClearMemory: do not call SecureZeroMemory on UWP

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -45,7 +45,8 @@
                                               (void)(size); \
                                           } while(0)
 #else
-#ifdef WIN32
+/* SecureZeroMemory is not supported on UWP */
+#ifdef WIN32 && !defined(LIBSSH2_WINDOWS_UWP)
 #define _libssh2_explicit_zero(buf, size) SecureZeroMemory(buf, size)
 #elif defined(HAVE_EXPLICIT_BZERO)
 #define _libssh2_explicit_zero(buf, size) explicit_bzero(buf, size)


### PR DESCRIPTION
SecureZeroMemory is not supported on UWP, and there is no replacement. See:

https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/aa366877(v=vs.85)