### PR TITLE
stop using leading underscores in macro names

### DIFF
--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -31,9 +31,9 @@
 #include <string.h>
 
 #if defined(_MSC_VER)
-#define __FILESIZE "I64u"
+#define LIBSSH2_FILESIZE_MASK "I64u"
 #else
-#define __FILESIZE "llu"
+#define LIBSSH2_FILESIZE_MASK "llu"
 #endif
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
                 }
 
                 if(attrs.flags & LIBSSH2_SFTP_ATTR_SIZE) {
-                    printf("%8" __FILESIZE " ", attrs.filesize);
+                    printf("%8" LIBSSH2_FILESIZE_MASK " ", attrs.filesize);
                 }
 
                 printf("%s\n", mem);

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -30,9 +30,9 @@
 #include <stdio.h>
 
 #if defined(_MSC_VER)
-#define __FILESIZE "I64u"
+#define LIBSSH2_FILESIZE_MASK "I64u"
 #else
-#define __FILESIZE "llu"
+#define LIBSSH2_FILESIZE_MASK "llu"
 #endif
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
             }
 
             if(attrs.flags & LIBSSH2_SFTP_ATTR_SIZE) {
-                printf("%8" __FILESIZE " ", attrs.filesize);
+                printf("%8" LIBSSH2_FILESIZE_MASK " ", attrs.filesize);
             }
 
             printf("%s\n", mem);

--- a/src/channel.h
+++ b/src/channel.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_CHANNEL_H
-#define __LIBSSH2_CHANNEL_H
+#ifndef LIBSSH2_CHANNEL_H
+#define LIBSSH2_CHANNEL_H
 /* Copyright (C) Daniel Stenberg
  *
  * All rights reserved.
@@ -139,4 +139,4 @@ int _libssh2_channel_close(LIBSSH2_CHANNEL * channel);
  */
 int _libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener);
 
-#endif /* __LIBSSH2_CHANNEL_H */
+#endif /* LIBSSH2_CHANNEL_H */

--- a/src/comp.h
+++ b/src/comp.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_COMP_H
-#define __LIBSSH2_COMP_H
+#ifndef LIBSSH2_COMP_H
+#define LIBSSH2_COMP_H
 /* Copyright (C) Daniel Stenberg
  *
  * Redistribution and use in source and binary forms,
@@ -42,4 +42,4 @@
 
 const LIBSSH2_COMP_METHOD **_libssh2_comp_methods(LIBSSH2_SESSION *session);
 
-#endif /* __LIBSSH2_COMP_H */
+#endif /* LIBSSH2_COMP_H */

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_CRYPTO_H
-#define __LIBSSH2_CRYPTO_H
+#ifndef LIBSSH2_CRYPTO_H
+#define LIBSSH2_CRYPTO_H
 /* Copyright (C) Simon Josefsson
  * Copyright (C) The Written Word, Inc.
  * Copyright (C) Daniel Stenberg
@@ -342,4 +342,4 @@ _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
                                        unsigned char *key_method,
                                        size_t key_method_len);
 
-#endif /* __LIBSSH2_CRYPTO_H */
+#endif /* LIBSSH2_CRYPTO_H */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_LIBGCRYPT_H
-#define __LIBSSH2_LIBGCRYPT_H
+#ifndef LIBSSH2_LIBGCRYPT_H
+#define LIBSSH2_LIBGCRYPT_H
 /*
  * Copyright (C) Simon Josefsson
  * Copyright (C) The Written Word, Inc.
@@ -258,4 +258,4 @@ extern int _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                               _libssh2_bn *f, _libssh2_bn *p);
 extern void _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
 
-#endif /* __LIBSSH2_LIBGCRYPT_H */
+#endif /* LIBSSH2_LIBGCRYPT_H */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_PRIV_H
-#define __LIBSSH2_PRIV_H
+#ifndef LIBSSH2_PRIV_H
+#define LIBSSH2_PRIV_H
 /* Copyright (C) Sara Golemon <sarag@libssh2.org>
  * Copyright (C) Daniel Stenberg
  * Copyright (C) Simon Josefsson
@@ -1224,4 +1224,4 @@ size_t plain_method(char *method, size_t method_len);
 #define FOPEN_APPENDTEXT "a"
 #endif
 
-#endif /* __LIBSSH2_PRIV_H */
+#endif /* LIBSSH2_PRIV_H */

--- a/src/mac.h
+++ b/src/mac.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_MAC_H
-#define __LIBSSH2_MAC_H
+#ifndef LIBSSH2_MAC_H
+#define LIBSSH2_MAC_H
 /* Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
@@ -69,4 +69,4 @@ const LIBSSH2_MAC_METHOD **_libssh2_mac_methods(void);
 const LIBSSH2_MAC_METHOD *_libssh2_mac_override(
         const LIBSSH2_CRYPT_METHOD *crypt);
 
-#endif /* __LIBSSH2_MAC_H */
+#endif /* LIBSSH2_MAC_H */

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_MBEDTLS_H
-#define __LIBSSH2_MBEDTLS_H
+#ifndef LIBSSH2_MBEDTLS_H
+#define LIBSSH2_MBEDTLS_H
 /* Copyright (C) Art <https://github.com/wildart>
  * All rights reserved.
  *
@@ -516,4 +516,4 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
 extern void
 _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
 
-#endif /* __LIBSSH2_MBEDTLS_H */
+#endif /* LIBSSH2_MBEDTLS_H */

--- a/src/misc.h
+++ b/src/misc.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_MISC_H
-#define __LIBSSH2_MISC_H
+#ifndef LIBSSH2_MISC_H
+#define LIBSSH2_MISC_H
 /* Copyright (C) Daniel Stenberg
  * All rights reserved.
  *
@@ -137,4 +137,4 @@ void _libssh2_xor_data(unsigned char *output,
 
 void _libssh2_aes_ctr_increment(unsigned char *ctr, size_t length);
 
-#endif /* _LIBSSH2_MISC_H */
+#endif /* LIBSSH2_MISC_H */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_OPENSSL_H
-#define __LIBSSH2_OPENSSL_H
+#ifndef LIBSSH2_OPENSSL_H
+#define LIBSSH2_OPENSSL_H
 /* Copyright (C) Simon Josefsson
  * Copyright (C) The Written Word, Inc.
  * All rights reserved.
@@ -497,4 +497,4 @@ const EVP_CIPHER *_libssh2_EVP_aes_128_ctr(void);
 const EVP_CIPHER *_libssh2_EVP_aes_192_ctr(void);
 const EVP_CIPHER *_libssh2_EVP_aes_256_ctr(void);
 
-#endif /* __LIBSSH2_OPENSSL_H */
+#endif /* LIBSSH2_OPENSSL_H */

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_OS400QC3_H
-#define __LIBSSH2_OS400QC3_H
+#ifndef LIBSSH2_OS400QC3_H
+#define LIBSSH2_OS400QC3_H
 /*
  * Copyright (C) Patrick Monnerat, D+H <patrick.monnerat@dh.com>
  * Copyright (C) Patrick Monnerat <patrick@monnerat.net>
@@ -421,6 +421,6 @@ extern int      _libssh2_os400qc3_dh_secret(_libssh2_dh_ctx *dhctx,
                                             _libssh2_bn *f, _libssh2_bn *p);
 extern void     _libssh2_os400qc3_dh_dtor(_libssh2_dh_ctx *dhctx);
 
-#endif /* __LIBSSH2_OS400QC3_H */
+#endif /* LIBSSH2_OS400QC3_H */
 
 /* vim: set expandtab ts=4 sw=4: */

--- a/src/packet.h
+++ b/src/packet.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_PACKET_H
-#define __LIBSSH2_PACKET_H
+#ifndef LIBSSH2_PACKET_H
+#define LIBSSH2_PACKET_H
 /*
  * Copyright (C) Daniel Stenberg
  * All rights reserved.
@@ -74,4 +74,4 @@ int _libssh2_packet_write(LIBSSH2_SESSION * session, unsigned char *data,
 int _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                         size_t datalen, int macstate);
 
-#endif /* __LIBSSH2_PACKET_H */
+#endif /* LIBSSH2_PACKET_H */

--- a/src/session.h
+++ b/src/session.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_SESSION_H
-#define __LIBSSH2_SESSION_H
+#ifndef LIBSSH2_SESSION_H
+#define LIBSSH2_SESSION_H
 /* Copyright (C) Sara Golemon <sarag@libssh2.org>
  * Copyright (C) Daniel Stenberg
  * Copyright (C) Simon Josefsson <simon@josefsson.org>
@@ -91,4 +91,4 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t entry_time);
 /* this is the lib-internal set blocking function */
 int _libssh2_session_set_blocking(LIBSSH2_SESSION * session, int blocking);
 
-#endif /* __LIBSSH2_SESSION_H */
+#endif /* LIBSSH2_SESSION_H */

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -1,5 +1,5 @@
-#ifndef LIBSSH2_SFTP_H
-#define LIBSSH2_SFTP_H
+#ifndef LIBSSH2_SFTP_PRIV_H
+#define LIBSSH2_SFTP_PRIV_H
 /*
  * Copyright (C) Daniel Stenberg
  * All rights reserved.
@@ -233,4 +233,4 @@ struct _LIBSSH2_SFTP
     uint32_t symlink_request_id;
 };
 
-#endif /* LIBSSH2_SFTP_H */
+#endif /* LIBSSH2_SFTP_PRIV_H */

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_SFTP_H
-#define __LIBSSH2_SFTP_H
+#ifndef LIBSSH2_SFTP_H
+#define LIBSSH2_SFTP_H
 /*
  * Copyright (C) Daniel Stenberg
  * All rights reserved.
@@ -233,4 +233,4 @@ struct _LIBSSH2_SFTP
     uint32_t symlink_request_id;
 };
 
-#endif /* __LIBSSH2_SFTP_H */
+#endif /* LIBSSH2_SFTP_H */

--- a/src/transport.h
+++ b/src/transport.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_TRANSPORT_H
-#define __LIBSSH2_TRANSPORT_H
+#ifndef LIBSSH2_TRANSPORT_H
+#define LIBSSH2_TRANSPORT_H
 /* Copyright (C) The Written Word, Inc.
  * Copyright (C) Daniel Stenberg
  * All rights reserved.
@@ -84,4 +84,4 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
  */
 int _libssh2_transport_read(LIBSSH2_SESSION * session);
 
-#endif /* __LIBSSH2_TRANSPORT_H */
+#endif /* LIBSSH2_TRANSPORT_H */

--- a/src/userauth.h
+++ b/src/userauth.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_USERAUTH_H
-#define __LIBSSH2_USERAUTH_H
+#ifndef LIBSSH2_USERAUTH_H
+#define LIBSSH2_USERAUTH_H
 /* Copyright (C) Sara Golemon <sarag@libssh2.org>
  * Copyright (C) Daniel Stenberg
  * All rights reserved.
@@ -50,4 +50,4 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                                 ((*sign_callback)),
                             void *abstract);
 
-#endif /* __LIBSSH2_USERAUTH_H */
+#endif /* LIBSSH2_USERAUTH_H */

--- a/src/userauth_kbd_packet.h
+++ b/src/userauth_kbd_packet.h
@@ -37,9 +37,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __LIBSSH2_USERAUTH_KBD_PARSE_H
-#define __LIBSSH2_USERAUTH_KBD_PARSE_H
+#ifndef LIBSSH2_USERAUTH_KBD_PACKET_H
+#define LIBSSH2_USERAUTH_KBD_PACKET_H
 
 int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *);
 
-#endif /* __LIBSSH2_USERAUTH_KBD_PARSE_H */
+#endif /* LIBSSH2_USERAUTH_KBD_PACKET_H */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -1,5 +1,5 @@
-#ifndef __LIBSSH2_WINCNG_H
-#define __LIBSSH2_WINCNG_H
+#ifndef LIBSSH2_WINCNG_H
+#define LIBSSH2_WINCNG_H
 /*
  * Copyright (C) Marc Hoersken <info@marc-hoersken.de>
  * All rights reserved.
@@ -516,4 +516,4 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
 extern void
 _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
 
-#endif /* __LIBSSH2_WINCNG_H */
+#endif /* LIBSSH2_WINCNG_H */


### PR DESCRIPTION
Underscored macros are reserved for the compiler / standard lib / etc.
Stop using them in user code.

We used them as header guards in `src` and in `__FILESIZE` in `example`.

Closes #1248