### PR TITLE
Split `sftp_packetlist_flush` into different functions.

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -413,9 +413,7 @@ window_adjust:
     /* WON'T REACH */
 }
 
-/*
-    process_sftp_chunk - Handle packet retrievement and data freeing
-*/
+// process_sftp_chunk - Handle packet retrievement and data freeing
 static int process_sftp_chunk(LIBSSH2_SFTP *sftp, struct sftp_pipeline_chunk *chunk) {
     unsigned char *data = NULL;
     size_t data_len = 0;
@@ -435,9 +433,7 @@ static int process_sftp_chunk(LIBSSH2_SFTP *sftp, struct sftp_pipeline_chunk *ch
     return rc;
 }
 
-/*
-    handle_zombie_chunk - Handle zombie requests
-*/
+// handle_zombie_chunk - Handle zombie requests
 static void handle_zombie_chunk(LIBSSH2_SFTP *sftp, struct sftp_pipeline_chunk *chunk) {
     // Mark the request as zombie if if was received but no response
     if(chunk->sent) {
@@ -445,9 +441,7 @@ static void handle_zombie_chunk(LIBSSH2_SFTP *sftp, struct sftp_pipeline_chunk *
     }
 }
 
-/*
-    free_sftp_chunk - Remove the referred chunk from the list by freeing it
-*/
+// free_sftp_chunk - Remove the referred chunk from the list by freeing it
 static void free_sftp_chunk(LIBSSH2_SESSION *session, struct sftp_pipeline_chunk *chunk) {
     _libssh2_list_remove(&chunk->node);
     LIBSSH2_FREE(session, chunk);

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -413,44 +413,67 @@ window_adjust:
     /* WON'T REACH */
 }
 
-/* sftp_packetlist_flush
- *
- * Remove all pending packets in the packet_list and the corresponding one(s)
- * in the SFTP packet brigade.
- */
-static void sftp_packetlist_flush(LIBSSH2_SFTP_HANDLE *handle)
-{
-    struct sftp_pipeline_chunk *chunk;
+/*
+    process_sftp_chunk - Handle packet retrievement and data freeing
+*/
+static int process_sftp_chunk(LIBSSH2_SFTP *sftp, struct sftp_pipeline_chunk *chunk) {
+    unsigned char *data = NULL;
+    size_t data_len = 0;
+    int rc;
+
+    // Try to get a status packet first
+    rc = sftp_packet_ask(sftp, SSH_FXP_STATUS, chunk->request_id, &data, &data_len);
+    if(rc) {
+        // If no status packet, try to get a data packet
+        rc = sftp_packet_ask(sftp, SSH_FXP_DATA, chunk->request_id, &data, &data_len);
+    }
+
+    // If packet was found, free the data
+    if(!rc && data) {
+        LIBSSH2_FREE(sftp->channel->session, data);
+    }
+    return rc;
+}
+
+/*
+    handle_zombie_chunk - Handle zombie requests
+*/
+static void handle_zombie_chunk(LIBSSH2_SFTP *sftp, struct sftp_pipeline_chunk *chunk) {
+    // Mark the request as zombie if if was received but no response
+    if(chunk->sent) {
+        add_zombie_request(sftp, chunk->request_id);
+    }
+}
+
+/*
+    free_sftp_chunk - Remove the referred chunk from the list by freeing it
+*/
+static void free_sftp_chunk(LIBSSH2_SESSION *session, struct sftp_pipeline_chunk *chunk) {
+    _libssh2_list_remove(&chunk->node);
+    LIBSSH2_FREE(session, chunk);
+}
+
+static void sftp_packetlist_flush(LIBSSH2_SFTP_HANDLE *handle) {
     LIBSSH2_SFTP *sftp = handle->sftp;
     LIBSSH2_SESSION *session = sftp->channel->session;
+    struct sftp_pipeline_chunk *chunk = _libssh2_list_first(&handle->packet_list);
 
-    /* remove pending packets, if any */
-    chunk = _libssh2_list_first(&handle->packet_list);
     while(chunk) {
-        unsigned char *data;
-        size_t data_len;
-        int rc;
         struct sftp_pipeline_chunk *next = _libssh2_list_next(&chunk->node);
 
-        rc = sftp_packet_ask(sftp, SSH_FXP_STATUS,
-                             chunk->request_id, &data, &data_len);
-        if(rc)
-            rc = sftp_packet_ask(sftp, SSH_FXP_DATA,
-                                 chunk->request_id, &data, &data_len);
+        // Process each chunk and check for errors
+        int rc = process_sftp_chunk(sftp, chunk);
+        if(rc) {
+            // Handle zombie request if no packet was found
+            handle_zombie_chunk(sftp, chunk);
+        }
 
-        if(!rc)
-            /* we found a packet, free it */
-            LIBSSH2_FREE(session, data);
-        else if(chunk->sent)
-            /* there was no incoming packet for this request, mark this
-               request as a zombie if it ever sent the request */
-            add_zombie_request(sftp, chunk->request_id);
-
-        _libssh2_list_remove(&chunk->node);
-        LIBSSH2_FREE(session, chunk);
+        // Free the processed chunk
+        free_sftp_chunk(session, chunk);
         chunk = next;
     }
 }
+
 
 
 /*


### PR DESCRIPTION
I splitted the already existent `sftp_packetlist_flush` into three different functions for future reusability. These functions include `process_sftp_chunk`, `handle_zombie_chunk`, `free_sftp_chunk`. All of these functions are used to rewrite the `sftp_packetlist_flush` function to make it more modular.