### PR TITLE
autotools: fix dotless gcc and Apple clang version detections

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -190,16 +190,30 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           fi
           clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`
           if test -z "$clangver"; then
-            if echo $fullclangver | grep "Apple LLVM version " >/dev/null; then
-              dnl Starting with Xcode 7 / clang 3.7, Apple clang won't tell its upstream version
-              clangver="3.7"
-            else
-              clangver=`echo $fullclangver | "$SED" 's/.*version \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
-            fi
+            clangver=`echo $fullclangver | "$SED" 's/.*version \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
+            oldapple=0
+          else
+            oldapple=1
           fi
           clangvhi=`echo $clangver | cut -d . -f1`
           clangvlo=`echo $clangver | cut -d . -f2`
           compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
+          if test "$clangname" = 'Apple clang' && test "$oldapple" = '0'; then
+            dnl Starting with Xcode 7 / clang 3.7, Apple clang won't tell its upstream version
+            if   test "$compiler_num" -ge '1300'; then compiler_num='1200'
+            elif test "$compiler_num" -ge '1205'; then compiler_num='1101'
+            elif test "$compiler_num" -ge '1204'; then compiler_num='1000'
+            elif test "$compiler_num" -ge '1107'; then compiler_num='900'
+            elif test "$compiler_num" -ge '1103'; then compiler_num='800'
+            elif test "$compiler_num" -ge '1003'; then compiler_num='700'
+            elif test "$compiler_num" -ge '1001'; then compiler_num='600'
+            elif test "$compiler_num" -ge  '904'; then compiler_num='500'
+            elif test "$compiler_num" -ge  '902'; then compiler_num='400'
+            elif test "$compiler_num" -ge  '803'; then compiler_num='309'
+            elif test "$compiler_num" -ge  '703'; then compiler_num='308'
+            else                                       compiler_num='307'
+            fi
+          fi
           AC_MSG_RESULT([$clangname '$compiler_num' (raw: '$fullclangver' / '$clangver')])
 
           tmp_CFLAGS="-pedantic"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -338,7 +338,11 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
         # strip '-suffix' parts, e.g. Ubuntu Windows cross-gcc returns '10-win32'
         gccver=`$CC -dumpversion | sed -E 's/-.+$//'`
         num1=`echo $gccver | cut -d . -f1`
-        num2=`echo $gccver | cut -d . -f2`
+        if echo $gccver | grep -F "." >/dev/null; then
+          num2=`echo $gccver | cut -d . -f2`
+        else
+          num2="0"
+        fi
         compiler_num=`(expr $num1 "*" 100 + $num2) 2>/dev/null`
         AC_MSG_RESULT([gcc '$compiler_num' (raw: '$gccver')])
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -337,13 +337,13 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
         AC_MSG_CHECKING([compiler version])
         # strip '-suffix' parts, e.g. Ubuntu Windows cross-gcc returns '10-win32'
         gccver=`$CC -dumpversion | sed -E 's/-.+$//'`
-        num1=`echo $gccver | cut -d . -f1`
+        gccvhi=`echo $gccver | cut -d . -f1`
         if echo $gccver | grep -F "." >/dev/null; then
-          num2=`echo $gccver | cut -d . -f2`
+          gccvlo=`echo $gccver | cut -d . -f2`
         else
-          num2="0"
+          gccvlo="0"
         fi
-        compiler_num=`(expr $num1 "*" 100 + $num2) 2>/dev/null`
+        compiler_num=`(expr $gccvhi "*" 100 + $gccvlo) 2>/dev/null`
         AC_MSG_RESULT([gcc '$compiler_num' (raw: '$gccver')])
 
         if test "$ICC" = "yes"; then

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -184,9 +184,9 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           AC_MSG_CHECKING([compiler version])
           fullclangver=`$CC -v 2>&1 | grep version`
           if echo $fullclangver | grep 'Apple' >/dev/null; then
-            clangname='Apple clang'
+            appleclang=1
           else
-            clangname='clang'
+            appleclang=0
           fi
           clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`
           if test -z "$clangver"; then
@@ -198,7 +198,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           clangvhi=`echo $clangver | cut -d . -f1`
           clangvlo=`echo $clangver | cut -d . -f2`
           compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
-          if test "$clangname" = 'Apple clang' && test "$oldapple" = '0'; then
+          if test "$appleclang" = '1' && test "$oldapple" = '0'; then
             dnl Starting with Xcode 7 / clang 3.7, Apple clang won't tell its upstream version
             if   test "$compiler_num" -ge '1300'; then compiler_num='1200'
             elif test "$compiler_num" -ge '1205'; then compiler_num='1101'
@@ -214,7 +214,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             else                                       compiler_num='307'
             fi
           fi
-          AC_MSG_RESULT([$clangname '$compiler_num' (raw: '$fullclangver' / '$clangver')])
+          AC_MSG_RESULT([clang '$compiler_num' (raw: '$fullclangver' / '$clangver')])
 
           tmp_CFLAGS="-pedantic"
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [all extra])


### PR DESCRIPTION
- fix parsing dotless (major-only) gcc versions.
  Follow-up to 00a3b88c51cdb407fbbb347a2e38c5c7d89875ad #1187

- sync gcc detection variable names with curl.

- fix Apple clang version detection for releases between
  'Apple LLVM version 7.3.0' and 'Apple LLVM version 10.0.1' where the
  version was under-detected as 3.7 llvm/clang equivalent.

- fix Apple clang version detection for 'Apple clang version 11.0.0'
  and newer where the Apple clang version was detected, instead of its
  llvm/clang equivalent.

- revert to show `clang` instead of `Apple clang`, because we follow it
  with an llvm/clang version number. (Apple-ness still visible in raw
  version.)

Used this collection for Apple clang / llvm/clang translation and test
inputs: https://gist.github.com/yamaya/2924292

Closes #1232
