### PR TITLE
ossfuzz: fix picky compiler warnings, make it pass `checksrc`

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -37,7 +37,6 @@ path = [
   "tests/openssh_server/ca_*",
   "tests/openssh_server/ssh_*",
   "tests/openssh_server/sshd_config",
-  "tests/ossfuzz/*",
   "tests/test_read_algos.txt",
   "vms/libssh2_config.h",
   "vms/libssh2_*.dcl",
@@ -51,6 +50,7 @@ path = [
   "m4/.gitignore",
   "src/.gitignore",
   "tests/.gitignore",
+  "tests/ossfuzz/.gitignore",
 ]
 SPDX-FileCopyrightText = "The libssh2 project and its contributors."
 SPDX-License-Identifier = "BSD-3-Clause"

--- a/ci/checksrc.sh
+++ b/ci/checksrc.sh
@@ -6,5 +6,5 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-git ls-files "*.[ch]" | xargs -n1 \
+git ls-files "*.[ch]" "*.cc" | xargs -n1 \
 ./ci/checksrc.pl -i4 -m79 -AFOPENMODE -ASNPRINTF -ATYPEDEFSTRUCT

--- a/tests/ossfuzz/Makefile.am
+++ b/tests/ossfuzz/Makefile.am
@@ -1,3 +1,6 @@
+# Copyright (C) The libssh2 project and its contributors.
+# SPDX-License-Identifier: BSD-3-Clause
+
 AM_CPPFLAGS = -I$(top_builddir)/include
 LDADD = $(top_builddir)/src/libssh2.la
 

--- a/tests/ossfuzz/ossfuzz.sh
+++ b/tests/ossfuzz/ossfuzz.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (C) The libssh2 project and its contributors.
+# SPDX-License-Identifier: BSD-3-Clause
 
 set -eu
 

--- a/tests/ossfuzz/ossfuzz.sh
+++ b/tests/ossfuzz/ossfuzz.sh
@@ -8,12 +8,12 @@ set -eu
 # Save off the current folder as the build root.
 export BUILD_ROOT="$PWD"
 
-echo "CC: $CC"
-echo "CXX: $CXX"
-echo "LIB_FUZZING_ENGINE: $LIB_FUZZING_ENGINE"
-echo "CFLAGS: $CFLAGS"
-echo "CXXFLAGS: $CXXFLAGS"
-echo "OUT: $OUT"
+echo "CC: ${CC:-}"
+echo "CXX: ${CXX:-}"
+echo "LIB_FUZZING_ENGINE: ${LIB_FUZZING_ENGINE:-}"
+echo "CFLAGS: ${CFLAGS:-}"
+echo "CXXFLAGS: ${CXXFLAGS:-}"
+echo "OUT: ${OUT:-}"
 
 MAKEFLAGS+="-j$(nproc)"
 export MAKEFLAGS

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -14,12 +14,14 @@
 #include "testinput.h"
 
 #define FUZZ_ASSERT(COND)                                                     \
-    if(!(COND))                                                               \
-    {                                                                         \
-      fprintf(stderr, "Assertion failed: " #COND "\n%s",                      \
-              strerror(errno));                                               \
-      assert((COND));                                                         \
-    }
+    do {                                                                      \
+        if(!(COND))                                                           \
+        {                                                                     \
+            fprintf(stderr, "Assertion failed: " #COND "\n%s",                \
+                    strerror(errno));                                         \
+            assert((COND));                                                   \
+        }                                                                     \
+    } while(0)
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
@@ -42,7 +44,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
   written = send(socket_fds[1], data, size, 0);
 
-  if(written != size)
+  if(written != (ssize_t)size)
   {
     // Handle whatever error case we're in.
     fprintf(stderr, "send() of %zu bytes returned %zu (%d)\n",

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -25,75 +25,73 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-  int socket_fds[2] = {-1, -1};
-  ssize_t written;
-  int rc;
-  LIBSSH2_SESSION *session = NULL;
-  int handshake_completed = 0;
+    int socket_fds[2] = {-1, -1};
+    ssize_t written;
+    int rc;
+    LIBSSH2_SESSION *session = NULL;
+    int handshake_completed = 0;
 
-  rc = libssh2_init(0);
+    rc = libssh2_init(0);
 
-  if(rc) {
-    fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
-    goto EXIT_LABEL;
-  }
+    if(rc) {
+        fprintf(stderr, "libssh2 initialization failed (%d)\n", rc);
+        goto EXIT_LABEL;
+    }
 
-  // Create a socket pair so data can be sent in.
-  rc = socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds);
-  FUZZ_ASSERT(rc == 0);
+    /* Create a socket pair so data can be sent in. */
+    rc = socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds);
+    FUZZ_ASSERT(rc == 0);
 
-  written = send(socket_fds[1], data, size, 0);
+    written = send(socket_fds[1], data, size, 0);
 
-  if(written != (ssize_t)size)
-  {
-    // Handle whatever error case we're in.
-    fprintf(stderr, "send() of %zu bytes returned %zu (%d)\n",
-            size,
-            written,
-            errno);
-    goto EXIT_LABEL;
-  }
+    if(written != (ssize_t)size) {
+        /* Handle whatever error case we're in. */
+        fprintf(stderr, "send() of %zu bytes returned %zu (%d)\n",
+                size,
+                written,
+                errno);
+        goto EXIT_LABEL;
+    }
 
-  rc = shutdown(socket_fds[1], SHUT_WR);
-  if(rc)
-  {
-    fprintf(stderr, "socket shutdown failed (%d)\n", rc);
-    goto EXIT_LABEL;
-  }
+    rc = shutdown(socket_fds[1], SHUT_WR);
+    if(rc) {
+        fprintf(stderr, "socket shutdown failed (%d)\n", rc);
+        goto EXIT_LABEL;
+    }
 
-  // Create a session and start the handshake using the fuzz data passed in.
-  session = libssh2_session_init();
-  if(session) {
-    libssh2_session_set_blocking(session, 1);
-  }
-  else {
-    goto EXIT_LABEL;
-  }
+    /* Create a session and start the handshake using the fuzz data
+       passed in. */
+    session = libssh2_session_init();
+    if(session) {
+        libssh2_session_set_blocking(session, 1);
+    }
+    else {
+        goto EXIT_LABEL;
+    }
 
-  if(libssh2_session_handshake(session, socket_fds[0])) {
-    goto EXIT_LABEL;
-  }
+    if(libssh2_session_handshake(session, socket_fds[0])) {
+        goto EXIT_LABEL;
+    }
 
-  // If we get here the handshake actually completed.
-  handshake_completed = 1;
+    /* If we get here the handshake actually completed. */
+    handshake_completed = 1;
 
 EXIT_LABEL:
 
-  if(session)
-  {
-    if(handshake_completed)
-    {
-      libssh2_session_disconnect(session,
-                                 "Normal Shutdown, Thank you for playing");
+    if(session) {
+        if(handshake_completed) {
+            libssh2_session_disconnect(session,
+                                       "Normal Shutdown, "
+                                       "Thank you for playing");
+        }
+
+        libssh2_session_free(session);
     }
 
-    libssh2_session_free(session);
-  }
+    libssh2_exit();
 
-  libssh2_exit();
+    close(socket_fds[0]);
+    close(socket_fds[1]);
 
-  close(socket_fds[0]);
-  close(socket_fds[1]);
-
-  return 0;
+    return 0;
 }

--- a/tests/ossfuzz/standaloneengine.cc
+++ b/tests/ossfuzz/standaloneengine.cc
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 
       /* Get the length of the file. */
       fseek(infile, 0L, SEEK_END);
-      buffer_len = ftell(infile);
+      buffer_len = (size_t)ftell(infile);
 
       /* Reset the file indicator to the beginning of the file. */
       fseek(infile, 0L, SEEK_SET);

--- a/tests/ossfuzz/standaloneengine.cc
+++ b/tests/ossfuzz/standaloneengine.cc
@@ -15,63 +15,59 @@
  */
 int main(int argc, char **argv)
 {
-  int ii;
-  for(ii = 1; ii < argc; ii++)
-  {
-    FILE *infile;
-    printf("[%s] ", argv[ii]);
+    int ii;
+    for(ii = 1; ii < argc; ii++) {
+        FILE *infile;
+        printf("[%s] ", argv[ii]);
 
-    /* Try and open the file. */
-    infile = fopen(argv[ii], "rb");
-    if(infile)
-    {
-      uint8_t *buffer = NULL;
-      size_t buffer_len;
+        /* Try and open the file. */
+        infile = fopen(argv[ii], "rb");
+        if(infile) {
+            uint8_t *buffer = NULL;
+            size_t buffer_len;
 
-      printf("Opened.. ");
+            printf("Opened.. ");
 
-      /* Get the length of the file. */
-      fseek(infile, 0L, SEEK_END);
-      buffer_len = (size_t)ftell(infile);
+            /* Get the length of the file. */
+            fseek(infile, 0L, SEEK_END);
+            buffer_len = (size_t)ftell(infile);
 
-      /* Reset the file indicator to the beginning of the file. */
-      fseek(infile, 0L, SEEK_SET);
+            /* Reset the file indicator to the beginning of the file. */
+            fseek(infile, 0L, SEEK_SET);
 
-      /* Allocate a buffer for the file contents. */
-      buffer = (uint8_t *)calloc(buffer_len, sizeof(uint8_t));
-      if(buffer)
-      {
-        /* Read all the text from the file into the buffer. */
-        fread(buffer, sizeof(uint8_t), buffer_len, infile);
-        printf("Read %zu bytes, fuzzing.. ", buffer_len);
+            /* Allocate a buffer for the file contents. */
+            buffer = (uint8_t *)calloc(buffer_len, sizeof(uint8_t));
+            if(buffer) {
+                /* Read all the text from the file into the buffer. */
+                fread(buffer, sizeof(uint8_t), buffer_len, infile);
+                printf("Read %zu bytes, fuzzing.. ", buffer_len);
 
-        /* Call the fuzzer with the data. */
-        LLVMFuzzerTestOneInput(buffer, buffer_len);
+                /* Call the fuzzer with the data. */
+                LLVMFuzzerTestOneInput(buffer, buffer_len);
 
-        printf("complete.");
+                printf("complete.");
 
-        /* Free the buffer as it's no longer needed. */
-        free(buffer);
-        buffer = NULL;
-      }
-      else
-      {
-        fprintf(stderr,
-                "[%s] Failed to allocate %zu bytes \n",
-                argv[ii],
-                buffer_len);
-      }
+                /* Free the buffer as it's no longer needed. */
+                free(buffer);
+                buffer = NULL;
+            }
+            else {
+                fprintf(stderr,
+                        "[%s] Failed to allocate %zu bytes \n",
+                        argv[ii],
+                        buffer_len);
+            }
 
-      /* Close the file as it's no longer needed. */
-      fclose(infile);
-      infile = NULL;
+            /* Close the file as it's no longer needed. */
+            fclose(infile);
+            infile = NULL;
+        }
+        else {
+            /* Failed to open the file.
+               Maybe wrong name or wrong permissions? */
+            fprintf(stderr, "[%s] Open failed. \n", argv[ii]);
+        }
+
+        printf("\n");
     }
-    else
-    {
-      /* Failed to open the file. Maybe wrong name or wrong permissions? */
-      fprintf(stderr, "[%s] Open failed. \n", argv[ii]);
-    }
-
-    printf("\n");
-  }
 }


### PR DESCRIPTION
- fix compiler warnings.
- make it pass `checksrc`.
- fix shell `set -u` errors.
  Follow-up to 50124428509ffc2f5d08d8d3c152fa36546c9a75 #901
- REUSE: tidy up ossfuzz files.

Cherry-picked from #1484