### PR TITLE
disable deprecated algos by default

### DIFF
--- a/src/crypto_config.h
+++ b/src/crypto_config.h
@@ -3,24 +3,24 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#define LIBSSH2_MD5_PEM LIBSSH2_MD5
-
-#ifdef LIBSSH2_NO_MD5
+#ifndef LIBSSH2_MD5_ENABLE
 #undef LIBSSH2_MD5
 #define LIBSSH2_MD5 0
 #endif
 
-#ifdef LIBSSH2_NO_MD5_PEM
+#ifndef LIBSSH2_MD5_PEM_ENABLE
 #undef LIBSSH2_MD5_PEM
-#define LIBSSH2_MD5_PEM 0
+#define LIBSSH2_MD5_PEM LIBSSH2_MD5
+#else
+#define LIBSSH2_MD5_PEM 1
 #endif
 
-#ifdef LIBSSH2_NO_HMAC_RIPEMD
+#ifndef LIBSSH2_HMAC_RIPEMD_ENABLE
 #undef LIBSSH2_HMAC_RIPEMD
 #define LIBSSH2_HMAC_RIPEMD 0
 #endif
 
-#if !defined(LIBSSH2_DSA_ENABLE)
+#ifndef LIBSSH2_DSA_ENABLE
 #undef LIBSSH2_DSA
 #define LIBSSH2_DSA 0
 #endif
@@ -55,22 +55,22 @@
 #define LIBSSH2_AES_CBC 0
 #endif
 
-#ifdef LIBSSH2_NO_BLOWFISH
+#ifndef LIBSSH2_BLOWFISH_ENABLE
 #undef LIBSSH2_BLOWFISH
 #define LIBSSH2_BLOWFISH 0
 #endif
 
-#ifdef LIBSSH2_NO_RC4
+#ifndef LIBSSH2_RC4_ENABLE
 #undef LIBSSH2_RC4
 #define LIBSSH2_RC4 0
 #endif
 
-#ifdef LIBSSH2_NO_CAST
+#ifndef LIBSSH2_CAST_ENABLE
 #undef LIBSSH2_CAST
 #define LIBSSH2_CAST 0
 #endif
 
-#ifdef LIBSSH2_NO_3DES
+#ifndef LIBSSH2_3DES_ENABLE
 #undef LIBSSH2_3DES
 #define LIBSSH2_3DES 0
 #endif


### PR DESCRIPTION
- MD5-based MACs and hashes: `hmac-md5`, `hmac-md5-96`,
  `LIBSSH2_HOSTKEY_HASH_MD5`
    You can enable it now with `-DLIBSSH2_MD5_ENABLE`.
    Disabled by default since OpenSSH 7.2 (2016-02-29).
- 3DES cipher: `3des-cbc`
    You can enable it now with `-DLIBSSH2_3DES_ENABLE`.
    Disabled by default since OpenSSH 7.4 (2016-12-19).
- RIPEMD-160 MACs: `hmac-ripemd160`, `hmac-ripemd160@openssh.com`
    You can enable it now with `-DLIBSSH2_HMAC_RIPEMD_ENABLE`.
    Removed in OpenSSH 7.6 (2017-10-03).
- Blowfish cipher: `blowfish-cbc`
    You can enable it now with `-DLIBSSH2_BLOWFISH_ENABLE`.
    Removed in OpenSSH 7.6 (2017-10-03).
- RC4 ciphers: `arcfour`, `arcfour128`
    You can enable it now with `-DLIBSSH2_RC4_ENABLE`.
    Removed in OpenSSH 7.6 (2017-10-03).
- CAST cipher: `cast128-cbc`
    You can enable it now with `-DLIBSSH2_CAST_ENABLE`.
    Removed in OpenSSH 7.6 (2017-10-03).

- old-style, MD5-based encrypted private keys.
    You can enable it now with `-DLIBSSH2_MD5_PEM_ENABLE`.
