### PR TITLE
example, tests: call `WSACleanup()` for each `WSAStartup()`

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -336,5 +336,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/scp.c
+++ b/example/scp.c
@@ -189,5 +189,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -292,5 +292,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -221,5 +221,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -279,5 +279,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -301,5 +301,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -353,5 +353,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -241,5 +241,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -179,5 +179,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -178,5 +178,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -295,5 +295,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -225,5 +225,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -280,5 +280,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -291,5 +291,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -302,5 +302,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -242,5 +242,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -356,5 +356,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return rc;
 }

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -245,5 +245,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return rc;
 }

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -292,5 +292,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -365,5 +365,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return exitcode;
 }

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -301,5 +301,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -300,5 +300,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -329,5 +329,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return 0;
 }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -477,6 +477,10 @@ void stop_openssh_fixture(void)
     else if(have_docker) {
         fprintf(stderr, "Cannot stop container - none started\n");
     }
+
+#ifdef _WIN32
+    WSACleanup();
+#endif
 }
 
 libssh2_socket_t open_socket_to_openssh_server(void)

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -269,5 +269,9 @@ shutdown:
 
     libssh2_exit();
 
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
     return rc;
 }


### PR DESCRIPTION
On Windows.

Closes #1283