### PR TITLE
wolfssl: fix `EVP_Cipher()` use with v5.6.0 and older

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,11 @@ jobs:
             crypto: wolfSSL-from-source
             build: cmake
             zlib: 'ON'
+          - compiler: clang
+            arch: amd64
+            crypto: wolfSSL-from-source-prev
+            build: cmake
+            zlib: 'ON'
           - compiler: gcc
             arch: amd64
             crypto: OpenSSL-3-no-deprecated
@@ -162,18 +167,25 @@ jobs:
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
       - name: 'install wolfSSL from source'
-        if: ${{ matrix.crypto == 'wolfSSL-from-source' }}
+        if: ${{ startsWith(matrix.crypto, 'wolfSSL-from-source') }}
         run: |
-          WOLFSSLVER=5.7.0
+          if [ '${{ matrix.crypto }}' = 'wolfSSL-from-source' ]; then
+            WOLFSSLVER=5.7.0
+          else
+            WOLFSSLVER=5.5.4
+            # Required to include `FIPS_mode()` API:
+            options='-DWOLFSSL_OPENSSLEXTRA=ON'
+            cppflags='-DOPENSSL_ALL'
+          fi
           curl -fsS -L https://github.com/wolfSSL/wolfssl/archive/refs/tags/v$WOLFSSLVER-stable.tar.gz | tar -xzf -
           cd wolfssl-$WOLFSSLVER-stable
-          cmake -B bld \
+          cmake -B bld ${options} \
             -DWOLFSSL_LIBSSH2=ON \
             -DBUILD_SELFTEST=OFF \
             -DWOLFSSL_OPENSSLALL=ON \
             -DWOLFSSL_EXAMPLES=OFF \
             -DWOLFSSL_CRYPT_TESTS=OFF \
-            '-DCMAKE_C_FLAGS=-fPIC -DWOLFSSL_AESGCM_STREAM' \
+            "-DCMAKE_C_FLAGS=-fPIC -DWOLFSSL_AESGCM_STREAM ${cppflags}" \
             "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
           make -j5 -C bld install
           cd ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: cmake --build bld --parallel 5 --target package
       - name: 'cmake tests'
-        if: ${{ matrix.build == 'cmake' && matrix.crypto != 'wolfSSL' }}
+        if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 10
         run: |
           export OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1056,7 +1056,13 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
                decrypt: verify tag, if applicable
                in!=NULL is equivalent to EVP_CipherUpdate
                in==NULL is equivalent to EVP_CipherFinal */
-#ifdef HAVE_OPAQUE_STRUCTS
+#if defined(LIBSSH2_WOLFSSL) && LIBWOLFSSL_VERSION_HEX < 0x05007000
+            /* Workaround for wolfSSL bug fixed in v5.7.0:
+               https://github.com/wolfSSL/wolfssl/pull/7143 */
+            unsigned char buf2[EVP_MAX_BLOCK_LENGTH];
+            int outb;
+            ret = EVP_CipherFinal(*ctx, buf2, &outb);
+#elif defined(HAVE_OPAQUE_STRUCTS)
             ret = EVP_Cipher(*ctx, NULL, NULL, 0); /* final */
 #else
             ret = EVP_Cipher(ctx, NULL, NULL, 0); /* final */


### PR DESCRIPTION
Add workaround for the wolfSSL `EVP_Cipher(*p, NULL, NULL, 0)` bug to
make libssh2 work with wolfSSL v5.6.0 and older.

wolfSSL fixed this issue in v5.7.0:
https://github.com/wolfSSL/wolfssl/pull/7143
https://github.com/wolfSSL/wolfssl/commit/b0de0a1c95119786cf5651dd76dd7d7bdfac5a04

Without our local workaround:

- v5.3.0 and older fail most tests:
  Ref: https://github.com/libssh2/libssh2/actions/runs/9646827522/job/26604211476#step:17:1263

- v5.4.0, v5.5.x, v5.6.0 fail these:
  ```
  29 - test_read-aes128-cbc (Failed)
  30 - test_read-aes128-ctr (Failed)
  32 - test_read-aes192-cbc (Failed)
  33 - test_read-aes192-ctr (Failed)
  34 - test_read-aes256-cbc (Failed)
  35 - test_read-aes256-ctr (Failed)
  ```
  Ref: https://github.com/libssh2/libssh2/actions/runs/9646827522/job/26604233819#step:17:978

Oddly enough the workaround breaks OpenSSL tests, so only enable it for
the affected wolfSSL versions.

Also add new build-from-source wolfSSL CI job to test the new codepath.

wolfSSL has a build bug where `wolfssl/options.h` and
`wolfssl/version.h` are not copied to the `install` destination with
autotools. With CMake it has a different bug where `wolfcrypt/sp_int.h`
is not copied (with v5.4.0). And another with CMake where `FIPS_mode()`
remains missing (with v5.6.0 and earlier.)

Therefore use CMake with v5.5.4 and a workaround for `FIPS_mode()`.
Another option is autotools with v5.4.0 and a workaround for `install`,
but CMake builds quicker.

Regression-from 3c953c05d67eb1ebcfd3316f279f12c4b1d600b4 #797
Fixes #1020
Fixes #1299
Assisted-by: Michael Buckley via #1394
Closes #1394 (another attempt to fix the mentioned wolfSSL bug)
Closes #1407
