### PR TITLE
ci: fixup FreeBSD version, bump mbedtls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: 'install mbedTLS from source'
         if: ${{ matrix.crypto == 'mbedTLS' }}
         run: |
-          MBEDTLSVER=mbedtls-3.5.0
+          MBEDTLSVER=mbedtls-3.5.1
           curl -L https://github.com/Mbed-TLS/mbedtls/archive/$MBEDTLSVER.tar.gz | tar -xzf -
           cd mbedtls-$MBEDTLSVER
           if [ '${{ matrix.arch }}' = 'i386' ]; then
@@ -484,10 +484,7 @@ jobs:
         run: cd bld && ctest -VV --output-on-failure
 
   build_freebsd:
-    strategy:
-      matrix:
-        osver: [13.2]
-    name: 'FreeBSD ${{ matrix.osver }}'
+    name: 'FreeBSD (autotools, quictls, gcc, amd64)'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
We haven't been using the FreeBSD version. Also it turns out,
the single version supported is 13.2 at the moment:
  https://github.com/vmactions/freebsd-vm/tree/main/conf

Stop trying to set the version and instead rely on the action
providing the latest supported one automatically.

Follow-up to a7d2a573be26238cc2b55e5ff6649bbe620cb8d9

Also:
- add more details to the FreeBSD job description.
- bump mbedtls version while here.

Closes #1217
