### PR TITLE
openssl: silence `-Wunused-value` warnings

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3515,7 +3515,7 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                               "file: Unable to open private key file");
     }
 
-    BIO_reset(bp);
+    (void)BIO_reset(bp);
     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
     BIO_free(bp);
 
@@ -3881,7 +3881,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                               "Unable to allocate memory when"
                               "computing public key");
-    BIO_reset(bp);
+    (void)BIO_reset(bp);
     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
 #ifdef HAVE_SSLERROR_BAD_DECRYPT
     sslError = ERR_get_error();
@@ -3992,7 +3992,7 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                               "Unable to allocate memory when"
                               "computing public key");
-    BIO_reset(bp);
+    (void)BIO_reset(bp);
     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
     BIO_free(bp);
 


### PR DESCRIPTION
Seen with gcc 12.

Manual: https://www.openssl.org/docs/man3.1/man3/BIO_reset.html

```
/home/runner/work/curl-for-win/curl-for-win/libssh2/src/openssl.c: In function '_libssh2_pub_priv_keyfile':
/home/runner/work/curl-for-win/curl-for-win/quictls/linux-a64-musl/usr/include/openssl/bio.h:555:34: warning: value computed is not used [-Wunused-value]
  555 | # define BIO_reset(b)            (int)BIO_ctrl(b,BIO_CTRL_RESET,0,NULL)
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/curl-for-win/curl-for-win/libssh2/src/openssl.c:3518:5: note: in expansion of macro 'BIO_reset'
 3518 |     BIO_reset(bp);
      |     ^~~~~~~~~
/home/runner/work/curl-for-win/curl-for-win/libssh2/src/openssl.c: In function '_libssh2_pub_priv_keyfilememory':
/home/runner/work/curl-for-win/curl-for-win/quictls/linux-a64-musl/usr/include/openssl/bio.h:555:34: warning: value computed is not used [-Wunused-value]
  555 | # define BIO_reset(b)            (int)BIO_ctrl(b,BIO_CTRL_RESET,0,NULL)
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/curl-for-win/curl-for-win/libssh2/src/openssl.c:3884:5: note: in expansion of macro 'BIO_reset'
 3884 |     BIO_reset(bp);
      |     ^~~~~~~~~
/home/runner/work/curl-for-win/curl-for-win/libssh2/src/openssl.c: In function '_libssh2_sk_pub_keyfilememory':
/home/runner/work/curl-for-win/curl-for-win/quictls/linux-a64-musl/usr/include/openssl/bio.h:555:34: warning: value computed is not used [-Wunused-value]
  555 | # define BIO_reset(b)            (int)BIO_ctrl(b,BIO_CTRL_RESET,0,NULL)
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/curl-for-win/curl-for-win/libssh2/src/openssl.c:3995:5: note: in expansion of macro 'BIO_reset'
 3995 |     BIO_reset(bp);
      |     ^~~~~~~~~
```
Ref: https://github.com/curl/curl-for-win/actions/runs/6696392318/job/18194032712#step:3:5060

Closes #1205