### PR TITLE
tests: avoid using `MAXPATHLEN`, for portability

### DIFF
--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -250,7 +250,7 @@ void stop_session_fixture(void)
 #define NUMPATHS 32
 char *srcdir_path(const char *file)
 {
-    static char* filepath[NUMPATHS];
+    static char *filepath[NUMPATHS];
     static int curpath;
     char *p = getenv("srcdir");
     if(curpath >= NUMPATHS) {
@@ -497,7 +497,8 @@ int test_auth_pubkey(LIBSSH2_SESSION *session, int flags,
         free(buffer);
     }
     else {
-        char *path_fn_pub = srcdir_path(fn_pub), *path_fn_priv = srcdir_path(fn_priv);
+        char *path_fn_pub = srcdir_path(fn_pub),
+             *path_fn_priv = srcdir_path(fn_priv);
         rc = libssh2_userauth_publickey_fromfile_ex(session, username,
                                                 (unsigned int)strlen(username),
                                                     path_fn_pub,

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -48,7 +48,7 @@
 #endif
 
 #include <stdio.h>
-#include <stdlib.h>
+#include <stdlib.h>  /* for getenv() */
 #include <assert.h>
 
 static LIBSSH2_SESSION *connected_session = NULL;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -255,7 +255,7 @@ char *srcdir_path(const char *file)
     static char *filepath[NUMPATHS];
     static int curpath;
     char *p = getenv("srcdir");
-    if(!file) {
+    if(file) {
         if(curpath >= NUMPATHS) {
             fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
         }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -254,26 +254,36 @@ char *srcdir_path(const char *file)
     static int curpath;
     char *p = getenv("srcdir");
     if(file) {
+        int len;
         if(curpath >= NUMPATHS) {
             fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
         }
         assert(curpath < NUMPATHS);
         if(p) {
-            int len = snprintf(NULL, 0, "%s/%s", p, file);
-            filepath[curpath] = malloc(len + 1);
-            snprintf(filepath[curpath], len + 1, "%s/%s", p, file);
+            len = snprintf(NULL, 0, "%s/%s", p, file);
+            if(len >= 0) {
+                filepath[curpath] = calloc(1, (size_t)len + 1);
+                snprintf(filepath[curpath], len + 1, "%s/%s", p, file);
+            }
+            else {
+               return NULL;
+            }
         }
         else {
-            int len = snprintf(NULL, 0, "%s", file);
-            filepath[curpath] = malloc(len + 1);
-            snprintf(filepath[curpath], len + 1, "%s", file);
+            len = snprintf(NULL, 0, "%s", file);
+            if(len >= 0) {
+                filepath[curpath] = calloc(1, (size_t)len + 1);
+                snprintf(filepath[curpath], len + 1, "%s", file);
+            }
+            else {
+               return NULL;
+            }
         }
-
         return filepath[curpath++];
     }
     else {
         int i;
-        for(i = 0; i<curpath; i++) {
+        for(i = 0; i < curpath; ++i) {
             free(filepath[curpath]);
         }
         curpath = 0;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -48,6 +48,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 
 static LIBSSH2_SESSION *connected_session = NULL;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -255,32 +255,32 @@ char *srcdir_path(const char *file)
     static char *filepath[NUMPATHS];
     static int curpath;
     char *p = getenv("srcdir");
-    if(NULL != file) {
-      if(curpath >= NUMPATHS) {
-          fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
-      }
-      assert(curpath < NUMPATHS);
-      if(p) {
-          int len = snprintf(NULL, 0, "%s/%s", p, file);
-          filepath[curpath] = malloc(len + 1);
-          snprintf(filepath[curpath], len + 1, "%s/%s", p, file);
-      }
-      else {
-          int len = snprintf(NULL, 0, "%s", file);
-          filepath[curpath] = malloc(len + 1);
-          snprintf(filepath[curpath], len + 1, "%s", file);
-      }
+    if(!file) {
+        if(curpath >= NUMPATHS) {
+            fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
+        }
+        assert(curpath < NUMPATHS);
+        if(p) {
+            int len = snprintf(NULL, 0, "%s/%s", p, file);
+            filepath[curpath] = malloc(len + 1);
+            snprintf(filepath[curpath], len + 1, "%s/%s", p, file);
+        }
+        else {
+            int len = snprintf(NULL, 0, "%s", file);
+            filepath[curpath] = malloc(len + 1);
+            snprintf(filepath[curpath], len + 1, "%s", file);
+        }
 
-      return filepath[curpath++];
+        return filepath[curpath++];
     }
     else {
-      /* cleanup allocated filepath */
-      int i;
-      for(i = 0; i<curpath; i++) {
-        free(filepath[curpath]);
-      }
-      curpath = 0;
-      return NULL;
+        /* cleanup allocated filepath */
+        int i;
+        for(i = 0; i<curpath; i++) {
+          free(filepath[curpath]);
+        }
+        curpath = 0;
+        return NULL;
     }
 }
 

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -46,12 +46,8 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_SYS_PARAM_H
-#include <sys/param.h>
-#endif
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <assert.h>
 
 static LIBSSH2_SESSION *connected_session = NULL;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -235,6 +235,7 @@ void stop_session_fixture(void)
     close_socket_to_openssh_server(connected_socket);
     connected_socket = LIBSSH2_INVALID_SOCKET;
 
+    /* cleanup allocated filepath */
     srcdir_path(NULL);
 
     libssh2_exit();
@@ -271,7 +272,6 @@ char *srcdir_path(const char *file)
         return filepath[curpath++];
     }
     else {
-        /* cleanup allocated filepath */
         int i;
         for(i = 0; i<curpath; i++) {
             free(filepath[curpath]);

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -263,7 +263,7 @@ char *srcdir_path(const char *file)
             len = snprintf(NULL, 0, "%s/%s", p, file);
             if(len >= 0) {
                 filepath[curpath] = calloc(1, (size_t)len + 1);
-                snprintf(filepath[curpath], len + 1, "%s/%s", p, file);
+                snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
             }
             else {
                return NULL;
@@ -273,7 +273,7 @@ char *srcdir_path(const char *file)
             len = snprintf(NULL, 0, "%s", file);
             if(len >= 0) {
                 filepath[curpath] = calloc(1, (size_t)len + 1);
-                snprintf(filepath[curpath], len + 1, "%s", file);
+                snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
             }
             else {
                return NULL;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -261,7 +261,7 @@ char *srcdir_path(const char *file)
         assert(curpath < NUMPATHS);
         if(p) {
             len = snprintf(NULL, 0, "%s/%s", p, file);
-            if(len > 1) {
+            if(len > 2) {
                 filepath[curpath] = calloc(1, (size_t)len + 1);
                 snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
             }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -252,10 +252,10 @@ void stop_session_fixture(void)
 #define NUMPATHS 32
 char *srcdir_path(const char *file)
 {
-    static char* filepath[NUMPATHS];
+    static char *filepath[NUMPATHS];
     static int curpath;
     char *p = getenv("srcdir");
-    if (NULL != file) {
+    if(NULL != file) {
       if(curpath >= NUMPATHS) {
           fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
       }
@@ -272,10 +272,11 @@ char *srcdir_path(const char *file)
       }
 
       return filepath[curpath++];
-    } else {
+    }
+    else {
       /* cleanup allocated filepath */
       int i;
-      for (i=0; i<curpath; i++) {
+      for(i = 0; i<curpath; i++) {
         free(filepath[curpath]);
       }
       curpath = 0;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -261,7 +261,7 @@ char *srcdir_path(const char *file)
         assert(curpath < NUMPATHS);
         if(p) {
             len = snprintf(NULL, 0, "%s/%s", p, file);
-            if(len >= 0) {
+            if(len > 1) {
                 filepath[curpath] = calloc(1, (size_t)len + 1);
                 snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
             }
@@ -271,7 +271,7 @@ char *srcdir_path(const char *file)
         }
         else {
             len = snprintf(NULL, 0, "%s", file);
-            if(len >= 0) {
+            if(len > 0) {
                 filepath[curpath] = calloc(1, (size_t)len + 1);
                 snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
             }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -277,7 +277,7 @@ char *srcdir_path(const char *file)
         /* cleanup allocated filepath */
         int i;
         for(i = 0; i<curpath; i++) {
-          free(filepath[curpath]);
+            free(filepath[curpath]);
         }
         curpath = 0;
         return NULL;

--- a/tests/session_fixture.h
+++ b/tests/session_fixture.h
@@ -47,7 +47,7 @@
 LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err);
 void stop_session_fixture(void);
 void print_last_session_error(const char *function);
-const char *srcdir_path(const char *file);
+char *srcdir_path(const char *file);
 
 #define TEST_AUTH_SHOULDFAIL  1
 #define TEST_AUTH_FROMMEM     2


### PR DESCRIPTION
`MAXPATHLEN` is not present in some systems, e.g. GNU Hurd.

Fixes #1414
Closes #1415