### PR TITLE
Session null checks to quiet fuzzer

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -740,12 +740,12 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 {
     int rc;
 
-    if(session == NULL) {
+    if(!session) {
         fprintf(stderr, "Session is NULL, error: %i\n",
                 LIBSSH2_ERROR_PROTO);
         return LIBSSH2_ERROR_PROTO;
     }
-    
+
     if(session->startup_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                        "session_startup for socket %ld", (long)sock));

--- a/src/session.c
+++ b/src/session.c
@@ -740,6 +740,12 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 {
     int rc;
 
+    if(session == NULL) {
+        fprintf(stderr, "Session is NULL, error: %i\n",
+                LIBSSH2_ERROR_PROTO);
+        return LIBSSH2_ERROR_PROTO;
+    }
+    
     if(session->startup_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                        "session_startup for socket %ld", (long)sock));

--- a/src/session.h
+++ b/src/session.h
@@ -59,7 +59,8 @@
             rc = x; \
             /* the order of the check below is important to properly \
                deal with the case when the 'sess' is freed */ \
-            if((rc != LIBSSH2_ERROR_EAGAIN) || !sess->api_block_mode) \
+            if((rc != LIBSSH2_ERROR_EAGAIN) || sess == NULL || \
+               !sess->api_block_mode) \
                 break; \
             rc = _libssh2_wait_socket(sess, entry_time);  \
         } while(!rc);   \
@@ -77,7 +78,7 @@
         int rc; \
         do { \
             ptr = x; \
-            if(!sess->api_block_mode || \
+            if(sess == NULL || !sess->api_block_mode || \
                (ptr != NULL) || \
                (libssh2_session_last_errno(sess) != LIBSSH2_ERROR_EAGAIN)) \
                 break; \

--- a/src/session.h
+++ b/src/session.h
@@ -59,7 +59,7 @@
             rc = x; \
             /* the order of the check below is important to properly \
                deal with the case when the 'sess' is freed */ \
-            if((rc != LIBSSH2_ERROR_EAGAIN) || sess == NULL || \
+            if((rc != LIBSSH2_ERROR_EAGAIN) || !sess || \
                !sess->api_block_mode) \
                 break; \
             rc = _libssh2_wait_socket(sess, entry_time);  \
@@ -78,7 +78,7 @@
         int rc; \
         do { \
             ptr = x; \
-            if(sess == NULL || !sess->api_block_mode || \
+            if(!sess || !sess->api_block_mode || \
                (ptr != NULL) || \
                (libssh2_session_last_errno(sess) != LIBSSH2_ERROR_EAGAIN)) \
                 break; \


### PR DESCRIPTION
Session null checks to quiet fuzzer errors if you try and start a connection with a null session.