### PR TITLE
build: prepare builds for clang-cl, add cmake ossfuzz support

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -31,7 +31,7 @@ jobs:
         dry-run: false
         language: c
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ failure() && steps.build.outcome == 'success' }}
       with:
         name: artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,8 +122,9 @@ endif()
 
 option(BUILD_EXAMPLES "Build libssh2 examples" ON)
 option(BUILD_TESTING "Build libssh2 test suite" ON)
+option(BUILD_OSSFUZZ "Build libssh2 OSS-Fuzz" OFF)
 
-if(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
+if((NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS) OR BUILD_OSSFUZZ)
   set(BUILD_STATIC_LIBS ON)
 endif()
 
@@ -149,7 +150,7 @@ if(HIDE_SYMBOLS)
          (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.0) OR
          (CMAKE_C_COMPILER_ID MATCHES "Intel" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
     set(LIB_SHARED_C_FLAGS "-fvisibility=hidden")
-    set(LIBSSH2_API "__attribute__ ((__visibility__ (\"default\")))")
+    set(LIBSSH2_API "__attribute__((__visibility__(\"default\")))")
   elseif(CMAKE_C_COMPILER_ID MATCHES "SunPro" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.0)
     set(LIB_SHARED_C_FLAGS "-xldscope=hidden")
     set(LIBSSH2_API "__global")
@@ -228,7 +229,7 @@ endif()
 # duration of these tests.
 if(MSVC AND ENABLE_WERROR)
   cmake_push_check_state()
-  set(CMAKE_REQUIRED_FLAGS "/WX-")
+  set(CMAKE_REQUIRED_FLAGS "-WX-")
 endif()
 
 if(HAVE_SYS_TIME_H)

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -114,13 +114,6 @@ if(PICKY_COMPILER)
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
-    set(_picky_common
-      -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
-      -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
-      -Wpragmas                            # clang  3.5  gcc  4.1  appleclang  6.0
-      -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
-    )
-
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
       list(APPEND _picky_enable
         ${_picky_common_old}
@@ -137,10 +130,13 @@ if(PICKY_COMPILER)
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
         list(APPEND _picky_enable
-          ${_picky_common}
-        # -Wunreachable-code-break         # clang  3.5            appleclang  6.0  # Not used: Silent in "unity" builds
+          -Wdouble-promotion               # clang  3.6  gcc  4.6  appleclang  6.3
+          -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
           -Wheader-guard                   # clang  3.4            appleclang  5.1
+          -Wpragmas                        # clang  3.5  gcc  4.1  appleclang  6.0
           -Wsometimes-uninitialized        # clang  3.2            appleclang  4.6
+        # -Wunreachable-code-break         # clang  3.5            appleclang  6.0  # Not used: Silent in "unity" builds
+          -Wunused-const-variable          # clang  3.4  gcc  6.0  appleclang  5.1
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR
@@ -164,9 +160,6 @@ if(PICKY_COMPILER)
         )
       endif()
     else()  # gcc
-      list(APPEND _picky_detect
-        ${_picky_common}
-      )
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
         list(APPEND _picky_enable
@@ -174,8 +167,8 @@ if(PICKY_COMPILER)
           -Wclobbered                      #             gcc  4.3
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
+          -Wpragmas                        # clang  3.5  gcc  4.1  appleclang  6.0
           -Wstrict-aliasing=3              #             gcc  4.0
-          -Wtrampolines                    #             gcc  4.3
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.5 AND MINGW)
@@ -185,7 +178,9 @@ if(PICKY_COMPILER)
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
         list(APPEND _picky_enable
+          -Wdouble-promotion               # clang  3.6  gcc  4.6  appleclang  6.3
           -Wformat=2                       # clang  3.0  gcc  4.8
+          -Wtrampolines                    #             gcc  4.6
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
@@ -200,6 +195,7 @@ if(PICKY_COMPILER)
             -fdelete-null-pointer-checks
           -Wshift-negative-value           # clang  3.7  gcc  6.0 (clang default)
           -Wshift-overflow=2               # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
+          -Wunused-const-variable          # clang  3.4  gcc  6.0  appleclang  5.1
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0)
@@ -215,6 +211,7 @@ if(PICKY_COMPILER)
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0)
         list(APPEND _picky_enable
           -Warith-conversion               #             gcc 10.0
+          -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
         )
       endif()
     endif()

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -89,7 +89,6 @@ if(PICKY_COMPILER)
       -Waddress                            # clang  2.7  gcc  4.3
       -Wattributes                         # clang  2.7  gcc  4.1
       -Wcast-align                         # clang  1.0  gcc  4.2
-      -Wcast-qual                          # clang  3.0  gcc  3.4.6
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
       -Wdiv-by-zero                        # clang  2.7  gcc  4.1
       -Wempty-body                         # clang  2.7  gcc  4.3

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -248,12 +248,12 @@ int main(int argc, char *argv[])
     for(;;) {
         fd_set fds;
         FD_ZERO(&fds);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
         FD_SET(forwardsock, &fds);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
         tv.tv_sec = 0;
@@ -263,12 +263,12 @@ int main(int argc, char *argv[])
             fprintf(stderr, "failed to select().\n");
             goto shutdown;
         }
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
         if(rc && FD_ISSET(forwardsock, &fds)) {
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
             len = recv(forwardsock, buf, sizeof(buf), 0);

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -64,12 +64,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -48,12 +48,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -56,12 +56,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -258,13 +258,13 @@ int main(int argc, char *argv[])
 
         FD_ZERO(&fd);
         FD_ZERO(&fd2);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
         FD_SET(sock, &fd);
         FD_SET(sock, &fd2);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -329,13 +329,13 @@ int main(int argc, char *argv[])
 
             FD_ZERO(&fd);
             FD_ZERO(&fd2);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
             FD_SET(sock, &fd);
             FD_SET(sock, &fd2);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -65,12 +65,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -54,12 +54,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -55,12 +55,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -50,12 +50,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -47,12 +47,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -51,12 +51,12 @@ static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 
     FD_ZERO(&fd);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(socket_fd, &fd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -246,12 +246,12 @@ int main(int argc, char *argv[])
     for(;;) {
         fd_set fds;
         FD_ZERO(&fds);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
         FD_SET(forwardsock, &fds);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
         tv.tv_sec = 0;
@@ -261,12 +261,12 @@ int main(int argc, char *argv[])
             fprintf(stderr, "failed to select().\n");
             goto shutdown;
         }
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
         if(rc && FD_ISSET(forwardsock, &fds)) {
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
             ssize_t nwritten;

--- a/example/x11.c
+++ b/example/x11.c
@@ -210,12 +210,12 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, libssh2_socket_t sock)
     timeval_out.tv_usec = 0;
 
     FD_ZERO(&set);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
     FD_SET(sock, &set);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -415,12 +415,12 @@ int main(int argc, char *argv[])
     for(;;) {
 
         FD_ZERO(&set);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
         FD_SET(fileno(stdin), &set);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 
 ## Options
 
-unset(_libssh2_definitions)
+set(_libssh2_definitions "")
 
 option(CLEAR_MEMORY "Enable clearing of memory before being freed" ON)
 if(NOT CLEAR_MEMORY)
@@ -76,8 +76,8 @@ list(APPEND LIBSSH2_LIBS ${LIBSSH2_LIBS_SOCKET})
 list(APPEND libssh2_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR})
 
 if(MSVC)
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /Zi /Od")
-  set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} /DEBUG")
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Zi -Od")
+  set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -DEBUG")
 endif()
 
 ## Sources
@@ -100,7 +100,7 @@ if(WIN32 AND (BUILD_STATIC_LIBS OR BUILD_STATIC_FOR_TESTS) AND BUILD_SHARED_LIBS
   set(STATIC_LIB_SUFFIX "_static")
 endif()
 
-unset(_libssh2_export)
+set(_libssh2_export "")
 
 # we want it to be called libssh2 on all platforms
 if(BUILD_STATIC_LIBS OR BUILD_STATIC_FOR_TESTS)
@@ -212,7 +212,7 @@ endif()
 set(_ldflags "")
 
 # Avoid getting unnecessary -L options for known system directories.
-unset(_sys_libdirs)
+set(_sys_libdirs "")
 foreach(_libdir IN LISTS CMAKE_SYSTEM_PREFIX_PATH)
   if(_libdir MATCHES "/$")
     set(_libdir "${_libdir}lib")
@@ -237,7 +237,7 @@ foreach(_libdir IN LISTS LIBSSH2_LIBDIRS)
   endif()
 endforeach()
 
-unset(_implicit_libs)
+set(_implicit_libs "")
 if(NOT MINGW AND NOT UNIX)
   set(_implicit_libs ${CMAKE_C_IMPLICIT_LINK_LIBRARIES})
 endif()
@@ -259,7 +259,7 @@ foreach(_lib IN LISTS _implicit_libs LIBSSH2_LIBS)
   endif()
   if(_lib MATCHES "^-")
     list(APPEND _ldflags "${_lib}")
-  elseif(_lib MATCHES ".*/.*")
+  elseif(_lib MATCHES "/")
     # This gets a bit more complex, because we want to specify the
     # directory separately, and only once per directory
     get_filename_component(_libdir ${_lib} DIRECTORY)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -45,7 +45,7 @@
 
 /* FIXME: Disable warnings for 'src' */
 #if !defined(LIBSSH2_TESTS) && !defined(LIBSSH2_WARN_SIGN_CONVERSION)
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 #endif

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -41,7 +41,7 @@
 
 #define LIBSSH2_CRYPTO_ENGINE libssh2_mbedtls
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 /* mbedTLS (as of v3.5.1) has a `[-Werror=arith-conversion]`
    warning in its public headers. */
@@ -73,7 +73,7 @@
 #include <mbedtls/pk.h>
 #include <mbedtls/error.h>
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/session.c
+++ b/src/session.c
@@ -675,12 +675,12 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
 
         if(dir & LIBSSH2_SESSION_BLOCK_INBOUND) {
             FD_ZERO(&rfd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
             FD_SET(session->socket_fd, &rfd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
             readfd = &rfd;
@@ -688,12 +688,12 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
 
         if(dir & LIBSSH2_SESSION_BLOCK_OUTBOUND) {
             FD_ZERO(&wfd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
             FD_SET(session->socket_fd, &wfd);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
             writefd = &wfd;
@@ -1655,24 +1655,24 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
         switch(fds[i].type) {
         case LIBSSH2_POLLFD_SOCKET:
             if(fds[i].events & LIBSSH2_POLLFD_POLLIN) {
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
                 FD_SET(fds[i].fd.socket, &rfds);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
                 if(fds[i].fd.socket > maxfd)
                     maxfd = fds[i].fd.socket;
             }
             if(fds[i].events & LIBSSH2_POLLFD_POLLOUT) {
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
                 FD_SET(fds[i].fd.socket, &wfds);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
                 if(fds[i].fd.socket > maxfd)
@@ -1681,12 +1681,12 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
             break;
 
         case LIBSSH2_POLLFD_CHANNEL:
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
             FD_SET(fds[i].fd.channel->session->socket_fd, &rfds);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
             if(fds[i].fd.channel->session->socket_fd > maxfd)
@@ -1696,12 +1696,12 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
             break;
 
         case LIBSSH2_POLLFD_LISTENER:
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
             FD_SET(fds[i].fd.listener->session->socket_fd, &rfds);
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
             if(fds[i].fd.listener->session->socket_fd > maxfd)
@@ -1880,7 +1880,7 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
             for(i = 0; i < nfds; i++) {
                 switch(fds[i].type) {
                 case LIBSSH2_POLLFD_SOCKET:
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
@@ -1893,7 +1893,7 @@ libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
                     if(fds[i].revents) {
                         active_fds++;
                     }
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
                     break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,7 +85,7 @@ foreach(_test IN LISTS DOCKER_TESTS STANDALONE_TESTS SSHD_TESTS)
   elseif(TARGET ${LIB_STATIC})
     set(_lib_for_tests ${LIB_STATIC})
   else()
-    unset(_lib_for_tests)
+    set(_lib_for_tests "")
     message(STATUS "Skip test requiring static libssh2 lib: ${_test}")
   endif()
 
@@ -132,7 +132,7 @@ foreach(_test IN LISTS STANDALONE_TESTS)
 endforeach()
 
 if(RUN_SSHD_TESTS AND SSHD_EXECUTABLE)
-  unset(_sshd_test_targets)
+  set(_sshd_test_targets "")
   foreach(_test IN LISTS SSHD_TESTS)
     if(TARGET ${_test})
       set(_sshd_test_targets "${_sshd_test_targets} $<TARGET_FILE:${_test}>")
@@ -176,3 +176,7 @@ add_target_to_copy_dependencies(
   TARGET copy_test_dependencies
   DEPENDENCIES ${RUNTIME_DEPENDENCIES}
   BEFORE_TARGETS ${TEST_TARGETS})
+
+if(BUILD_OSSFUZZ)
+  add_subdirectory(ossfuzz)
+endif()

--- a/tests/ossfuzz/CMakeLists.txt
+++ b/tests/ossfuzz/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (C) Viktor Szakats
+# SPDX-License-Identifier: BSD-3-Clause
+
+enable_language(CXX)
+
+add_library(standaloneengine STATIC "standaloneengine.cc")
+target_include_directories(standaloneengine PRIVATE
+  "${PROJECT_SOURCE_DIR}/include")
+set_target_properties(standaloneengine PROPERTIES UNITY_BUILD OFF)
+
+add_executable(ssh2_client_fuzzer "ssh2_client_fuzzer.cc" "testinput.h")
+target_include_directories(ssh2_client_fuzzer PRIVATE
+  "${PROJECT_SOURCE_DIR}/include")
+if(LIB_FUZZING_ENGINE)
+  if(LIB_FUZZING_ENGINE STREQUAL "-fsanitize=fuzzer")  # FIXME: compiler-specific
+    set_target_properties(ssh2_client_fuzzer PROPERTIES LINK_FLAGS "${LIB_FUZZING_ENGINE}")
+  else()
+    target_link_libraries(ssh2_client_fuzzer ${LIB_FUZZING_ENGINE})
+  endif()
+else()
+  target_link_libraries(ssh2_client_fuzzer standaloneengine)
+endif()
+target_link_libraries(ssh2_client_fuzzer ${LIB_STATIC} ${LIBSSH2_LIBS_SOCKET})
+set_target_properties(ssh2_client_fuzzer PROPERTIES UNITY_BUILD OFF)

--- a/tests/ossfuzz/Makefile.am
+++ b/tests/ossfuzz/Makefile.am
@@ -31,4 +31,4 @@ ssh2_client_fuzzer_LDFLAGS = $(AM_LDFLAGS) -static
 libstandaloneengine_a_SOURCES = standaloneengine.cc
 libstandaloneengine_a_CXXFLAGS = $(AM_CXXFLAGS)
 
-EXTRA_DIST = ossfuzz.sh
+EXTRA_DIST = CMakeLists.txt ossfuzz.sh


### PR DESCRIPTION
- cmake: add support to build ossfuzz.
  Enable with `-DBUILD_OSSFUZZ=ON`.
  Also supports `-DLIB_FUZZING_ENGINE=` like autotools does.
- check for `__clang__` when suppressing warnings in source. Necessary
  for clang-cl, which set `__clang__`, but doesn't set `__GNU__`.
- cmake: optimize out 4 picky warning option detections with gcc.
- cmake: bring `-pedantic-error`, `-Wall` use closer to curl's.
- cmake: set `-Wno-language-extension-token` for clang-cl.
- cmake: escape only the necessary `-W` options for clang-cl.
- cmake: apply picky warnings to C++.
- cmake: replace `unset(VAR)` with `set(VAR "")` for init.
- cmake: prefer dash-style MSVC options.
- cmake: simplify `MATCHES` expression.
- cmake: formatting/whitespace.
- ci/GHA: bump `actions/upload-artifact` to v4
