### PR TITLE
ci: revert to debian:testing-slim after xz backdoor removal

### DIFF
--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM debian:stable-slim
+FROM debian:testing-slim
 
 RUN apt-get update \
  && apt-get install -y openssh-server \


### PR DESCRIPTION
The unexplained CI fallouts are gone with the latest debian:testing (20240330).

Ref #1328 #1329 #1338.
Closes #1346
