### PR TITLE
appveyor: delete UWP job broken since Visual Studio upgrade

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,13 +39,6 @@ environment:
       PLATFORM: 'x64'
       CRYPTO_BACKEND: 'OpenSSL'
 
-    - job_name: 'VS2022, OpenSSL 3, x64, UWP, Build-only'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
-      GENERATOR: 'Visual Studio 17 2022'
-      PLATFORM: 'x64'
-      CRYPTO_BACKEND: 'OpenSSL'
-      UWP: 'ON'
-
     - job_name: 'VS2015, OpenSSL 1.1, x86, Server 2016'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       GENERATOR: 'Visual Studio 14 2015'
@@ -167,10 +160,6 @@ build_script:
       if($env:ENABLE_DEBUG_LOGGING -eq 'ON') {
         $options += '-DENABLE_DEBUG_LOGGING=ON'
       }
-      if($env:UWP -eq 'ON') {
-        $options += '-DCMAKE_SYSTEM_NAME=WindowsStore'
-        $options += '-DCMAKE_SYSTEM_VERSION=10.0'
-      }
       if($env:UNITY -eq 'ON') {
         $options += '-DCMAKE_UNITY_BUILD=ON'
       }
@@ -191,7 +180,7 @@ build_script:
 
 test_script:
   - ps: |
-      if($env:SKIP_CTEST -ne 'yes' -and $env:PLATFORM -ne 'ARM64' -and $env:UWP -ne 'ON') {
+      if($env:SKIP_CTEST -ne 'yes' -and $env:PLATFORM -ne 'ARM64') {
         appveyor-retry choco install --yes --no-progress --limit-output --timeout 180 docker-cli
         Write-Host 'Waiting for SSH connection from GitHub Actions' -NoNewline
         $endDate = (Get-Date).AddMinutes(3)


### PR DESCRIPTION
Few days ago UWP job started permafailing.

fail: https://ci.appveyor.com/project/libssh2org/libssh2/builds/48678129/job/yb8n2pox8mfjwv6m
good: https://ci.appveyor.com/project/libssh2org/libssh2/builds/48673013

Other projects also affected:
https://ci.appveyor.com/project/c-ares/c-ares/builds/48687390/job/l0fo4b0sijvqkw9r

No related local update. Same CMake version. Same CI image.

This seems to be the culprit, which could mean that this update broke CMake detection, needs a different CMake configuration on our end, or that this MSVC update pulled support for UWP apps:

fail: -- The C compiler identification is MSVC 19.38.33130.0 (~ Visual Studio 2022 v17.8)
good: -- The C compiler identification is MSVC 19.37.32825.0 (~ Visual Studio 2022 v17.7)

If this is v17.8, release notes don't readily suggest a feature removal: https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes-v17.8

So it might just be UWP accidentally broken in this VS release.

Closes #1275
