### PR TITLE
build: enable `-pedantic-errors`

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -217,6 +217,9 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           AC_MSG_RESULT([clang '$compiler_num' (raw: '$fullclangver' / '$clangver')])
 
           tmp_CFLAGS="-pedantic"
+          if test "$want_werror" = "yes"; then
+            LIBSSH2_CFLAG_EXTRAS="$LIBSSH2_CFLAG_EXTRAS -pedantic-errors"
+          fi
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [all extra])
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pointer-arith write-strings])
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shadow])
@@ -373,6 +376,9 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
         else dnl $ICC = yes
           dnl this is a set of options we believe *ALL* gcc versions support:
           tmp_CFLAGS="-pedantic"
+          if test "$want_werror" = "yes"; then
+            LIBSSH2_CFLAG_EXTRAS="$LIBSSH2_CFLAG_EXTRAS -pedantic-errors"
+          fi
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [all])
           tmp_CFLAGS="$tmp_CFLAGS -W"
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pointer-arith write-strings])
@@ -945,6 +951,6 @@ AS_HELP_STRING([--disable-werror],[Disable compiler warnings as errors]),
   AC_MSG_RESULT([$want_werror])
 
   if test X"$want_werror" = Xyes; then
-    CFLAGS="$CFLAGS -Werror"
+    LIBSSH2_CFLAG_EXTRAS="$LIBSSH2_CFLAG_EXTRAS -Werror"
   fi
 ])

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -58,6 +58,12 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
       -pedantic
     )
 
+    if(ENABLE_WERROR)
+      list(APPEND WPICKY_ENABLE
+        -pedantic-errors
+      )
+    endif()
+
     # ----------------------------------
     # Add new options here, if in doubt:
     # ----------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,10 @@ else
   enable_clear_memory=yes
 fi
 
+LIBSSH2_CFLAG_EXTRAS=""
+
+LIBSSH2_CHECK_OPTION_WERROR
+
 dnl ************************************************************
 dnl option to switch on compiler debug options
 dnl
@@ -202,6 +206,8 @@ AS_HELP_STRING([--disable-debug],[Disable debug options]),
        enable_debug=no
        AC_MSG_RESULT(no)
 )
+
+AC_SUBST(LIBSSH2_CFLAG_EXTRAS)
 
 dnl ************************************************************
 dnl Enable hiding of internal symbols in library to reduce its size and
@@ -376,7 +382,6 @@ AM_CONDITIONAL([HAVE_WINDRES],
 AM_CONDITIONAL([HAVE_LIB_STATIC], [test "x$enable_static" != "xno"])
 
 # Configure parameters
-LIBSSH2_CHECK_OPTION_WERROR
 
 # Append crypto lib
 if   test "$found_crypto" = "openssl"; then

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -2,7 +2,7 @@
 .libs
 Makefile
 Makefile.in
-Makefile.am.cmake
+Makefile.inc.cmake
 *.gcno
 *.gcda
 stamp-h2

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -40,9 +40,9 @@ include(CopyRuntimeDependencies)
 
 list(APPEND LIBRARIES ${SOCKET_LIBRARIES})
 
-transform_makefile_inc("Makefile.am" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.am.cmake")
+transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 # Get 'noinst_PROGRAMS' variable
-include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.am.cmake")
+include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 set(EXAMPLES ${noinst_PROGRAMS})
 
 foreach(example IN LISTS EXAMPLES)

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -4,32 +4,8 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 
 EXTRA_DIST = CMakeLists.txt
 
-# examples
-noinst_PROGRAMS = \
-  direct_tcpip \
-  scp \
-  scp_nonblock \
-  scp_write \
-  scp_write_nonblock \
-  sftp \
-  sftp_RW_nonblock \
-  sftp_append \
-  sftp_mkdir \
-  sftp_mkdir_nonblock \
-  sftp_nonblock \
-  sftp_write \
-  sftp_write_nonblock \
-  sftp_write_sliding \
-  sftpdir \
-  sftpdir_nonblock \
-  ssh2 \
-  ssh2_agent \
-  ssh2_agent_forwarding \
-  ssh2_echo \
-  ssh2_exec \
-  subsystem_netconf \
-  tcpip-forward \
-  x11
+# Get noing_PROGRAMS
+include Makefile.inc
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/src -I$(top_srcdir)/include
 LDADD = $(top_builddir)/src/libssh2.la

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -33,3 +33,6 @@ noinst_PROGRAMS = \
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/src -I$(top_srcdir)/include
 LDADD = $(top_builddir)/src/libssh2.la
+
+# This might hold -Werror
+CFLAGS += @LIBSSH2_CFLAG_EXTRAS@

--- a/example/Makefile.inc
+++ b/example/Makefile.inc
@@ -1,0 +1,28 @@
+# Copyright (C) The libssh2 project and its contributors.
+# SPDX-License-Identifier: BSD-3-Clause
+
+noinst_PROGRAMS = \
+  direct_tcpip \
+  scp \
+  scp_nonblock \
+  scp_write \
+  scp_write_nonblock \
+  sftp \
+  sftp_RW_nonblock \
+  sftp_append \
+  sftp_mkdir \
+  sftp_mkdir_nonblock \
+  sftp_nonblock \
+  sftp_write \
+  sftp_write_nonblock \
+  sftp_write_sliding \
+  sftpdir \
+  sftpdir_nonblock \
+  ssh2 \
+  ssh2_agent \
+  ssh2_agent_forwarding \
+  ssh2_echo \
+  ssh2_exec \
+  subsystem_netconf \
+  tcpip-forward \
+  x11

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,9 @@ lib_LTLIBRARIES = libssh2.la
 # tree
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/include
 
+# This might hold -Werror
+CFLAGS += @LIBSSH2_CFLAG_EXTRAS@
+
 VERSION=-version-info 1:1:0
 
 # This flag accepts an argument of the form current[:revision[:age]]. So,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,6 +4,9 @@ SUBDIRS = ossfuzz
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/src -I$(top_srcdir)/include
 
+# This might hold -Werror
+CFLAGS += @LIBSSH2_CFLAG_EXTRAS@
+
 # Get DOCKER_TESTS, DOCKER_TESTS_STATIC, STANDALONE_TESTS, STANDALONE_TESTS_STATOC, SSHD_TESTS,
 # librunner_la_SOURCES defines and *_LDFLAGS for statically linked tests.
 include Makefile.inc


### PR DESCRIPTION
According to the manual, this isn't the same as `-Werror -pedantic`.
Enable it together with `-Werror`.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-pedantic-errors-1

This option results in autotools feature detection going into crazies.
To avoid this, we add it to `CFLAGS` late. Idea copied from curl.

This option has an effect only with gcc 5.0 and newer as of this commit.
Let's enable it for clang and older versions too for simplicity. Ref:
https://github.com/curl/curl/commit/d5c0351055d5709da8f3e16c91348092fdb481aa
https://github.com/curl/curl/pull/2747

Closes #1286
