### PR TITLE
libssh2.h: Add note about release versions to LIBSSH2_VERSION

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -47,7 +47,9 @@
 /* We use underscore instead of dash when appending DEV in dev versions just
    to make the BANNER define (used by src/session.c) be a valid SSH
    banner. Release versions have no appended strings and may of course not
-   have dashes either. */
+   have dashes either. The release version (without "_DEV") is not stored in
+   the source code repo, as the version is properly set in the tarballs by the
+   maketgz script.*/
 #define LIBSSH2_VERSION                             "1.11.2_DEV"
 
 /* The numeric version number is also available "in parts" by using these


### PR DESCRIPTION
As noted in #771 and #1473, the blessed and signed releases are on libssh2.org and any other archives, like those generated by GitHub, are just a collection of files from the tag and are not the official releases.

This adds a note, which already exists for LIBSSH2_TIMESTAMP, to LIBSSH2_VERSION, to clarify this fact.

Closes #1473 