### PR TITLE
ci: use `pkg_add` with NetBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,7 +548,7 @@ jobs:
           architecture: "x86_64"
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake
+            sudo pkg_add cmake
             cmake -B bld \
               -DENABLE_WERROR=ON \
               -DENABLE_DEBUG_LOGGING=ON \


### PR DESCRIPTION
"More native" and works with `vmactions/netbsd-vm` as well.

Ref: https://www.netbsd.org/docs/pkgsrc/using.html#installing-binary-packages

Follow-up to 65c7a7a55af037bcc9ee67c2f69ecdb9109ecbb1

Closes #1252