### PR TITLE
configure: fix `--without-lib*-prefix` when `lib*` is detected anyway

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -835,21 +835,21 @@ dnl
 dnl For convenience, $4 is expanded if [lib]$1 is found.
 
 AC_DEFUN([LIBSSH2_LIB_HAVE_LINKFLAGS], [
-  libssh2_save_CPPFLAGS="$CPPFLAGS"
-  libssh2_save_LDFLAGS="$LDFLAGS"
 
   if test "${with_lib$1_prefix+set}" = set; then
+    libssh2_save_CPPFLAGS="$CPPFLAGS"
+    libssh2_save_LDFLAGS="$LDFLAGS"
     CPPFLAGS="$CPPFLAGS${CPPFLAGS:+ }-I${with_lib$1_prefix}/include"
     LDFLAGS="$LDFLAGS${LDFLAGS:+ }-L${with_lib$1_prefix}/lib"
+    AC_LIB_HAVE_LINKFLAGS([$1], [$2], [$3])
+    CPPFLAGS="$libssh2_save_CPPFLAGS"
+    LDFLAGS="$libssh2_save_LDFLAGS"
+  else
+    AC_LIB_HAVE_LINKFLAGS([$1], [$2], [$3])
   fi
-
-  AC_LIB_HAVE_LINKFLAGS([$1], [$2], [$3])
 
   if test "$ac_cv_lib$1" = "yes"; then :
     $4
-  else
-    CPPFLAGS="$libssh2_save_CPPFLAGS"
-    LDFLAGS="$libssh2_save_LDFLAGS"
   fi
 ])
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -835,21 +835,21 @@ dnl
 dnl For convenience, $4 is expanded if [lib]$1 is found.
 
 AC_DEFUN([LIBSSH2_LIB_HAVE_LINKFLAGS], [
+  libssh2_save_CPPFLAGS="$CPPFLAGS"
+  libssh2_save_LDFLAGS="$LDFLAGS"
 
   if test "${with_lib$1_prefix+set}" = set -a "${with_lib$1_prefix}" != 'no'; then
-    libssh2_save_CPPFLAGS="$CPPFLAGS"
-    libssh2_save_LDFLAGS="$LDFLAGS"
     CPPFLAGS="$CPPFLAGS${CPPFLAGS:+ }-I${with_lib$1_prefix}/include"
     LDFLAGS="$LDFLAGS${LDFLAGS:+ }-L${with_lib$1_prefix}/lib"
-    AC_LIB_HAVE_LINKFLAGS([$1], [$2], [$3])
-    CPPFLAGS="$libssh2_save_CPPFLAGS"
-    LDFLAGS="$libssh2_save_LDFLAGS"
-  else
-    AC_LIB_HAVE_LINKFLAGS([$1], [$2], [$3])
   fi
+
+  AC_LIB_HAVE_LINKFLAGS([$1], [$2], [$3])
 
   if test "$ac_cv_lib$1" = "yes"; then :
     $4
+  else
+    CPPFLAGS="$libssh2_save_CPPFLAGS"
+    LDFLAGS="$libssh2_save_LDFLAGS"
   fi
 ])
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -836,7 +836,7 @@ dnl For convenience, $4 is expanded if [lib]$1 is found.
 
 AC_DEFUN([LIBSSH2_LIB_HAVE_LINKFLAGS], [
 
-  if test "${with_lib$1_prefix+set}" = set; then
+  if test "${with_lib$1_prefix+set}" = set -a "${with_lib$1_prefix}" != 'no'; then
     libssh2_save_CPPFLAGS="$CPPFLAGS"
     libssh2_save_LDFLAGS="$LDFLAGS"
     CPPFLAGS="$CPPFLAGS${CPPFLAGS:+ }-I${with_lib$1_prefix}/include"


### PR DESCRIPTION
Do not test the prefix when set to `no`.
(as with `--without-lib*-prefix`)

Before this patch this test was always made and when detected despite
the wrong prefix, the `no` prefix remained in `LDFLAGS` causing a build
failure later in `libtool`.

Fixes:
```
$ ../configure --without-libssl-prefix
[...]
../libtool: line 7756: cd: no/lib: No such file or directory
libtool:   error: cannot determine absolute directory name of 'no/lib'
make[2]: *** [libssh2.la] Error 1
```

Follow-up to d19b61907039554b8261a90898f2f31e1a706f38 #1384

Reported-by: Christoph Reiter
Fixes #1505
