### PR TITLE
ci/appveyor: fix PowerShell warning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -149,7 +149,7 @@ build_script:
       }
 
       $options += "-DCRYPTO_BACKEND=$env:CRYPTO_BACKEND"
-      if($env:OPENSSL_ROOT_DIR -ne '') {
+      if($env:OPENSSL_ROOT_DIR) {
         if(Test-Path $env:OPENSSL_ROOT_DIR) {
           $options += "-DOPENSSL_ROOT_DIR=$env:OPENSSL_ROOT_DIR"
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -149,7 +149,7 @@ build_script:
       }
 
       $options += "-DCRYPTO_BACKEND=$env:CRYPTO_BACKEND"
-      if($env:OPENSSL_ROOT_DIR) {
+      if($env:OPENSSL_ROOT_DIR -and $env:OPENSSL_ROOT_DIR -ne '') {
         if(Test-Path $env:OPENSSL_ROOT_DIR) {
           $options += "-DOPENSSL_ROOT_DIR=$env:OPENSSL_ROOT_DIR"
         }


### PR DESCRIPTION
in WinCNG builds, e.g. VS2015, WinCNG, x86, Server 2016:
```
Test-Path : Cannot bind argument to parameter 'Path' because it is null.
At line:10 char:16
+   if(Test-Path $env:OPENSSL_ROOT_DIR) {
+                ~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.TestPathCommand
```
https://ci.appveyor.com/project/libssh2org/libssh2/builds/51280178/job/9ddtkb91w54si3da#L85