### PR TITLE
tests: delete CMake ExternalProject integration test

### DIFF
--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -10,16 +10,7 @@ option(TEST_INTEGRATION_MODE "Integration mode" "find_package")
 
 message(STATUS "TEST_INTEGRATION_MODE: ${TEST_INTEGRATION_MODE}")
 
-if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
-   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
-  if(TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
-    include(ExternalProject)
-    ExternalProject_Add(libssh2
-      URL "${FROM_ARCHIVE}"
-      URL_HASH "SHA256=${FROM_HASH}"
-      INSTALL_COMMAND ""
-      DOWNLOAD_EXTRACT_TIMESTAMP ON)
-  endif()
+if(TEST_INTEGRATION_MODE STREQUAL "find_package")
   find_package(libssh2 REQUIRED CONFIG)
   find_package(libssh2 REQUIRED CONFIG)  # test for double-inclusion
   foreach(result_var IN ITEMS libssh2_FOUND libssh2_VERSION)
@@ -51,8 +42,7 @@ target_link_libraries(test-dependent-shared-ns PRIVATE "libssh2::libssh2_shared"
 add_executable(test-dependent-selected-ns "test.c")
 target_link_libraries(test-dependent-selected-ns PRIVATE "libssh2::libssh2")
 
-if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
-   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
+if(TEST_INTEGRATION_MODE STREQUAL "find_package")
 
   # Compatibility alias
   add_executable(test-dependent-compat "test.c")

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -22,9 +22,3 @@ make -C bld-libssh2 DESTDIR=pkg install
 rm -rf bld-find_package; cmake -B bld-find_package -DTEST_INTEGRATION_MODE=find_package \
   -DCMAKE_PREFIX_PATH="${PWD}/bld-libssh2/pkg/usr/local/lib/cmake/libssh2"
 make -C bld-find_package
-
-(cd ../..; git archive --format=tar HEAD) | gzip > source.tar.gz
-rm -rf bld-externalproject; cmake -B bld-externalproject -DTEST_INTEGRATION_MODE=ExternalProject \
-  -DFROM_ARCHIVE="${PWD}/source.tar.gz" \
-  -DFROM_HASH="$(openssl dgst -sha256 source.tar.gz | grep -a -i -o -E '[0-9a-f]{64}$')"
-make -C bld-externalproject


### PR DESCRIPTION
For no reason it broke when trying to silence a CMake deprecation
warning in #1510. Then when tested locally, it did not work either with
or without the patch in #1510.

I'm not sure, but existing implementation may have worked by accident
by re-using leftovers from the preceding two integration tests.

After spending a days trying to fix this, I declare defeat. If such
amount of time of testing, reading documentation, blog posts, variable
traces, logs, bug reports is not enough to make this work, or even
to understand how this should work, this seems like a lost cause.

CMake makes it impossible to cleanly query the properties of a target,
which would be essential for debugging. There are rough workarounds
with years of iteration, and those still don't work to this day:
https://stackoverflow.com/questions/32183975/how-to-print-all-the-properties-of-a-target-in-cmake

Copy-pasting an incantation from a blog post that made this work:
https://inhzus.io/posts/2023-12-01-cmake-external-project/
almost made it work, except that it had a workaround for a 10-year old
pending bug, another workaround for Ninja which required CMake 3.29,
with settings hard-wired, and explicitly configured in weird ways. But,
it still missed to pass the libssh2 library to the test target and
failed to link.

Then tried to pass the libssh2 lib the "usual" way via:
```
target_link_libraries(test PRIVATE libssh2)
```

That also did not work because CMake decided that the external libssh2
target is of "UTILITY" type, and errored with:
```
CMake Error at CMakeLists.txt:39 (target_link_libraries):
  Target "libssh2" of type UTILITY may not be linked into another target.
  One may link only to INTERFACE, OBJECT, STATIC or SHARED libraries, or to
  executables with the ENABLE_EXPORTS property set.
```

This type property is read-only, and documentation has no mention of it,
or how to set it whatsoever:
https://cmake.org/cmake/help/latest/module/ExternalProject.html

libssh2's `docs/INSTALL_CMAKE.md` mentions ExternalProject as a way to
use libssh2. Added there with the initial CMake commit. We should
probably delete it from there.

This consumption method has a single mention in public issues:
https://github.com/libssh2/libssh2/issues/1116
