### PR TITLE
autotools: delete `--disable-tests` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,8 +283,7 @@ jobs:
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
-            --with-crypto=openssl \
-            --disable-tests
+            --with-crypto=openssl
           make -j3
           make check VERBOSE=1
 
@@ -553,8 +552,7 @@ jobs:
             setenv CC clang
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
-              --with-crypto=openssl \
-              --disable-tests
+              --with-crypto=openssl
             make check VERBOSE=1
 
   build_netbsd:

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,9 +3,7 @@
 AUTOMAKE_OPTIONS = foreign nostdinc
 
 SUBDIRS = src docs
-if ENABLE_TESTS
 SUBDIRS += tests
-endif
 if BUILD_EXAMPLES
 SUBDIRS += example
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -253,17 +253,6 @@ AC_ARG_ENABLE([deprecated],
   esac],
   [with_deprecated="yes"])
 
-# Build tests?
-AC_ARG_ENABLE([tests],
-  [AS_HELP_STRING([--disable-tests], [Disable tests @<:@default=enabled@:>@])],
-  [
-    if ! test "x${enable_tests}" = "xyes"; then
-      enable_tests="no"
-    fi
-  ],
-  [enable_tests="yes"])
-AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = xyes])
-
 # Run Docker tests?
 AC_ARG_ENABLE([docker-tests],
   [AS_HELP_STRING([--disable-docker-tests],


### PR DESCRIPTION
Originally added to improve build performance by skipping building tests. But, there seems to be no point in this, because autotools doesn't build tests by default, unless explicitly invoking `make check`.

Reverts 7483edfada1f7e17cf8f9ac1c87ffa3d814c987e #715

Closes #xxxx
