### PR TITLE
Fix an out-of-bounds read in _libssh2_kex_agree_instr when searching …

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -3349,6 +3349,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
         left = end_haystack - s;
         if((left >= 1) && (left <= haystack_len) && (left > needle_len)) {
             s++;
+            left--;
         }
         else {
             return NULL;


### PR DESCRIPTION
…for a KEX not in the server list

Found by oss-fuzz. https://oss-fuzz.com/testcase?key=5912608611631104

A single-byte out-of-bounds read can occur in `memchr` when searching for a KEX algorithm not present in the server list.

This is not a new issue. The code in question is 2 years old. Before that, the out-of-bounds read was larger than one byte. However, since we are now searching for `kex-strict-s-v00@openssh.com`, the fuzzer was able to identify the problem. Presulably, because the server it connects to has not been patched for terrapin. Previously, fuzzing the server output was more likely to create a packet that would cause us to return before calling `memchr`.

We should fix this, but I don't think the impact is that large. An out-of-bounds read is undefined behavior. I confirmed on macOS that the read does not cause a crash. I presume that the same is true on Windows and Linux, or we would have seen reports before now.

```#0 0x43a747 in memchr /src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:931:3
    #1 0x50e32c in _libssh2_kex_agree_instr libssh2/src/kex.c:3347:34
    #2 0x538abc in _libssh2_packet_add libssh2/src/packet.c:709:24
    #3 0x4e982a in fullpacket libssh2/src/transport.c:319:14
    #4 0x4e982a in _libssh2_transport_read libssh2/src/transport.c:736:18
    #5 0x53d298 in _libssh2_packet_require libssh2/src/packet.c:1502:15
    #6 0x50fd11 in _libssh2_kex_exchange libssh2/src/kex.c:3901:17
    #7 0x4e062a in session_startup libssh2/src/session.c:772:14
    #8 0x4e062a in libssh2_session_handshake libssh2/src/session.c:863:5
    #9 0x4de653 in LLVMFuzzerTestOneInput libssh2/tests/ossfuzz/ssh2_client_fuzzer.cc:67:6
    #10 0x55089d in ExecuteFilesOnyByOne /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:255:7
    #11 0x5506a8 in LLVMFuzzerRunDriver /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:0
    #12 0x550268 in main /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:300:10
    #13 0x7c956a075082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/libc-start.c:308:16
    #14 0x41fc1d in _start
0x607000000063 is located 0 bytes to the right of 67-byte region [0x607000000020,0x607000000063)
allocated by thread T0 here:
    #0 0x4a1056 in malloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:69:3
    #1 0x4e84a7 in _libssh2_transport_read libssh2/src/transport.c:592:26
    #2 0x53d298 in _libssh2_packet_require libssh2/src/packet.c:1502:15
    #3 0x50fd11 in _libssh2_kex_exchange libssh2/src/kex.c:3901:17
    #4 0x4e062a in session_startup libssh2/src/session.c:772:14
    #5 0x4e062a in libssh2_session_handshake libssh2/src/session.c:863:5
    #6 0x4de653 in LLVMFuzzerTestOneInput libssh2/tests/ossfuzz/ssh2_client_fuzzer.cc:67:6
    #7 0x55089d in ExecuteFilesOnyByOne /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:255:7
```