### PR TITLE
tidy-up: around `stdint.h`

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -145,7 +145,7 @@ API
  New functions:
 
     LIBSSH2_SFTP_HANDLE *libssh2_sftp_send(SFTP_SESSION *sftp,
-                                           uint64_t filesize,
+                                           libssh2_uint64_t filesize,
                                            char *remote_path,
                                            size_t remote_path_len,
                                            long mode);

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -91,9 +91,6 @@
 /* use SO_NONBLOCK for non-blocking sockets */
 #undef HAVE_SO_NONBLOCK
 
-/* Define to 1 if you have the <stdint.h> header file. */
-#define HAVE_STDINT_H 1
-
 /* Define to 1 if you have the <stdio.h> header file. */
 #define HAVE_STDIO_H 1
 

--- a/tests/ossfuzz/standaloneengine.cc
+++ b/tests/ossfuzz/standaloneengine.cc
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
- os400: delete unused `HAVE_STDINT_H`.

- fuzz: delete redundant `stdint.h` use.
  `inttypes.h` is already included via `testinput.h`.

- docs/TODO: adjust type in planned function.

Closes #1212
