### PR TITLE
maketgz: add reproducible dir entries to tarballs

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -124,8 +124,8 @@ retar() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find libssh2-* -type f -exec touch -c -t "$filestamp" '{}' +
-  find libssh2-* -type f | sort | tar --create --format=ustar --owner=0 --group=0 --numeric-owner --files-from - | gzip --best --no-name > out.tar.gz
+  find libssh2-* -depth -exec touch -c -t "$filestamp" '{}' +
+  tar --create --format=ustar --owner=0 --group=0 --numeric-owner --sort=name libssh2-* | gzip --best --no-name > out.tar.gz
   mv out.tar.gz ../
   cd ..
   rm -rf "$tempdir"
@@ -162,7 +162,6 @@ makezip() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find . -depth -type d -exec touch -c -t "$filestamp" '{}' +
   find . | sort | zip -9 -X "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..


### PR DESCRIPTION
In the initial implementation of reproducible tarballs, they were
missing directory entries, while .zip archives had them. It meant
that on extracting the tarball, on-disk directory entries got the
current timestamp.

This patch fixes this by including directory entries in the tarball,
with reproducible timestamps. It also moves sorting inside tar,
to ensure reproducible directory entry timestamps on extract
(without the need of `--delay-directory-restore` option, when
extracting with GNU tar. BSD tar got that right by default.)

GNU tar 1.28 (2014-07-28) introduced `--sort=`.

Follow-up to d52fe1b4358fab891037d86b5c73c098079567db #1357
Closes #1359
