### PR TITLE
cmake: initialize variables where missing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,13 @@ set(_sources ${CSOURCES} ${HHEADERS})
 
 ## Library definition
 
+if(NOT DEFINED IMPORT_LIB_SUFFIX)
+  set(IMPORT_LIB_SUFFIX "")
+endif()
+if(NOT DEFINED STATIC_LIB_SUFFIX)
+  set(STATIC_LIB_SUFFIX "")
+endif()
+
 # Ensure that the static library and import library filenames are different,
 # when building both static and shared library. On Windows, with certain
 # toolchains (e.g. MSVC) these libraries get the same by default, overwriting


### PR DESCRIPTION
As detected using `cmake --warn-uninitialized`.

It also lists documented CMake global variables, which is unexpected:
`CMAKE_MODULE_PATH`, `CMAKE_IMPORT_LIBRARY_SUFFIX`.
I'd expect CMake to initialize its namespace.

https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-warn-uninitialized
