### PR TITLE
tests: fix excluding AES-GCM tests

### DIFF
--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -95,8 +95,7 @@ static char const *skip_crypt[] = {
     "3des-cbc",
 #endif
 
-#if defined(LIBSSH2_LIBGCRYPT) || defined(LIBSSH2_OS400QC3) || \
-    defined(LIBSSH2_WINCNG)
+#if !LIBSSH2_AES_GCM
     /* Support for AES-GCM hasn't been added to these back-ends yet */
     "aes128-gcm@openssh.com",
     "aes256-gcm@openssh.com",


### PR DESCRIPTION
Replace hard-coded crypto backends and rely on `LIBSSH2_GCM` macro
to decide whether to run AES-GCM tests.

Without this tests attempted to run AES-GCM (and failed) for crypto
backends that have conditional support for this feature, e.g. wolfSSL.

Closes #xxxx