### PR TITLE
Dockerfile: switch to Debian stable (from testing)

### DIFF
--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -20,6 +20,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 
 #include <stdio.h>
 #include <time.h>  /* for time() */

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -27,6 +27,9 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 
 #include <stdio.h>
 

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -26,6 +26,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 
 #include <stdio.h>
 #include <time.h>  /* for time() */

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -26,6 +26,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 
 #include <stdio.h>
 #include <time.h>  /* for time() */

--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM debian:testing-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update \
  && apt-get install -y openssh-server \

--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM debian:bookworm-slim
+FROM debian:stable-slim
 
 RUN apt-get update \
  && apt-get install -y openssh-server \


### PR DESCRIPTION
This fixes flakiness experienced recently with two OpenSSL jobs and one
libgcrypt job, and/or intermittently causing all Docker-based tests to
fail.

Fixes #1328
Fixes #1329
Closes #1338
