### PR TITLE
build: drop `-Wformat-nonliteral` warning suppressions

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -72,14 +72,7 @@ int _libssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
     if(cp_max_len < 2)
         return 0;
     va_start(args, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     n = vsnprintf(cp, cp_max_len, fmt, args);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     va_end(args);
     return (n < (int)cp_max_len) ? n : (int)(cp_max_len - 1);
 }
@@ -575,14 +568,7 @@ _libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
         buflen -= len;
         msglen = len;
         va_start(vargs, format);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
         len = vsnprintf(buffer + msglen, buflen, format, vargs);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
         va_end(vargs);
         msglen += len < buflen ? len : buflen - 1;
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -80,6 +80,9 @@ int openssh_fixture_have_docker(void)
 }
 
 static int run_command_varg(char **output, const char *command, va_list args)
+    LIBSSH2_PRINTF(2, 0);
+
+static int run_command_varg(char **output, const char *command, va_list args)
 {
     static const char redirect_stderr[] = "%s 2>&1";
 
@@ -94,14 +97,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
     }
 
     /* Format the command string */
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     ret = vsnprintf(command_buf, sizeof(command_buf), command, args);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     if(ret < 0 || ret >= BUFSIZ) {
         fprintf(stderr, "Unable to format command (%s)\n", command);
         return -1;


### PR DESCRIPTION
Also markup a vararg function as such.

In functions marked up as vararg functions, there is no need to suppress
`-Wformat-nonliteral` warnings. It's done automatically by the compiler.

Closes #1342