### PR TITLE
tidy-up: bump casts from int to long for large C99 types in printfs

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -276,8 +276,8 @@ int main(int argc, char *argv[])
                     continue;
                 }
                 if(nwritten < 0) {
-                    fprintf(stderr, "libssh2_channel_write: %d\n",
-                            (int)nwritten);
+                    fprintf(stderr, "libssh2_channel_write: %ld\n",
+                            (long)nwritten);
                     goto shutdown;
                 }
                 wr += nwritten;
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
             if(LIBSSH2_ERROR_EAGAIN == len)
                 break;
             else if(len < 0) {
-                fprintf(stderr, "libssh2_channel_read: %d", (int)len);
+                fprintf(stderr, "libssh2_channel_read: %ld", (long)len);
                 goto shutdown;
             }
             wr = 0;

--- a/example/scp.c
+++ b/example/scp.c
@@ -163,8 +163,8 @@ int main(int argc, char *argv[])
             write(1, mem, (size_t)nread);
         }
         else if(nread < 0) {
-            fprintf(stderr, "libssh2_channel_read() failed: %d\n",
-                    (int)nread);
+            fprintf(stderr, "libssh2_channel_read() failed: %ld\n",
+                    (long)nread);
             break;
         }
         got += nread;

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
             /* write the same data over and over, until error or completion */
             nwritten = libssh2_channel_write(channel, ptr, nread);
             if(nwritten < 0) {
-                fprintf(stderr, "ERROR %d\n", (int)nwritten);
+                fprintf(stderr, "ERROR %ld\n", (long)nwritten);
                 break;
             }
             else {

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -230,8 +230,9 @@ int main(int argc, char *argv[])
                 prev = 0;
             }
             if(nwritten < 0) {
-                fprintf(stderr, "ERROR %d total %ld / %d prev %d\n",
-                        (int)nwritten, (long)total, (int)nread, (int)prev);
+                fprintf(stderr, "ERROR %ld total %ld / %lu prev %lu\n",
+                        (long)nwritten, (long)total,
+                        (unsigned long)nread, (unsigned long)prev);
                 break;
             }
             else {

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -227,8 +227,8 @@ int main(int argc, char *argv[])
         do {
             /* read in a loop until we block */
             nread = libssh2_sftp_read(sftp_handle, mem, sizeof(mem));
-            fprintf(stderr, "libssh2_sftp_read returned %d\n",
-                    (int)nread);
+            fprintf(stderr, "libssh2_sftp_read returned %ld\n",
+                    (long)nread);
 
             if(nread > 0) {
                 /* write to stderr */
@@ -321,8 +321,7 @@ int main(int argc, char *argv[])
             if(rc <= 0) {
                 /* negative is error
                    0 is timeout */
-                fprintf(stderr, "SFTP upload timed out: %d\n",
-                        rc);
+                fprintf(stderr, "SFTP upload timed out: %d\n", rc);
                 break;
             }
         } while(1);

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -317,7 +317,7 @@ int main(int argc, char *argv[])
             char buf[1024];
             ssize_t err = libssh2_channel_read(channel, buf, sizeof(buf));
             if(err < 0)
-                fprintf(stderr, "Unable to read response: %d\n", (int)err);
+                fprintf(stderr, "Unable to read response: %ld\n", (long)err);
             else {
                 fwrite(buf, 1, (size_t)err, stdout);
             }

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -241,8 +241,8 @@ int main(int argc, char *argv[])
             else {
                 if(nread != LIBSSH2_ERROR_EAGAIN)
                     /* no need to output this for the EAGAIN case */
-                    fprintf(stderr, "libssh2_channel_read returned %d\n",
-                            (int)nread);
+                    fprintf(stderr, "libssh2_channel_read returned %ld\n",
+                            (long)nread);
             }
         }
         while(nread > 0);
@@ -269,8 +269,8 @@ int main(int argc, char *argv[])
         fprintf(stderr, "\nGot signal: %s\n", exitsignal);
     }
     else {
-        fprintf(stderr, "\nEXIT: %d bytecount: %d\n",
-                exitcode, (int)bytecount);
+        fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
+                exitcode, (long)bytecount);
     }
 
     libssh2_channel_free(channel);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -263,8 +263,8 @@ int main(int argc, char *argv[])
                 }
                 else {
                     totread += (size_t)n;
-                    fprintf(stderr, "read %d bytes (%d in total)\n",
-                            (int)n, (int)totread);
+                    fprintf(stderr, "read %ld bytes (%lu in total)\n",
+                            (long)n, (unsigned long)totread);
                 }
             }
 
@@ -288,8 +288,8 @@ int main(int argc, char *argv[])
                     }
                     else {
                         totwritten += (size_t)n;
-                        fprintf(stderr, "wrote %d bytes (%d in total)",
-                                (int)n, (int)totwritten);
+                        fprintf(stderr, "wrote %ld bytes (%lu in total)",
+                                (long)n, (unsigned long)totwritten);
                         if(left >= bufsize && (size_t)n != bufsize) {
                             fprintf(stderr, " PARTIAL");
                         }
@@ -338,12 +338,13 @@ int main(int argc, char *argv[])
         libssh2_channel_free(channel);
         channel = NULL;
 
-        fprintf(stderr, "\nrereads: %d rewrites: %d totwritten %d\n",
-                rereads, rewrites, (int)totwritten);
+        fprintf(stderr, "\nrereads: %d rewrites: %d totwritten %lu\n",
+                rereads, rewrites, (unsigned long)totwritten);
 
         if(totwritten != totread) {
-            fprintf(stderr, "\n*** FAIL bytes written: %d bytes "
-                    "read: %d ***\n", (int)totwritten, (int)totread);
+            fprintf(stderr, "\n*** FAIL bytes written: "
+                    "%lu bytes read: %lu ***\n",
+                    (unsigned long)totwritten, (unsigned long)totread);
             exit(1);
         }
     }

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -252,8 +252,8 @@ int main(int argc, char *argv[])
             else {
                 if(nread != LIBSSH2_ERROR_EAGAIN)
                     /* no need to output this for the EAGAIN case */
-                    fprintf(stderr, "libssh2_channel_read returned %d\n",
-                            (int)nread);
+                    fprintf(stderr, "libssh2_channel_read returned %ld\n",
+                            (long)nread);
             }
         }
         while(nread > 0);
@@ -279,8 +279,8 @@ int main(int argc, char *argv[])
     if(exitsignal)
         fprintf(stderr, "\nGot signal: %s\n", exitsignal);
     else
-        fprintf(stderr, "\nEXIT: %d bytecount: %d\n",
-                exitcode, (int)bytecount);
+        fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
+                exitcode, (long)bytecount);
 
     libssh2_channel_free(channel);
     channel = NULL;

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -47,7 +47,7 @@ static int netconf_write(LIBSSH2_CHANNEL *channel, const char *buf, size_t len)
     do {
         i = libssh2_channel_write(channel, buf, len);
         if(i < 0) {
-            fprintf(stderr, "libssh2_channel_write: %d\n", (int)i);
+            fprintf(stderr, "libssh2_channel_write: %ld\n", (long)i);
             return -1;
         }
         wr += i;
@@ -70,7 +70,7 @@ static ssize_t netconf_read_until(LIBSSH2_CHANNEL *channel, const char *endtag,
         if(LIBSSH2_ERROR_EAGAIN == len)
             continue;
         else if(len < 0) {
-            fprintf(stderr, "libssh2_channel_read: %d\n", (int)len);
+            fprintf(stderr, "libssh2_channel_read: %ld\n", (long)len);
             return -1;
         }
         rd += (size_t)len;
@@ -260,8 +260,8 @@ int main(int argc, char *argv[])
     if(-1 == len)
         goto shutdown;
 
-    fprintf(stderr, "Got %d bytes:\n----------------------\n%s",
-            (int)len, buf);
+    fprintf(stderr, "Got %ld bytes:\n----------------------\n%s",
+            (long)len, buf);
 
     fprintf(stderr, "Sending NETCONF <rpc>\n");
     len = snprintf(buf, sizeof(buf),
@@ -280,8 +280,8 @@ int main(int argc, char *argv[])
     if(-1 == len)
         goto shutdown;
 
-    fprintf(stderr, "Got %d bytes:\n----------------------\n%s",
-            (int)len, buf);
+    fprintf(stderr, "Got %ld bytes:\n----------------------\n%s",
+            (long)len, buf);
 
 shutdown:
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -270,8 +270,8 @@ int main(int argc, char *argv[])
             do {
                 nwritten = libssh2_channel_write(channel, buf, (size_t)len);
                 if(nwritten < 0) {
-                    fprintf(stderr, "libssh2_channel_write: %d\n",
-                            (int)nwritten);
+                    fprintf(stderr, "libssh2_channel_write: %ld\n",
+                            (long)nwritten);
                     goto shutdown;
                 }
                 wr += nwritten;
@@ -283,8 +283,8 @@ int main(int argc, char *argv[])
             if(LIBSSH2_ERROR_EAGAIN == len)
                 break;
             else if(len < 0) {
-                fprintf(stderr, "libssh2_channel_read: %d",
-                        (int)len);
+                fprintf(stderr, "libssh2_channel_read: %ld",
+                        (long)len);
                 goto shutdown;
             }
             wr = 0;

--- a/src/channel.c
+++ b/src/channel.c
@@ -2081,9 +2081,9 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
     LIBSSH2_PACKET *read_next;
 
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                   "channel_read() wants %d bytes from channel %u/%u "
+                   "channel_read() wants %ld bytes from channel %u/%u "
                    "stream #%d",
-                   (int) buflen, channel->local.id, channel->remote.id,
+                   (long)buflen, channel->local.id, channel->remote.id,
                    stream_id));
 
     /* expand the receiving window first if it has become too narrow */
@@ -2356,8 +2356,8 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         unsigned char *s = channel->write_packet;
 
         _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                       "Writing %d bytes on channel %u/%u, stream #%d",
-                       (int) buflen, channel->local.id, channel->remote.id,
+                       "Writing %ld bytes on channel %u/%u, stream #%d",
+                       (long)buflen, channel->local.id, channel->remote.id,
                        stream_id));
 
         if(channel->local.close)
@@ -2425,8 +2425,8 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         channel->write_packet_len = s - channel->write_packet;
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Sending %d bytes on channel %u/%u, stream_id=%d",
-                       (int) channel->write_bufwrite, channel->local.id,
+                       "Sending %ld bytes on channel %u/%u, stream_id=%d",
+                       (long)channel->write_bufwrite, channel->local.id,
                        channel->remote.id, stream_id));
 
         channel->write_state = libssh2_NB_state_created;

--- a/src/packet.c
+++ b/src/packet.c
@@ -645,8 +645,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
     switch(session->packAdd_state) {
     case libssh2_NB_state_idle:
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "Packet type %u received, length=%d",
-                       (unsigned int) msg, (int) datalen));
+                       "Packet type %u received, length=%ld",
+                       (unsigned int) msg, (long) datalen));
 
         if((macstate == LIBSSH2_MAC_INVALID) &&
             (!session->macerror ||
@@ -921,8 +921,8 @@ libssh2_packet_add_jump_point5:
                     stream_id = _libssh2_ntohu32(data + 5);
 
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                               "%d bytes packet_add() for %u/%u/%u",
-                               (int) (datalen - data_head),
+                               "%ld bytes packet_add() for %u/%u/%u",
+                               (long) (datalen - data_head),
                                channelp->local.id,
                                channelp->remote.id,
                                stream_id));
@@ -935,8 +935,8 @@ libssh2_packet_add_jump_point5:
                 LIBSSH2_FREE(session, data);
 
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                               "Ignoring extended data and refunding %d bytes",
-                               (int) (datalen - 13)));
+                              "Ignoring extended data and refunding %ld bytes",
+                               (long) (datalen - 13)));
                 if(channelp->read_avail + datalen - data_head >=
                     channelp->remote.window_size)
                     datalen = channelp->remote.window_size -

--- a/src/session.c
+++ b/src/session.c
@@ -132,11 +132,11 @@ banner_receive(LIBSSH2_SESSION * session)
             if(session->api_block_mode || (ret != -EAGAIN))
                 /* ignore EAGAIN when non-blocking */
                 _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                               "Error recving %d bytes: %d", 1, (int)-ret));
+                               "Error recving %d bytes: %ld", 1, (long)-ret));
         }
         else
             _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                           "Recved %d bytes banner", (int)ret));
+                           "Recved %ld bytes banner", (long)ret));
 
         if(ret < 0) {
             if(ret == -EAGAIN) {

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1567,8 +1567,9 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
                more packets */
             count -= LIBSSH2_MIN(size, count);
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                           "read request id %d sent (offset: %d, size: %d)",
-                           request_id, (int)chunk->offset, (int)chunk->len));
+                           "read request id %d sent (offset: %lu, size: %lu)",
+                           request_id, (unsigned long)chunk->offset,
+                           (unsigned long)chunk->len));
         }
         LIBSSH2_FALLTHROUGH();
     case libssh2_NB_state_sent:

--- a/src/transport.c
+++ b/src/transport.c
@@ -69,8 +69,8 @@ debugdump(LIBSSH2_SESSION * session,
         return;
     }
 
-    used = snprintf(buffer, sizeof(buffer), "=> %s (%d bytes)\n",
-                    desc, (int) size);
+    used = snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
+                    desc, (unsigned long) size);
     if(session->tracehandler)
         (session->tracehandler)(session, session->tracehandler_context,
                                 buffer, used);

--- a/tests/test_aa_warmup.c
+++ b/tests/test_aa_warmup.c
@@ -17,8 +17,8 @@ int test(LIBSSH2_SESSION *session)
     (void)hostkey;
 
     fprintf(stdout,
-            "libssh2_session_hostkey returned len, type: %d, %d\n",
-            (int)len, type);
+            "libssh2_session_hostkey returned len, type: %ld, %d\n",
+            (long)len, type);
 
     return 0;  /* always return success */
 }

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -96,7 +96,7 @@ int test(LIBSSH2_SESSION *session)
         char buf[1024];
         ssize_t err = libssh2_channel_read(channel, buf, sizeof(buf));
         if(err < 0)
-            fprintf(stderr, "Unable to read response: %d\n", (int)err);
+            fprintf(stderr, "Unable to read response: %ld\n", (long)err);
         else {
             unsigned int i;
             for(i = 0; i < (unsigned long)err; ++i) {


### PR DESCRIPTION
Cast large integer types to avoid dealing with printf masks for
`size_t` and other C99 types. Some of existing code used `int`
for this, bump them to `long`.

Ref: afa6b865604019ab27ec033294edfe3ded9ae0c0 #1257

Closes #1264
