### PR TITLE
Update the man page for libssh2_userauth_publickey_fromfile_ex to eliminate confusion 

### DIFF
--- a/docs/libssh2_userauth_publickey_fromfile_ex.3
+++ b/docs/libssh2_userauth_publickey_fromfile_ex.3
@@ -2,7 +2,7 @@
 .\" SPDX-License-Identifier: BSD-3-Clause
 .TH libssh2_userauth_publickey_fromfile_ex 3 "1 Jun 2007" "libssh2 0.15" "libssh2"
 .SH NAME
-libssh2_userauth_publickey_fromfile_ex - authenticate a session based on local public key cryptography
+libssh2_userauth_publickey_fromfile_ex - reading a local file to authenticate a session with public key cryptography
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>

--- a/docs/libssh2_userauth_publickey_fromfile_ex.3
+++ b/docs/libssh2_userauth_publickey_fromfile_ex.3
@@ -2,7 +2,7 @@
 .\" SPDX-License-Identifier: BSD-3-Clause
 .TH libssh2_userauth_publickey_fromfile_ex 3 "1 Jun 2007" "libssh2 0.15" "libssh2"
 .SH NAME
-libssh2_userauth_publickey_fromfile_ex - authenticate a session with a public key, read from a file
+libssh2_userauth_publickey_fromfile_ex - authenticate a session based on local public key authentication
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>
@@ -31,14 +31,16 @@ can be set to NULL.
 
 \fIpassphrase\fP - Passphrase to use when decoding \fIprivatekey\fP.
 
-Attempt public key authentication using a PEM encoded private key file stored
-on disk
+Attempts public key authentication based on a either local public and private
+key pair stored on disk or use a PEM encoded private key file stored on disk
 .SH RETURN VALUE
 Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.
 .SH ERRORS
 \fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
+
+\fILIBSSH2_ERROR_FILE\fP - An issue accessing, parsing or reading the file(s) on disk.
 
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 

--- a/docs/libssh2_userauth_publickey_fromfile_ex.3
+++ b/docs/libssh2_userauth_publickey_fromfile_ex.3
@@ -2,7 +2,7 @@
 .\" SPDX-License-Identifier: BSD-3-Clause
 .TH libssh2_userauth_publickey_fromfile_ex 3 "1 Jun 2007" "libssh2 0.15" "libssh2"
 .SH NAME
-libssh2_userauth_publickey_fromfile_ex - authenticate a session based on local public key authentication
+libssh2_userauth_publickey_fromfile_ex - authenticate a session based on local public key cryptography
 .SH SYNOPSIS
 .nf
 #include <libssh2.h>
@@ -31,8 +31,8 @@ can be set to NULL.
 
 \fIpassphrase\fP - Passphrase to use when decoding \fIprivatekey\fP.
 
-Attempts public key authentication based on a either local public and private
-key pair stored on disk or use a PEM encoded private key file stored on disk
+Attempts to authenticate using public key cryptography using either local public and 
+private key pair stored on disk or use a PEM encoded private key file stored on disk.
 .SH RETURN VALUE
 Return 0 on success or negative on failure. It returns
 LIBSSH2_ERROR_EAGAIN when it would otherwise block. While


### PR DESCRIPTION
Based on #652 I have clarified the man page for libssh2_userauth_publickey_fromfile_ex to show that it is not a public key but rather PKI and what is required to use it. Also added a missing possible error return value: LIBSSH2_ERROR_FILE