### PR TITLE
ci/GHA: bump NetBSD/OpenBSD, add NetBSD arm64 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,17 +591,20 @@ jobs:
         run: cd bld && ctest -VV --output-on-failure
 
   build_netbsd:
-    name: 'NetBSD (cmake, openssl, clang, amd64)'
+    name: 'NetBSD (cmake, openssl, clang)'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        arch: ['x86_64', 'arm64']
     steps:
       - uses: actions/checkout@v4
       - name: 'cmake'
-        uses: cross-platform-actions/action@v0.23.0
+        uses: cross-platform-actions/action@v0.24.0
         with:
           operating_system: 'netbsd'
-          version: '9.3'
-          architecture: 'x86_64'
+          version: '10.0'
+          architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
             sudo pkgin -y install cmake
@@ -616,17 +619,20 @@ jobs:
             cmake --build bld --parallel 3
 
   build_openbsd:
-    name: 'OpenBSD (cmake, libressl, clang, amd64)'
+    name: 'OpenBSD (cmake, libressl, clang)'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        arch: ['x86_64']
     steps:
       - uses: actions/checkout@v4
       - name: 'cmake'
-        uses: cross-platform-actions/action@v0.23.0
+        uses: cross-platform-actions/action@v0.24.0
         with:
           operating_system: 'openbsd'
-          version: '7.4'
-          architecture: 'x86_64'
+          version: '7.5'
+          architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
             sudo pkg_add cmake
@@ -648,11 +654,11 @@ jobs:
       CC: clang
     strategy:
       matrix:
-        arch: [x86-64, arm64]
+        arch: ['x86_64', 'arm64']
     steps:
       - uses: actions/checkout@v4
       - name: 'autotools'
-        uses: cross-platform-actions/action@v0.23.0
+        uses: cross-platform-actions/action@v0.24.0
         with:
           operating_system: 'freebsd'
           version: '14.0'


### PR DESCRIPTION
OpenBSD arm64 jobs were very slow, so skipped that.

Closes #1388
