### PR TITLE
use built-in `_WIN32` macro to detect Windows

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -6,7 +6,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <ws2tcpip.h>  /* for socklen_t */
 #define recv(s, b, l, f)  recv((s), (b), (int)(l), (f))
 #define send(s, b, l, f)  send((s), (b), (int)(l), (f))
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
     libssh2_socket_t listensock = LIBSSH2_INVALID_SOCKET;
     libssh2_socket_t forwardsock = LIBSSH2_INVALID_SOCKET;
 
-#ifdef WIN32
+#ifdef _WIN32
     char sockopt;
     WSADATA wsadata;
 
@@ -311,7 +311,7 @@ shutdown:
 
     if(forwardsock != LIBSSH2_INVALID_SOCKET) {
         shutdown(forwardsock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(forwardsock);
 #else
         close(forwardsock);
@@ -320,7 +320,7 @@ shutdown:
 
     if(listensock != LIBSSH2_INVALID_SOCKET) {
         shutdown(listensock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(listensock);
 #else
         close(listensock);
@@ -337,7 +337,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/scp.c
+++ b/example/scp.c
@@ -8,7 +8,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
     libssh2_struct_stat fileinfo;
     libssh2_struct_stat_size got = 0;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -182,7 +182,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -13,7 +13,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
     libssh2_struct_stat_size got = 0;
     libssh2_struct_stat_size total = 0;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -285,7 +285,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
     char *ptr;
     struct stat fileinfo;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -211,7 +211,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
     int duration;
     size_t prev;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -271,7 +271,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -294,7 +294,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
     fd_set fd;
     fd_set fd2;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -342,7 +342,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     ssize_t nwritten;
     char *ptr;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -231,7 +231,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -172,7 +172,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -171,7 +171,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define write(f, b, c)  write((f), (b), (unsigned int)(c))
 #endif
 
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
     libssh2_struct_stat_size total = 0;
     int spin = 0;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -288,7 +288,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     ssize_t nwritten;
     char *ptr;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -215,7 +215,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
     libssh2_struct_stat_size total = 0;
     int duration;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -273,7 +273,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     libssh2_struct_stat_size total = 0;
     int duration;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -284,7 +284,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -295,7 +295,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -235,7 +235,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -341,7 +341,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
     LIBSSH2_AGENT *agent = NULL;
     struct libssh2_agent_publickey *identity, *prev_identity = NULL;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -238,7 +238,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     char *exitsignal = (char *)"none";
     ssize_t bytecount = 0;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -285,7 +285,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     LIBSSH2_KNOWNHOSTS *nh;
     int type;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -356,7 +356,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     LIBSSH2_KNOWNHOSTS *nh;
     int type;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -294,7 +294,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
     ssize_t len;
     libssh2_socket_t sock;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -291,7 +291,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -6,7 +6,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <ws2tcpip.h>  /* for socklen_t */
 #define recv(s, b, l, f)  recv((s), (b), (int)(l), (f))
 #define send(s, b, l, f)  send((s), (b), (int)(l), (f))
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
     libssh2_socket_t sock;
     libssh2_socket_t forwardsock = LIBSSH2_INVALID_SOCKET;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -306,7 +306,7 @@ shutdown:
 
     if(forwardsock != LIBSSH2_INVALID_SOCKET) {
         shutdown(forwardsock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(forwardsock);
 #else
         close(forwardsock);
@@ -326,7 +326,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);

--- a/src/agent.c
+++ b/src/agent.c
@@ -53,7 +53,7 @@
 #undef PF_UNIX
 #endif
 
-#if defined(WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
+#if defined(_WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
 #define HAVE_WIN32_AGENTS
 #endif
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -86,7 +86,7 @@
 #include "libssh2_sftp.h"
 #include "misc.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 /* Detect Windows App environment which has a restricted access
    to the Win32 APIs. */
 # if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
@@ -134,7 +134,7 @@ int _libssh2_gettimeofday(struct timeval *tp, void *tzp);
 #endif
 
 /* 3DS doesn't seem to have iovec */
-#if defined(WIN32) || defined(_3DS)
+#if defined(_WIN32) || defined(_3DS)
 
 struct iovec {
     size_t iov_len;
@@ -1204,12 +1204,12 @@ size_t plain_method(char *method, size_t method_len);
 /* In Windows the default file mode is text but an application can override it.
    Therefore we specify it explicitly. https://github.com/curl/curl/pull/258
  */
-#if defined(WIN32) || defined(MSDOS)
+#if defined(_WIN32) || defined(MSDOS)
 #define FOPEN_READTEXT "rt"
 #define FOPEN_WRITETEXT "wt"
 #define FOPEN_APPENDTEXT "at"
 #elif defined(__CYGWIN__)
-/* Cygwin has specific behavior we need to address when WIN32 is not defined.
+/* Cygwin has specific behavior we need to address when _WIN32 is not defined.
      https://cygwin.com/cygwin-ug-net/using-textbinary.html
    For write we want our output to have line endings of LF and be compatible
    with other Cygwin utilities. For read we want to handle input that may have

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -9,10 +9,6 @@
 /* Header for platform/compiler-specific initialization.
    Used by 'src', 'example', 'tests' */
 
-#if defined(_WIN32) && !defined(WIN32)
-#define WIN32
-#endif
-
 /* Define mingw-w64 version macros, eg __MINGW{32,64}_{MINOR,MAJOR}_VERSION */
 #ifdef __MINGW32__
 #include <_mingw.h>
@@ -26,7 +22,7 @@
 
 /* Hand-crafted configuration for platforms which lack config tool.
    Keep this synced with root CMakeLists.txt */
-#elif defined(WIN32)
+#elif defined(_WIN32)
 
 #define HAVE_SELECT
 #define HAVE_SNPRINTF
@@ -54,7 +50,7 @@
 
 /* Below applies to both auto-detected and hand-crafted configs */
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -103,6 +99,6 @@
 # endif
 #endif
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 #endif /* LIBSSH2_SETUP_H */

--- a/src/misc.c
+++ b/src/misc.c
@@ -48,7 +48,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 /* Force parameter type. */
 #define recv(s, b, l, f)  recv((s), (b), (int)(l), (f))
 #define send(s, b, l, f)  send((s), (b), (int)(l), (f))
@@ -125,7 +125,7 @@ int _libssh2_error(LIBSSH2_SESSION* session, int errcode, const char *errmsg)
     return _libssh2_error_flags(session, errcode, errmsg, 0);
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 static int wsa2errno(void)
 {
     switch(WSAGetLastError()) {
@@ -160,7 +160,7 @@ _libssh2_recv(libssh2_socket_t sock, void *buffer, size_t length,
     (void)abstract;
 
     rc = recv(sock, buffer, length, flags);
-#ifdef WIN32
+#ifdef _WIN32
     if(rc < 0)
         return -wsa2errno();
 #else
@@ -193,7 +193,7 @@ _libssh2_send(libssh2_socket_t sock, const void *buffer, size_t length,
     (void)abstract;
 
     rc = send(sock, buffer, length, flags);
-#ifdef WIN32
+#ifdef _WIN32
     if(rc < 0)
         return -wsa2errno();
 #else
@@ -708,7 +708,7 @@ int _libssh2_gettimeofday(struct timeval *tp, void *tzp)
 {
     (void)tzp;
     if(tp) {
-#ifdef WIN32
+#ifdef _WIN32
         /* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
         #define _WIN32_FT_OFFSET (116444736000000000)
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -44,7 +44,7 @@
                                               (void)(buf); \
                                               (void)(size); \
                                           } while(0)
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #define _libssh2_explicit_zero(buf, size) SecureZeroMemory(buf, size)
 #elif defined(HAVE_EXPLICIT_BZERO)
 #define _libssh2_explicit_zero(buf, size) explicit_bzero(buf, size)

--- a/src/session.c
+++ b/src/session.c
@@ -41,7 +41,7 @@
 
 #include "libssh2_priv.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <ws2tcpip.h>  /* for socklen_t */
 #endif
 #ifdef HAVE_UNISTD_H
@@ -60,7 +60,7 @@
 #include "channel.h"
 #include "mac.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #define libssh2_usec_t long
 #elif defined(__APPLE__)
 #define libssh2_usec_t suseconds_t
@@ -313,7 +313,7 @@ session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
     /* BeOS */
     long b = nonblock ? 1 : 0;
     return setsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
-#elif defined(WIN32)
+#elif defined(_WIN32)
     unsigned long flags;
 
     flags = nonblock;
@@ -366,7 +366,7 @@ get_socket_nonblocking(libssh2_socket_t sockfd)
         return 1;
     }
     return 0;
-#elif defined(WIN32)
+#elif defined(_WIN32)
     unsigned int option_value;
     socklen_t option_len = sizeof(option_value);
 

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -58,7 +58,7 @@
 #include <stdarg.h>
 #include <ctype.h>
 
-#if defined(WIN32) && defined(_WIN64)
+#if defined(_WIN32) && defined(_WIN64)
 #define LIBSSH2_SOCKET_MASK "%lld"
 #else
 #define LIBSSH2_SOCKET_MASK "%d"
@@ -67,7 +67,7 @@
 #ifdef LIBSSH2_WINDOWS_UWP
 #define popen(x, y) (NULL)
 #define pclose(x) (-1)
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #define popen _popen
 #define pclose _pclose
 #endif
@@ -232,7 +232,7 @@ static const char *docker_machine_name(void)
 
 static int is_running_inside_a_container(void)
 {
-#ifdef WIN32
+#ifdef _WIN32
     return 0;
 #else
     const char *cgroup_filename = "/proc/self/cgroup";
@@ -260,7 +260,7 @@ static int is_running_inside_a_container(void)
 
 static void portable_sleep(unsigned int seconds)
 {
-#ifdef WIN32
+#ifdef _WIN32
     Sleep(seconds);
 #else
     sleep(seconds);
@@ -426,7 +426,7 @@ static void close_socket_to_container(libssh2_socket_t sock)
 {
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2 /* SHUT_RDWR */);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);
@@ -439,7 +439,7 @@ static char *running_container_id = NULL;
 int start_openssh_fixture(void)
 {
     int ret;
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     ret = WSAStartup(MAKEWORD(2, 0), &wsadata);

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -252,7 +252,7 @@ void stop_session_fixture(void)
 #define NUMPATHS 32
 const char *srcdir_path(const char *file)
 {
-#ifdef WIN32
+#ifdef _WIN32
     static char filepath[NUMPATHS][_MAX_PATH];
 #else
     static char filepath[NUMPATHS][MAXPATHLEN];
@@ -458,7 +458,7 @@ int test_auth_pubkey(LIBSSH2_SESSION *session, int flags,
     /* Ignore our hard-wired Dockerfile user when not running under Docker */
     if(!openssh_fixture_have_docker() && strcmp(username, "libssh2") == 0) {
         username = getenv("USER");
-#ifdef WIN32
+#ifdef _WIN32
         if(!username)
             username = getenv("USERNAME");
 #endif

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -38,7 +38,7 @@ int test(LIBSSH2_SESSION *session)
     /* Ignore our hard-wired Dockerfile user when not running under Docker */
     if(!openssh_fixture_have_docker()) {
         username = getenv("USER");
-#ifdef WIN32
+#ifdef _WIN32
         if(!username)
             username = getenv("USERNAME");
 #endif

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -33,7 +33,7 @@ static const char *password = "password";
 
 static void portable_sleep(unsigned int seconds)
 {
-#ifdef WIN32
+#ifdef _WIN32
     Sleep(seconds);
 #else
     sleep(seconds);
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     LIBSSH2_CHANNEL *channel;
     int counter;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsadata;
 
     rc = WSAStartup(MAKEWORD(2, 0), &wsadata);
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
 
     if(getenv("USER"))
         username = getenv("USER");
-#ifdef WIN32
+#ifdef _WIN32
     else if(getenv("USERNAME"))
         username = getenv("USERNAME");
 #endif
@@ -254,7 +254,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2 /* SHUT_RDWR */);
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(sock);
 #else
         close(sock);


### PR DESCRIPTION
Instead of `WIN32`.

The compiler defines `_WIN32`. Windows SDK headers or build env defines
`WIN32`, or we have to take care of it. The agreement seems to be that
`_WIN32` is the preferred practice here.

Minor downside is that CMake uses `WIN32` and we also adopted it in
`Makefile.mk`.

In public libssh2 headers we stick with accepting either `_WIN32` or
`WIN32` and define our own namespaced `LIBSSH2_WIN32` based on them.

grepping for `WIN32` remains useful to lookup Windows-specific code.

Closes #1195
