### PR TITLE
ci/GHA: bump BoringSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,7 @@ jobs:
             cmake -B . \
               -DOPENSSL_SMALL=ON \
               -DCMAKE_C_FLAGS=-fPIC \
+              -DCMAKE_CXX_FLAGS=-fPIC \
               -DCMAKE_INSTALL_PREFIX="$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,8 @@ jobs:
             -DWOLFSSL_OPENSSLALL=ON \
             -DWOLFSSL_EXAMPLES=OFF \
             -DWOLFSSL_CRYPT_TESTS=OFF \
-            -DCMAKE_C_FLAGS='-fPIC -DWOLFSSL_AESGCM_STREAM' \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_C_FLAGS='-DWOLFSSL_AESGCM_STREAM' \
             -DCMAKE_INSTALL_PREFIX="$HOME/usr"
           cmake --build bld --parallel 5
           cmake --install bld
@@ -255,8 +256,7 @@ jobs:
             echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
             cmake -B . \
               -DOPENSSL_SMALL=ON \
-              -DCMAKE_C_FLAGS=-fPIC \
-              -DCMAKE_CXX_FLAGS=-fPIC \
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
               -DCMAKE_INSTALL_PREFIX="$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
       mbedtls-version: 3.6.2
       wolfssl-version: 5.7.4
       wolfssl-version-prev: 5.5.4
-      boringssl-version: 0.20241024.0
+      boringssl-version: 0.20250114.0
       libressl-version: 4.0.0
       openssl-version: 3.4.0
       openssl111-version: 1.1.1w


### PR DESCRIPTION
Also replace manual `-fPIC` C flag with
`-DCMAKE_POSITION_INDEPENDENT_CODE=ON`. It makes it pass it to C++,
which is necessary for BoringSSL after this bump.

Fixes:
```
/usr/bin/ld: /home/runner/usr/lib/libcrypto.a(crypto.cc.o): warning: relocation against `stderr@@GLIBC_2.2.5' in read-only section `.text'
/usr/bin/ld: /home/runner/usr/lib/libcrypto.a(urandom.cc.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
```
https://github.com/libssh2/libssh2/actions/runs/13065421829/job/36456862458#step:27:23
