### PR TITLE
AIX build fix

### DIFF
--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -22,6 +22,9 @@
 #endif
 
 #include <stdio.h>
+#ifdef _AIX
+#include <sys/time.h>
+#endif
 #include <time.h>  /* for time() */
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -29,6 +29,9 @@
 #endif
 
 #include <stdio.h>
+#ifdef _AIX
+#include <sys/time.h>
+#endif
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -28,6 +28,9 @@
 #endif
 
 #include <stdio.h>
+#ifdef _AIX
+#include <sys/time.h>
+#endif
 #include <time.h>  /* for time() */
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -28,6 +28,9 @@
 #endif
 
 #include <stdio.h>
+#ifdef _AIX
+#include <sys/time.h>
+#endif
 #include <time.h>  /* for time() */
 #include <string.h>
 


### PR DESCRIPTION
In AIX, time.h  header file doesn't have definitions  like fd_set, struct timeval, which are found in sys/time.h.
Hence added a condition to facilitate the missing definitions through sys/time.h.