### PR TITLE
cmake: exclude `CMAKE_C_IMPLICIT_LINK_DIRECTORIES` from `libssh2.pc`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,7 +211,7 @@ endif()
 set(_ldflags "")
 
 # Avoid getting unnecessary -L options for known system directories.
-set(_sys_libdirs "")
+set(_sys_libdirs ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
 foreach(_libdir IN LISTS CMAKE_SYSTEM_PREFIX_PATH)
   if(_libdir MATCHES "/$")
     string(APPEND _libdir "lib")


### PR DESCRIPTION
Co-authored-by: Kai Pastor
Ref: https://github.com/curl/curl/commit/f72b84809216657e4ad3c1a0184775c911080d63
Ref: https://github.com/curl/curl/pull/16233