### PR TITLE
autotools: use `AM_CFLAGS`

### DIFF
--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -11,4 +11,4 @@ AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/src -I$(top_srcdir)/include
 LDADD = $(top_builddir)/src/libssh2.la
 
 # This might hold -Werror
-CFLAGS += @LIBSSH2_CFLAG_EXTRAS@
+AM_CFLAGS = @LIBSSH2_CFLAG_EXTRAS@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,7 @@ lib_LTLIBRARIES = libssh2.la
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/include
 
 # This might hold -Werror
-CFLAGS += @LIBSSH2_CFLAG_EXTRAS@
+AM_CFLAGS = @LIBSSH2_CFLAG_EXTRAS@
 
 VERSION=-version-info 1:1:0
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS = ossfuzz
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/src -I$(top_srcdir)/include
 
 # This might hold -Werror
-CFLAGS += @LIBSSH2_CFLAG_EXTRAS@
+AM_CFLAGS = @LIBSSH2_CFLAG_EXTRAS@
 
 # Get DOCKER_TESTS, DOCKER_TESTS_STATIC, STANDALONE_TESTS, STANDALONE_TESTS_STATOC, SSHD_TESTS,
 # librunner_la_SOURCES defines and *_LDFLAGS for statically linked tests.


### PR DESCRIPTION
Use `AM_CFLAGS` to pass custom, per-target C flags. This replaces using
`CFLAGS` which triggered this warning when running `autoreconf -fi`:
```
tests/Makefile.am:8: warning: 'CFLAGS' is a user variable, you should not override it;
tests/Makefile.am:8: use 'AM_CFLAGS' instead
```
(Only for `tests`, even though `example` and `src` also used this
method. The warning is also missing from curl, that also uses
`CFLAGS`.)

Follow-up to 3ec53f3ea26f61cbf2e0fbbeccb852fca7f9b156 #1286
Closes #1378
