### PR TITLE
cmake: add integration tests

### DIFF
--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Copyright (C) Viktor Szakats
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.7)
+
+project(test-dependent)
+
+if(NOT DEFINED TEST_INTEGRATION_MODE)
+  set(TEST_INTEGRATION_MODE "find_package")
+endif()
+
+message(STATUS "TEST_INTEGRATION_MODE: ${TEST_INTEGRATION_MODE}")
+
+if(TEST_INTEGRATION_MODE STREQUAL "find_package")
+  set(CMAKE_FIND_DEBUG_MODE TRUE)
+  find_package(libssh2 REQUIRED CONFIG)
+  message(STATUS "|${LIBSSH2_FOUND}|")  # Empty even if found. Why?
+elseif(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory")
+  add_subdirectory(libssh2)
+elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
+  include(FetchContent)
+  FetchContent_Declare(libssh2 GIT_REPOSITORY "https://github.com/libssh2/libssh2.git" GIT_TAG "master")
+  FetchContent_MakeAvailable(libssh2)
+endif()
+
+add_executable(test-dependent-static-ns "test.c")
+target_link_libraries(test-dependent-static-ns PRIVATE "libssh2::libssh2_static")
+
+add_executable(test-dependent-shared-ns "test.c")
+target_link_libraries(test-dependent-shared-ns PRIVATE "libssh2::libssh2_shared")
+
+# Alias for either shared or static library
+add_executable(test-dependent-selected-ns "test.c")
+target_link_libraries(test-dependent-selected-ns PRIVATE "libssh2::libssh2")
+
+if(TEST_INTEGRATION_MODE STREQUAL "find_package")
+
+  # Compatibility alias
+  add_executable(test-dependent-compat "test.c")
+  target_link_libraries(test-dependent-compat PRIVATE "Libssh2::libssh2")
+
+elseif(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory" OR
+       TEST_INTEGRATION_MODE STREQUAL "FetchContent")
+
+  add_executable(test-dependent-static-bare "test.c")
+  target_link_libraries(test-dependent-static-bare PRIVATE "libssh2_static")
+
+  add_executable(test-dependent-shared-bare "test.c")
+  target_link_libraries(test-dependent-shared-bare PRIVATE "libssh2_shared")
+
+  add_executable(test-dependent-selected-bare "test.c")
+  target_link_libraries(test-dependent-selected-bare PRIVATE "libssh2")
+endif()

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -1,0 +1,13 @@
+/* Copyright (C) Viktor Szakats
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "libssh2.h"
+#include <stdio.h>
+
+int main(void)
+{
+    printf("libssh2_version(0): |%s|\n", libssh2_version(0));
+    return 0;
+}

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Copyright (C) Viktor Szakats
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -e
+set -u
+
+cd "$(dirname "$0")"
+
+rm -rf bld; cmake -B bld -DTEST_INTEGRATION_MODE=FetchContent
+make -C bld -j3
+
+rm -rf libssh2; ln -s ../.. libssh2
+rm -rf bld; cmake -B bld -DTEST_INTEGRATION_MODE=add_subdirectory
+make -C bld -j3
+
+rm -rf bld-libssh2; cmake ../.. -B bld-libssh2
+make -C bld-libssh2 -j3 DESTDIR=pkg install
+rm -rf bld; cmake -B bld -DTEST_INTEGRATION_MODE=find_package -DCMAKE_PREFIX_PATH="${PWD}/bld-libssh2/pkg/usr/local/lib/cmake/libssh2"
+make -C bld -j3


### PR DESCRIPTION
Add a small project to test dependent/downstream CMake build using
libssh2. This test can be run manually via .

Test three methods of integrating libssh2 into a project:
- via `find_package()`:
  https://cmake.org/cmake/help/latest/command/find_package.html
- via `add_subdirectory()`:
  https://cmake.org/cmake/help/latest/command/add_subdirectory.html
- via `FetchContent`:
  https://cmake.org/cmake/help/latest/module/FetchContent.html

Closes #1170
