### PR TITLE
os400: fix shellcheck warnings in scripts (fixups)

### DIFF
--- a/os400/config400.default
+++ b/os400/config400.default
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/os400/initscript.sh
+++ b/os400/initscript.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
@@ -94,6 +94,7 @@ action_needed()
 {
         [ ! -e "${1}" ] && return 0
         [ -n "${2}" ] || return 1
+        # shellcheck disable=SC3013
         [ "${1}" -ot "${2}" ] && return 0
         return 1
 }

--- a/os400/initscript.sh
+++ b/os400/initscript.sh
@@ -122,8 +122,7 @@ canonicalize_path()
         do      IFS="${IFSSAVE}"
                 case "${C}" in
                 .)      ;;
-                ..)     R=$(expr \
-                                 "${R}" : '^\(.*/\)..*')
+                ..)     R="$(expr "${R}" : '^\(.*/\)..*')"
                         ;;
                 ?*)     R="${R}${C}/"
                         ;;
@@ -148,8 +147,7 @@ make_module()
         MODULES="${MODULES} ${1}"
         MODIFSNAME="${LIBIFSNAME}/${1}.MODULE"
         action_needed "${MODIFSNAME}" "${2}" || return 0;
-        SRCDIR="$(dirname \
-                          "$(canonicalize_path "${2}")")"
+        SRCDIR="$(dirname "$(canonicalize_path "${2}")")"
 
         #       #pragma convert has to be in the source file itself, i.e.
         #               putting it in an include file makes it only active

--- a/os400/make-include.sh
+++ b/os400/make-include.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make-rpg.sh
+++ b/os400/make-rpg.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make-src.sh
+++ b/os400/make-src.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/os400/make.sh
+++ b/os400/make.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
- Build scripts must be executed by the os/400 shell (sh), not bash which
  is a PASE program: The `-ot` non-POSIX test extension works in os/400 as
  well. Ref: https://github.com/libssh2/libssh2/pull/1364#issue-2241646754

- Drop/fixup mods trying to make some syntax highlighters happier.

Follow-up to c6625707b94d9093f38f1a0a4d89c11b64f12ba8 #1358
Assisted-by: Patrick Monnerat
Closes #1364
Closes #1366
