### PR TITLE
build: picky warning updates

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -434,7 +434,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
            CURL_ADD_COMPILER_WARNINGS([WARN], [restrict])
            CURL_ADD_COMPILER_WARNINGS([WARN], [alloc-zero])
            WARN="$WARN -Wformat-overflow=2"
-           WARN="$WARN -Wformat-truncation=2"
+           WARN="$WARN -Wformat-truncation=1"  # =2 causes false positives
          fi
          #
          dnl Only gcc 10 or later

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -215,6 +215,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
       CURL_ADD_COMPILER_WARNINGS([WARN], [inline nested-externs])
       CURL_ADD_COMPILER_WARNINGS([WARN], [missing-declarations])
       CURL_ADD_COMPILER_WARNINGS([WARN], [missing-prototypes])
+      CURL_ADD_COMPILER_WARNINGS([WARN], [old-style-definition])
       WARN="$WARN -Wno-long-long"
       CURL_ADD_COMPILER_WARNINGS([WARN], [float-equal])
       CURL_ADD_COMPILER_WARNINGS([WARN], [no-multichar sign-compare])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -362,6 +362,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          if test "$compiler_num" -ge "304"; then
            # try these on gcc 3.4
            WARN="$WARN -Wdeclaration-after-statement"
+           WARN="$WARN -Wold-style-definition"
          fi
 
          dnl Only gcc 4.0 or later
@@ -383,7 +384,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
          if test "$compiler_num" -ge "403"; then
            CURL_ADD_COMPILER_WARNINGS([WARN], [type-limits old-style-declaration])
            CURL_ADD_COMPILER_WARNINGS([WARN], [missing-parameter-type empty-body])
-           CURL_ADD_COMPILER_WARNINGS([WARN], [ignored-qualifiers])
+           CURL_ADD_COMPILER_WARNINGS([WARN], [clobbered ignored-qualifiers])
            CURL_ADD_COMPILER_WARNINGS([WARN], [conversion])
            WARN="$WARN -Wno-sign-conversion"
            CURL_ADD_COMPILER_WARNINGS([WARN], [vla])
@@ -432,7 +433,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
            CURL_ADD_COMPILER_WARNINGS([WARN], [restrict])
            CURL_ADD_COMPILER_WARNINGS([WARN], [alloc-zero])
            WARN="$WARN -Wformat-overflow=2"
-           WARN="$WARN -Wformat-truncation=1"
+           WARN="$WARN -Wformat-truncation=2"
          fi
          #
          dnl Only gcc 10 or later

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -176,7 +176,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
           -Walloc-zero                     #             gcc  7.0
           -Wduplicated-branches            #             gcc  7.0
           -Wformat-overflow=2              #             gcc  7.0
-          -Wformat-truncation=2            #             gcc  7.0
+          -Wformat-truncation=1            #             gcc  7.0 (=2 causes false positives)
           -Wrestrict                       #             gcc  7.0
         )
       endif()

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -140,8 +140,10 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
         list(APPEND WPICKY_ENABLE
           ${WPICKY_COMMON_OLD}
+          -Wclobbered                      #             gcc  4.3
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
+          -Wold-style-definition           #             gcc  3.4
           -Wstrict-aliasing=3              #             gcc  4.0
         )
       endif()
@@ -174,7 +176,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
           -Walloc-zero                     #             gcc  7.0
           -Wduplicated-branches            #             gcc  7.0
           -Wformat-overflow=2              #             gcc  7.0
-          -Wformat-truncation=1            #             gcc  7.0
+          -Wformat-truncation=2            #             gcc  7.0
           -Wrestrict                       #             gcc  7.0
         )
       endif()

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -94,6 +94,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wno-format-nonliteral               # clang  1.0  gcc  2.96 (3.0)
       -Wno-sign-conversion                 # clang  3.0  gcc  4.3
       -Wno-system-headers                  # clang  1.0  gcc  3.0
+      -Wold-style-definition               # clang  2.7  gcc  3.4
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
       -Wtype-limits                        # clang  3.0  gcc  4.3
       -Wvla                                # clang  2.8  gcc  4.3
@@ -143,7 +144,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
           -Wclobbered                      #             gcc  4.3
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
-          -Wold-style-definition           #             gcc  3.4
           -Wstrict-aliasing=3              #             gcc  4.0
         )
       endif()

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -67,8 +67,8 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.95 or later.
     list(APPEND WPICKY_ENABLE
-      -Wbad-function-cast                  # clang  3.0  gcc  2.95
-      -Wconversion                         # clang  3.0  gcc  2.95
+      -Wbad-function-cast                  # clang  2.7  gcc  2.95
+      -Wconversion                         # clang  2.7  gcc  2.95
       -Winline                             # clang  1.0  gcc  1.0
       -Wmissing-declarations               # clang  1.0  gcc  2.7
       -Wmissing-prototypes                 # clang  1.0  gcc  1.0
@@ -87,16 +87,16 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
     set(WPICKY_COMMON_OLD
       -Wcast-align                         # clang  1.0  gcc  4.2
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
-      -Wempty-body                         # clang  3.0  gcc  4.3
+      -Wempty-body                         # clang  2.7  gcc  4.3
       -Wendif-labels                       # clang  1.0  gcc  3.3
       -Wfloat-equal                        # clang  1.0  gcc  2.96 (3.0)
-      -Wignored-qualifiers                 # clang  3.0  gcc  4.3
+      -Wignored-qualifiers                 # clang  2.8  gcc  4.3
       -Wno-format-nonliteral               # clang  1.0  gcc  2.96 (3.0)
-      -Wno-sign-conversion                 # clang  3.0  gcc  4.3
+      -Wno-sign-conversion                 # clang  2.9  gcc  4.3
       -Wno-system-headers                  # clang  1.0  gcc  3.0
       -Wold-style-definition               # clang  2.7  gcc  3.4
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
-      -Wtype-limits                        # clang  3.0  gcc  4.3
+      -Wtype-limits                        # clang  2.7  gcc  4.3
       -Wvla                                # clang  2.8  gcc  4.3
     )
 


### PR DESCRIPTION
- cmake, autotools: sync picky gcc warnings with curl.
- cmake, autotools: add `-Wold-style-definition` for clang too.
- cmake: more precise version info for old clang options.
- cmake, autotools: add comment for `-Wformat-truncation=1`.

Closes #1219
