### PR TITLE
libssh2.h: use `_WIN32` for Windows detection instead of rolling our own

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -90,11 +90,7 @@
 extern "C" {
 #endif
 
-#if defined(_WIN32) || defined(WIN32)
-#define LIBSSH2_WIN32
-#endif
-
-#ifdef LIBSSH2_WIN32
+#ifdef _WIN32
 # include <basetsd.h>
 # include <winsock2.h>
 #endif
@@ -106,7 +102,7 @@ extern "C" {
 
 /* Allow alternate API prefix from CFLAGS or calling app */
 #ifndef LIBSSH2_API
-# ifdef LIBSSH2_WIN32
+# ifdef _WIN32
 #  if defined(LIBSSH2_EXPORTS) || defined(_WINDLL)
 #   ifdef LIBSSH2_LIBRARY
 #    define LIBSSH2_API __declspec(dllexport)
@@ -116,9 +112,9 @@ extern "C" {
 #  else
 #   define LIBSSH2_API
 #  endif
-# else /* !LIBSSH2_WIN32 */
+# else /* !_WIN32 */
 #  define LIBSSH2_API
-# endif /* LIBSSH2_WIN32 */
+# endif /* _WIN32 */
 #endif /* LIBSSH2_API */
 
 #ifdef HAVE_SYS_UIO_H
@@ -144,13 +140,13 @@ typedef unsigned long long libssh2_uint64_t;
 typedef long long libssh2_int64_t;
 #endif
 
-#ifdef LIBSSH2_WIN32
+#ifdef _WIN32
 typedef SOCKET libssh2_socket_t;
 #define LIBSSH2_INVALID_SOCKET INVALID_SOCKET
-#else /* !LIBSSH2_WIN32 */
+#else /* !_WIN32 */
 typedef int libssh2_socket_t;
 #define LIBSSH2_INVALID_SOCKET -1
-#endif /* LIBSSH2_WIN32 */
+#endif /* _WIN32 */
 
 /*
  * Determine whether there is small or large file support on windows.
@@ -176,7 +172,7 @@ typedef int libssh2_socket_t;
 #  undef LIBSSH2_USE_WIN32_LARGE_FILES
 #endif
 
-#if defined(LIBSSH2_WIN32) && !defined(LIBSSH2_USE_WIN32_LARGE_FILES) && \
+#if defined(_WIN32) && !defined(LIBSSH2_USE_WIN32_LARGE_FILES) && \
     !defined(LIBSSH2_USE_WIN32_SMALL_FILES)
 #  define LIBSSH2_USE_WIN32_SMALL_FILES
 #endif

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -42,7 +42,7 @@
 
 #include "libssh2.h"
 
-#ifndef LIBSSH2_WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Sync up `libssh2.h` Windows detection with the libssh2 source code.

`libssh2.h` was using `WIN32` and `LIBSSH2_WIN32` for Windows detection,
next to the official `_WIN32`. After this patch it only uses `_WIN32`
for this. Also, make it stop defining `LIBSSH2_WIN32`.

There is a slight chance these break compatibility with Windows
compilers that fail to define `_WIN32`. I'm not aware of any obsolete
or modern compiler affected, but in case there is one, one possible
solution is to define this macro manually.

Closes #1238
