### PR TITLE
openssl: fix cppcheck found NULL dereferences

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1305,11 +1305,11 @@ gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
     memcpy(method_buf, "ssh-rsa", 7);
     *method         = method_buf;
     if(method_len) {
-	*method_len = 7;
+        *method_len = 7;
     }
     *pubkeydata     = key;
     if(pubkeydata_len) {
-	*pubkeydata_len = key_len;
+        *pubkeydata_len = key_len;
     }
     return 0;
 
@@ -1748,11 +1748,11 @@ gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
     memcpy(method_buf, "ssh-dss", 7);
     *method         = method_buf;
     if(method_len) {
-	*method_len = 7;
+        *method_len = 7;
     }
     *pubkeydata     = key;
     if(pubkeydata_len) {
-	*pubkeydata_len = key_len;
+        *pubkeydata_len = key_len;
     }
     return 0;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1303,11 +1303,11 @@ gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
 #endif
 
     memcpy(method_buf, "ssh-rsa", 7);
-    *method         = method_buf;
+    *method = method_buf;
     if(method_len) {
         *method_len = 7;
     }
-    *pubkeydata     = key;
+    *pubkeydata = key;
     if(pubkeydata_len) {
         *pubkeydata_len = key_len;
     }
@@ -1746,11 +1746,11 @@ gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
 #endif
 
     memcpy(method_buf, "ssh-dss", 7);
-    *method         = method_buf;
+    *method = method_buf;
     if(method_len) {
         *method_len = 7;
     }
-    *pubkeydata     = key;
+    *pubkeydata = key;
     if(pubkeydata_len) {
         *pubkeydata_len = key_len;
     }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1751,7 +1751,7 @@ gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
 	*method_len = 7;
     }
     *pubkeydata     = key;
-    if(pubkeydata_len) { 
+    if(pubkeydata_len) {
 	*pubkeydata_len = key_len;
     }
     return 0;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3269,14 +3269,19 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
                               "out of memory");
     }
 
-    if(is_sk)
-        memcpy(method_buf, "sk-ecdsa-sha2-nistp256@openssh.com", method_buf_len);
-    else if(type == LIBSSH2_EC_CURVE_NISTP256)
+    if(is_sk) {
+        memcpy(method_buf, "sk-ecdsa-sha2-nistp256@openssh.com",
+               method_buf_len);
+    }
+    else if(type == LIBSSH2_EC_CURVE_NISTP256) {
         memcpy(method_buf, "ecdsa-sha2-nistp256", method_buf_len);
-    else if(type == LIBSSH2_EC_CURVE_NISTP384)
+    }
+    else if(type == LIBSSH2_EC_CURVE_NISTP384) {
         memcpy(method_buf, "ecdsa-sha2-nistp384", method_buf_len);
-    else if(type == LIBSSH2_EC_CURVE_NISTP521)
+    }
+    else if(type == LIBSSH2_EC_CURVE_NISTP521) {
         memcpy(method_buf, "ecdsa-sha2-nistp521", method_buf_len);
+    }
     else {
         _libssh2_debug((session,
                        LIBSSH2_TRACE_ERROR,
@@ -3314,8 +3319,8 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     }
 #endif
 
-    /* Key form is: type_len(4) + type(method_buf_len) + domain_len(4) + domain(8)
-       + pub_key_len(4) + pub_key(~65). */
+    /* Key form is: type_len(4) + type(method_buf_len) + domain_len(4)
+       + domain(8) + pub_key_len(4) + pub_key(~65). */
     key_len = 4 + method_buf_len + 4 + 8 + 4 + octal_len;
     key = LIBSSH2_ALLOC(session, key_len);
     if(!key) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1304,9 +1304,9 @@ gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
 
     memcpy(method_buf, "ssh-rsa", 7);
     *method         = method_buf;
-    *method_len     = 7;
+    if(NULL != method_len) { *method_len = 7; }
     *pubkeydata     = key;
-    *pubkeydata_len = key_len;
+    if(NULL != pubkeydata_len) { *pubkeydata_len = key_len; }
     return 0;
 
 __alloc_error:
@@ -1743,9 +1743,9 @@ gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
 
     memcpy(method_buf, "ssh-dss", 7);
     *method         = method_buf;
-    *method_len     = 7;
+    if(NULL != method_len) { *method_len = 7; }
     *pubkeydata     = key;
-    *pubkeydata_len = key_len;
+    if(NULL != pubkeydata_len) { *pubkeydata_len = key_len; }
     return 0;
 
 __alloc_error:

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2136,10 +2136,14 @@ gen_publickey_from_ed_evp(LIBSSH2_SESSION *session,
         goto fail;
     }
 
-    *method         = methodBuf;
-    *method_len     = sizeof(methodName) - 1;
-    *pubkeydata     = keyBuf;
-    *pubkeydata_len = bufLen;
+    *method = methodBuf;
+    if(method_len) {
+        *method_len = sizeof(methodName) - 1;
+    }
+    *pubkeydata = keyBuf;
+    if(pubkeydata_len) {
+        *pubkeydata_len = bufLen;
+    }
     return 0;
 
 fail:
@@ -3217,6 +3221,7 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     unsigned char *p;
     unsigned char *method_buf = NULL;
     unsigned char *key;
+    size_t  method_buf_len = 0;
     size_t  key_len = 0;
     unsigned char *octal_value = NULL;
     size_t octal_len;
@@ -3254,24 +3259,24 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
 #endif
 
     if(is_sk)
-        *method_len = 34;
+        method_buf_len = 34;
     else
-        *method_len = 19;
+        method_buf_len = 19;
 
-    method_buf = LIBSSH2_ALLOC(session, *method_len);
+    method_buf = LIBSSH2_ALLOC(session, method_buf_len);
     if(!method_buf) {
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                               "out of memory");
     }
 
     if(is_sk)
-        memcpy(method_buf, "sk-ecdsa-sha2-nistp256@openssh.com", *method_len);
+        memcpy(method_buf, "sk-ecdsa-sha2-nistp256@openssh.com", method_buf_len);
     else if(type == LIBSSH2_EC_CURVE_NISTP256)
-        memcpy(method_buf, "ecdsa-sha2-nistp256", *method_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp256", method_buf_len);
     else if(type == LIBSSH2_EC_CURVE_NISTP384)
-        memcpy(method_buf, "ecdsa-sha2-nistp384", *method_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp384", method_buf_len);
     else if(type == LIBSSH2_EC_CURVE_NISTP521)
-        memcpy(method_buf, "ecdsa-sha2-nistp521", *method_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp521", method_buf_len);
     else {
         _libssh2_debug((session,
                        LIBSSH2_TRACE_ERROR,
@@ -3309,9 +3314,9 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     }
 #endif
 
-    /* Key form is: type_len(4) + type(method_len) + domain_len(4) + domain(8)
+    /* Key form is: type_len(4) + type(method_buf_len) + domain_len(4) + domain(8)
        + pub_key_len(4) + pub_key(~65). */
-    key_len = 4 + *method_len + 4 + 8 + 4 + octal_len;
+    key_len = 4 + method_buf_len + 4 + 8 + 4 + octal_len;
     key = LIBSSH2_ALLOC(session, key_len);
     if(!key) {
         rc = -1;
@@ -3322,7 +3327,7 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     p = key;
 
     /* Key type */
-    _libssh2_store_str(&p, (const char *)method_buf, *method_len);
+    _libssh2_store_str(&p, (const char *)method_buf, method_buf_len);
 
     /* Name domain */
     if(is_sk) {
@@ -3335,9 +3340,14 @@ gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     /* Public key */
     _libssh2_store_str(&p, (const char *)octal_value, octal_len);
 
-    *method         = method_buf;
-    *pubkeydata     = key;
-    *pubkeydata_len = key_len;
+    *method = method_buf;
+    if(method_len) {
+        *method_len = method_buf_len;
+    }
+    *pubkeydata = key;
+    if(pubkeydata_len) {
+        *pubkeydata_len = key_len;
+    }
 
 clean_exit:
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1304,9 +1304,13 @@ gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
 
     memcpy(method_buf, "ssh-rsa", 7);
     *method         = method_buf;
-    if(method_len) { *method_len = 7; }
+    if(method_len) {
+	*method_len = 7;
+    }
     *pubkeydata     = key;
-    if(pubkeydata_len) { *pubkeydata_len = key_len; }
+    if(pubkeydata_len) {
+	*pubkeydata_len = key_len;
+    }
     return 0;
 
 __alloc_error:
@@ -1743,9 +1747,13 @@ gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
 
     memcpy(method_buf, "ssh-dss", 7);
     *method         = method_buf;
-    if(method_len) { *method_len = 7; }
+    if(method_len) {
+	*method_len = 7;
+    }
     *pubkeydata     = key;
-    if(pubkeydata_len) { *pubkeydata_len = key_len; }
+    if(pubkeydata_len) { 
+	*pubkeydata_len = key_len;
+    }
     return 0;
 
 __alloc_error:

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1304,9 +1304,9 @@ gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
 
     memcpy(method_buf, "ssh-rsa", 7);
     *method         = method_buf;
-    if(NULL != method_len) { *method_len = 7; }
+    if(method_len) { *method_len = 7; }
     *pubkeydata     = key;
-    if(NULL != pubkeydata_len) { *pubkeydata_len = key_len; }
+    if(pubkeydata_len) { *pubkeydata_len = key_len; }
     return 0;
 
 __alloc_error:
@@ -1743,9 +1743,9 @@ gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
 
     memcpy(method_buf, "ssh-dss", 7);
     *method         = method_buf;
-    if(NULL != method_len) { *method_len = 7; }
+    if(method_len) { *method_len = 7; }
     *pubkeydata     = key;
-    if(NULL != pubkeydata_len) { *pubkeydata_len = key_len; }
+    if(pubkeydata_len) { *pubkeydata_len = key_len; }
     return 0;
 
 __alloc_error:


### PR DESCRIPTION
Toying with cppcheck and it found 4 cases of a null pointer being dereferenced in the code. There were 2 functions that called the respective sections of code that set NULL for method_len and pubkeydata_len causing the dereference when they get assigned a value without being checked.

---

https://github.com/libssh2/libssh2/pull/1304/files?w=1