### PR TITLE
build: sync up picky warnings with curl, fix fallouts

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -475,6 +475,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           #
           dnl Only gcc 4.5 or later
           if test "$compiler_num" -ge "405"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [jump-misses-init])
             dnl Only windows targets
             case $host_os in
             mingw*)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -333,6 +333,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           dnl clang 10 or later
           if test "$compiler_num" -ge "1000"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"  # we have silencing markup for clang 10.0 and above only
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [xor-used-as-pow])
           fi
 
           CFLAGS="$CFLAGS $tmp_CFLAGS"
@@ -524,6 +525,18 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [arith-conversion])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [enum-conversion])
           fi
+          #
+          dnl Only gcc 12 or later
+          if test "$compiler_num" -ge "1200"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [array-compare])
+          fi
+          #
+          dnl Only gcc 13 or later
+          if test "$compiler_num" -ge "1300"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [enum-int-mismatch])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [xor-used-as-pow])
+          fi
+          #
 
           for flag in $CPPFLAGS; do
             case "$flag" in

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -289,13 +289,13 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [enum-conversion])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [sometimes-uninitialized])
             case $host_os in
-            cygwin* | mingw*)
-              dnl skip missing-variable-declarations warnings for cygwin and
-              dnl mingw because the libtool wrapper executable causes them
-              ;;
-            *)
-              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-variable-declarations])
-              ;;
+              cygwin* | mingw*)
+                dnl skip missing-variable-declarations warnings for Cygwin and
+                dnl MinGW because the libtool wrapper executable causes them
+                ;;
+              *)
+                CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-variable-declarations])
+                ;;
             esac
           fi
           #
@@ -477,11 +477,11 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           dnl Only gcc 4.5 or later
           if test "$compiler_num" -ge "405"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [jump-misses-init])
-            dnl Only windows targets
+            dnl Only Windows targets
             case $host_os in
-            mingw*)
-              tmp_CFLAGS="$tmp_CFLAGS -Wno-pedantic-ms-format"
-              ;;
+              mingw*)
+                tmp_CFLAGS="$tmp_CFLAGS -Wno-pedantic-ms-format"
+                ;;
             esac
           fi
           #

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -466,7 +466,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [type-limits old-style-declaration])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-parameter-type empty-body])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [clobbered ignored-qualifiers])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion trampolines])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [sign-conversion])
             tmp_CFLAGS="$tmp_CFLAGS -Wno-error=sign-conversion"          # FIXME
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [vla])
@@ -488,6 +488,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           dnl Only gcc 4.6 or later
           if test "$compiler_num" -ge "406"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [double-promotion])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [trampolines])
           fi
           #
           dnl only gcc 4.8 or later

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -243,6 +243,24 @@ if(PICKY_COMPILER)
         list(APPEND _picky "${_ccopt}")
       endif()
     endforeach()
+  elseif(MSVC AND MSVC_VERSION LESS_EQUAL 1943)  # Skip for untested/unreleased newer versions
+    list(APPEND _picky "-Wall")
+    list(APPEND _picky "-wd4061")  # enumerator 'A' in switch of enum 'B' is not explicitly handled by a case label
+    list(APPEND _picky "-wd4191")  # 'type cast': unsafe conversion from 'FARPROC' to 'void (__cdecl *)(void)'
+    list(APPEND _picky "-wd4255")  # no function prototype given: converting '()' to '(void)' (in winuser.h)
+    list(APPEND _picky "-wd4464")  # relative include path contains '..'
+    list(APPEND _picky "-wd4548")  # expression before comma has no effect; expected expression with side-effect (in FD_SET())
+    list(APPEND _picky "-wd4574")  # 'M' is defined to be '0': did you mean to use '#if M'? (in ws2tcpip.h)
+    list(APPEND _picky "-wd4668")  # 'M' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif' (in winbase.h)
+    list(APPEND _picky "-wd4710")  # 'snprintf': function not inlined
+    list(APPEND _picky "-wd4711")  # function 'A' selected for automatic inline expansion
+    list(APPEND _picky "-wd4746")  # volatile access of '<expression>' is subject to /volatile:<iso|ms> setting;
+                                   #   consider using __iso_volatile_load/store intrinsic functions (ARM64)
+    list(APPEND _picky "-wd4774")  # 'snprintf': format string expected in argument 3 is not a string literal
+    list(APPEND _picky "-wd4820")  # 'A': 'N' bytes padding added after data member 'B'
+    if(MSVC_VERSION GREATER_EQUAL 1900)
+      list(APPEND _picky "-wd5045")  # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+    endif()
   endif()
 endif()
 

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -165,6 +165,7 @@ if(PICKY_COMPILER)
           -Wold-style-declaration          #             gcc  4.3
           -Wpragmas                        # clang  3.5  gcc  4.1  appleclang  6.0
           -Wstrict-aliasing=3              #             gcc  4.0
+          -ftree-vrp                       #             gcc  4.3 (required for -Warray-bounds, included in -Wall)
         )
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.5 AND MINGW)
@@ -181,7 +182,7 @@ if(PICKY_COMPILER)
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
         list(APPEND _picky_enable
-          -Warray-bounds=2 -ftree-vrp      # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
+          -Warray-bounds=2                 # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
         )
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0)

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -168,10 +168,15 @@ if(PICKY_COMPILER)
           -ftree-vrp                       #             gcc  4.3 (required for -Warray-bounds, included in -Wall)
         )
       endif()
-      if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.5 AND MINGW)
+      if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.5)
         list(APPEND _picky_enable
-          -Wno-pedantic-ms-format          #             gcc  4.5 (MinGW-only)
+          -Wjump-misses-init               #             gcc  4.5
         )
+        if(MINGW)
+          list(APPEND _picky_enable
+            -Wno-pedantic-ms-format        #             gcc  4.5 (MinGW-only)
+          )
+        endif()
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.8)
         list(APPEND _picky_enable

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -153,6 +153,7 @@ if(PICKY_COMPILER)
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.4))
         list(APPEND _picky_enable
           -Wimplicit-fallthrough           # clang  4.0  gcc  7.0  appleclang 12.4  # We do silencing for clang 10.0 and above only
+          -Wxor-used-as-pow                # clang 10.0  gcc 13.0
         )
       endif()
     else()  # gcc
@@ -214,6 +215,13 @@ if(PICKY_COMPILER)
         list(APPEND _picky_enable
           -Warith-conversion               #             gcc 10.0
           -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
+        )
+      endif()
+      if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+        list(APPEND _picky_enable
+          -Warray-compare                  # clang 20.0  gcc 12.0
+          -Wenum-int-mismatch              #             gcc 13.0
+          -Wxor-used-as-pow                # clang 10.0  gcc 13.0
         )
       endif()
     endif()

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -28,10 +28,7 @@ if(ENABLE_WERROR)
 endif()
 
 if(MSVC)
-  # Use the highest warning level for Visual Studio.
-  string(REGEX REPLACE "[/-]W[0-4]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-  string(REGEX REPLACE "[/-]W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  list(APPEND _picky "-W4")
+  list(APPEND _picky "-W4")  # Use the highest warning level for Visual Studio.
 endif()
 
 if(PICKY_COMPILER)

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -41,21 +41,6 @@
 
 #define LIBSSH2_CRYPTO_ENGINE libssh2_mbedtls
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-/* mbedTLS (as of v3.5.1) has a `[-Werror=arith-conversion]`
-   warning in its public headers. */
-#if !defined(__clang__) && __GNUC__ >= 10
-#pragma GCC diagnostic ignored "-Warith-conversion"
-#endif
-#ifdef __clang__
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#endif
-/* mbedTLS (as of v3.5.1) has a duplicate function declaration
-   in its public headers. Disable the warning that detects it. */
-#pragma GCC diagnostic ignored "-Wredundant-decls"
-#endif
-
 #include <mbedtls/version.h>
 #include <mbedtls/platform.h>
 #include <mbedtls/md.h>
@@ -72,10 +57,6 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/pk.h>
 #include <mbedtls/error.h>
-
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 /* Define which features are supported. */
 #define LIBSSH2_MD5             1

--- a/src/packet.c
+++ b/src/packet.c
@@ -641,6 +641,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
     size_t data_head = 0;
     unsigned char msg = data[0];
 
+    uint32_t channel = 0;
+    uint32_t len = 0;
+    unsigned char want_reply = 0;
+
     switch(session->packAdd_state) {
     case libssh2_NB_state_idle:
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
@@ -916,8 +920,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
         case SSH_MSG_GLOBAL_REQUEST:
             if(datalen >= 5) {
-                uint32_t len = 0;
-                unsigned char want_reply = 0;
+                want_reply = 0;
                 len = _libssh2_ntohu32(data + 1);
                 if((len <= (UINT_MAX - 6)) && (datalen >= (6 + len))) {
                     want_reply = data[5 + len];
@@ -1116,9 +1119,9 @@ libssh2_packet_add_jump_point1:
 
         case SSH_MSG_CHANNEL_REQUEST:
             if(datalen >= 9) {
-                uint32_t channel = _libssh2_ntohu32(data + 1);
-                uint32_t len = _libssh2_ntohu32(data + 5);
-                unsigned char want_reply = 1;
+                channel = _libssh2_ntohu32(data + 1);
+                len = _libssh2_ntohu32(data + 5);
+                want_reply = 1;
 
                 if((len + 9) < datalen)
                     want_reply = data[len + 9];

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -58,7 +58,7 @@ static int test_libssh2_base64_decode(LIBSSH2_SESSION *session)
     if(datalen != 5 || strcmp(data, "fnord") != 0) {
         fprintf(stderr,
                 "_libssh2_base64_decode() failed (%d, %.*s)\n",
-                (unsigned int)datalen, (unsigned int)datalen, data);
+                (int)datalen, (int)datalen, data);
         return 1;
     }
 


### PR DESCRIPTION
- cmake: sync `-ftree-vrp` behavior with autotools.
- build: enable `-Wjump-misses-init` for GCC 4.5+.
  Credits-to: Marcel Raad
- packet: fix `-Wjump-misses-init` warnings.
  ```
  src/packet.c: In function ‘_libssh2_packet_add’:
  src/packet.c:671:9: error: jump skips variable initialization [-Werror=jump-misses-init]
  src/packet.c:920:31: note: ‘want_reply’ declared here
  src/packet.c:671:9: error: jump skips variable initialization [-Werror=jump-misses-init]
  src/packet.c:919:26: note: ‘len’ declared here
  src/packet.c:669:9: error: jump skips variable initialization [-Werror=jump-misses-init]
  src/packet.c:1121:31: note: ‘want_reply’ declared here
  src/packet.c:669:9: error: jump skips variable initialization [-Werror=jump-misses-init]
  src/packet.c:1120:26: note: ‘len’ declared here
  src/packet.c:669:9: error: jump skips variable initialization [-Werror=jump-misses-init]
  src/packet.c:1119:26: note: ‘channel’ declared here
  ```
- build: enable gcc-12/13+, clang-10+ picky warnings
- acinclude.m4: sync formatting/comments with curl.
- autotools: fix `-Wtrampolines` picky warning for gcc 4.x versions.
  Follow-up to 854cfa8292d251d2133ff41b9fc2e232ab200a9c #1524
- cmake: enable `-Wall` for MSVC when `PICKY_COMPILER=ON`.
- MSVC: fix `-Wall` warnings.
  Seen on VS2015. Not seen on VS2022. Unknown for other versions.
  ```
  tests\test_simple.c(60): warning C4777: 'fprintf' : format string '%d' requires an argument of type 'int', but variadic argument 1 has type 'std::size_t'
  tests\test_simple.c(60): warning C4777: 'fprintf' : format string '%.*s' requires an argument of type 'int', but variadic argument 2 has type 'std::size_t'
  ```
- mbedtls: stop silencing warnings in 3rd-party header.
  Follow-up to a3aa6b4ca83bb8a3ed159612a44b25261dc9f537 #1525
- cmake: stop deleting `-W<n>` from `CMAKE_C_FLAGS` (MSVC)
  1. `CMAKE_C_FLAGS` may apply to other projects, and deleting/altering it
     may be unexpected.
  2. We pass `-W4`/`-Wall` internally now, which do override custom
     `-W<n>` options as tested with VS2008 and newer VS generators.

---

w/o ws https://github.com/libssh2/libssh2/pull/1588/files?w=1
