### PR TITLE
userauth: avoid oob with huge interactive kbd response

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -292,7 +292,7 @@ typedef struct _LIBSSH2_USERAUTH_KBDINT_PROMPT
 typedef struct _LIBSSH2_USERAUTH_KBDINT_RESPONSE
 {
     char *text;
-    unsigned int length;
+    unsigned int length;  /* FIXME: change type to size_t */
 } LIBSSH2_USERAUTH_KBDINT_RESPONSE;
 
 typedef struct _LIBSSH2_SK_SIG_INFO {

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2188,7 +2188,7 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
                 if(session->userauth_kybd_responses[i].length <=
                    (SIZE_MAX - 4 - session->userauth_kybd_packet_len)) {
                     session->userauth_kybd_packet_len +=
-                        4 + session->userauth_kybd_responses[i].length;
+                        4 + (size_t)session->userauth_kybd_responses[i].length;
                 }
                 else {
                     _libssh2_error(session, LIBSSH2_ERROR_ALLOC,


### PR DESCRIPTION
- If the length of a response is `UINT_MAX - 3` or larger, an unsigned
  integer overflow occurs on 64-bit systems. Avoid such truncation to
  always allocate enough memory to avoid subsequent out of boundary
  writes.

  Patch-by: Tobias Stoeckmann

- also add FIXME to bump up length field to `size_t` (ABI break)

Closes #1337
