### PR TITLE
ci/GHA: fix `Dockerfile` failing after Ubuntu package update

### DIFF
--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
  && apt-get install -y openssh-server \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-RUN mkdir /var/run/sshd
+RUN [ -d /var/run/sshd ] || mkdir /var/run/sshd
 
 # Chmodding because, when building on Windows, files are copied in with
 # -rwxr-xr-x permissions.


### PR DESCRIPTION
Likely due an upstream Ubuntu package update (requiring an apt-get
install call beforehand), tests run via autotools started failing with
no change in the libssh2 repo:
```
FAIL: test_aa_warmup
====================

Error running command 'docker build --quiet -t libssh2/openssh_server %s' (exit 256): Dockerfile:10
--------------------
   8 |      && apt-get clean \
   9 |      && rm -rf /var/lib/apt/lists/*
  10 | >>> RUN mkdir /var/run/sshd
  11 |.....
  12 |     # Chmodding because, when building on Windows, files are copied in with
--------------------
ERROR: failed to solve: process "/bin/sh -c mkdir /var/run/sshd" did not complete successfully: exit code: 1

Failed to build docker image
Cannot stop session - none started
Cannot stop container - none started
Command: docker build --quiet -t libssh2/openssh_server ../../tests/openssh_server
FAIL test_aa_warmup (exit status: 1)
```
Ref: https://github.com/libssh2/libssh2/actions/runs/9322194756/job/25662748095#step:11:390

Fix it by skipping `mkdir` if `/var/run/sshd` already exists.

(Why cmake-based jobs aren't affected, I don't know.)

Ref: https://github.com/libssh2/libssh2/commit/50143d5867d35df76a6cf589ca8a13b22105aa64#commitcomment-142560875
Closes #1400
