### PR TITLE
cmake: add one missed `PROJECT_NAME` variable

### DIFF
--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
-include("${CMAKE_CURRENT_LIST_DIR}/libssh2-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
 # Alias for either shared or static library
 add_library(@PROJECT_NAME@::libssh2 ALIAS @PROJECT_NAME@::@LIB_SELECTED@)


### PR DESCRIPTION
Follow-up to 72fd25958a7dc6f8e68f2b2d5d72839a2da98f9c

Closes #1158