### PR TITLE
openssl: fix DSA code to use OpenSSL 3 API

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1490,7 +1490,7 @@ _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
 }
 
 static unsigned char *
-gen_publickey_from_dsa(LIBSSH2_SESSION* session, DSA *dsa,
+gen_publickey_from_dsa(LIBSSH2_SESSION* session, libssh2_dsa_ctx *dsa,
                        size_t *key_len)
 {
     int            p_bytes, q_bytes, g_bytes, k_bytes;
@@ -1553,7 +1553,7 @@ gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
                            size_t *pubkeydata_len,
                            EVP_PKEY *pk)
 {
-    DSA*           dsa = NULL;
+    libssh2_dsa_ctx *dsa = NULL;
     unsigned char *key;
     unsigned char *method_buf = NULL;
     size_t  key_len;


### PR DESCRIPTION
- fix missing `DSA` type when building for OpenSSL 3 `no-deprecated`.
- fix fallouts after fixing the above by switching away from `DSA`
  with OpenSSL 3.

Follow-up to b0ab005fe79260e6e9fe08f8d73b58dd4856943d #1207

Closes #1244

---

```
/home/runner/work/libssh2/libssh2/src/openssl.c:1494:50: error: unknown type name ‘DSA’
 1494 | gen_publickey_from_dsa(LIBSSH2_SESSION* session, DSA *dsa,
      |                                                  ^~~
/home/runner/work/libssh2/libssh2/src/openssl.c: In function ‘gen_publickey_from_dsa_evp’:
/home/runner/work/libssh2/libssh2/src/openssl.c:1557:5: error: unknown type name ‘DSA’
 1557 |     DSA*           dsa = NULL;
      |     ^~~
```
Ref: https://github.com/libssh2/libssh2/actions/runs/6985678233/job/19010227364#step:14:44

```
../../src/openssl.c:1507:18: error: incompatible pointer types passing 'EVP_PKEY *' (aka 'struct evp_pkey_st *') to parameter of type 'const DSA *' (aka 'const struct dsa_st *') [-Werror,-Wincompatible-pointer-types]
    DSA_get0_pqg(dsa, &p_bn, &q, &g);
                 ^~~
/usr/include/openssl/dsa.h:201:52: note: passing argument to parameter 'd' here
OSSL_DEPRECATEDIN_3_0 void DSA_get0_pqg(const DSA *d, const BIGNUM **p,
                                                   ^
In file included from ../../src/crypto.c:10:
../../src/openssl.c:1515:18: error: incompatible pointer types passing 'EVP_PKEY *' (aka 'struct evp_pkey_st *') to parameter of type 'const DSA *' (aka 'const struct dsa_st *') [-Werror,-Wincompatible-pointer-types]
    DSA_get0_key(dsa, &pub_key, NULL);
                 ^~~
/usr/include/openssl/dsa.h:204:52: note: passing argument to parameter 'd' here
OSSL_DEPRECATEDIN_3_0 void DSA_get0_key(const DSA *d, const BIGNUM **pub_key,
                                                   ^
In file included from ../../src/crypto.c:10:
../../src/openssl.c:1566:9: error: incompatible pointer types assigning to 'EVP_PKEY *' (aka 'struct evp_pkey_st *') from 'struct dsa_st *' [-Werror,-Wincompatible-pointer-types]
    dsa = EVP_PKEY_get1_DSA(pk);
        ^ ~~~~~~~~~~~~~~~~~~~~~
../../src/openssl.c:1581:14: error: incompatible pointer types passing 'EVP_PKEY *' (aka 'struct evp_pkey_st *') to parameter of type 'DSA *' (aka 'struct dsa_st *') [-Werror,-Wincompatible-pointer-types]
    DSA_free(dsa);
             ^~~
/usr/include/openssl/dsa.h:127:42: note: passing argument to parameter 'r' here
OSSL_DEPRECATEDIN_3_0 void DSA_free(DSA *r);
                                         ^
In file included from ../../src/crypto.c:10:
../../src/openssl.c:1592:18: error: incompatible pointer types passing 'EVP_PKEY *' (aka 'struct evp_pkey_st *') to parameter of type 'DSA *' (aka 'struct dsa_st *') [-Werror,-Wincompatible-pointer-types]
        DSA_free(dsa);
                 ^~~
/usr/include/openssl/dsa.h:127:42: note: passing argument to parameter 'r' here
OSSL_DEPRECATEDIN_3_0 void DSA_free(DSA *r);
                                         ^
```
Ref: https://github.com/libssh2/libssh2/actions/runs/6985846488/job/19010620365#step:10:20
