### PR TITLE
ci: use Linux runner for BSDs, add arm64 FreeBSD 14 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,12 +541,12 @@ jobs:
 
   build_netbsd:
     name: 'NetBSD (cmake, openssl, clang, amd64)'
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: 'cmake'
-        uses: cross-platform-actions/action@v0.21.1
+        uses: cross-platform-actions/action@v0.23.0
         with:
           operating_system: 'netbsd'
           version: '9.3'
@@ -565,12 +565,12 @@ jobs:
 
   build_openbsd:
     name: 'OpenBSD (cmake, libressl, clang, amd64)'
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: 'cmake'
-        uses: cross-platform-actions/action@v0.21.1
+        uses: cross-platform-actions/action@v0.23.0
         with:
           operating_system: 'openbsd'
           version: '7.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,11 +588,14 @@ jobs:
             cmake --build bld --parallel 3
 
   build_freebsd:
-    name: 'FreeBSD (autotools, openssl, clang, amd64)'
+    name: 'FreeBSD (autotools, openssl, clang)'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       CC: clang
+    strategy:
+      matrix:
+        arch: [x86-64, arm64]
     steps:
       - uses: actions/checkout@v4
       - name: 'autotools'
@@ -600,7 +603,7 @@ jobs:
         with:
           operating_system: 'freebsd'
           version: '14.0'
-          architecture: 'x86_64'
+          architecture: ${{ matrix.arch }}
           environment_variables: 'CC'
           run: |
             # https://ports.freebsd.org/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,17 +589,22 @@ jobs:
 
   build_freebsd:
     name: 'FreeBSD (autotools, openssl, clang, amd64)'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      CC: clang
     steps:
       - uses: actions/checkout@v4
       - name: 'autotools'
-        uses: vmactions/freebsd-vm@v1
+        uses: cross-platform-actions/action@v0.23.0
         with:
-          # https://ports.freebsd.org/
-          prepare: pkg install -y autoconf automake libtool bash
+          operating_system: 'freebsd'
+          version: '14.0'
+          architecture: 'x86_64'
+          environment_variables: 'CC'
           run: |
-            setenv CC clang
+            # https://ports.freebsd.org/
+            sudo pkg install -y autoconf automake libtool
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
               --with-crypto=openssl \


### PR DESCRIPTION
- bump cross-platform-actions to 0.23.0.
  Ref: https://github.com/cross-platform-actions/action/releases/tag/v0.23.0

- switch to linux runners (from macOS) for cross-platform-actions.
  It's significantly faster.

- switch back FreeBSD 14 job to cross-platform-actions.
  Also switch back to default shell.

- add FreeBSD 14 arm64 job.

Closes #1343
