### PR TITLE
add portable `LIBSSH2_SOCKET_CLOSE()` macro

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -313,20 +313,12 @@ shutdown:
 
     if(forwardsock != LIBSSH2_INVALID_SOCKET) {
         shutdown(forwardsock, 2);
-#ifdef _WIN32
-        closesocket(forwardsock);
-#else
-        close(forwardsock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(forwardsock);
     }
 
     if(listensock != LIBSSH2_INVALID_SOCKET) {
         shutdown(listensock, 2);
-#ifdef _WIN32
-        closesocket(listensock);
-#else
-        close(listensock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(listensock);
     }
 
     if(channel)
@@ -339,11 +331,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     libssh2_exit();

--- a/example/scp.c
+++ b/example/scp.c
@@ -182,11 +182,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -285,11 +285,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -211,11 +211,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     if(local)

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -272,11 +272,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -294,11 +294,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -343,11 +343,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     if(tempstorage)

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -231,11 +231,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     if(local)

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -172,11 +172,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -171,11 +171,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -288,11 +288,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -215,11 +215,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     if(local)

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -273,11 +273,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -284,11 +284,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -295,11 +295,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -235,11 +235,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -349,11 +349,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -238,11 +238,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -285,11 +285,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -358,11 +358,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -294,11 +294,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     fprintf(stderr, "all done\n");

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -295,11 +295,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     libssh2_exit();

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -308,11 +308,7 @@ shutdown:
 
     if(forwardsock != LIBSSH2_INVALID_SOCKET) {
         shutdown(forwardsock, 2);
-#ifdef _WIN32
-        closesocket(forwardsock);
-#else
-        close(forwardsock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(forwardsock);
     }
 
     if(channel)
@@ -328,11 +324,7 @@ shutdown:
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        LIBSSH2_SOCKET_CLOSE(sock);
     }
 
     libssh2_exit();

--- a/example/x11.c
+++ b/example/x11.c
@@ -186,7 +186,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
             }
             else {
                 shutdown(sock, SHUT_RDWR);
-                close(sock);
+                LIBSSH2_SOCKET_CLOSE(sock);
             }
         }
     }
@@ -353,7 +353,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to authenticate\n");
         session_shutdown(session);
         shutdown(sock, SHUT_RDWR);
-        close(sock);
+        LIBSSH2_SOCKET_CLOSE(sock);
         return -1;
     }
 
@@ -363,7 +363,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to open a new channel\n");
         session_shutdown(session);
         shutdown(sock, SHUT_RDWR);
-        close(sock);
+        LIBSSH2_SOCKET_CLOSE(sock);
         return -1;
     }
 
@@ -373,7 +373,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to request a pty\n");
         session_shutdown(session);
         shutdown(sock, SHUT_RDWR);
-        close(sock);
+        LIBSSH2_SOCKET_CLOSE(sock);
         return -1;
     }
 
@@ -383,7 +383,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to request X11 forwarding\n");
         session_shutdown(session);
         shutdown(sock, SHUT_RDWR);
-        close(sock);
+        LIBSSH2_SOCKET_CLOSE(sock);
         return -1;
     }
 
@@ -393,7 +393,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to open a shell\n");
         session_shutdown(session);
         shutdown(sock, SHUT_RDWR);
-        close(sock);
+        LIBSSH2_SOCKET_CLOSE(sock);
         return -1;
     }
 
@@ -402,7 +402,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to entered in raw mode\n");
         session_shutdown(session);
         shutdown(sock, SHUT_RDWR);
-        close(sock);
+        LIBSSH2_SOCKET_CLOSE(sock);
         return -1;
     }
 
@@ -460,7 +460,7 @@ int main(int argc, char *argv[])
             next_node = current_node->next;
             if(rc == -1) {
                 shutdown(current_node->sock, SHUT_RDWR);
-                close(current_node->sock);
+                LIBSSH2_SOCKET_CLOSE(current_node->sock);
                 remove_node(current_node);
             }
 

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -143,9 +143,11 @@ typedef long long libssh2_int64_t;
 #ifdef _WIN32
 typedef SOCKET libssh2_socket_t;
 #define LIBSSH2_INVALID_SOCKET INVALID_SOCKET
+#define LIBSSH2_SOCKET_CLOSE(s) closesocket(s)
 #else /* !_WIN32 */
 typedef int libssh2_socket_t;
 #define LIBSSH2_INVALID_SOCKET -1
+#define LIBSSH2_SOCKET_CLOSE(s) close(s)
 #endif /* _WIN32 */
 
 /*


### PR DESCRIPTION
Add `LIBSSH2_SOCKET_CLOSE()` to the public `libssh2.h` header, for user
code. It translates to `closesocket()` on Windows and `close()` on other
platforms.

Use it in example code.

It makes them more readable by reducing the number of `_WIN32` guards.

Closes #1278
