### PR TITLE
fix for issue 1580

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -134,7 +134,7 @@ decrypt(LIBSSH2_SESSION * session, unsigned char *source,
     /* if we get called with a len that isn't an even number of blocksizes
        we risk losing those extra bytes. AAD is an exception, since those first
        few bytes aren't encrypted so it throws off the rest of the count. */
-    if(!CRYPT_FLAG_L(session, PKTLEN_AAD))
+    if(!CRYPT_FLAG_R(session, PKTLEN_AAD))
         assert((len % blocksize) == 0);
 
     while(len > 0) {
@@ -149,7 +149,7 @@ decrypt(LIBSSH2_SESSION * session, unsigned char *source,
         /* If the last block would be less than a whole blocksize, combine it
            with the previous block to make it larger. This ensures that the
            whole MAC is included in a single decrypt call. */
-        if(CRYPT_FLAG_L(session, PKTLEN_AAD) && IS_LAST(firstlast)
+        if(CRYPT_FLAG_R(session, PKTLEN_AAD) && IS_LAST(firstlast)
            && (len < blocksize*2)) {
             decryptlen = len;
             lowerfirstlast = LAST_BLOCK;
@@ -1051,7 +1051,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
     encrypted = (session->state & LIBSSH2_STATE_NEWKEYS) ? 1 : 0;
 
     if(encrypted && session->local.crypt &&
-        CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
+        CRYPT_FLAG_L(session, REQUIRES_FULL_PACKET)) {
         auth_len = session->local.crypt->auth_len;
     }
     else {
@@ -1124,7 +1124,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
     /* subtract 4 bytes of the packet_length field when padding AES-GCM
        or with ETM */
     crypt_offset = (etm || auth_len ||
-                    (encrypted && CRYPT_FLAG_R(session, PKTLEN_AAD)))
+                    (encrypted && CRYPT_FLAG_L(session, PKTLEN_AAD)))
                    ? 4 : 0;
     etm_crypt_offset = etm ? 4 : 0;
 


### PR DESCRIPTION
This is a fix for my bug report here:
https://github.com/libssh2/libssh2/issues/1580
Connection fails when using one encryption method with integrated MAC and one without