### PR TITLE
Fix unstable connections over nonblocking sockets

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -919,7 +919,8 @@ send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
            make the caller really notice his/hers flaw, we return error for
            this case */
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Address is different, but will resume nonetheless"));
+                       "Address is different, returning EAGAIN"));
+        return LIBSSH2_ERROR_EAGAIN;
     }
 
     *ret = 1;                   /* set to make our parent return */


### PR DESCRIPTION
This is the patch described in #1397 

I've tested this branch and I cannot reproduce the bug in #1431 anymore with it.
I've provided a description of the bug in the commit message.