### PR TITLE
cmake: add `ExternalProject` integration test

### DIFF
--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -9,7 +9,16 @@ option(TEST_INTEGRATION_MODE "Integration mode" "find_package")
 
 message(STATUS "TEST_INTEGRATION_MODE: ${TEST_INTEGRATION_MODE}")
 
-if(TEST_INTEGRATION_MODE STREQUAL "find_package")
+if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
+   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
+  if(TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
+    include(ExternalProject)
+    ExternalProject_Add(libssh2
+      URL "${FROM_ARCHIVE}"
+      URL_HASH "SHA256=${FROM_HASH}"
+      INSTALL_COMMAND ""
+      DOWNLOAD_EXTRACT_TIMESTAMP ON)
+  endif()
   find_package(libssh2 REQUIRED CONFIG)
   message(STATUS "libssh2_FOUND: |${libssh2_FOUND}|")
 elseif(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory")
@@ -34,7 +43,8 @@ target_link_libraries(test-dependent-shared-ns PRIVATE "libssh2::libssh2_shared"
 add_executable(test-dependent-selected-ns "test.c")
 target_link_libraries(test-dependent-selected-ns PRIVATE "libssh2::libssh2")
 
-if(TEST_INTEGRATION_MODE STREQUAL "find_package")
+if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
+   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
 
   # Compatibility alias
   add_executable(test-dependent-compat "test.c")

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -5,9 +5,7 @@ cmake_minimum_required(VERSION 3.7)
 
 project(test-dependent)
 
-if(NOT DEFINED TEST_INTEGRATION_MODE)
-  set(TEST_INTEGRATION_MODE "find_package")
-endif()
+option(TEST_INTEGRATION_MODE "Integration mode" "find_package")
 
 message(STATUS "TEST_INTEGRATION_MODE: ${TEST_INTEGRATION_MODE}")
 
@@ -18,7 +16,11 @@ elseif(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory")
   add_subdirectory(libssh2)
 elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
   include(FetchContent)
-  FetchContent_Declare(libssh2 GIT_REPOSITORY "https://github.com/libssh2/libssh2.git" GIT_TAG "master")
+  option(FROM_GIT_REPO "Git URL" "https://github.com/libssh2/libssh2.git")
+  option(FROM_GIT_TAG "Git tag" "master")
+  FetchContent_Declare(libssh2
+    GIT_REPOSITORY "${FROM_GIT_REPO}"
+    GIT_TAG "${FROM_GIT_TAG}")
   FetchContent_MakeAvailable(libssh2)
 endif()
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -22,3 +22,9 @@ make -C bld-libssh2 -j3 DESTDIR=pkg install
 rm -rf bld-find_package; cmake -B bld-find_package -DTEST_INTEGRATION_MODE=find_package \
   -DCMAKE_PREFIX_PATH="${PWD}/bld-libssh2/pkg/usr/local/lib/cmake/libssh2"
 make -C bld-find_package -j3
+
+(cd ../..; git archive --format=tar HEAD) | gzip > source.tar.gz
+rm -rf bld-externalproject; cmake -B bld-externalproject -DTEST_INTEGRATION_MODE=ExternalProject \
+  -DFROM_ARCHIVE="${PWD}/source.tar.gz" \
+  -DFROM_HASH="$(openssl dgst -sha256 source.tar.gz | grep -a -i -o -E '[0-9a-f]{64}$')"
+make -C bld-externalproject -j3

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -8,7 +8,9 @@ set -u
 
 cd "$(dirname "$0")"
 
-rm -rf bld-fetchcontent; cmake -B bld-fetchcontent -DTEST_INTEGRATION_MODE=FetchContent
+rm -rf bld-fetchcontent; cmake -B bld-fetchcontent -DTEST_INTEGRATION_MODE=FetchContent \
+  -DFROM_GIT_REPO="${PWD}/../.." \
+  -DFROM_GIT_TAG="$(git rev-parse HEAD)"
 make -C bld-fetchcontent -j3
 
 rm -rf libssh2; ln -s ../.. libssh2
@@ -17,5 +19,6 @@ make -C bld-add_subdirectory -j3
 
 rm -rf bld-libssh2; cmake ../.. -B bld-libssh2
 make -C bld-libssh2 -j3 DESTDIR=pkg install
-rm -rf bld-find_package; cmake -B bld-find_package -DTEST_INTEGRATION_MODE=find_package -DCMAKE_PREFIX_PATH="${PWD}/bld-libssh2/pkg/usr/local/lib/cmake/libssh2"
+rm -rf bld-find_package; cmake -B bld-find_package -DTEST_INTEGRATION_MODE=find_package \
+  -DCMAKE_PREFIX_PATH="${PWD}/bld-libssh2/pkg/usr/local/lib/cmake/libssh2"
 make -C bld-find_package -j3


### PR DESCRIPTION
- via `ExternalProject_Add()`:
  https://cmake.org/cmake/help/latest/module/ExternalProject.html
  (as documented in `docs/INSTALL_CMAKE.md`)

- also make `FetchContent` fetch from local repo instead of live master.

Closes #1171
