### PR TITLE
_libssh2_base64_decode() handle malformed data

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -389,9 +389,9 @@ int _libssh2_base64_decode(LIBSSH2_SESSION *session,
     unsigned char *d;
     const char *s;
     short v;
-    ssize_t i = 0, len = 0;
+    size_t i = 0, len = 0;
 
-    *data = LIBSSH2_ALLOC(session, ((src_len / 4) * 3) + 1);
+    *data = LIBSSH2_ALLOC(session, src_len);
     d = (unsigned char *) *data;
     if(!d) {
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,


### PR DESCRIPTION
Make sure to allocate enough space for malformed base64 encoded data.  Changed signed size values to unsigned to match input so we can't possibly truncate input.

Credit:
Stanislav Osipov