### PR TITLE
docs: update INSTALL_AUTOTOOLS

### DIFF
--- a/docs/INSTALL_AUTOTOOLS
+++ b/docs/INSTALL_AUTOTOOLS
@@ -286,7 +286,7 @@ Some ./configure options deserve additional comments:
 
  * --with-mbedtls
  * --without-mbedtls
- * --with-libmbedtls-prefix=[DIR]
+ * --with-libmbedcrypto-prefix=[DIR]
 
         libssh2 can use the mbedTLS library
         (https://tls.mbed.org) for cryptographic operations.
@@ -296,7 +296,7 @@ Some ./configure options deserve additional comments:
         default location.
 
         If your installation of mbedTLS is in another
-        location, specify it using --with-libmbedtls-prefix.
+        location, specify it using --with-libmbedcrypto-prefix.
 
  * --with-libz
  * --without-libz


### PR DESCRIPTION
corrected --with-libmbedtls-prefix to current option --with-libmbedcrypto-prefix

Edit:

Updated to latest version at time of writing (1.11.0) and scripting up build process for libssh2 which will use mbedTLS as crypto backend, installed in a non-standard location. 

Docs mentioned `--with-libmbedtls-prefix` which resulted in:

```
configure: WARNING: unrecognized options: --with-libmbedtls-prefix
configure: error: Required dependencies are missing!
```

However, using `--with-libmbedcrypto-prefix` seems to work OK.