### PR TITLE
Increase SFTP_HANDLE_MAXLEN back to 4092

### DIFF
--- a/src/sftp.h
+++ b/src/sftp.h
@@ -78,7 +78,8 @@ struct _LIBSSH2_SFTP_PACKET
 
 typedef struct _LIBSSH2_SFTP_PACKET LIBSSH2_SFTP_PACKET;
 
-#define SFTP_HANDLE_MAXLEN 256 /* according to spec! */
+/* Increasing from 256 to 4092 since OpenSSH doesn't honor it. */
+#define SFTP_HANDLE_MAXLEN 4092 /* according to spec, this should be 256! */
 
 struct _LIBSSH2_SFTP_HANDLE
 {


### PR DESCRIPTION
Finally back to submitting patches upstream. This one's real small. I'll have another small one soon, and then a couple large ones.

According to the spec SFTP_HANDLE_MAXLEN should be 256. However, we had a customer contact us to explain that they weren't able to download or upload files with long paths in our products, but were able to do so in OpenSSH.

As it turns out, OpenSSH enforces a much larger maximum handle length than 256. So this change updates to match.