### PR TITLE
src: fix gcc 13 `-Wconversion` warning on Darwin

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1773,7 +1773,11 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
         }
 #elif defined(HAVE_SELECT)
         tv.tv_sec = timeout_remaining / 1000;
+#ifdef libssh2_usec_t
+        tv.tv_usec = (libssh2_usec_t)((timeout_remaining % 1000) * 1000);
+#else
         tv.tv_usec = (timeout_remaining % 1000) * 1000;
+#endif
 
         {
             struct timeval tv_begin, tv_end;


### PR DESCRIPTION
```
src/session.c: In function 'libssh2_poll':
src/session.c:1776:22: warning: conversion from 'long int' to '__darwin_suseconds_t' {aka 'int'} may change value [-Wconversion]
 1776 |         tv.tv_usec = (timeout_remaining % 1000) * 1000;
      |                      ^
```
Ref: https://github.com/curl/curl-for-win/actions/runs/6711735060/job/18239768548#step:3:4368

Follow-up to 08354e0abbe86d4cc5088d210d53531be6d8981a

Closes #1209
