### PR TITLE
Add CI test for AWS-LC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,11 @@ jobs:
             zlib: 'ON'
           - compiler: gcc
             arch: amd64
+            crypto: AWS-LC
+            build: cmake
+            zlib: 'ON'
+          - compiler: gcc
+            arch: amd64
             crypto: LibreSSL
             build: cmake
             zlib: 'ON'
@@ -167,6 +172,7 @@ jobs:
       wolfssl-version: 5.7.4
       wolfssl-version-prev: 5.5.4
       boringssl-version: 0.20250114.0
+      awslc-version: 1.46.1
       libressl-version: 4.0.0
       openssl-version: 3.4.0
       openssl111-version: 1.1.1w
@@ -269,6 +275,29 @@ jobs:
               -DOPENSSL_SMALL=ON \
               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
               -DCMAKE_INSTALL_PREFIX="$HOME/usr"
+            cmake --build . --parallel 5
+            cmake --install .
+            cd ..
+          fi
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/usr/lib" >> $GITHUB_ENV
+          echo "TOOLCHAIN_OPTION=$TOOLCHAIN_OPTION -DCMAKE_PREFIX_PATH=$HOME/usr" >> $GITHUB_ENV
+
+      - name: 'cache AWS-LC'
+        if: ${{ matrix.crypto == 'AWS-LC' }}
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        id: cache-aws-lc
+        with:
+          path: ~/usr
+          key: ${{ runner.os }}-aws-lc-${{ env.awslc-version }}-${{ matrix.arch }}
+
+      - name: 'install AWS-LC from source'
+        if: ${{ matrix.crypto == 'AWS-LC' }}
+        run: |
+          if [ '${{ steps.cache-aws-lc.outputs.cache-hit }}' != 'true' ]; then
+            mkdir aws-lc
+            cd aws-lc
+            curl -fsS -L https://github.com/aws/aws-lc/archive/refs/tags/v${{ env.awslc-version }}.tar.gz | tar -xzf -
+            cmake aws-lc-${{ env.awslc-version }} -B . -DCMAKE_INSTALL_PREFIX="$HOME/usr"
             cmake --build . --parallel 5
             cmake --install .
             cd ..
@@ -448,6 +477,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: |
           if [ '${{ matrix.crypto }}' = 'BoringSSL' ] || \
+             [ '${{ matrix.crypto }}' = 'AWS-LC' ] || \
              [ '${{ matrix.crypto }}' = 'LibreSSL' ] || \
              [[ '${{ matrix.crypto }}' = 'OpenSSL-'* ]]; then
             crypto='OpenSSL'

--- a/docs/INSTALL_CMAKE.md
+++ b/docs/INSTALL_CMAKE.md
@@ -90,6 +90,12 @@ The following options are available:
     Disable secure zero memory before freeing it (not recommended).
     Can be `ON` or `OFF`. Default: `ON`
 
+Using BoringSSL or AWS-LC
+-------------------------
+You can also build against [BoringSSL](https://github.com/google/boringssl)
+or [AWS-LC](https://github.com/aws/aws-lc). Specify `CRYPTO_BACKEND=OpenSSL`, then indicate
+the installation directory of the cryptography library using `OPENSSL_ROOT_DIR=`
+
 Build tools
 -----------
 


### PR DESCRIPTION
* Adds AWS-LC (cmake, gcc, amd64) to the GitHub CI tests.
* Adds note on how to build w/ BoringSSL or AWS-LC in `INSTALL_CMAKE.md`

AWS-LC recently added CI integration tests for Libssh2 to the AWS-LC GitHub repo to ensure that we maintain our compatibility with libssh2: https://github.com/aws/aws-lc/pull/2222

I've verified this change by running the CI job on my fork, which completed successfully: https://github.com/justsmth/libssh2/actions/runs/13547314774/job/37862097664

Any feedback is welcome. Thanks!