### PR TITLE
ci: add mingw-w64 UWP build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           - { build: 'autotools', sys: clang64, env: clang-x86_64 }
           - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64 }
           - { build: 'cmake'    , sys: clang64, env: clang-x86_64 }
-          - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
+          - { build: 'cmake'    , sys: mingw64, env: x86_64, api: uwp }
           - { build: 'make'     , sys: mingw64, env: x86_64 }
       fail-fast: false
     steps:
@@ -203,7 +203,7 @@ jobs:
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
-          if [[ '${{ matrix.mode }}' = 'uwp' ]]; then
+          if [[ '${{ matrix.api }}' = 'uwp' ]]; then
             options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
@@ -232,7 +232,7 @@ jobs:
         run: cmake --build bld --parallel 3
       - name: 'cmake tests'
         # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
-        if: ${{ matrix.build == 'cmake' && matrix.mode != 'uwp' }}
+        if: ${{ matrix.build == 'cmake' && matrix.api != 'uwp' }}
         timeout-minutes: 10
         shell: msys2 {0}
         run: cd bld && ctest -VV --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
-            options='-DCMAKE_C_COMPILER=gcc -DCMAKE_RC_COMPILER=rc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
+            options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
-            rc_flags='--target=pe-x86-64'
+            rc_flags='-O coff'
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
             options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
-            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat -lruntimeobject/' -e 's/-lmsvcrt/-lvcruntime140_app/' > "${specs}"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE -D__MSVCRT_VERSION__=0xE00"
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,14 @@ jobs:
     strategy:
       matrix:
         include:
+          - { build: 'autotools', sys: mingw64, env: x86_64 }
+          - { build: 'autotools', sys: mingw32, env: i686 }
+          - { build: 'autotools', sys: ucrt64,  env: ucrt-x86_64 }
+          - { build: 'autotools', sys: clang64, env: clang-x86_64 }
+          - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64 }
+          - { build: 'cmake'    , sys: clang64, env: clang-x86_64 }
           - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
+          - { build: 'make'     , sys: mingw64, env: x86_64 }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -202,14 +209,16 @@ jobs:
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT"
+            rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
           else
             cflags=''
+            rcopts=''
           fi
           cmake -B bld ${options} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
-            '-DCMAKE_RC_COMPILE_OBJECT=<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>' \
+            "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
             -DCRYPTO_BACKEND=OpenSSL \
             -DENABLE_ZLIB_COMPRESSION=ON \
             -DRUN_DOCKER_TESTS=OFF \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           c_flags=''
           crypto='OpenSSL'
           zlib='ON'
-          rc_flags='m
+          rc_flags=''
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT"
             # Hack to fix CMake (as of v3.26.4) misjudging the situation and
-            # applying the MSVC rc.exe command-line template for windres.
+            # applying the MSVC rc.exe command-line template to windres.
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
           else
             cflags=''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
           - { build: 'autotools', sys: clang64, env: clang-x86_64 }
           - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64 }
           - { build: 'cmake'    , sys: clang64, env: clang-x86_64 }
+          - { build: 'cmake'    , sys: mingw64, env: x86_64 }
           - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
           - { build: 'make'     , sys: mingw64, env: x86_64 }
       fail-fast: false
@@ -220,7 +221,7 @@ jobs:
             -DRUN_SSHD_TESTS=OFF
 
       - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' && matrix.mode == 'uwp' }}
+        if: ${{ matrix.build == 'cmake' && matrix.env == 'x86_64' }}
         shell: msys2 {0}
         run: cd bld; make VERBOSE=1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,11 +197,12 @@ jobs:
             options='-DCMAKE_C_COMPILER=gcc'
           fi
           if [[ '${{ matrix.mode }}' = 'uwp' ]]; then
+            cmake --version
             options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat -lruntimeobject/' -e 's/-lmsvcrt/-lvcruntime140_app/' > "${specs}"
-            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT"
+            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE -D__MSVCRT_VERSION__=0xE00"
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
           else
             cflags=''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,10 @@ jobs:
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
-            options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
+            options='-DCMAKE_C_COMPILER=gcc -DCMAKE_RC_COMPILER=rc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
-            options="${options} -DCMAKE_RC_COMPILE_OBJECT=<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>"
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,14 @@ jobs:
     strategy:
       matrix:
         include:
+          - { build: 'autotools', sys: mingw64, env: x86_64 }
+          - { build: 'autotools', sys: mingw32, env: i686 }
+          - { build: 'autotools', sys: ucrt64,  env: ucrt-x86_64 }
+          - { build: 'autotools', sys: clang64, env: clang-x86_64 }
+          - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64 }
+          - { build: 'cmake'    , sys: clang64, env: clang-x86_64 }
           - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
+          - { build: 'make'     , sys: mingw64, env: x86_64 }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -197,12 +204,13 @@ jobs:
             options='-DCMAKE_C_COMPILER=gcc'
           fi
           if [[ '${{ matrix.mode }}' = 'uwp' ]]; then
-            cmake --version
             options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
-            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE -D__MSVCRT_VERSION__=0xE00"
+            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT"
+            # Hack to fix CMake (as of v3.26.4) misjudging the situation and
+            # applying the MSVC rc.exe command-line template for windres.
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
           else
             cflags=''
@@ -210,9 +218,9 @@ jobs:
           fi
           cmake -B bld ${options} \
             "-DCMAKE_C_FLAGS=${cflags}" \
+            "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
-            "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
             -DCRYPTO_BACKEND=OpenSSL \
             -DENABLE_ZLIB_COMPRESSION=ON \
             -DRUN_DOCKER_TESTS=OFF \
@@ -223,6 +231,7 @@ jobs:
         shell: msys2 {0}
         run: cmake --build bld --parallel 3
       - name: 'cmake tests'
+        # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
         if: ${{ matrix.build == 'cmake' && matrix.mode != 'uwp' }}
         timeout-minutes: 10
         shell: msys2 {0}
@@ -236,12 +245,6 @@ jobs:
           OPENSSL_PATH: /${{ matrix.sys }}
         shell: msys2 {0}
         run: mkdir bld && cd bld && BLD_DIR=bld make -C .. -j3 -f Makefile.mk dyn example test
-      # https://github.com/actions/upload-artifact
-      - uses: actions/upload-artifact@v3
-        with:
-          name: 'results'
-          retention-days: 2
-          path: .
 
   build_msvc:
     name: 'msvc'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
       matrix:
         include:
           - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
+          - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64, mode: uwp }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -199,6 +200,8 @@ jobs:
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
             options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             specs="$(realpath gcc-specs-uwp)"
+            find D:/a/_temp/msys64
+            gcc -dumpspecs
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwinstorecompat -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
           else
@@ -214,7 +217,7 @@ jobs:
             -DRUN_SSHD_TESTS=OFF
 
       - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' && matrix.env == 'x86_64' }}
+        if: ${{ matrix.build == 'cmake' }}
         shell: msys2 {0}
         run: cd bld; make VERBOSE=1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,6 @@ jobs:
           c_flags=''
           crypto='OpenSSL'
           zlib='ON'
-          rc_flags=''
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
@@ -210,12 +209,11 @@ jobs:
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
-            rc_flags='-O coff'
+            options="${options} -DCMAKE_RC_COMPILE_OBJECT=<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>"
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
           cmake -B bld ${options} "-DCMAKE_C_FLAGS=${c_flags}" \
-            "-DCMAKE_RC_FLAGS=${rc_flags}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
             "-DCRYPTO_BACKEND=${crypto}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
             options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             specs="$(realpath gcc-specs-uwp)"
-            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwinstorecompat -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
           else
             options='-DCMAKE_C_COMPILER=gcc'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,16 +220,16 @@ jobs:
             -DRUN_SSHD_TESTS=OFF
 
       - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' && matrix.env == 'uwp' }}
+        if: ${{ matrix.build == 'cmake' && matrix.mode == 'uwp' }}
         shell: msys2 {0}
         run: cd bld; make V=1
 
       - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' && matrix.env != 'uwp' }}
+        if: ${{ matrix.build == 'cmake' && matrix.mode != 'uwp' }}
         shell: msys2 {0}
         run: cmake --build bld --parallel 3
       - name: 'cmake tests'
-        if: ${{ matrix.build == 'cmake' && matrix.env != 'uwp___' }}
+        if: ${{ matrix.build == 'cmake' && matrix.mode != 'uwp___' }}
         timeout-minutes: 10
         shell: msys2 {0}
         run: cd bld && ctest -VV --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' && matrix.mode == 'uwp' }}
         shell: msys2 {0}
-        run: cd bld; make V=1
+        run: cd bld; make VERBOSE=1
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' && matrix.mode != 'uwp' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
-            rc_flags='--target=x86_64'
+            rc_flags='--target=pe-x86-64'
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
             options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
-            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwinstorecompat -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT"
           else
             cflags=''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
             options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             specs="$(realpath gcc-specs-uwp)"
-            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
           else
             options='-DCMAKE_C_COMPILER=gcc'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
           - { build: 'autotools', sys: clang64, env: clang-x86_64 }
           - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64 }
           - { build: 'cmake'    , sys: clang64, env: clang-x86_64 }
+          - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
           - { build: 'make'     , sys: mingw64, env: x86_64 }
       fail-fast: false
     steps:
@@ -197,12 +198,18 @@ jobs:
           CMAKE_GENERATOR: 'MSYS Makefiles'
         shell: msys2 {0}
         run: |
+          c_flags=''
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
+          elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
+            options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
+            specs="$(realpath gcc-specs-uwp)"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
+            c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
-          cmake -B bld ${options} \
+          cmake -B bld ${options} "-DCMAKE_C_FLAGS=${c_flags}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
             -DCRYPTO_BACKEND=OpenSSL \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
       matrix:
         include:
           - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
-          - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64, mode: uwp }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -198,6 +197,7 @@ jobs:
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
+            pacman --noconfirm --ask 20 --noprogressbar --sync --needed mingw-w64-x86_64-winstorecompat-git
             options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             specs="$(realpath gcc-specs-uwp)"
             find D:/a/_temp/msys64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,15 +148,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', sys: mingw64, env: x86_64 }
-          - { build: 'autotools', sys: mingw32, env: i686 }
-          - { build: 'autotools', sys: ucrt64,  env: ucrt-x86_64 }
-          - { build: 'autotools', sys: clang64, env: clang-x86_64 }
-          - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64 }
-          - { build: 'cmake'    , sys: clang64, env: clang-x86_64 }
-          - { build: 'cmake'    , sys: mingw64, env: x86_64 }
           - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
-          - { build: 'make'     , sys: mingw64, env: x86_64 }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -215,6 +207,7 @@ jobs:
           cmake -B bld ${options} "-DCMAKE_C_FLAGS=${c_flags}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
+            '-DCMAKE_RC_COMPILE_OBJECT=<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>' \
             "-DCRYPTO_BACKEND=${crypto}" \
             "-DENABLE_ZLIB_COMPRESSION=${zlib}" \
             -DRUN_DOCKER_TESTS=OFF \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,20 +191,22 @@ jobs:
           CMAKE_GENERATOR: 'MSYS Makefiles'
         shell: msys2 {0}
         run: |
-          c_flags=''
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
-          elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
-            pacman --noconfirm --ask 20 --noprogressbar --sync --needed mingw-w64-x86_64-winstorecompat-git
-            options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
-            specs="$(realpath gcc-specs-uwp)"
-            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwinstorecompat -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
-            c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
+          if [[ '${{ matrix.mode }}' = 'uwp' ]]; then
+            options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
+            pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
+            specs="$(realpath gcc-specs-uwp)"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwinstorecompat -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
+            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT"
+          else
+            cflags=''
+          fi
           cmake -B bld ${options} \
-            "-DCMAKE_C_FLAGS=${c_flags}" \
+            "-DCMAKE_C_FLAGS=${cflags}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
             '-DCMAKE_RC_COMPILE_OBJECT=<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>' \
@@ -214,7 +216,7 @@ jobs:
             -DRUN_SSHD_TESTS=OFF
 
       - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' && matrix.mode == 'uwp' }}
+        if: ${{ matrix.build == 'cmake' }}
         shell: msys2 {0}
         run: cmake --build bld --parallel 3
       - name: 'cmake tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
-            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT"
+            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
             # Hack to fix CMake (as of v3.26.4) misjudging the situation and
             # applying the MSVC rc.exe command-line template to windres.
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,41 +192,33 @@ jobs:
         shell: msys2 {0}
         run: |
           c_flags=''
-          crypto='OpenSSL'
-          zlib='ON'
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed mingw-w64-x86_64-winstorecompat-git
             options='-DCMAKE_C_COMPILER=gcc -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             specs="$(realpath gcc-specs-uwp)"
-            find D:/a/_temp/msys64
-            gcc -dumpspecs
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwinstorecompat -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
-          cmake -B bld ${options} "-DCMAKE_C_FLAGS=${c_flags}" \
+          cmake -B bld ${options} \
+            "-DCMAKE_C_FLAGS=${c_flags}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
             '-DCMAKE_RC_COMPILE_OBJECT=<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>' \
-            "-DCRYPTO_BACKEND=${crypto}" \
-            "-DENABLE_ZLIB_COMPRESSION=${zlib}" \
+            -DCRYPTO_BACKEND=OpenSSL \
+            -DENABLE_ZLIB_COMPRESSION=ON \
             -DRUN_DOCKER_TESTS=OFF \
             -DRUN_SSHD_TESTS=OFF
 
       - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' }}
-        shell: msys2 {0}
-        run: cd bld; make VERBOSE=1
-
-      - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' && matrix.mode != 'uwp' }}
+        if: ${{ matrix.build == 'cmake' && matrix.mode == 'uwp' }}
         shell: msys2 {0}
         run: cmake --build bld --parallel 3
       - name: 'cmake tests'
-        if: ${{ matrix.build == 'cmake' && matrix.mode != 'uwp___' }}
+        if: ${{ matrix.build == 'cmake' && matrix.mode != 'uwp' }}
         timeout-minutes: 10
         shell: msys2 {0}
         run: cd bld && ctest -VV --output-on-failure
@@ -239,6 +231,12 @@ jobs:
           OPENSSL_PATH: /${{ matrix.sys }}
         shell: msys2 {0}
         run: mkdir bld && cd bld && BLD_DIR=bld make -C .. -j3 -f Makefile.mk dyn example test
+      # https://github.com/actions/upload-artifact
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'results'
+          retention-days: 2
+          path: .
 
   build_msvc:
     name: 'msvc'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,8 @@ jobs:
         shell: msys2 {0}
         run: |
           c_flags=''
+          crypto='OpenSSL'
+          zlib='ON'
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
@@ -212,17 +214,22 @@ jobs:
           cmake -B bld ${options} "-DCMAKE_C_FLAGS=${c_flags}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
-            -DCRYPTO_BACKEND=OpenSSL \
-            -DENABLE_ZLIB_COMPRESSION=ON \
+            "-DCRYPTO_BACKEND=${crypto}" \
+            "-DENABLE_ZLIB_COMPRESSION=${zlib}" \
             -DRUN_DOCKER_TESTS=OFF \
             -DRUN_SSHD_TESTS=OFF
 
       - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' }}
+        if: ${{ matrix.build == 'cmake' && matrix.env == 'uwp' }}
+        shell: msys2 {0}
+        run: cd bld; make V=1
+
+      - name: 'cmake build'
+        if: ${{ matrix.build == 'cmake' && matrix.env != 'uwp' }}
         shell: msys2 {0}
         run: cmake --build bld --parallel 3
       - name: 'cmake tests'
-        if: ${{ matrix.build == 'cmake' }}
+        if: ${{ matrix.build == 'cmake' && matrix.env != 'uwp___' }}
         timeout-minutes: 10
         shell: msys2 {0}
         run: cd bld && ctest -VV --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,14 +148,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', sys: mingw64, env: x86_64 }
-          - { build: 'autotools', sys: mingw32, env: i686 }
-          - { build: 'autotools', sys: ucrt64,  env: ucrt-x86_64 }
-          - { build: 'autotools', sys: clang64, env: clang-x86_64 }
-          - { build: 'cmake'    , sys: ucrt64,  env: ucrt-x86_64 }
-          - { build: 'cmake'    , sys: clang64, env: clang-x86_64 }
           - { build: 'cmake'    , sys: mingw64, env: x86_64, mode: uwp }
-          - { build: 'make'     , sys: mingw64, env: x86_64 }
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -207,7 +200,7 @@ jobs:
             options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
-            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat -lruntimeobject/' -e 's/-lmsvcrt/-lvcruntime140_app/' > "${specs}"
             cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT"
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
           c_flags=''
           crypto='OpenSSL'
           zlib='ON'
+          rc_flags='m
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang -DCMAKE_UNITY_BUILD=ON'
           elif [[ '${{ matrix.mode }}' = 'uwp' ]]; then
@@ -209,10 +210,12 @@ jobs:
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lole32 -lruntimeobject/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             c_flags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DHAVE_WINRT -D_UNICODE -DUNICODE"
+            rc_flags='--target=x86_64'
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
           cmake -B bld ${options} "-DCMAKE_C_FLAGS=${c_flags}" \
+            "-DCMAKE_RC_FLAGS=${rc_flags}" \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
             "-DCRYPTO_BACKEND=${crypto}" \

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -86,6 +86,19 @@
 #include "libssh2_sftp.h"
 #include "misc.h"
 
+#ifdef WIN32
+/* Detect Windows App environment which has a restricted access
+   to the Win32 APIs. */
+# if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
+  defined(WINAPI_FAMILY)
+#  include <winapifamily.h>
+#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
+     !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#    define LIBSSH2_WINDOWS_UWP
+#  endif
+# endif
+#endif
+
 #ifndef FALSE
 #define FALSE 0
 #endif

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -86,19 +86,6 @@
 #include "libssh2_sftp.h"
 #include "misc.h"
 
-#ifdef WIN32
-/* Detect Windows App environment which has a restricted access
-   to the Win32 APIs. */
-# if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
-  defined(WINAPI_FAMILY)
-#  include <winapifamily.h>
-#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
-     !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#    define LIBSSH2_WINDOWS_UWP
-#  endif
-# endif
-#endif
-
 #ifndef FALSE
 #define FALSE 0
 #endif


### PR DESCRIPTION
Add a CI test for Windows UWP builds using mingw-w64. Before this patch
we had UWP builds tested with MSVC only.

Alike existing UWP jobs, it's not possible to run the binaries due to
the missing UWP runtime DLL:
https://github.com/libssh2/libssh2/actions/runs/5821297010/job/15783475118#step:11:42

We could install `winstorecompat-git` in the setup-msys2 step, but opted
to do it manually to avoid the overhead for every matrix job.

All this would work smoother with llvm-mingw, which features an UWP
toolchain prefix and provides all necessary implibs by default.

This also hit a CMake bug (with v3.26.4), where CMake gets confused and
sets up `windres.exe` to use the MSVC rc.exe-style command-line:
https://github.com/libssh2/libssh2/actions/runs/5819232677/job/15777236773#step:9:126

Notice that MS "sunset" UWP in 2021:
https://github.com/microsoft/WindowsAppSDK/discussions/1615

If this particular CI job turns out to be not worth the maintenance
burden or CPU time, or too much of a hack, feel free to delete it.

Ref: https://github.com/libssh2/libssh2/pull/1147#issuecomment-1670850890
Closes #1155
