### PR TITLE
tests: fall back to `$LOGNAME` for username

### DIFF
--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -458,10 +458,13 @@ int test_auth_pubkey(LIBSSH2_SESSION *session, int flags,
     /* Ignore our hard-wired Dockerfile user when not running under Docker */
     if(!openssh_fixture_have_docker() && strcmp(username, "libssh2") == 0) {
         username = getenv("USER");
+        if(!username) {
 #ifdef _WIN32
-        if(!username)
             username = getenv("USERNAME");
+#else
+            username = getenv("LOGNAME");
 #endif
+        }
     }
 
     userauth_list = libssh2_userauth_list(session, username,

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -66,12 +66,16 @@ int main(int argc, char *argv[])
     (void)argc;
     (void)argv;
 
+    #ifdef _WIN32
+    #define LIBSSH2_FALLBACK_USER_ENV "USERNAME"
+    #else
+    #define LIBSSH2_FALLBACK_USER_ENV "LOGNAME"
+    #endif
+
     if(getenv("USER"))
         username = getenv("USER");
-#ifdef _WIN32
-    else if(getenv("USERNAME"))
-        username = getenv("USERNAME");
-#endif
+    else if(getenv(LIBSSH2_FALLBACK_USER_ENV))
+        username = getenv(LIBSSH2_FALLBACK_USER_ENV);
 
     if(getenv("PRIVKEY"))
         privkey = getenv("PRIVKEY");


### PR DESCRIPTION
If the `$USER` variable is empty, fall back to using `$LOGNAME` to
retrieve the logged-in username.

In POSIX, `$LOGNAME` is a mandatory variable, while `$USER` isn't, and
on some systems it may not be set. Without this value, tests were unable
to provide the correct username when logging into the SSH server running
under the active user's session.

Reported-by: Nicolas Mora
Suggested-by: Nicolas Mora
Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1056348
Fixes #1240
Closes #1241
