### PR TITLE
cmake: fix `STREQUAL` check in error branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,8 +240,8 @@ if(MSVC AND ENABLE_WERROR)
   cmake_pop_check_state()
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR
-   ${CMAKE_SYSTEM_NAME} STREQUAL "Interix")
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
+   CMAKE_SYSTEM_NAME STREQUAL "Interix")
   # poll() does not work on these platforms
   #
   # Interix: "does provide poll(), but the implementing developer must
@@ -293,7 +293,7 @@ WinCNG, mbedTLS, or empty to try any available")
 # we are able to find, the find_package commands must abort configuration
 # and report to the user.
 if(CRYPTO_BACKEND)
-  set(SPECIFIC_CRYPTO_REQUIREMENT REQUIRED)
+  set(SPECIFIC_CRYPTO_REQUIREMENT "REQUIRED")
 endif()
 
 if(CRYPTO_BACKEND STREQUAL "OpenSSL" OR NOT CRYPTO_BACKEND)
@@ -407,7 +407,7 @@ if(CRYPTO_BACKEND STREQUAL "WinCNG" OR NOT CRYPTO_BACKEND)
 
     list(APPEND LIBRARIES crypt32 bcrypt)
     list(APPEND LIBSSH2_PC_LIBS_PRIVATE -lcrypt32 -lbcrypt)
-  elseif(${SPECIFIC_CRYPTO_REQUIREMENT} STREQUAL ${REQUIRED})
+  elseif(SPECIFIC_CRYPTO_REQUIREMENT STREQUAL "REQUIRED")
     message(FATAL_ERROR "WinCNG not available")
   endif()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,7 +93,7 @@ foreach(test ${DOCKER_TESTS} ${STANDALONE_TESTS} ${SSHD_TESTS})
     set_target_properties(${test} PROPERTIES UNITY_BUILD FALSE)
 
     # build a single test with gcov
-    if(GCOV_PATH AND test STREQUAL test_auth_keyboard_info_request AND TARGET ${LIB_STATIC})
+    if(GCOV_PATH AND test STREQUAL "test_auth_keyboard_info_request" AND TARGET ${LIB_STATIC})
       target_compile_options(${test} BEFORE PRIVATE ${GCOV_CFLAGS})
       target_link_libraries(${test} runner ${LIB_FOR_TESTS} ${LIBRARIES} gcov)
     else()


### PR DESCRIPTION
This caused a CMake error instead of our custom error when manually selecting the `WinCNG` crypto-backend for a non-Windows target.

Also cleanup `STREQUAL` checks to use variable name without `${}` on the left side and quoted string literals on the right.

Closes #1151