### PR TITLE
tests: improve `SSHD` default value (fixup)

### DIFF
--- a/tests/test_sshd.test
+++ b/tests/test_sshd.test
@@ -45,7 +45,7 @@ fi
 
 d="$(cd "${d}" || exit; pwd)"  # sshd needs absolute paths
 
-SSHD="$(command -v "${SSH:-sshd}" || true)"
+SSHD="$(command -v "${SSHD:-sshd}" || true)"
 [[ "${uname}" = *'_NT'* ]] && SSHD="$(cygpath "${SSHD}")"
 ver="$("${SSHD}" -V 2>&1 || true)"
 if [[ "${ver}" =~ OpenSSH_[a-zA-Z0-9_\ .,]+ ]]; then


### PR DESCRIPTION
Fix typo in the commit improving `SSHD` default.

Regression from fb12d87e0edbcd7abc84498b202375a6a1d6938e #1563

Reported-by: Paul Howarth
Bug: https://github.com/libssh2/libssh2/pull/1563#issuecomment-2753676646
