### PR TITLE
gen_publickey_from_dsa: Initialize BIGNUMs to NULL for OpenSSL 3

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1665,10 +1665,10 @@ gen_publickey_from_dsa(LIBSSH2_SESSION* session, libssh2_dsa_ctx *dsa,
     unsigned char *p;
 
 #ifdef USE_OPENSSL_3
-    BIGNUM * p_bn;
-    BIGNUM * q;
-    BIGNUM * g;
-    BIGNUM * pub_key;
+    BIGNUM * p_bn = NULL;
+    BIGNUM * q = NULL;
+    BIGNUM * g = NULL;
+    BIGNUM * pub_key = NULL;
 
     EVP_PKEY_get_bn_param(dsa, OSSL_PKEY_PARAM_FFC_P, &p_bn);
     EVP_PKEY_get_bn_param(dsa, OSSL_PKEY_PARAM_FFC_G, &q);


### PR DESCRIPTION
I've begun the process of merging the current master branch into our repo. Previouslly, we were cherry-picking commits or manually applying them to our repo, due to changes we had made which were wholly incompatible with the AES-GCM changes made last year. My goal is to get things in a place where we can upstream the remaining changes from our repo, including `chacha20-poly1305@openssh.com` support, and then get in the habit of upstreaming our improvements more quickly so that we're not maintaining radically different versions of the code.

When running the current master branch through our internal test suite however, I noticed crashes and assert failures that must not be getting executed by the project's test suite. (However, I have never been able to get libssh2's test suite to run on any of my machines. Docker always complains that the arguments are incorrect. Otherwise, I'd be submitting tests to go along with these changes.)

First up, A crash when reading DSA keys using OpenSSL 3. Probably the simplest patch I'll submit. OpenSSL 3 is very particular about uninitialized memory in a way that OpenSSL 1.1.x was not. In general, you cannot pass any uninitalized pointers to OpenSSL 3 and expect it to do the right thing. You mist initialize pointers to `NULL` if you're going to pass them to an OpenSSL function.