### PR TITLE
wincng: fix DH_GEX_MAXGROUP being set higher than what is supported

### DIFF
--- a/src/wincng.h
+++ b/src/wincng.h
@@ -476,7 +476,7 @@ struct _libssh2_wincng_bignum {
    diffie-hellman-group-exchange-sha1 */
 #define LIBSSH2_DH_GEX_MINGROUP     2048
 #define LIBSSH2_DH_GEX_OPTGROUP     4096
-#define LIBSSH2_DH_GEX_MAXGROUP     8192
+#define LIBSSH2_DH_GEX_MAXGROUP     4096
 
 #define LIBSSH2_DH_MAX_MODULUS_BITS 16384
 


### PR DESCRIPTION
In 6dc42e9d625deb816a051d312d09e68926959e78, `LIBSSH2_DH_GEX_MAXGROUP` was introduced to specify crypto-backend-specific modulus sizes. Unfortunately, the max size for the wincng DH modulus was defined to 8192, probably because this is the value most other backends support.

According to [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgeneratekeypair), `BCryptGenerateKeyPair` currently only supports up to 4096 bit keys when the selected algorithm is `BCRYPT_DH_ALGORITHM`. Requesting larger keys when calling `BCryptGenerateKeyPair` in `_libssh2_dh_key_pair` will always result in `STATUS_INVALID_PARAMETER` being returned and ultimately key exchange failing.

When attempting to connect to any server that offers 8192 bit DH, this will cause key exchange to always fail when using the wincng backend. Reducing `LIBSSH2_DH_GEX_MAXGROUP` to 4096 fixes the issue.