### PR TITLE
cmake: simplify showing CMake version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
             crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}'
             cflags='-m32 -mpclmul -msse2 -maes'
           fi
-          cmake --version
           cmake ${crossoptions} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
@@ -153,7 +152,6 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: |
           [ '${{ matrix.arch }}' = 'i386' ] && crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} -DCMAKE_C_FLAGS=-m32'
-          cmake --version
           cmake -B bld ${crossoptions} $TOOLCHAIN_OPTION \
             -DENABLE_WERROR=ON \
             -DCRYPTO_BACKEND=${{ matrix.crypto }} \
@@ -195,7 +193,6 @@ jobs:
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         run: |
-          cmake --version
           cmake -B bld \
             -DCMAKE_SYSTEM_NAME=Windows \
             -DCMAKE_C_COMPILER_TARGET=${TRIPLET} \
@@ -246,7 +243,6 @@ jobs:
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
-          cmake --version
           cmake -B bld \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \
@@ -339,7 +335,6 @@ jobs:
             cflags=''
             rcopts=''
           fi
-          cmake --version
           cmake -B bld ${options} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
@@ -397,7 +392,6 @@ jobs:
           else
             system='Windows'
           fi
-          cmake --version
           cmake -B bld ${options} \
             -DCMAKE_SYSTEM_NAME=${system} \
             -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake \
@@ -479,7 +473,6 @@ jobs:
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         run: |
-          cmake --version
           cmake -B bld ${{ matrix.crypto.cmake }} \
             -DCMAKE_UNITY_BUILD=ON \
             -DENABLE_WERROR=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.7)
+message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -185,7 +185,6 @@ build_script:
       #        'libssh2_session_handshake failed (-43): Failed getting banner'
       $options += '-DRUN_SSHD_TESTS=OFF'
 
-      cmake --version
       Write-Host 'CMake options:' $options
       cmake -B _builds $options
       cmake --build _builds --config "$env:CONFIGURATION"

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.7)
+message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 project(test-dependent C)
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -8,8 +8,6 @@ set -u
 
 cd "$(dirname "$0")"
 
-cmake --version
-
 rm -rf bld-fetchcontent; cmake -B bld-fetchcontent -DTEST_INTEGRATION_MODE=FetchContent \
   -DFROM_GIT_REPO="${PWD}/../.." \
   -DFROM_GIT_TAG="$(git rev-parse HEAD)"


### PR DESCRIPTION
Move it to `CMakeLists.txt`. Drop `cmake --version` commands.

Credit to the `zlib-ng` project for the idea:
https://github.com/zlib-ng/zlib-ng/blob/61e181c8ae93dbf56040336179c9954078bd1399/CMakeLists.txt#L7

Closes #1203
