### PR TITLE
ci/gha: review/fixup auto-cancel settings

### DIFF
--- a/.github/workflows/appveyor_docker.yml
+++ b/.github/workflows/appveyor_docker.yml
@@ -42,6 +42,10 @@ on:
       ssh_privkey:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/appveyor_status.yml
+++ b/.github/workflows/appveyor_status.yml
@@ -30,7 +30,7 @@ on:
   status
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.sha }}-${{ github.event.target_url }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -5,6 +5,10 @@
 name: CIFuzz
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
- use the group expression from `reuse.yml` (via curl).
- add auto-cancel for `ci` and `cifuzz`.
- add auto-cancel to `appveyor_docker`. I'm just guessing here.
  The hope is that it fixes AppVeyor CI runs when re-pushing a PR.
  This frequently caused the freshly pushed session to fail waiting for
  a connection.
- sync group expression in `appveyor_status` with `reuse`.

Closes #1292
