### PR TITLE
autotools: fix to update `LDFLAGS` for each detected dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,8 +558,6 @@ jobs:
       - name: 'autotools configure'
         if: ${{ matrix.build == 'autotools' }}
         run: |
-          # Workaround for GHA ARM runner issue
-          [ '${{ matrix.crypto.name }}' = 'mbedTLS' ] && export LDFLAGS="-L$(brew --prefix)/lib"
           mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
             --with-libz ${{ matrix.crypto.configure }} \
             --disable-docker-tests \

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -845,12 +845,11 @@ AC_DEFUN([LIBSSH2_LIB_HAVE_LINKFLAGS], [
 
   AC_LIB_HAVE_LINKFLAGS([$1], [$2], [$3])
 
-  LDFLAGS="$libssh2_save_LDFLAGS"
-
   if test "$ac_cv_lib$1" = "yes"; then :
     $4
   else
     CPPFLAGS="$libssh2_save_CPPFLAGS"
+    LDFLAGS="$libssh2_save_LDFLAGS"
   fi
 ])
 


### PR DESCRIPTION
autotools lib detection routine failed to extend LDFLAGS for each
detection. This could cause successful detection of a dependency, but
later failing to use it. This did not cause an issue as long as all
dependencies lived under the same prefix, but started breaking on macOS
ARM + Homebrew where this was no longer true for mbedTLS and zlib in
particular.

Follow-up to 844115393bffb4e92c6569204cbe4cd8e553480d #1381
Follow-up to ae2770de25949bc7c74e60b4cc6a011bbe1d3d7c #1377
Closes #1384
