### PR TITLE
src: use `UINT32_MAX`

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -113,6 +113,10 @@
 #define TRUE 1
 #endif
 
+#ifndef UINT32_MAX
+#define UINT32_MAX 0xffffffffU
+#endif
+
 #if (defined(__GNUC__) || defined(__clang__)) && \
     defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
     !defined(LIBSSH2_NO_FMT_CHECKS)

--- a/src/misc.c
+++ b/src/misc.c
@@ -296,7 +296,7 @@ int _libssh2_store_bignum2_bytes(unsigned char **buf,
 
     extraByte = (len > 0 && (p[0] & 0x80) != 0);
     len_stored = (uint32_t)len;
-    if(extraByte && len_stored == 0xffffffff)
+    if(extraByte && len_stored == UINT32_MAX)
         len_stored--;
     _libssh2_store_u32(buf, len_stored + extraByte);
 


### PR DESCRIPTION
Needs to be defined for platforms missing it, e.g. VS2008.

Closes #1413