### PR TITLE
ci/GHA: fix Cygwin breakage in `mansyntax.sh`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
       - uses: cygwin/cygwin-install-action@v5
         with:
           platform: ${{ matrix.platform }}
-          packages: ${{ matrix.build == 'automake' && 'autoconf libtool make' || 'ninja' }} ${{ matrix.build }} gcc-core gcc-g++ binutils libssl-devel zlib-devel
+          packages: ${{ matrix.build == 'automake' && 'autoconf libtool make' || 'ninja' }} ${{ matrix.build }} gcc-core gcc-g++ binutils libssl-devel zlib-devel util-linux
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
       - name: 'autotools'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
       - uses: cygwin/cygwin-install-action@v5
         with:
           platform: ${{ matrix.platform }}
-          packages: ${{ matrix.build == 'automake' && 'autoconf libtool make' || 'ninja' }} ${{ matrix.build }} gcc-core gcc-g++ binutils libssl-devel zlib-devel util-linux
+          packages: ${{ matrix.build == 'automake' && 'autoconf libtool make' || 'ninja' }} ${{ matrix.build }} gcc-core gcc-g++ binutils libssl-devel zlib-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
       - name: 'autotools'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,9 @@ jobs:
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/System32"
+          echo '----------------------------'
+          ls -1 /usr/bin
+          echo '----------------------------'
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
             --with-crypto=openssl \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,9 +373,6 @@ jobs:
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/System32"
-          echo '----------------------------'
-          ls -1 /usr/bin
-          echo '----------------------------'
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
             --with-crypto=openssl \

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -19,18 +19,6 @@ mandir="$(dirname "$0")/../docs"
 
 ec=0
 
-echo '----------------------'
-command -v man || true
-file "$(command -v man)" || true
-echo '----------------------'
-command -v col || true
-file "$(command -v col)" || true
-echo '----------------------'
-echo "${MANPAGER:-}"
-echo '----------------------'
-echo "${PAGER:-}"
-echo '----------------------'
-
 #
 # Only test if suitable man is available
 #

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -33,7 +33,8 @@ if command -v grep >/dev/null 2>&1 && \
 
   for manpage in "$mandir"/libssh2_*.*; do
     echo "$manpage"
-    warnings=$(man -M "$dstdir" --warnings -l "$manpage")
+    warnings=$(LANG=en_US.UTF-8 MANWIDTH=80 man -M "$dstdir" --warnings \
+      -E UTF-8 -l "$manpage" >/dev/null 2>&1)
     if [ -n "$warnings" ]; then
       echo "$warnings"
       ec=1

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -26,9 +26,9 @@ echo '----------------------'
 command -v col || true
 file "$(command -v col)" || true
 echo '----------------------'
-echo "$MANPAGER"
+echo "${MANPAGER:-}"
 echo '----------------------'
-echo "$PAGER"
+echo "${PAGER:-}"
 echo '----------------------'
 
 #

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -43,7 +43,7 @@ if command -v grep >/dev/null 2>&1 && \
 
   for manpage in "$mandir"/libssh2_*.*; do
     echo "$manpage"
-    warnings=$(LANG=en_US.UTF-8 MANWIDTH=80 man -M "$dstdir" --warnings \
+    warnings=$(LANG=en_US.UTF-8 MANWIDTH=80 man -M "$dstdir" --pager=true --warnings \
       -E UTF-8 -l "$manpage")
     if [ -n "$warnings" ]; then
       echo "$warnings"

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -31,7 +31,7 @@ if command -v grep >/dev/null 2>&1 && \
 
   for manpage in "$mandir"/libssh2_*.*; do
     echo "$manpage"
-    warnings=$(LANG=C MANWIDTH=80 man -M "$dstdir" --warnings -l "$manpage")
+    warnings=$(MANWIDTH=80 man -M "$dstdir" --warnings -l "$manpage")
     if [ -n "$warnings" ]; then
       echo "$warnings"
       ec=1

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -19,6 +19,9 @@ mandir="$(dirname "$0")/../docs"
 
 ec=0
 
+command -v man || true
+command -v col || true
+
 #
 # Only test if suitable man is available
 #

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -31,7 +31,7 @@ if command -v grep >/dev/null 2>&1 && \
 
   for manpage in "$mandir"/libssh2_*.*; do
     echo "$manpage"
-    warnings=$(MANWIDTH=80 man -M "$dstdir" --warnings -l "$manpage")
+    warnings=$(man -M "$dstdir" --warnings -l "$manpage")
     if [ -n "$warnings" ]; then
       echo "$warnings"
       ec=1

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -17,8 +17,6 @@ command -v gman >/dev/null 2>&1 && man() { gman "$@"; }
 dstdir="${builddir:-$PWD}"
 mandir="$(dirname "$0")/../docs"
 
-export MAN_KEEP_FORMATTING=1
-
 ec=0
 
 #
@@ -28,6 +26,10 @@ if command -v grep >/dev/null 2>&1 && \
    man --help 2>/dev/null | grep -q warnings; then
 
   trap 'rm -f "$dstdir/man3"' EXIT HUP INT TERM
+
+  # Tell 'man' to not pipe the output through 'col'.
+  # 'col' is missing from Cygwin since util-linux 2.40.2-1 (2024-12-24).
+  export MAN_KEEP_FORMATTING=1
 
   ln -sf "$mandir" "$dstdir/man3"
 

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -32,7 +32,7 @@ if command -v grep >/dev/null 2>&1 && \
   for manpage in "$mandir"/libssh2_*.*; do
     echo "$manpage"
     warnings=$(LANG=en_US.UTF-8 MANWIDTH=80 man -M "$dstdir" --warnings \
-      -E UTF-8 -l "$manpage" >/dev/null 2>&1)
+      -E UTF-8 -l "$manpage")
     if [ -n "$warnings" ]; then
       echo "$warnings"
       ec=1

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -31,7 +31,7 @@ if command -v grep >/dev/null 2>&1 && \
 
   for manpage in "$mandir"/libssh2_*.*; do
     echo "$manpage"
-    warnings=$(LANG=C.UTF-8 MANWIDTH=80 man -M "$dstdir" --warnings -l "$manpage")
+    warnings=$(LANG=C MANWIDTH=80 man -M "$dstdir" --warnings -l "$manpage")
     if [ -n "$warnings" ]; then
       echo "$warnings"
       ec=1

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -17,6 +17,8 @@ command -v gman >/dev/null 2>&1 && man() { gman "$@"; }
 dstdir="${builddir:-$PWD}"
 mandir="$(dirname "$0")/../docs"
 
+export MAN_KEEP_FORMATTING=1
+
 ec=0
 
 #

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -19,8 +19,17 @@ mandir="$(dirname "$0")/../docs"
 
 ec=0
 
+echo '----------------------'
 command -v man || true
+file "$(command -v man)" || true
+echo '----------------------'
 command -v col || true
+file "$(command -v col)" || true
+echo '----------------------'
+echo "$MANPAGER"
+echo '----------------------'
+echo "$PAGER"
+echo '----------------------'
 
 #
 # Only test if suitable man is available

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -31,8 +31,7 @@ if command -v grep >/dev/null 2>&1 && \
 
   for manpage in "$mandir"/libssh2_*.*; do
     echo "$manpage"
-    warnings=$(LANG=en_US.UTF-8 MANWIDTH=80 man -M "$dstdir" --pager=true --warnings \
-      -E UTF-8 -l "$manpage")
+    warnings=$(LANG=C.UTF-8 MANWIDTH=80 man -M "$dstdir" --warnings -l "$manpage")
     if [ -n "$warnings" ]; then
       echo "$warnings"
       ec=1


### PR DESCRIPTION
Cygwin CI jobs started failing while running `mansyntax.sh`.

The reason for the fallout is `util-linux` packaged by Cygwin no
longer shipping `col.exe`, that is required by `man.exe`:
https://cygwin.com/packages/x86_64/util-linux/util-linux-2.39.3-2 (2024-04-02)
https://cygwin.com/packages/x86_64/util-linux/util-linux-2.40.2-1 (2024-12-24)

Work it around by telling `man` to not call `col`.

Relevant links:
https://github.com/util-linux/util-linux
https://gitlab.com/man-db/man-db
https://cygwin.com/packages/summary/util-linux.html
https://cygwin.com/cgit/cygwin-packages/util-linux/log/ (no visible commit for 2.40.2-1)
https://cygwin.com/pipermail/cygwin/2025-January/date.html (no reports)

Fixes:
```
test 1
    Start 1: mansyntax

1: Test command: /usr/bin/sh.exe "-c" "/cygdrive/d/a/libssh2/libssh2/tests/mansyntax.sh"
1: Working Directory: /cygdrive/d/a/libssh2/libssh2/bld/tests
1: Test timeout computed to be: 10000000
1: /cygdrive/d/a/libssh2/libssh2/tests/../docs/libssh2_agent_connect.3
1: man: can't execute col: No such file or directory
1: man: command exited with status 127: col -b -p -x | sed -e '/^[[:space:]]*$/{ N; /^[[:space:]]*\n[[:space:]]*$/D; }'
1/2 Test #1: mansyntax ........................***Failed    0.24 sec
/cygdrive/d/a/libssh2/libssh2/tests/../docs/libssh2_agent_connect.3
man: can't execute col: No such file or directory
man: command exited with status 127: col -b -p -x | sed -e '/^[[:space:]]*$/{ N; /^[[:space:]]*\n[[:space:]]*$/D; }'
```
https://github.com/libssh2/libssh2/actions/runs/13021305834/job/36322366102?pr=1510#step:6:216
