### PR TITLE
fix 32-bit timestamp issue in public API #735

### DIFF
--- a/docs/libssh2_sftp_fstat_ex.3
+++ b/docs/libssh2_sftp_fstat_ex.3
@@ -52,7 +52,7 @@ struct _LIBSSH2_SFTP_ATTRIBUTES {
     unsigned long permissions;
 
     /* access time and modified time of file */
-    unsigned long atime, mtime;
+    time_t atime, mtime;
 };
 .fi
 

--- a/docs/libssh2_sftp_stat_ex.3
+++ b/docs/libssh2_sftp_stat_ex.3
@@ -56,8 +56,8 @@ struct LIBSSH2_SFTP_ATTRIBUTES {
     unsigned long uid;
     unsigned long gid;
     unsigned long permissions;
-    unsigned long atime;
-    unsigned long mtime;
+    time_t atime;
+    time_t mtime;
 };
 .fi
 .SH RETURN VALUE

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -104,7 +104,7 @@ struct _LIBSSH2_SFTP_ATTRIBUTES {
     libssh2_uint64_t filesize;
     unsigned long uid, gid;
     unsigned long permissions;
-    unsigned long atime, mtime;
+    time_t atime, mtime;
 };
 
 struct _LIBSSH2_SFTP_STATVFS {


### PR DESCRIPTION
libssh2 issue #735 reported that timestamp fields in LIBSSH2_SFTP_ATTRIBUTES struct were limited to 32 bits on non 64 bit machines

Closes: #735 