### PR TITLE
mbedtls: improve disabling `-Wredundant-decls`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,10 +387,6 @@ if(CRYPTO_BACKEND STREQUAL "mbedTLS" OR NOT CRYPTO_BACKEND)
     list(APPEND LIBRARIES ${MBEDTLS_LIBRARIES})
     list(APPEND LIBSSH2_PC_LIBS_PRIVATE "-lmbedcrypto")
     link_directories(${MBEDTLS_LIBRARY_DIR})
-
-    # mbedTLS (as of v3.5.1) has a duplicate function declaration
-    # in its own public headers. Disable the warning that detects it.
-    string(REGEX REPLACE "-Wredundant-decls" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   endif()
 endif()
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -46,7 +46,16 @@
 #elif defined(LIBSSH2_LIBGCRYPT)
 #include "libgcrypt.h"
 #elif defined(LIBSSH2_MBEDTLS)
+/* mbedTLS (as of v3.5.1) has a duplicate function declaration
+   in its own public headers. Disable the warning that detects it. */
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wredundant-decls"
+#endif
 #include "mbedtls.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #elif defined(LIBSSH2_OS400QC3)
 #include "os400qc3.h"
 #elif defined(LIBSSH2_WINCNG)


### PR DESCRIPTION
Disable these warnings specifically for the mbedTLS public headers
and leave it on for the the rest of the code. This also fixes this
issue for autotools. Previous solution was globally disabling this
warning for the whole code when using mbedTLS and only with CMake.

Follow-up to 7ecc309cd10454c54814b478c4f85d0041da6721 #1224

Closes #1226
