### PR TITLE
build: silence warnings inside `FD_SET()`/`FD_ISSET()` macros

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -64,7 +64,6 @@ int main(int argc, char *argv[])
     LIBSSH2_CHANNEL *channel = NULL;
     const char *shost;
     int sport;
-    fd_set fds;
     struct timeval tv;
     ssize_t len, wr;
     char buf[16384];
@@ -247,8 +246,16 @@ int main(int argc, char *argv[])
     libssh2_session_set_blocking(session, 0);
 
     for(;;) {
+        fd_set fds;
         FD_ZERO(&fds);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
         FD_SET(forwardsock, &fds);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         tv.tv_sec = 0;
         tv.tv_usec = 100000;
         rc = select((int)(forwardsock + 1), &fds, NULL, NULL, &tv);
@@ -256,7 +263,14 @@ int main(int argc, char *argv[])
             fprintf(stderr, "failed to select().\n");
             goto shutdown;
         }
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
         if(rc && FD_ISSET(forwardsock, &fds)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             len = recv(forwardsock, buf, sizeof(buf), 0);
             if(len < 0) {
                 fprintf(stderr, "failed to recv().\n");

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -64,7 +64,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -48,7 +48,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -56,7 +56,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);
@@ -251,8 +258,15 @@ int main(int argc, char *argv[])
 
         FD_ZERO(&fd);
         FD_ZERO(&fd2);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
         FD_SET(sock, &fd);
         FD_SET(sock, &fd2);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
         /* wait for readable or writeable */
         rc = select((int)(sock + 1), &fd, &fd2, NULL, &timeout);
@@ -316,8 +330,15 @@ int main(int argc, char *argv[])
 
             FD_ZERO(&fd);
             FD_ZERO(&fd2);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
             FD_SET(sock, &fd);
             FD_SET(sock, &fd2);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
             /* wait for readable or writeable */
             rc = select((int)(sock + 1), &fd, &fd2, NULL, &timeout);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -65,7 +65,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -54,7 +54,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -55,7 +55,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -50,7 +50,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -47,7 +47,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -51,7 +51,14 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(socket_fd, &fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* now make sure we wait in the correct direction */
     dir = libssh2_session_block_directions(session);

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -66,7 +66,6 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_LISTENER *listener = NULL;
     LIBSSH2_CHANNEL *channel = NULL;
-    fd_set fds;
     struct timeval tv;
     ssize_t len, wr;
     char buf[16384];
@@ -245,8 +244,16 @@ int main(int argc, char *argv[])
     libssh2_session_set_blocking(session, 0);
 
     for(;;) {
+        fd_set fds;
         FD_ZERO(&fds);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
         FD_SET(forwardsock, &fds);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         tv.tv_sec = 0;
         tv.tv_usec = 100000;
         rc = select((int)(forwardsock + 1), &fds, NULL, NULL, &tv);
@@ -254,7 +261,14 @@ int main(int argc, char *argv[])
             fprintf(stderr, "failed to select().\n");
             goto shutdown;
         }
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
         if(rc && FD_ISSET(forwardsock, &fds)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             ssize_t nwritten;
             len = recv(forwardsock, buf, sizeof(buf), 0);
             if(len < 0) {

--- a/example/x11.c
+++ b/example/x11.c
@@ -210,7 +210,14 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, libssh2_socket_t sock)
     timeval_out.tv_usec = 0;
 
     FD_ZERO(&set);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(sock, &set);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     buf = calloc(bufsize, sizeof(char));
     if(!buf)
@@ -408,7 +415,14 @@ int main(int argc, char *argv[])
     for(;;) {
 
         FD_ZERO(&set);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
         FD_SET(fileno(stdin), &set);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
         /* Search if a resize pty has to be send */
         ioctl(fileno(stdin), TIOCGWINSZ, &w_size);

--- a/src/session.c
+++ b/src/session.c
@@ -674,13 +674,27 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
 
         if(dir & LIBSSH2_SESSION_BLOCK_INBOUND) {
             FD_ZERO(&rfd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
             FD_SET(session->socket_fd, &rfd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             readfd = &rfd;
         }
 
         if(dir & LIBSSH2_SESSION_BLOCK_OUTBOUND) {
             FD_ZERO(&wfd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
             FD_SET(session->socket_fd, &wfd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             writefd = &wfd;
         }
 
@@ -1635,19 +1649,40 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
         switch(fds[i].type) {
         case LIBSSH2_POLLFD_SOCKET:
             if(fds[i].events & LIBSSH2_POLLFD_POLLIN) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
                 FD_SET(fds[i].fd.socket, &rfds);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
                 if(fds[i].fd.socket > maxfd)
                     maxfd = fds[i].fd.socket;
             }
             if(fds[i].events & LIBSSH2_POLLFD_POLLOUT) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
                 FD_SET(fds[i].fd.socket, &wfds);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
                 if(fds[i].fd.socket > maxfd)
                     maxfd = fds[i].fd.socket;
             }
             break;
 
         case LIBSSH2_POLLFD_CHANNEL:
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
             FD_SET(fds[i].fd.channel->session->socket_fd, &rfds);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             if(fds[i].fd.channel->session->socket_fd > maxfd)
                 maxfd = fds[i].fd.channel->session->socket_fd;
             if(!session)
@@ -1655,7 +1690,14 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
             break;
 
         case LIBSSH2_POLLFD_LISTENER:
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
             FD_SET(fds[i].fd.listener->session->socket_fd, &rfds);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             if(fds[i].fd.listener->session->socket_fd > maxfd)
                 maxfd = fds[i].fd.listener->session->socket_fd;
             if(!session)
@@ -1832,6 +1874,10 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
             for(i = 0; i < nfds; i++) {
                 switch(fds[i].type) {
                 case LIBSSH2_POLLFD_SOCKET:
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
                     if(FD_ISSET(fds[i].fd.socket, &rfds)) {
                         fds[i].revents |= LIBSSH2_POLLFD_POLLIN;
                     }
@@ -1841,6 +1887,9 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
                     if(fds[i].revents) {
                         active_fds++;
                     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
                     break;
 
                 case LIBSSH2_POLLFD_CHANNEL:


### PR DESCRIPTION
Use an ugly workaround to silence `-Wsign-conversion` warnings triggered
by the internals of `FD_SET()`/`FD_ISSET()` macros. They've been showing
up in OmniOS CI builds when compiling `example` programs. They also have
been seen with older Cygwin and other envs and configurations.

Also scope two related variables in examples.

E.g.:
```
../../example/direct_tcpip.c:251:9: warning: conversion to 'long unsigned int' from 'libssh2_socket_t' {aka 'int'} may change the sign of the result [-Wsign-conversion]
  251 |         FD_SET(forwardsock, &fds);
      |         ^~~~~~
../../example/direct_tcpip.c:251:9: warning: conversion to 'long unsigned int' from 'libssh2_socket_t' {aka 'int'} may change the sign of the result [-Wsign-conversion]
../../example/direct_tcpip.c:251:9: warning: conversion to 'long unsigned int' from 'long int' may change the sign of the result [-Wsign-conversion]
../../example/direct_tcpip.c:251:9: warning: conversion to 'long int' from 'long unsigned int' may change the sign of the result [-Wsign-conversion]
../../example/direct_tcpip.c:259:18: warning: conversion to 'long unsigned int' from 'libssh2_socket_t' {aka 'int'} may change the sign of the result [-Wsign-conversion]
  259 |         if(rc && FD_ISSET(forwardsock, &fds)) {
      |                  ^~~~~~~~
../../example/direct_tcpip.c:259:18: warning: conversion to 'long unsigned int' from 'libssh2_socket_t' {aka 'int'} may change the sign of the result [-Wsign-conversion]
../../example/direct_tcpip.c:259:18: warning: conversion to 'long unsigned int' from 'long int' may change the sign of the result [-Wsign-conversion]
```
Ref: https://github.com/libssh2/libssh2/actions/runs/8854199687/job/24316762831#step:3:2020

Closes #1379