### PR TITLE
ci/GHA: try fixing `autoreconf` failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,7 +550,7 @@ jobs:
             cmake: -DCRYPTO_BACKEND=mbedTLS "-DMBEDTLS_INCLUDE_DIR=$(brew --prefix)/opt/mbedtls/include" "-DMBEDCRYPTO_LIBRARY=$(brew --prefix)/opt/mbedtls/lib/libmbedcrypto.a"
     steps:
       - name: 'install packages'
-        run: brew install automake ${{ matrix.crypto.install }}
+        run: brew install automake libtool ${{ matrix.crypto.install }}
       - uses: actions/checkout@v4
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}


### PR DESCRIPTION
```
autoreconf -fi
  shell: /bin/bash -e {0}
configure.ac:75: error: possibly undefined macro: AC_LIBTOOL_WIN32_DLL
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:76: error: possibly undefined macro: AC_PROG_LIBTOOL
autoreconf: error: /opt/homebrew/Cellar/autoconf/2.72/bin/autoconf failed with exit status: 1
```
Ref: https://github.com/libssh2/libssh2/actions/runs/8833608758/job/24253334557#step:4:1