### PR TITLE
cmake: `IMPORTED` target improvements and fixes

### DIFF
--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -40,25 +40,23 @@ if(NOT TARGET Libssh2::@LIB_NAME@)
   add_library(Libssh2::@LIB_NAME@ ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
 endif()
 
-# CMake before CMP0099 (CMake 3.17 2020-03-20) did not propagate libdirs to
-# targets. It expected libs to have an absolute filename. As a workaround,
-# manually apply dependency libdirs, for CMake consumers without this policy.
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-  cmake_policy(GET CMP0099 _has_CMP0099)  # https://cmake.org/cmake/help/latest/policy/CMP0099.html
-endif()
-if(NOT _has_CMP0099 AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.13 AND _libs)
-  set(_libdirs "")
-  foreach(_lib IN LISTS _libs)
-    get_target_property(_libdir "${_lib}" INTERFACE_LINK_DIRECTORIES)
-    if(_libdir)
-      list(APPEND _libdirs "${_libdir}")
-    endif()
-  endforeach()
-  if(_libdirs)
-    foreach(_target IN ITEMS @PROJECT_NAME@::@LIB_STATIC@)
-      if(TARGET "${_target}")
-        target_link_directories("${_target}" INTERFACE ${_libdirs})
+if(TARGET @PROJECT_NAME@::@LIB_STATIC@)
+  # CMake before CMP0099 (CMake 3.17 2020-03-20) did not propagate libdirs to
+  # targets. It expected libs to have an absolute filename. As a workaround,
+  # manually apply dependency libdirs, for CMake consumers without this policy.
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+    cmake_policy(GET CMP0099 _has_CMP0099)  # https://cmake.org/cmake/help/latest/policy/CMP0099.html
+  endif()
+  if(NOT _has_CMP0099 AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.13 AND _libs)
+    set(_libdirs "")
+    foreach(_lib IN LISTS _libs)
+      get_target_property(_libdir "${_lib}" INTERFACE_LINK_DIRECTORIES)
+      if(_libdir)
+        list(APPEND _libdirs "${_libdir}")
       endif()
     endforeach()
+    if(_libdirs)
+      target_link_directories(@PROJECT_NAME@::@LIB_STATIC@ INTERFACE ${_libdirs})
+    endif()
   endif()
 endif()

--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -48,7 +48,7 @@ if(NOT _has_CMP0099 AND _lib)
   # to the libssh2 target, for CMake consumers without this policy set.
   get_target_property(_libdirs "${_lib}" INTERFACE_LINK_DIRECTORIES)
   if(_libdirs)
-    foreach(_target IN ITEMS @PROJECT_NAME@::@LIB_SHARED@ @PROJECT_NAME@::@LIB_STATIC@)
+    foreach(_target IN ITEMS @PROJECT_NAME@::@LIB_STATIC@)
       if(TARGET "${_target}")
         target_link_directories("${_target}" INTERFACE ${_libdirs})
       endif()

--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -6,18 +6,18 @@ option(LIBSSH2_USE_PKGCONFIG "Enable pkg-config to detect @PROJECT_NAME@ depende
 include(CMakeFindDependencyMacro)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
-set(_lib "")
+set(_libs "")
 if("@CRYPTO_BACKEND@" STREQUAL "OpenSSL")
   find_dependency(OpenSSL)
 elseif("@CRYPTO_BACKEND@" STREQUAL "wolfSSL")
   find_dependency(WolfSSL)
-  set(_lib libssh2::wolfssl)
+  list(APPEND _libs libssh2::wolfssl)
 elseif("@CRYPTO_BACKEND@" STREQUAL "Libgcrypt")
   find_dependency(Libgcrypt)
-  set(_lib libssh2::libgcrypt)
+  list(APPEND _libs libssh2::libgcrypt)
 elseif("@CRYPTO_BACKEND@" STREQUAL "mbedTLS")
   find_dependency(MbedTLS)
-  set(_lib libssh2::mbedcrypto)
+  list(APPEND _libs libssh2::mbedcrypto)
 endif()
 
 if(@ZLIB_FOUND@)
@@ -41,12 +41,18 @@ if(NOT TARGET Libssh2::@LIB_NAME@)
 endif()
 
 cmake_policy(GET CMP0099 _has_CMP0099)  # https://cmake.org/cmake/help/latest/policy/CMP0099.html
-if(NOT _has_CMP0099 AND _lib)
+if(NOT _has_CMP0099 AND _libs)
   message(STATUS "libssh2: CMP0099 not detected, resorting to workaround.")
   # CMake before CMP0099 (CMake 3.17 2020-03-20) did not endorse the concept of libdirs and lib names.
   # It expected libs to have an absolute filename. As a workaround, manually apply dependency libdirs
   # to the libssh2 target, for CMake consumers without this policy set.
-  get_target_property(_libdirs "${_lib}" INTERFACE_LINK_DIRECTORIES)
+  set(_libdirs "")
+  foreach(_lib IN LISTS _libs)
+    get_target_property(_libdir "${_lib}" INTERFACE_LINK_DIRECTORIES)
+    if(_libdir)
+      list(APPEND _libdirs "${_libdir}")
+    endif()
+  endforeach()
   if(_libdirs)
     foreach(_target IN ITEMS @PROJECT_NAME@::@LIB_STATIC@)
       if(TARGET "${_target}")

--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -40,14 +40,13 @@ if(NOT TARGET Libssh2::@LIB_NAME@)
   add_library(Libssh2::@LIB_NAME@ ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
 endif()
 
+# CMake before CMP0099 (CMake 3.17 2020-03-20) did not propagate libdirs to
+# targets. It expected libs to have an absolute filename. As a workaround,
+# manually apply dependency libdirs, for CMake consumers without this policy.
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
   cmake_policy(GET CMP0099 _has_CMP0099)  # https://cmake.org/cmake/help/latest/policy/CMP0099.html
 endif()
-if(NOT _has_CMP0099 AND _libs)
-  message(STATUS "@PROJECT_NAME@: CMP0099 not detected, resorting to workaround.")
-  # CMake before CMP0099 (CMake 3.17 2020-03-20) did not endorse the concept of libdirs and lib names.
-  # It expected libs to have an absolute filename. As a workaround, manually apply dependency libdirs
-  # to the @PROJECT_NAME@ target, for CMake consumers without this policy set.
+if(NOT _has_CMP0099 AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.13 AND _libs)
   set(_libdirs "")
   foreach(_lib IN LISTS _libs)
     get_target_property(_libdir "${_lib}" INTERFACE_LINK_DIRECTORIES)

--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -42,10 +42,10 @@ endif()
 
 cmake_policy(GET CMP0099 _has_CMP0099)  # https://cmake.org/cmake/help/latest/policy/CMP0099.html
 if(NOT _has_CMP0099 AND _libs)
-  message(STATUS "libssh2: CMP0099 not detected, resorting to workaround.")
+  message(STATUS "@PROJECT_NAME@: CMP0099 not detected, resorting to workaround.")
   # CMake before CMP0099 (CMake 3.17 2020-03-20) did not endorse the concept of libdirs and lib names.
   # It expected libs to have an absolute filename. As a workaround, manually apply dependency libdirs
-  # to the libssh2 target, for CMake consumers without this policy set.
+  # to the @PROJECT_NAME@ target, for CMake consumers without this policy set.
   set(_libdirs "")
   foreach(_lib IN LISTS _libs)
     get_target_property(_libdir "${_lib}" INTERFACE_LINK_DIRECTORIES)

--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -40,7 +40,9 @@ if(NOT TARGET Libssh2::@LIB_NAME@)
   add_library(Libssh2::@LIB_NAME@ ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
 endif()
 
-cmake_policy(GET CMP0099 _has_CMP0099)  # https://cmake.org/cmake/help/latest/policy/CMP0099.html
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+  cmake_policy(GET CMP0099 _has_CMP0099)  # https://cmake.org/cmake/help/latest/policy/CMP0099.html
+endif()
 if(NOT _has_CMP0099 AND _libs)
   message(STATUS "@PROJECT_NAME@: CMP0099 not detected, resorting to workaround.")
   # CMake before CMP0099 (CMake 3.17 2020-03-20) did not endorse the concept of libdirs and lib names.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,27 @@ if(BUILD_STATIC_LIBS OR BUILD_STATIC_FOR_TESTS)
     PUBLIC
       "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
       "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+
+  # CMake before CMP0099 (CMake 3.17 2020-03-20) did not propagate libdirs to
+  # targets. It expected libs to have an absolute filename. As a workaround,
+  # manually apply dependency libdirs, for CMake consumers without this policy.
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+    cmake_policy(GET CMP0099 _has_CMP0099)  # https://cmake.org/cmake/help/latest/policy/CMP0099.html
+  endif()
+  if(NOT _has_CMP0099 AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.13 AND LIBSSH2_LIBS)
+    set(_libdirs "")
+    foreach(_lib IN LISTS LIBSSH2_LIBS)
+      if(TARGET "${_lib}")
+        get_target_property(_libdir "${_lib}" INTERFACE_LINK_DIRECTORIES)
+        if(_libdir)
+          list(APPEND _libdirs "${_libdir}")
+        endif()
+      endif()
+    endforeach()
+    if(_libdirs)
+      target_link_directories(${LIB_STATIC} INTERFACE ${_libdirs})
+    endif()
+  endif()
 endif()
 if(BUILD_SHARED_LIBS)
   list(APPEND _libssh2_export ${LIB_SHARED})


### PR DESCRIPTION
- fix `add_subdirectory` builds for old CMake versions.
- libssh2-config.cmake: fix to set CMP0099 for CMake 3.17+ only.
- libssh2-config.cmake: generalize code to support any number of deps.
  (mainly to sync with curl.)
- libssh2-config.cmake: bind dependencies to the static libssh2 only.

Follow-up to a0d8529b08831a1acf50d4afc0fde24a1716862f #1571
Follow-up to df0563a85732fd9a33bbb116d8c07ca18ba6af38 #1535
