### PR TITLE
os400: fix shellcheck warnings in scripts

### DIFF
--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: curl
 
-# FIXME: os400/* scripts
-
 shellcheck --version
 # shellcheck disable=SC2046
 shellcheck --exclude=1091 \
   --enable=avoid-nullary-conditions,deprecate-which \
-  $(grep -l -E '^#!(/usr/bin/env bash|/bin/sh|/bin/bash)' $(git ls-files | grep -v -F 'os400/'))
+  $(grep -l -E '^#!(/usr/bin/env bash|/bin/sh|/bin/bash)' $(git ls-files))

--- a/os400/config400.default
+++ b/os400/config400.default
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/os400/initscript.sh
+++ b/os400/initscript.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
@@ -94,8 +94,6 @@ action_needed()
 {
         [ ! -e "${1}" ] && return 0
         [ -n "${2}" ] || return 1
-        # FIXME: not POSIX
-        # shellcheck disable=SC3013
         [ "${1}" -ot "${2}" ] && return 0
         return 1
 }

--- a/os400/initscript.sh
+++ b/os400/initscript.sh
@@ -7,14 +7,14 @@ setenv()
 {
         #       Define and export.
 
-        eval ${1}="${2}"
-        export ${1}
+        eval "${1}=${2}"
+        export "${1?}"
 }
 
 
 case "${SCRIPTDIR}" in
 /*)     ;;
-*)      SCRIPTDIR="`pwd`/${SCRIPTDIR}"
+*)      SCRIPTDIR="$(pwd)/${SCRIPTDIR}"
 esac
 
 while true
@@ -26,13 +26,14 @@ done
 
 #  The script directory is supposed to be in $TOPDIR/os400.
 
-TOPDIR=`dirname "${SCRIPTDIR}"`
+TOPDIR=$(dirname "${SCRIPTDIR}")
 export SCRIPTDIR TOPDIR
 
 #  Extract the SONAME from the library makefile.
 
-SONAME=`sed -e '/^VERSION=/!d' -e 's/^.* \([0-9]*\):.*$/\1/' -e 'q'     \
-                                                < "${TOPDIR}/src/Makefile.am"`
+SONAME=$(sed -e '/^VERSION=/!d'                                         \
+             -e 's/^.* \([0-9]*\):.*$/\1/' -e 'q'                       \
+                                                < "${TOPDIR}/src/Makefile.am")
 export SONAME
 
 #       Get OS/400 configuration parameters.
@@ -44,24 +45,24 @@ fi
 
 #       Need to get the version definitions.
 
-LIBSSH2_VERSION=`grep '^#define  *LIBSSH2_VERSION '                     \
+LIBSSH2_VERSION=$(grep '^#define  *LIBSSH2_VERSION '                    \
                         "${TOPDIR}/include/libssh2.h"                   |
-                sed 's/.*"\(.*\)".*/\1/'`
-LIBSSH2_VERSION_MAJOR=`grep '^#define  *LIBSSH2_VERSION_MAJOR '         \
+                sed 's/.*"\(.*\)".*/\1/')
+LIBSSH2_VERSION_MAJOR=$(grep '^#define  *LIBSSH2_VERSION_MAJOR '        \
                         "${TOPDIR}/include/libssh2.h"                   |
-                sed 's/^#define  *LIBSSH2_VERSION_MAJOR  *\([^ ]*\).*/\1/'`
-LIBSSH2_VERSION_MINOR=`grep '^#define  *LIBSSH2_VERSION_MINOR '         \
+                sed 's/^#define  *LIBSSH2_VERSION_MAJOR  *\([^ ]*\).*/\1/')
+LIBSSH2_VERSION_MINOR=$(grep '^#define  *LIBSSH2_VERSION_MINOR '        \
                         "${TOPDIR}/include/libssh2.h"                   |
-                sed 's/^#define  *LIBSSH2_VERSION_MINOR  *\([^ ]*\).*/\1/'`
-LIBSSH2_VERSION_PATCH=`grep '^#define  *LIBSSH2_VERSION_PATCH '         \
+                sed 's/^#define  *LIBSSH2_VERSION_MINOR  *\([^ ]*\).*/\1/')
+LIBSSH2_VERSION_PATCH=$(grep '^#define  *LIBSSH2_VERSION_PATCH '        \
                         "${TOPDIR}/include/libssh2.h"                   |
-                sed 's/^#define  *LIBSSH2_VERSION_PATCH  *\([^ ]*\).*/\1/'`
-LIBSSH2_VERSION_NUM=`grep '^#define  *LIBSSH2_VERSION_NUM '             \
+                sed 's/^#define  *LIBSSH2_VERSION_PATCH  *\([^ ]*\).*/\1/')
+LIBSSH2_VERSION_NUM=$(grep '^#define  *LIBSSH2_VERSION_NUM '            \
                         "${TOPDIR}/include/libssh2.h"                   |
-                sed 's/^#define  *LIBSSH2_VERSION_NUM  *0x\([^ ]*\).*/\1/'`
-LIBSSH2_TIMESTAMP=`grep '^#define  *LIBSSH2_TIMESTAMP '                 \
+                sed 's/^#define  *LIBSSH2_VERSION_NUM  *0x\([^ ]*\).*/\1/')
+LIBSSH2_TIMESTAMP=$(grep '^#define  *LIBSSH2_TIMESTAMP '                \
                         "${TOPDIR}/include/libssh2.h"                   |
-                sed 's/.*"\(.*\)".*/\1/'`
+                sed 's/.*"\(.*\)".*/\1/')
 export LIBSSH2_VERSION
 export LIBSSH2_VERSION_MAJOR LIBSSH2_VERSION_MINOR LIBSSH2_VERSION_PATCH
 export LIBSSH2_VERSION_NUM LIBSSH2_TIMESTAMP
@@ -92,7 +93,9 @@ action_needed()
 
 {
         [ ! -e "${1}" ] && return 0
-        [ "${2}" ] || return 1
+        [ -n "${2}" ] || return 1
+        # FIXME: not POSIX
+        # shellcheck disable=SC3013
         [ "${1}" -ot "${2}" ] && return 0
         return 1
 }
@@ -109,7 +112,7 @@ canonicalize_path()
 {
         if expr "${1}" : '^/' > /dev/null
         then    P="${1}"
-        else    P="`pwd`/${1}"
+        else    P="$(pwd)/${1}"
         fi
 
         R=
@@ -120,7 +123,8 @@ canonicalize_path()
         do      IFS="${IFSSAVE}"
                 case "${C}" in
                 .)      ;;
-                ..)     R=`expr "${R}" : '^\(.*/\)..*'`
+                ..)     R=$(expr \
+                                 "${R}" : '^\(.*/\)..*')
                         ;;
                 ?*)     R="${R}${C}/"
                         ;;
@@ -129,7 +133,7 @@ canonicalize_path()
         done
 
         IFS="${IFSSAVE}"
-        echo "/`expr "${R}" : '^\(.*\)/'`"
+        echo "/$(expr "${R}" : '^\(.*\)/')"
 }
 
 
@@ -145,7 +149,8 @@ make_module()
         MODULES="${MODULES} ${1}"
         MODIFSNAME="${LIBIFSNAME}/${1}.MODULE"
         action_needed "${MODIFSNAME}" "${2}" || return 0;
-        SRCDIR=`dirname \`canonicalize_path "${2}"\``
+        SRCDIR="$(dirname \
+                          "$(canonicalize_path "${2}")")"
 
         #       #pragma convert has to be in the source file itself, i.e.
         #               putting it in an include file makes it only active
@@ -153,10 +158,12 @@ make_module()
         #       Thus we build a temporary file with the pragma prepended to
         #               the source file and we compile that temporary file.
 
-        echo "#line 1 \"${2}\"" > __tmpsrcf.c
-        echo "#pragma convert(819)" >> __tmpsrcf.c
-        echo "#line 1" >> __tmpsrcf.c
-        cat "${2}" >> __tmpsrcf.c
+        {
+                echo "#line 1 \"${2}\""
+                echo "#pragma convert(819)"
+                echo "#line 1"
+                cat "${2}"
+        } > __tmpsrcf.c
         CMD="CRTCMOD MODULE(${TARGETLIB}/${1}) SRCSTMF('__tmpsrcf.c')"
 #       CMD="${CMD} SYSIFCOPT(*IFS64IO) OPTION(*INCDIRFIRST *SHOWINC *SHOWSYS)"
         CMD="${CMD} SYSIFCOPT(*IFS64IO) OPTION(*INCDIRFIRST)"
@@ -185,12 +192,13 @@ make_module()
         then    DEFINES="${DEFINES} LIBSSH2_NO_MD5"
         fi
 
-        if [ "${DEFINES}" ]
+        if [ -n "${DEFINES}" ]
         then    CMD="${CMD} DEFINE(${DEFINES})"
         fi
 
         system "${CMD}"
         rm -f __tmpsrcf.c
+        # shellcheck disable=SC2034
         LINK=YES
 }
 

--- a/os400/make-include.sh
+++ b/os400/make-include.sh
@@ -5,9 +5,9 @@
 #       Installation of the header files in the OS/400 library.
 #
 
-SCRIPTDIR=`dirname "${0}"`
+SCRIPTDIR=$(dirname "${0}")
 . "${SCRIPTDIR}/initscript.sh"
-cd "${TOPDIR}/include"
+cd "${TOPDIR}/include" || exit 1
 
 
 #       Create the OS/400 source program file for the header files.
@@ -47,11 +47,11 @@ copy_hfile()
 #       Copy the header files.
 
 for HFILE in *.h "${TOPDIR}/os400/libssh2_ccsid.h"
-do      DEST="${SRCPF}/`db2_name \"${HFILE}\"`.MBR"
+do      DEST="${SRCPF}/$(db2_name "${HFILE}").MBR"
 
         if action_needed "${DEST}" "${HFILE}"
         then    copy_hfile "${DEST}" "${HFILE}"
-                IFSDEST="${IFSINCLUDE}/`basename \"${HFILE}\"`"
+                IFSDEST="${IFSINCLUDE}/$(basename "${HFILE}")"
                 rm -f "${IFSDEST}"
                 ln -s "${DEST}" "${IFSDEST}"
         fi

--- a/os400/make-include.sh
+++ b/os400/make-include.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make-rpg.sh
+++ b/os400/make-rpg.sh
@@ -5,9 +5,9 @@
 #       Installation of the ILE/RPG header files in the OS/400 library.
 #
 
-SCRIPTDIR=`dirname "${0}"`
+SCRIPTDIR=$(dirname "${0}")
 . "${SCRIPTDIR}/initscript.sh"
-cd "${TOPDIR}/os400/libssh2rpg"
+cd "${TOPDIR}/os400/libssh2rpg" || exit 1
 
 
 #       Create the OS/400 source program file for the ILE/RPG header files.
@@ -24,9 +24,9 @@ fi
 #       Map file names to DB2 name syntax.
 
 for HFILE in *.rpgle *.rpgle.in
-do      NAME="`basename \"${HFILE}\" .in`"
-        VAR="`basename \"${NAME}\" .rpgle`"
-        VAL="`db2_name \"${NAME}\"`"
+do      NAME="$(basename "${HFILE}" .in)"
+        VAR="$(basename "${NAME}" .rpgle)"
+        VAL="$(db2_name "${NAME}")"
 
         eval "VAR_${VAR}=\"${VAL}\""
         echo "${VAR} s/${VAR}/${VAL}/g"
@@ -64,7 +64,7 @@ fi
 for HFILE in *.rpgle *.rpgle.in
 do      IFSCMD="cat \"${HFILE}\""
         DB2CMD="change_include < \"${HFILE}\""
-        IFSFILE="`basename \"${HFILE}\" .in`"
+        IFSFILE="$(basename "${HFILE}" .in)"
 
         case "${HFILE}" in
 
@@ -79,7 +79,7 @@ do      IFSCMD="cat \"${HFILE}\""
         then    eval "${IFSCMD}" > "${IFSDEST}"
         fi
 
-        eval DB2MBR="\"\${VAR_`basename \"${IFSDEST}\" .rpgle`}\""
+        eval DB2MBR="\"\${VAR_$(basename "${IFSDEST}" .rpgle)}\""
         DB2DEST="${SRCPF}/${DB2MBR}.MBR"
 
         if action_needed "${DB2DEST}" "${HFILE}"
@@ -87,7 +87,7 @@ do      IFSCMD="cat \"${HFILE}\""
 
                 #       Need to translate to target CCSID.
 
-                CMD="CPY OBJ('`pwd`/tmphdrfile') TOOBJ('${DB2DEST}')"
+                CMD="CPY OBJ('$(pwd)/tmphdrfile') TOOBJ('${DB2DEST}')"
                 CMD="${CMD} TOCCSID(${TGTCCSID}) DTAFMT(*TEXT) REPLACE(*YES)"
                 system "${CMD}"
         fi

--- a/os400/make-rpg.sh
+++ b/os400/make-rpg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make-src.sh
+++ b/os400/make-src.sh
@@ -5,9 +5,9 @@
 #       libssh2 compilation script for the OS/400.
 #
 
-SCRIPTDIR=`dirname "${0}"`
+SCRIPTDIR=$(dirname "${0}")
 . "${SCRIPTDIR}/initscript.sh"
-cd "${TOPDIR}/src"
+cd "${TOPDIR}/src" || exit 1
 
 
 #       Function to extract external prototypes from header files.
@@ -48,10 +48,12 @@ fi
 
 #      Create and compile the identification source file.
 
-echo '#pragma comment(user, "libssh2 version '"${LIBSSH2_VERSION}"'")' > os400.c
-echo '#pragma comment(user, __DATE__)' >> os400.c
-echo '#pragma comment(user, __TIME__)' >> os400.c
-echo '#pragma comment(copyright, "See COPYING file. OS/400 version by P. Monnerat")' >> os400.c
+{
+        echo '#pragma comment(user, "libssh2 version '"${LIBSSH2_VERSION}"'")'
+        echo '#pragma comment(user, __DATE__)'
+        echo '#pragma comment(user, __TIME__)'
+        echo '#pragma comment(copyright, "See COPYING file. OS/400 version by P. Monnerat")'
+} > os400.c
 make_module     OS400           os400.c
 LINK=                           # No need to rebuild service program yet.
 MODULES=
@@ -80,28 +82,28 @@ fi
 
 #       Get source list.
 
-cat Makefile.inc                                                        |
-  sed -e ':begin'                                                       \
-    -e '/\\$/{'                                                         \
-    -e 's/\\$/ /'                                                       \
-    -e 'N'                                                              \
-    -e 'bbegin'                                                         \
-    -e '}'                                                              \
-    -e 's/\n//g'                                                        \
-    -e 's/[[:space:]]*$//'                                              \
-    -e 's/^\([A-Za-z][A-Za-z0-9_]*\)[[:space:]]*=[[:space:]]*\(.*\)/\1="\2"/' \
-    -e 's/\$(\([A-Za-z][A-Za-z0-9_]*\))/${\1}/g'                        \
-        > tmpscript.sh
+sed -e ':begin'                                                         \
+  -e '/\\$/{'                                                           \
+  -e 's/\\$/ /'                                                         \
+  -e 'N'                                                                \
+  -e 'bbegin'                                                           \
+  -e '}'                                                                \
+  -e 's/\n//g'                                                          \
+  -e 's/[[:space:]]*$//'                                                \
+  -e 's/^\([A-Za-z][A-Za-z0-9_]*\)[[:space:]]*=[[:space:]]*\(.*\)/\1="\2"/' \
+  -e 's/\$(\([A-Za-z][A-Za-z0-9_]*\))/${\1}/g'                          \
+      < Makefile.inc > tmpscript.sh
 . ./tmpscript.sh
 
 
 #       Compile the sources into modules.
 
-INCLUDES="'`pwd`'"
+# shellcheck disable=SC2034
+INCLUDES="'$(pwd)'"
 
 for SRC in "${TOPDIR}/os400/os400sys.c" "${TOPDIR}/os400/ccsid.c"       \
            ${CSOURCES} macros.c
-do      MODULE=`db2_name "${SRC}"`
+do      MODULE=$(db2_name "${SRC}")
         make_module "${MODULE}" "${SRC}"
 done
 
@@ -112,7 +114,7 @@ if action_needed "${LIBIFSNAME}/${STATBNDDIR}.BNDDIR"
 then    LINK=YES
 fi
 
-if [ "${LINK}" ]
+if [ -n "${LINK}" ]
 then    rm -rf "${LIBIFSNAME}/${STATBNDDIR}.BNDDIR"
         CMD="CRTBNDDIR BNDDIR(${TARGETLIB}/${STATBNDDIR})"
         CMD="${CMD} TEXT('libssh2 API static binding directory')"
@@ -145,10 +147,10 @@ fi
 
 #       Gather the list of symbols to export.
 
-EXPORTS=`cat "${TOPDIR}"/include/*.h "${TOPDIR}/os400/macros.h"         \
+EXPORTS=$(cat "${TOPDIR}"/include/*.h "${TOPDIR}/os400/macros.h"        \
              "${TOPDIR}/os400/libssh2_ccsid.h"                          |
          extproto                                                       |
-         sed -e 's/(.*//;s/[^A-Za-z0-9_]/ /g;s/ *$//;s/^.* //'`
+         sed -e 's/(.*//;s/[^A-Za-z0-9_]/ /g;s/ *$//;s/^.* //')
 
 #       Create the service program exportation file in DB2 member if needed.
 
@@ -158,7 +160,7 @@ if action_needed "${BSF}" Makefile.am
 then    LINK=YES
 fi
 
-if [ "${LINK}" ]
+if [ -n "${LINK}" ]
 then    echo " STRPGMEXP PGMLVL(*CURRENT) SIGNATURE('LIBSSH2_${SONAME}')" \
             > "${BSF}"
         for EXPORT in ${EXPORTS}
@@ -175,7 +177,7 @@ if action_needed "${LIBIFSNAME}/${SRVPGM}.SRVPGM"
 then    LINK=YES
 fi
 
-if [ "${LINK}" ]
+if [ -n "${LINK}" ]
 then    CMD="CRTSRVPGM SRVPGM(${TARGETLIB}/${SRVPGM})"
         CMD="${CMD} SRCFILE(${TARGETLIB}/TOOLS) SRCMBR(BNDSRC)"
         CMD="${CMD} MODULE(${TARGETLIB}/OS400)"
@@ -199,7 +201,7 @@ if action_needed "${LIBIFSNAME}/${DYNBNDDIR}.BNDDIR"
 then    LINK=YES
 fi
 
-if [ "${LINK}" ]
+if [ -n "${LINK}" ]
 then    rm -rf "${LIBIFSNAME}/${DYNBNDDIR}.BNDDIR"
         CMD="CRTBNDDIR BNDDIR(${TARGETLIB}/${DYNBNDDIR})"
         CMD="${CMD} TEXT('libssh2 API dynamic binding directory')"

--- a/os400/make-src.sh
+++ b/os400/make-src.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make.sh
+++ b/os400/make.sh
@@ -7,9 +7,9 @@
 #
 #       This is a shell script since make is not a standard component of OS/400.
 
-SCRIPTDIR=`dirname "${0}"`
+SCRIPTDIR=$(dirname "${0}")
 . "${SCRIPTDIR}/initscript.sh"
-cd "${TOPDIR}"
+cd "${TOPDIR}" || exit 1
 
 
 #       Create the OS/400 library if it does not exist.
@@ -34,7 +34,7 @@ fi
 for TEXT in "${TOPDIR}/COPYING" "${SCRIPTDIR}/README400"                \
     "${TOPDIR}/NEWS" "${TOPDIR}/README" "${TOPDIR}/docs/AUTHORS"        \
     "${TOPDIR}/docs/BINDINGS.md"
-do      MEMBER="${LIBIFSNAME}/DOCS.FILE/`db2_name \"${TEXT}\"`.MBR"
+do      MEMBER="${LIBIFSNAME}/DOCS.FILE/$(db2_name "${TEXT}").MBR"
 
         if action_needed "${MEMBER}" "${TEXT}"
         then    CMD="CPY OBJ('${TEXT}') TOOBJ('${MEMBER}') TOCCSID(${TGTCCSID})"
@@ -56,8 +56,8 @@ fi
 #       Copy RPG examples if needed.
 
 for EXAMPLE in "${SCRIPTDIR}/rpg-examples"/*
-do      MEMBER="`basename \"${EXAMPLE}\"`"
-        IFSMEMBER="${LIBIFSNAME}/RPGXAMPLES.FILE/`db2_name \"${MEMBER}\"`.MBR"
+do      MEMBER="$(basename "${EXAMPLE}")"
+        IFSMEMBER="${LIBIFSNAME}/RPGXAMPLES.FILE/$(db2_name "${MEMBER}").MBR"
 
         [ -e "${EXAMPLE}" ] || continue
 
@@ -65,8 +65,8 @@ do      MEMBER="`basename \"${EXAMPLE}\"`"
         then    CMD="CPY OBJ('${EXAMPLE}') TOOBJ('${IFSMEMBER}')"
                 CMD="${CMD} TOCCSID(${TGTCCSID}) DTAFMT(*TEXT) REPLACE(*YES)"
                 system "${CMD}"
-                MBRTEXT=`sed -e '1!d;/^      \*/!d;s/^ *\* *//'         \
-                             -e 's/ *$//;s/'"'"'/&&/g' < "${EXAMPLE}"`
+                MBRTEXT=$(sed -e '1!d;/^      \*/!d;s/^ *\* *//'        \
+                              -e 's/ *$//;s/'"'"'/&&/g' < "${EXAMPLE}")
                 CMD="CHGPFM FILE(${TARGETLIB}/RPGXAMPLES) MBR(${MEMBER})"
                 CMD="${CMD} SRCTYPE(RPGLE) TEXT('${MBRTEXT}')"
                 system "${CMD}"

--- a/os400/make.sh
+++ b/os400/make.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
- use `$()` instead of backticks, and re-arrange double-quotes inside.
- add missing `|| exit 1` to `cd` calls. (could be dropped by using `set -eu`.)
- add `-n` to a few `if`s.
- shorten redirections by using `{} >` (as shellcheck recommended).
- silence warnings where variables were detected as unused (SC2034).
- a couple misc updates to silence warnings.
- switch to bash shebang for `-ot` feature.
- split two lines to unbreak syntax highlighting in my editor. (`$(expr \`, `$(dirname \`)

Also enable CI checks for OS/400 shell scripts.

Ref: d88b9bcdafe9d19aad2fb120d0a0acb3edab64f7
Closes #1358

/cc @monnerat 
