### PR TITLE
ci: add FreeBSD 13.2 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,5 +502,5 @@ jobs:
             mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
               --with-crypto=openssl \
               --disable-tests
-            make -j1
+            make -j2
             make check VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
       - name: 'autotools'
         uses: vmactions/freebsd-vm@v1
         with:
-          prepare: pkg install -y gcc make openssl
+          prepare: pkg install -y autoconf automake libtool gcc openssl-quictls
           usesh: true
           run: |
             autoreconf -fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,8 +516,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: 'install packages'
-        run: brew install automake autoconf libtool
       - name: 'autotools'
         uses: vmactions/freebsd-vm@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,30 +483,6 @@ jobs:
         timeout-minutes: 10
         run: cd bld && ctest -VV --output-on-failure
 
-#  build_solaris:
-#    strategy:
-#      matrix:
-#        osver: [11.4]
-#    name: 'Solaris ${{ matrix.osver }}'
-#    runs-on: macos-12
-#    timeout-minutes: 30
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: 'install packages'
-#        run: brew install automake autoconf libtool
-#      - name: 'autotools'
-#        uses: vmactions/solaris-vm@v0
-#        with:
-#          prepare: pkg install gcc make openssl
-#          run: |
-#            export MAKE=gmake
-#            autoreconf -fi
-#            mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
-#              --with-crypto=openssl \
-#              --disable-tests
-#            "${MAKE}" -j3
-#            "${MAKE}" check VERBOSE=1
-
   build_freebsd:
     strategy:
       matrix:
@@ -526,5 +502,5 @@ jobs:
             mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
               --with-crypto=openssl \
               --disable-tests
-            make -j3
+            make -j2
             make check VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,29 +483,29 @@ jobs:
         timeout-minutes: 10
         run: cd bld && ctest -VV --output-on-failure
 
-  build_solaris:
-    strategy:
-      matrix:
-        osver: [11.4]
-    name: 'Solaris ${{ matrix.osver }}'
-    runs-on: macos-12
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'install packages'
-        run: brew install automake autoconf libtool
-      - name: 'autotools'
-        uses: vmactions/solaris-vm@v0
-        with:
-          prepare: pkg install gcc make openssl
-          run: |
-            export MAKE=gmake
-            autoreconf -fi
-            mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
-              --with-crypto=openssl \
-              --disable-tests
-            "${MAKE}" -j3
-            "${MAKE}" check VERBOSE=1
+#  build_solaris:
+#    strategy:
+#      matrix:
+#        osver: [11.4]
+#    name: 'Solaris ${{ matrix.osver }}'
+#    runs-on: macos-12
+#    timeout-minutes: 30
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: 'install packages'
+#        run: brew install automake autoconf libtool
+#      - name: 'autotools'
+#        uses: vmactions/solaris-vm@v0
+#        with:
+#          prepare: pkg install gcc make openssl
+#          run: |
+#            export MAKE=gmake
+#            autoreconf -fi
+#            mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
+#              --with-crypto=openssl \
+#              --disable-tests
+#            "${MAKE}" -j3
+#            "${MAKE}" check VERBOSE=1
 
   build_freebsd:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,7 +497,6 @@ jobs:
         with:
           # https://ports.freebsd.org/
           prepare: pkg install -y autoconf automake libtool gcc openssl-quictls
-          usesh: true
           run: |
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-werror --enable-debug \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,5 +502,4 @@ jobs:
             mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
               --with-crypto=openssl \
               --disable-tests
-            make -j2
             make check VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,5 +502,5 @@ jobs:
             mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
               --with-crypto=openssl \
               --disable-tests
-            make -j2
+            make -j1
             make check VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,3 +482,51 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 10
         run: cd bld && ctest -VV --output-on-failure
+
+  build_solaris:
+    strategy:
+      matrix:
+        osver: [11.4]
+    name: 'Solaris ${{ matrix.osver }}'
+    runs-on: macos-12
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'install packages'
+        run: brew install automake autoconf libtool
+      - name: 'autotools'
+        uses: vmactions/solaris-vm@v0
+        with:
+          prepare: pkg install gcc make openssl
+          run: |
+            export MAKE=gmake
+            autoreconf -fi
+            mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
+              --with-crypto=openssl \
+              --disable-tests
+            "${MAKE}" -j3
+            "${MAKE}" check VERBOSE=1
+
+  build_freebsd:
+    strategy:
+      matrix:
+        osver: [13.2]
+    name: 'FreeBSD ${{ matrix.osver }}'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'install packages'
+        run: brew install automake autoconf libtool
+      - name: 'autotools'
+        uses: vmactions/freebsd-vm@v1
+        with:
+          prepare: pkg install -y gcc make openssl
+          usesh: true
+          run: |
+            autoreconf -fi
+            mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
+              --with-crypto=openssl \
+              --disable-tests
+            make -j3
+            make check VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,6 +495,7 @@ jobs:
       - name: 'autotools'
         uses: vmactions/freebsd-vm@v1
         with:
+          # https://ports.freebsd.org/
           prepare: pkg install -y autoconf automake libtool gcc openssl-quictls
           usesh: true
           run: |


### PR DESCRIPTION
It runs over Linux via qemu. First two runs were (very) slow, then it
became (much) more performant at just 2x slower than a native Linux
build. Then got slow again, then fast again. Still seems acceptable
for the value this adds.

The build uses autotools and quictls.

Successful builds:
1. https://github.com/libssh2/libssh2/actions/runs/6802676786/job/18496286419 (13m59s, -j3)
2. https://github.com/libssh2/libssh2/actions/runs/6802976375/job/18497243225 (11m5s, -j2)
3. https://github.com/libssh2/libssh2/actions/runs/6803142201/job/18497785049 (3m6s, -j1)
4. https://github.com/libssh2/libssh2/actions/runs/6803194839/job/18497962766 (3m10s, -j2)
5. https://github.com/libssh2/libssh2/actions/runs/6803267201/job/18498208501 (3m13s)
6. https://github.com/libssh2/libssh2/actions/runs/6803510333/job/18498993698 (15m25s)
7. https://github.com/libssh2/libssh2/actions/runs/6813602863/job/18528571057 (3m13s)

Similar solution exists for Solaris (over macOS via VirtualBox), but it
hangs forever at `Waiting for text: solaris console login`:
https://github.com/libssh2/libssh2/actions/runs/6802388128/job/18495391869#step:4:185

Idea taken from LibreSSL.

FIXME: Unrelated, the `distcheck` job became flaky in recent days:
https://github.com/libssh2/libssh2/actions/runs/6802976375/job/18497256437#step:10:536
```
FAIL: test_auth_pubkey_ok_rsa_aes256gcm
```
https://github.com/libssh2/libssh2/actions/runs/6813602863/job/18528588933#step:10:533
```
FAIL: test_read
```

Closes #1215
