### PR TITLE
maketgz: `set -eu`, reproducibility, improve zip, add CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
         if: ${{ matrix.target == 'maketgz' }}
         timeout-minutes: 10
         run: |
-          ./configure --enable-werror --enable-debug ${{ matrix.options }}
+          ./configure --enable-werror --disable-debug ${{ matrix.options }}
           ./maketgz 9.99.9
 
       - name: 'cmake configure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,6 @@ jobs:
           ./configure --enable-werror --enable-debug \
             ${crossoptions} ${{ matrix.options }}
           ./maketgz 9.99.9
-          ls -l libssh2*
 
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,12 @@ jobs:
             build: autotools
             zlib: 'ON'
             target: 'distcheck'
+          - compiler: clang
+            arch: amd64
+            crypto: OpenSSL
+            build: autotools
+            zlib: 'ON'
+            target: 'maketgz'
           - compiler: gcc
             arch: i386
             crypto: mbedTLS
@@ -98,9 +104,6 @@ jobs:
             build: autotools
             zlib: 'ON'
             options: --disable-static
-          - arch: amd64
-            build: autotools
-            target: 'maketgz'
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -179,7 +182,7 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         run: autoreconf -fi
       - name: 'autotools configure'
-        if: ${{ matrix.build == 'autotools' && matrix.target != 'maketgz' }}
+        if: ${{ matrix.build == 'autotools' }}
         run: |
           if [ '${{ matrix.arch }}' = 'i386' ]; then
             crossoptions='--host=i686-pc-linux-gnu'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         run: autoreconf -fi
       - name: 'autotools configure'
-        if: ${{ matrix.build == 'autotools' }}
+        if: ${{ matrix.build == 'autotools' && matrix.target != 'maketgz' }}
         run: |
           if [ '${{ matrix.arch }}' = 'i386' ]; then
             crossoptions='--host=i686-pc-linux-gnu'
@@ -205,7 +205,11 @@ jobs:
       - name: 'maketgz'
         if: ${{ matrix.target == 'maketgz' }}
         timeout-minutes: 10
-        run: ./maketgz 9.99.9; ls -l
+        run: |
+          ./configure --enable-werror --enable-debug \
+            ${crossoptions} ${{ matrix.options }}
+          ./maketgz 9.99.9; ls -l
+
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,7 @@ jobs:
         if: ${{ matrix.target == 'maketgz' }}
         timeout-minutes: 10
         run: |
-          ./configure --enable-werror --enable-debug \
-            ${crossoptions} ${{ matrix.options }}
+          ./configure --enable-werror --enable-debug ${{ matrix.options }}
           ./maketgz 9.99.9
 
       - name: 'cmake configure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
             build: autotools
             zlib: 'ON'
             options: --disable-static
+          - arch: amd64
+            build: autotools
+            target: 'maketgz'
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -176,7 +179,7 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         run: autoreconf -fi
       - name: 'autotools configure'
-        if: ${{ matrix.build == 'autotools' }}
+        if: ${{ matrix.build == 'autotools' && matrix.target != 'maketgz' }}
         run: |
           if [ '${{ matrix.arch }}' = 'i386' ]; then
             crossoptions='--host=i686-pc-linux-gnu'
@@ -196,6 +199,10 @@ jobs:
         if: ${{ matrix.target == 'distcheck' }}
         timeout-minutes: 10
         run: make -C bld distcheck
+      - name: 'maketgz'
+        if: ${{ matrix.target == 'maketgz' }}
+        timeout-minutes: 10
+        run: ./maketgz 9.99.9; ls -l
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,8 @@ jobs:
         run: |
           ./configure --enable-werror --enable-debug \
             ${crossoptions} ${{ matrix.options }}
-          ./maketgz 9.99.9; ls -l
+          ./maketgz 9.99.9
+          ls -l libssh2*
 
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}

--- a/maketgz
+++ b/maketgz
@@ -143,7 +143,7 @@ makezip() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find . | sort | zip --no-extra "$zip" -@ >/dev/null
+  find . | sort | zip -9 --no-extra "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..
   rm -rf "$tempdir"

--- a/maketgz
+++ b/maketgz
@@ -143,7 +143,7 @@ makezip() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find . | sort | zip "$zip" -@ >/dev/null
+  find . | sort | zip --no-extra "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..
   rm -rf "$tempdir"

--- a/maketgz
+++ b/maketgz
@@ -18,6 +18,8 @@ fi
 if [ "only" = "${2:-}" ]; then
   echo "Setup version number only!"
   only=1
+else
+  only=
 fi
 
 libversion="$version"

--- a/maketgz
+++ b/maketgz
@@ -22,6 +22,9 @@ else
   only=
 fi
 
+export LC_ALL=C
+export TZ=UTC
+
 libversion="$version"
 
 major="$(echo "$libversion" | cut -d. -f1 | sed -e "s/[^0-9]//g")"
@@ -41,8 +44,7 @@ if test -z "$only"; then
   HEADER="$HEADER$ext"
 fi
 
-# requires a date command that knows -u for UTC time zone
-datestamp="$(LC_TIME=C date -u)"
+datestamp="$(date)"
 
 # Replace in-place version number in header file:
 sed -i.bak \
@@ -141,7 +143,7 @@ makezip() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find . | LC_ALL=C sort | zip "$zip" -@ >/dev/null
+  find . | sort | zip "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..
   rm -rf "$tempdir"

--- a/maketgz
+++ b/maketgz
@@ -6,14 +6,16 @@
 # from git and you should first run 'autoreconf -fi' and './configure'.
 #
 
-version="$1"
+set -eu
+
+version="${1:-}"
 
 if [ -z "$version" ]; then
   echo "Specify a version number!"
   exit
 fi
 
-if [ "only" = "$2" ]; then
+if [ "only" = "${2:-}" ]; then
   echo "Setup version number only!"
   only=1
 fi
@@ -135,11 +137,11 @@ gzip -dc "$targz" | xz -6e - > "$xz"
 makezip() {
   rm -rf "$tempdir"
   mkdir "$tempdir"
-  cd "$tempdir" || exit 1
+  cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
   find . | zip "$zip" -@ >/dev/null
   mv "$zip" ../
-  cd .. || exit 1
+  cd ..
   rm -rf "$tempdir"
 }
 

--- a/maketgz
+++ b/maketgz
@@ -141,7 +141,7 @@ makezip() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find . | zip "$zip" -@ >/dev/null
+  find . | LC_ALL=C sort | zip "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..
   rm -rf "$tempdir"

--- a/maketgz
+++ b/maketgz
@@ -143,7 +143,7 @@ makezip() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find . | sort | zip -9 --no-extra "$zip" -@ >/dev/null
+  find . | sort | zip -9 -X "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..
   rm -rf "$tempdir"

--- a/maketgz
+++ b/maketgz
@@ -156,3 +156,6 @@ echo "------------------"
 echo "maketgz report:"
 echo ""
 ls -l "$targz" "$bzip2" "$zip" "$xz"
+
+echo "Run this:"
+echo "gpg -b -a '$targz' && gpg -b -a '$bzip2' && gpg -b -a '$zip' && gpg -b -a '$xz'"


### PR DESCRIPTION
- set bash `-eu`.
- fix bash `-eu` issues.
- apply `TZ=UTC` and `LC_ALL=C` for reproducibility.
- sort `.zip` entries for reproducibility.
- zip with `--no-extra` for reproducibliity.
- use maximum zip compression.
- add the gpg sign command-line. Copied from curl.
- add CI test for `maketgz`.

Closes #1353
