### PR TITLE
build: add mingw-w64 support to `LIBSSH2_PRINTF()` attribute

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -115,9 +115,16 @@
 
 #if (defined(__GNUC__) || defined(__clang__)) && \
     defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
-    !defined(__MINGW32__) && !defined(LIBSSH2_NO_FMT_CHECKS)
-#define LIBSSH2_PRINTF(fmt, arg)  __attribute__((format(printf, fmt, arg)))
-#else
+    !defined(LIBSSH2_NO_FMT_CHECKS)
+#ifdef __MINGW_PRINTF_FORMAT
+#define LIBSSH2_PRINTF(fmt, arg) \
+    __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
+#elif !defined(__MINGW32__)
+#define LIBSSH2_PRINTF(fmt, arg) \
+    __attribute__((format(printf, fmt, arg)))
+#endif
+#endif
+#ifndef LIBSSH2_PRINTF
 #define LIBSSH2_PRINTF(fmt, arg)
 #endif
 

--- a/src/session.c
+++ b/src/session.c
@@ -699,7 +699,7 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 
     if(session->startup_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "session_startup for socket %d", sock));
+                       "session_startup for socket %ld", (long)sock));
         if(LIBSSH2_INVALID_SOCKET == sock) {
             /* Did we forget something? */
             return _libssh2_error(session, LIBSSH2_ERROR_BAD_SOCKET,


### PR DESCRIPTION
And fix the warning it detected.

Closes #1287
