### PR TITLE
src: disable `-Wsign-conversion` warnings, add option to re-enable

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -41,7 +41,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/* Header used by 'src' */
+/* Header used by 'src' and 'tests' */
+
+/* FIXME: Disable warnings for 'src' */
+#if !defined(LIBSSH2_TESTS) && !defined(LIBSSH2_WARN_SIGN_CONVERSION)
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+#endif
 
 #define LIBSSH2_LIBRARY
 


### PR DESCRIPTION
To avoid the log noise till we fix those ~360 compiler warnings.

Also add macro `LIBSSH2_WARN_SIGN_CONVERSION` to re-enable them.

Follow-up to afa6b865604019ab27ec033294edfe3ded9ae0c0 #1257

Closes #1284