### PR TITLE
cmake: fix `libssh2-config.cmake` for cmake <3.15

### DIFF
--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -4,7 +4,7 @@
 option(LIBSSH2_USE_PKGCONFIG "Enable pkg-config to detect @PROJECT_NAME@ dependencies. Default: @LIBSSH2_USE_PKGCONFIG@" "@LIBSSH2_USE_PKGCONFIG@")
 
 include(CMakeFindDependencyMacro)
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
 set(_lib "")
 if("@CRYPTO_BACKEND@" STREQUAL "OpenSSL")


### PR DESCRIPTION
Replace `list(PREPEND ...)` for compatibility with CMake < 3.15.

Ref: https://cmake.org/cmake/help/latest/command/list.html#prepend

Follow-up to 82b09f9b3aae97f641fbcc2d746d2a6383abe857 #1322
Cherry-picked from #1581
