### PR TITLE
tests: add support for wine/qemu

### DIFF
--- a/tests/test_read_algos.test
+++ b/tests/test_read_algos.test
@@ -19,13 +19,13 @@ echo "${count}..${total}"
 
 while read -r test; do
   if [[ "${test}" = *'mac-'* ]]; then
-    if FIXTURE_TEST_MAC="${test}" "${testbin}"; then
+    if FIXTURE_TEST_MAC="${test}" ${LIBSSH2_TEST_EXE_RUNNER:-} "${testbin}"; then
       res='ok'
     else
       res='not ok'
     fi
   else
-    if FIXTURE_TEST_CRYPT="${test}" "${testbin}"; then
+    if FIXTURE_TEST_CRYPT="${test}" ${LIBSSH2_TEST_EXE_RUNNER:-} "${testbin}"; then
       res='ok'
     else
       res='not ok'

--- a/tests/test_sshd.test
+++ b/tests/test_sshd.test
@@ -146,7 +146,7 @@ echo "${count}..${total}"
 export OPENSSH_NO_DOCKER=1
 
 for test in ${tests}; do
-  if "${test}"; then
+  if ${LIBSSH2_TEST_EXE_RUNNER:-} "${test}"; then
     res='ok'
   else
     testerr=$?


### PR DESCRIPTION
To run test program via `wine`:
```shell
export LIBSSH2_TEST_EXE_RUNNER=wine
```

It prefixes commands with the specified runner. For systems where this
isn't automatic or supported, e.g. macOS.
