### PR TITLE
cmake: fix multiple include of libssh2 package

### DIFF
--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -4,7 +4,11 @@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
 # Alias for either shared or static library
-add_library(@PROJECT_NAME@::@LIB_NAME@ ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+if(NOT TARGET @PROJECT_NAME@::@LIB_NAME@)
+  add_library(@PROJECT_NAME@::@LIB_NAME@ ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+endif()
 
 # Compatibility alias
-add_library(Libssh2::@LIB_NAME@ ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+if(NOT TARGET Libssh2::@LIB_NAME@)
+  add_library(Libssh2::@LIB_NAME@ ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+endif()

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -21,6 +21,7 @@ if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
       DOWNLOAD_EXTRACT_TIMESTAMP ON)
   endif()
   find_package(libssh2 REQUIRED CONFIG)
+  find_package(libssh2 REQUIRED CONFIG)  # test for double-inclusion
   foreach(result_var IN ITEMS libssh2_FOUND libssh2_VERSION)
     if(${result_var})
       message(STATUS "${result_var}: |${${result_var}}|")


### PR DESCRIPTION
Also extend our integration test double inclusion. It will still not
catch this case, because that requires
`cmake_minimum_required(VERSION 3.18)` or higher.

Fixes:
```
CMake Error at .../lib/cmake/libssh2/libssh2-config.cmake:8 (add_library):
  add_library cannot create ALIAS target "libssh2::libssh2" because another
  target with the same name already exists.
Call Stack (most recent call first):
  CMakeLists.txt:24 (find_package)

CMake Error at .../lib/cmake/libssh2/libssh2-config.cmake:13 (add_library):
  add_library cannot create ALIAS target "Libssh2::libssh2" because another
  target with the same name already exists.
Call Stack (most recent call first):
  CMakeLists.txt:24 (find_package)
```

Test to reproduce:
```cmake
cmake_minimum_required(VERSION 3.18)  # must be 3.18 or higher

project(test)

find_package(libssh2 CONFIG)
find_package(libssh2 CONFIG)  # fails

add_executable(test main.c)
target_link_libraries(test libssh2::libssh2)
```

Ref: https://cmake.org/cmake/help/latest/release/3.18.html#other-changes
Ref: https://cmake.org/cmake/help/v3.18/policy/CMP0107.html

Assisted-by: Kai Pastor
Assisted-by: Harry Mallon
Ref: https://github.com/curl/curl/pull/11913

Closes #1216