### PR TITLE
Add flags parameter to LIBSSH2_AUTHAGENT_SIGN_FUNC

### DIFF
--- a/docs/libssh2_session_callback_set2.3
+++ b/docs/libssh2_session_callback_set2.3
@@ -121,6 +121,7 @@ The prototype of the callback:
 
 .nf
 void sign(LIBSSH2_SESSION* session,
+          unsigned int flags,
           unsigned char *blob, unsigned int blen,
           const unsigned char *data, unsigned int dlen,
           unsigned char **sig, unsigned int *sig_len,
@@ -129,7 +130,33 @@ void sign(LIBSSH2_SESSION* session,
 .fi
 
 When interfacing with an ssh-agent installed on the client system, this method
-can call libssh2_agent_sign(3) to perform signing.
+can call \fIlibssh2_agent_sign(3)\fP to perform signing.
+
+\fBflags\fP Flags to pass to the agent during the signing request, if any.
+Currently, the only flags SSH_AGENT_RSA_SHA2_256 (2) and SSH_AGENT_RSA_SHA2_512
+(4). You are responsible for defining constants for these flags if you need
+them.
+
+\fBblob\fP The key requested to perform the signature.
+
+\fBblen\fP The length of the key blob.
+
+\fBdata\fP The data to sign.
+
+\fBdlen\fP The length of the data.
+
+\fBsig\fP On a successful return, this should point to a buffer allocated by
+the callback using LIBSSH2_ALLOC. The function that calls the callback is
+responsible for zeroing out the buffer and freeing it using LIBSSH2_FREE.
+
+\fBsig_len\fP On a successful return, this should be set to the length of the
+signature.
+
+\fBagent_path\fP The path to a running ssh-agent on the client machine, from
+which identities were listed.
+
+\fBabstract\fP A pointer to the abstract pointer set in the
+\fIlibssh2_session_init_ex(3)\fP call.
 
 .SH RETURN VALUE
 Pointer to previous callback handler. Returns NULL if no prior callback

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -370,12 +370,11 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
               const char *agent_path, void **abstract)
 
 #define LIBSSH2_AUTHAGENT_SIGN_FUNC(name) \
-    int name(LIBSSH2_SESSION* session, \
+    int name(LIBSSH2_SESSION* session, unsigned int flags, \
              unsigned char *blob, unsigned int blen, \
-             const unsigned char *data, unsigned int dlen, \
+             unsigned char *data, unsigned int dlen, \
              unsigned char **signature, unsigned int *sigLen, \
-             const char *agentPath, \
-             void **abstract)
+             const char *agentPath, void** abstract)
 
 #define LIBSSH2_CHANNEL_CLOSE_FUNC(name) \
     void name(LIBSSH2_SESSION *session, void **session_abstract, \

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -248,10 +248,10 @@ struct iovec {
     session->addLocalIdentities((session), (buffer), \
                                 (agentPath), (&(session->abstract)))
 
-#define LIBSSH2_AUTHAGENT_SIGN(session, blob, blen, \
+#define LIBSSH2_AUTHAGENT_SIGN(session, flags, blob, blen, \
                                data, dlen, sig, sigLen, \
                                agentPath) \
-    session->agentSignCallback((session), (blob), (blen), \
+    session->agentSignCallback((session), (flags), (blob), (blen), \
                                (data), (dlen), (sig), (sigLen), \
                                (agentPath), (&(session->abstract)))
 


### PR DESCRIPTION
Another change from the Panic repo. Allows agent signing using rsa-sha2-256 and rsa-sha-512 when setting a callback with `LIBSSH2_CALLBACK_AUTHAGENT_SIGN`.