### PR TITLE
autotools: fix selecting wincng in cross-builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,43 @@ jobs:
           export OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
           cd bld && ctest -VV --output-on-failure
 
+  build_linux_cross_mingw64:
+    name: 'linux -> mingw-w64'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [autotools, cmake]
+    env:
+      TRIPLET: 'x86_64-w64-mingw32'
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'install packages'
+        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install mingw-w64
+      - name: 'autotools autoreconf'
+        if: ${{ matrix.build == 'autotools' }}
+        run: autoreconf -fi
+      - name: 'autotools configure'
+        if: ${{ matrix.build == 'autotools' }}
+        run: mkdir bld && cd bld && ../configure --enable-werror --enable-debug --host=${TRIPLET}
+      - name: 'autotools build'
+        if: ${{ matrix.build == 'autotools' }}
+        run: make -C bld -j3
+      - name: 'cmake configure'
+        if: ${{ matrix.build == 'cmake' }}
+        run: |
+          cmake --version
+          cmake -B bld \
+            -DCMAKE_SYSTEM_NAME=Windows \
+            -DCMAKE_C_COMPILER_TARGET=${TRIPLET} \
+            -DCMAKE_C_COMPILER=${TRIPLET}-gcc \
+            -DENABLE_WERROR=ON
+
+      - name: 'cmake build'
+        if: ${{ matrix.build == 'cmake' }}
+        run: cmake --build bld --parallel 3
+
   build_cygwin:
     name: 'cygwin'
     runs-on: windows-latest

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -298,7 +298,8 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
 
        dnl figure out gcc version!
        AC_MSG_CHECKING([gcc version])
-       gccver=`$CC -dumpversion`
+       # strip '-suffix' parts, e.g. Ubuntu Windows cross-gcc returns '10-win32'
+       gccver=`$CC -dumpversion | sed -E 's/-.+$//'`
        num1=`echo $gccver | cut -d . -f1`
        num2=`echo $gccver | cut -d . -f2`
        compiler_num=`(expr $num1 "*" 100 + $num2) 2>/dev/null`

--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,16 @@ AC_C_BIGENDIAN
 
 LT_LANG([Windows Resource])
 
+dnl check for windows.h
+case $host in
+  *-*-msys | *-*-cygwin* | *-*-cegcc*)
+    # These are POSIX-like systems using BSD-like sockets API.
+    ;;
+  *)
+    AC_CHECK_HEADERS([windows.h], [have_windows_h=yes], [have_windows_h=no])
+    ;;
+esac
+
 dnl check for how to do large files
 AC_SYS_LARGEFILE
 
@@ -293,15 +303,6 @@ AC_CHECK_HEADERS([errno.h fcntl.h stdio.h unistd.h sys/param.h sys/uio.h])
 AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/ioctl.h sys/time.h])
 AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
 AC_CHECK_HEADERS([sys/un.h])
-
-case $host in
-  *-*-msys | *-*-cygwin* | *-*-cegcc*)
-    # These are POSIX-like systems using BSD-like sockets API.
-    ;;
-  *)
-    AC_CHECK_HEADERS([windows.h], [have_windows_h=yes], [have_windows_h=no])
-    ;;
-esac
 
 case $host in
   *darwin*|*interix*)


### PR DESCRIPTION
- Fix explicitly selecting WinCNG in autotools cross-builds by
  moving `windows.h` header check before the WinCNG availability
  check.
  Follow-up to d43b8d9b0b9cd62668459fe5d582ed83aabf77e7

  Reported-by: Jack L
  Fixes #1186

- Add Linux -> mingw-w64 cross-builds for autotools and CMake.
  This doesn't detect #1186, because that only happened when
  explicitly specifying WinCNG via `--with-crypto=wincng`, but
  not when falling back to WinCNG by default.

- autotools: fix to strip suffix from gcc version

  Before this patch we expected `n.n` `-dumpversion` output, but Ubuntu
  may return `n-win32` (also with `-dumpfullversion`). Causing these
  errors and failing to enable picky warnings:
  ```
  ../configure: line 23845: test: : integer expression expected
  ```
  Ref: https://github.com/libssh2/libssh2/actions/runs/6263453828/job/17007893718#step:5:143

  Fix that by stripping any dash-suffix.

  gcc version detection is still half broken because we translate '10' to
  '10.10' because `cut -d. -f2` returns the first word if the delimiter
  missing.

  More possible `-dumpversion` output:
  `10-posix`, `10-win32`, `9.3-posix`, `9.3-win32`, `6`, `9.3.0`, `11`, `11.2`, `11.2.0`
  Ref: https://github.com/mamedev/mame/pull/9767

Closes #1187
