### PR TITLE
ci: update actions, use shallow clones with appveyor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'checksrc'
         run: ./ci/checksrc.sh
 
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'install tools'
         run: pip install -U codespell
       - name: 'spellcheck'
@@ -38,7 +38,7 @@ jobs:
     env:
       CC: clang
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'cmake'
         run: |
           sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install libssl-dev
@@ -87,7 +87,7 @@ jobs:
     env:
       CC: ${{ matrix.compiler }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'install architecture'
         if: ${{ matrix.arch != 'amd64' }}
         run: |
@@ -176,7 +176,7 @@ jobs:
     env:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'install packages'
         run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install mingw-w64
       - name: 'autotools autoreconf'
@@ -216,7 +216,7 @@ jobs:
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cygwin/cygwin-install-action@v4
         with:
           platform: ${{ matrix.platform }}
@@ -273,7 +273,7 @@ jobs:
           - { build: 'make'     , sys: mingw64, env: x86_64 }
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys == 'msys' }}
         with:
@@ -382,7 +382,7 @@ jobs:
           - { arch: x86  , plat: windows, crypto: WinCNG , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'cmake configure'
         shell: bash
         run: |
@@ -453,7 +453,7 @@ jobs:
     steps:
       - name: 'install packages'
         run: brew install automake ${{ matrix.crypto.install }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}
         run: autoreconf -fi

--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -34,13 +34,13 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - shell: bash
         id: hash
@@ -51,7 +51,7 @@ jobs:
         run: docker manifest inspect ghcr.io/${{ github.repository_owner }}/ci_tests_openssh_server:${{ steps.hash.outputs.hash }}
         continue-on-error: true
 
-      - uses: docker/metadata-action@v4
+      - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/ci_tests_openssh_server
@@ -59,7 +59,7 @@ jobs:
             type=raw,value=${{ steps.hash.outputs.hash }}
         if: ${{ steps.poll.outcome == 'failure' }}
 
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
           context: ./tests/openssh_server
           push: true

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -24,6 +24,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v1
+        uses: fsfe/reuse-action@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -226,6 +226,8 @@ skip_commits:
   files:
     - '.github/**/*'
 
+clone_depth: 10
+
 # Limit branches to avoid testing feature branches twice (as branch and as pull request)
 branches:
   only:


### PR DESCRIPTION
- update GitHub Actions to their latest versions.

- use shallow git clones in AppVeyor CI to save data over the wire.

Closes #1199
