### PR TITLE
src: drop a redundant `#include`

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -40,7 +40,6 @@
  */
 
 #include "libssh2_priv.h"
-#include "misc.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>


### PR DESCRIPTION
We include `misc.h` via `libssh2_priv.h` already.

Closes #1153