### PR TITLE
packet: fix memory leak in `packet_x11_open()`

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -405,6 +405,7 @@ packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
             rc = _libssh2_transport_send(session, x11open_state->packet, 17,
                                          NULL, 0);
             if(rc == LIBSSH2_ERROR_EAGAIN) {
+                LIBSSH2_FREE(session, channel);
                 return rc;
             }
             else if(rc) {


### PR DESCRIPTION
Reported-by: 尹麓鸣
Ref: https://github.com/LuMingYinDetect/libssh_defects
Closes #xxxx

---

/cc @LuMingYinDetect
