### PR TITLE
src: check the return value from `_libssh2_bn_*()` functions

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -522,9 +522,9 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        if (_libssh2_bn_from_bin(exchange_state->f,
-                                 exchange_state->f_value_len,
-                                 exchange_state->f_value)) {
+        if(_libssh2_bn_from_bin(exchange_state->f,
+                                exchange_state->f_value_len,
+                                exchange_state->f_value)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                                  "Invalid DH-SHA f value");
             goto clean_exit;
@@ -1473,7 +1473,7 @@ kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        if (_libssh2_bn_from_bin(key_state->g, g_len, g)) {
+        if(_libssh2_bn_from_bin(key_state->g, g_len, g)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Invalid DH-SHA1 g");
             goto dh_gex_clean_exit;
@@ -1595,13 +1595,13 @@ kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        if (_libssh2_bn_from_bin(key_state->p, p_len, p)) {
+        if(_libssh2_bn_from_bin(key_state->p, p_len, p)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Invalid DH-SHA256 p");
             goto dh_gex_clean_exit;
         }
 
-        if (_libssh2_bn_from_bin(key_state->g, g_len, g)) {
+        if(_libssh2_bn_from_bin(key_state->g, g_len, g)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "Invalid DH-SHA256 g");
             goto dh_gex_clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -567,8 +567,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
         else {
             exchange_state->k_value[4] = 0;
-           if(_libssh2_bn_to_bin(exchange_state->k,
-                                 exchange_state->k_value + 5)) {
+            if(_libssh2_bn_to_bin(exchange_state->k,
+                                  exchange_state->k_value + 5)) {
                 ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                      "Can't write exchange_state->k");
                 goto clean_exit;
@@ -1010,7 +1010,7 @@ kex_method_diffie_hellman_group1_sha1_key_exchange(LIBSSH2_SESSION *session,
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     };
 
-    int ret = LIBSSH2_ERROR_NONE;
+    int ret;
     libssh2_sha1_ctx exchange_hash_ctx;
 
     if(key_state->state == libssh2_NB_state_idle) {
@@ -1023,28 +1023,29 @@ kex_method_diffie_hellman_group1_sha1_key_exchange(LIBSSH2_SESSION *session,
         if(_libssh2_bn_set_word(key_state->g, 2)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                  "Failed to allocate key state g.");
+            goto clean_exit;
         }
-        else if(_libssh2_bn_from_bin(key_state->p, 128, p_value)) {
+        if(_libssh2_bn_from_bin(key_state->p, 128, p_value)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                  "Failed to allocate key state p.");
+            goto clean_exit;
         }
-        else {
-            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Initiating Diffie-Hellman Group1 Key Exchange"));
 
-            key_state->state = libssh2_NB_state_created;
-        }
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating Diffie-Hellman Group1 Key Exchange"));
+
+        key_state->state = libssh2_NB_state_created;
     }
 
-    ret = ret || diffie_hellman_sha_algo(session, key_state->g, key_state->p,
-                                         128, 1, (void *)&exchange_hash_ctx,
-                                         SSH_MSG_KEXDH_INIT,
-                                         SSH_MSG_KEXDH_REPLY, NULL, 0,
-                                         &key_state->exchange_state);
+    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 128, 1,
+                                  (void *)&exchange_hash_ctx,
+                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
+                                  NULL, 0, &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN) {
         return ret;
     }
 
+clean_exit:
     _libssh2_bn_free(key_state->p);
     key_state->p = NULL;
     _libssh2_bn_free(key_state->g);
@@ -1112,7 +1113,7 @@ kex_method_diffie_hellman_group14_key_exchange(LIBSSH2_SESSION *session,
         0x15, 0x72, 0x8E, 0x5A, 0x8A, 0xAC, 0xAA, 0x68,
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     };
-    int ret = LIBSSH2_ERROR_NONE;
+    int ret;
 
     if(key_state->state == libssh2_NB_state_idle) {
         key_state->p = _libssh2_bn_init_from_bin(); /* SSH2 defined value
@@ -1124,26 +1125,27 @@ kex_method_diffie_hellman_group14_key_exchange(LIBSSH2_SESSION *session,
         if(_libssh2_bn_set_word(key_state->g, 2)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                  "Failed to allocate key state g.");
+            goto clean_exit;
         }
         else if(_libssh2_bn_from_bin(key_state->p, 256, p_value)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                  "Failed to allocate key state p.");
+            goto clean_exit;
         }
-        else {
-            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Initiating Diffie-Hellman Group14 Key Exchange"));
 
-            key_state->state = libssh2_NB_state_created;
-        }
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating Diffie-Hellman Group14 Key Exchange"));
+
+        key_state->state = libssh2_NB_state_created;
     }
-    ret = ret || hashfunc(session, key_state->g, key_state->p,
-                          256, sha_algo_value, exchange_hash_ctx,
-                          SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY, NULL, 0,
-                          &key_state->exchange_state);
+    ret = hashfunc(session, key_state->g, key_state->p,
+                   256, sha_algo_value, exchange_hash_ctx, SSH_MSG_KEXDH_INIT,
+                   SSH_MSG_KEXDH_REPLY, NULL, 0, &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN) {
         return ret;
     }
 
+clean_exit:
     key_state->state = libssh2_NB_state_idle;
     _libssh2_bn_free(key_state->p);
     key_state->p = NULL;
@@ -1240,7 +1242,7 @@ kex_method_diffie_hellman_group16_sha512_key_exchange(LIBSSH2_SESSION *session,
     0x90, 0xA6, 0xC0, 0x8F, 0x4D, 0xF4, 0x35, 0xC9, 0x34, 0x06, 0x31, 0x99,
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     };
-    int ret = LIBSSH2_ERROR_NONE;
+    int ret;
     libssh2_sha512_ctx exchange_hash_ctx;
 
     if(key_state->state == libssh2_NB_state_idle) {
@@ -1253,28 +1255,29 @@ kex_method_diffie_hellman_group16_sha512_key_exchange(LIBSSH2_SESSION *session,
         if(_libssh2_bn_set_word(key_state->g, 2)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                  "Failed to allocate key state g.");
+            goto clean_exit;
         }
-        else if(_libssh2_bn_from_bin(key_state->p, 512, p_value)) {
+        if(_libssh2_bn_from_bin(key_state->p, 512, p_value)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                  "Failed to allocate key state p.");
+            goto clean_exit;
         }
-        else {
-            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Initiating Diffie-Hellman Group16 Key Exchange"));
 
-            key_state->state = libssh2_NB_state_created;
-        }
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating Diffie-Hellman Group16 Key Exchange"));
+
+        key_state->state = libssh2_NB_state_created;
     }
 
-    ret = ret || diffie_hellman_sha_algo(session, key_state->g, key_state->p,
-                                         512, 512, (void *)&exchange_hash_ctx,
-                                         SSH_MSG_KEXDH_INIT,
-                                         SSH_MSG_KEXDH_REPLY, NULL, 0,
-                                         &key_state->exchange_state);
+    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 512,
+                                  512, (void *)&exchange_hash_ctx,
+                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
+                                  NULL, 0, &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN) {
         return ret;
     }
 
+clean_exit:
     key_state->state = libssh2_NB_state_idle;
     _libssh2_bn_free(key_state->p);
     key_state->p = NULL;
@@ -1380,7 +1383,7 @@ kex_method_diffie_hellman_group18_sha512_key_exchange(LIBSSH2_SESSION *session,
     0x60, 0xC9, 0x80, 0xDD, 0x98, 0xED, 0xD3, 0xDF, 0xFF, 0xFF, 0xFF, 0xFF,
     0xFF, 0xFF, 0xFF, 0xFF
     };
-    int ret = LIBSSH2_ERROR_NONE;
+    int ret;
     libssh2_sha512_ctx exchange_hash_ctx;
 
     if(key_state->state == libssh2_NB_state_idle) {
@@ -1393,28 +1396,29 @@ kex_method_diffie_hellman_group18_sha512_key_exchange(LIBSSH2_SESSION *session,
         if(_libssh2_bn_set_word(key_state->g, 2)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                  "Failed to allocate key state g.");
+            goto clean_exit;
         }
         else if(_libssh2_bn_from_bin(key_state->p, 1024, p_value)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                  "Failed to allocate key state p.");
+            goto clean_exit;
         }
-        else {
-            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Initiating Diffie-Hellman Group18 Key Exchange"));
 
-            key_state->state = libssh2_NB_state_created;
-        }
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                       "Initiating Diffie-Hellman Group18 Key Exchange"));
+
+        key_state->state = libssh2_NB_state_created;
     }
 
-    ret = ret || diffie_hellman_sha_algo(session, key_state->g, key_state->p,
-                                         1024, 512, (void *)&exchange_hash_ctx,
-                                         SSH_MSG_KEXDH_INIT,
-                                         SSH_MSG_KEXDH_REPLY, NULL, 0,
-                                         &key_state->exchange_state);
+    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 1024,
+                                  512, (void *)&exchange_hash_ctx,
+                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
+                                  NULL, 0, &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN) {
         return ret;
     }
 
+clean_exit:
     key_state->state = libssh2_NB_state_idle;
     _libssh2_bn_free(key_state->p);
     key_state->p = NULL;

--- a/src/kex.c
+++ b/src/kex.c
@@ -563,7 +563,12 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         _libssh2_htonu32(exchange_state->k_value,
                          (uint32_t)(exchange_state->k_value_len - 4));
         if(_libssh2_bn_bits(exchange_state->k) % 8) {
-            _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 4);
+            if (_libssh2_bn_to_bin(exchange_state->k,
+                                   exchange_state->k_value + 4)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                                     "Can't write exchange_state->k");
+                goto clean_exit;
+            }
         }
         else {
             exchange_state->k_value[4] = 0;

--- a/src/kex.c
+++ b/src/kex.c
@@ -563,8 +563,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         _libssh2_htonu32(exchange_state->k_value,
                          (uint32_t)(exchange_state->k_value_len - 4));
         if(_libssh2_bn_bits(exchange_state->k) % 8) {
-            if (_libssh2_bn_to_bin(exchange_state->k,
-                                   exchange_state->k_value + 4)) {
+            if(_libssh2_bn_to_bin(exchange_state->k,
+                                  exchange_state->k_value + 4)) {
                 ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                      "Can't write exchange_state->k");
                 goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -1010,7 +1010,7 @@ kex_method_diffie_hellman_group1_sha1_key_exchange(LIBSSH2_SESSION *session,
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     };
 
-    int ret;
+    int ret = LIBSSH2_ERROR_NONE;
     libssh2_sha1_ctx exchange_hash_ctx;
 
     if(key_state->state == libssh2_NB_state_idle) {
@@ -1020,19 +1020,27 @@ kex_method_diffie_hellman_group1_sha1_key_exchange(LIBSSH2_SESSION *session,
         key_state->g = _libssh2_bn_init();      /* SSH2 defined value (2) */
 
         /* Initialize P and G */
-        _libssh2_bn_set_word(key_state->g, 2);
-        _libssh2_bn_from_bin(key_state->p, 128, p_value);
+        if(_libssh2_bn_set_word(key_state->g, 2)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                 "Failed to allocate key state g.");
+        }
+        else if(_libssh2_bn_from_bin(key_state->p, 128, p_value)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                 "Failed to allocate key state p.");
+        }
+        else {
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Initiating Diffie-Hellman Group1 Key Exchange"));
 
-        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group1 Key Exchange"));
-
-        key_state->state = libssh2_NB_state_created;
+            key_state->state = libssh2_NB_state_created;
+        }
     }
 
-    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 128, 1,
-                                  (void *)&exchange_hash_ctx,
-                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
-                                  NULL, 0, &key_state->exchange_state);
+    ret = ret || diffie_hellman_sha_algo(session, key_state->g, key_state->p,
+                                         128, 1, (void *)&exchange_hash_ctx,
+                                         SSH_MSG_KEXDH_INIT,
+                                         SSH_MSG_KEXDH_REPLY, NULL, 0,
+                                         &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN) {
         return ret;
     }
@@ -1104,7 +1112,7 @@ kex_method_diffie_hellman_group14_key_exchange(LIBSSH2_SESSION *session,
         0x15, 0x72, 0x8E, 0x5A, 0x8A, 0xAC, 0xAA, 0x68,
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     };
-    int ret;
+    int ret = LIBSSH2_ERROR_NONE;
 
     if(key_state->state == libssh2_NB_state_idle) {
         key_state->p = _libssh2_bn_init_from_bin(); /* SSH2 defined value
@@ -1113,17 +1121,25 @@ kex_method_diffie_hellman_group14_key_exchange(LIBSSH2_SESSION *session,
 
         /* g == 2 */
         /* Initialize P and G */
-        _libssh2_bn_set_word(key_state->g, 2);
-        _libssh2_bn_from_bin(key_state->p, 256, p_value);
+        if(_libssh2_bn_set_word(key_state->g, 2)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                 "Failed to allocate key state g.");
+        }
+        else if(_libssh2_bn_from_bin(key_state->p, 256, p_value)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                 "Failed to allocate key state p.");
+        }
+        else {
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Initiating Diffie-Hellman Group14 Key Exchange"));
 
-        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group14 Key Exchange"));
-
-        key_state->state = libssh2_NB_state_created;
+            key_state->state = libssh2_NB_state_created;
+        }
     }
-    ret = hashfunc(session, key_state->g, key_state->p,
-                   256, sha_algo_value, exchange_hash_ctx, SSH_MSG_KEXDH_INIT,
-                   SSH_MSG_KEXDH_REPLY, NULL, 0, &key_state->exchange_state);
+    ret = ret || hashfunc(session, key_state->g, key_state->p,
+                          256, sha_algo_value, exchange_hash_ctx,
+                          SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY, NULL, 0,
+                          &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN) {
         return ret;
     }
@@ -1224,7 +1240,7 @@ kex_method_diffie_hellman_group16_sha512_key_exchange(LIBSSH2_SESSION *session,
     0x90, 0xA6, 0xC0, 0x8F, 0x4D, 0xF4, 0x35, 0xC9, 0x34, 0x06, 0x31, 0x99,
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     };
-    int ret;
+    int ret = LIBSSH2_ERROR_NONE;
     libssh2_sha512_ctx exchange_hash_ctx;
 
     if(key_state->state == libssh2_NB_state_idle) {
@@ -1234,19 +1250,27 @@ kex_method_diffie_hellman_group16_sha512_key_exchange(LIBSSH2_SESSION *session,
 
         /* g == 2 */
         /* Initialize P and G */
-        _libssh2_bn_set_word(key_state->g, 2);
-        _libssh2_bn_from_bin(key_state->p, 512, p_value);
+        if(_libssh2_bn_set_word(key_state->g, 2)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                 "Failed to allocate key state g.");
+        }
+        else if(_libssh2_bn_from_bin(key_state->p, 512, p_value)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                 "Failed to allocate key state p.");
+        }
+        else {
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Initiating Diffie-Hellman Group16 Key Exchange"));
 
-        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group16 Key Exchange"));
-
-        key_state->state = libssh2_NB_state_created;
+            key_state->state = libssh2_NB_state_created;
+        }
     }
 
-    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 512,
-                                  512, (void *)&exchange_hash_ctx,
-                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
-                                  NULL, 0, &key_state->exchange_state);
+    ret = ret || diffie_hellman_sha_algo(session, key_state->g, key_state->p,
+                                         512, 512, (void *)&exchange_hash_ctx,
+                                         SSH_MSG_KEXDH_INIT,
+                                         SSH_MSG_KEXDH_REPLY, NULL, 0,
+                                         &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN) {
         return ret;
     }
@@ -1356,7 +1380,7 @@ kex_method_diffie_hellman_group18_sha512_key_exchange(LIBSSH2_SESSION *session,
     0x60, 0xC9, 0x80, 0xDD, 0x98, 0xED, 0xD3, 0xDF, 0xFF, 0xFF, 0xFF, 0xFF,
     0xFF, 0xFF, 0xFF, 0xFF
     };
-    int ret;
+    int ret = LIBSSH2_ERROR_NONE;
     libssh2_sha512_ctx exchange_hash_ctx;
 
     if(key_state->state == libssh2_NB_state_idle) {
@@ -1366,19 +1390,27 @@ kex_method_diffie_hellman_group18_sha512_key_exchange(LIBSSH2_SESSION *session,
 
         /* g == 2 */
         /* Initialize P and G */
-        _libssh2_bn_set_word(key_state->g, 2);
-        _libssh2_bn_from_bin(key_state->p, 1024, p_value);
+        if(_libssh2_bn_set_word(key_state->g, 2)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                 "Failed to allocate key state g.");
+        }
+        else if(_libssh2_bn_from_bin(key_state->p, 1024, p_value)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                                 "Failed to allocate key state p.");
+        }
+        else {
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
+                           "Initiating Diffie-Hellman Group18 Key Exchange"));
 
-        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group18 Key Exchange"));
-
-        key_state->state = libssh2_NB_state_created;
+            key_state->state = libssh2_NB_state_created;
+        }
     }
 
-    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 1024,
-                                  512, (void *)&exchange_hash_ctx,
-                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
-                                  NULL, 0, &key_state->exchange_state);
+    ret = ret || diffie_hellman_sha_algo(session, key_state->g, key_state->p,
+                                         1024, 512, (void *)&exchange_hash_ctx,
+                                         SSH_MSG_KEXDH_INIT,
+                                         SSH_MSG_KEXDH_REPLY, NULL, 0,
+                                         &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN) {
         return ret;
     }

--- a/src/kex.c
+++ b/src/kex.c
@@ -522,8 +522,13 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        _libssh2_bn_from_bin(exchange_state->f, exchange_state->f_value_len,
-                             exchange_state->f_value);
+        if (_libssh2_bn_from_bin(exchange_state->f,
+                                 exchange_state->f_value_len,
+                                 exchange_state->f_value)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_HOSTKEY_INIT,
+                                 "Invalid DH-SHA f value");
+            goto clean_exit;
+        }
 
         if(_libssh2_get_string(&buf, &(exchange_state->h_sig),
                                &(exchange_state->h_sig_len))) {
@@ -1462,8 +1467,17 @@ kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        _libssh2_bn_from_bin(key_state->p, p_len, p);
-        _libssh2_bn_from_bin(key_state->g, g_len, g);
+        if(_libssh2_bn_from_bin(key_state->p, p_len, p)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                                 "Invalid DH-SHA1 p");
+            goto dh_gex_clean_exit;
+        }
+
+        if (_libssh2_bn_from_bin(key_state->g, g_len, g)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                                 "Invalid DH-SHA1 g");
+            goto dh_gex_clean_exit;
+        }
 
         ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p,
                                       (int)p_len, 1,
@@ -1581,8 +1595,17 @@ kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        _libssh2_bn_from_bin(key_state->p, p_len, p);
-        _libssh2_bn_from_bin(key_state->g, g_len, g);
+        if (_libssh2_bn_from_bin(key_state->p, p_len, p)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                                 "Invalid DH-SHA256 p");
+            goto dh_gex_clean_exit;
+        }
+
+        if (_libssh2_bn_from_bin(key_state->g, g_len, g)) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                                 "Invalid DH-SHA256 g");
+            goto dh_gex_clean_exit;
+        }
 
         ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p,
                                       (int)p_len, 256,

--- a/src/kex.c
+++ b/src/kex.c
@@ -316,13 +316,21 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         _libssh2_htonu32(exchange_state->e_packet + 1,
                          (uint32_t)(exchange_state->e_packet_len - 5));
         if(_libssh2_bn_bits(exchange_state->e) % 8) {
-            _libssh2_bn_to_bin(exchange_state->e,
-                               exchange_state->e_packet + 5);
+            if(_libssh2_bn_to_bin(exchange_state->e,
+                                  exchange_state->e_packet + 5)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                                     "Can't write exchange_state->e");
+                goto clean_exit;
+            }
         }
         else {
             exchange_state->e_packet[5] = 0;
-            _libssh2_bn_to_bin(exchange_state->e,
-                               exchange_state->e_packet + 6);
+            if(_libssh2_bn_to_bin(exchange_state->e,
+                                  exchange_state->e_packet + 6)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                                     "Can't write exchange_state->e");
+                goto clean_exit;
+            }
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX, "Sending KEX packet %u",
@@ -559,7 +567,12 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
         else {
             exchange_state->k_value[4] = 0;
-            _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 5);
+           if(_libssh2_bn_to_bin(exchange_state->k,
+                                 exchange_state->k_value + 5)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                                     "Can't write exchange_state->k");
+                goto clean_exit;
+            }
         }
 
         exchange_state->exchange_hash = (void *)&exchange_hash_ctx;
@@ -1964,11 +1977,21 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
         _libssh2_htonu32(exchange_state->k_value,
                          (uint32_t)(exchange_state->k_value_len - 4));
         if(_libssh2_bn_bits(exchange_state->k) % 8) {
-            _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 4);
+            if(_libssh2_bn_to_bin(exchange_state->k,
+                                  exchange_state->k_value + 4)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                                     "Can't write exchange_state->k");
+                goto clean_exit;
+            }
         }
         else {
             exchange_state->k_value[4] = 0;
-            _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 5);
+            if(_libssh2_bn_to_bin(exchange_state->k,
+                                  exchange_state->k_value + 5)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                                     "Can't write exchange_state->e");
+                goto clean_exit;
+            }
         }
 
         /* verify hash */
@@ -2602,11 +2625,21 @@ curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         _libssh2_htonu32(exchange_state->k_value,
                          (uint32_t)(exchange_state->k_value_len - 4));
         if(_libssh2_bn_bits(exchange_state->k) % 8) {
-            _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 4);
+            if(_libssh2_bn_to_bin(exchange_state->k,
+                                  exchange_state->k_value + 4)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                                     "Can't write exchange_state->e");
+                goto clean_exit;
+            }
         }
         else {
             exchange_state->k_value[4] = 0;
-            _libssh2_bn_to_bin(exchange_state->k, exchange_state->k_value + 5);
+            if(_libssh2_bn_to_bin(exchange_state->k,
+                                  exchange_state->k_value + 5)) {
+                ret = _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                                     "Can't write exchange_state->e");
+                goto clean_exit;
+            }
         }
 
         /*/ verify hash */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5123,7 +5123,7 @@ _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
 int
 _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len, const unsigned char *val)
 {
-    if(BN_bin2bn(val, (int)len, bn) == NULL) {
+    if(!BN_bin2bn(val, (int)len, bn)) {
         return -1;
     }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5120,6 +5120,16 @@ _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
     *dhctx = NULL;
 }
 
+int
+_libssh2_bn_from_bin(_libssh2_bn *bn, size_t len, const unsigned char *val)
+{
+    if(BN_bin2bn(val, (int)len, bn) == NULL) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /* _libssh2_supported_key_sign_algorithms
  *
  * Return supported key hash algo upgrades, see crypto.h

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -402,7 +402,7 @@ libssh2_curve_type;
 #define _libssh2_bn_set_word(bn, val) !BN_set_word(bn, val)
 extern int _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
                                 const unsigned char *v);
-#define _libssh2_bn_to_bin(bn, val) BN_bn2bin(bn, val) <= 0
+#define _libssh2_bn_to_bin(bn, val) (BN_bn2bin(bn, val) <= 0)
 #define _libssh2_bn_bytes(bn) BN_num_bytes(bn)
 #define _libssh2_bn_bits(bn) BN_num_bits(bn)
 #define _libssh2_bn_free(bn) BN_clear_free(bn)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -402,7 +402,7 @@ libssh2_curve_type;
 #define _libssh2_bn_set_word(bn, val) !BN_set_word(bn, val)
 extern int _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
                                 const unsigned char *v);
-#define _libssh2_bn_to_bin(bn, val) BN_bn2bin(bn, val)
+#define _libssh2_bn_to_bin(bn, val) BN_bn2bin(bn, val) <= 0
 #define _libssh2_bn_bytes(bn) BN_num_bytes(bn)
 #define _libssh2_bn_bits(bn) BN_num_bits(bn)
 #define _libssh2_bn_free(bn) BN_clear_free(bn)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -400,7 +400,8 @@ libssh2_curve_type;
 #define _libssh2_bn_init() BN_new()
 #define _libssh2_bn_init_from_bin() _libssh2_bn_init()
 #define _libssh2_bn_set_word(bn, val) BN_set_word(bn, val)
-#define _libssh2_bn_from_bin(bn, len, val) BN_bin2bn(val, (int)len, bn)
+extern int _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
+                                const unsigned char *v);
 #define _libssh2_bn_to_bin(bn, val) BN_bn2bin(bn, val)
 #define _libssh2_bn_bytes(bn) BN_num_bytes(bn)
 #define _libssh2_bn_bits(bn) BN_num_bits(bn)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -399,7 +399,7 @@ libssh2_curve_type;
 #define _libssh2_bn_ctx_free(bnctx) BN_CTX_free(bnctx)
 #define _libssh2_bn_init() BN_new()
 #define _libssh2_bn_init_from_bin() _libssh2_bn_init()
-#define _libssh2_bn_set_word(bn, val) BN_set_word(bn, val)
+#define _libssh2_bn_set_word(bn, val) !BN_set_word(bn, val)
 extern int _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
                                 const unsigned char *v);
 #define _libssh2_bn_to_bin(bn, val) BN_bn2bin(bn, val)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -458,9 +458,9 @@ _libssh2_bn_bits(_libssh2_bn *bn)
 }
 
 int
-_libssh2_bn_from_bin(_libssh2_bn *bn, int len, const unsigned char *val)
+_libssh2_bn_from_bin(_libssh2_bn *bn, size_t len, const unsigned char *val)
 {
-    int i;
+    size_t i;
 
     if(!bn || (len && !val))
         return -1;

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -358,7 +358,7 @@ typedef struct {        /* Diffie-Hellman context. */
 extern _libssh2_bn *    _libssh2_bn_init(void);
 extern void     _libssh2_bn_free(_libssh2_bn *bn);
 extern unsigned long    _libssh2_bn_bits(_libssh2_bn *bn);
-extern int      _libssh2_bn_from_bin(_libssh2_bn *bn, int len,
+extern int      _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
                                      const unsigned char *v);
 extern int      _libssh2_bn_set_word(_libssh2_bn *bn, unsigned long val);
 extern int      _libssh2_bn_to_bin(_libssh2_bn *bn, unsigned char *val);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2410,11 +2410,13 @@ _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
         if(bignum) {
             bn->bignum = bignum;
             bn->length = length;
-            return 0;
+        }
+        else {
+            return -1;
         }
     }
 
-    return -1;
+    return 0;
 }
 
 void

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2419,12 +2419,15 @@ _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
     return 0;
 }
 
-void
+int
 _libssh2_wincng_bignum_to_bin(const _libssh2_bn *bn, unsigned char *bin)
 {
     if(bin && bn && bn->bignum && bn->length > 0) {
         memcpy(bin, bn->bignum, bn->length);
+        return 0;
     }
+
+    return -1;
 }
 
 void

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2382,7 +2382,7 @@ _libssh2_wincng_bignum_bits(const _libssh2_bn *bn)
     return bits;
 }
 
-void
+int
 _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
                                 const unsigned char *bin)
 {
@@ -2390,10 +2390,10 @@ _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
     ULONG offset, length, bits;
 
     if(!bn || !bin || !len)
-        return;
+        return -1;
 
     if(_libssh2_wincng_bignum_resize(bn, len))
-        return;
+        return -1;
 
     memcpy(bn->bignum, bin, len);
 
@@ -2410,8 +2410,11 @@ _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
         if(bignum) {
             bn->bignum = bignum;
             bn->length = length;
+            return 0;
         }
     }
+
+    return -1;
 }
 
 void

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -463,7 +463,7 @@ _libssh2_wincng_bignum_bits(const _libssh2_bn *bn);
 int
 _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
                                 const unsigned char *bin);
-void
+int
 _libssh2_wincng_bignum_to_bin(const _libssh2_bn *bn, unsigned char *bin);
 void
 _libssh2_wincng_bignum_free(_libssh2_bn *bn);

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -460,7 +460,7 @@ int
 _libssh2_wincng_bignum_set_word(_libssh2_bn *bn, ULONG word);
 ULONG
 _libssh2_wincng_bignum_bits(const _libssh2_bn *bn);
-void
+int
 _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
                                 const unsigned char *bin);
 void


### PR DESCRIPTION
Found by oss-fuzz. In `diffie_hellman_sha_algo()`, we were calling
`_libssh2_bn_from_bin()` with data recieved by the server without
checking whether that data was zero-length or ridiculously long.
In the OpenSSL backend, this would cause `_libssh2_bn_from_bin()`
to fail an allocation, which would eventually lead to a NULL
dereference when the bignum was used.

Add the same check for `_libssh2_bn_set_word()` and
`_libssh2_bn_to_bin()`.
