### PR TITLE
ci: add MSYS builds (autotools and cmake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - { build: 'autotools', sys: msys   , env: x86_64 }
+          - { build: 'cmake'    , sys: msys   , env: x86_64 }
           - { build: 'autotools', sys: mingw64, env: x86_64 }
           - { build: 'autotools', sys: mingw32, env: i686 }
           - { build: 'autotools', sys: ucrt64,  env: ucrt-x86_64 }
@@ -214,6 +216,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
+        if: ${{ matrix.sys == 'msys' }}
+        with:
+          msystem: ${{ matrix.sys }}
+          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel
+      - uses: msys2/setup-msys2@v2
+        if: ${{ matrix.sys != 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
           install: >-
@@ -248,8 +256,6 @@ jobs:
         run: make -C bld check VERBOSE=1
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
-        env:
-          CMAKE_GENERATOR: 'MSYS Makefiles'
         shell: msys2 {0}
         run: |
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -814,19 +814,21 @@ m4_case([$1],
 ],
 
 [wincng], [
-  # Look for Windows Cryptography API: Next Generation
+  if test "x$have_windows_h" = "xyes"; then
+    # Look for Windows Cryptography API: Next Generation
 
-  LIBS="$LIBS -lcrypt32"
+    LIBS="$LIBS -lcrypt32"
 
-  # Check necessary for old-MinGW
-  LIBSSH2_LIB_HAVE_LINKFLAGS([bcrypt], [], [
-    #include <windows.h>
-    #include <bcrypt.h>
-  ], [
-    AC_DEFINE(LIBSSH2_WINCNG, 1, [Use $1])
-    found_crypto="$1"
-    found_crypto_str="Windows Cryptography API: Next Generation"
-  ])
+    # Check necessary for old-MinGW
+    LIBSSH2_LIB_HAVE_LINKFLAGS([bcrypt], [], [
+      #include <windows.h>
+      #include <bcrypt.h>
+    ], [
+      AC_DEFINE(LIBSSH2_WINCNG, 1, [Use $1])
+      found_crypto="$1"
+      found_crypto_str="Windows Cryptography API: Next Generation"
+    ])
+  fi
 ],
 )
   test "$found_crypto" = "none" &&

--- a/configure.ac
+++ b/configure.ac
@@ -295,7 +295,7 @@ AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
 AC_CHECK_HEADERS([sys/un.h])
 
 case $host in
-  *-*-cygwin* | *-*-cegcc*)
+  *-*-msys | *-*-cygwin* | *-*-cegcc*)
     # These are POSIX-like systems using BSD-like sockets API.
     ;;
   *)


### PR DESCRIPTION
Use existing MSYS2 section and extend it with builds for the MSYS environment with both autotools and cmake.

MSYS builds resemble Cygwin ones: The env is Unixy, where Windows headers are all available but we don't use them.

Also:

- extend existing autotools logic for Cygwin to skip detecting `windows.h` for MSYS targets too.

- require `windows.h` for the WinCNG backend in autotools. Before this patch, autotools allowed selecting WinCNG on the Cygwin and MSYS platforms, but the builds then fell apart due to the resulting mixed Unixy + Windowsy environment. The general expectation for Cygwin/MSYS builds is not to use the Windows API directly in them.

- stop manually selecting the `MSYS Makefiles` CMake generator for MSYS2-based GHA CI builds. mingw-w64 builds work fine without it, but it broke MSYS build which use `Unix Makefiles`. Deleting this setting fixes all build flavours.

Closes #1162