### PR TITLE
cmake/Find*: clear package version after `pkg-config` detection

### DIFF
--- a/cmake/FindLibgcrypt.cmake
+++ b/cmake/FindLibgcrypt.cmake
@@ -32,6 +32,7 @@ else()
   find_path(LIBGCRYPT_INCLUDE_DIR NAMES "gcrypt.h")
   find_library(LIBGCRYPT_LIBRARY NAMES "gcrypt" "libgcrypt")
 
+  unset(LIBGCRYPT_VERSION CACHE)
   if(LIBGCRYPT_INCLUDE_DIR AND EXISTS "${LIBGCRYPT_INCLUDE_DIR}/gcrypt.h")
     set(_version_regex "#[\t ]*define[\t ]+GCRYPT_VERSION[\t ]+\"([^\"]*)\"")
     file(STRINGS "${LIBGCRYPT_INCLUDE_DIR}/gcrypt.h" _version_str REGEX "${_version_regex}")

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -32,6 +32,7 @@ else()
   find_path(MBEDTLS_INCLUDE_DIR NAMES "mbedtls/version.h")
   find_library(MBEDCRYPTO_LIBRARY NAMES "mbedcrypto" "libmbedcrypto")
 
+  unset(MBEDTLS_VERSION CACHE)
   if(MBEDTLS_INCLUDE_DIR)
     if(EXISTS "${MBEDTLS_INCLUDE_DIR}/mbedtls/build_info.h")  # 3.x
       set(_version_header "${MBEDTLS_INCLUDE_DIR}/mbedtls/build_info.h")

--- a/cmake/FindWolfSSL.cmake
+++ b/cmake/FindWolfSSL.cmake
@@ -32,6 +32,7 @@ else()
   find_path(WOLFSSL_INCLUDE_DIR NAMES "wolfssl/options.h")
   find_library(WOLFSSL_LIBRARY NAMES "wolfssl")
 
+  unset(WOLFSSL_VERSION CACHE)
   if(WOLFSSL_INCLUDE_DIR AND EXISTS "${WOLFSSL_INCLUDE_DIR}/wolfssl/version.h")
     set(_version_regex "#[\t ]*define[\t ]+LIBWOLFSSL_VERSION_STRING[\t ]+\"([^\"]*)\"")
     file(STRINGS "${WOLFSSL_INCLUDE_DIR}/wolfssl/version.h" _version_str REGEX "${_version_regex}")


### PR DESCRIPTION
`pkg_check_modules()` seems to leave `<PACKAGE>_VERSION` defined with an
empty value, if the package is not found.

When the package is also not found in the fallback branch,
`find_package_handle_standard_args()` logs and error message. In this
message it includes the bogus empty value as: `(found version "")`:
```
  Could NOT find Libgcrypt (missing: LIBGCRYPT_INCLUDE_DIR LIBGCRYPT_LIBRARY)
  (found version "")
```

Clear the version number to avoid the confusion:
```
  Could NOT find Libgcrypt (missing: LIBGCRYPT_INCLUDE_DIR LIBGCRYPT_LIBRARY)
```

Seen with CMake v3.30.3 and 3.30.5.
