### PR TITLE
maketgz: reproducible tarballs/zip, display tarball hashes

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -8,6 +8,9 @@
 
 set -eu
 
+export LC_ALL=C
+export TZ=UTC
+
 version="${1:-}"
 
 if [ -z "$version" ]; then
@@ -22,14 +25,11 @@ else
   only=
 fi
 
-export LC_ALL=C
-export TZ=UTC
-
 libversion="$version"
 
-major="$(echo "$libversion" | cut -d. -f1 | sed -e "s/[^0-9]//g")"
-minor="$(echo "$libversion" | cut -d. -f2 | sed -e "s/[^0-9]//g")"
-patch="$(echo "$libversion" | cut -d. -f3 | cut -d- -f1 | sed -e "s/[^0-9]//g")"
+major=$(echo "$libversion" | cut -d. -f1 | sed -e "s/[^0-9]//g")
+minor=$(echo "$libversion" | cut -d. -f2 | sed -e "s/[^0-9]//g")
+patch=$(echo "$libversion" | cut -d. -f3 | cut -d- -f1 | sed -e "s/[^0-9]//g")
 
 numeric="$(printf "%02x%02x%02x\n" "$major" "$minor" "$patch")"
 
@@ -44,9 +44,12 @@ if test -z "$only"; then
   HEADER="$HEADER$ext"
 fi
 
-datestamp="$(date)"
+# requires a date command that knows + for format and -d for date input
+timestamp=${SOURCE_DATE_EPOCH:-$(date +"%s")}
+datestamp=$(date -d "@$timestamp")
+filestamp=$(date -d "@$timestamp" +"%Y%m%d%H%M.%S")
 
-# Replace in-place version number in header file:
+# Replace version number in header file:
 sed -i.bak \
   -e "s/^#define LIBSSH2_VERSION .*/#define LIBSSH2_VERSION \"$libversion\"/g" \
   -e "s/^#define LIBSSH2_VERSION_NUM .*/#define LIBSSH2_VERSION_NUM 0x$numeric/g" \
@@ -55,17 +58,16 @@ sed -i.bak \
   -e "s/^#define LIBSSH2_VERSION_PATCH .*/#define LIBSSH2_VERSION_PATCH $patch/g" \
   -e "s/^#define LIBSSH2_TIMESTAMP .*/#define LIBSSH2_TIMESTAMP \"$datestamp\"/g" \
   "$HEADER"
-
 rm -f "$HEADER.bak"
-
-echo "libssh2 version $libversion"
-echo "libssh2 numerical $numeric"
-echo "datestamp $datestamp"
 
 if test -n "$only"; then
   # done!
   exit
 fi
+
+echo "libssh2 version $libversion"
+echo "libssh2 numerical $numeric"
+echo "datestamp $datestamp"
 
 findprog() {
   file="$1"
@@ -94,7 +96,7 @@ else
   automake --include-deps Makefile >/dev/null
 fi
 
-#######################################################################
+############################################################################
 #
 # Generate the changelog
 #
@@ -115,6 +117,23 @@ if test "$res" != 0; then
   echo "make dist failed"
   exit 2
 fi
+
+retar() {
+  tempdir=$1
+  rm -rf "$tempdir"
+  mkdir "$tempdir"
+  cd "$tempdir"
+  gzip -dc "../$targz" | tar -xf -
+  find libssh2-* -type f -exec touch -c -t "$filestamp" '{}' +
+  find libssh2-* -type f | sort | tar --create --format=ustar --owner=0 --group=0 --numeric-owner --files-from - | gzip --best --no-name > out.tar.gz
+  mv out.tar.gz ../
+  cd ..
+  rm -rf "$tempdir"
+}
+
+retar ".tarbuild"
+echo "replace $targz with out.tar.gz"
+mv out.tar.gz "$targz"
 
 ############################################################################
 #
@@ -143,6 +162,7 @@ makezip() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
+  find . -depth -type d -exec touch -c -t "$filestamp" '{}' +
   find . | sort | zip -9 -X "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..
@@ -154,10 +174,14 @@ echo "Generating $zip"
 tempdir=".builddir"
 makezip
 
+# Set deterministic timestamp
+touch -c -t "$filestamp" "$targz" "$bzip2" "$xz" "$zip"
+
 echo "------------------"
 echo "maketgz report:"
 echo ""
-ls -l "$targz" "$bzip2" "$zip" "$xz"
+ls -l "$targz" "$bzip2" "$xz" "$zip"
+sha256sum "$targz" "$bzip2" "$xz" "$zip"
 
 echo "Run this:"
-echo "gpg -b -a '$targz' && gpg -b -a '$bzip2' && gpg -b -a '$zip' && gpg -b -a '$xz'"
+echo "gpg -b -a '$targz' && gpg -b -a '$bzip2' && gpg -b -a '$xz' && gpg -b -a '$zip'"


### PR DESCRIPTION
- support `SOURCE_DATE_EPOCH` for reproducibility.
- make tarballs reproducible.
- make file timestamps in tarball/zip reproducible.
- make directory timestamps in zip reproducible.
- make timestamps of tarballs/zip reproducible.
- make file order in tarball/zip reproducible.
- use POSIX ustar tarball format to avoid supply chain vulnerability: https://seclists.org/oss-sec/2021/q4/0
- make uid/gid in tarball reproducible.
- omit owner user/group names from tarball for reproducibility and privacy.
- omit current timestamp from .gz header for reproducibility.
- display SHA-256 hashes of produced tarballs/zip. (Requires `sha256sum`)
- re-sync formatting with curl's `maketgz`.

Closes #1357