### PR TITLE
openssl: use OpenSSL 3 HMAC API, add `no-deprecated` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,11 @@ jobs:
             crypto: BoringSSL
             build: cmake
             zlib: 'ON'
+          - compiler: gcc
+            arch: amd64
+            crypto: OpenSSL-3-no-deprecated
+            build: cmake
+            zlib: 'ON'
           - compiler: clang
             arch: i386
             crypto: Libgcrypt
@@ -103,12 +108,13 @@ jobs:
           sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install gcc-multilib build-essential zlib1g-dev:${{ matrix.arch }}
 
       - name: 'install packages'
-        if: ${{ matrix.crypto != 'mbedTLS' && matrix.crypto != 'BoringSSL' }}
         run: |
           [ '${{ matrix.crypto }}' = 'OpenSSL' ] && pkg='libssl-dev'
           [ '${{ matrix.crypto }}' = 'wolfSSL' ] && pkg='libwolfssl-dev'
           [ '${{ matrix.crypto }}' = 'Libgcrypt' ] && pkg='libgcrypt-dev'
-          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install "${pkg}:${{ matrix.arch }}"
+          if [ -n "${pkg}" ]; then
+            sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install "${pkg}:${{ matrix.arch }}"
+          fi
 
       - name: 'install mbedTLS from source'
         if: ${{ matrix.crypto == 'mbedTLS' }}
@@ -148,6 +154,20 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
+      - name: 'install OpenSSL from source'
+        if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
+        run: |
+          OPENSSLVER=openssl-3.2.0
+          curl -L https://www.openssl.org/source/$OPENSSLVER.tar.gz | tar -xzf -
+          cd $OPENSSLVER
+          ./Configure no-deprecated \
+            no-apps no-docs no-tests no-makedepend \
+            no-comp no-quic no-legacy --prefix=/usr
+          make -j3 install DESTDIR=$PWD/..
+          cd ..
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}
         run: autoreconf -fi
@@ -175,7 +195,8 @@ jobs:
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         run: |
-          if [ '${{ matrix.crypto }}' = 'BoringSSL' ]; then
+          if [ '${{ matrix.crypto }}' = 'BoringSSL' ] || \
+             [[ '${{ matrix.crypto }}' = 'OpenSSL-'* ]]; then
             crypto='OpenSSL'
           else
             crypto='${{ matrix.crypto }}'

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -165,6 +165,9 @@ struct iovec {
 #define LIBSSH2_MAX(x, y)  ((x) > (y) ? (x) : (y))
 #define LIBSSH2_MIN(x, y)  ((x) < (y) ? (x) : (y))
 
+#define MAX_BLOCKSIZE 32    /* MUST fit biggest crypto block size we use/get */
+#define MAX_MACSIZE 64      /* MUST fit biggest MAC length we support */
+
 /* RFC4253 section 6.1 Maximum Packet Length says:
  *
  * "All implementations MUST be able to process packets with

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -92,6 +92,32 @@ write_bn(unsigned char *buf, const BIGNUM *bn, int bn_bytes)
 }
 #endif
 
+#ifdef USE_OPENSSL_3
+int _libssh2_hmac_init(libssh2_hmac_ctx *ctx, void *key, size_t keylen,
+                       const char *digest_name)
+{
+    EVP_MAC* mac;
+    OSSL_PARAM params[3];
+
+    mac = EVP_MAC_fetch(NULL, OSSL_MAC_NAME_HMAC, NULL);
+    if(!mac)
+        return 0;
+
+    *ctx = EVP_MAC_CTX_new(mac);
+    EVP_MAC_free(mac);
+    if(!*ctx)
+        return 0;
+
+    params[0] = OSSL_PARAM_construct_octet_string(
+        OSSL_MAC_PARAM_KEY, (void *)key, keylen);
+    params[1] = OSSL_PARAM_construct_utf8_string(
+        OSSL_MAC_PARAM_DIGEST, (char *)digest_name, 0);
+    params[2] = OSSL_PARAM_construct_end();
+
+    return EVP_MAC_init(*ctx, NULL, 0, params);
+}
+#endif
+
 static inline void
 _libssh2_swap_bytes(unsigned char *buf, unsigned long len)
 {

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -325,6 +325,31 @@ int _libssh2_md5_init(libssh2_md5_ctx *ctx);
 #endif /* HAVE_OPAQUE_STRUCTS */
 #endif /* LIBSSH2_MD5 || LIBSSH2_MD5_PEM */
 
+#ifdef USE_OPENSSL_3
+
+#define libssh2_hmac_ctx EVP_MAC_CTX *
+#define libssh2_hmac_ctx_init(ctx)
+#define libssh2_hmac_sha1_init(ctx, key, keylen) \
+    _libssh2_hmac_init(ctx, (void *)key, keylen, OSSL_DIGEST_NAME_SHA1)
+#define libssh2_hmac_md5_init(ctx, key, keylen) \
+    _libssh2_hmac_init(ctx, (void *)key, keylen, OSSL_DIGEST_NAME_MD5)
+#define libssh2_hmac_ripemd160_init(ctx, key, keylen) \
+    _libssh2_hmac_init(ctx, (void *)key, keylen, OSSL_DIGEST_NAME_RIPEMD160)
+#define libssh2_hmac_sha256_init(ctx, key, keylen) \
+    _libssh2_hmac_init(ctx, (void *)key, keylen, OSSL_DIGEST_NAME_SHA2_256)
+#define libssh2_hmac_sha512_init(ctx, key, keylen) \
+    _libssh2_hmac_init(ctx, (void *)key, keylen, OSSL_DIGEST_NAME_SHA2_512)
+#define libssh2_hmac_update(ctx, data, datalen) \
+    EVP_MAC_update(ctx, data, datalen)
+#define libssh2_hmac_final(ctx, data) EVP_MAC_final(ctx, data, NULL, \
+                                                    MAX_MACSIZE)
+#define libssh2_hmac_cleanup(ctx) EVP_MAC_CTX_free(*(ctx))
+
+int _libssh2_hmac_init(libssh2_hmac_ctx *ctx, void *key, size_t keylen,
+                       const char *digest_name);
+
+#else /* USE_OPENSSL_3 */
+
 #ifdef HAVE_OPAQUE_STRUCTS
 #define libssh2_hmac_ctx HMAC_CTX *
 #define libssh2_hmac_ctx_init(ctx) ctx = HMAC_CTX_new()
@@ -369,6 +394,7 @@ int _libssh2_md5_init(libssh2_md5_ctx *ctx);
 #define libssh2_hmac_final(ctx, data) HMAC_Final(&(ctx), data, NULL)
 #define libssh2_hmac_cleanup(ctx) HMAC_cleanup(ctx)
 #endif /* HAVE_OPAQUE_STRUCTS */
+#endif /* USE_OPENSSL_3 */
 
 extern void _libssh2_openssl_crypto_init(void);
 extern void _libssh2_openssl_crypto_exit(void);

--- a/src/transport.c
+++ b/src/transport.c
@@ -51,9 +51,6 @@
 #include "transport.h"
 #include "mac.h"
 
-#define MAX_BLOCKSIZE 32    /* MUST fit biggest crypto block size we use/get */
-#define MAX_MACSIZE 64      /* MUST fit biggest MAC length we support */
-
 #ifdef LIBSSH2DEBUG
 #define UNPRINTABLE_CHAR '.'
 static void


### PR DESCRIPTION
- use OpenSSL 3 API when available for HMAC.
  This fixes building with OpenSSL 3 `no-deprecated` builds.

- ensure we support pure OpenSSL 3 API by adding a CI job using
  OpenSSL 3 custom-built with `no-deprecated`.

Follow-up to b0ab005fe79260e6e9fe08f8d73b58dd4856943d #1207

Fixes #1235
Closes #1243

---

- [x] #1235
- [x] 82581941d6cd91cd00cf6d8bee1b2a660864ca19
  #1244
- [x] 487152f4fa8bc155fc6cb8a03896947425dc0632
  #1236
- [x] b0ab005fe79260e6e9fe08f8d73b58dd4856943d
  #1207
  #1206
