### PR TITLE
build: disable warning `-Wunreachable-code-break`

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -307,7 +307,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           dnl Only clang 3.5 or later
           if test "$compiler_num" -ge "305"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pragmas])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code-break])
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code-break])  # Not used: Silent in "unity" builds
           fi
           #
           dnl Only clang 3.6 or later

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -139,7 +139,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
         list(APPEND _picky_enable
           ${_picky_common}
-          -Wunreachable-code-break         # clang  3.5            appleclang  6.0
+        # -Wunreachable-code-break         # clang  3.5            appleclang  6.0  # Not used: Silent in "unity" builds
           -Wheader-guard                   # clang  3.4            appleclang  5.1
           -Wsometimes-uninitialized        # clang  3.2            appleclang  4.6
         )


### PR DESCRIPTION
This warning remains silent in unity builds. Since we're using unity
in CI for most jobs, warnings remain undetected there.
Disable them for all builds to avoid a surprise warning outside our CI.

It also doesn't work in any #included `.c` sources, like the crypto
backend sources.

The issue caught by the warning is useful for a tidy codebase, but
doesn't affect executed code. It was enabled in
84338c4de2d7c798e3c270c9610d51a4ad18a90b #12331 (2023-11-15).

llvm source: https://github.com/llvm/llvm-project/blob/fee2953f23bd8a8a71e574e6a8db08033778d3a4/clang/lib/Sema/AnalysisBasedWarnings.cpp#L125-L134
llvm issue: https://github.com/llvm/llvm-project/issues/71046

Follow-up to 7ecc309cd10454c54814b478c4f85d0041da6721 #1224
