### PR TITLE
build: enable missing OpenSSF-recommended warnings

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -268,7 +268,8 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           #
           dnl Only clang 2.9 or later
           if test "$compiler_num" -ge "209"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wno-sign-conversion"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [sign-conversion])
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-error=sign-conversion"
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shift-sign-overflow])
           # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [padded])  # Not used because we cannot change public structs
           fi
@@ -276,6 +277,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           dnl Only clang 3.0 or later
           if test "$compiler_num" -ge "300"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [language-extension-token])
+            tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
           fi
           #
           dnl Only clang 3.2 or later
@@ -323,6 +325,10 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           if test "$compiler_num" -ge "700"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [assign-enum])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [extra-semi-stmt])
+          fi
+          dnl clang 10 or later
+          if test "$compiler_num" -ge "1000"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"  # we have silencing markup for clang 10.0 and above only
           fi
 
           CFLAGS="$CFLAGS $tmp_CFLAGS"
@@ -451,8 +457,9 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [type-limits old-style-declaration])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-parameter-type empty-body])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [clobbered ignored-qualifiers])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion])
-            tmp_CFLAGS="$tmp_CFLAGS -Wno-sign-conversion"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion trampolines])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [sign-conversion])
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-error=sign-conversion"
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [vla])
             dnl required for -Warray-bounds, included in -Wall
             tmp_CFLAGS="$tmp_CFLAGS -ftree-vrp"
@@ -500,6 +507,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [alloc-zero])
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-overflow=2"
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-truncation=2"
+            tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"
           fi
           #
           dnl Only gcc 10 or later

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -98,11 +98,12 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -Wmissing-field-initializers         # clang  2.7  gcc  4.1
       -Wmissing-noreturn                   # clang  2.7  gcc  4.1
       -Wno-format-nonliteral               # clang  1.0  gcc  2.96 (3.0)
-      -Wno-sign-conversion                 # clang  2.9  gcc  4.3
       -Wno-system-headers                  # clang  1.0  gcc  3.0
     # -Wpadded                             # clang  2.9  gcc  4.1               # Not used because we cannot change public structs
       -Wold-style-definition               # clang  2.7  gcc  3.4
       -Wredundant-decls                    # clang  2.7  gcc  4.1
+      -Wsign-conversion                    # clang  2.9  gcc  4.3
+        -Wno-error=sign-conversion
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
     # -Wswitch-enum                        # clang  2.7  gcc  4.1               # Not used because this basically disallows default case
       -Wtype-limits                        # clang  2.7  gcc  4.3
@@ -125,6 +126,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
         -Wlanguage-extension-token         # clang  3.0
+        -Wformat=2                         # clang  3.0  gcc  4.8
       )
       # Enable based on compiler version
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
@@ -150,6 +152,12 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
           -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
         )
       endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 12.4))
+        list(APPEND WPICKY_ENABLE
+          -Wimplicit-fallthrough           # clang  4.0  gcc  7.0  appleclang 12.4  # we have silencing markup for clang 10.0 and above only
+        )
+      endif()
     else()  # gcc
       list(APPEND WPICKY_DETECT
         ${WPICKY_COMMON}
@@ -162,6 +170,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
           -Wstrict-aliasing=3              #             gcc  4.0
+          -Wtrampolines                    #             gcc  4.3
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.5 AND MINGW)
@@ -171,7 +180,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
         list(APPEND WPICKY_ENABLE
-          -Wformat=2                       # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
+          -Wformat=2                       # clang  3.0  gcc  4.8
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
@@ -194,6 +203,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
           -Wduplicated-branches            #             gcc  7.0
           -Wformat-overflow=2              #             gcc  7.0
           -Wformat-truncation=2            #             gcc  7.0
+          -Wimplicit-fallthrough           # clang  4.0  gcc  7.0
           -Wrestrict                       #             gcc  7.0
         )
       endif()

--- a/docs/TODO
+++ b/docs/TODO
@@ -1,6 +1,8 @@
 Things TODO
 ===========
 
+* Fix -Wsign-conversion warnings in src
+
 * Fix the numerous malloc+copy operations for sending data, see "Buffering
   Improvements" below for details
 

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -41,10 +41,10 @@ static const char *password = "";
 static const char *server_ip = "127.0.0.1";
 
 static const char *local_listenip = "127.0.0.1";
-static unsigned int local_listenport = 2222;
+static int local_listenport = 2222;
 
 static const char *remote_desthost = "localhost"; /* resolved by the server */
-static unsigned int remote_destport = 22;
+static int remote_destport = 22;
 
 enum {
     AUTH_NONE = 0,
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel = NULL;
     const char *shost;
-    unsigned int sport;
+    int sport;
     fd_set fds;
     struct timeval tv;
     ssize_t len, wr;
@@ -270,7 +270,8 @@ int main(int argc, char *argv[])
             wr = 0;
             while(wr < len) {
                 ssize_t nwritten = libssh2_channel_write(channel,
-                                                         buf + wr, len - wr);
+                                                         buf + wr,
+                                                         (size_t)(len - wr));
                 if(nwritten == LIBSSH2_ERROR_EAGAIN) {
                     continue;
                 }
@@ -292,7 +293,8 @@ int main(int argc, char *argv[])
             }
             wr = 0;
             while(wr < len) {
-                ssize_t nsent = send(forwardsock, buf + wr, len - wr, 0);
+                ssize_t nsent = send(forwardsock, buf + wr,
+                                     (size_t)(len - wr), 0);
                 if(nsent <= 0) {
                     fprintf(stderr, "failed to send().\n");
                     goto shutdown;

--- a/example/scp.c
+++ b/example/scp.c
@@ -158,9 +158,9 @@ int main(int argc, char *argv[])
             amount = (int)(fileinfo.st_size - got);
         }
 
-        nread = libssh2_channel_read(channel, mem, amount);
+        nread = libssh2_channel_read(channel, mem, (size_t)amount);
         if(nread > 0) {
-            write(1, mem, nread);
+            write(1, mem, (size_t)nread);
         }
         else if(nread < 0) {
             fprintf(stderr, "libssh2_channel_read() failed: %d\n",

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -243,9 +243,9 @@ int main(int argc, char *argv[])
             }
 
             /* loop until we block */
-            nread = libssh2_channel_read(channel, mem, amount);
+            nread = libssh2_channel_read(channel, mem, (size_t)amount);
             if(nread > 0) {
-                write(1, mem, nread);
+                write(1, mem, (size_t)nread);
                 got += nread;
                 total += nread;
             }

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
             else {
                 /* nwritten indicates how many bytes were written this time */
                 ptr += nwritten;
-                nread -= nwritten;
+                nread -= (size_t)nwritten;
             }
         } while(nread);
 

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
         }
         ptr = mem;
 
-        total += nread;
+        total += (libssh2_struct_stat_size)nread;
 
         prev = 0;
         do {
@@ -238,8 +238,8 @@ int main(int argc, char *argv[])
                 prev = nread;
 
                 /* nwritten indicates how many bytes were written this time */
-                nread -= nwritten;
                 ptr += nwritten;
+                nread -= (size_t)nwritten;
             }
         } while(nread);
     } while(!nread); /* only continue if nread was drained */

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -55,11 +55,11 @@ static void kbd_callback(const char *name, int name_len,
     fprintf(stderr, "Performing keyboard-interactive authentication.\n");
 
     fprintf(stderr, "Authentication name: '");
-    fwrite(name, 1, name_len, stderr);
+    fwrite(name, 1, (size_t)name_len, stderr);
     fprintf(stderr, "'\n");
 
     fprintf(stderr, "Authentication instruction: '");
-    fwrite(instruction, 1, instruction_len, stderr);
+    fwrite(instruction, 1, (size_t)instruction_len, stderr);
     fprintf(stderr, "'\n");
 
     fprintf(stderr, "Number of prompts: %d\n\n", num_prompts);
@@ -275,7 +275,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "libssh2_sftp_read().\n");
         nread = libssh2_sftp_read(sftp_handle, mem, sizeof(mem));
         if(nread > 0) {
-            write(1, mem, nread);
+            write(1, mem, (size_t)nread);
         }
         else {
             break;

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -232,9 +232,9 @@ int main(int argc, char *argv[])
 
             if(nread > 0) {
                 /* write to stderr */
-                write(2, mem, nread);
+                write(2, mem, (size_t)nread);
                 /* write to temporary storage area */
-                fwrite(mem, nread, 1, tempstorage);
+                fwrite(mem, (size_t)nread, 1, tempstorage);
             }
         } while(nread > 0);
 
@@ -297,8 +297,10 @@ int main(int argc, char *argv[])
                 /* write data in a loop until we block */
                 nwritten = libssh2_sftp_write(sftp_handle, ptr,
                                               nread);
+                if(nwritten < 0)
+                    break;
                 ptr += nwritten;
-                nread -= nwritten;
+                nread -= (size_t)nwritten;
             } while(nwritten >= 0);
 
             if(nwritten != LIBSSH2_ERROR_EAGAIN) {

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
             if(nwritten < 0)
                 break;
             ptr += nwritten;
-            nread -= nwritten;
+            nread -= (size_t)nwritten;
         } while(nread);
 
     } while(nwritten > 0);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -257,7 +257,7 @@ int main(int argc, char *argv[])
         }
         if(nread > 0) {
             total += nread;
-            write(1, mem, nread);
+            write(1, mem, (size_t)nread);
         }
         else {
             break;

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
             if(nwritten < 0)
                 break;
             ptr += nwritten;
-            nread -= nwritten;
+            nread -= (size_t)nwritten;
         } while(nread);
     } while(nwritten > 0);
 

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
         }
         ptr = mem;
 
-        total += nread;
+        total += (libssh2_struct_stat_size)nread;
 
         do {
             /* write data in a loop until we block */
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
             if(nwritten < 0)
                 break;
             ptr += nwritten;
-            nread -= nwritten;
+            nread -= (size_t)nwritten;
         } while(nread);
     } while(nwritten > 0);
 

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
                 break;
         }
         memuse += nread;
-        total += nread;
+        total += (libssh2_struct_stat_size)nread;
 
         /* write data in a loop until we block */
         while((nwritten = libssh2_sftp_write(sftp_handle, mem, memuse)) ==
@@ -254,10 +254,10 @@ int main(int argc, char *argv[])
         if(nwritten < 0)
             break;
 
-        if(memuse - nwritten) {
+        if(memuse - (size_t)nwritten) {
             /* make room for more data at the end of the buffer */
-            memmove(&mem[0], &mem[nwritten], memuse - nwritten);
-            memuse -= nwritten;
+            memmove(&mem[0], &mem[nwritten], memuse - (size_t)nwritten);
+            memuse -= (size_t)nwritten;
         }
         else
             /* 'mem' was consumed fully */

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -319,7 +319,7 @@ int main(int argc, char *argv[])
             if(err < 0)
                 fprintf(stderr, "Unable to read response: %d\n", (int)err);
             else {
-                fwrite(buf, 1, err, stdout);
+                fwrite(buf, 1, (size_t)err, stdout);
             }
         }
     }

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -219,11 +219,11 @@ int main(int argc, char *argv[])
     else {
         LIBSSH2_POLLFD *fds = NULL;
         int running = 1;
-        ssize_t bufsize = BUFSIZE;
+        size_t bufsize = BUFSIZE;
         char buffer[BUFSIZE];
-        ssize_t totsize = 1500000;
-        ssize_t totwritten = 0;
-        ssize_t totread = 0;
+        size_t totsize = 1500000;
+        size_t totwritten = 0;
+        size_t totread = 0;
         int rereads = 0;
         int rewrites = 0;
         int i;
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
                     exit(1);
                 }
                 else {
-                    totread += n;
+                    totread += (size_t)n;
                     fprintf(stderr, "read %d bytes (%d in total)\n",
                             (int)n, (int)totread);
                 }
@@ -273,8 +273,8 @@ int main(int argc, char *argv[])
 
                 if(totwritten < totsize) {
                     /* we have not written all data yet */
-                    ssize_t left = totsize - totwritten;
-                    ssize_t size = (left < bufsize) ? left : bufsize;
+                    size_t left = totsize - totwritten;
+                    size_t size = (left < bufsize) ? left : bufsize;
                     ssize_t n = libssh2_channel_write_ex(channel, 0,
                                                          buffer, size);
 
@@ -287,10 +287,10 @@ int main(int argc, char *argv[])
                         exit(1);
                     }
                     else {
-                        totwritten += n;
+                        totwritten += (size_t)n;
                         fprintf(stderr, "wrote %d bytes (%d in total)",
                                 (int)n, (int)totwritten);
-                        if(left >= bufsize && n != bufsize) {
+                        if(left >= bufsize && (size_t)n != bufsize) {
                             fprintf(stderr, " PARTIAL");
                         }
                         fprintf(stderr, "\n");
@@ -310,7 +310,8 @@ int main(int argc, char *argv[])
                     else {
                         fprintf(stderr, "sent eof\n");
                         /* we're done writing, stop listening for OUT events */
-                        fds[0].events &= ~LIBSSH2_POLLFD_POLLOUT;
+                        fds[0].events &=
+                            ~(unsigned long)LIBSSH2_POLLFD_POLLOUT;
                     }
                 }
             }

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -73,7 +73,7 @@ static ssize_t netconf_read_until(LIBSSH2_CHANNEL *channel, const char *endtag,
             fprintf(stderr, "libssh2_channel_read: %d\n", (int)len);
             return -1;
         }
-        rd += len;
+        rd += (size_t)len;
 
         /* read more data until we see a rpc-reply closing tag followed by
          * the special sequence ]]>]]> */
@@ -93,10 +93,10 @@ static ssize_t netconf_read_until(LIBSSH2_CHANNEL *channel, const char *endtag,
     }
 
     /* discard the special sequence so that only XML is returned */
-    rd = specialsequence - buf;
+    rd = (size_t)(specialsequence - buf);
     buf[rd] = 0;
 
-    return rd;
+    return (ssize_t)rd;
 }
 
 int main(int argc, char *argv[])
@@ -250,7 +250,9 @@ int main(int argc, char *argv[])
         "</capabilities>"
         "</hello>\n"
         "]]>]]>\n");
-    if(-1 == netconf_write(channel, buf, len))
+    if(len < 0)
+        goto shutdown;
+    if(-1 == netconf_write(channel, buf, (size_t)len))
         goto shutdown;
 
     fprintf(stderr, "Reading NETCONF server <hello>\n");
@@ -268,7 +270,9 @@ int main(int argc, char *argv[])
         "<get-interface-information><terse/></get-interface-information>"
         "</rpc>\n"
         "]]>]]>\n");
-    if(-1 == netconf_write(channel, buf, len))
+    if(len < 0)
+        goto shutdown;
+    if(-1 == netconf_write(channel, buf, (size_t)len))
         goto shutdown;
 
     fprintf(stderr, "Reading NETCONF <rpc-reply>\n");

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -268,7 +268,7 @@ int main(int argc, char *argv[])
             }
             wr = 0;
             do {
-                nwritten = libssh2_channel_write(channel, buf, len);
+                nwritten = libssh2_channel_write(channel, buf, (size_t)len);
                 if(nwritten < 0) {
                     fprintf(stderr, "libssh2_channel_write: %d\n",
                             (int)nwritten);
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
             }
             wr = 0;
             while(wr < len) {
-                nsent = send(forwardsock, buf + wr, len - wr, 0);
+                nsent = send(forwardsock, buf + wr, (size_t)(len - wr), 0);
                 if(nsent <= 0) {
                     fprintf(stderr, "failed to send().\n");
                     goto shutdown;

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -279,6 +279,7 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
              const unsigned char *data, size_t data_len, void **abstract)
 
 /* 'keyboard-interactive' authentication callback */
+/* FIXME: name_len, instruction_len -> size_t, num_prompts -> unsigned int? */
 #define LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(name_) \
     void name_(const char *name, int name_len, const char *instruction, \
                int instruction_len, int num_prompts, \

--- a/src/agent.c
+++ b/src/agent.c
@@ -563,7 +563,7 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
         _libssh2_debug((session,
                        LIBSSH2_TRACE_KEX,
                        "Agent sign method %.*s",
-                       method_len, method_name));
+                       (int)method_len, method_name));
 
         rc = LIBSSH2_ERROR_ALGO_UNSUPPORTED;
         goto error;

--- a/src/channel.c
+++ b/src/channel.c
@@ -84,7 +84,7 @@ _libssh2_channel_nextid(LIBSSH2_SESSION * session)
      */
     session->next_channel = id + 1;
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                   "Allocated new channel ID#%lu", id));
+                   "Allocated new channel ID#%u", id));
     return id;
 }
 
@@ -265,8 +265,8 @@ _libssh2_channel_open(LIBSSH2_SESSION * session, const char *channel_type,
             session->open_channel->local.packet_size =
                 _libssh2_ntohu32(session->open_data + 13);
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Connection Established - ID: %lu/%lu win: %lu/%lu"
-                           " pack: %lu/%lu",
+                           "Connection Established - ID: %u/%u win: %u/%u"
+                           " pack: %u/%u",
                            session->open_channel->local.id,
                            session->open_channel->remote.id,
                            session->open_channel->local.window_size,
@@ -902,7 +902,7 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                        "Setting remote environment variable: %s=%s on "
-                       "channel %lu/%lu",
+                       "channel %u/%u",
                        varname, value, channel->local.id, channel->remote.id));
 
         s = channel->setenv_packet =
@@ -1036,7 +1036,7 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
                sizeof(channel->reqPTY_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Allocating tty on channel %lu/%lu", channel->local.id,
+                       "Allocating tty on channel %u/%u", channel->local.id,
                        channel->remote.id));
 
         s = channel->reqPTY_packet;
@@ -1139,7 +1139,7 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
                sizeof(channel->req_auth_agent_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Requesting auth agent on channel %lu/%lu",
+                       "Requesting auth agent on channel %u/%u",
                        channel->local.id, channel->remote.id));
 
         /*
@@ -1303,7 +1303,7 @@ channel_request_pty_size(LIBSSH2_CHANNEL * channel, int width,
                sizeof(channel->reqPTY_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "changing tty size on channel %lu/%lu",
+                       "changing tty size on channel %u/%u",
                        channel->local.id,
                        channel->remote.id));
 
@@ -1392,7 +1392,7 @@ channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
                sizeof(channel->reqX11_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Requesting x11-req for channel %lu/%lu: single=%d "
+                       "Requesting x11-req for channel %u/%u: single=%d "
                        "proto=%s cookie=%s screen=%d",
                        channel->local.id, channel->remote.id,
                        single_connection,
@@ -1550,7 +1550,7 @@ _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
             channel->process_packet_len += + 4;
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "starting request(%s) on channel %lu/%lu, message=%s",
+                       "starting request(%s) on channel %u/%u, message=%s",
                        request, channel->local.id, channel->remote.id,
                        message ? message : "<null>"));
         s = channel->process_packet =
@@ -1719,9 +1719,9 @@ _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
                         packet->data_head;
 
                     _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                                   "Flushing %d bytes of data from stream "
-                                   "%lu on channel %lu/%lu",
-                                   bytes_to_flush, packet_stream_id,
+                                   "Flushing %ld bytes of data from stream "
+                                   "%d on channel %u/%u",
+                                   (long)bytes_to_flush, packet_stream_id,
                                    channel->local.id, channel->remote.id));
 
                     /* It's one of the streams we wanted to flush */
@@ -1882,8 +1882,8 @@ _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL * channel,
             && (adjustment + channel->adjust_queue <
                 LIBSSH2_CHANNEL_MINADJUST)) {
             _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                           "Queueing %lu bytes for receive window adjustment "
-                           "for channel %lu/%lu",
+                           "Queueing %u bytes for receive window adjustment "
+                           "for channel %u/%u",
                            adjustment, channel->local.id, channel->remote.id));
             channel->adjust_queue += adjustment;
             return 0;
@@ -1901,8 +1901,8 @@ _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL * channel,
         _libssh2_htonu32(&channel->adjust_adjust[1], channel->remote.id);
         _libssh2_htonu32(&channel->adjust_adjust[5], adjustment);
         _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                       "Adjusting window %lu bytes for data on "
-                       "channel %lu/%lu",
+                       "Adjusting window %u bytes for data on "
+                       "channel %u/%u",
                        adjustment, channel->local.id, channel->remote.id));
 
         channel->adjust_state = libssh2_NB_state_created;
@@ -1998,7 +1998,7 @@ _libssh2_channel_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode)
 {
     if(channel->extData2_state == libssh2_NB_state_idle) {
         _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                       "Setting channel %lu/%lu handle_extended_data"
+                       "Setting channel %u/%u handle_extended_data"
                        " mode to %d",
                        channel->local.id, channel->remote.id, ignore_mode));
         channel->remote.extended_data_ignore_mode = (char)ignore_mode;
@@ -2081,7 +2081,7 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
     LIBSSH2_PACKET *read_next;
 
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                   "channel_read() wants %d bytes from channel %lu/%lu "
+                   "channel_read() wants %d bytes from channel %u/%u "
                    "stream #%d",
                    (int) buflen, channel->local.id, channel->remote.id,
                    stream_id));
@@ -2178,8 +2178,8 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
             }
 
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "channel_read() got %d of data from %lu/%lu/%d%s",
-                           bytes_want, channel->local.id,
+                           "channel_read() got %ld of data from %u/%u/%d%s",
+                           (long)bytes_want, channel->local.id,
                            channel->remote.id, stream_id,
                            unlink_packet?" [ul]":""));
 
@@ -2356,7 +2356,7 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         unsigned char *s = channel->write_packet;
 
         _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                       "Writing %d bytes on channel %lu/%lu, stream #%d",
+                       "Writing %d bytes on channel %u/%u, stream #%d",
                        (int) buflen, channel->local.id, channel->remote.id,
                        stream_id));
 
@@ -2405,16 +2405,16 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         /* REMEMBER local means local as the SOURCE of the data */
         if(channel->write_bufwrite > channel->local.window_size) {
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Splitting write block due to %lu byte "
-                           "window_size on %lu/%lu/%d",
+                           "Splitting write block due to %u byte "
+                           "window_size on %u/%u/%d",
                            channel->local.window_size, channel->local.id,
                            channel->remote.id, stream_id));
             channel->write_bufwrite = channel->local.window_size;
         }
         if(channel->write_bufwrite > channel->local.packet_size) {
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Splitting write block due to %lu byte "
-                           "packet_size on %lu/%lu/%d",
+                           "Splitting write block due to %u byte "
+                           "packet_size on %u/%u/%d",
                            channel->local.packet_size, channel->local.id,
                            channel->remote.id, stream_id));
             channel->write_bufwrite = channel->local.packet_size;
@@ -2425,7 +2425,7 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         channel->write_packet_len = s - channel->write_packet;
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Sending %d bytes on channel %lu/%lu, stream_id=%d",
+                       "Sending %d bytes on channel %u/%u, stream_id=%d",
                        (int) channel->write_bufwrite, channel->local.id,
                        channel->remote.id, stream_id));
 
@@ -2500,7 +2500,7 @@ static int channel_send_eof(LIBSSH2_CHANNEL *channel)
     int rc;
 
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                   "Sending EOF on channel %lu/%lu",
+                   "Sending EOF on channel %u/%u",
                    channel->local.id, channel->remote.id));
     packet[0] = SSH_MSG_CHANNEL_EOF;
     _libssh2_htonu32(packet + 1, channel->remote.id);
@@ -2590,7 +2590,7 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
 
     if(channel->wait_eof_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Awaiting EOF for channel %lu/%lu", channel->local.id,
+                       "Awaiting EOF for channel %u/%u", channel->local.id,
                        channel->remote.id));
 
         channel->wait_eof_state = libssh2_NB_state_created;
@@ -2671,7 +2671,7 @@ int _libssh2_channel_close(LIBSSH2_CHANNEL * channel)
        late for us to wait for it. Continue closing! */
 
     if(channel->close_state == libssh2_NB_state_idle) {
-        _libssh2_debug((session, LIBSSH2_TRACE_CONN, "Closing channel %lu/%lu",
+        _libssh2_debug((session, LIBSSH2_TRACE_CONN, "Closing channel %u/%u",
                        channel->local.id, channel->remote.id));
 
         channel->close_packet[0] = SSH_MSG_CHANNEL_CLOSE;
@@ -2762,7 +2762,7 @@ static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
 
     if(channel->wait_closed_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Awaiting close of channel %lu/%lu", channel->local.id,
+                       "Awaiting close of channel %u/%u", channel->local.id,
                        channel->remote.id));
 
         channel->wait_closed_state = libssh2_NB_state_created;
@@ -2825,7 +2825,7 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
 
     if(channel->free_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Freeing channel %lu/%lu resources", channel->local.id,
+                       "Freeing channel %u/%u resources", channel->local.id,
                        channel->remote.id));
 
         channel->free_state = libssh2_NB_state_created;

--- a/src/comp.c
+++ b/src/comp.c
@@ -208,7 +208,7 @@ comp_method_zlib_comp(LIBSSH2_SESSION *session,
     }
 
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                   "unhandled zlib compression error %d, avail_out",
+                   "unhandled zlib compression error %d, avail_out %u",
                    status, strm->avail_out));
     return _libssh2_error(session, LIBSSH2_ERROR_ZLIB, "compression failure");
 }

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -106,7 +106,7 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
 #endif
     {
         _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
-                       "unexpected rsa type: %.*s", type_len, type));
+                       "unexpected rsa type: %.*s", (int)type_len, type));
         return -1;
     }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -302,8 +302,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                exchange_state->e_packet + 6);
         }
 
-        _libssh2_debug((session, LIBSSH2_TRACE_KEX, "Sending KEX packet %d",
-                       (int) packet_type_init));
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX, "Sending KEX packet %u",
+                       (unsigned int) packet_type_init));
         exchange_state->state = libssh2_NB_state_created;
     }
 

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -1049,7 +1049,7 @@ knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
             break;
         }
         /* otherwise fallback to default and error */
-        /* FALL-THROUGH */
+        LIBSSH2_FALLTHROUGH();
     default:
         return _libssh2_error(hosts->session,
                               LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -106,12 +106,21 @@
 #define TRUE 1
 #endif
 
+#if (defined(__GNUC__) || defined(__clang__)) && \
+    defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+    !defined(__MINGW32__) && !defined(LIBSSH2_NO_FMT_CHECKS)
+#define LIBSSH2_PRINTF(fmt, arg)  __attribute__((format(printf, fmt, arg)))
+#else
+#define LIBSSH2_PRINTF(fmt, arg)
+#endif
+
 /* Use local implementation when not available */
 #if !defined(HAVE_SNPRINTF)
 #undef snprintf
 #define snprintf _libssh2_snprintf
 #define LIBSSH2_SNPRINTF
-int _libssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...);
+int _libssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
+    LIBSSH2_PRINTF(3, 4);
 #endif
 
 #if !defined(HAVE_GETTIMEOFDAY)
@@ -1057,7 +1066,7 @@ struct _LIBSSH2_COMP_METHOD
 #ifdef LIBSSH2DEBUG
 void
 _libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
-                   ...);
+                   ...) LIBSSH2_PRINTF(3, 4);
 #define _libssh2_debug(x) _libssh2_debug_low x
 #else
 #define _libssh2_debug(x) do {} while(0)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -124,6 +124,15 @@ int _libssh2_gettimeofday(struct timeval *tp, void *tzp);
 #include <sys/time.h>
 #endif
 
+#if !defined(LIBSSH2_FALLTHROUGH)
+#if (defined(__GNUC__) && __GNUC__ >= 7) || \
+    (defined(__clang__) && __clang_major__ >= 10)
+#  define LIBSSH2_FALLTHROUGH()  __attribute__((fallthrough))
+#else
+#  define LIBSSH2_FALLTHROUGH()  do {} while (0)
+#endif
+#endif
+
 /* "inline" keyword is valid only with C++ engine! */
 #ifdef __GNUC__
 #undef inline

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -41,10 +41,18 @@
 
 #define LIBSSH2_CRYPTO_ENGINE libssh2_mbedtls
 
-/* mbedTLS (as of v3.5.1) has a duplicate function declaration
-   in its own public headers. Disable the warning that detects it. */
 #ifdef __GNUC__
 #pragma GCC diagnostic push
+/* mbedTLS (as of v3.5.1) has a `[-Werror=arith-conversion]`
+   warning in its public headers. */
+#if !defined(__clang__) && __GNUC__ >= 10
+#pragma GCC diagnostic ignored "-Warith-conversion"
+#endif
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+/* mbedTLS (as of v3.5.1) has a duplicate function declaration
+   in its public headers. Disable the warning that detects it. */
 #pragma GCC diagnostic ignored "-Wredundant-decls"
 #endif
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -72,7 +72,14 @@ int _libssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
     if(cp_max_len < 2)
         return 0;
     va_start(args, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     n = vsnprintf(cp, cp_max_len, fmt, args);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     va_end(args);
     return (n < (int)cp_max_len) ? n : (int)(cp_max_len - 1);
 }
@@ -556,7 +563,14 @@ _libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
         buflen -= len;
         msglen = len;
         va_start(vargs, format);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
         len = vsnprintf(buffer + msglen, buflen, format, vargs);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
         va_end(vargs);
         msglen += len < buflen ? len : buflen - 1;
     }

--- a/src/packet.c
+++ b/src/packet.c
@@ -889,7 +889,7 @@ libssh2_packet_add_jump_point5:
             /* streamid(4) */
             data_head += 4;
 
-            /* fall-through */
+            LIBSSH2_FALLTHROUGH();
 
             /*
               byte      SSH_MSG_CHANNEL_DATA

--- a/src/packet.c
+++ b/src/packet.c
@@ -126,7 +126,7 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Remote received connection from %s:%ld to %s:%ld",
+                       "Remote received connection from %s:%u to %s:%u",
                        listen_state->shost, listen_state->sport,
                        listen_state->host, listen_state->port));
 
@@ -199,8 +199,8 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
                     channel->local.packet_size = listen_state->packet_size;
 
                     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                                   "Connection queued: channel %lu/%lu "
-                                   "win %lu/%lu packet %lu/%lu",
+                                   "Connection queued: channel %u/%u "
+                                   "win %u/%u packet %u/%u",
                                    channel->local.id, channel->remote.id,
                                    channel->local.window_size,
                                    channel->remote.window_size,
@@ -339,7 +339,7 @@ packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "X11 Connection Received from %s:%ld on channel %lu",
+                       "X11 Connection Received from %s:%u on channel %u",
                        x11open_state->shost, x11open_state->sport,
                        x11open_state->sender_channel));
 
@@ -384,8 +384,8 @@ packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
             channel->local.packet_size = x11open_state->packet_size;
 
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "X11 Connection established: channel %lu/%lu "
-                           "win %lu/%lu packet %lu/%lu",
+                           "X11 Connection established: channel %u/%u "
+                           "win %u/%u packet %u/%u",
                            channel->local.id, channel->remote.id,
                            channel->local.window_size,
                            channel->remote.window_size,
@@ -497,7 +497,7 @@ packet_authagent_open(LIBSSH2_SESSION * session,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Auth Agent Connection Received on channel %lu",
+                       "Auth Agent Connection Received on channel %u",
                        authagent_state->sender_channel));
 
         authagent_state->state = libssh2_NB_state_allocated;
@@ -545,7 +545,7 @@ packet_authagent_open(LIBSSH2_SESSION * session,
 
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                            "Auth Agent Connection established: channel "
-                           "%lu/%lu win %lu/%lu packet %lu/%lu",
+                           "%u/%u win %u/%u packet %u/%u",
                            channel->local.id, channel->remote.id,
                            channel->local.window_size,
                            channel->remote.window_size,
@@ -645,8 +645,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
     switch(session->packAdd_state) {
     case libssh2_NB_state_idle:
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "Packet type %d received, length=%d",
-                       (int) msg, (int) datalen));
+                       "Packet type %u received, length=%d",
+                       (unsigned int) msg, (int) datalen));
 
         if((macstate == LIBSSH2_MAC_INVALID) &&
             (!session->macerror ||
@@ -812,7 +812,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                         _libssh2_debug((session,
                                        LIBSSH2_TRACE_KEX,
                                        "Server to Client extension %.*s: %.*s",
-                                       name_len, name, value_len, value));
+                                       (int)name_len, name,
+                                       (int)value_len, value));
                     }
 
                     if(name_len == 15 &&
@@ -860,7 +861,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     _libssh2_debug((session,
                                    LIBSSH2_TRACE_CONN,
                                    "Received global request type %.*s (wr %X)",
-                                   len, data + 5, want_reply));
+                                   (int)len, data + 5, want_reply));
                 }
 
 
@@ -920,7 +921,7 @@ libssh2_packet_add_jump_point5:
                     stream_id = _libssh2_ntohu32(data + 5);
 
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                               "%d bytes packet_add() for %lu/%lu/%lu",
+                               "%d bytes packet_add() for %u/%u/%u",
                                (int) (datalen - data_head),
                                channelp->local.id,
                                channelp->remote.id,
@@ -944,11 +945,11 @@ libssh2_packet_add_jump_point5:
                 channelp->remote.window_size -= (uint32_t)(datalen -
                                                            data_head);
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                               "shrinking window size by %lu bytes to %lu, "
-                               "read_avail %lu",
-                               datalen - data_head,
+                               "shrinking window size by %ld bytes to %u, "
+                               "read_avail %ld",
+                               (long) (datalen - data_head),
                                channelp->remote.window_size,
-                               channelp->read_avail));
+                               (long) channelp->read_avail));
 
                 session->packAdd_channelp = channelp;
 
@@ -1010,10 +1011,10 @@ libssh2_packet_add_jump_point1:
             channelp->read_avail += datalen - data_head;
 
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "increasing read_avail by %lu bytes to %lu/%lu",
+                           "increasing read_avail by %ld bytes to %ld/%u",
                            (long)(datalen - data_head),
                            (long)channelp->read_avail,
-                           (long)channelp->remote.window_size));
+                           channelp->remote.window_size));
 
             break;
 
@@ -1033,7 +1034,7 @@ libssh2_packet_add_jump_point1:
             else {
                 _libssh2_debug((session,
                                LIBSSH2_TRACE_CONN,
-                               "EOF received for channel %lu/%lu",
+                               "EOF received for channel %u/%u",
                                channelp->local.id,
                                channelp->remote.id));
                 channelp->remote.eof = 1;
@@ -1061,8 +1062,8 @@ libssh2_packet_add_jump_point1:
 
                 _libssh2_debug((session,
                                LIBSSH2_TRACE_CONN,
-                               "Channel %d received request type %.*s (wr %X)",
-                               channel, len, data + 9, want_reply));
+                               "Channel %u received request type %.*s (wr %X)",
+                               channel, (int)len, data + 9, want_reply));
 
                 if(len == strlen("exit-status")
                     && (strlen("exit-status") + 9) <= datalen
@@ -1079,8 +1080,8 @@ libssh2_packet_add_jump_point1:
                             _libssh2_ntohu32(data + 10 +
                                              strlen("exit-status"));
                         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                                       "Exit status %lu received for "
-                                       "channel %lu/%lu",
+                                       "Exit status %d received for "
+                                       "channel %u/%u",
                                        channelp->exit_status,
                                        channelp->local.id,
                                        channelp->remote.id));
@@ -1120,7 +1121,7 @@ libssh2_packet_add_jump_point1:
                             /* TODO: save error message and language tag */
                             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                            "Exit signal %s received for "
-                                           "channel %lu/%lu",
+                                           "channel %u/%u",
                                            channelp->exit_signal,
                                            channelp->local.id,
                                            channelp->remote.id));
@@ -1161,7 +1162,7 @@ libssh2_packet_add_jump_point4:
                 return 0;
             }
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Close received for channel %lu/%lu",
+                           "Close received for channel %u/%u",
                            channelp->local.id,
                            channelp->remote.id));
 
@@ -1251,8 +1252,8 @@ libssh2_packet_add_jump_authagent:
                     channelp->local.window_size += bytestoadd;
 
                     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                                   "Window adjust for channel %lu/%lu, "
-                                   "adding %lu bytes, new window_size=%lu",
+                                   "Window adjust for channel %u/%u, "
+                                   "adding %u bytes, new window_size=%u",
                                    channelp->local.id,
                                    channelp->remote.id,
                                    bytestoadd,
@@ -1344,7 +1345,8 @@ _libssh2_packet_ask(LIBSSH2_SESSION * session, unsigned char packet_type,
     LIBSSH2_PACKET *packet = _libssh2_list_first(&session->packets);
 
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                   "Looking for packet of type: %d", (int) packet_type));
+                   "Looking for packet of type: %u",
+                   (unsigned int)packet_type));
 
     while(packet) {
         if(packet->data[0] == packet_type

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -516,13 +516,13 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
                     LIBSSH2_PUBLICKEY_VERSION) {
                     _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
                                    "Truncate remote publickey version "
-                                   "from %lu",
+                                   "from %u",
                                    session->pkeyInit_pkey->version));
                     session->pkeyInit_pkey->version =
                         LIBSSH2_PUBLICKEY_VERSION;
                 }
                 _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                               "Enabling publickey subsystem version %lu",
+                               "Enabling publickey subsystem version %u",
                                session->pkeyInit_pkey->version));
                 LIBSSH2_FREE(session, session->pkeyInit_data);
                 session->pkeyInit_data = NULL;

--- a/src/scp.c
+++ b/src/scp.c
@@ -748,7 +748,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
                 }
                 _libssh2_debug((session, LIBSSH2_TRACE_SCP,
                                "mode = 0%lo size = %ld", session->scpRecv_mode,
-                               session->scpRecv_size));
+                               (long)session->scpRecv_size));
 
                 /* We *should* check that basename is valid, but why let that
                    stop us? */

--- a/src/session.c
+++ b/src/session.c
@@ -253,13 +253,14 @@ banner_send(LIBSSH2_SESSION * session)
                        LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(ret < 0)
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Error sending %d bytes: %d",
-                       banner_len - session->banner_TxRx_total_send, -ret));
+                       "Error sending %ld bytes: %ld",
+                       (long)(banner_len - session->banner_TxRx_total_send),
+                       (long)-ret));
     else
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Sent %d/%d bytes at %p+%d", ret,
-                       banner_len - session->banner_TxRx_total_send,
-                       banner, session->banner_TxRx_total_send));
+                       "Sent %ld/%ld bytes at %p+%ld", (long)ret,
+                       (long)(banner_len - session->banner_TxRx_total_send),
+                       (void *)banner, (long)session->banner_TxRx_total_send));
 
     if(ret != (ssize_t)(banner_len - session->banner_TxRx_total_send)) {
         if(ret >= 0 || ret == -EAGAIN) {
@@ -864,8 +865,8 @@ session_free(LIBSSH2_SESSION *session)
 
     if(session->free_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "Freeing session resource",
-                       session->remote.banner));
+                       "Freeing session resource %p",
+                       (void *)session->remote.banner));
 
         session->free_state = libssh2_NB_state_created;
     }

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -310,7 +310,7 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                        "partial read cont, already recvd: %lu",
                        sftp->partial_received));
-        /* fall-through */
+        LIBSSH2_FALLTHROUGH();
     default:
         if(!packet) {
             /* only do this if there's not already a packet buffer allocated
@@ -1570,7 +1570,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
                            "read request id %d sent (offset: %d, size: %d)",
                            request_id, (int)chunk->offset, (int)chunk->len));
         }
-        /* FALL-THROUGH */
+        LIBSSH2_FALLTHROUGH();
     case libssh2_NB_state_sent:
 
         sftp->read_state = libssh2_NB_state_idle;
@@ -1610,7 +1610,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
             /* move on to the next chunk with data to send */
             chunk = _libssh2_list_next(&chunk->node);
         }
-        /* FALL-THROUGH */
+        LIBSSH2_FALLTHROUGH();
 
     case libssh2_NB_state_sent2:
 
@@ -2184,7 +2184,8 @@ static ssize_t sftp_write(LIBSSH2_SFTP_HANDLE *handle, const char *buffer,
             chunk = _libssh2_list_next(&chunk->node);
         }
 
-        /* fall-through */
+        LIBSSH2_FALLTHROUGH();
+
     case libssh2_NB_state_sent:
 
         sftp->write_state = libssh2_NB_state_idle;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -152,7 +152,7 @@ remove_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
                                                               request_id);
     if(zombie) {
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Removing request ID %ld from the list of "
+                       "Removing request ID %u from the list of "
                        "zombie requests",
                        request_id));
 
@@ -169,13 +169,13 @@ add_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
     struct sftp_zombie_requests *zombie;
 
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                   "Marking request ID %ld as a zombie request", request_id));
+                   "Marking request ID %u as a zombie request", request_id));
 
     zombie = LIBSSH2_ALLOC(sftp->channel->session,
                            sizeof(struct sftp_zombie_requests));
     if(!zombie)
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                              "malloc fail for zombie request  ID");
+                              "malloc fail for zombie request ID");
     else {
         zombie->request_id = request_id;
         _libssh2_list_add(&sftp->zombie_requests, &zombie->node);
@@ -199,8 +199,8 @@ sftp_packet_add(LIBSSH2_SFTP *sftp, unsigned char *data,
     }
 
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                   "Received packet type %d (len %d)",
-                   (int) data[0], data_len));
+                   "Received packet type %u (len %lu)",
+                   (unsigned int)data[0], (unsigned long)data_len));
 
     /*
      * Experience shows that if we mess up EAGAIN handling somewhere or
@@ -306,10 +306,10 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
         packet = sftp->partial_packet;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "partial read cont, len: %lu", sftp->partial_len));
+                       "partial read cont, len: %u", sftp->partial_len));
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                        "partial read cont, already recvd: %lu",
-                       sftp->partial_received));
+                       (unsigned long)sftp->partial_received));
         LIBSSH2_FALLTHROUGH();
     default:
         if(!packet) {
@@ -359,7 +359,7 @@ sftp_packet_read(LIBSSH2_SFTP *sftp)
 
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
                            "Data begin - Packet Length: %lu",
-                           sftp->partial_len));
+                           (unsigned long)sftp->partial_len));
             packet = LIBSSH2_ALLOC(session, sftp->partial_len);
             if(!packet)
                 return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -526,13 +526,13 @@ sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
         return LIBSSH2_ERROR_BAD_USE;
     }
 
-    _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Requiring packet %d id %ld",
-                   (int) packet_type, request_id));
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Requiring packet %u id %u",
+                   (unsigned int) packet_type, request_id));
 
     if(sftp_packet_ask(sftp, packet_type, request_id, data, data_len) == 0) {
         /* The right packet was available in the packet brigade */
-        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %d",
-                       (int) packet_type));
+        _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %u",
+                       (unsigned int) packet_type));
 
         if(*data_len < required_size) {
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
@@ -550,7 +550,7 @@ sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
         if(!sftp_packet_ask(sftp, packet_type, request_id, data, data_len)) {
             /* The right packet was available in the packet brigade */
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %d",
-                           (int) packet_type));
+                           (unsigned int) packet_type));
 
             if(*data_len < required_size) {
                 return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
@@ -979,12 +979,12 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
 
     if(sftp_handle->version > LIBSSH2_SFTP_VERSION) {
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Truncating remote SFTP version from %lu",
+                       "Truncating remote SFTP version from %u",
                        sftp_handle->version));
         sftp_handle->version = LIBSSH2_SFTP_VERSION;
     }
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                   "Enabling SFTP version %lu compatibility",
+                   "Enabling SFTP version %u compatibility",
                    sftp_handle->version));
     while(buf.dataptr < endp) {
         unsigned char *extname, *extdata;
@@ -1921,8 +1921,8 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
 
 end:
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                           "libssh2_sftp_readdir_ex() return %d",
-                           filename_len));
+                           "libssh2_sftp_readdir_ex() return %lu",
+                           (unsigned long)filename_len));
             return (ssize_t)filename_len;
         }
 
@@ -2002,7 +2002,7 @@ end:
     sftp->readdir_state = libssh2_NB_state_idle;
 
     num_names = _libssh2_ntohu32(data + 5);
-    _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "%lu entries returned",
+    _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "%u entries returned",
                    num_names));
     if(!num_names) {
         LIBSSH2_FREE(session, data);

--- a/src/transport.c
+++ b/src/transport.c
@@ -464,13 +464,15 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
                     return LIBSSH2_ERROR_EAGAIN;
                 }
                 _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                               "Error recving %d bytes (got %d)",
-                               PACKETBUFSIZE - remainbuf, -nread));
+                               "Error recving %ld bytes (got %ld)",
+                               (long)(PACKETBUFSIZE - remainbuf),
+                               (long)-nread));
                 return LIBSSH2_ERROR_SOCKET_RECV;
             }
             _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                           "Recved %d/%d bytes to %p+%d", nread,
-                           PACKETBUFSIZE - remainbuf, p->buf, remainbuf));
+                           "Recved %ld/%ld bytes to %p+%ld", (long)nread,
+                           (long)(PACKETBUFSIZE - remainbuf), (void *)p->buf,
+                           (long)remainbuf));
 
             debugdump(session, "libssh2_transport_read() raw",
                       &p->buf[remainbuf], nread);
@@ -787,11 +789,12 @@ send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
                       LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(rc < 0)
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Error sending %d bytes: %d", length, -rc));
+                       "Error sending %ld bytes: %ld",
+                       (long)length, (long)-rc));
     else {
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Sent %d/%d bytes at %p+%d", rc, length, p->outbuf,
-                       p->osent));
+                       "Sent %ld/%ld bytes at %p+%lu", (long)rc, (long)length,
+                       (void *)p->outbuf, (unsigned long)p->osent));
         debugdump(session, "libssh2_transport_write send()",
                   &p->outbuf[p->osent], rc);
     }
@@ -1055,8 +1058,8 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
                     i += bsize - session->local.crypt->blocksize;
                 }
             _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                           "crypting bytes %d-%d", i,
-                           i + bsize - 1));
+                           "crypting bytes %lu-%lu", (unsigned long)i,
+                           (unsigned long)(i + bsize - 1)));
             if(session->local.crypt->crypt(session, ptr,
                                            bsize,
                                            &session->local.crypt_abstract,
@@ -1094,11 +1097,12 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
                        LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(ret < 0)
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Error sending %d bytes: %d", total_length, -ret));
+                       "Error sending %ld bytes: %ld",
+                       (long)total_length, (long)-ret));
     else {
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Sent %d/%d bytes at %p",
-                       ret, total_length, p->outbuf));
+                       "Sent %ld/%ld bytes at %p",
+                       (long)ret, (long)total_length, (void *)p->outbuf));
         debugdump(session, "libssh2_transport_write send()", p->outbuf, ret);
     }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1517,7 +1517,7 @@ retry_auth:
             _libssh2_debug((session,
                            LIBSSH2_TRACE_KEX,
                            "Signing using %.*s",
-                           session->userauth_pblc_method_len,
+                           (int)session->userauth_pblc_method_len,
                            session->userauth_pblc_method));
         }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1294,7 +1294,7 @@ _libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
     BCRYPT_PKCS1_PADDING_INFO paddingInfo;
     unsigned char *data, *sig;
     ULONG cbData, datalen, siglen;
-    int ret;
+    NTSTATUS ret;
 
     if(hash_len == SHA_DIGEST_LENGTH)
         paddingInfo.pszAlgId = BCRYPT_SHA1_ALGORITHM;
@@ -1336,7 +1336,7 @@ _libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
             }
         }
         else
-            ret = STATUS_NO_MEMORY;
+            ret = (NTSTATUS)STATUS_NO_MEMORY;
     }
 
     _libssh2_wincng_safe_free(data, datalen);
@@ -1627,7 +1627,7 @@ _libssh2_wincng_dsa_sha1_sign(libssh2_dsa_ctx *dsa,
 {
     unsigned char *data, *sig;
     ULONG cbData, datalen, siglen;
-    int ret;
+    NTSTATUS ret;
 
     datalen = (ULONG)hash_len;
     data = malloc(datalen);
@@ -1653,10 +1653,10 @@ _libssh2_wincng_dsa_sha1_sign(libssh2_dsa_ctx *dsa,
                 _libssh2_wincng_safe_free(sig, siglen);
             }
             else
-                ret = STATUS_NO_MEMORY;
+                ret = (NTSTATUS)STATUS_NO_MEMORY;
         }
         else
-            ret = STATUS_NO_MEMORY;
+            ret = (NTSTATUS)STATUS_NO_MEMORY;
     }
 
     _libssh2_wincng_safe_free(data, datalen);
@@ -2051,7 +2051,7 @@ _libssh2_wincng_cipher_crypt(_libssh2_cipher_ctx *ctx,
 {
     unsigned char *pbOutput, *pbInput;
     ULONG cbOutput, cbInput;
-    int ret;
+    NTSTATUS ret;
 
     (void)type;
     (void)firstlast;
@@ -2099,7 +2099,7 @@ _libssh2_wincng_cipher_crypt(_libssh2_cipher_ctx *ctx,
             _libssh2_wincng_safe_free(pbOutput, cbOutput);
         }
         else
-            ret = STATUS_NO_MEMORY;
+            ret = (NTSTATUS)STATUS_NO_MEMORY;
     }
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
@@ -2218,7 +2218,7 @@ _libssh2_wincng_bignum_mod_exp(_libssh2_bn *r,
     BCRYPT_RSAKEY_BLOB *rsakey;
     unsigned char *bignum;
     ULONG keylen, offset, length;
-    int ret;
+    NTSTATUS ret;
 
     if(!r || !a || !p || !m)
         return -1;
@@ -2270,10 +2270,10 @@ _libssh2_wincng_bignum_mod_exp(_libssh2_bn *r,
                     }
                 }
                 else
-                    ret = STATUS_NO_MEMORY;
+                    ret = (NTSTATUS)STATUS_NO_MEMORY;
             }
             else
-                ret = STATUS_NO_MEMORY;
+                ret = (NTSTATUS)STATUS_NO_MEMORY;
         }
 
         BCryptDestroyKey(hKey);
@@ -2628,7 +2628,7 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
         BCRYPT_KEY_HANDLE peer_public = NULL;
         BCRYPT_SECRET_HANDLE agreement = NULL;
         ULONG secret_len_bytes = 0;
-        int status;
+        NTSTATUS status;
         unsigned char *start, *end;
         BCRYPT_DH_KEY_BLOB *public_blob;
         ULONG key_length_bytes = max(f->length, dhctx->dh_params->cbKeyLength);
@@ -2694,7 +2694,7 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
         /* Expand the secret bignum to be ready to receive the derived secret
          * */
         if(_libssh2_wincng_bignum_resize(secret, secret_len_bytes)) {
-            status = STATUS_NO_MEMORY;
+            status = (NTSTATUS)STATUS_NO_MEMORY;
             goto out;
         }
 

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -276,7 +276,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
            https://github.com/docker/machine/issues/2612), so we retry a few
            times with exponential backoff if it fails */
         int attempt_no = 0;
-        int wait_time = 500;
+        unsigned int wait_time = 500;
         for(;;) {
             int ret = run_command(ip_address_out, "docker-machine ip %s",
                                   active_docker_machine);
@@ -338,7 +338,7 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     uint32_t hostaddr;
     libssh2_socket_t sock;
     struct sockaddr_in sin;
-    int counter;
+    unsigned int counter;
     libssh2_socket_t ret = LIBSSH2_INVALID_SOCKET;
 
     if(have_docker) {
@@ -393,7 +393,7 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     }
 
     sin.sin_family = AF_INET;
-    sin.sin_port = htons((short)strtol(port_string, NULL, 0));
+    sin.sin_port = htons((unsigned short)strtol(port_string, NULL, 0));
     sin.sin_addr.s_addr = hostaddr;
 
     for(counter = 0; counter < 3; ++counter) {

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -152,6 +152,9 @@ static int run_command_varg(char **output, const char *command, va_list args)
 }
 
 static int run_command(char **output, const char *command, ...)
+    LIBSSH2_PRINTF(2, 3);
+
+static int run_command(char **output, const char *command, ...)
 {
     va_list args;
     int ret;
@@ -171,7 +174,6 @@ static const char *openssh_server_image(void)
 static int build_openssh_server_docker_image(void)
 {
     if(have_docker) {
-        char buildcmd[1024];
         const char *container_image_name = openssh_server_image();
         if(container_image_name) {
             int ret = run_command(NULL, "docker pull %s",
@@ -184,12 +186,9 @@ static int build_openssh_server_docker_image(void)
                 }
             }
         }
-        buildcmd[sizeof(buildcmd)-1] = 0;
-        snprintf(buildcmd, sizeof(buildcmd)-1,
-                 "docker build --quiet -t libssh2/openssh_server %s",
-                 srcdir_path("openssh_server"));
-
-        return run_command(NULL, buildcmd);
+        return run_command(NULL,
+                           "docker build --quiet -t libssh2/openssh_server %s",
+                           srcdir_path("openssh_server"));
     }
     else {
         return 0;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -94,7 +94,14 @@ static int run_command_varg(char **output, const char *command, va_list args)
     }
 
     /* Format the command string */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     ret = vsnprintf(command_buf, sizeof(command_buf), command, args);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     if(ret < 0 || ret >= BUFSIZ) {
         fprintf(stderr, "Unable to format command (%s)\n", command);
         return -1;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -403,7 +403,7 @@ static int read_file(const char *path, char **out_buffer, size_t *out_len)
 {
     FILE *fp;
     char *buffer;
-    size_t len;
+    ssize_t len;
 
     if(!out_buffer || !out_len || !path) {
         fprintf(stderr, "invalid params.\n");
@@ -422,16 +422,21 @@ static int read_file(const char *path, char **out_buffer, size_t *out_len)
 
     fseek(fp, 0L, SEEK_END);
     len = ftell(fp);
+    if(len < 0) {
+        fclose(fp);
+        fprintf(stderr, "Could not determine input size of: %s\n", path);
+        return 1;
+    }
     rewind(fp);
 
-    buffer = calloc(1, len + 1);
+    buffer = calloc(1, (size_t)len + 1);
     if(!buffer) {
         fclose(fp);
         fprintf(stderr, "Could not alloc memory.\n");
         return 1;
     }
 
-    if(1 != fread(buffer, len, 1, fp)) {
+    if(1 != fread(buffer, (size_t)len, 1, fp)) {
         fclose(fp);
         free(buffer);
         fprintf(stderr, "Could not read file into memory.\n");
@@ -441,7 +446,7 @@ static int read_file(const char *path, char **out_buffer, size_t *out_len)
     fclose(fp);
 
     *out_buffer = buffer;
-    *out_len = len;
+    *out_len = (size_t)len;
 
     return 0;
 }

--- a/tests/test_auth_keyboard_info_request.c
+++ b/tests/test_auth_keyboard_info_request.c
@@ -52,7 +52,7 @@ struct expected {
 };
 struct test_case {
     const char *data;
-    int data_len;
+    unsigned int data_len;
     struct expected expected;
 };
 
@@ -248,7 +248,7 @@ LIBSSH2_FREE_FUNC(test_free)
 
 static
 int test_case(int num,
-              const char *data, int data_len, void *abstract,
+              const char *data, unsigned int data_len, void *abstract,
               struct expected expected)
 {
     int rc;

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -46,10 +46,10 @@ static const char *EXPECTED_ED25519_SHA256_HASH_DIGEST =
     "2638B020F6121FA750A7F4754B718419F621814C6E779D68ADF26AA68814ADDF";
 
 #if LIBSSH2_MD5
-static const int MD5_HASH_SIZE = 16;
+static const size_t MD5_HASH_SIZE = 16;
 #endif
-static const int SHA1_HASH_SIZE = 20;
-static const int SHA256_HASH_SIZE = 32;
+static const size_t SHA1_HASH_SIZE = 20;
+static const size_t SHA256_HASH_SIZE = 32;
 
 static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
                              size_t buffer_len)
@@ -59,7 +59,7 @@ static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
     char *end = buffer + buffer_len;
 
     for(i = 0; i < hash_len && p < end; ++i) {
-        p += snprintf(p, end - p, "%02X", (unsigned char)hash[i]);
+        p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
     }
 }
 

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
     int rc;
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
-    int counter;
+    unsigned int counter;
 
 #ifdef _WIN32
     WSADATA wsadata;


### PR DESCRIPTION
Ref: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html

Enable new warnings:

- replace `-Wno-sign-conversion` with `-Wsign-conversion`.

  This patch fixes them in example, tests and wincng, but there remain
  about 360 of these warnings in `src`. Add a TODO item for those and
  disable `-Werror` for this particular warning.

- enable `-Wformat=2` for clang (in both cmake and autotools).

- enable `__attribute__((format))` for `_libssh2_debug()`,
  `_libssh2_snprintf()` and in tests for `run_command()`.

  `LIBSSH2_PRINTF()` copied from `CURL_TEMP_PRINTF()` in curl.

- enable `-Wimplicit-fallthrough`.

- enable `-Wtrampolines`.

Fix them:

- src: replace obsolete fall-through-comments with
  `__attribute__((fallthrough))`.
- wincng: fix `-Wsign-conversion` warnings.
- tests: fix `-Wsign-conversion` warnings.
- example: fix `-Wsign-conversion` warnings.
- src: fix `-Wformat` issues in trace calls.

  Also, where necessary fix `int` and `unsigned char` casts to
  `unsigned int` and adjust printf format strings. These were not
  causing compiler warnings.

  Cast large types to `long` to avoid dealing with printf masks for
  `size_t` and other C99 types. Existing code often used `int` for this.
  I'll update them to `long` in an upcoming commit.

- tests: fix `-Wformat` warning.
- silence `-Wformat-nonliteral` warnings.
- mbedtls: silence `-Wsign-conversion`/`-Warith-conversion`
  in external header.

Closes #1257
