### PR TITLE
kex: fix null pointer dereference in `diffie_hellman_sha_algo()`

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -571,6 +571,11 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 #endif /* LIBSSH2DEBUG */
 
 
+        if(!session->hostkey) {
+            ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                                 "hostkey is NULL");
+            goto clean_exit;
+        }
         if(session->hostkey->init(session, session->server_hostkey,
                                   session->server_hostkey_len,
                                   &session->server_hostkey_abstract)) {


### PR DESCRIPTION
[Warning] This PR is generated by AI
1. **PR Title**: Fix NPD in libssh2

2. **PR Description**:  
   - **Bug Type**: Segv on unknown address  
   - **Summary**: A vulnerability was discovered in the `libssh2` program where an invalid memory access occurred due to dereferencing a `NULL` pointer. The issue was identified in the `diffie_hellman_sha_algo` function within `kex.c`.  
   - **Fix Summary**: The patch resolves the issue by introducing a `NULL` pointer check for `session->hostkey` before dereferencing it. If the pointer is `NULL`, a corresponding error is returned, and the function exits gracefully. This fix ensures the program does not attempt to access invalid memory. The patch improves the security and stability of the program by preventing segmentation faults caused by invalid memory access.  

3. **Sanitizer Report Summary**:  
   The sanitizer detected an invalid memory access error, caused by the program attempting to dereference a `NULL` pointer at address `0x000000000010`. This occurred in `diffie_hellman_sha_algo` within `kex.c:574:30`. The issue propagated through various functions, ultimately causing a segmentation fault.  

4. **Full Sanitizer Report**:
   ```
   ==38642==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000010 (pc 0x561cf276068e bp 0x7fffbff5b4c0 sp 0x7fffbff5a740 T0)
   ==38642==The signal is caused by a READ memory access.
   ==38642==Hint: address points to the zero page.
       #0 0x561cf276068e in diffie_hellman_sha_algo /root/src/kex.c:574:30
       #1 0x561cf2767e0f in kex_method_diffie_hellman_group1_sha1_key_exchange /root/src/kex.c:1077:11
       #2 0x561cf2743362 in _libssh2_kex_exchange /root/src/kex.c:4153:23
       #3 0x561cf270c441 in session_startup /root/src/session.c:787:14
       #4 0x561cf270bd67 in libssh2_session_handshake /root/src/session.c:878:5
       #5 0x561cf270a243 in LLVMFuzzerTestOneInput /root/tests/ossfuzz/ssh2_client_fuzzer.cc:71:6
       #6 0x561cf2615284 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/root/out/ssh2_client_fuzzer+0x5e284) (BuildId: 2c3721615ef3d2cdc333d6b89d473a794a8fb25f)
       #7 0x561cf25fe3b6 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/root/out/ssh2_client_fuzzer+0x473b6) (BuildId: 2c3721615ef3d2cdc333d6b89d473a794a8fb25f)
       #8 0x561cf2603e6a in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/root/out/ssh2_client_fuzzer+0x4ce6a) (BuildId: 2c3721615ef3d2cdc333d6b89d473a794a8fb25f)
       #9 0x561cf262e626 in main (/root/out/ssh2_client_fuzzer+0x77626) (BuildId: 2c3721615ef3d2cdc333d6b89d473a794a8fb25f)
       #10 0x7f444be691c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
       #11 0x7f444be6928a in __libc_start_main csu/../csu/libc-start.c:360:3
       #12 0x561cf25f8f84 in _start (/root/out/ssh2_client_fuzzer+0x41f84) (BuildId: 2c3721615ef3d2cdc333d6b89d473a794a8fb25f)

   AddressSanitizer can not provide additional info.
   SUMMARY: AddressSanitizer
   ```

5. **Files Modified**: `src/kex.c`  
   ```diff
   --- a/src/kex.c
   +++ b/src/kex.c
   @@ -571,6 +571,11 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
    #endif /* LIBSSH2DEBUG */
    
   
   +        if(!session->hostkey) {
   +            ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
   +                                 "hostkey is NULL");
   +            goto clean_exit;
   +        }
            if(session->hostkey->init(session, session->server_hostkey,
                                      session->server_hostkey_len,
                                      &session->server_hostkey_abstract)) {
   ```

6. **Patch Validation**: The patch has been validated and confirmed to resolve the issue identified in the sanitizer report. Testing with the provided PoC confirmed that the invalid memory access no longer occurs, and no new issues were introduced.

7. **Links**:  
   - [PoC URL](https://github.com/aled-ua/PoC/blob/patch/libssh2/crash-c7c664759c840b3f1c438b7232f713b756ed640f/%40POC%40)  