### PR TITLE
reuse: fix duplicate copyright warning

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,7 +4,12 @@ Upstream-Contact: The libssh2 team <libssh2-devel@lists.haxx.se>
 Source: https://libssh2.org/
 
 # Test data
-Files: tests/openssh_server/* tests/ossfuzz/* tests/key_* tests/test_read_algos.txt ci/spellcheck-words.txt
+Files: tests/ossfuzz/* tests/key_* tests/test_read_algos.txt ci/spellcheck-words.txt
+Copyright: The libssh2 project and its contributors.
+License: BSD-3-Clause
+
+# Test server
+Files: tests/openssh_server/.gitattributes tests/openssh_server/authorized_keys tests/openssh_server/ca_* tests/openssh_server/ssh_* tests/openssh_server/sshd_config
 Copyright: The libssh2 project and its contributors.
 License: BSD-3-Clause
 

--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -1,4 +1,5 @@
 # Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
 
 FROM debian:testing-slim
 


### PR DESCRIPTION
```
/opt/venv/lib/python3.10/site-packages/reuse/project.py:224: PendingDeprecationWarning:
Copyright and licensing information for 'tests/openssh_server/Dockerfile' has been found
in both 'tests/openssh_server/Dockerfile' and in the DEP5 file located at '.reuse/dep5'.
The information for these two sources has been aggregated. In the future this behaviour
will change, and you will need to explicitly enable aggregation. See
<https://github.com/fsfe/reuse-tool/issues/779>. You need do nothing yet.
Run with `--suppress-deprecation` to hide this warning.
```
Ref: https://github.com/libssh2/libssh2/actions/runs/6789274955/job/18456085964#step:4:4