### PR TITLE
ci/GHA: fix wolfSSL-from-source AES-GCM tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
             -DWOLFSSL_OPENSSLALL=ON \
             -DWOLFSSL_EXAMPLES=OFF \
             -DWOLFSSL_CRYPT_TESTS=OFF \
-            -DCMAKE_C_FLAGS=-fPIC \
+            '-DCMAKE_C_FLAGS=-fPIC -DWOLFSSL_AESGCM_STREAM' \
             "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
           make -j5 -C bld install
           cd ..
@@ -284,7 +284,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: cmake --build bld --parallel 5 --target package
       - name: 'cmake tests'
-        if: ${{ matrix.build == 'cmake' && matrix.crypto != 'wolfSSL' && matrix.crypto != 'wolfSSL-from-source' }}
+        if: ${{ matrix.build == 'cmake' && matrix.crypto != 'wolfSSL' }}
         timeout-minutes: 10
         run: |
           export OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)


### PR DESCRIPTION
Turns out these tests:
```
31 - test_read-aes128-gcm@openssh.com (Failed)
36 - test_read-aes256-gcm@openssh.com (Failed)
```
were failing because AES-GCM wasn't enabled in libssh2. This in turn
happened because the `WOLFSSL_AESGCM_STREAM` macro wasn't enabled while
building wolfSSL. Which happened because this macro isn't enabled by
any CMake-level wolfSSL option. Passing it as `CPPFLAGS` fixes it.

This allows enabling tests with wolfSSL 5.7.0.

Follow-up to d4cea53f53c78febad14b4caa600e25d1aaf92fd #1408
Closes #1409
