### PR TITLE
ci: boost mbedTLS build speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
           fi
           cmake ${crossoptions} \
             "-DCMAKE_C_FLAGS=${cflags}" \
+            -DENABLE_PROGRAMS=OFF \
+            -DENABLE_TESTING=OFF \
+            -DUSE_STATIC_MBEDTLS_LIBRARY=OFF \
             -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
             -DCMAKE_INSTALL_PREFIX:PATH=../usr
           make -j3 install


### PR DESCRIPTION
Build times down to 4 seconds (from 18-20).

Closes #1245
