### PR TITLE
autotools: enable `-Wunused-macros` with gcc

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -437,7 +437,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pragmas])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [redundant-decls])
           # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [switch-enum])      # Not used because this basically disallows default case
-          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused-macros])    # Not practical
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused-macros])
           fi
           #
           dnl Only gcc 4.2 or later


### PR DESCRIPTION
It works with gcc without the libtool warnings seen with clang
on Windows in 96682bd5e14c20828e18bf10ed5b4b5c7543924a #1227.

Sync usage of of this macro with CMake and
autotools + clang + non-Windows. Making it enabled everywhere except
autotools + clang + Windows due to the libtool stub issue.

Follow-up to 7ecc309cd10454c54814b478c4f85d0041da6721 #1224

Closes #1262
