### PR TITLE
cmake: tidy-up concatenation in `CMAKE_MODULE_PATH`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@
 
 cmake_minimum_required(VERSION 3.7)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 include(CheckFunctionExists)
 include(CheckSymbolExists)


### PR DESCRIPTION
Former solution was appending an empty element to the array if `CMAKE_MODULE_PATH` was originally empty. The new syntax doesn't have this side-effect.

There is no known issue caused by this. Fixing it for good measure.

Closes #1157