### PR TITLE
ci/GHA: fixup Homebrew location (for ARM runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,28 +526,28 @@ jobs:
         crypto:
           - name: 'OpenSSL 3'
             install: openssl
-            configure: --with-crypto=openssl --with-libssl-prefix=/usr/local/opt/openssl
-            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
+            configure: --with-crypto=openssl "--with-libssl-prefix=$(brew --prefix)/opt/openssl"
+            cmake: -DCRYPTO_BACKEND=OpenSSL "-DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl"
           - name: 'OpenSSL 1.1'
             install: openssl@1.1
-            configure: --with-crypto=openssl --with-libssl-prefix=/usr/local/opt/openssl@1.1
-            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1
+            configure: --with-crypto=openssl "--with-libssl-prefix=$(brew --prefix)/opt/openssl@1.1"
+            cmake: -DCRYPTO_BACKEND=OpenSSL "-DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl@1.1"
           - name: 'LibreSSL'
             install: libressl
-            configure: --with-crypto=openssl --with-libssl-prefix=/usr/local/opt/libressl
-            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/usr/local/opt/libressl
+            configure: --with-crypto=openssl "--with-libssl-prefix=$(brew --prefix)/opt/libressl"
+            cmake: -DCRYPTO_BACKEND=OpenSSL "-DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/libressl"
           - name: 'wolfSSL'
             install: wolfssl
-            configure: --with-crypto=wolfssl --with-libwolfssl-prefix=/usr/local/opt/wolfssl
+            configure: --with-crypto=wolfssl "--with-libwolfssl-prefix=$(brew --prefix)/opt/wolfssl"
             cmake: -DCRYPTO_BACKEND=wolfSSL
           - name: 'libgcrypt'
             install: libgcrypt
-            configure: --with-crypto=libgcrypt --with-libgcrypt-prefix=/usr/local/opt/libgcrypt
+            configure: --with-crypto=libgcrypt "--with-libgcrypt-prefix=$(brew --prefix)/opt/libgcrypt"
             cmake: -DCRYPTO_BACKEND=Libgcrypt
           - name: 'mbedTLS'
             install: mbedtls
-            configure: --with-crypto=mbedtls --with-libmbedcrypto-prefix=/usr/local/opt/mbedtls
-            cmake: -DCRYPTO_BACKEND=mbedTLS -DMBEDTLS_INCLUDE_DIR=/usr/local/opt/mbedtls/include -DMBEDCRYPTO_LIBRARY=/usr/local/opt/mbedtls/lib/libmbedcrypto.a
+            configure: --with-crypto=mbedtls "--with-libmbedcrypto-prefix=$(brew --prefix)/opt/mbedtls"
+            cmake: -DCRYPTO_BACKEND=mbedTLS "-DMBEDTLS_INCLUDE_DIR=$(brew --prefix)/opt/mbedtls/include" "-DMBEDCRYPTO_LIBRARY=$(brew --prefix)/opt/mbedtls/lib/libmbedcrypto.a"
     steps:
       - name: 'install packages'
         run: brew install automake ${{ matrix.crypto.install }}


### PR DESCRIPTION
GHA macOS runners became ARM64 machines. Make the Homebrew prefix
dynamic to adapt to these installations.

Closes #1373
