### PR TITLE
ci/GHA: add clang-tidy jobs for Linux and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc, clang, clang-tidy]
         arch: [amd64]
         crypto: [OpenSSL, Libgcrypt, mbedTLS, wolfSSL]
         build: [cmake]
         zlib: ['OFF', 'ON']
+        exclude:
+          - { compiler: clang-tidy, zlib: 'OFF' }
         include:
           - compiler: gcc
             arch: amd64
@@ -177,7 +179,7 @@ jobs:
             zlib: 'ON'
             options: --disable-static
     env:
-      CC: ${{ matrix.compiler }}
+      CC: ${{ matrix.compiler == 'clang-tidy' && 'clang' || matrix.compiler }}
       mbedtls-version: 3.6.2
       wolfssl-version: 5.7.4
       wolfssl-version-prev: 5.5.4
@@ -504,6 +506,7 @@ jobs:
             -DENABLE_WERROR=ON \
             -DCRYPTO_BACKEND=${crypto} \
             -DENABLE_ZLIB_COMPRESSION=${{ matrix.zlib }} \
+            ${{ matrix.compiler == 'clang-tidy' && '-DLIBSSH2_CLANG_TIDY=ON' || '' }} \
             || { cat bld/CMakeFiles/CMake*.yaml; false; }
 
       - name: 'cmake build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,12 +526,16 @@ jobs:
         include:
           - { build: 'autotools', compiler: 'gcc' }
           - { build: 'cmake'    , compiler: 'gcc' }
+          - { build: 'cmake'    , compiler: 'clang-tidy' }
     env:
       MAKEFLAGS: -j 5
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: |
+          sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 \
+            ${{ matrix.build == 'cmake' && 'ninja-build' || '' }} \
+            ${{ matrix.compiler == 'clang-tidy' && 'clang' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -544,12 +548,19 @@ jobs:
       - name: 'configure'
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
+            if [ '${{ matrix.compiler }}' = 'clang-tidy' ]; then
+              options+=' -DLIBSSH2_CLANG_TIDY=ON'
+              options+=' -DCMAKE_C_COMPILER=clang'
+              options+=" -DCMAKE_RC_COMPILER=llvm-windres-$(clang -dumpversion | cut -d '.' -f 1)"
+            else
+              options+=" -DCMAKE_C_COMPILER=${TRIPLET}-gcc"
+            fi
             cmake -B bld -G Ninja \
               -DCMAKE_SYSTEM_NAME=Windows \
               -DCMAKE_C_COMPILER_TARGET=${TRIPLET} \
-              -DCMAKE_C_COMPILER=${TRIPLET}-gcc \
               -DCMAKE_UNITY_BUILD=ON \
               -DENABLE_WERROR=ON \
+              ${options} \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
           else
             mkdir bld && cd bld && ../configure --enable-werror --enable-debug \


### PR DESCRIPTION
With their supported crypto backends.

Cherry-picked from #1561

---

- [x] rebase on #1561
