### PR TITLE
src: fix type warning in `libssh2_sftp_unlink` macro

### DIFF
--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -307,7 +307,7 @@ LIBSSH2_API int libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp,
                                        const char *filename,
                                        unsigned int filename_len);
 #define libssh2_sftp_unlink(sftp, filename) \
-    libssh2_sftp_unlink_ex((sftp), (filename), strlen(filename))
+    libssh2_sftp_unlink_ex((sftp), (filename), (unsigned int)strlen(filename))
 
 LIBSSH2_API int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
                                       LIBSSH2_SFTP_STATVFS *st);


### PR DESCRIPTION
The `libssh2_sftp_unlink` macro was implicitly casting the `size_t` returned by `strlen` to the `unsigned int` type expected by `libssh2_sftp_unlink_ex`. This fix adds an explicit cast to match similar macro definitions in the same file (e.g. `libssh2_sftp_rename`, `libssh2_sftp_mkdir`).