### PR TITLE
userauth.c: fix possible memory leaks #1504

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -793,7 +793,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
          * The 'sftpInit_sftp' and 'sftpInit_channel' struct fields within the
          * session struct are only to be used during the setup phase. As soon
          * as the SFTP session is created they are cleared and can thus be
-         * re-used again to allow any amount of SFTP handles per sessions.
+         * reused again to allow any amount of SFTP handles per sessions.
          *
          * Note that you MUST NOT try to call libssh2_sftp_init() again to get
          * another handle until the previous call has finished and either

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1621,7 +1621,7 @@ retry_auth:
          *
          * Note that the 'pubkeydata_len' extra bytes allocated here will not
          * be used in this first send, but will be used in the later one where
-         * this same allocation is re-used.
+         * this same allocation is reused.
          */
         s = session->userauth_pblc_packet =
             LIBSSH2_ALLOC(session,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -82,6 +82,10 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
 
         session->userauth_list_data_len = username_len + 27;
 
+        if(session->userauth_list_data != NULL) {
+            LIBSSH2_FREE(session, session->userauth_list_data);
+        }
+        
         s = session->userauth_list_data =
             LIBSSH2_ALLOC(session, session->userauth_list_data_len);
         if(!session->userauth_list_data) {
@@ -154,6 +158,11 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                                "Unexpected userauth banner size");
                 return NULL;
             }
+
+            if(session->userauth_banner != NULL) {
+                LIBSSH2_FREE(session, session->userauth_banner);
+            }
+            
             session->userauth_banner = LIBSSH2_ALLOC(session, banner_len + 1);
             if(!session->userauth_banner) {
                 LIBSSH2_FREE(session, session->userauth_list_data);

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -82,7 +82,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
 
         session->userauth_list_data_len = username_len + 27;
 
-        if(session->userauth_list_data != NULL) {
+        if(!session->userauth_list_data) {
             LIBSSH2_FREE(session, session->userauth_list_data);
         }
         
@@ -159,7 +159,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                 return NULL;
             }
 
-            if(session->userauth_banner != NULL) {
+            if(!session->userauth_banner) {
                 LIBSSH2_FREE(session, session->userauth_banner);
             }
             

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -85,7 +85,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
         if(!session->userauth_list_data) {
             LIBSSH2_FREE(session, session->userauth_list_data);
         }
-        
+
         s = session->userauth_list_data =
             LIBSSH2_ALLOC(session, session->userauth_list_data_len);
         if(!session->userauth_list_data) {
@@ -162,7 +162,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
             if(!session->userauth_banner) {
                 LIBSSH2_FREE(session, session->userauth_banner);
             }
-            
+
             session->userauth_banner = LIBSSH2_ALLOC(session, banner_len + 1);
             if(!session->userauth_banner) {
                 LIBSSH2_FREE(session, session->userauth_list_data);


### PR DESCRIPTION
Notes:
Fix possible memory leaks if `userauth_list()` is called more than once, e.g. an auth error case. 

Author:
Will Cosgrove

Credit:
pyscripter