### PR TITLE
ci/appveyor: re-enable parallel mode

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -176,7 +176,7 @@ build_script:
 
       Write-Host 'CMake options:' $options
       cmake -B _builds $options
-      cmake --build _builds --config "$env:CONFIGURATION"
+      cmake --build _builds --config "$env:CONFIGURATION" --parallel 2
 
 test_script:
   - ps: |


### PR DESCRIPTION
The comment cited earlier is no longer true with recent CMake versions.
This options does actually enable parallel builds with MSVC since CMake
v3.26.0: https://gitlab.kitware.com/cmake/cmake/-/issues/20564

The effect isn't much for libssh2, because it spends most time in tests,
but let's enable it anyway for efficiency.

Ref: 0d08974633cfc02641e6593db8d569ddb3644255 #884
Ref: 7a039d9a7a2945c10b4622f38eeed21ba6b4ec55 #867

Closes #1294
