### PR TITLE
build: enable `-Wcast-qual`, fix fallouts

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -279,6 +279,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           #
           dnl Only clang 3.0 or later
           if test "$compiler_num" -ge "300"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-qual])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [language-extension-token])
             tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
           fi
@@ -435,6 +436,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           #
           dnl Only gcc 4.0 or later
           if test "$compiler_num" -ge "400"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-qual])
             tmp_CFLAGS="$tmp_CFLAGS -Wstrict-aliasing=3"
           fi
           #

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -89,6 +89,7 @@ if(PICKY_COMPILER)
       -Waddress                            # clang  2.7  gcc  4.3
       -Wattributes                         # clang  2.7  gcc  4.1
       -Wcast-align                         # clang  1.0  gcc  4.2
+      -Wcast-qual                          # clang  3.0  gcc  3.4.6
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
       -Wdiv-by-zero                        # clang  2.7  gcc  4.1
       -Wempty-body                         # clang  2.7  gcc  4.3

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
     LIBSSH2_AGENT *agent = NULL;
     struct libssh2_agent_publickey *identity, *prev_identity = NULL;
     int exitcode;
-    char *exitsignal = (char *)"none";
+    char *exitsignal = NULL;
     ssize_t bytecount = 0;
 
 #ifdef _WIN32
@@ -272,7 +272,8 @@ int main(int argc, char *argv[])
     }
 
     if(exitsignal) {
-        fprintf(stderr, "\nGot signal: %s\n", exitsignal);
+        fprintf(stderr, "\nGot signal: %s\n",
+                exitsignal ? exitsignal : "none");
     }
     else {
         fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     int exitcode = 0;
-    char *exitsignal = (char *)"none";
+    char *exitsignal = NULL;
     size_t len;
     LIBSSH2_KNOWNHOSTS *nh;
     int type;
@@ -340,7 +340,8 @@ int main(int argc, char *argv[])
         }
 
         if(exitsignal)
-            fprintf(stderr, "\nGot signal: %s\n", exitsignal);
+            fprintf(stderr, "\nGot signal: %s\n",
+                    exitsignal ? exitsignal : "none");
 
         libssh2_channel_free(channel);
         channel = NULL;

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     int exitcode;
-    char *exitsignal = (char *)"none";
+    char *exitsignal = NULL;
     ssize_t bytecount = 0;
     size_t len;
     LIBSSH2_KNOWNHOSTS *nh;
@@ -283,7 +283,8 @@ int main(int argc, char *argv[])
     }
 
     if(exitsignal)
-        fprintf(stderr, "\nGot signal: %s\n", exitsignal);
+        fprintf(stderr, "\nGot signal: %s\n",
+                exitsignal ? exitsignal : "none");
     else
         fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
                 exitcode, (long)bytecount);

--- a/src/agent.c
+++ b/src/agent.c
@@ -223,14 +223,16 @@ static ssize_t _send_all(LIBSSH2_SEND_FUNC(func), libssh2_socket_t socket,
                          const void *buffer, size_t length,
                          int flags, void **abstract)
 {
-    RECV_SEND_ALL(func, socket, buffer, length, flags, abstract);
+    RECV_SEND_ALL(func, socket, LIBSSH2_UNCONST(buffer), length,
+                  flags, abstract);
 }
 
 static ssize_t _recv_all(LIBSSH2_RECV_FUNC(func), libssh2_socket_t socket,
                          void *buffer, size_t length,
                          int flags, void **abstract)
 {
-    RECV_SEND_ALL(func, socket, buffer, length, flags, abstract);
+    RECV_SEND_ALL(func, socket, buffer, length,
+                  flags, abstract);
 }
 
 #undef RECV_SEND_ALL

--- a/src/channel.c
+++ b/src/channel.c
@@ -368,7 +368,7 @@ libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *type,
     BLOCK_ADJUST_ERRNO(ptr, session,
                        _libssh2_channel_open(session, type, type_len,
                                              window_size, packet_size,
-                                             (unsigned char *)msg,
+                                             (const unsigned char *)msg,
                                              msg_len));
     return ptr;
 }
@@ -1043,7 +1043,7 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
 
         *(s++) = SSH_MSG_CHANNEL_REQUEST;
         _libssh2_store_u32(&s, channel->remote.id);
-        _libssh2_store_str(&s, (char *)"pty-req", sizeof("pty-req") - 1);
+        _libssh2_store_str(&s, (const char *)"pty-req", sizeof("pty-req") - 1);
 
         *(s++) = 0x01;
 
@@ -1151,7 +1151,7 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
         s = channel->req_auth_agent_packet;
         *(s++) = SSH_MSG_CHANNEL_REQUEST;
         _libssh2_store_u32(&s, channel->remote.id);
-        _libssh2_store_str(&s, (char *)request_str, request_str_len);
+        _libssh2_store_str(&s, (const char *)request_str, request_str_len);
         *(s++) = 0x01;
 
         channel->req_auth_agent_state = libssh2_NB_state_created;
@@ -1311,7 +1311,7 @@ channel_request_pty_size(LIBSSH2_CHANNEL * channel, int width,
 
         *(s++) = SSH_MSG_CHANNEL_REQUEST;
         _libssh2_store_u32(&s, channel->remote.id);
-        _libssh2_store_str(&s, (char *)"window-change",
+        _libssh2_store_str(&s, (const char *)"window-change",
                            sizeof("window-change") - 1);
         *(s++) = 0x00; /* Don't reply */
         _libssh2_store_u32(&s, width);
@@ -1575,7 +1575,8 @@ _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
         rc = _libssh2_transport_send(session,
                                      channel->process_packet,
                                      channel->process_packet_len,
-                                     (unsigned char *)message, message_len);
+                                     (const unsigned char *)message,
+                                     message_len);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             _libssh2_error(session, rc,
                            "Would block sending channel request");
@@ -2483,7 +2484,7 @@ libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
 
     BLOCK_ADJUST(rc, channel->session,
                  _libssh2_channel_write(channel, stream_id,
-                                        (unsigned char *)buf, buflen));
+                                        (const unsigned char *)buf, buflen));
     return rc;
 }
 

--- a/src/comp.c
+++ b/src/comp.c
@@ -90,7 +90,7 @@ comp_method_none_decomp(LIBSSH2_SESSION * session,
     (void)session;
     (void)payload_limit;
     (void)abstract;
-    *dest = (unsigned char *) src;
+    *dest = (const unsigned char *) src;
     *dest_len = src_len;
     return 0;
 }

--- a/src/comp.c
+++ b/src/comp.c
@@ -195,7 +195,7 @@ comp_method_zlib_comp(LIBSSH2_SESSION *session,
     uInt out_maxlen = (uInt)*dest_len;
     int status;
 
-    strm->next_in = (unsigned char *) src;
+    strm->next_in = (unsigned char *) LIBSSH2_UNCONST(src);
     strm->avail_in = (uInt)src_len;
     strm->next_out = dest;
     strm->avail_out = out_maxlen;
@@ -249,7 +249,7 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
     if(out_maxlen > payload_limit)
         out_maxlen = payload_limit;
 
-    strm->next_in = (unsigned char *) src;
+    strm->next_in = (unsigned char *) LIBSSH2_UNCONST(src);
     strm->avail_in = (uInt)src_len;
     strm->next_out = (unsigned char *) LIBSSH2_ALLOC(session,
                                                      (uInt)out_maxlen);

--- a/src/comp.c
+++ b/src/comp.c
@@ -88,10 +88,13 @@ comp_method_none_decomp(LIBSSH2_SESSION * session,
                         size_t src_len, void **abstract)
 {
     (void)session;
+    (void)dest;
+    (void)dest_len;
     (void)payload_limit;
+    (void)src;
+    (void)src_len;
     (void)abstract;
-    *dest = (const unsigned char *) src;
-    *dest_len = src_len;
+
     return 0;
 }
 

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -80,7 +80,7 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
         return -1;
     }
 
-    buf.data = (unsigned char *)hostkey_data;
+    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
     buf.dataptr = buf.data;
     buf.len = hostkey_data_len;
 
@@ -563,7 +563,7 @@ hostkey_method_ssh_dss_init(LIBSSH2_SESSION * session,
         return -1;
     }
 
-    buf.data = (unsigned char *)hostkey_data;
+    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
     buf.dataptr = buf.data;
     buf.len = hostkey_data_len;
 
@@ -804,7 +804,7 @@ hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION * session,
         return -1;
     }
 
-    buf.data = (unsigned char *)hostkey_data;
+    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
     buf.dataptr = buf.data;
     buf.len = hostkey_data_len;
 
@@ -944,7 +944,7 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
 
     /* keyname_len(4) + keyname(19){"ecdsa-sha2-nistp256"} +
        signature_len(4) */
-    buf.data = (unsigned char *)sig;
+    buf.data = (unsigned char *)LIBSSH2_UNCONST(sig);
     buf.dataptr = buf.data;
     buf.len = sig_len;
 
@@ -1156,7 +1156,7 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
         return -1;
     }
 
-    buf.data = (unsigned char *)hostkey_data;
+    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
     buf.dataptr = buf.data;
     buf.len = hostkey_data_len;
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -149,7 +149,7 @@ static int _libssh2_sha_algo_ctx_init(int sha_algo, void *ctx)
 }
 
 static int _libssh2_sha_algo_ctx_update(int sha_algo, void *ctx,
-                                        void *data, size_t len)
+                                        const void *data, size_t len)
 {
     if(sha_algo == 512) {
         libssh2_sha512_ctx *_ctx = (libssh2_sha512_ctx*)ctx;
@@ -663,7 +663,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                                 exchange_state->h_sig_comp, 4);
             hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
                                                 exchange_hash_ctx,
-                                   (unsigned char *)LIBSSH2_SSH_DEFAULT_BANNER,
+                                      (const void *)LIBSSH2_SSH_DEFAULT_BANNER,
                                        sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
         }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -3542,7 +3542,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
     left = end_haystack - s;
 
     /* Needle at start of haystack */
-    if((strncmp((char *) haystack, (char *) needle, needle_len) == 0) &&
+    if((strncmp((char *) haystack, (const char *) needle, needle_len) == 0) &&
         (needle_len == haystack_len || haystack[needle_len] == ',')) {
         return haystack;
     }
@@ -3562,7 +3562,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
         }
 
         /* Needle at X position */
-        if((strncmp((char *) s, (char *) needle, needle_len) == 0) &&
+        if((strncmp((char *) s, (const char *) needle, needle_len) == 0) &&
             (((s - haystack) + needle_len) == haystack_len
              || s[needle_len] == ',')) {
             return s;

--- a/src/kex.c
+++ b/src/kex.c
@@ -3280,7 +3280,7 @@ typedef struct _LIBSSH2_COMMON_METHOD
  * Another sign of bad coding practices gone mad.  Pretend you don't see this.
  */
 static size_t
-kex_method_strlen(LIBSSH2_COMMON_METHOD ** method)
+kex_method_strlen(const LIBSSH2_COMMON_METHOD ** method)
 {
     size_t len = 0;
 
@@ -3303,7 +3303,7 @@ kex_method_strlen(LIBSSH2_COMMON_METHOD ** method)
  */
 static uint32_t
 kex_method_list(unsigned char *buf, uint32_t list_strlen,
-                LIBSSH2_COMMON_METHOD ** method)
+                const LIBSSH2_COMMON_METHOD ** method)
 {
     _libssh2_htonu32(buf, list_strlen);
     buf += 4;
@@ -3327,20 +3327,20 @@ kex_method_list(unsigned char *buf, uint32_t list_strlen,
 
 #define LIBSSH2_METHOD_PREFS_LEN(prefvar, defaultvar)           \
     (uint32_t)((prefvar) ? strlen(prefvar) :                    \
-        kex_method_strlen((LIBSSH2_COMMON_METHOD**)(defaultvar)))
+        kex_method_strlen((const LIBSSH2_COMMON_METHOD**)(defaultvar)))
 
-#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)     \
-    do {                                                                   \
-        if(prefvar) {                                                      \
-            _libssh2_htonu32((buf), (prefvarlen));                         \
-            buf += 4;                                                      \
-            memcpy((buf), (prefvar), (prefvarlen));                        \
-            buf += (prefvarlen);                                           \
-        }                                                                  \
-        else {                                                             \
-            buf += kex_method_list((buf), (prefvarlen),                    \
-                                   (LIBSSH2_COMMON_METHOD**)(defaultvar)); \
-        }                                                                  \
+#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)        \
+    do {                                                                      \
+        if(prefvar) {                                                         \
+            _libssh2_htonu32((buf), (prefvarlen));                            \
+            buf += 4;                                                         \
+            memcpy((buf), (prefvar), (prefvarlen));                           \
+            buf += (prefvarlen);                                              \
+        }                                                                     \
+        else {                                                                \
+            buf += kex_method_list((buf), (prefvarlen),                       \
+                                (const LIBSSH2_COMMON_METHOD**)(defaultvar)); \
+        }                                                                     \
     } while(0)
 
 /* kexinit
@@ -3643,7 +3643,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION * session,
 
     while(hostkeyp && (*hostkeyp) && (*hostkeyp)->name) {
         s = _libssh2_kex_agree_instr(hostkey, hostkey_len,
-                                     (unsigned char *) (*hostkeyp)->name,
+                                     (const unsigned char *) (*hostkeyp)->name,
                                      strlen((*hostkeyp)->name));
         if(s) {
             /* So far so good, but does it suit our purposes? (Encrypting vs
@@ -3679,7 +3679,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
     const LIBSSH2_KEX_METHOD **kexp = libssh2_kex_methods;
     unsigned char *s;
     const unsigned char *strict =
-        (unsigned char *)"kex-strict-s-v00@openssh.com";
+        (const unsigned char *)"kex-strict-s-v00@openssh.com";
 
     if(_libssh2_kex_agree_instr(kex, kex_len, strict, 28)) {
         session->kex_strict = 1;
@@ -3726,7 +3726,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
 
     while(*kexp && (*kexp)->name) {
         s = _libssh2_kex_agree_instr(kex, kex_len,
-                                     (unsigned char *) (*kexp)->name,
+                                     (const unsigned char *) (*kexp)->name,
                                      strlen((*kexp)->name));
         if(s) {
             /* We've agreed on a key exchange method,
@@ -3794,7 +3794,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION * session,
 
     while(*cryptp && (*cryptp)->name) {
         s = _libssh2_kex_agree_instr(crypt, crypt_len,
-                                     (unsigned char *) (*cryptp)->name,
+                                     (const unsigned char *) (*cryptp)->name,
                                      strlen((*cryptp)->name));
         if(s) {
             endpoint->crypt = *cryptp;
@@ -3857,7 +3857,7 @@ static int kex_agree_mac(LIBSSH2_SESSION * session,
 
     while(*macp && (*macp)->name) {
         s = _libssh2_kex_agree_instr(mac, mac_len,
-                                     (unsigned char *) (*macp)->name,
+                                     (const unsigned char *) (*macp)->name,
                                      strlen((*macp)->name));
         if(s) {
             endpoint->mac = *macp;
@@ -3912,7 +3912,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
 
     while(*compp && (*compp)->name) {
         s = _libssh2_kex_agree_instr(comp, comp_len,
-                                     (unsigned char *) (*compp)->name,
+                                     (const unsigned char *) (*compp)->name,
                                      strlen((*compp)->name));
         if(s) {
             endpoint->comp = *compp;

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -88,7 +88,7 @@
 #define libssh2_sha1_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA1, 0))
 #define libssh2_sha1_update(ctx, data, len) \
-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
+    (gcry_md_write(ctx, data, len), 1)
 #define libssh2_sha1_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), SHA_DIGEST_LENGTH), \
     gcry_md_close(ctx), 1)
@@ -99,7 +99,7 @@
 #define libssh2_sha256_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA256, 0))
 #define libssh2_sha256_update(ctx, data, len) \
-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
+    (gcry_md_write(ctx, data, len), 1)
 #define libssh2_sha256_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), SHA256_DIGEST_LENGTH), \
     gcry_md_close(ctx), 1)
@@ -110,7 +110,7 @@
 #define libssh2_sha384_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA384, 0))
 #define libssh2_sha384_update(ctx, data, len) \
-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
+    (gcry_md_write(ctx, data, len), 1)
 #define libssh2_sha384_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), SHA384_DIGEST_LENGTH), \
     gcry_md_close(ctx), 1)
@@ -121,7 +121,7 @@
 #define libssh2_sha512_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA512, 0))
 #define libssh2_sha512_update(ctx, data, len) \
-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
+    (gcry_md_write(ctx, data, len), 1)
 #define libssh2_sha512_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), SHA512_DIGEST_LENGTH), \
     gcry_md_close(ctx), 1)
@@ -133,7 +133,7 @@
 #define libssh2_md5_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_MD5, 0))
 #define libssh2_md5_update(ctx, data, len) \
-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
+    (gcry_md_write(ctx, data, len), 1)
 #define libssh2_md5_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), MD5_DIGEST_LENGTH), \
     gcry_md_close(ctx), 1)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -117,6 +117,14 @@
 #define UINT32_MAX 0xffffffffU
 #endif
 
+#ifdef _WIN64
+#define LIBSSH2_UNCONST(p)  ((void *)(libssh2_uint64_t)(const void *)(p))
+#elif defined(_MSC_VER)
+#define LIBSSH2_UNCONST(p)  ((void *)(unsigned int)(const void *)(p))
+#else
+#define LIBSSH2_UNCONST(p)  ((void *)(uintptr_t)(const void *)(p))
+#endif
+
 #if (defined(__GNUC__) || defined(__clang__)) && \
     defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
     !defined(LIBSSH2_NO_FMT_CHECKS)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -476,11 +476,11 @@ _libssh2_mbedtls_rsa_new_private(libssh2_rsa_ctx **rsa,
     mbedtls_pk_init(&pkey);
 
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
-    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (char *)passphrase,
+    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase,
                                    mbedtls_ctr_drbg_random,
                                    &_libssh2_mbedtls_ctr_drbg);
 #else
-    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (char *)passphrase);
+    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase);
 #endif
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);

--- a/src/misc.c
+++ b/src/misc.c
@@ -88,7 +88,7 @@ int _libssh2_error_flags(LIBSSH2_SESSION* session, int errcode,
     }
 
     if(session->err_flags & LIBSSH2_ERR_FLAG_DUP)
-        LIBSSH2_FREE(session, (char *)session->err_msg);
+        LIBSSH2_FREE(session, (char *)LIBSSH2_UNCONST(session->err_msg));
 
     session->err_code = errcode;
     session->err_flags = 0;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -78,7 +78,7 @@ static int _libssh2_hmac_init(libssh2_hmac_ctx *ctx,
     params[0] = OSSL_PARAM_construct_octet_string(
         OSSL_MAC_PARAM_KEY, (void *)key, keylen);
     params[1] = OSSL_PARAM_construct_utf8_string(
-        OSSL_MAC_PARAM_DIGEST, (char *)digest_name, 0);
+        OSSL_MAC_PARAM_DIGEST, (char *)LIBSSH2_UNCONST(digest_name), 0);
     params[2] = OSSL_PARAM_construct_end();
 
     return EVP_MAC_init(*ctx, NULL, 0, params);
@@ -1200,7 +1200,7 @@ read_private_key_from_memory(void **key_ctx,
     }
 
     *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
-                                (void *) passphrase);
+                                (void *) LIBSSH2_UNCONST(passphrase));
 
     BIO_free(bp);
     return (*key_ctx) ? 0 : -1;
@@ -1224,7 +1224,7 @@ read_private_key_from_file(void **key_ctx,
     }
 
     *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
-                                (void *) passphrase);
+                                (void *) LIBSSH2_UNCONST(passphrase));
 
     BIO_free(bp);
     return (*key_ctx) ? 0 : -1;
@@ -2435,7 +2435,8 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
             *key_handle = LIBSSH2_ALLOC(session, *handle_len);
 
             if(key_handle) {
-                memcpy((void *)*key_handle, handle, *handle_len);
+                memcpy((void *)LIBSSH2_UNCONST(*key_handle),
+                       handle, *handle_len);
             }
         }
     }
@@ -2476,8 +2477,9 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
 
         if(application && app_len > 0) {
             *application = (const char *)LIBSSH2_ALLOC(session, app_len + 1);
-            _libssh2_explicit_zero((void *)*application, app_len + 1);
-            memcpy((void *)*application, app, app_len);
+            _libssh2_explicit_zero((void *)LIBSSH2_UNCONST(*application),
+                                   app_len + 1);
+            memcpy((void *)LIBSSH2_UNCONST(*application), app, app_len);
         }
 
         memcpy(method_buf, key_type, strlen(key_type));
@@ -3789,7 +3791,8 @@ gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
             *key_handle = LIBSSH2_ALLOC(session, *handle_len);
 
             if(*key_handle) {
-                memcpy((void *)*key_handle, handle, *handle_len);
+                memcpy((void *)LIBSSH2_UNCONST(*key_handle),
+                       handle, *handle_len);
             }
         }
     }
@@ -3828,8 +3831,9 @@ gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
 
         if(application && app_len > 0) {
             *application = (const char *)LIBSSH2_ALLOC(session, app_len + 1);
-            _libssh2_explicit_zero((void *)*application, app_len + 1);
-            memcpy((void *)*application, app, app_len);
+            _libssh2_explicit_zero((void *)LIBSSH2_UNCONST(*application),
+                                   app_len + 1);
+            memcpy((void *)LIBSSH2_UNCONST(*application), app, app_len);
         }
 
         LIBSSH2_FREE(session, *pubkeydata);
@@ -4661,7 +4665,8 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     }
 
     (void)BIO_reset(bp);
-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
+    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
+                                 (void *)LIBSSH2_UNCONST(passphrase));
     BIO_free(bp);
 
     if(!pk) {
@@ -5011,7 +5016,8 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                               "Unable to allocate memory when"
                               "computing public key");
     (void)BIO_reset(bp);
-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
+    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
+                                 (void *)LIBSSH2_UNCONST(passphrase));
 #ifdef HAVE_SSLERROR_BAD_DECRYPT
     sslError = ERR_get_error();
 #endif
@@ -5122,7 +5128,8 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               "Unable to allocate memory when"
                               "computing public key");
     (void)BIO_reset(bp);
-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
+    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
+                                 (void *)LIBSSH2_UNCONST(passphrase));
     BIO_free(bp);
 
     if(!pk) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1190,7 +1190,7 @@ read_private_key_from_memory(void **key_ctx,
 
     *key_ctx = NULL;
 
-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
     bp = BIO_new_mem_buf(filedata, (int)filedata_len);
 #else
     bp = BIO_new_mem_buf((char *)filedata, (int)filedata_len);
@@ -5006,7 +5006,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing public key from private key."));
 
-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
 #else
     bp = BIO_new_mem_buf((char *)privatekeydata, (int)privatekeydata_len);
@@ -5118,7 +5118,7 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                    LIBSSH2_TRACE_AUTH,
                    "Computing public key from private key."));
 
-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
 #else
     bp = BIO_new_mem_buf((char *)privatekeydata, (int)privatekeydata_len);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2476,7 +2476,7 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
         _libssh2_store_str(&p, (const char *)app, app_len);
 
         if(application && app_len > 0) {
-            *application = (const char *)LIBSSH2_ALLOC(session, app_len + 1);
+            *application = LIBSSH2_ALLOC(session, app_len + 1);
             _libssh2_explicit_zero((void *)LIBSSH2_UNCONST(*application),
                                    app_len + 1);
             memcpy((void *)LIBSSH2_UNCONST(*application), app, app_len);
@@ -3830,7 +3830,7 @@ gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
         _libssh2_store_str(&p, (const char *)app, app_len);
 
         if(application && app_len > 0) {
-            *application = (const char *)LIBSSH2_ALLOC(session, app_len + 1);
+            *application = LIBSSH2_ALLOC(session, app_len + 1);
             _libssh2_explicit_zero((void *)LIBSSH2_UNCONST(*application),
                                    app_len + 1);
             memcpy((void *)LIBSSH2_UNCONST(*application), app, app_len);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -487,7 +487,7 @@ _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
 #else
 
     ret = RSA_verify(nid_type, hash, (unsigned int) hash_len,
-                     (unsigned char *) sig,
+                     (const unsigned char *) sig,
                      (unsigned int) sig_len, rsactx);
 #endif
 

--- a/src/packet.c
+++ b/src/packet.c
@@ -687,7 +687,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 }
                 else {
                     const unsigned char *strict =
-                    (unsigned char *)"kex-strict-s-v00@openssh.com";
+                        (const unsigned char *)"kex-strict-s-v00@openssh.com";
                     struct string_buf buf;
                     unsigned char *algs = NULL;
                     size_t algs_len = 0;
@@ -1642,7 +1642,7 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
             }
         }
 
-        if(strchr((char *) packet_types, ret)) {
+        if(strchr((const char *) packet_types, ret)) {
             /* Be lazy, let packet_ask pull it out of the brigade */
             ret = _libssh2_packet_askv(session, packet_types, data,
                                        data_len, match_ofs, match_buf,

--- a/src/pem.c
+++ b/src/pem.c
@@ -219,7 +219,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
         /* Perform key derivation (PBKDF1/MD5) */
         if(!libssh2_md5_init(&fingerprint_ctx) ||
            !libssh2_md5_update(fingerprint_ctx, passphrase,
-                               strlen((char *)passphrase)) ||
+                               strlen((const char *)passphrase)) ||
            !libssh2_md5_update(fingerprint_ctx, iv, 8) ||
            !libssh2_md5_final(fingerprint_ctx, secret)) {
             ret = -1;
@@ -230,7 +230,8 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
                !libssh2_md5_update(fingerprint_ctx,
                                    secret, MD5_DIGEST_LENGTH) ||
                !libssh2_md5_update(fingerprint_ctx,
-                                   passphrase, strlen((char *)passphrase)) ||
+                                   passphrase,
+                                   strlen((const char *)passphrase)) ||
                !libssh2_md5_update(fingerprint_ctx, iv, 8) ||
                !libssh2_md5_final(fingerprint_ctx,
                                   secret + MD5_DIGEST_LENGTH)) {

--- a/src/pem.c
+++ b/src/pem.c
@@ -432,7 +432,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         goto out;
     }
 
-    if(strncmp((char *) decoded.dataptr, AUTH_MAGIC,
+    if(strncmp((const char *) decoded.dataptr, AUTH_MAGIC,
                strlen(AUTH_MAGIC)) != 0) {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                              "key auth magic mismatch");

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -597,7 +597,7 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
     /*  19 = packet_len(4) + add_len(4) + "add"(3) + name_len(4) + {name}
         blob_len(4) + {blob} */
     unsigned long i, packet_len = 19 + name_len + blob_len;
-    unsigned char *comment = NULL;
+    const unsigned char *comment = NULL;
     unsigned long comment_len = 0;
     int rc;
 
@@ -619,7 +619,7 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
                 if(attrs[i].name_len == (sizeof("comment") - 1) &&
                     strncmp(attrs[i].name, "comment",
                             sizeof("comment") - 1) == 0) {
-                    comment = (unsigned char *) attrs[i].value;
+                    comment = (const unsigned char *) attrs[i].value;
                     comment_len = attrs[i].value_len;
                     break;
                 }

--- a/src/session.c
+++ b/src/session.c
@@ -212,7 +212,7 @@ banner_receive(LIBSSH2_SESSION * session)
 static int
 banner_send(LIBSSH2_SESSION * session)
 {
-    char *banner = (char *) LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
+    const char *banner = LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
     size_t banner_len = sizeof(LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF) - 1;
     ssize_t ret;
 
@@ -260,7 +260,8 @@ banner_send(LIBSSH2_SESSION * session)
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
                        "Sent %ld/%ld bytes at %p+%ld", (long)ret,
                        (long)(banner_len - session->banner_TxRx_total_send),
-                       (void *)banner, (long)session->banner_TxRx_total_send));
+                       (const void *)banner,
+                       (long)session->banner_TxRx_total_send));
 
     if(ret != (ssize_t)(banner_len - session->banner_TxRx_total_send)) {
         if(ret >= 0 || ret == -EAGAIN) {

--- a/src/session.c
+++ b/src/session.c
@@ -1273,31 +1273,31 @@ libssh2_session_methods(LIBSSH2_SESSION * session, int method_type)
         break;
 
     case LIBSSH2_METHOD_HOSTKEY:
-        method = (LIBSSH2_KEX_METHOD *) session->hostkey;
+        method = (const LIBSSH2_KEX_METHOD *) session->hostkey;
         break;
 
     case LIBSSH2_METHOD_CRYPT_CS:
-        method = (LIBSSH2_KEX_METHOD *) session->local.crypt;
+        method = (const LIBSSH2_KEX_METHOD *) session->local.crypt;
         break;
 
     case LIBSSH2_METHOD_CRYPT_SC:
-        method = (LIBSSH2_KEX_METHOD *) session->remote.crypt;
+        method = (const LIBSSH2_KEX_METHOD *) session->remote.crypt;
         break;
 
     case LIBSSH2_METHOD_MAC_CS:
-        method = (LIBSSH2_KEX_METHOD *) session->local.mac;
+        method = (const LIBSSH2_KEX_METHOD *) session->local.mac;
         break;
 
     case LIBSSH2_METHOD_MAC_SC:
-        method = (LIBSSH2_KEX_METHOD *) session->remote.mac;
+        method = (const LIBSSH2_KEX_METHOD *) session->remote.mac;
         break;
 
     case LIBSSH2_METHOD_COMP_CS:
-        method = (LIBSSH2_KEX_METHOD *) session->local.comp;
+        method = (const LIBSSH2_KEX_METHOD *) session->local.comp;
         break;
 
     case LIBSSH2_METHOD_COMP_SC:
-        method = (LIBSSH2_KEX_METHOD *) session->remote.comp;
+        method = (const LIBSSH2_KEX_METHOD *) session->remote.comp;
         break;
 
     case LIBSSH2_METHOD_LANG_CS:

--- a/src/session.c
+++ b/src/session.c
@@ -1158,7 +1158,7 @@ session_free(LIBSSH2_SESSION *session)
     /* error string */
     if(session->err_msg &&
        ((session->err_flags & LIBSSH2_ERR_FLAG_DUP) != 0)) {
-        LIBSSH2_FREE(session, (char *)session->err_msg);
+        LIBSSH2_FREE(session, (char *)LIBSSH2_UNCONST(session->err_msg));
     }
 
     LIBSSH2_FREE(session, session);
@@ -1351,7 +1351,7 @@ libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
                 }
             }
             else {
-                *errmsg = (char *) "";
+                *errmsg = (char *)LIBSSH2_UNCONST("");
             }
         }
         if(errmsg_len) {
@@ -1374,7 +1374,7 @@ libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
             }
         }
         else
-            *errmsg = (char *)error;
+            *errmsg = (char *)LIBSSH2_UNCONST(error);
     }
 
     if(errmsg_len) {

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -675,7 +675,7 @@ sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs, const unsigned char *p,
 {
     struct string_buf buf;
     uint32_t flags = 0;
-    buf.data = (unsigned char *)p;
+    buf.data = (unsigned char *)LIBSSH2_UNCONST(p);
     buf.dataptr = buf.data;
     buf.len = data_len;
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -105,7 +105,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
     if(session->userauth_list_state == libssh2_NB_state_created) {
         rc = _libssh2_transport_send(session, session->userauth_list_data,
                                      session->userauth_list_data_len,
-                                     (unsigned char *)"none", 4);
+                                     (const unsigned char *)"none", 4);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
                            "Would block requesting userauth list");
@@ -485,7 +485,8 @@ password_response:
                         _libssh2_store_str(&s, "password",
                                            sizeof("password") - 1);
                         *s++ = 0x01;
-                        _libssh2_store_str(&s, (char *)password, password_len);
+                        _libssh2_store_str(&s, (const char *)password,
+                                           password_len);
                         _libssh2_store_u32(&s,
                                            session->userauth_pswd_newpw_len);
                         /* send session->userauth_pswd_newpw separately */
@@ -498,7 +499,7 @@ password_response:
                         rc = _libssh2_transport_send(session,
                                             session->userauth_pswd_data,
                                             session->userauth_pswd_data_len,
-                                            (unsigned char *)
+                                            (const unsigned char *)
                                             session->userauth_pswd_newpw,
                                             session->userauth_pswd_newpw_len);
                         if(rc == LIBSSH2_ERROR_EAGAIN) {
@@ -563,7 +564,8 @@ libssh2_userauth_password_ex(LIBSSH2_SESSION *session, const char *username,
     int rc;
     BLOCK_ADJUST(rc, session,
                  userauth_password(session, username, username_len,
-                                   (unsigned char *)password, password_len,
+                                   (const unsigned char *)password,
+                                   password_len,
                                    passwd_change_cb));
     return rc;
 }
@@ -774,7 +776,7 @@ memory_read_privatekey(LIBSSH2_SESSION * session,
 
     if((*hostkey_method)->
         initPEMFromMemory(session, privkeyfiledata, privkeyfiledata_len,
-                          (unsigned char *) passphrase,
+                          (const unsigned char *) passphrase,
                           hostkey_abstract)) {
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                               "Unable to initialize private key from memory");
@@ -815,7 +817,7 @@ file_read_privatekey(LIBSSH2_SESSION * session,
     }
 
     if((*hostkey_method)->
-        initPEM(session, privkeyfile, (unsigned char *) passphrase,
+        initPEM(session, privkeyfile, (const unsigned char *) passphrase,
                 hostkey_abstract)) {
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                               "Unable to initialize private key from file");
@@ -855,7 +857,7 @@ sign_frommemory(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
         return rc;
 
     libssh2_prepare_iovec(&datavec, 1);
-    datavec.iov_base = (void *)data;
+    datavec.iov_base = (void *)LIBSSH2_UNCONST(data);
     datavec.iov_len  = data_len;
 
     if(privkeyobj->signv(session, sig, sig_len, 1, &datavec,
@@ -891,7 +893,7 @@ sign_fromfile(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
         return rc;
 
     libssh2_prepare_iovec(&datavec, 1);
-    datavec.iov_base = (void *)data;
+    datavec.iov_base = (void *)LIBSSH2_UNCONST(data);
     datavec.iov_len  = data_len;
 
     if(privkeyobj->signv(session, sig, sig_len, 1, &datavec,
@@ -2508,7 +2510,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
         LIBSSH2_FREE(session, tmp_publickeydata);
 
     if(sk_info.application) {
-        LIBSSH2_FREE(session, (void *)sk_info.application);
+        LIBSSH2_FREE(session, (void *)LIBSSH2_UNCONST(sk_info.application));
     }
 
     return rc;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2461,7 +2461,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
                 LIBSSH2_FREE(session, tmp_method);
             }
 
-            if(!strncmp((char *)publickeydata, ecdsa, strlen(ecdsa))) {
+            if(!strncmp((const char *)publickeydata, ecdsa, strlen(ecdsa))) {
                 session->userauth_pblc_method_len = strlen(ecdsa);
                 session->userauth_pblc_method =
                     LIBSSH2_ALLOC(session, session->userauth_pblc_method_len);
@@ -2469,7 +2469,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
                 memcpy(session->userauth_pblc_method, ecdsa,
                        session->userauth_pblc_method_len);
             }
-            else if(!strncmp((char *)publickeydata, ed25519,
+            else if(!strncmp((const char *)publickeydata, ed25519,
                              strlen(ed25519))) {
                 session->userauth_pblc_method_len = strlen(ed25519);
                 session->userauth_pblc_method =
@@ -2483,7 +2483,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
                                        &session->userauth_pblc_method,
                                        &session->userauth_pblc_method_len,
                                        &pubkeydata, &pubkeydata_len,
-                                       (char *)publickeydata,
+                                       (const char *)publickeydata,
                                        publickeydata_len);
         }
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2888,9 +2888,9 @@ _libssh2_wincng_ecdsa_new_private_frommemory(
     }
 
     data_buffer.len = data_len;
-    data_buffer.data = (unsigned char *)data;
-    data_buffer.dataptr =
-        (unsigned char *)data + strlen(OPENSSL_PRIVATEKEY_AUTH_MAGIC) + 1;
+    data_buffer.data = (unsigned char *)LIBSSH2_UNCONST(data);
+    data_buffer.dataptr = data_buffer.data +
+                          strlen(OPENSSL_PRIVATEKEY_AUTH_MAGIC) + 1;
 
     /* Read ciphername, should be 'none' as we don't support passphrases */
     result = _libssh2_match_string(&data_buffer, "none");

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -431,7 +431,7 @@ _libssh2_wincng_init(void)
     if(BCRYPT_SUCCESS(ret)) {
         ret = BCryptSetProperty(_libssh2_wincng.hAlgAES_CBC,
                                 BCRYPT_CHAINING_MODE,
-                                (PBYTE)BCRYPT_CHAIN_MODE_CBC,
+                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_CBC),
                                 sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
         if(!BCRYPT_SUCCESS(ret)) {
             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgAES_CBC, 0);
@@ -446,7 +446,7 @@ _libssh2_wincng_init(void)
     if(BCRYPT_SUCCESS(ret)) {
         ret = BCryptSetProperty(_libssh2_wincng.hAlgAES_ECB,
                                 BCRYPT_CHAINING_MODE,
-                                (PBYTE)BCRYPT_CHAIN_MODE_ECB,
+                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_ECB),
                                 sizeof(BCRYPT_CHAIN_MODE_ECB), 0);
         if(!BCRYPT_SUCCESS(ret)) {
             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgAES_ECB, 0);
@@ -461,7 +461,7 @@ _libssh2_wincng_init(void)
     if(BCRYPT_SUCCESS(ret)) {
         ret = BCryptSetProperty(_libssh2_wincng.hAlgRC4_NA,
                                 BCRYPT_CHAINING_MODE,
-                                (PBYTE)BCRYPT_CHAIN_MODE_NA,
+                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_NA),
                                 sizeof(BCRYPT_CHAIN_MODE_NA), 0);
         if(!BCRYPT_SUCCESS(ret)) {
             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgRC4_NA, 0);
@@ -476,7 +476,7 @@ _libssh2_wincng_init(void)
     if(BCRYPT_SUCCESS(ret)) {
         ret = BCryptSetProperty(_libssh2_wincng.hAlg3DES_CBC,
                                 BCRYPT_CHAINING_MODE,
-                                (PBYTE)BCRYPT_CHAIN_MODE_CBC,
+                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_CBC),
                                 sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
         if(!BCRYPT_SUCCESS(ret)) {
             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlg3DES_CBC,
@@ -676,7 +676,8 @@ _libssh2_wincng_hash_update(_libssh2_wincng_hash_ctx *ctx,
 {
     int ret;
 
-    ret = BCryptHashData(ctx->hHash, (PUCHAR)data, datalen, 0);
+    ret = BCryptHashData(ctx->hHash,
+                         (PUCHAR)LIBSSH2_UNCONST(data), datalen, 0);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }


### PR DESCRIPTION
- enable compiler warning `-Wcast-qual`.
- add `LIBSSH2_UNCONST()` macro to strip const where absolutely
  necessary to avoid compiler warnings.
- fix const stripping by constifying where necessary.
- fix const stripping by using `LIBSSH2_UNCONST()`.
- libgcrypt.h: drop unnecessary casts.
- openssl: fix to use new `BIO_new_mem_buf()` parameter types
  with wolfSSL.

Cherry-picked from #1484