### PR TITLE
transport: stop passing newline to the trace handler via `debugdump()`

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -104,14 +104,13 @@ debugdump(LIBSSH2_SESSION * session,
             buffer[used++] = isprint(ptr[i + c]) ?
                 ptr[i + c] : UNPRINTABLE_CHAR;
         }
-        buffer[used++] = '\n';
         buffer[used] = 0;
 
         if(session->tracehandler)
             (session->tracehandler)(session, session->tracehandler_context,
                                     buffer, used);
         else
-            fprintf(stderr, "%s", buffer);
+            fprintf(stderr, "%s\n", buffer);
     }
 }
 #else


### PR DESCRIPTION
The trace handler is called from two places in libssh2. One of them was
passing a newline at the end of the trace message string, the other one
was not.

When the trace handler feature was introduced, a newline was passed both
via `debugdump()` and `libssh2_debug()`:
44eba0c9936af05a50651ecd2845a0b081052f8c (2010-01-15)

Shortly after a commit deleted the newline for `libssh2_debug()`:
0f0652a3093111fc7dac0205fdcf8d02bf16e89f (2010-06-23)

This patch re-syncs behaviour between the traceback callbacks by
dropping the newline for trace handler calls made from `debugdump()`.

Reported-by: Chris Emsen
Fixes #1485
Follow-up to 0f0652a3093111fc7dac0205fdcf8d02bf16e89f
