### PR TITLE
ci/appveyor: reduce test runs (workaround for infrastructure permafails)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,12 +110,6 @@ else()
   endif()
 endif()
 
-# Detect if testing was explicitly enabled and make sure to build the
-# static libssh2 lib in this case, to also build those tests that require it.
-if(BUILD_TESTING)
-  set(BUILD_TESTING_EXPLICIT ON)
-endif()
-
 option(BUILD_EXAMPLES "Build libssh2 examples" ON)
 option(BUILD_TESTING "Build libssh2 test suite" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,12 @@ else()
   endif()
 endif()
 
+# Detect if testing was explicitly enabled and make sure to build the
+# static libssh2 lib in this case, to also build those tests that require it.
+if(BUILD_TESTING)
+  set(BUILD_TESTING_EXPLICIT ON)
+endif()
+
 option(BUILD_EXAMPLES "Build libssh2 examples" ON)
 option(BUILD_TESTING "Build libssh2 test suite" ON)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,8 @@
 environment:
   CONFIGURATION: 'Release'
   FIXTURE_XFER_COUNT: 35020
+  SKIP_CTEST: 'yes'  # Connection to test server has been failing consistently since 2024-08-29
+
   matrix:
     - job_name: 'VS2022, OpenSSL 3, x64, Server 2019'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
@@ -118,6 +120,7 @@ environment:
       PLATFORM: 'x64'
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'OFF'
+      SKIP_CTEST: 'no'
 
 matrix:
   fast_finish: true
@@ -209,7 +212,8 @@ test_script:
           $env:FIXTURE_TRACE_ALL_CONNECT = '1'
         }
         $env:OPENSSH_SERVER_IMAGE=[string] (& bash -c "echo ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)")
-        cd _builds; ctest -VV -C $($env:CONFIGURATION) --output-on-failure --timeout 900
+        cd _builds
+        ctest -VV -C $($env:CONFIGURATION) --output-on-failure --timeout 900
       }
 
 on_failure:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@
 environment:
   CONFIGURATION: 'Release'
   FIXTURE_XFER_COUNT: 35020
-  SKIP_CTEST: 'yes'  # Connection to test server has been failing consistently since 2024-08-29
+  #SKIP_CTEST: 'yes'  # Connection to test server has been failing consistently since 2024-08-29
 
   matrix:
     - job_name: 'VS2022, OpenSSL 3, x64, Server 2019'
@@ -120,7 +120,7 @@ environment:
       PLATFORM: 'x64'
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'OFF'
-      SKIP_CTEST: 'no'
+      #SKIP_CTEST: 'no'
 
 matrix:
   fast_finish: true
@@ -195,7 +195,7 @@ test_script:
       if($env:SKIP_CTEST -ne 'yes' -and $env:PLATFORM -ne 'ARM64') {
         appveyor-retry choco install --yes --no-progress --limit-output --timeout 180 docker-cli
         Write-Host 'Waiting for SSH connection from GitHub Actions' -NoNewline
-        $endDate = (Get-Date).AddMinutes(5)
+        $endDate = (Get-Date).AddMinutes(10)
         while((Get-Process -Name 'sshd' -ErrorAction SilentlyContinue).Count -eq 1 -and (Get-Date) -lt $endDate) {
           Write-Host '.' -NoNewline
           Start-Sleep -Seconds 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,6 +66,7 @@ environment:
       PLATFORM: 'x86'
       BUILD_STATIC_LIBS: 'OFF'
       CRYPTO_BACKEND: 'OpenSSL'
+      SKIP_CTEST: 'no'
 
     - job_name: 'VS2013, OpenSSL 1.0.2, x64, Build-only, Static-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
@@ -99,6 +100,7 @@ environment:
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'ON'
       ENABLE_DEBUG_LOGGING: 'ON'
+      SKIP_CTEST: 'no'
 
     - job_name: 'VS2022, WinCNG, ARM64, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
@@ -106,6 +108,7 @@ environment:
       PLATFORM: 'ARM64'
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'ON'
+      SKIP_CTEST: 'no'
 
     - job_name: 'VS2015, WinCNG, x86, Server 2016'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
@@ -113,6 +116,7 @@ environment:
       PLATFORM: 'x86'
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'ON'
+      SKIP_CTEST: 'no'
 
     - job_name: 'VS2015, WinCNG, x64, Server 2012 R2'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,7 +100,6 @@ environment:
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'ON'
       ENABLE_DEBUG_LOGGING: 'ON'
-      SKIP_CTEST: 'no'
 
     - job_name: 'VS2022, WinCNG, ARM64, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
@@ -108,7 +107,6 @@ environment:
       PLATFORM: 'ARM64'
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'ON'
-      SKIP_CTEST: 'no'
 
     - job_name: 'VS2015, WinCNG, x86, Server 2016'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
@@ -116,7 +114,6 @@ environment:
       PLATFORM: 'x86'
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'ON'
-      SKIP_CTEST: 'no'
 
     - job_name: 'VS2015, WinCNG, x64, Server 2012 R2'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@
 environment:
   CONFIGURATION: 'Release'
   FIXTURE_XFER_COUNT: 35020
-  #SKIP_CTEST: 'yes'  # Connection to test server has been failing consistently since 2024-08-29
+  SKIP_CTEST: 'yes'  # Connection to test server has been failing consistently since 2024-08-29
 
   matrix:
     - job_name: 'VS2022, OpenSSL 3, x64, Server 2019'
@@ -120,7 +120,7 @@ environment:
       PLATFORM: 'x64'
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'OFF'
-      #SKIP_CTEST: 'no'
+      SKIP_CTEST: 'no'
 
 matrix:
   fast_finish: true
@@ -195,7 +195,7 @@ test_script:
       if($env:SKIP_CTEST -ne 'yes' -and $env:PLATFORM -ne 'ARM64') {
         appveyor-retry choco install --yes --no-progress --limit-output --timeout 180 docker-cli
         Write-Host 'Waiting for SSH connection from GitHub Actions' -NoNewline
-        $endDate = (Get-Date).AddMinutes(10)
+        $endDate = (Get-Date).AddMinutes(5)
         while((Get-Process -Name 'sshd' -ErrorAction SilentlyContinue).Count -eq 1 -and (Get-Date) -lt $endDate) {
           Write-Host '.' -NoNewline
           Start-Sleep -Seconds 1


### PR DESCRIPTION
Jobs consistently fail to connect to the test server (run in GHA) since
2024-Aug-29:
https://ci.appveyor.com/project/libssh2org/libssh2/builds/50498393

There was an earlier phase of failures one month before that, that got
fixed by increasing the wait for the server in
bf3af90b3f1bb14cf452df7a8eb55cc9088f3e7f.

Thus, skip running tests in AppVeyor CI jobs, except: After some
experiments, it seems that running tests with the last OpenSSL job and
the last WinCrypt job _work_, which still leaves some coverage.
It remains to be seen how stable this is.

This is meant as a temporary fix till there is a solution to make all 
jobs run tests reliable like up until a few months ago.

---

Bumping up the timeout to 10 minutes doesn't help. But it turns out
by accident, that running the tests only in the last AppVeyor job _does_
pick up the server and run correctly. So it's not serving as a "canary"
or a signal after all.
