### PR TITLE
[WIP] cmake: fix libssh2 lib export alias

### DIFF
--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -3,8 +3,5 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/libssh2-targets.cmake")
 
-# Alias for either shared or static library
-add_library(@PROJECT_NAME@::libssh2 ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
-
 # Compatibility alias
 add_library(Libssh2::libssh2 ALIAS @PROJECT_NAME@::@LIB_SELECTED@)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 # export libcurl alias as target name
-set_property(TARGET ${LIB_SELECTED} PROPERTY EXPORT_NAME libssh2)
+set_property(TARGET ${LIB_SELECTED} PROPERTY EXPORT_NAME "libssh2")
 
 ## Installation
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,9 @@ if(BUILD_SHARED_LIBS)
       $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
 endif()
 
+# export libcurl alias as target name
+set_property(TARGET ${LIB_SELECTED} PROPERTY EXPORT_NAME libssh2)
+
 ## Installation
 
 install(FILES


### PR DESCRIPTION
Fixes:
```
[build] CMake Error at ***/cmake/libssh2/libssh2-config.cmake:7 (add library):
[build]   add library cannot create ALIAS target "libssh2::libssh2" because target
[build]   "libssh2::libssh2_static" is imported but not globally visible.
```

Reported-by: bilal614 on Github
Suggested-by: balikalina on Github
Ref: https://github.com/curl/curl/pull/11629#issuecomment-1671596059
Ref: https://github.com/curl/curl/pull/11646
Fixes: #1150
Closes #1154
