### PR TITLE
src: check hash init success

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -587,7 +587,7 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_RANDGEN                   -49
 #define LIBSSH2_ERROR_MISSING_USERAUTH_BANNER   -50
 #define LIBSSH2_ERROR_ALGO_UNSUPPORTED          -51
-#define LIBSSH2_ERROR_HASH                      -53
+#define LIBSSH2_ERROR_HASH_INIT                 -53
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -587,6 +587,7 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_RANDGEN                   -49
 #define LIBSSH2_ERROR_MISSING_USERAUTH_BANNER   -50
 #define LIBSSH2_ERROR_ALGO_UNSUPPORTED          -51
+#define LIBSSH2_ERROR_HASH                      -53
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -127,7 +127,10 @@ bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
     memcpy(countsalt, salt, saltlen);
 
     /* collapse password */
-    (void)libssh2_sha512_init(&ctx);
+    if(!libssh2_sha512_init(&ctx)) {
+        free(countsalt);
+        return -1;
+    }
     libssh2_sha512_update(ctx, pass, passlen);
     libssh2_sha512_final(ctx, sha2pass);
 

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -142,7 +142,11 @@ bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
         countsalt[saltlen + 3] = count & 0xff;
 
         /* first round, salt is salt */
-        (void)libssh2_sha512_init(&ctx);
+        if(!libssh2_sha512_init(&ctx)) {
+            _libssh2_explicit_zero(out, sizeof(out));
+            free(countsalt);
+            return -1;
+        }
         libssh2_sha512_update(ctx, countsalt, saltlen + 4);
         libssh2_sha512_final(ctx, sha2salt);
 
@@ -151,7 +155,11 @@ bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
 
         for(i = 1; i < rounds; i++) {
             /* subsequent rounds, salt is previous output */
-            (void)libssh2_sha512_init(&ctx);
+            if(!libssh2_sha512_init(&ctx)) {
+                _libssh2_explicit_zero(out, sizeof(out));
+                free(countsalt);
+                return -1;
+            }
             libssh2_sha512_update(ctx, tmpout, sizeof(tmpout));
             libssh2_sha512_final(ctx, sha2salt);
 

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -242,7 +242,9 @@ hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION * session,
     unsigned char hash[SHA_DIGEST_LENGTH];
     libssh2_sha1_ctx ctx;
 
-    (void)libssh2_sha1_init(&ctx);
+    if(!libssh2_sha1_init(&ctx))
+        return -1;
+
     for(i = 0; i < veccount; i++) {
         libssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len);
     }
@@ -659,6 +661,12 @@ hostkey_method_ssh_dss_signv(LIBSSH2_SESSION * session,
     libssh2_sha1_ctx ctx;
     int i;
 
+    if(!libssh2_sha1_init(&ctx)) {
+        *signature = NULL;
+        *signature_len = 0;
+        return -1;
+    }
+
     *signature = LIBSSH2_CALLOC(session, 2 * SHA_DIGEST_LENGTH);
     if(!*signature) {
         return -1;
@@ -666,7 +674,6 @@ hostkey_method_ssh_dss_signv(LIBSSH2_SESSION * session,
 
     *signature_len = 2 * SHA_DIGEST_LENGTH;
 
-    (void)libssh2_sha1_init(&ctx);
     for(i = 0; i < veccount; i++) {
         libssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len);
     }

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -921,7 +921,10 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
         unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];           \
         libssh2_sha##digest_type##_ctx ctx;                             \
         int i;                                                          \
-        (void)libssh2_sha##digest_type##_init(&ctx);                    \
+        if(!libssh2_sha##digest_type##_init(&ctx)) {                    \
+            ret = -1;                                                   \
+            break;                                                      \
+        }                                                               \
         for(i = 0; i < veccount; i++) {                                 \
             libssh2_sha##digest_type##_update(ctx, datavec[i].iov_base, \
                                               datavec[i].iov_len);      \

--- a/src/kex.c
+++ b/src/kex.c
@@ -67,9 +67,6 @@
         else if(type == LIBSSH2_EC_CURVE_NISTP521) {                        \
             LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(512, value, reqlen, version); \
         }                                                                   \
-        else {                                                              \
-            value = NULL;                                                   \
-        }                                                                   \
     } while(0)
 #endif
 
@@ -82,11 +79,11 @@ do {                                                                        \
         value = LIBSSH2_ALLOC(session,                                      \
                               reqlen + SHA##digest_type##_DIGEST_LENGTH);   \
     }                                                                       \
-    if(value) {                                                             \
-        int err = 0;                                                        \
+    if(value)                                                               \
         while(len < (size_t)reqlen) {                                       \
             if(!libssh2_sha##digest_type##_init(&hash)) {                   \
-                err = 1;                                                    \
+                LIBSSH2_FREE(session, value);                               \
+                value = NULL;                                               \
                 break;                                                      \
             }                                                               \
             libssh2_sha##digest_type##_update(hash,                         \
@@ -106,11 +103,6 @@ do {                                                                        \
             libssh2_sha##digest_type##_final(hash, (value) + len);          \
             len += SHA##digest_type##_DIGEST_LENGTH;                        \
         }                                                                   \
-        if(err) {                                                           \
-            LIBSSH2_FREE(session, value);                                   \
-            value = NULL;                                                   \
-        }                                                                   \
-    }                                                                       \
 } while(0)
 
 /*!
@@ -200,8 +192,6 @@ static void _libssh2_sha_algo_value_hash(int sha_algo,
                                          unsigned char **data, size_t data_len,
                                          const unsigned char *version)
 {
-    *data = NULL;
-
     if(sha_algo == 512) {
         LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(512, *data, data_len, version);
     }

--- a/src/kex.c
+++ b/src/kex.c
@@ -542,7 +542,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 
         exchange_state->exchange_hash = (void *)&exchange_hash_ctx;
         if(!_libssh2_sha_algo_ctx_init(sha_algo_value, exchange_hash_ctx)) {
-            ret = _libssh2_error(session, LIBSSH2_ERROR_HASH,
+            ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_INIT,
                                  "Unable to initialize hash context");
             goto clean_exit;
         }

--- a/src/kex.c
+++ b/src/kex.c
@@ -1677,10 +1677,10 @@ do {                                                                         \
     libssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp);       \
                                                                              \
     if(session->hostkey->                                                    \
-       sig_verify(session, exchange_state->h_sig,                            \
-                  exchange_state->h_sig_len, exchange_state->h_sig_comp,     \
-                  SHA##digest_type##_DIGEST_LENGTH,                          \
-                  &session->server_hostkey_abstract)) {                      \
+        sig_verify(session, exchange_state->h_sig,                           \
+                   exchange_state->h_sig_len, exchange_state->h_sig_comp,    \
+                   SHA##digest_type##_DIGEST_LENGTH,                         \
+                   &session->server_hostkey_abstract)) {                     \
         rc = -1;                                                             \
     }                                                                        \
 } while(0)
@@ -1914,7 +1914,6 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
             case LIBSSH2_EC_CURVE_NISTP256:
                 LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(256);
                 break;
-
             case LIBSSH2_EC_CURVE_NISTP384:
                 LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(384);
                 break;


### PR DESCRIPTION
Before this patch, SHA2 and SHA1 init function results were cast to
`void`. This patch makes sure to verify these values.

Also:
- exclude an `assert(0)` from release builds in `_libssh2_sha_algo_ctx_init()`.
  (return error instead)
- fix indentation / whitespace

Closes #1301
