### PR TITLE
cmake: always run the tests even when static libs are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ else()
   endif()
 endif()
 
+# Some tests are only built if BUILD_TESTING is deliberately passed on the command line.
+if(BUILD_TESTING)
+  set(BUILD_TESTING_EXPLICIT ON)
+endif()
+
 option(BUILD_EXAMPLES "Build libssh2 examples" ON)
 option(BUILD_TESTING "Build libssh2 test suite" ON)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,7 @@ set(_sources ${CSOURCES} ${HHEADERS})
 # when building both static and shared library. On Windows, with certain
 # toolchains (e.g. MSVC) these libraries get the same by default, overwriting
 # each other. MinGW is not affected.
-if(WIN32 AND BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS AND
+if(WIN32 AND BUILD_SHARED_LIBS AND
    NOT STATIC_LIB_SUFFIX AND NOT IMPORT_LIB_SUFFIX AND
    CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX)
   set(STATIC_LIB_SUFFIX "_static")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 unset(_libssh2_export)
 
 # we want it to be called libssh2 on all platforms
-if(BUILD_STATIC_LIBS OR BUILD_TESTING)
+if(BUILD_STATIC_LIBS OR BUILD_TESTING_EXPLICIT)
   if(BUILD_STATIC_LIBS)
     list(APPEND _libssh2_export ${LIB_STATIC})
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,8 +103,10 @@ endif()
 unset(_libssh2_export)
 
 # we want it to be called libssh2 on all platforms
-if(BUILD_STATIC_LIBS)
-  list(APPEND _libssh2_export ${LIB_STATIC})
+if(BUILD_STATIC_LIBS OR BUILD_TESTING)
+  if(BUILD_STATIC_LIBS)
+    list(APPEND _libssh2_export ${LIB_STATIC})
+  endif()
   add_library(${LIB_STATIC} STATIC ${_sources})
   add_library(${PROJECT_NAME}::${LIB_STATIC} ALIAS ${LIB_STATIC})
   target_compile_definitions(${LIB_STATIC} PRIVATE ${PRIVATE_COMPILE_DEFINITIONS} ${_libssh2_definitions})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,16 +82,12 @@ target_link_libraries(runner PRIVATE libssh2)
 foreach(_test IN LISTS DOCKER_TESTS STANDALONE_TESTS SSHD_TESTS)
   if(NOT ";${DOCKER_TESTS_STATIC};${STANDALONE_TESTS_STATIC};" MATCHES ";${_test};")
     set(_lib_for_tests ${LIB_SELECTED})
-  elseif(TARGET ${LIB_STATIC})
-    set(_lib_for_tests ${LIB_STATIC})
   else()
-    unset(_lib_for_tests)
-    message(STATUS "Skip test requiring static libssh2 lib: ${_test}")
+    set(_lib_for_tests ${LIB_STATIC})
   endif()
 
   # We support the same target as both Docker and SSHD test. Build those just once.
-  # Skip building tests that require the static lib when the static lib is disabled.
-  if(NOT TARGET ${_test} AND _lib_for_tests)
+  if(NOT TARGET ${_test})
     add_executable(${_test} "${_test}.c")
     target_compile_definitions(${_test} PRIVATE "${CRYPTO_BACKEND_DEFINE}")
     target_include_directories(${_test} PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,12 +82,17 @@ target_link_libraries(runner PRIVATE libssh2)
 foreach(_test IN LISTS DOCKER_TESTS STANDALONE_TESTS SSHD_TESTS)
   if(NOT ";${DOCKER_TESTS_STATIC};${STANDALONE_TESTS_STATIC};" MATCHES ";${_test};")
     set(_lib_for_tests ${LIB_SELECTED})
-  else()
+  elseif(TARGET ${LIB_STATIC})
     set(_lib_for_tests ${LIB_STATIC})
+  else()
+    unset(_lib_for_tests)
+    message(STATUS "Skip test requiring static libssh2 lib: ${_test}")
   endif()
 
   # We support the same target as both Docker and SSHD test. Build those just once.
-  if(NOT TARGET ${_test})
+  # Skip building tests that require the static lib if tests weren't explicitly
+  # enabled via the command line.
+  if(NOT TARGET ${_test} AND _lib_for_tests)
     add_executable(${_test} "${_test}.c")
     target_compile_definitions(${_test} PRIVATE "${CRYPTO_BACKEND_DEFINE}")
     target_include_directories(${_test} PRIVATE


### PR DESCRIPTION
The BUILD_STATIC_LIBS option is intended for the use case where users do not wish to build and install a static lib because it is not one of the artifacts they are interested in. The option should not be used to disable running the testsuite.

Instead, when tests are enabled, define the target. Just don't export or install it. Build systems build lots of things that aren't deliverable artifacts, and this becomes just one more of them.