### PR TITLE
cmake: avoid 'target is imported but not globally visible' when consuming libcurl with old cmake

### DIFF
--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -26,6 +26,10 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11 AND CMAKE_VERSION VERSION_LESS 3.18)
+  set_target_properties(@PROJECT_NAME@::@LIB_SELECTED@ PROPERTIES IMPORTED_GLOBAL TRUE)
+endif()
+
 # Alias for either shared or static library
 if(NOT TARGET @PROJECT_NAME@::@LIB_NAME@)
   add_library(@PROJECT_NAME@::@LIB_NAME@ ALIAS @PROJECT_NAME@::@LIB_SELECTED@)


### PR DESCRIPTION
Fixes:
```
CMake Error at bld-libssh2/_pkg/lib/cmake/libssh2/libssh2-config.cmake:35 (add_library):
  add_library cannot create ALIAS target "libssh2::libssh2" because target
  "libssh2::libssh2_shared" is imported but not globally visible.
Call Stack (most recent call first):
  CMakeLists.txt:27 (find_package)

CMake Error at bld-libssh2/_pkg/lib/cmake/libssh2/libssh2-config.cmake:40 (add_library):
  add_library cannot create ALIAS target "Libssh2::libssh2" because target
  "libssh2::libssh2_shared" is imported but not globally visible.
Call Stack (most recent call first):
  CMakeLists.txt:27 (find_package)
```

tests/cmake reproducer (requires #1581):
```shell
export CMAKE_CONSUMER=/path/to/CMake-3.12.0/bin/cmake
./test.sh find_package
```

I don't understand what this error says, why it happens in certain CMake
versions, and why a workaround is necessary for what seems like
a standard export/consume configuration. This patch is based on internet
suggestions and other projects ending up with this workaround.

Ref: https://github.com/curl/curl/pull/16973
Ref: https://github.com/curl/curl/pull/17140
Cherry-picked from #1581
