### PR TITLE
ci/GHA: general maintenance, security, add LibreSSL and old OpenSSL jobs with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,7 @@ jobs:
             curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl102-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr -fPIC
+            make -j5
             make -j1 install_sw
             cd ..
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,12 +204,12 @@ jobs:
               cflags='-m32 -mpclmul -msse2 -maes'
             fi
             cmake -B . ${crossoptions} \
-              "-DCMAKE_C_FLAGS=${cflags}" \
+              -DCMAKE_C_FLAGS="${cflags}" \
               -DENABLE_PROGRAMS=OFF \
               -DENABLE_TESTING=OFF \
               -DUSE_STATIC_MBEDTLS_LIBRARY=OFF \
               -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
-              "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
+              -DCMAKE_INSTALL_PREFIX="$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .
             cd ..
@@ -234,8 +234,8 @@ jobs:
             -DWOLFSSL_OPENSSLALL=ON \
             -DWOLFSSL_EXAMPLES=OFF \
             -DWOLFSSL_CRYPT_TESTS=OFF \
-            '-DCMAKE_C_FLAGS=-fPIC -DWOLFSSL_AESGCM_STREAM' \
-            "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
+            -DCMAKE_C_FLAGS='-fPIC -DWOLFSSL_AESGCM_STREAM' \
+            -DCMAKE_INSTALL_PREFIX="$HOME/usr"
           cmake --build bld --parallel 5
           cmake --install bld
           cd ..
@@ -262,7 +262,7 @@ jobs:
             cmake -B . \
               -DOPENSSL_SMALL=ON \
               -DCMAKE_C_FLAGS=-fPIC \
-              "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
+              -DCMAKE_INSTALL_PREFIX="$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .
             cd ..
@@ -287,7 +287,7 @@ jobs:
             cmake -B . \
               -DLIBRESSL_APPS=OFF \
               -DLIBRESSL_TESTS=OFF \
-              "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
+              -DCMAKE_INSTALL_PREFIX="$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .
             cd ..
@@ -655,7 +655,7 @@ jobs:
             cflags=''
           fi
           cmake -B bld -G Ninja ${options} \
-            "-DCMAKE_C_FLAGS=${cflags}" \
+            -DCMAKE_C_FLAGS="${cflags}" \
             -DCMAKE_UNITY_BUILD=ON \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,21 @@ jobs:
             crypto: OpenSSL-3-no-deprecated
             build: cmake
             zlib: 'ON'
+          - compiler: gcc
+            arch: amd64
+            crypto: OpenSSL-111-from-source
+            build: cmake
+            zlib: 'ON'
+          - compiler: gcc
+            arch: amd64
+            crypto: OpenSSL-110-from-source
+            build: cmake
+            zlib: 'ON'
+          - compiler: gcc
+            arch: amd64
+            crypto: OpenSSL-102-from-source
+            build: cmake
+            zlib: 'ON'
           - compiler: clang
             arch: i386
             crypto: Libgcrypt
@@ -221,6 +236,42 @@ jobs:
             no-apps no-docs no-tests no-makedepend \
             no-comp no-quic no-legacy --prefix=/usr
           make -j5 install "DESTDIR=$PWD/.."
+          cd ..
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+
+      - name: 'install OpenSSL 1.1.1 from source'
+        if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
+        run: |
+          curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz | tar -xzf -
+          cd openssl-1.1.1w
+          ./config no-unit-test no-makedepend --prefix=/usr no-tests
+          make -j1
+          make -j5 install "DESTDIR=$PWD/../"
+          cd ..
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+
+      - name: 'install OpenSSL 1.1.0 from source'
+        if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
+        run: |
+          curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-1.1.0l.tar.gz | tar -xzf -
+          cd openssl-1.1.0l
+          ./config no-unit-test no-makedepend --prefix=/usr
+          make -j1
+          make -j5 install "DESTDIR=$PWD/../"
+          cd ..
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+
+      - name: 'install OpenSSL 1.0.2 from source'
+        if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}
+        run: |
+          curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz | tar -xzf -
+          cd openssl-1.0.2u
+          ./config no-unit-test no-makedepend --prefix=$PWD/../usr -fPIC
+          make -j1
+          make -j5 install
           cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,12 +146,12 @@ jobs:
             options: --disable-static
     env:
       CC: ${{ matrix.compiler }}
-      mbedtls-version: 3.5.1
-      wolfssl-version: 5.7.0
+      mbedtls-version: 3.6.2
+      wolfssl-version: 5.7.4
       wolfssl-version-prev: 5.5.4
       boringssl-version: 0.20241024.0
       libressl-version: 4.0.0
-      openssl-version: 3.2.0
+      openssl-version: 3.4.0
       openssl111-version: 1.1.1w
       openssl110-version: 1.1.0l
       openssl102-version: 1.0.2u
@@ -187,8 +187,8 @@ jobs:
         if: ${{ matrix.crypto == 'mbedTLS' }}
         run: |
           if [ '${{ steps.cache-mbedtls.outputs.cache-hit }}' != 'true' ]; then
-            curl -fsS -L https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-${{ env.mbedtls-version }}.tar.gz | tar -xzf -
-            cd mbedtls-mbedtls-${{ env.mbedtls-version }}
+            curl -fsS -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${{ env.mbedtls-version }}/mbedtls-${{ env.mbedtls-version }}.tar.bz2 | tar -xjf -
+            cd mbedtls-${{ env.mbedtls-version }}
             if [ '${{ matrix.arch }}' = 'i386' ]; then
               crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}'
               cflags='-m32 -mpclmul -msse2 -maes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,11 @@ jobs:
   spellcheck:
     runs-on: ubuntu-24.04
     steps:
+      - name: 'install tools'
+        run: pip install --break-system-packages -U codespell
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - name: 'install tools'
-        run: pip install --break-system-packages -U codespell
       - name: 'spellcheck'
         run: ./ci/spellcheck.sh
 
@@ -164,9 +164,6 @@ jobs:
       openssl110-version: 1.1.0l
       openssl102-version: 1.0.2u
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
       - name: 'install architecture'
         if: ${{ matrix.arch != 'amd64' }}
         run: |
@@ -384,6 +381,9 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}
         run: autoreconf -fi
@@ -477,14 +477,14 @@ jobs:
     env:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
       - name: 'install packages'
         run: |
           sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
             mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}
         run: autoreconf -fi
@@ -523,15 +523,16 @@ jobs:
           - { build: 'cmake'   , platform: 'x86_64', compiler: 'gcc' }
     steps:
       - run: git config --global core.autocrlf input
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
+
       - uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
         with:
           platform: ${{ matrix.platform }}
           packages: ${{ matrix.build == 'automake' && 'autoconf libtool make' || 'ninja' }} ${{ matrix.build }} gcc-core gcc-g++ binutils libssl-devel zlib-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
       - name: 'autotools'
         if: ${{ matrix.build == 'automake' }}
         timeout-minutes: 10
@@ -586,9 +587,6 @@ jobs:
           - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'uwp' }
           - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'no-options' }
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
       - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
         if: ${{ matrix.sys == 'msys' }}
         with:
@@ -603,6 +601,9 @@ jobs:
             mingw-w64-${{ matrix.env }}-${{ matrix.build }} ${{ matrix.build == 'autotools' && 'make' || '' }}
             mingw-w64-${{ matrix.env }}-openssl
 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}
         shell: msys2 {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,15 +294,27 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
+      - name: 'cache OpenSSL 1.1.0'
+        if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
+        uses: actions/cache@v4
+        id: cache-openssl110
+        env:
+          cache-name: cache-openssl110
+        with:
+          path: /home/runner/usr
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl110-version }}
+
       - name: 'install OpenSSL 1.1.0 from source'
         if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
         run: |
-          curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
-          cd openssl-${{ env.openssl110-version }}
-          ./config no-unit-test no-makedepend --prefix=/usr
-          make -j1
-          make -j5 install "DESTDIR=$PWD/../"
-          cd ..
+          if [ '${{ steps.cache-openssl110.outputs.cache-hit }}' != 'true' ]; then
+            curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
+            cd openssl-${{ env.openssl110-version }}
+            ./config no-unit-test no-makedepend --prefix=/usr
+            make -j1
+            make -j5 install "DESTDIR=$PWD/../"
+            cd ..
+          fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,6 +766,8 @@ jobs:
           run: |
             # https://openbsd.app/
             sudo pkg_add cmake ninja
+            pkg_info || true
+            pkg_info libressl | true
             cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON \
               -DENABLE_WERROR=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
             cd openssl-${{ env.openssl-version }}
             ./Configure no-deprecated \
               no-apps no-docs no-tests no-makedepend \
-              no-comp no-quic no-legacy --prefix=$HOME/usr
+              no-comp no-quic no-legacy --prefix="$HOME/usr"
             make -j5 install_sw
             cd ..
           fi
@@ -326,7 +326,7 @@ jobs:
           if [ '${{ steps.cache-openssl111.outputs.cache-hit }}' != 'true' ]; then
             curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${{ env.openssl111-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl111-version }}
-            ./config no-unit-test no-makedepend --prefix=$HOME/usr no-tests
+            ./config no-unit-test no-makedepend --prefix="$HOME/usr" no-tests
             make -j5
             make -j1 install_sw
             cd ..
@@ -348,7 +348,7 @@ jobs:
           if [ '${{ steps.cache-openssl110.outputs.cache-hit }}' != 'true' ]; then
             curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_0l/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl110-version }}
-            ./config no-unit-test no-makedepend --prefix=$HOME/usr
+            ./config no-unit-test no-makedepend --prefix="$HOME/usr"
             make -j5
             make -j1 install_sw
             cd ..
@@ -370,7 +370,7 @@ jobs:
           if [ '${{ steps.cache-openssl102.outputs.cache-hit }}' != 'true' ]; then
             curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_0_2u/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl102-version }}
-            ./config no-unit-test no-makedepend --prefix=$HOME/usr -fPIC
+            ./config no-unit-test no-makedepend --prefix="$HOME/usr" -fPIC
             make -j5
             make -j1 install_sw
             cd ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
             mkdir boringssl
             cd boringssl
             curl -fsS https://boringssl.googlesource.com/boringssl/+archive/${{ env.boringssl-version }}.tar.gz | tar -xzf -
-            # Skip tests to make the build finish faster
+            # Skip tests to finish the build faster
             echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
             cmake -B . \
               -DOPENSSL_SMALL=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,16 +269,28 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
+      - name: 'cache OpenSSL'
+        if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
+        uses: actions/cache@v4
+        id: cache-openssl
+        env:
+          cache-name: cache-openssl
+        with:
+          path: /home/runner/usr
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl-version }}
+
       - name: 'install OpenSSL from source'
         if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
         run: |
-          curl -fsS -L https://github.com/openssl/openssl/releases/download/openssl-${{ env.openssl-version }}/openssl-${{ env.openssl-version }}.tar.gz | tar -xzf -
-          cd openssl-${{ env.openssl-version }}
-          ./Configure no-deprecated \
-            no-apps no-docs no-tests no-makedepend \
-            no-comp no-quic no-legacy --prefix=/usr
-          make -j5 install "DESTDIR=$PWD/.."
-          cd ..
+          if [ '${{ steps.cache-openssl.outputs.cache-hit }}' != 'true' ]; then
+            curl -fsS -L https://github.com/openssl/openssl/releases/download/openssl-${{ env.openssl-version }}/openssl-${{ env.openssl-version }}.tar.gz | tar -xzf -
+            cd openssl-${{ env.openssl-version }}
+            ./Configure no-deprecated \
+              no-apps no-docs no-tests no-makedepend \
+              no-comp no-quic no-legacy --prefix=/usr
+            make -j5 install "DESTDIR=$PWD/.."
+            cd ..
+          fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-openssl111
         env:
-          cache-name: cache-openssl111
+          cache-name: cache-openssl
         with:
           path: /home/runner/usr
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl111-version }}-${{ matrix.arch }}
@@ -347,7 +347,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-openssl110
         env:
-          cache-name: cache-openssl110
+          cache-name: cache-openssl
         with:
           path: /home/runner/usr
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl110-version }}-${{ matrix.arch }}
@@ -371,7 +371,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-openssl102
         env:
-          cache-name: cache-openssl102
+          cache-name: cache-openssl
         with:
           path: /home/runner/usr
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl102-version }}-${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,19 +648,14 @@ jobs:
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
             cflags="-specs=$(cygpath -w "${specs}") -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
-            # CMake (as of v3.26.4) gets confused and applies the MSVC rc.exe command-line
-            # template to windres. Reset it to the windres template manually:
-            rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
           elif [ '${{ matrix.test }}' = 'no-options' ]; then
             options+=' -DLIBSSH2_NO_DEPRECATED=ON'
             cflags='-DLIBSSH2_NO_MD5 -DLIBSSH2_NO_MD5_PEM -DLIBSSH2_NO_HMAC_RIPEMD -DLIBSSH2_DSA_ENABLE -DLIBSSH2_NO_AES_CBC -DLIBSSH2_NO_AES_CTR -DLIBSSH2_NO_BLOWFISH -DLIBSSH2_NO_RC4 -DLIBSSH2_NO_CAST -DLIBSSH2_NO_3DES'
           else
             cflags=''
-            rcopts=''
           fi
           cmake -B bld -G Ninja ${options} \
             "-DCMAKE_C_FLAGS=${cflags}" \
-            "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
             -DCMAKE_UNITY_BUILD=ON \
             -DENABLE_WERROR=ON \
             -DENABLE_DEBUG_LOGGING=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,9 +214,7 @@ jobs:
             WOLFSSLVER=${{ env.wolfssl-version }}
           else
             WOLFSSLVER=${{ env.wolfssl-version-prev }}
-            # Required to include `FIPS_mode()` API:
             options='-DWOLFSSL_OPENSSLEXTRA=ON'
-            cppflags='-DOPENSSL_ALL'
           fi
           curl -fsS -L https://github.com/wolfSSL/wolfssl/archive/refs/tags/v$WOLFSSLVER-stable.tar.gz | tar -xzf -
           cd wolfssl-$WOLFSSLVER-stable
@@ -226,7 +224,7 @@ jobs:
             -DWOLFSSL_OPENSSLALL=ON \
             -DWOLFSSL_EXAMPLES=OFF \
             -DWOLFSSL_CRYPT_TESTS=OFF \
-            "-DCMAKE_C_FLAGS=-fPIC -DWOLFSSL_AESGCM_STREAM ${cppflags}" \
+            '-DCMAKE_C_FLAGS=-fPIC -DWOLFSSL_AESGCM_STREAM' \
             "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
           cmake --build bld --parallel 5
           cmake --install bld

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'checksrc'
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'shellcheck'
@@ -41,7 +41,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'install tools'
@@ -57,7 +57,7 @@ jobs:
       CC: clang
       MAKEFLAGS: -j5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'cmake'
@@ -164,7 +164,7 @@ jobs:
       openssl110-version: 1.1.0l
       openssl102-version: 1.0.2u
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'install architecture'
@@ -187,7 +187,7 @@ jobs:
 
       - name: 'cache mbedTLS'
         if: ${{ matrix.crypto == 'mbedTLS' }}
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-mbedtls
         with:
           path: /home/runner/usr
@@ -244,7 +244,7 @@ jobs:
 
       - name: 'cache BoringSSL'
         if: ${{ matrix.crypto == 'BoringSSL' }}
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-boringssl
         with:
           path: /home/runner/usr
@@ -272,7 +272,7 @@ jobs:
 
       - name: 'cache LibreSSL'
         if: ${{ matrix.crypto == 'LibreSSL' }}
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-libressl
         with:
           path: /home/runner/usr
@@ -297,7 +297,7 @@ jobs:
 
       - name: 'cache OpenSSL'
         if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-openssl
         with:
           path: /home/runner/usr
@@ -320,7 +320,7 @@ jobs:
 
       - name: 'cache OpenSSL 1.1.1'
         if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-openssl111
         with:
           path: /home/runner/usr
@@ -342,7 +342,7 @@ jobs:
 
       - name: 'cache OpenSSL 1.1.0'
         if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-openssl110
         with:
           path: /home/runner/usr
@@ -364,7 +364,7 @@ jobs:
 
       - name: 'cache OpenSSL 1.0.2'
         if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-openssl102
         with:
           path: /home/runner/usr
@@ -477,7 +477,7 @@ jobs:
     env:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'install packages'
@@ -523,10 +523,10 @@ jobs:
           - { build: 'cmake'   , platform: 'x86_64', compiler: 'gcc' }
     steps:
       - run: git config --global core.autocrlf input
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: cygwin/cygwin-install-action@v5
+      - uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
         with:
           platform: ${{ matrix.platform }}
           packages: ${{ matrix.build == 'automake' && 'autoconf libtool make' || 'ninja' }} ${{ matrix.build }} gcc-core gcc-g++ binutils libssl-devel zlib-devel
@@ -586,15 +586,15 @@ jobs:
           - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'uwp' }
           - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'no-options' }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
         if: ${{ matrix.sys == 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
           install: gcc ${{ matrix.build }} ${{ matrix.build == 'autotools' && 'make' || 'ninja' }} openssl-devel zlib-devel
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
         if: ${{ matrix.sys != 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
@@ -698,7 +698,7 @@ jobs:
           - { arch: arm64, plat: uwp    , crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
           - { arch: x86  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'cmake configure'
@@ -772,7 +772,7 @@ jobs:
     steps:
       - name: 'install packages'
         run: brew install ${{ matrix.build == 'autotools' && 'automake libtool' || 'ninja' }} ${{ matrix.crypto.install }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'autotools autoreconf'
@@ -823,11 +823,11 @@ jobs:
       matrix:
         arch: ['x86_64', 'arm64']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'cmake'
-        uses: cross-platform-actions/action@v0.25.0
+        uses: cross-platform-actions/action@a0672d7f6de3a78e7784bbaf491c7303f68d94b3 # v0.26.0
         with:
           operating_system: 'netbsd'
           version: '10.0'
@@ -855,11 +855,11 @@ jobs:
       matrix:
         arch: ['x86_64']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'cmake'
-        uses: cross-platform-actions/action@v0.25.0
+        uses: cross-platform-actions/action@a0672d7f6de3a78e7784bbaf491c7303f68d94b3 # v0.26.0
         with:
           operating_system: 'openbsd'
           version: '7.5'
@@ -891,11 +891,11 @@ jobs:
       matrix:
         arch: ['x86_64', 'arm64']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'autotools'
-        uses: cross-platform-actions/action@v0.25.0
+        uses: cross-platform-actions/action@a0672d7f6de3a78e7784bbaf491c7303f68d94b3 # v0.26.0
         with:
           operating_system: 'freebsd'
           version: '14.1'
@@ -917,11 +917,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'autotools'
-        uses: vmactions/omnios-vm@v1
+        uses: vmactions/omnios-vm@16b5996777bc675acd3d537f13df536a526cd16d # v1
         with:
           usesh: true
           # https://pkg.omnios.org/r151050/core/en/index.shtml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
             crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}'
             cflags='-m32 -mpclmul -msse2 -maes'
           fi
-          cmake . ${crossoptions} \
+          cmake -B . ${crossoptions} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             -DENABLE_PROGRAMS=OFF \
             -DENABLE_TESTING=OFF \
@@ -230,7 +230,7 @@ jobs:
           curl -fsS https://boringssl.googlesource.com/boringssl/+archive/${{ env.boringssl-version }}.tar.gz | tar -xzf -
           # Skip tests to make the build finish faster
           echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
-          cmake . \
+          cmake -B . \
             -DOPENSSL_SMALL=ON \
             -DCMAKE_C_FLAGS=-fPIC \
             "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
@@ -244,7 +244,7 @@ jobs:
         run: |
           curl -fsS https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${{ env.libressl-version }}.tar.gz | tar -xzf -
           cd libressl-${{ env.libressl-version }}
-          cmake . \
+          cmake -B . \
             -DLIBRESSL_APPS=OFF \
             -DLIBRESSL_TESTS=OFF \
             "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,15 @@ jobs:
             options: --disable-static
     env:
       CC: ${{ matrix.compiler }}
+      mbedtls-version: 3.5.1
+      wolfssl-version: 5.7.0
+      wolfssl-version-prev: 5.5.4
+      boringssl-version: ddc0647304a8ed854b2d84117f095a5f73571d37
+      libressl-version: 4.0.0
+      openssl-version: 3.2.0
+      openssl111-version: 1.1.1w
+      openssl110-version: 1.1.0l
+      openssl102-version: 1.0.2u
     steps:
       - uses: actions/checkout@v4
       - name: 'install architecture'
@@ -169,9 +178,8 @@ jobs:
       - name: 'install mbedTLS from source'
         if: ${{ matrix.crypto == 'mbedTLS' }}
         run: |
-          MBEDTLSVER=mbedtls-3.5.1
-          curl -fsS -L https://github.com/Mbed-TLS/mbedtls/archive/$MBEDTLSVER.tar.gz | tar -xzf -
-          cd mbedtls-$MBEDTLSVER
+          curl -fsS -L https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-${{ env.mbedtls-version }}.tar.gz | tar -xzf -
+          cd mbedtls-mbedtls-${{ env.mbedtls-version }}
           if [ '${{ matrix.arch }}' = 'i386' ]; then
             crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}'
             cflags='-m32 -mpclmul -msse2 -maes'
@@ -192,9 +200,9 @@ jobs:
         if: ${{ startsWith(matrix.crypto, 'wolfSSL-from-source') }}
         run: |
           if [ '${{ matrix.crypto }}' = 'wolfSSL-from-source' ]; then
-            WOLFSSLVER=5.7.0
+            WOLFSSLVER=${{ env.wolfssl-version }}
           else
-            WOLFSSLVER=5.5.4
+            WOLFSSLVER=${{ env.wolfssl-version-prev }}
             # Required to include `FIPS_mode()` API:
             options='-DWOLFSSL_OPENSSLEXTRA=ON'
             cppflags='-DOPENSSL_ALL'
@@ -217,10 +225,9 @@ jobs:
       - name: 'install BoringSSL from source'
         if: ${{ matrix.crypto == 'BoringSSL' }}
         run: |
-          BORINGSSLVER=ddc0647304a8ed854b2d84117f095a5f73571d37
           mkdir boringssl
           cd boringssl
-          curl -fsS https://boringssl.googlesource.com/boringssl/+archive/$BORINGSSLVER.tar.gz | tar -xzf -
+          curl -fsS https://boringssl.googlesource.com/boringssl/+archive/${{ env.boringssl-version }}.tar.gz | tar -xzf -
           # Skip tests to make the build finish faster
           echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
           cmake . \
@@ -235,9 +242,8 @@ jobs:
       - name: 'install LibreSSL from source'
         if: ${{ matrix.crypto == 'LibreSSL' }}
         run: |
-          LIBRESSLVER=4.0.0
-          curl -fsS https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$LIBRESSLVER.tar.gz | tar -xzf -
-          cd libressl-$LIBRESSLVER
+          curl -fsS https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${{ env.libressl-version }}.tar.gz | tar -xzf -
+          cd libressl-${{ env.libressl-version }}
           cmake . \
             -DLIBRESSL_APPS=OFF \
             -DLIBRESSL_TESTS=OFF \
@@ -250,9 +256,8 @@ jobs:
       - name: 'install OpenSSL from source'
         if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
         run: |
-          OPENSSLVER=openssl-3.2.0
-          curl -fsS -L https://github.com/openssl/openssl/releases/download/$OPENSSLVER/$OPENSSLVER.tar.gz | tar -xzf -
-          cd $OPENSSLVER
+          curl -fsS -L https://github.com/openssl/openssl/releases/download/openssl-${{ env.openssl-version }}/openssl-${{ env.openssl-version }}.tar.gz | tar -xzf -
+          cd openssl-${{ env.openssl-version }}
           ./Configure no-deprecated \
             no-apps no-docs no-tests no-makedepend \
             no-comp no-quic no-legacy --prefix=/usr
@@ -264,8 +269,8 @@ jobs:
       - name: 'install OpenSSL 1.1.1 from source'
         if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
         run: |
-          curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz | tar -xzf -
-          cd openssl-1.1.1w
+          curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${{ env.openssl111-version }}.tar.gz | tar -xzf -
+          cd openssl-${{ env.openssl111-version }}
           ./config no-unit-test no-makedepend --prefix=/usr no-tests
           make -j1
           make -j5 install "DESTDIR=$PWD/../"
@@ -276,8 +281,8 @@ jobs:
       - name: 'install OpenSSL 1.1.0 from source'
         if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
         run: |
-          curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-1.1.0l.tar.gz | tar -xzf -
-          cd openssl-1.1.0l
+          curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
+          cd openssl-${{ env.openssl110-version }}
           ./config no-unit-test no-makedepend --prefix=/usr
           make -j1
           make -j5 install "DESTDIR=$PWD/../"
@@ -288,8 +293,8 @@ jobs:
       - name: 'install OpenSSL 1.0.2 from source'
         if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}
         run: |
-          curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz | tar -xzf -
-          cd openssl-1.0.2u
+          curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
+          cd openssl-${{ env.openssl102-version }}
           ./config no-unit-test no-makedepend --prefix=$PWD/../usr -fPIC
           make -j1
           make -j5 install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
             ./Configure no-deprecated \
               no-apps no-docs no-tests no-makedepend \
               no-comp no-quic no-legacy --prefix=$HOME/usr
-            make -j5 install
+            make -j5 install_sw
             cd ..
           fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
@@ -335,7 +335,7 @@ jobs:
             curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${{ env.openssl111-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl111-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr no-tests
-            make -j1 install
+            make -j1 install_sw
             cd ..
           fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
@@ -358,7 +358,7 @@ jobs:
             curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl110-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr
-            make -j1 install
+            make -j1 install_sw
             cd ..
           fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
@@ -381,7 +381,7 @@ jobs:
             curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl102-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr -fPIC
-            make -j1 install
+            make -j1 install_sw
             cd ..
           fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,15 +306,27 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
+      - name: 'cache OpenSSL 1.0.2'
+        if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}
+        uses: actions/cache@v4
+        id: cache-openssl102
+        env:
+          cache-name: cache-openssl102
+        with:
+          path: /home/runner/usr
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl102-version }}
+
       - name: 'install OpenSSL 1.0.2 from source'
         if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}
         run: |
-          curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
-          cd openssl-${{ env.openssl102-version }}
-          ./config no-unit-test no-makedepend --prefix=$PWD/../usr -fPIC
-          make -j1
-          make -j5 install
-          cd ..
+          if [ '${{ steps.cache-openssl102.outputs.cache-hit }}' != 'true' ]; then
+            curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
+            cd openssl-${{ env.openssl102-version }}
+            ./config no-unit-test no-makedepend --prefix=$PWD/../usr -fPIC
+            make -j1
+            make -j5 install
+            cd ..
+          fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
           mkdir boringssl
           cd boringssl
           curl -fsS https://boringssl.googlesource.com/boringssl/+archive/$BORINGSSLVER.tar.gz | tar -xzf -
+          # Skip tests to make the build finish faster
           echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
           cmake . \
             -DOPENSSL_SMALL=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,7 +859,6 @@ jobs:
             # https://openbsd.app/
             sudo pkg_add cmake ninja
             pkg_info || true
-            pkg_info libressl | true
             cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON \
               -DENABLE_WERROR=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,8 +335,7 @@ jobs:
             curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${{ env.openssl111-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl111-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr no-tests
-            make -j1
-            make -j5 install
+            make -j1 install
             cd ..
           fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
@@ -359,8 +358,7 @@ jobs:
             curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl110-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr
-            make -j1
-            make -j5 install
+            make -j1 install
             cd ..
           fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
@@ -383,8 +381,7 @@ jobs:
             curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl102-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr -fPIC
-            make -j1
-            make -j5 install
+            make -j1 install
             cd ..
           fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,7 @@ jobs:
           # Test build from tarball
           tar -xvf libssh2-99.98.97.tar.gz
           cd libssh2-99.98.97
-          ./configure --enable-werror --enable-debug "--prefix=${HOME}/temp" \
+          ./configure --enable-werror --enable-debug --prefix="${HOME}/temp" \
             ${{ matrix.options }} --disable-dependency-tracking
           make -j5 install
           cd ..
@@ -485,7 +485,7 @@ jobs:
         run: autoreconf -fi
       - name: 'autotools configure'
         if: ${{ matrix.build == 'autotools' }}
-        run: mkdir bld && cd bld && ../configure --enable-werror --enable-debug "--host=${TRIPLET}" --disable-dependency-tracking || { tail -n 1000 config.log; false; }
+        run: mkdir bld && cd bld && ../configure --enable-werror --enable-debug --host="${TRIPLET}" --disable-dependency-tracking || { tail -n 1000 config.log; false; }
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}
         run: make -C bld -j5
@@ -738,27 +738,27 @@ jobs:
         crypto:
           - name: 'OpenSSL 3'
             install: openssl
-            configure: --with-crypto=openssl "--with-libssl-prefix=$(brew --prefix)/opt/openssl"
-            cmake: -DCRYPTO_BACKEND=OpenSSL "-DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl"
+            configure: --with-crypto=openssl --with-libssl-prefix="$(brew --prefix)/opt/openssl"
+            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR="$(brew --prefix)/opt/openssl"
           - name: 'OpenSSL 1.1'
             install: openssl@1.1
-            configure: --with-crypto=openssl "--with-libssl-prefix=$(brew --prefix)/opt/openssl@1.1"
-            cmake: -DCRYPTO_BACKEND=OpenSSL "-DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl@1.1"
+            configure: --with-crypto=openssl --with-libssl-prefix="$(brew --prefix)/opt/openssl@1.1"
+            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR="$(brew --prefix)/opt/openssl@1.1"
           - name: 'LibreSSL'
             install: libressl
-            configure: --with-crypto=openssl "--with-libssl-prefix=$(brew --prefix)/opt/libressl"
-            cmake: -DCRYPTO_BACKEND=OpenSSL "-DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/libressl"
+            configure: --with-crypto=openssl --with-libssl-prefix="$(brew --prefix)/opt/libressl"
+            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR="$(brew --prefix)/opt/libressl"
           - name: 'wolfSSL'
             install: wolfssl
-            configure: --with-crypto=wolfssl "--with-libwolfssl-prefix=$(brew --prefix)"
+            configure: --with-crypto=wolfssl --with-libwolfssl-prefix="$(brew --prefix)"
             cmake: -DCRYPTO_BACKEND=wolfSSL
           - name: 'Libgcrypt'
             install: libgcrypt
-            configure: --with-crypto=libgcrypt "--with-libgcrypt-prefix=$(brew --prefix)"
+            configure: --with-crypto=libgcrypt --with-libgcrypt-prefix="$(brew --prefix)"
             cmake: -DCRYPTO_BACKEND=Libgcrypt
           - name: 'mbedTLS'
             install: mbedtls
-            configure: --with-crypto=mbedtls "--with-libmbedcrypto-prefix=$(brew --prefix)"
+            configure: --with-crypto=mbedtls --with-libmbedcrypto-prefix="$(brew --prefix)"
             cmake: -DCRYPTO_BACKEND=mbedTLS
     steps:
       - name: 'install packages'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,11 +179,9 @@ jobs:
         if: ${{ matrix.crypto == 'mbedTLS' }}
         uses: actions/cache@v4
         id: cache-mbedtls
-        env:
-          cache-name: cache-mbedtls
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.mbedtls-version }}-${{ matrix.arch }}
+          key: ${{ runner.os }}-mbedtls-${{ env.mbedtls-version }}-${{ matrix.arch }}
 
       - name: 'install mbedTLS from source'
         if: ${{ matrix.crypto == 'mbedTLS' }}
@@ -240,11 +238,9 @@ jobs:
         if: ${{ matrix.crypto == 'BoringSSL' }}
         uses: actions/cache@v4
         id: cache-boringssl
-        env:
-          cache-name: cache-boringssl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.boringssl-version }}-${{ matrix.arch }}
+          key: ${{ runner.os }}-boringssl-${{ env.boringssl-version }}-${{ matrix.arch }}
 
       - name: 'install BoringSSL from source'
         if: ${{ matrix.crypto == 'BoringSSL' }}
@@ -270,11 +266,9 @@ jobs:
         if: ${{ matrix.crypto == 'LibreSSL' }}
         uses: actions/cache@v4
         id: cache-libressl
-        env:
-          cache-name: cache-libressl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.libressl-version }}-${{ matrix.arch }}
+          key: ${{ runner.os }}-libressl-${{ env.libressl-version }}-${{ matrix.arch }}
 
       - name: 'install LibreSSL from source'
         if: ${{ matrix.crypto == 'LibreSSL' }}
@@ -297,11 +291,9 @@ jobs:
         if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
         uses: actions/cache@v4
         id: cache-openssl
-        env:
-          cache-name: cache-openssl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl-version }}-${{ matrix.arch }}
+          key: ${{ runner.os }}-openssl-${{ env.openssl-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL from source'
         if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
@@ -322,11 +314,9 @@ jobs:
         if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
         uses: actions/cache@v4
         id: cache-openssl111
-        env:
-          cache-name: cache-openssl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl111-version }}-${{ matrix.arch }}
+          key: ${{ runner.os }}-openssl-${{ env.openssl111-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.1.1 from source'
         if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
@@ -346,11 +336,9 @@ jobs:
         if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
         uses: actions/cache@v4
         id: cache-openssl110
-        env:
-          cache-name: cache-openssl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl110-version }}-${{ matrix.arch }}
+          key: ${{ runner.os }}-openssl-${{ env.openssl110-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.1.0 from source'
         if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
@@ -370,11 +358,9 @@ jobs:
         if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}
         uses: actions/cache@v4
         id: cache-openssl102
-        env:
-          cache-name: cache-openssl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl102-version }}-${{ matrix.arch }}
+          key: ${{ runner.os }}-openssl-${{ env.openssl102-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.0.2 from source'
         if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,8 @@ jobs:
             -DUSE_STATIC_MBEDTLS_LIBRARY=OFF \
             -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
             "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
-          make -j5 install
+          cmake --build . --parallel 5
+          cmake --install .
           cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
@@ -217,7 +218,8 @@ jobs:
             -DWOLFSSL_CRYPT_TESTS=OFF \
             "-DCMAKE_C_FLAGS=-fPIC -DWOLFSSL_AESGCM_STREAM ${cppflags}" \
             "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
-          make -j5 -C bld install
+          cmake --build bld --parallel 5
+          cmake --install bld
           cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
@@ -234,7 +236,8 @@ jobs:
             -DOPENSSL_SMALL=ON \
             -DCMAKE_C_FLAGS=-fPIC \
             "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
-          make -j5 install
+          cmake --build . --parallel 5
+          cmake --install .
           cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
@@ -248,7 +251,8 @@ jobs:
             -DLIBRESSL_APPS=OFF \
             -DLIBRESSL_TESTS=OFF \
             "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
-          make -j5 install
+          cmake --build . --parallel 5
+          cmake --install .
           cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,7 @@ jobs:
           persist-credentials: false
       - name: 'cmake'
         run: |
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
-            libssl-dev
+          sudo apt-get --option Dpkg::Use-Pty=0 install libssl-dev
           ./tests/cmake/test.sh
 
   build_linux:
@@ -169,8 +168,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture '${{ matrix.arch }}'
           sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
-            gcc-multilib build-essential zlib1g-dev:${{ matrix.arch }}
+          sudo apt-get --option Dpkg::Use-Pty=0 install gcc-multilib build-essential zlib1g-dev:${{ matrix.arch }}
 
       - name: 'install packages'
         run: |
@@ -178,8 +176,7 @@ jobs:
           [ '${{ matrix.crypto }}' = 'wolfSSL' ] && pkg='libwolfssl-dev'
           [ '${{ matrix.crypto }}' = 'Libgcrypt' ] && pkg='libgcrypt-dev'
           if [ -n "${pkg}" ]; then
-            sudo apt-get --option Dpkg::Use-Pty=0 install \
-              "${pkg}:${{ matrix.arch }}"
+            sudo apt-get --option Dpkg::Use-Pty=0 install "${pkg}:${{ matrix.arch }}"
           fi
 
       - name: 'cache mbedTLS'
@@ -478,9 +475,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: |
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
-            mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get --option Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,15 +282,27 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
+      - name: 'cache OpenSSL 1.1.1'
+        if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
+        uses: actions/cache@v4
+        id: cache-openssl111
+        env:
+          cache-name: cache-openssl111
+        with:
+          path: /home/runner/usr
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl111-version }}
+
       - name: 'install OpenSSL 1.1.1 from source'
         if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
         run: |
-          curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${{ env.openssl111-version }}.tar.gz | tar -xzf -
-          cd openssl-${{ env.openssl111-version }}
-          ./config no-unit-test no-makedepend --prefix=/usr no-tests
-          make -j1
-          make -j5 install "DESTDIR=$PWD/../"
-          cd ..
+          if [ '${{ steps.cache-openssl111.outputs.cache-hit }}' != 'true' ]; then
+            curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${{ env.openssl111-version }}.tar.gz | tar -xzf -
+            cd openssl-${{ env.openssl111-version }}
+            ./config no-unit-test no-makedepend --prefix=/usr no-tests
+            make -j1
+            make -j5 install "DESTDIR=$PWD/../"
+            cd ..
+          fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,13 @@ jobs:
               -DENABLE_TESTING=OFF \
               -DUSE_STATIC_MBEDTLS_LIBRARY=OFF \
               -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
-              "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
+              "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .
             cd ..
           fi
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
-          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
       - name: 'install wolfSSL from source'
         if: ${{ startsWith(matrix.crypto, 'wolfSSL-from-source') }}
@@ -229,12 +229,12 @@ jobs:
             -DWOLFSSL_EXAMPLES=OFF \
             -DWOLFSSL_CRYPT_TESTS=OFF \
             "-DCMAKE_C_FLAGS=-fPIC -DWOLFSSL_AESGCM_STREAM ${cppflags}" \
-            "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
+            "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
           cmake --build bld --parallel 5
           cmake --install bld
           cd ..
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
-          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
       - name: 'cache BoringSSL'
         if: ${{ matrix.crypto == 'BoringSSL' }}
@@ -258,13 +258,13 @@ jobs:
             cmake -B . \
               -DOPENSSL_SMALL=ON \
               -DCMAKE_C_FLAGS=-fPIC \
-              "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
+              "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .
             cd ..
           fi
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
-          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
       - name: 'cache LibreSSL'
         if: ${{ matrix.crypto == 'LibreSSL' }}
@@ -285,13 +285,13 @@ jobs:
             cmake -B . \
               -DLIBRESSL_APPS=OFF \
               -DLIBRESSL_TESTS=OFF \
-              "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
+              "-DCMAKE_INSTALL_PREFIX=$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .
             cd ..
           fi
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
-          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
       - name: 'cache OpenSSL'
         if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
@@ -311,12 +311,12 @@ jobs:
             cd openssl-${{ env.openssl-version }}
             ./Configure no-deprecated \
               no-apps no-docs no-tests no-makedepend \
-              no-comp no-quic no-legacy --prefix=/usr
-            make -j5 install "DESTDIR=$PWD/.."
+              no-comp no-quic no-legacy --prefix=$HOME/usr
+            make -j5 install
             cd ..
           fi
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
-          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
       - name: 'cache OpenSSL 1.1.1'
         if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
@@ -334,13 +334,13 @@ jobs:
           if [ '${{ steps.cache-openssl111.outputs.cache-hit }}' != 'true' ]; then
             curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${{ env.openssl111-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl111-version }}
-            ./config no-unit-test no-makedepend --prefix=/usr no-tests
+            ./config no-unit-test no-makedepend --prefix=$HOME/usr no-tests
             make -j1
-            make -j5 install "DESTDIR=$PWD/../"
+            make -j5 install
             cd ..
           fi
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
-          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
       - name: 'cache OpenSSL 1.1.0'
         if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
@@ -358,13 +358,13 @@ jobs:
           if [ '${{ steps.cache-openssl110.outputs.cache-hit }}' != 'true' ]; then
             curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl110-version }}
-            ./config no-unit-test no-makedepend --prefix=/usr
+            ./config no-unit-test no-makedepend --prefix=$HOME/usr
             make -j1
-            make -j5 install "DESTDIR=$PWD/../"
+            make -j5 install
             cd ..
           fi
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
-          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
       - name: 'cache OpenSSL 1.0.2'
         if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}
@@ -382,13 +382,13 @@ jobs:
           if [ '${{ steps.cache-openssl102.outputs.cache-hit }}' != 'true' ]; then
             curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl102-version }}
-            ./config no-unit-test no-makedepend --prefix=$PWD/../usr -fPIC
+            ./config no-unit-test no-makedepend --prefix=$HOME/usr -fPIC
             make -j1
             make -j5 install
             cd ..
           fi
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
-          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
 
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
       mbedtls-version: 3.5.1
       wolfssl-version: 5.7.0
       wolfssl-version-prev: 5.5.4
-      boringssl-version: ddc0647304a8ed854b2d84117f095a5f73571d37
+      boringssl-version: 0.20241024.0
       libressl-version: 4.0.0
       openssl-version: 3.2.0
       openssl111-version: 1.1.1w

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
       - name: 'cmake'
         run: |
-          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+          sudo apt-get --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
             libssl-dev
           ./tests/cmake/test.sh
 
@@ -168,8 +168,8 @@ jobs:
         if: ${{ matrix.arch != 'amd64' }}
         run: |
           sudo dpkg --add-architecture '${{ matrix.arch }}'
-          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 update
-          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+          sudo apt-get --option Dpkg::Use-Pty=0 update
+          sudo apt-get --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
             gcc-multilib build-essential zlib1g-dev:${{ matrix.arch }}
 
       - name: 'install packages'
@@ -178,7 +178,7 @@ jobs:
           [ '${{ matrix.crypto }}' = 'wolfSSL' ] && pkg='libwolfssl-dev'
           [ '${{ matrix.crypto }}' = 'Libgcrypt' ] && pkg='libgcrypt-dev'
           if [ -n "${pkg}" ]; then
-            sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+            sudo apt-get --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
               "${pkg}:${{ matrix.arch }}"
           fi
 
@@ -479,7 +479,7 @@ jobs:
     steps:
       - name: 'install packages'
         run: |
-          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+          sudo apt-get --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
             mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./ci/shellcheck.sh
 
   spellcheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: 'install tools'
         run: pip install --break-system-packages -U codespell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,10 +818,10 @@ jobs:
         with:
           persist-credentials: false
       - name: 'cmake'
-        uses: cross-platform-actions/action@a0672d7f6de3a78e7784bbaf491c7303f68d94b3 # v0.26.0
+        uses: cross-platform-actions/action@fe0167d8082ac584754ef3ffb567fded22642c7d # v0.27.0
         with:
           operating_system: 'netbsd'
-          version: '10.0'
+          version: '10.1'
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
@@ -850,7 +850,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 'cmake'
-        uses: cross-platform-actions/action@a0672d7f6de3a78e7784bbaf491c7303f68d94b3 # v0.26.0
+        uses: cross-platform-actions/action@fe0167d8082ac584754ef3ffb567fded22642c7d # v0.27.0
         with:
           operating_system: 'openbsd'
           version: '7.5'
@@ -886,7 +886,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 'autotools'
-        uses: cross-platform-actions/action@a0672d7f6de3a78e7784bbaf491c7303f68d94b3 # v0.26.0
+        uses: cross-platform-actions/action@fe0167d8082ac584754ef3ffb567fded22642c7d # v0.27.0
         with:
           operating_system: 'freebsd'
           version: '14.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,31 +94,6 @@ jobs:
             zlib: 'ON'
             target: 'maketgz'
           - compiler: gcc
-            arch: i386
-            crypto: mbedTLS
-            build: cmake
-            zlib: 'ON'
-          - compiler: gcc
-            arch: amd64
-            crypto: BoringSSL
-            build: cmake
-            zlib: 'ON'
-          - compiler: gcc
-            arch: amd64
-            crypto: LibreSSL
-            build: cmake
-            zlib: 'ON'
-          - compiler: clang
-            arch: amd64
-            crypto: wolfSSL-from-source
-            build: cmake
-            zlib: 'ON'
-          - compiler: clang
-            arch: amd64
-            crypto: wolfSSL-from-source-prev
-            build: cmake
-            zlib: 'ON'
-          - compiler: gcc
             arch: amd64
             crypto: OpenSSL-3-no-deprecated
             build: cmake
@@ -136,6 +111,31 @@ jobs:
           - compiler: gcc
             arch: amd64
             crypto: OpenSSL-102-from-source
+            build: cmake
+            zlib: 'ON'
+          - compiler: gcc
+            arch: amd64
+            crypto: BoringSSL
+            build: cmake
+            zlib: 'ON'
+          - compiler: gcc
+            arch: amd64
+            crypto: LibreSSL
+            build: cmake
+            zlib: 'ON'
+          - compiler: gcc
+            arch: i386
+            crypto: mbedTLS
+            build: cmake
+            zlib: 'ON'
+          - compiler: clang
+            arch: amd64
+            crypto: wolfSSL-from-source
+            build: cmake
+            zlib: 'ON'
+          - compiler: clang
+            arch: amd64
+            crypto: wolfSSL-from-source-prev
             build: cmake
             zlib: 'ON'
           - compiler: clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,11 @@ jobs:
       - name: 'install BoringSSL from source'
         if: ${{ matrix.crypto == 'BoringSSL' }}
         run: |
-          BORINGSSLVER=1b7fdbd9101dedc3e0aa3fcf4ff74eacddb34ecc
+          BORINGSSLVER=ddc0647304a8ed854b2d84117f095a5f73571d37
           mkdir boringssl
           cd boringssl
           curl -fsS https://boringssl.googlesource.com/boringssl/+archive/$BORINGSSLVER.tar.gz | tar -xzf -
+          echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
           cmake . \
             -DOPENSSL_SMALL=ON \
             -DCMAKE_C_FLAGS=-fPIC \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,9 @@ jobs:
             WOLFSSLVER=${{ env.wolfssl-version }}
           else
             WOLFSSLVER=${{ env.wolfssl-version-prev }}
+            # Required to include `FIPS_mode()` API:
             options='-DWOLFSSL_OPENSSLEXTRA=ON'
+            cppflags='-DOPENSSL_ALL'
           fi
           curl -fsS -L https://github.com/wolfSSL/wolfssl/archive/refs/tags/v$WOLFSSLVER-stable.tar.gz | tar -xzf -
           cd wolfssl-$WOLFSSLVER-stable
@@ -228,7 +230,7 @@ jobs:
             -DWOLFSSL_OPENSSLALL=ON \
             -DWOLFSSL_EXAMPLES=OFF \
             -DWOLFSSL_CRYPT_TESTS=OFF \
-            -DCMAKE_C_FLAGS='-fPIC -DWOLFSSL_AESGCM_STREAM' \
+            -DCMAKE_C_FLAGS="-fPIC -DWOLFSSL_AESGCM_STREAM ${cppflags}" \
             -DCMAKE_INSTALL_PREFIX="$HOME/usr"
           cmake --build bld --parallel 5
           cmake --install bld

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,11 @@ jobs:
             crypto: BoringSSL
             build: cmake
             zlib: 'ON'
+          - compiler: gcc
+            arch: amd64
+            crypto: LibreSSL
+            build: cmake
+            zlib: 'ON'
           - compiler: clang
             arch: amd64
             crypto: wolfSSL-from-source
@@ -227,6 +232,21 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
+      - name: 'install LibreSSL from source'
+        if: ${{ matrix.crypto == 'LibreSSL' }}
+        run: |
+          LIBRESSLVER=4.0.0
+          curl -fsS https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$LIBRESSLVER.tar.gz | tar -xzf -
+          cd libressl-$LIBRESSLVER
+          cmake . \
+            -DLIBRESSL_APPS=OFF \
+            -DLIBRESSL_TESTS=OFF \
+            "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
+          make -j5 install
+          cd ..
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
+
       - name: 'install OpenSSL from source'
         if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
         run: |
@@ -332,6 +352,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: |
           if [ '${{ matrix.crypto }}' = 'BoringSSL' ] || \
+             [ '${{ matrix.crypto }}' = 'LibreSSL' ] || \
              [[ '${{ matrix.crypto }}' = 'OpenSSL-'* ]]; then
             crypto='OpenSSL'
           elif [[ '${{ matrix.crypto }}' = 'wolfSSL-'* ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,7 @@ jobs:
             curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${{ env.openssl111-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl111-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr no-tests
+            make -j5
             make -j1 install_sw
             cd ..
           fi
@@ -358,6 +359,7 @@ jobs:
             curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl110-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr
+            make -j5
             make -j1 install_sw
             cd ..
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'checksrc'
         run: ./ci/checksrc.sh
 
@@ -31,6 +33,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'shellcheck'
         run: ./ci/shellcheck.sh
 
@@ -38,6 +42,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'install tools'
         run: pip install --break-system-packages -U codespell
       - name: 'spellcheck'
@@ -52,6 +58,8 @@ jobs:
       MAKEFLAGS: -j5
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'cmake'
         run: |
           sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
@@ -157,6 +165,8 @@ jobs:
       openssl102-version: 1.0.2u
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'install architecture'
         if: ${{ matrix.arch != 'amd64' }}
         run: |
@@ -468,6 +478,8 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'install packages'
         run: |
           sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
@@ -512,6 +524,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf input
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: cygwin/cygwin-install-action@v5
         with:
           platform: ${{ matrix.platform }}
@@ -573,6 +587,8 @@ jobs:
           - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'no-options' }
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys == 'msys' }}
         with:
@@ -683,6 +699,8 @@ jobs:
           - { arch: x86  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'cmake configure'
         shell: bash
         run: |
@@ -755,6 +773,8 @@ jobs:
       - name: 'install packages'
         run: brew install ${{ matrix.build == 'autotools' && 'automake libtool' || 'ninja' }} ${{ matrix.crypto.install }}
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}
         run: autoreconf -fi
@@ -804,6 +824,8 @@ jobs:
         arch: ['x86_64', 'arm64']
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'cmake'
         uses: cross-platform-actions/action@v0.25.0
         with:
@@ -834,6 +856,8 @@ jobs:
         arch: ['x86_64']
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'cmake'
         uses: cross-platform-actions/action@v0.25.0
         with:
@@ -868,6 +892,8 @@ jobs:
         arch: ['x86_64', 'arm64']
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'autotools'
         uses: cross-platform-actions/action@v0.25.0
         with:
@@ -892,6 +918,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: 'autotools'
         uses: vmactions/omnios-vm@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,25 +175,37 @@ jobs:
               "${pkg}:${{ matrix.arch }}"
           fi
 
+      - name: 'cache mbedTLS'
+        if: ${{ matrix.crypto == 'mbedTLS' }}
+        uses: actions/cache@v4
+        id: cache-mbedtls
+        env:
+          cache-name: cache-mbedtls
+        with:
+          path: /home/runner/usr
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.mbedtls-version }}
+
       - name: 'install mbedTLS from source'
         if: ${{ matrix.crypto == 'mbedTLS' }}
         run: |
-          curl -fsS -L https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-${{ env.mbedtls-version }}.tar.gz | tar -xzf -
-          cd mbedtls-mbedtls-${{ env.mbedtls-version }}
-          if [ '${{ matrix.arch }}' = 'i386' ]; then
-            crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}'
-            cflags='-m32 -mpclmul -msse2 -maes'
+          if [ '${{ steps.cache-mbedtls.outputs.cache-hit }}' != 'true' ]; then
+            curl -fsS -L https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-${{ env.mbedtls-version }}.tar.gz | tar -xzf -
+            cd mbedtls-mbedtls-${{ env.mbedtls-version }}
+            if [ '${{ matrix.arch }}' = 'i386' ]; then
+              crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}'
+              cflags='-m32 -mpclmul -msse2 -maes'
+            fi
+            cmake -B . ${crossoptions} \
+              "-DCMAKE_C_FLAGS=${cflags}" \
+              -DENABLE_PROGRAMS=OFF \
+              -DENABLE_TESTING=OFF \
+              -DUSE_STATIC_MBEDTLS_LIBRARY=OFF \
+              -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
+              "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
+            cmake --build . --parallel 5
+            cmake --install .
+            cd ..
           fi
-          cmake -B . ${crossoptions} \
-            "-DCMAKE_C_FLAGS=${cflags}" \
-            -DENABLE_PROGRAMS=OFF \
-            -DENABLE_TESTING=OFF \
-            -DUSE_STATIC_MBEDTLS_LIBRARY=OFF \
-            -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
-            "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
-          cmake --build . --parallel 5
-          cmake --install .
-          cd ..
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,11 +353,11 @@ jobs:
     env:
       SHELLOPTS: 'igncr'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - { build: 'automake', platform: 'x86_64', compiler: 'gcc' }
           - { build: 'cmake'   , platform: 'x86_64', compiler: 'gcc' }
-      fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
       - uses: actions/checkout@v4
@@ -405,6 +405,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         include:
           - { build: 'autotools', sys: msys   , crypto: openssl, env: x86_64 }
@@ -419,7 +420,6 @@ jobs:
           - { build: 'cmake'    , sys: clang64, crypto: OpenSSL, env: clang-x86_64 }
           - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'uwp' }
           - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'no-options' }
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
@@ -520,6 +520,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         include:
           - { arch: x64  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'OFF', zlib: 'OFF', unity: 'ON' }
@@ -529,7 +530,6 @@ jobs:
           - { arch: arm64, plat: windows, crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
           - { arch: arm64, plat: uwp    , crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
           - { arch: x86  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - name: 'cmake configure'
@@ -648,6 +648,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         arch: ['x86_64', 'arm64']
     steps:
@@ -677,6 +678,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         arch: ['x86_64']
     steps:
@@ -708,6 +710,7 @@ jobs:
     env:
       CC: clang
     strategy:
+      fail-fast: false
       matrix:
         arch: ['x86_64', 'arm64']
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,18 +254,30 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
+      - name: 'cache LibreSSL'
+        if: ${{ matrix.crypto == 'LibreSSL' }}
+        uses: actions/cache@v4
+        id: cache-libressl
+        env:
+          cache-name: cache-libressl
+        with:
+          path: /home/runner/usr
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.libressl-version }}
+
       - name: 'install LibreSSL from source'
         if: ${{ matrix.crypto == 'LibreSSL' }}
         run: |
-          curl -fsS https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${{ env.libressl-version }}.tar.gz | tar -xzf -
-          cd libressl-${{ env.libressl-version }}
-          cmake -B . \
-            -DLIBRESSL_APPS=OFF \
-            -DLIBRESSL_TESTS=OFF \
-            "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
-          cmake --build . --parallel 5
-          cmake --install .
-          cd ..
+          if [ '${{ steps.cache-libressl.outputs.cache-hit }}' != 'true' ]; then
+            curl -fsS https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${{ env.libressl-version }}.tar.gz | tar -xzf -
+            cd libressl-${{ env.libressl-version }}
+            cmake -B . \
+              -DLIBRESSL_APPS=OFF \
+              -DLIBRESSL_TESTS=OFF \
+              "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
+            cmake --build . --parallel 5
+            cmake --install .
+            cd ..
+          fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
       - name: 'cmake'
         run: |
-          sudo apt-get --option Dpkg::Use-Pty=0 install libssl-dev
+          sudo apt-get -o Dpkg::Use-Pty=0 install libssl-dev
           ./tests/cmake/test.sh
 
   build_linux:
@@ -167,8 +167,8 @@ jobs:
         if: ${{ matrix.arch != 'amd64' }}
         run: |
           sudo dpkg --add-architecture '${{ matrix.arch }}'
-          sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install gcc-multilib build-essential zlib1g-dev:${{ matrix.arch }}
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install gcc-multilib build-essential zlib1g-dev:${{ matrix.arch }}
 
       - name: 'install packages'
         run: |
@@ -176,7 +176,7 @@ jobs:
           [ '${{ matrix.crypto }}' = 'wolfSSL' ] && pkg='libwolfssl-dev'
           [ '${{ matrix.crypto }}' = 'Libgcrypt' ] && pkg='libgcrypt-dev'
           if [ -n "${pkg}" ]; then
-            sudo apt-get --option Dpkg::Use-Pty=0 install "${pkg}:${{ matrix.arch }}"
+            sudo apt-get -o Dpkg::Use-Pty=0 install "${pkg}:${{ matrix.arch }}"
           fi
 
       - name: 'cache mbedTLS'
@@ -475,7 +475,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --option Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,21 +236,33 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 
+      - name: 'cache BoringSSL'
+        if: ${{ matrix.crypto == 'BoringSSL' }}
+        uses: actions/cache@v4
+        id: cache-boringssl
+        env:
+          cache-name: cache-boringssl
+        with:
+          path: /home/runner/usr
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.boringssl-version }}
+
       - name: 'install BoringSSL from source'
         if: ${{ matrix.crypto == 'BoringSSL' }}
         run: |
-          mkdir boringssl
-          cd boringssl
-          curl -fsS https://boringssl.googlesource.com/boringssl/+archive/${{ env.boringssl-version }}.tar.gz | tar -xzf -
-          # Skip tests to make the build finish faster
-          echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
-          cmake -B . \
-            -DOPENSSL_SMALL=ON \
-            -DCMAKE_C_FLAGS=-fPIC \
-            "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
-          cmake --build . --parallel 5
-          cmake --install .
-          cd ..
+          if [ '${{ steps.cache-boringssl.outputs.cache-hit }}' != 'true' ]; then
+            mkdir boringssl
+            cd boringssl
+            curl -fsS https://boringssl.googlesource.com/boringssl/+archive/${{ env.boringssl-version }}.tar.gz | tar -xzf -
+            # Skip tests to make the build finish faster
+            echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
+            cmake -B . \
+              -DOPENSSL_SMALL=ON \
+              -DCMAKE_C_FLAGS=-fPIC \
+              "-DCMAKE_INSTALL_PREFIX=$PWD/../usr"
+            cmake --build . --parallel 5
+            cmake --install .
+            cd ..
+          fi
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/usr/lib" >> $GITHUB_ENV
           echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$PWD/usr" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
         if: ${{ matrix.crypto == 'LibreSSL' }}
         run: |
           if [ '${{ steps.cache-libressl.outputs.cache-hit }}' != 'true' ]; then
-            curl -fsS https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${{ env.libressl-version }}.tar.gz | tar -xzf -
+            curl -fsS -L https://github.com/libressl/portable/releases/download/v${{ env.libressl-version }}/libressl-${{ env.libressl-version }}.tar.gz | tar -xzf -
             cd libressl-${{ env.libressl-version }}
             cmake -B . \
               -DLIBRESSL_APPS=OFF \
@@ -344,7 +344,7 @@ jobs:
         if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
         run: |
           if [ '${{ steps.cache-openssl110.outputs.cache-hit }}' != 'true' ]; then
-            curl -fsS -L https://openssl.org/source/old/1.1.0/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
+            curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_0l/openssl-${{ env.openssl110-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl110-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr
             make -j5
@@ -366,7 +366,7 @@ jobs:
         if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}
         run: |
           if [ '${{ steps.cache-openssl102.outputs.cache-hit }}' != 'true' ]; then
-            curl -fsS -L https://openssl.org/source/old/1.0.2/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
+            curl -fsS -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_0_2u/openssl-${{ env.openssl102-version }}.tar.gz | tar -xzf -
             cd openssl-${{ env.openssl102-version }}
             ./config no-unit-test no-makedepend --prefix=$HOME/usr -fPIC
             make -j5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-mbedtls
         with:
-          path: /home/runner/usr
+          path: ~/usr
           key: ${{ runner.os }}-mbedtls-${{ env.mbedtls-version }}-${{ matrix.arch }}
 
       - name: 'install mbedTLS from source'
@@ -241,7 +241,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-boringssl
         with:
-          path: /home/runner/usr
+          path: ~/usr
           key: ${{ runner.os }}-boringssl-${{ env.boringssl-version }}-${{ matrix.arch }}
 
       - name: 'install BoringSSL from source'
@@ -269,7 +269,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-libressl
         with:
-          path: /home/runner/usr
+          path: ~/usr
           key: ${{ runner.os }}-libressl-${{ env.libressl-version }}-${{ matrix.arch }}
 
       - name: 'install LibreSSL from source'
@@ -294,7 +294,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-openssl
         with:
-          path: /home/runner/usr
+          path: ~/usr
           key: ${{ runner.os }}-openssl-${{ env.openssl-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL from source'
@@ -317,7 +317,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-openssl111
         with:
-          path: /home/runner/usr
+          path: ~/usr
           key: ${{ runner.os }}-openssl-${{ env.openssl111-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.1.1 from source'
@@ -339,7 +339,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-openssl110
         with:
-          path: /home/runner/usr
+          path: ~/usr
           key: ${{ runner.os }}-openssl-${{ env.openssl110-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.1.0 from source'
@@ -361,7 +361,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-openssl102
         with:
-          path: /home/runner/usr
+          path: ~/usr
           key: ${{ runner.os }}-openssl-${{ env.openssl102-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.0.2 from source'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
       - name: 'cmake'
         run: |
-          sudo apt-get --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             libssl-dev
           ./tests/cmake/test.sh
 
@@ -169,7 +169,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture '${{ matrix.arch }}'
           sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             gcc-multilib build-essential zlib1g-dev:${{ matrix.arch }}
 
       - name: 'install packages'
@@ -178,7 +178,7 @@ jobs:
           [ '${{ matrix.crypto }}' = 'wolfSSL' ] && pkg='libwolfssl-dev'
           [ '${{ matrix.crypto }}' = 'Libgcrypt' ] && pkg='libgcrypt-dev'
           if [ -n "${pkg}" ]; then
-            sudo apt-get --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+            sudo apt-get --option Dpkg::Use-Pty=0 install \
               "${pkg}:${{ matrix.arch }}"
           fi
 
@@ -479,7 +479,7 @@ jobs:
     steps:
       - name: 'install packages'
         run: |
-          sudo apt-get --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           cache-name: cache-mbedtls
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.mbedtls-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.mbedtls-version }}-${{ matrix.arch }}
 
       - name: 'install mbedTLS from source'
         if: ${{ matrix.crypto == 'mbedTLS' }}
@@ -244,7 +244,7 @@ jobs:
           cache-name: cache-boringssl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.boringssl-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.boringssl-version }}-${{ matrix.arch }}
 
       - name: 'install BoringSSL from source'
         if: ${{ matrix.crypto == 'BoringSSL' }}
@@ -274,7 +274,7 @@ jobs:
           cache-name: cache-libressl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.libressl-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.libressl-version }}-${{ matrix.arch }}
 
       - name: 'install LibreSSL from source'
         if: ${{ matrix.crypto == 'LibreSSL' }}
@@ -301,7 +301,7 @@ jobs:
           cache-name: cache-openssl
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL from source'
         if: ${{ matrix.crypto == 'OpenSSL-3-no-deprecated' }}
@@ -326,7 +326,7 @@ jobs:
           cache-name: cache-openssl111
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl111-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl111-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.1.1 from source'
         if: ${{ matrix.crypto == 'OpenSSL-111-from-source' }}
@@ -350,7 +350,7 @@ jobs:
           cache-name: cache-openssl110
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl110-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl110-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.1.0 from source'
         if: ${{ matrix.crypto == 'OpenSSL-110-from-source' }}
@@ -374,7 +374,7 @@ jobs:
           cache-name: cache-openssl102
         with:
           path: /home/runner/usr
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl102-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl102-version }}-${{ matrix.arch }}
 
       - name: 'install OpenSSL 1.0.2 from source'
         if: ${{ matrix.crypto == 'OpenSSL-102-from-source' }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -31,7 +31,7 @@ jobs:
         dry-run: false
         language: c
     - name: Upload Crash
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       if: ${{ failure() && steps.build.outcome == 'success' }}
       with:
         name: artifacts

--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -34,13 +34,13 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -53,7 +53,7 @@ jobs:
         run: docker manifest inspect ghcr.io/${{ github.repository_owner }}/ci_tests_openssh_server:${{ steps.hash.outputs.hash }}
         continue-on-error: true
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/ci_tests_openssh_server
@@ -61,7 +61,7 @@ jobs:
             type=raw,value=${{ steps.hash.outputs.hash }}
         if: ${{ steps.poll.outcome == 'failure' }}
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6
         with:
           context: ./tests/openssh_server
           push: true

--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -41,6 +41,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - shell: bash
         id: hash

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -24,8 +24,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v4
+        uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -25,5 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,13 @@ function(libssh2_dumpvars)  # Dump all defined variables with their values
   message("::endgroup::")
 endfunction()
 
+# CMake does not recognize some targets accurately. Touch up configuration manually as a workaround.
+if(WINDOWS_STORE AND MINGW)  # mingw UWP build
+  # CMake (as of v3.31.2) gets confused and applies the MSVC rc.exe command-line
+  # template to windres. Reset it to the windres template via 'Modules/Platform/Windows-windres.cmake':
+  set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>")
+endif()
+
 set(_target_flags "")
 if(APPLE)
   set(_target_flags "${_target_flags} APPLE")

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3353,8 +3353,7 @@ _libssh2_md5_init(libssh2_md5_ctx *ctx)
      */
 #if OPENSSL_VERSION_NUMBER >= 0x000907000L && \
     !defined(USE_OPENSSL_3) && \
-    !defined(LIBRESSL_VERSION_NUMBER) && \
-    !defined(LIBSSH2_WOLFSSL)
+    !defined(LIBRESSL_VERSION_NUMBER)
 
     if(FIPS_mode())
         return 0;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3353,7 +3353,8 @@ _libssh2_md5_init(libssh2_md5_ctx *ctx)
      */
 #if OPENSSL_VERSION_NUMBER >= 0x000907000L && \
     !defined(USE_OPENSSL_3) && \
-    !defined(LIBRESSL_VERSION_NUMBER)
+    !defined(LIBRESSL_VERSION_NUMBER) && \
+    !defined(LIBSSH2_WOLFSSL)
 
     if(FIPS_mode())
         return 0;


### PR DESCRIPTION
- add Linux jobs with old OpenSSL versions: 1.1.1, 1.1.0, 1.0.2, with
  tests.
  (Meaning we test these again after losing them in AppVeyor CI)
- add LibreSSL Linux job with tests.
- cache most dependency packages built from source.
  (exception: wolfSSL, which would have added too much complexity
  due to the multiple versions, and it's fast to build anyway.)
- change source tarball sources to GitHub for better stability and
  performance.
- move dependency versions to the env.
- set `persist-credentials: false` for checkout steps for security.
- pin actions to hash for security.
- checkout repo later, right before use.
- skip building BoringSSL tests to finish quicker.
- set `fail-fast: false` in the BSD build matrix.
- cmake: move UWP workaround from GHA to `CMakeLists.txt`, making it
  available for everyone.
- list installed packages in OpenBSD job.
- bump BoringSSL, mbedTLS, wolfSSL, OpenSSL.
- bump cross-platform-actions to v0.26.
- bump docker/build-push-action to v6.
- bump actions/upload-artifact to v4.
- bump NetBSD to 10.1.
- drop `--quiet 2` `apt-get` option to keep useful output.
- drop `--no-install-suggests --no-install-recommends` `apt-get`
  options. They are the defaults with the `ubuntu-24.04` image.
- tidy up quotes.

Cherry-picked from #1484