### PR TITLE
tidy-up: replace `exit()` with `return`

### DIFF
--- a/docs/libssh2_version.3
+++ b/docs/libssh2_version.3
@@ -28,7 +28,7 @@ To make sure you run with the correct libssh2 version:
 .nf
 if(!libssh2_version(LIBSSH2_VERSION_NUM)) {
   fprintf(stderr, \&"Runtime libssh2 version too old.\&");
-  exit(1);
+  return -1;  /* return error */
 }
 .fi
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -209,7 +209,7 @@ int main(int argc, char *argv[])
     } while(1);
     if(!channel) {
         fprintf(stderr, "Error\n");
-        exit(1);
+        return 1;
     }
     while((rc = libssh2_channel_request_auth_agent(channel)) ==
           LIBSSH2_ERROR_EAGAIN) {
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
     if(rc) {
         fprintf(stderr, "Error, could not request auth agent, "
                 "error code %d.\n", rc);
-        exit(1);
+        return 1;
     }
     else {
         fprintf(stdout, "Agent forwarding request succeeded.\n");
@@ -229,7 +229,7 @@ int main(int argc, char *argv[])
     }
     if(rc) {
         fprintf(stderr, "Error\n");
-        exit(1);
+        return 1;
     }
     for(;;) {
         ssize_t nread;

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
               LIBSSH2_ERROR_EAGAIN);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
-            exit(1);
+            return 1;
         }
     }
 
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
     } while(1);
     if(!channel) {
         fprintf(stderr, "Error\n");
-        exit(1);
+        return 1;
     }
     while((rc = libssh2_channel_exec(channel, commandline)) ==
           LIBSSH2_ERROR_EAGAIN) {
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
     }
     if(rc) {
         fprintf(stderr, "exec error\n");
-        exit(1);
+        return 1;
     }
     else {
         LIBSSH2_POLLFD *fds = NULL;
@@ -241,7 +241,7 @@ int main(int argc, char *argv[])
         fds = malloc(sizeof(LIBSSH2_POLLFD));
         if(!fds) {
             fprintf(stderr, "malloc failed\n");
-            exit(1);
+            return 1;
         }
 
         fds[0].type = LIBSSH2_POLLFD_CHANNEL;
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
                 }
                 else if(n < 0) {
                     fprintf(stderr, "read failed\n");
-                    exit(1);
+                    return 1;
                 }
                 else {
                     totread += (size_t)n;
@@ -291,7 +291,7 @@ int main(int argc, char *argv[])
                     }
                     else if(n < 0) {
                         fprintf(stderr, "write failed\n");
-                        exit(1);
+                        return 1;
                     }
                     else {
                         totwritten += (size_t)n;
@@ -312,7 +312,7 @@ int main(int argc, char *argv[])
                     }
                     else if(rc < 0) {
                         fprintf(stderr, "send eof failed\n");
-                        exit(1);
+                        return 1;
                     }
                     else {
                         fprintf(stderr, "sent eof\n");
@@ -353,7 +353,7 @@ int main(int argc, char *argv[])
             fprintf(stderr, "\n*** FAIL bytes written: "
                     "%lu bytes read: %lu ***\n",
                     (unsigned long)totwritten, (unsigned long)totread);
-            exit(1);
+            return 1;
         }
     }
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
     } while(1);
     if(!channel) {
         fprintf(stderr, "Error\n");
-        exit(1);
+        return 1;
     }
     while((rc = libssh2_channel_exec(channel, commandline)) ==
           LIBSSH2_ERROR_EAGAIN) {
@@ -240,7 +240,7 @@ int main(int argc, char *argv[])
     }
     if(rc) {
         fprintf(stderr, "exec error\n");
-        exit(1);
+        return 1;
     }
     for(;;) {
         ssize_t nread;


### PR DESCRIPTION
In examples and the manual page for `libssh2_version()`.