### PR TITLE
cmake: fix cmake warnings

### DIFF
--- a/cmake/CopyRuntimeDependencies.cmake
+++ b/cmake/CopyRuntimeDependencies.cmake
@@ -57,8 +57,7 @@ function(add_target_to_copy_dependencies)
 
   foreach(_dependency IN LISTS COPY_DEPENDENCIES)
     add_custom_command(
-      TARGET ${COPY_TARGET}
-      DEPENDS ${_dependency}
+      TARGET ${COPY_TARGET} POST_BUILD
       # Make directory first otherwise file is copied in place of
       # directory instead of into it
       COMMAND ${CMAKE_COMMAND} ARGS -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}"


### PR DESCRIPTION
```
CMake Warning (dev) at cmake/CopyRuntimeDependencies.cmake:59 (add_custom_command):
  The following keywords are not supported when using
  add_custom_command(TARGET): DEPENDS.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
Call Stack (most recent call first):
  example/CMakeLists.txt:58 (add_target_to_copy_dependencies)
```
```
CMake Warning (dev) at cmake/CopyRuntimeDependencies.cmake:59 (add_custom_command):
  Exactly one of PRE_BUILD, PRE_LINK, or POST_BUILD must be given.  Assuming
  POST_BUILD to preserve backward compatibility.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
Call Stack (most recent call first):
  example/CMakeLists.txt:58 (add_target_to_copy_dependencies)
```
Ref: https://github.com/libssh2/libssh2/actions/runs/12614228505/job/35152908184?pr=1510#step:15:77