### PR TITLE
Some fixes for the os/400

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ WIN32FILES = src/libssh2.rc
 
 OS400FILES = os400/README400 os400/initscript.sh os400/make.sh \
   os400/make-src.sh os400/make-rpg.sh os400/make-include.sh \
+  os400/config400.default \
   os400/os400sys.c os400/ccsid.c \
   os400/libssh2_config.h os400/macros.h os400/libssh2_ccsid.h \
   os400/include/alloca.h os400/include/sys/socket.h os400/include/stdio.h \
@@ -33,7 +34,8 @@ OS400FILES = os400/README400 os400/initscript.sh os400/make.sh \
   os400/libssh2rpg/libssh2.rpgle.in \
   os400/libssh2rpg/libssh2_ccsid.rpgle.in \
   os400/libssh2rpg/libssh2_publickey.rpgle \
-  os400/libssh2rpg/libssh2_sftp.rpgle
+  os400/libssh2rpg/libssh2_sftp.rpgle \
+  os400/rpg-examples/SFTPXMPLE
 
 EXTRA_DIST = $(WIN32FILES) get_ver.awk \
   maketgz RELEASE-NOTES libssh2.pc.in $(VMSFILES) config.rpath \

--- a/os400/config400.default
+++ b/os400/config400.default
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/os400/initscript.sh
+++ b/os400/initscript.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/os400/make-include.sh
+++ b/os400/make-include.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make-rpg.sh
+++ b/os400/make-rpg.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make-src.sh
+++ b/os400/make-src.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make.sh
+++ b/os400/make.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
Add two recent files to the distribution.

Build scripts must be executed by the os/400 shell (sh), not bash which is a PASE program: The `-ot` non-posix test extension works in os/400 as well.

This is a follow-up to 8457c37 and c662570.

Thanks for considering it.