### PR TITLE
ci/GHA: fix gcrypt with autotools/macOS/Homebrew/ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,7 +542,7 @@ jobs:
             cmake: -DCRYPTO_BACKEND=wolfSSL
           - name: 'libgcrypt'
             install: libgcrypt
-            configure: --with-crypto=libgcrypt "--with-libgcrypt-prefix=$(brew --prefix)/opt/libgcrypt"
+            configure: --with-crypto=libgcrypt "--with-libgcrypt-prefix=$(brew --prefix)"
             cmake: -DCRYPTO_BACKEND=Libgcrypt
           - name: 'mbedTLS'
             install: mbedtls


### PR DESCRIPTION
mbedtls configure fails to detect anything due to this:
```
configure:23101: gcc -o conftest -g -O2 -I/opt/homebrew/include  conftest.c  -lmbedcrypto -lz >&5
ld: library 'mbedcrypto' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
