### PR TITLE
session: support server banners up to 8192 bytes (was: 256)

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -778,7 +778,7 @@ struct _LIBSSH2_SESSION
 
     /* State variables used in libssh2_banner_send() */
     libssh2_nonblocking_states banner_TxRx_state;
-    char banner_TxRx_banner[256];
+    char banner_TxRx_banner[8192];
     ssize_t banner_TxRx_total_send;
 
     /* State variables used in libssh2_kexinit() */


### PR DESCRIPTION
If server had banner exceeding 256 bytes there wasn't enough room in
`_LIBSSH2_SESSION.banner_TxRx_banner`. Only the first 256 bytes would be
read making the first packet read fail but also dooming key exchange as
`session->remote.banner` didn't include everything.

This change makes `banner_receive` keep reading until the banner
completes with `\n` by growing `session->remote.banner` in chunks of
256 bytes.

Fixes #1442
