### PR TITLE
tests: improve `SSHD` default value

### DIFF
--- a/tests/test_sshd.test
+++ b/tests/test_sshd.test
@@ -45,7 +45,7 @@ fi
 
 d="$(cd "${d}" || exit; pwd)"  # sshd needs absolute paths
 
-SSHD="${SSHD:-/usr/sbin/sshd}"
+SSHD="$(command -v "${SSH:-sshd}" || true)"
 [[ "${uname}" = *'_NT'* ]] && SSHD="$(cygpath "${SSHD}")"
 ver="$("${SSHD}" -V 2>&1 || true)"
 if [[ "${ver}" =~ OpenSSH_[a-zA-Z0-9_\ .,]+ ]]; then


### PR DESCRIPTION
Instead of going for a hardcoded `/usr/sbin/sshd`, use `command -v`
to figure out the default `sshd` executable.
