### PR TITLE
man: fix double spaces and dash escaping

### DIFF
--- a/docs/libssh2_agent_free.3
+++ b/docs/libssh2_agent_free.3
@@ -11,7 +11,7 @@ void
 libssh2_agent_free(LIBSSH2_AGENT *agent);
 .fi
 .SH DESCRIPTION
-Free an ssh-agent handle.  This function also frees the internal
+Free an ssh-agent handle. This function also frees the internal
 collection of public keys.
 .SH RETURN VALUE
 None.

--- a/docs/libssh2_agent_init.3
+++ b/docs/libssh2_agent_init.3
@@ -12,7 +12,7 @@ libssh2_agent_init(LIBSSH2_SESSION *session);
 .fi
 .SH DESCRIPTION
 Init an ssh-agent handle. Returns the handle to an internal
-representation of an ssh-agent connection.  After the successful
+representation of an ssh-agent connection. After the successful
 initialization, an application can call \fBlibssh2_agent_connect(3)\fP
 to connect to a running ssh-agent.
 

--- a/docs/libssh2_agent_list_identities.3
+++ b/docs/libssh2_agent_list_identities.3
@@ -12,7 +12,7 @@ libssh2_agent_list_identities(LIBSSH2_AGENT *agent);
 .fi
 .SH DESCRIPTION
 Request an ssh-agent to list of public keys, and stores them in the
-internal collection of the handle.  Call
+internal collection of the handle. Call
 \fIlibssh2_agent_get_identity(3)\fP to get a public key off the
 collection.
 

--- a/docs/libssh2_banner_set.3
+++ b/docs/libssh2_banner_set.3
@@ -30,6 +30,6 @@ LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH AVAILABILITY
 Marked as deprecated since 1.4.0
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 .SH SEE ALSO
 .BR libssh2_session_handshake(3)

--- a/docs/libssh2_banner_set.3
+++ b/docs/libssh2_banner_set.3
@@ -22,9 +22,10 @@ instead!
 Set the banner that will be sent to the remote host when the SSH session is
 started with
 .BR libssh2_session_handshake(3)
-  This is optional; a banner corresponding to the protocol and libssh2 version will be sent by default.
+This is optional; a banner corresponding to the protocol and libssh2 version
+will be sent by default.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH AVAILABILITY

--- a/docs/libssh2_channel_close.3
+++ b/docs/libssh2_channel_close.3
@@ -20,7 +20,7 @@ its own close message in response. To wait for the remote end to close its
 connection as well, follow this command with
 .BR libssh2_channel_wait_closed(3)
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_channel_direct_streamlocal_ex.3
+++ b/docs/libssh2_channel_direct_streamlocal_ex.3
@@ -29,6 +29,6 @@ in cleartext.
 .SH RETURN VALUE
 Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 .SH SEE ALSO
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_channel_direct_tcpip_ex.3
+++ b/docs/libssh2_channel_direct_tcpip_ex.3
@@ -35,6 +35,6 @@ in cleartext.
 .SH RETURN VALUE
 Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 .SH SEE ALSO
 .BR libssh2_session_init_ex(3)

--- a/docs/libssh2_channel_forward_cancel.3
+++ b/docs/libssh2_channel_forward_cancel.3
@@ -20,7 +20,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 .SH SEE ALSO

--- a/docs/libssh2_channel_forward_cancel.3
+++ b/docs/libssh2_channel_forward_cancel.3
@@ -14,9 +14,10 @@ libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener);
 \fIlistener\fP - Forwarding listener instance as returned by
 .BR libssh2_channel_forward_listen_ex(3)
 
-Instruct the remote host to stop listening for new connections on a previously requested host/port.
+Instruct the remote host to stop listening for new connections on a previously
+requested host/port.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_channel_free.3
+++ b/docs/libssh2_channel_free.3
@@ -19,7 +19,7 @@ not yet been closed with
 , it will be called automatically so that the remote end may know that it
 can safely free its own resources.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH SEE ALSO

--- a/docs/libssh2_channel_open_ex.3
+++ b/docs/libssh2_channel_open_ex.3
@@ -47,7 +47,7 @@ or
 .SH RETURN VALUE
 Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_channel_process_startup.3
+++ b/docs/libssh2_channel_process_startup.3
@@ -29,7 +29,7 @@ defines shell, exec, and subsystem as standard process services.
 Initiate a request on a session type channel such as returned by
 .BR libssh2_channel_open_ex(3)
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_channel_process_startup.3
+++ b/docs/libssh2_channel_process_startup.3
@@ -33,7 +33,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_channel_request_auth_agent.3
+++ b/docs/libssh2_channel_request_auth_agent.3
@@ -19,6 +19,6 @@ for the duration of the SSH session.
 \fIchannel\fP - Previously opened channel instance such as returned by
 .BR libssh2_channel_open_ex(3)
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.

--- a/docs/libssh2_channel_request_pty_ex.3
+++ b/docs/libssh2_channel_request_pty_ex.3
@@ -41,7 +41,7 @@ Request a PTY on an established channel. Note that this does not make sense
 for all channel types and may be ignored by the server despite returning
 success.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_channel_request_pty_ex.3
+++ b/docs/libssh2_channel_request_pty_ex.3
@@ -45,7 +45,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_channel_send_eof.3
+++ b/docs/libssh2_channel_send_eof.3
@@ -14,7 +14,7 @@ libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel);
 Tell the remote host that no further data will be sent on the specified
 channel. Processes typically interpret this as a closed stdin descriptor.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_channel_setenv_ex.3
+++ b/docs/libssh2_channel_setenv_ex.3
@@ -33,7 +33,7 @@ Set an environment variable in the remote channel's process space. Note that
 this does not make sense for all channel types and may be ignored by the
 server despite returning success.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 

--- a/docs/libssh2_channel_setenv_ex.3
+++ b/docs/libssh2_channel_setenv_ex.3
@@ -38,7 +38,7 @@ LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_channel_signal_ex.3
+++ b/docs/libssh2_channel_signal_ex.3
@@ -13,7 +13,7 @@ libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
                           size_t signame_len)
 .fi
 .SH DESCRIPTION
-A signal can be delivered to the remote process/service.  Some servers or
+A signal can be delivered to the remote process/service. Some servers or
 systems may not implement signals, in which case they will probably ignore this
 message.
 

--- a/docs/libssh2_channel_x11_req_ex.3
+++ b/docs/libssh2_channel_x11_req_ex.3
@@ -37,7 +37,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_channel_x11_req_ex.3
+++ b/docs/libssh2_channel_x11_req_ex.3
@@ -33,7 +33,7 @@ Request an X11 forwarding on \fIchannel\fP. To use X11 forwarding,
 must first be called to set \fBLIBSSH2_CALLBACK_X11\fP. This callback will be
 invoked when the remote host accepts the X11 forwarding.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_free.3
+++ b/docs/libssh2_free.3
@@ -11,9 +11,9 @@ void
 libssh2_free(LIBSSH2_SESSION *session, void *ptr);
 .fi
 .SH DESCRIPTION
-Deallocate memory allocated by earlier call to libssh2 functions.  It
-uses the memory allocation callbacks provided by the application, if
-any.  Otherwise, this will call free().
+Deallocate memory allocated by earlier call to libssh2 functions. It
+uses the memory allocation callbacks provided by the application, if any.
+Otherwise, this will call free().
 
 This function is mostly useful under Windows when libssh2 is linked to
 one run-time library and the application to another.

--- a/docs/libssh2_init.3
+++ b/docs/libssh2_init.3
@@ -13,8 +13,8 @@ int
 libssh2_init(int flags);
 .fi
 .SH DESCRIPTION
-Initialize the libssh2 functions.  This typically initialize the
-crypto library.  It uses a global state, and is not thread safe -- you
+Initialize the libssh2 functions. This typically initialize the
+crypto library. It uses a global state, and is not thread safe -- you
 must make sure this function is not called concurrently.
 .SH RETURN VALUE
 Returns 0 if succeeded, or a negative value for error.

--- a/docs/libssh2_keepalive_config.3
+++ b/docs/libssh2_keepalive_config.3
@@ -16,7 +16,7 @@ libssh2_keepalive_config(LIBSSH2_SESSION *session,
 Set how often keepalive messages should be sent. \fBwant_reply\fP indicates
 whether the keepalive messages should request a response from the server.
 \fBinterval\fP is number of seconds that can pass without any I/O, use 0 (the
-default) to disable keepalives.  To avoid some busy-loop corner-cases, if you
+default) to disable keepalives. To avoid some busy-loop corner-cases, if you
 specify an interval of 1 it will be treated as 2.
 
 Note that non-blocking applications are responsible for sending the keepalive

--- a/docs/libssh2_keepalive_send.3
+++ b/docs/libssh2_keepalive_send.3
@@ -12,7 +12,7 @@ libssh2_keepalive_send(LIBSSH2_SESSION *session,
                        int *seconds_to_next);
 .fi
 .SH DESCRIPTION
-Send a keepalive message if needed.  \fBseconds_to_next\fP indicates how many
+Send a keepalive message if needed. \fBseconds_to_next\fP indicates how many
 seconds you can sleep after this call before you need to call it again.
 .SH RETURN VALUE
 Returns 0 on success, or LIBSSH2_ERROR_SOCKET_SEND on I/O errors.

--- a/docs/libssh2_scp_recv.3
+++ b/docs/libssh2_scp_recv.3
@@ -26,7 +26,7 @@ Request a file from the remote host via SCP.
 .SH RETURN VALUE
 Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SCP_PROTOCOL\fP -
 

--- a/docs/libssh2_scp_recv2.3
+++ b/docs/libssh2_scp_recv2.3
@@ -23,7 +23,7 @@ Request a file from the remote host via SCP.
 .SH RETURN VALUE
 Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SCP_PROTOCOL\fP -
 

--- a/docs/libssh2_scp_send64.3
+++ b/docs/libssh2_scp_send64.3
@@ -35,7 +35,7 @@ Send a file to the remote host via SCP.
 Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_scp_send_ex.3
+++ b/docs/libssh2_scp_send_ex.3
@@ -36,7 +36,7 @@ Send a file to the remote host via SCP.
 Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_session_banner_set.3
+++ b/docs/libssh2_session_banner_set.3
@@ -21,7 +21,7 @@ Set the banner that will be sent to the remote host when the SSH session is
 started with \fIlibssh2_session_handshake(3)\fP This is optional; a banner
 corresponding to the protocol and libssh2 version will be sent by default.
 .SH RETURN VALUE
-Returns 0 on success or negative on failure.  It returns LIBSSH2_ERROR_EAGAIN
+Returns 0 on success or negative on failure. It returns LIBSSH2_ERROR_EAGAIN
 when it would otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative
 number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_session_banner_set.3
+++ b/docs/libssh2_session_banner_set.3
@@ -25,7 +25,7 @@ Returns 0 on success or negative on failure.  It returns LIBSSH2_ERROR_EAGAIN
 when it would otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative
 number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 .SH AVAILABILITY
 Added in 1.4.0.
 

--- a/docs/libssh2_session_block_directions.3
+++ b/docs/libssh2_session_block_directions.3
@@ -27,7 +27,7 @@ LIBSSH2_SESSION_BLOCK_OUTBOUND: Outbound direction blocked.
 
 Application should wait for data to be available for socket prior to calling a
 libssh2 function again. If \fBLIBSSH2_SESSION_BLOCK_INBOUND\fP is set select
-should contain the session socket in readfds set.  Correspondingly in case of
+should contain the session socket in readfds set. Correspondingly in case of
 \fBLIBSSH2_SESSION_BLOCK_OUTBOUND\fP writefds set should contain the socket.
 .SH AVAILABILITY
 Added in 1.0

--- a/docs/libssh2_session_callback_set.3
+++ b/docs/libssh2_session_callback_set.3
@@ -51,7 +51,7 @@ send, \fBlength\fP is the size of the data, \fBflags\fP is the flags that
 would have been used to a \fIsend()\fP call and \fBabstract\fP is a pointer
 to the abstract pointer set in the \fIlibssh2_session_init_ex(3)\fP call.
 
-The callback returns the number of bytes sent, or -1 for error. The special
+The callback returns the number of bytes sent, or \-1 for error. The special
 return code \fB-EAGAIN\fP can be returned to signal that the send was aborted
 to prevent getting blocked and it needs to be called again.
 .IP LIBSSH2_CALLBACK_RECV
@@ -70,7 +70,7 @@ data into, \fBlength\fP is the size of the buffer, \fBflags\fP is the flags
 that would have been used to a \fIrecv()\fP call and \fBabstract\fP is a pointer
 to the abstract pointer set in the \fIlibssh2_session_init_ex(3)\fP call.
 
-The callback returns the number of bytes read, or -1 for error. The special
+The callback returns the number of bytes read, or \-1 for error. The special
 return code \fB-EAGAIN\fP can be returned to signal that the read was aborted
 to prevent getting blocked and it needs to be called again.
 .IP LIBSSH2_CALLBACK_AUTHAGENT

--- a/docs/libssh2_session_callback_set.3
+++ b/docs/libssh2_session_callback_set.3
@@ -36,7 +36,7 @@ function returns 0, the packet will be accepted nonetheless.
 .IP LIBSSH2_CALLBACK_X11
 Called when an X11 connection has been accepted
 .IP LIBSSH2_CALLBACK_SEND
-Called when libssh2 wants to send data on the connection.  Can be set to a
+Called when libssh2 wants to send data on the connection. Can be set to a
 custom function to handle I/O your own way.
 
 The prototype of the callback:

--- a/docs/libssh2_session_disconnect_ex.3
+++ b/docs/libssh2_session_disconnect_ex.3
@@ -36,7 +36,7 @@ is provided. It calls
 with \fIreason\fP set to SSH_DISCONNECT_BY_APPLICATION
 and \fIlang\fP set to an empty string.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH SEE ALSO

--- a/docs/libssh2_session_free.3
+++ b/docs/libssh2_session_free.3
@@ -14,7 +14,7 @@ libssh2_session_free(LIBSSH2_SESSION *session);
 Frees all resources associated with a session instance. Typically called after
 .BR libssh2_session_disconnect_ex(3)
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH SEE ALSO

--- a/docs/libssh2_session_get_blocking.3
+++ b/docs/libssh2_session_get_blocking.3
@@ -2,7 +2,7 @@
 .\" SPDX-License-Identifier: BSD-3-Clause
 .TH libssh2_session_get_blocking 3 "1 Jun 2007" "libssh2 0.15" "libssh2"
 .SH NAME
-libssh2_session_get_blocking \- evaluate blocking mode on session
+libssh2_session_get_blocking - evaluate blocking mode on session
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>

--- a/docs/libssh2_session_method_pref.3
+++ b/docs/libssh2_session_method_pref.3
@@ -33,7 +33,7 @@ LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
 \fILIBSSH2_ERROR_INVAL\fP - The requested method type was invalid.
 
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_METHOD_NOT_SUPPORTED\fP - The requested method is not supported.
 .SH SEE ALSO

--- a/docs/libssh2_session_method_pref.3
+++ b/docs/libssh2_session_method_pref.3
@@ -27,7 +27,7 @@ preferences must be set prior to calling
 .BR libssh2_session_handshake(3)
 as they are used during the protocol initiation phase.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_session_set_blocking.3
+++ b/docs/libssh2_session_set_blocking.3
@@ -17,13 +17,13 @@ libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking);
 \fIblocking\fP - Set to a non-zero value to make the channel block, or zero to
 make it non-blocking.
 
-Set or clear blocking mode on the selected on the session.  This will
+Set or clear blocking mode on the selected on the session. This will
 instantly affect any channels associated with this session. If a read is
 performed on a session with no data currently available, a blocking session
-will wait for data to arrive and return what it receives.  A non-blocking
-session will return immediately with an empty buffer.  If a write is performed
+will wait for data to arrive and return what it receives. A non-blocking
+session will return immediately with an empty buffer. If a write is performed
 on a session with no room for more data, a blocking session will wait for
-room.  A non-blocking session will return immediately without writing
+room. A non-blocking session will return immediately without writing
 anything.
 .SH RETURN VALUE
 None

--- a/docs/libssh2_session_supported_algs.3
+++ b/docs/libssh2_session_supported_algs.3
@@ -66,7 +66,7 @@ is returned.  0 should never be returned.
 .SH ERRORS
 \fILIBSSH2_ERROR_BAD_USE\fP - Invalid address of algs.
 
-\fILIBSSH2_ERROR_METHOD_NOT_SUPPORTED\fP -  Unknown method type.
+\fILIBSSH2_ERROR_METHOD_NOT_SUPPORTED\fP - Unknown method type.
 
 \fILIBSSH2_ERROR_INVAL\fP - Internal error (normally should not occur).
 

--- a/docs/libssh2_session_supported_algs.3
+++ b/docs/libssh2_session_supported_algs.3
@@ -14,8 +14,8 @@ libssh2_session_supported_algs(LIBSSH2_SESSION* session,
 .fi
 .SH DESCRIPTION
 \fIsession\fP - An instance of initialized LIBSSH2_SESSION (the function will
-use its pointer to the memory allocation function).  \fImethod_type\fP -
-Method type. See \fIlibssh2_session_method_pref(3)\fP.  \fIalgs\fP - Address
+use its pointer to the memory allocation function). \fImethod_type\fP -
+Method type. See \fIlibssh2_session_method_pref(3)\fP. \fIalgs\fP - Address
 of a pointer that will point to an array of returned algorithms
 
 Get a list of supported algorithms for the given \fImethod_type\fP. The
@@ -30,7 +30,7 @@ libssh2_session_flag(session, LIBSSH2_FLAG_COMPRESS, 1) must be called before
 calling this function, otherwise only "none" will be returned.
 
 If successful, the function will allocate and fill the array with supported
-algorithms (the same names as defined in RFC 4253).  The array is not NULL
+algorithms (the same names as defined in RFC 4253). The array is not NULL
 terminated.
 .SH EXAMPLE
 .nf
@@ -61,8 +61,8 @@ else {
 .fi
 .SH RETURN VALUE
 On success, a number of returned algorithms (i.e a positive number will be
-returned).  In case of a failure, an error code (a negative number, see below)
-is returned.  0 should never be returned.
+returned). In case of a failure, an error code (a negative number, see below)
+is returned. 0 should never be returned.
 .SH ERRORS
 \fILIBSSH2_ERROR_BAD_USE\fP - Invalid address of algs.
 

--- a/docs/libssh2_sftp_close_handle.3
+++ b/docs/libssh2_sftp_close_handle.3
@@ -30,7 +30,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_close_handle.3
+++ b/docs/libssh2_sftp_close_handle.3
@@ -26,7 +26,7 @@ same underlying storage mechanism these methods may be used
 interchangeably. \fBlibssh2_sftp_close(3)\fP and \fBlibssh2_sftp_closedir(3)\fP
 are macros for \fBlibssh2_sftp_close_handle(3)\fP.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_sftp_fstat_ex.3
+++ b/docs/libssh2_sftp_fstat_ex.3
@@ -85,7 +85,7 @@ Test for a pipe or FIFO special file
 .IP LIBSSH2_SFTP_S_ISSOCK
 Test for a socket
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_sftp_fstat_ex.3
+++ b/docs/libssh2_sftp_fstat_ex.3
@@ -89,7 +89,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_fsync.3
+++ b/docs/libssh2_sftp_fsync.3
@@ -30,7 +30,7 @@ LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 
 \fILIBSSH2_ERROR_SFTP_PROTOCOL\fP - An invalid SFTP protocol response
 was received on the socket, or an SFTP operation caused an errorcode
-to be returned by the server.  In particular, this can be returned if
+to be returned by the server. In particular, this can be returned if
 the SSH server does not support the fsync operation: the SFTP subcode
 \fILIBSSH2_FX_OP_UNSUPPORTED\fP will be returned in this case.
 .SH AVAILABILITY

--- a/docs/libssh2_sftp_fsync.3
+++ b/docs/libssh2_sftp_fsync.3
@@ -24,7 +24,7 @@ Returns 0 on success or negative on failure. If used in non-blocking mode, it
 returns LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_init.3
+++ b/docs/libssh2_sftp_init.3
@@ -25,7 +25,7 @@ function.
 .SH RETURN VALUE
 A pointer to the newly allocated SFTP instance or NULL on failure.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_mkdir_ex.3
+++ b/docs/libssh2_sftp_mkdir_ex.3
@@ -35,7 +35,7 @@ Return 0 on success or negative on failure.
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_open_ex.3
+++ b/docs/libssh2_sftp_open_ex.3
@@ -53,7 +53,7 @@ LIBSSH2_SFTP_OPENDIR (to open a directory).
 A pointer to the newly created LIBSSH2_SFTP_HANDLE instance or NULL on
 failure.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_open_ex.3
+++ b/docs/libssh2_sftp_open_ex.3
@@ -27,7 +27,7 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
 .IP LIBSSH2_FXF_READ
 Open the file for reading.
 .IP LIBSSH2_FXF_WRITE
-Open the file for writing.  If both this and LIBSSH2_FXF_READ are specified,
+Open the file for writing. If both this and LIBSSH2_FXF_READ are specified,
 the file is opened for both reading and writing.
 .IP LIBSSH2_FXF_APPEND
 Force all writes to append data at the end of the file.

--- a/docs/libssh2_sftp_open_ex_r.3
+++ b/docs/libssh2_sftp_open_ex_r.3
@@ -58,7 +58,7 @@ libssh2_sftp_fstat_ex for detailed usage.
 A pointer to the newly created LIBSSH2_SFTP_HANDLE instance or NULL on
 failure.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_open_ex_r.3
+++ b/docs/libssh2_sftp_open_ex_r.3
@@ -28,7 +28,7 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
 .IP LIBSSH2_FXF_READ
 Open the file for reading.
 .IP LIBSSH2_FXF_WRITE
-Open the file for writing.  If both this and LIBSSH2_FXF_READ are specified,
+Open the file for writing. If both this and LIBSSH2_FXF_READ are specified,
 the file is opened for both reading and writing.
 .IP LIBSSH2_FXF_APPEND
 Force all writes to append data at the end of the file.

--- a/docs/libssh2_sftp_read.3
+++ b/docs/libssh2_sftp_read.3
@@ -33,7 +33,7 @@ Number of bytes actually populated into buffer, or negative on failure.
 It returns LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_readdir_ex.3
+++ b/docs/libssh2_sftp_readdir_ex.3
@@ -50,7 +50,7 @@ Passing in a too small buffer for 'buffer' or 'longentry' when receiving data
 only results in libssh2 1.2.7 or earlier to not copy the entire data amount,
 and it is not possible for the application to tell when it happens!
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_readdir_ex.3
+++ b/docs/libssh2_sftp_readdir_ex.3
@@ -42,7 +42,7 @@ the full directory entry is longer than the space provided by
 statbuf style data into.
 .SH RETURN VALUE
 Number of bytes actually populated into buffer (not counting the terminating
-zero), or negative on failure.  It returns LIBSSH2_ERROR_EAGAIN when it would
+zero), or negative on failure. It returns LIBSSH2_ERROR_EAGAIN when it would
 otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative number, it is not
 really a failure per se.
 .SH BUG

--- a/docs/libssh2_sftp_rename_ex.3
+++ b/docs/libssh2_sftp_rename_ex.3
@@ -46,7 +46,7 @@ will fail. Use of the other two flags indicate a preference (but not a
 requirement) for the remote end to perform an atomic rename operation
 and/or using native system calls when possible.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_sftp_rename_ex.3
+++ b/docs/libssh2_sftp_rename_ex.3
@@ -50,7 +50,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_rmdir_ex.3
+++ b/docs/libssh2_sftp_rmdir_ex.3
@@ -23,7 +23,7 @@ Remove a directory from the remote file system.
 \fIsourcefile_len\fP - Length of the full path of the existing directory to
 remove.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_sftp_rmdir_ex.3
+++ b/docs/libssh2_sftp_rmdir_ex.3
@@ -27,7 +27,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_shutdown.3
+++ b/docs/libssh2_sftp_shutdown.3
@@ -18,7 +18,7 @@ libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp);
 Destroys a previously initialized SFTP session and frees all resources
 associated with it.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH SEE ALSO

--- a/docs/libssh2_sftp_stat_ex.3
+++ b/docs/libssh2_sftp_stat_ex.3
@@ -61,7 +61,7 @@ struct LIBSSH2_SFTP_ATTRIBUTES {
 };
 .fi
 .SH RETURN VALUE
-Returns 0 on success or negative on failure.  It returns LIBSSH2_ERROR_EAGAIN
+Returns 0 on success or negative on failure. It returns LIBSSH2_ERROR_EAGAIN
 when it would otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative
 number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_sftp_stat_ex.3
+++ b/docs/libssh2_sftp_stat_ex.3
@@ -65,7 +65,7 @@ Returns 0 on success or negative on failure.  It returns LIBSSH2_ERROR_EAGAIN
 when it would otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative
 number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_statvfs.3
+++ b/docs/libssh2_sftp_statvfs.3
@@ -64,7 +64,7 @@ Returns 0 on success or negative on failure. If used in non-blocking mode, it
 returns LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_symlink_ex.3
+++ b/docs/libssh2_sftp_symlink_ex.3
@@ -68,7 +68,7 @@ Passing in a too small buffer when receiving data only results in libssh2
 1.2.7 or earlier to not copy the entire data amount, and it is not possible
 for the application to tell when it happens!
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_unlink_ex.3
+++ b/docs/libssh2_sftp_unlink_ex.3
@@ -25,7 +25,7 @@ filesystem entry
 
 Unlink (delete) a file from the remote filesystem.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_sftp_unlink_ex.3
+++ b/docs/libssh2_sftp_unlink_ex.3
@@ -29,7 +29,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_sftp_write.3
+++ b/docs/libssh2_sftp_write.3
@@ -60,7 +60,7 @@ really a failure per se.
 If this function returns 0 (zero) it should not be considered an error, but
 that there was no error but yet no payload data got sent to the other end.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_trace_sethandler.3
+++ b/docs/libssh2_trace_sethandler.3
@@ -20,9 +20,9 @@ libssh2_trace_sethandler(LIBSSH2_SESSION *session,
 .SH DESCRIPTION
 libssh2_trace_sethandler installs a trace output handler for your application.
 By default, when tracing has been switched on via a call to libssh2_trace(),
-all output is written to stderr.  By calling this method and passing a
+all output is written to stderr. By calling this method and passing a
 function pointer that matches the libssh2_trace_handler_func prototype,
-libssh2 will call back as it generates trace output.  This can be used to
+libssh2 will call back as it generates trace output. This can be used to
 capture the trace output and put it into a log file or diagnostic window.
 This function has no effect unless libssh2 was built to support this option,
 and a typical "release build" might not.

--- a/docs/libssh2_userauth_keyboard_interactive_ex.3
+++ b/docs/libssh2_userauth_keyboard_interactive_ex.3
@@ -47,7 +47,7 @@ requesting actual password as response, but it is not required by the
 protocol, and various authentication schemes, such as smartcard authentication
 may use keyboard-interactive authentication type too.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns LIBSSH2_ERROR_EAGAIN
+Return 0 on success or negative on failure. It returns LIBSSH2_ERROR_EAGAIN
 when it would otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative
 number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_userauth_keyboard_interactive_ex.3
+++ b/docs/libssh2_userauth_keyboard_interactive_ex.3
@@ -51,7 +51,7 @@ Return 0 on success or negative on failure.  It returns LIBSSH2_ERROR_EAGAIN
 when it would otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative
 number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_userauth_list.3
+++ b/docs/libssh2_userauth_list.3
@@ -31,8 +31,8 @@ authentication succeeds, this method with return NULL. This case may be
 distinguished from a failing case by examining
 \fIlibssh2_userauth_authenticated(3)\fP.
 .SH RETURN VALUE
-On success a comma delimited list of supported authentication schemes.  This
-list is internally managed by libssh2.  On failure returns NULL.
+On success a comma delimited list of supported authentication schemes. This
+list is internally managed by libssh2. On failure returns NULL.
 .SH ERRORS
 \fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 

--- a/docs/libssh2_userauth_list.3
+++ b/docs/libssh2_userauth_list.3
@@ -34,7 +34,7 @@ distinguished from a failing case by examining
 On success a comma delimited list of supported authentication schemes.  This
 list is internally managed by libssh2.  On failure returns NULL.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_userauth_password_ex.3
+++ b/docs/libssh2_userauth_password_ex.3
@@ -48,7 +48,7 @@ LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
 Some of the errors this function may return include:
 
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_userauth_password_ex.3
+++ b/docs/libssh2_userauth_password_ex.3
@@ -42,7 +42,7 @@ which appear to support ordinary password authentication actually have
 it disabled and use Keyboard Interactive authentication (routed via
 PAM or another authentication backed) instead.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_userauth_publickey_fromfile_ex.3
+++ b/docs/libssh2_userauth_publickey_fromfile_ex.3
@@ -34,7 +34,7 @@ can be set to NULL.
 Attempt public key authentication using a PEM encoded private key file stored
 on disk
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS

--- a/docs/libssh2_userauth_publickey_fromfile_ex.3
+++ b/docs/libssh2_userauth_publickey_fromfile_ex.3
@@ -38,7 +38,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_userauth_publickey_frommemory.3
+++ b/docs/libssh2_userauth_publickey_frommemory.3
@@ -43,7 +43,7 @@ Return 0 on success or negative on failure.  It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
-\fILIBSSH2_ERROR_ALLOC\fP -  An internal memory allocation call failed.
+\fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_userauth_publickey_frommemory.3
+++ b/docs/libssh2_userauth_publickey_frommemory.3
@@ -39,7 +39,7 @@ It is only supported when libssh2 is backed by OpenSSL.
 
 Attempt public key authentication using a PEM encoded private key file stored in memory.
 .SH RETURN VALUE
-Return 0 on success or negative on failure.  It returns
+Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS


### PR DESCRIPTION
- `-  ` -> `- `
- `.  ` -> `. `
- `\- ` -> `- `
- `-1` -> `\-1`
- fold long lines along the way

This makes the minus sign come out as a Unicode minus sign
(0x2212), and title separator dashes as Unicode hyphen (0x2010),
with `groff -Tutf8` v1.23.0.

Ref: https://lwn.net/Articles/947941/

Closes #1210
