### PR TITLE
build: enable more compiler warnings and fix them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,10 @@ if(CRYPTO_BACKEND STREQUAL "mbedTLS" OR NOT CRYPTO_BACKEND)
     list(APPEND LIBRARIES ${MBEDTLS_LIBRARIES})
     list(APPEND LIBSSH2_PC_LIBS_PRIVATE "-lmbedcrypto")
     link_directories(${MBEDTLS_LIBRARY_DIR})
+
+    # mbedTLS (as of v3.5.1) has a duplicate function declaration
+    # in its own public headers. Disable the warning that detects it.
+    string(REGEX REPLACE "-Wredundant-decls" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   endif()
 endif()
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -236,11 +236,19 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           #
           dnl Only clang 2.7 or later
           if test "$compiler_num" -ge "207"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [address])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [attributes])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [bad-function-cast])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [div-by-zero format-security])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [empty-body])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-field-initializers missing-noreturn])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [old-style-definition])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [redundant-decls])
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [switch-enum])       # Not used because this basically disallows default case
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [type-limits])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused-macros])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code unused-parameter])
           fi
           #
           dnl Only clang 2.8 or later
@@ -253,16 +261,18 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           if test "$compiler_num" -ge "209"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wno-sign-conversion"
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shift-sign-overflow])
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [padded])  # Not used because we cannot change public structs
           fi
           #
-          dnl Only clang 3.0 or later (possibly earlier)
+          dnl Only clang 3.0 or later
           if test "$compiler_num" -ge "300"; then
-            tmp_CFLAGS="$tmp_CFLAGS"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [language-extension-token])
           fi
           #
           dnl Only clang 3.2 or later
           if test "$compiler_num" -ge "302"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [enum-conversion])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [sometimes-uninitialized])
             case $host_os in
             cygwin* | mingw*)
               dnl skip missing-variable-declarations warnings for cygwin and
@@ -276,7 +286,14 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           #
           dnl Only clang 3.4 or later
           if test "$compiler_num" -ge "304"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [header-guard])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused-const-variable])
+          fi
+          #
+          dnl Only clang 3.5 or later
+          if test "$compiler_num" -ge "305"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pragmas])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code-break])
           fi
           #
           dnl Only clang 3.6 or later
@@ -398,7 +415,15 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           #
           dnl Only gcc 4.1 or later (possibly earlier)
           if test "$compiler_num" -ge "401"; then
-            tmp_CFLAGS="$tmp_CFLAGS"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [attributes])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [div-by-zero format-security])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-field-initializers missing-noreturn])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code unused-parameter])
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [padded])           # Not used because we cannot change public structs
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pragmas])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [redundant-decls])
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [switch-enum])      # Not used because this basically disallows default case
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused-macros])    # Not practical
           fi
           #
           dnl Only gcc 4.2 or later
@@ -408,6 +433,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           #
           dnl Only gcc 4.3 or later
           if test "$compiler_num" -ge "403"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [address])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [type-limits old-style-declaration])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-parameter-type empty-body])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [clobbered ignored-qualifiers])

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -85,24 +85,42 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
 
     # Always enable with clang, version dependent with gcc
     set(WPICKY_COMMON_OLD
+      -Waddress                            # clang  2.7  gcc  4.3
+      -Wattributes                         # clang  2.7  gcc  4.1
       -Wcast-align                         # clang  1.0  gcc  4.2
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
+      -Wdiv-by-zero                        # clang  2.7  gcc  4.1
       -Wempty-body                         # clang  2.7  gcc  4.3
       -Wendif-labels                       # clang  1.0  gcc  3.3
       -Wfloat-equal                        # clang  1.0  gcc  2.96 (3.0)
+      -Wformat-security                    # clang  2.7  gcc  4.1
       -Wignored-qualifiers                 # clang  2.8  gcc  4.3
+      -Wmissing-field-initializers         # clang  2.7  gcc  4.1
+      -Wmissing-noreturn                   # clang  2.7  gcc  4.1
       -Wno-format-nonliteral               # clang  1.0  gcc  2.96 (3.0)
       -Wno-sign-conversion                 # clang  2.9  gcc  4.3
       -Wno-system-headers                  # clang  1.0  gcc  3.0
+    # -Wpadded                             # clang  2.9  gcc  4.1               # Not used because we cannot change public structs
       -Wold-style-definition               # clang  2.7  gcc  3.4
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
+    # -Wswitch-enum                        # clang  2.7  gcc  4.1               # Not used because this basically disallows default case
       -Wtype-limits                        # clang  2.7  gcc  4.3
+      -Wunreachable-code                   # clang  2.7  gcc  4.1
+      -Wunused-macros                      # clang  2.7  gcc  4.1
+      -Wunused-parameter                   # clang  2.7  gcc  4.1
       -Wvla                                # clang  2.8  gcc  4.3
     )
+
+    if(NOT CMAKE_UNITY_BUILD)
+      list(APPEND WPICKY_COMMON_OLD
+        -Wredundant-decls                  # clang  2.7  gcc  4.1
+      )
+    endif()
 
     set(WPICKY_COMMON
       -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
       -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
+      -Wpragmas                            # clang  3.5  gcc  4.1  appleclang  6.0
       -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
     )
 
@@ -111,12 +129,16 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         ${WPICKY_COMMON_OLD}
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
+        -Wlanguage-extension-token         # clang  3.0
       )
       # Enable based on compiler version
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
         list(APPEND WPICKY_ENABLE
           ${WPICKY_COMMON}
+          -Wunreachable-code-break         # clang  3.5            appleclang  6.0
+          -Wheader-guard                   # clang  3.4            appleclang  5.1
+          -Wsometimes-uninitialized        # clang  3.2            appleclang  4.6
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR

--- a/cmake/max_warnings.cmake
+++ b/cmake/max_warnings.cmake
@@ -102,6 +102,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wno-system-headers                  # clang  1.0  gcc  3.0
     # -Wpadded                             # clang  2.9  gcc  4.1               # Not used because we cannot change public structs
       -Wold-style-definition               # clang  2.7  gcc  3.4
+      -Wredundant-decls                    # clang  2.7  gcc  4.1
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
     # -Wswitch-enum                        # clang  2.7  gcc  4.1               # Not used because this basically disallows default case
       -Wtype-limits                        # clang  2.7  gcc  4.3
@@ -110,12 +111,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wunused-parameter                   # clang  2.7  gcc  4.1
       -Wvla                                # clang  2.8  gcc  4.3
     )
-
-    if(NOT CMAKE_UNITY_BUILD)
-      list(APPEND WPICKY_COMMON_OLD
-        -Wredundant-decls                  # clang  2.7  gcc  4.1
-      )
-    endif()
 
     set(WPICKY_COMMON
       -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3

--- a/src/agent.c
+++ b/src/agent.c
@@ -60,6 +60,7 @@
 #include "userauth.h"
 #include "session.h"
 
+#if 0
 /* Requests from client to agent for protocol 1 key operations */
 #define SSH_AGENTC_REQUEST_RSA_IDENTITIES 1
 #define SSH_AGENTC_RSA_CHALLENGE 3
@@ -67,10 +68,12 @@
 #define SSH_AGENTC_REMOVE_RSA_IDENTITY 8
 #define SSH_AGENTC_REMOVE_ALL_RSA_IDENTITIES 9
 #define SSH_AGENTC_ADD_RSA_ID_CONSTRAINED 24
+#endif
 
 /* Requests from client to agent for protocol 2 key operations */
 #define SSH2_AGENTC_REQUEST_IDENTITIES 11
 #define SSH2_AGENTC_SIGN_REQUEST 13
+#if 0
 #define SSH2_AGENTC_ADD_IDENTITY 17
 #define SSH2_AGENTC_REMOVE_IDENTITY 18
 #define SSH2_AGENTC_REMOVE_ALL_IDENTITIES 19
@@ -91,13 +94,14 @@
 #define SSH_AGENT_RSA_IDENTITIES_ANSWER 2
 #define SSH_AGENT_RSA_RESPONSE 4
 
-/* Replies from agent to client for protocol 2 key operations */
-#define SSH2_AGENT_IDENTITIES_ANSWER 12
-#define SSH2_AGENT_SIGN_RESPONSE 14
-
 /* Key constraint identifiers */
 #define SSH_AGENT_CONSTRAIN_LIFETIME 1
 #define SSH_AGENT_CONSTRAIN_CONFIRM 2
+#endif
+
+/* Replies from agent to client for protocol 2 key operations */
+#define SSH2_AGENT_IDENTITIES_ANSWER 12
+#define SSH2_AGENT_SIGN_RESPONSE 14
 
 /* Signature request methods */
 #define SSH_AGENT_RSA_SHA2_256 2

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -81,16 +81,16 @@ int _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
                              const char *filename,
                              unsigned const char *passphrase);
 #if LIBSSH2_RSA_SHA1
-int _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
-                             const unsigned char *sig,
-                             size_t sig_len,
-                             const unsigned char *m, size_t m_len);
 int _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
                            libssh2_rsa_ctx * rsactx,
                            const unsigned char *hash,
                            size_t hash_len,
                            unsigned char **signature,
                            size_t *signature_len);
+int _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsa,
+                             const unsigned char *sig,
+                             size_t sig_len,
+                             const unsigned char *m, size_t m_len);
 #endif
 #if LIBSSH2_RSA_SHA2
 int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -1326,18 +1326,15 @@ libssh2_hostkey_hash(LIBSSH2_SESSION * session, int hash_type)
         return (session->server_hostkey_md5_valid)
           ? (char *) session->server_hostkey_md5
           : NULL;
-        break;
 #endif /* LIBSSH2_MD5 */
     case LIBSSH2_HOSTKEY_HASH_SHA1:
         return (session->server_hostkey_sha1_valid)
           ? (char *) session->server_hostkey_sha1
           : NULL;
-        break;
     case LIBSSH2_HOSTKEY_HASH_SHA256:
         return (session->server_hostkey_sha256_valid)
           ? (char *) session->server_hostkey_sha256
           : NULL;
-        break;
     default:
         return NULL;
     }

--- a/src/kex.c
+++ b/src/kex.c
@@ -55,6 +55,7 @@
 /* Helper macro called from
    kex_method_diffie_hellman_group1_sha1_key_exchange */
 
+#if LIBSSH2_ECDSA
 #define LIBSSH2_KEX_METHOD_EC_SHA_VALUE_HASH(value, reqlen, version)        \
     do {                                                                    \
         if(type == LIBSSH2_EC_CURVE_NISTP256) {                             \
@@ -67,6 +68,7 @@
             LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(512, value, reqlen, version); \
         }                                                                   \
     } while(0)
+#endif
 
 #define LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(digest_type, value,               \
                                           reqlen, version)                  \
@@ -1568,6 +1570,7 @@ dh_gex_clean_exit:
     return ret;
 }
 
+#if LIBSSH2_ECDSA
 
 /* LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY
  *
@@ -1585,7 +1588,6 @@ dh_gex_clean_exit:
  * mpint    K,   shared secret
  *
  */
-
 #define LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(digest_type)            \
 do {                                                                         \
     libssh2_sha##digest_type##_ctx ctx;                                      \
@@ -1676,9 +1678,6 @@ do {                                                                         \
         rc = -1;                                                             \
     }                                                                        \
 } while(0)
-
-
-#if LIBSSH2_ECDSA
 
 /* kex_session_ecdh_curve_type
  * returns the EC curve type by name used in key exchange

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -470,18 +470,6 @@ _libssh2_mbedtls_free(void);
 int
 _libssh2_mbedtls_random(unsigned char *buf, size_t len);
 
-int
-_libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
-                             _libssh2_cipher_type(type),
-                             unsigned char *iv,
-                             unsigned char *secret,
-                             int encrypt);
-int
-_libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
-                              _libssh2_cipher_type(type),
-                              int encrypt,
-                              unsigned char *block,
-                              size_t blocklen, int firstlast);
 void
 _libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx);
 
@@ -502,124 +490,10 @@ _libssh2_mbedtls_bignum_init(void);
 void
 _libssh2_mbedtls_bignum_free(_libssh2_bn *bn);
 
-int
-_libssh2_mbedtls_rsa_new(libssh2_rsa_ctx **rsa,
-                         const unsigned char *edata,
-                         unsigned long elen,
-                         const unsigned char *ndata,
-                         unsigned long nlen,
-                         const unsigned char *ddata,
-                         unsigned long dlen,
-                         const unsigned char *pdata,
-                         unsigned long plen,
-                         const unsigned char *qdata,
-                         unsigned long qlen,
-                         const unsigned char *e1data,
-                         unsigned long e1len,
-                         const unsigned char *e2data,
-                         unsigned long e2len,
-                         const unsigned char *coeffdata,
-                         unsigned long coefflen);
-
-int
-_libssh2_mbedtls_rsa_new_private(libssh2_rsa_ctx **rsa,
-                                 LIBSSH2_SESSION *session,
-                                 const char *filename,
-                                 const unsigned char *passphrase);
-
-int
-_libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
-                                            LIBSSH2_SESSION *session,
-                                            const char *filedata,
-                                            size_t filedata_len,
-                                            unsigned const char *passphrase);
-int
-_libssh2_mbedtls_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
-                                 const unsigned char *sig,
-                                 size_t sig_len,
-                                 const unsigned char *m,
-                                 size_t m_len);
-int
-_libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION *session,
-                               libssh2_rsa_ctx *rsa,
-                               const unsigned char *hash,
-                               size_t hash_len,
-                               unsigned char **signature,
-                               size_t *signature_len);
-int
-_libssh2_mbedtls_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
-                                 size_t hash_len,
-                                 const unsigned char *sig,
-                                 size_t sig_len,
-                                 const unsigned char *m,
-                                 size_t m_len);
-int
-_libssh2_mbedtls_rsa_sha2_sign(LIBSSH2_SESSION *session,
-                               libssh2_rsa_ctx *rsa,
-                               const unsigned char *hash,
-                               size_t hash_len,
-                               unsigned char **signature,
-                               size_t *signature_len);
 void
 _libssh2_mbedtls_rsa_free(libssh2_rsa_ctx *rsa);
 
-int
-_libssh2_mbedtls_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                                  unsigned char **method,
-                                  size_t *method_len,
-                                  unsigned char **pubkeydata,
-                                  size_t *pubkeydata_len,
-                                  const char *privatekey,
-                                  const char *passphrase);
-int
-_libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                        unsigned char **method,
-                                        size_t *method_len,
-                                        unsigned char **pubkeydata,
-                                        size_t *pubkeydata_len,
-                                        const char *privatekeydata,
-                                        size_t privatekeydata_len,
-                                        const char *passphrase);
 #if LIBSSH2_ECDSA
-int
-_libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
-                                  _libssh2_ec_key **privkey,
-                                  unsigned char **pubkey_octal,
-                                  size_t *pubkey_octal_len,
-                                  libssh2_curve_type curve);
-int
-_libssh2_mbedtls_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx **ctx,
-                                                 const unsigned char *k,
-                                                 size_t k_len,
-                                                 libssh2_curve_type curve);
-int
-_libssh2_mbedtls_ecdh_gen_k(_libssh2_bn **k,
-                            _libssh2_ec_key *privkey,
-                            const unsigned char *server_pubkey,
-                            size_t server_pubkey_len);
-int
-_libssh2_mbedtls_ecdsa_verify(libssh2_ecdsa_ctx *ctx,
-                              const unsigned char *r, size_t r_len,
-                              const unsigned char *s, size_t s_len,
-                              const unsigned char *m, size_t m_len);
-int
-_libssh2_mbedtls_ecdsa_new_private(libssh2_ecdsa_ctx **ctx,
-                                   LIBSSH2_SESSION *session,
-                                   const char *filename,
-                                   const unsigned char *passphrase);
-int
-_libssh2_mbedtls_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ctx,
-                                              LIBSSH2_SESSION *session,
-                                              const char *filedata,
-                                              size_t filedata_len,
-                                              const unsigned char *passphrase);
-int
-_libssh2_mbedtls_ecdsa_sign(LIBSSH2_SESSION *session,
-                            libssh2_ecdsa_ctx *ctx,
-                            const unsigned char *hash,
-                            size_t hash_len,
-                            unsigned char **signature,
-                            size_t *signature_len);
 libssh2_curve_type
 _libssh2_mbedtls_ecdsa_key_get_curve_type(libssh2_ecdsa_ctx *ctx);
 int

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1690,7 +1690,6 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
                     return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                           "SFTP READ error");
                 }
-                break;
 
             case SSH_FXP_DATA:
                 if(chunk->offset != filep->offset) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1283,7 +1283,7 @@ _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx *rsa,
 }
 #endif
 
-int
+static int
 _libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
                              libssh2_rsa_ctx *rsa,
                              const unsigned char *hash,
@@ -1342,6 +1342,32 @@ _libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
     _libssh2_wincng_safe_free(data, datalen);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
+}
+
+int
+_libssh2_wincng_rsa_sha1_sign(LIBSSH2_SESSION *session,
+                              libssh2_rsa_ctx *rsa,
+                              const unsigned char *hash,
+                              size_t hash_len,
+                              unsigned char **signature,
+                              size_t *signature_len)
+{
+    return _libssh2_wincng_rsa_sha_sign(session, rsa,
+                                        hash, hash_len,
+                                        signature, signature_len);
+}
+
+int
+_libssh2_wincng_rsa_sha2_sign(LIBSSH2_SESSION *session,
+                              libssh2_rsa_ctx *rsa,
+                              const unsigned char *hash,
+                              size_t hash_len,
+                              unsigned char **signature,
+                              size_t *signature_len)
+{
+    return _libssh2_wincng_rsa_sha_sign(session, rsa,
+                                        hash, hash_len,
+                                        signature, signature_len);
 }
 
 void

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -281,9 +281,9 @@ typedef struct __libssh2_wincng_key_ctx {
     _libssh2_wincng_rsa_new_private_frommemory(rsactx, s, filedata, \
                                                filedata_len, passphrase)
 #define _libssh2_rsa_sha1_sign(s, rsactx, hash, hash_len, sig, sig_len) \
-    _libssh2_wincng_rsa_sha_sign(s, rsactx, hash, hash_len, sig, sig_len)
+    _libssh2_wincng_rsa_sha1_sign(s, rsactx, hash, hash_len, sig, sig_len)
 #define _libssh2_rsa_sha2_sign(s, rsactx, hash, hash_len, sig, sig_len) \
-    _libssh2_wincng_rsa_sha_sign(s, rsactx, hash, hash_len, sig, sig_len)
+    _libssh2_wincng_rsa_sha2_sign(s, rsactx, hash, hash_len, sig, sig_len)
 #define _libssh2_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len) \
     _libssh2_wincng_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len)
 #define _libssh2_rsa_sha2_verify(rsactx, hash_len, sig, sig_len, m, m_len) \

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -126,9 +126,6 @@ extern struct _libssh2_wincng_ctx _libssh2_wincng;
  * Windows CNG backend: Generic functions
  */
 
-void _libssh2_wincng_init(void);
-void _libssh2_wincng_free(void);
-
 #define libssh2_crypto_init() \
     _libssh2_wincng_init()
 #define libssh2_crypto_exit() \
@@ -408,8 +405,6 @@ struct _libssh2_wincng_bignum {
 /*
  * Windows CNG backend: BigNumber functions
  */
-
-_libssh2_bn *_libssh2_wincng_bignum_init(void);
 
 #define _libssh2_bn_init() \
     _libssh2_wincng_bignum_init()

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -481,119 +481,14 @@ _libssh2_wincng_hmac_final(_libssh2_wincng_hash_ctx *ctx,
 void
 _libssh2_wincng_hmac_cleanup(_libssh2_wincng_hash_ctx *ctx);
 
-int
-_libssh2_wincng_rsa_new(libssh2_rsa_ctx **rsa,
-                        const unsigned char *edata,
-                        unsigned long elen,
-                        const unsigned char *ndata,
-                        unsigned long nlen,
-                        const unsigned char *ddata,
-                        unsigned long dlen,
-                        const unsigned char *pdata,
-                        unsigned long plen,
-                        const unsigned char *qdata,
-                        unsigned long qlen,
-                        const unsigned char *e1data,
-                        unsigned long e1len,
-                        const unsigned char *e2data,
-                        unsigned long e2len,
-                        const unsigned char *coeffdata,
-                        unsigned long coefflen);
-int
-_libssh2_wincng_rsa_new_private(libssh2_rsa_ctx **rsa,
-                                LIBSSH2_SESSION *session,
-                                const char *filename,
-                                const unsigned char *passphrase);
-int
-_libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
-                                           LIBSSH2_SESSION *session,
-                                           const char *filedata,
-                                           size_t filedata_len,
-                                           unsigned const char *passphrase);
-int
-_libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsa,
-                                const unsigned char *sig,
-                                size_t sig_len,
-                                const unsigned char *m,
-                                size_t m_len);
-int
-_libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
-                             libssh2_rsa_ctx *rsa,
-                             const unsigned char *hash,
-                             size_t hash_len,
-                             unsigned char **signature,
-                             size_t *signature_len);
 void
 _libssh2_wincng_rsa_free(libssh2_rsa_ctx *rsa);
 
 #if LIBSSH2_DSA
-int
-_libssh2_wincng_dsa_new(libssh2_dsa_ctx **dsa,
-                        const unsigned char *pdata,
-                        unsigned long plen,
-                        const unsigned char *qdata,
-                        unsigned long qlen,
-                        const unsigned char *gdata,
-                        unsigned long glen,
-                        const unsigned char *ydata,
-                        unsigned long ylen,
-                        const unsigned char *xdata,
-                        unsigned long xlen);
-int
-_libssh2_wincng_dsa_new_private(libssh2_dsa_ctx **dsa,
-                                LIBSSH2_SESSION *session,
-                                const char *filename,
-                                const unsigned char *passphrase);
-int
-_libssh2_wincng_dsa_new_private_frommemory(libssh2_dsa_ctx **dsa,
-                                           LIBSSH2_SESSION *session,
-                                           const char *filedata,
-                                           size_t filedata_len,
-                                           unsigned const char *passphrase);
-int
-_libssh2_wincng_dsa_sha1_verify(libssh2_dsa_ctx *dsa,
-                                const unsigned char *sig_fixed,
-                                const unsigned char *m,
-                                size_t m_len);
-int
-_libssh2_wincng_dsa_sha1_sign(libssh2_dsa_ctx *dsa,
-                              const unsigned char *hash,
-                              size_t hash_len,
-                              unsigned char *sig_fixed);
 void
 _libssh2_wincng_dsa_free(libssh2_dsa_ctx *dsa);
 #endif
 
-int
-_libssh2_wincng_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                                 unsigned char **method,
-                                 size_t *method_len,
-                                 unsigned char **pubkeydata,
-                                 size_t *pubkeydata_len,
-                                 const char *privatekey,
-                                 const char *passphrase);
-int
-_libssh2_wincng_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                       unsigned char **method,
-                                       size_t *method_len,
-                                       unsigned char **pubkeydata,
-                                       size_t *pubkeydata_len,
-                                       const char *privatekeydata,
-                                       size_t privatekeydata_len,
-                                       const char *passphrase);
-
-int
-_libssh2_wincng_cipher_init(_libssh2_cipher_ctx *ctx,
-                            _libssh2_cipher_type(type),
-                            unsigned char *iv,
-                            unsigned char *secret,
-                            int encrypt);
-int
-_libssh2_wincng_cipher_crypt(_libssh2_cipher_ctx *ctx,
-                             _libssh2_cipher_type(type),
-                             int encrypt,
-                             unsigned char *block,
-                             size_t blocklen, int firstlast);
 void
 _libssh2_wincng_cipher_dtor(_libssh2_cipher_ctx *ctx);
 


### PR DESCRIPTION
Enable more picky compiler warnings. I've found these options in the
nghttp3 project when implementing the CMake quick picky warning
functionality for it.

Fix issues found along the way:

- wincng, mbedtls: delete duplicate function declarations.
  Most of this was due to re-#defining crypto functions to
  crypto-backend specific implementations These redefines also remapped
  the declarations in `crypto.h`, making the backend-specific
  declarations duplicates.
  This patch deletes the backend-specific declarations.

- wincng mapped two crypto functions to the same local function.
  Also causing double declarations.
  Fix this by adding two disctinct wrappers and moving
  the common function to a static one.

- delete unreachable `break;` statements.

- kex: disable macros when unused.

- agent: disable unused constants.

- mbedtls: disable double declaration warnings because public mbedTLS
  headers trigger it. (with function `psa_set_key_domain_parameters`)

- crypto.h: formatting.

Ref: https://github.com/ngtcp2/nghttp3/blob/a70edb08e954d690e8fb2c1df999b5a056f8bf9f/cmake/PickyWarningsC.cmake

Closes #1224
