### PR TITLE
ci/GHA: use more Ninja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
               crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}'
               cflags='-m32 -mpclmul -msse2 -maes'
             fi
-            cmake -B . ${crossoptions} \
+            cmake -B . -G Ninja ${crossoptions} \
               -DCMAKE_C_FLAGS="${cflags}" \
               -DENABLE_PROGRAMS=OFF \
               -DENABLE_TESTING=OFF \
@@ -254,7 +254,7 @@ jobs:
           fi
           curl -fsS -L https://github.com/wolfSSL/wolfssl/archive/refs/tags/v$WOLFSSLVER-stable.tar.gz | tar -xzf -
           cd wolfssl-$WOLFSSLVER-stable
-          cmake -B bld ${options} \
+          cmake -B bld -G Ninja ${options} \
             -DWOLFSSL_LIBSSH2=ON \
             -DBUILD_SELFTEST=OFF \
             -DWOLFSSL_OPENSSLALL=ON \
@@ -286,7 +286,7 @@ jobs:
             curl -fsS https://boringssl.googlesource.com/boringssl/+archive/${{ env.boringssl-version }}.tar.gz | tar -xzf -
             # Skip tests to finish the build faster
             echo 'set_target_properties(decrepit bssl_shim test_fips boringssl_gtest test_support_lib urandom_test crypto_test ssl_test decrepit_test all_tests pki pki_test run_tests PROPERTIES EXCLUDE_FROM_ALL TRUE)' >> ./CMakeLists.txt
-            cmake -B . \
+            cmake -B . -G Ninja \
               -DOPENSSL_SMALL=ON \
               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
               -DCMAKE_INSTALL_PREFIX="$HOME/usr"
@@ -334,7 +334,7 @@ jobs:
           if [ '${{ steps.cache-libressl.outputs.cache-hit }}' != 'true' ]; then
             curl -fsS -L https://github.com/libressl/portable/releases/download/v${{ env.libressl-version }}/libressl-${{ env.libressl-version }}.tar.gz | tar -xzf -
             cd libressl-${{ env.libressl-version }}
-            cmake -B . \
+            cmake -B . -G Ninja \
               -DLIBRESSL_APPS=OFF \
               -DLIBRESSL_TESTS=OFF \
               -DCMAKE_INSTALL_PREFIX="$HOME/usr"
@@ -504,7 +504,7 @@ jobs:
             crypto='${{ matrix.crypto }}'
           fi
           [ '${{ matrix.arch }}' = 'i386' ] && crossoptions='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} -DCMAKE_C_FLAGS=-m32'
-          cmake -B bld ${crossoptions} $TOOLCHAIN_OPTION \
+          cmake -B bld -G Ninja ${crossoptions} $TOOLCHAIN_OPTION \
             -DCMAKE_UNITY_BUILD=ON \
             -DENABLE_WERROR=ON \
             -DCRYPTO_BACKEND=${crypto} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,9 @@ jobs:
         run: |
           if [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
-            sudo apt-get -o Dpkg::Use-Pty=0 install ninja-build libgcrypt-dev libssl-dev libmbedtls-dev libwolfssl-dev
+            sudo apt-get -o Dpkg::Use-Pty=0 install libgcrypt-dev libssl-dev libmbedtls-dev libwolfssl-dev
           else
-            brew install ninja libgcrypt openssl mbedtls wolfssl
+            brew install libgcrypt openssl mbedtls wolfssl
           fi
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -541,7 +541,6 @@ jobs:
         run: |
           sudo rm -f /var/lib/man-db/auto-update
           sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 \
-            ${{ matrix.build == 'cmake' && 'ninja-build' || '' }} \
             ${{ matrix.compiler == 'clang-tidy' && 'clang' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -844,7 +843,7 @@ jobs:
             cmake: -DCRYPTO_BACKEND=wolfSSL
     steps:
       - name: 'install packages'
-        run: brew install ${{ matrix.build == 'autotools' && 'automake libtool' || 'ninja' }} ${{ matrix.crypto.install }}
+        run: brew install ${{ matrix.build == 'autotools' && 'automake libtool' || '' }} ${{ matrix.crypto.install }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false


### PR DESCRIPTION
It's installed now on all GHA runners by default.

Also drop explicit installs.
