### PR TITLE
autotools: avoid warnings in libtool stub code

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -247,7 +247,9 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [redundant-decls])
           # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [switch-enum])       # Not used because this basically disallows default case
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [type-limits])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused-macros])
+            if test "x$have_windows_h" != "xyes"; then
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused-macros])  # Seen to clash with libtool-generated stub code
+            fi
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code unused-parameter])
           fi
           #


### PR DESCRIPTION
Seen on Windows with clang64, in libtool-generated stub code for
examples and tests.

The error didn't break the CI job for some reason.

msys2 (autotools, clang64, clang-x86_64:
```
[...]
2023-11-17T20:14:17.8639574Z ./.libs/lt-test_read.c:91:10: error: macro is not used [-Werror,-Wunused-macros]
[...]
2023-11-17T20:14:39.8729255Z ./.libs/lt-sftp_write_nonblock.c:91:10: error: macro is not used [-Werror,-Wunused-macros]
[...]
```
Ref: https://github.com/libssh2/libssh2/actions/runs/6908585056/job/18798193405?pr=1226#step:8:474

Follow-up to 7ecc309cd10454c54814b478c4f85d0041da6721 #1224

Closes #1227
