### PR TITLE
example: Replace remaining libssh2_scp_recv with libssh2_scp_recv2 in…

### DIFF
--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -224,12 +224,12 @@ int main(int argc, char *argv[])
                 goto shutdown;
             }
             else {
-                fprintf(stderr, "libssh2_scp_recv() spin\n");
+                fprintf(stderr, "libssh2_scp_recv2() spin\n");
                 waitsocket(sock, session);
             }
         }
     } while(!channel);
-    fprintf(stderr, "libssh2_scp_recv() is done, now receive data.\n");
+    fprintf(stderr, "libssh2_scp_recv2() is done, now receive data.\n");
 
     while(got < fileinfo.st_size) {
         char mem[1024 * 24];


### PR DESCRIPTION
… a scp example

libssh2_scp_recv is deprecated and has been replaced by libssh2_scp_recv2 in prior commit.