### PR TITLE
example: restore `sys/time.h` for AIX

### DIFF
--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -20,6 +20,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 
 #include <stdio.h>
 #include <time.h>  /* for time() */

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -27,6 +27,9 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 
 #include <stdio.h>
 

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -26,6 +26,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 
 #include <stdio.h>
 #include <time.h>  /* for time() */

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -26,6 +26,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
 
 #include <stdio.h>
 #include <time.h>  /* for time() */


### PR DESCRIPTION
In AIX, `time.h` header file doesn't have definitions like
`fd_set`, `struct timeval`, which are found in `sys/time.h`.

Add `sys/time.h` to files affected when available.

Regression from e53aae0e16dbf53ddd1a4fcfc50e365a15fcb8b9 #1001.

Reported-by: shubhamhii on GitHub
Assisted-by: shubhamhii on GitHub
Fixes #1334
Fixes #1335
Closes #1340
