### PR TITLE
ci: use absolute path in `CMAKE_INSTALL_PREFIX`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
             -DENABLE_TESTING=OFF \
             -DUSE_STATIC_MBEDTLS_LIBRARY=OFF \
             -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
-            -DCMAKE_INSTALL_PREFIX:PATH=../usr
+            -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../usr
           make -j3 install
           cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
@@ -142,7 +142,7 @@ jobs:
           cmake \
             -DOPENSSL_SMALL=ON \
             -DCMAKE_C_FLAGS=-fPIC \
-            -DCMAKE_INSTALL_PREFIX:PATH=../usr
+            -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../usr
           make -j3 install
           cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV


### PR DESCRIPTION
To make the installed locations unambiguous in the build logs.

Closes #1247