### PR TITLE
cmake: extend integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
           persist-credentials: false
       - name: 'via FetchContent'
         run: ./tests/cmake/test.sh FetchContent
-      - name: 'via add_subdirectory'
+      - name: 'via add_subdirectory OpenSSL'
+        run: ./tests/cmake/test.sh add_subdirectory
+      - name: 'via add_subdirectory Libgcrypt'
         run: ./tests/cmake/test.sh add_subdirectory
       - name: 'via find_package OpenSSL'
         run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
     timeout-minutes: 5
     env:
       CC: clang
-      CMAKE_GENERATOR: Ninja
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
       - name: 'via FetchContent'
         run: ./tests/cmake/test.sh FetchContent
       - name: 'via add_subdirectory OpenSSL'
-        run: ./tests/cmake/test.sh add_subdirectory
+        run: ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL
       - name: 'via add_subdirectory Libgcrypt'
-        run: ./tests/cmake/test.sh add_subdirectory
+        run: ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=Libgcrypt
       - name: 'via find_package OpenSSL'
         run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL
       - name: 'via find_package Libgcrypt'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,29 @@ jobs:
     name: 'integration on ${{ matrix.image }}'
     runs-on: ${{ matrix.image }}
     timeout-minutes: 5
+    defaults:
+      run:
+        shell: ${{ contains(matrix.image, 'windows') && 'msys2 {0}' || 'bash' }}
     env:
-      CC: clang
+      CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-latest, macos-latest]
+        image: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
+        if: ${{ contains(matrix.image, 'windows') }}
+        with:
+          msystem: mingw64
+          release: false
+          update: false
+          cache: false
+          path-type: inherit
+          install: >-
+            mingw-w64-x86_64-zlib mingw-w64-x86_64-libgcrypt mingw-w64-x86_64-openssl mingw-w64-x86_64-mbedtls
+
       - name: 'install packages'
+        if: ${{ !contains(matrix.image, 'windows') }}
         run: |
           if [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
@@ -85,6 +100,7 @@ jobs:
       - name: 'via find_package mbedTLS'
         run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=mbedTLS
       - name: 'via find_package wolfSSL'
+        if: ${{ !contains(matrix.image, 'windows') }}  # MSYS2 wolfSSL package not built with the OpenSSL compatibility option
         run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=wolfSSL
 
   build_linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,13 @@ jobs:
       - name: 'via add_subdirectory'
         run: ./tests/cmake/test.sh add_subdirectory
       - name: 'via find_package OpenSSL'
-        run: ./tests/cmake/test.sh find_package OpenSSL
+        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL
       - name: 'via find_package Libgcrypt'
-        run: ./tests/cmake/test.sh find_package Libgcrypt
+        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=Libgcrypt
       - name: 'via find_package mbedTLS'
-        run: ./tests/cmake/test.sh find_package mbedTLS
+        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=mbedTLS
       - name: 'via find_package wolfSSL'
-        run: ./tests/cmake/test.sh find_package wolfSSL
+        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=wolfSSL
 
   build_linux:
     name: 'linux'

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.7...3.16 FATAL_ERROR)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
-project(test-dependent C)
+project(test-consumer C)
 
 option(TEST_INTEGRATION_MODE "Integration mode" "find_package")
 
@@ -59,32 +59,32 @@ elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
   FetchContent_MakeAvailable(libssh2)  # Requires CMake 3.14
 endif()
 
-add_executable(test-dependent-static-ns "test.c")
-target_link_libraries(test-dependent-static-ns PRIVATE "libssh2::libssh2_static")
+add_executable(test-consumer-static-ns "test.c")
+target_link_libraries(test-consumer-static-ns PRIVATE "libssh2::libssh2_static")
 
-add_executable(test-dependent-shared-ns "test.c")
-target_link_libraries(test-dependent-shared-ns PRIVATE "libssh2::libssh2_shared")
+add_executable(test-consumer-shared-ns "test.c")
+target_link_libraries(test-consumer-shared-ns PRIVATE "libssh2::libssh2_shared")
 
 # Alias for either shared or static library
-add_executable(test-dependent-selected-ns "test.c")
-target_link_libraries(test-dependent-selected-ns PRIVATE "libssh2::libssh2")
+add_executable(test-consumer-selected-ns "test.c")
+target_link_libraries(test-consumer-selected-ns PRIVATE "libssh2::libssh2")
 
 if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
    TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
 
   # Compatibility alias
-  add_executable(test-dependent-compat "test.c")
-  target_link_libraries(test-dependent-compat PRIVATE "Libssh2::libssh2")
+  add_executable(test-consumer-compat "test.c")
+  target_link_libraries(test-consumer-compat PRIVATE "Libssh2::libssh2")
 
 elseif(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory" OR
        TEST_INTEGRATION_MODE STREQUAL "FetchContent")
 
-  add_executable(test-dependent-static-bare "test.c")
-  target_link_libraries(test-dependent-static-bare PRIVATE "libssh2_static")
+  add_executable(test-consumer-static-bare "test.c")
+  target_link_libraries(test-consumer-static-bare PRIVATE "libssh2_static")
 
-  add_executable(test-dependent-shared-bare "test.c")
-  target_link_libraries(test-dependent-shared-bare PRIVATE "libssh2_shared")
+  add_executable(test-consumer-shared-bare "test.c")
+  target_link_libraries(test-consumer-shared-bare PRIVATE "libssh2_shared")
 
-  add_executable(test-dependent-selected-bare "test.c")
-  target_link_libraries(test-dependent-selected-bare PRIVATE "libssh2")
+  add_executable(test-consumer-selected-bare "test.c")
+  target_link_libraries(test-consumer-selected-bare PRIVATE "libssh2")
 endif()

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -14,7 +14,18 @@ if(TEST_INTEGRATION_MODE STREQUAL "FetchContent" AND CMAKE_VERSION VERSION_LESS 
   message(FATAL_ERROR "This test requires CMake 3.14 or upper")
 endif()
 
-if(TEST_INTEGRATION_MODE STREQUAL "find_package")
+# Note: this does not work
+if(TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
+  include(ExternalProject)
+  ExternalProject_Add(libssh2
+    URL "${FROM_ARCHIVE}"
+    URL_HASH "SHA256=${FROM_HASH}"
+    INSTALL_COMMAND ""
+    DOWNLOAD_EXTRACT_TIMESTAMP ON)
+endif()
+
+if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
+   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
   find_package(libssh2 REQUIRED CONFIG)
   find_package(libssh2 REQUIRED CONFIG)  # Double-inclusion test
   foreach(result_var IN ITEMS
@@ -60,7 +71,8 @@ target_link_libraries(test-dependent-shared-ns PRIVATE "libssh2::libssh2_shared"
 add_executable(test-dependent-selected-ns "test.c")
 target_link_libraries(test-dependent-selected-ns PRIVATE "libssh2::libssh2")
 
-if(TEST_INTEGRATION_MODE STREQUAL "find_package")
+if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
+   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
 
   # Compatibility alias
   add_executable(test-dependent-compat "test.c")

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -14,12 +14,10 @@ if(TEST_INTEGRATION_MODE STREQUAL "FetchContent" AND CMAKE_VERSION VERSION_LESS 
   message(FATAL_ERROR "This test requires CMake 3.14 or upper")
 endif()
 
-# Note: this does not work
-if(TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
+if(TEST_INTEGRATION_MODE STREQUAL "ExternalProject")  # Broken
   include(ExternalProject)
   ExternalProject_Add(libssh2
-    URL "${FROM_ARCHIVE}"
-    URL_HASH "SHA256=${FROM_HASH}"
+    URL "${FROM_ARCHIVE}" URL_HASH "SHA256=${FROM_HASH}"
     INSTALL_COMMAND ""
     DOWNLOAD_EXTRACT_TIMESTAMP ON)
 endif()

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -6,9 +6,11 @@
 #include "libssh2.h"
 #include <stdio.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     const char *crypto_str;
+
+    (void)argc;
 
     switch(libssh2_crypto_engine()) {
     case libssh2_gcrypt:
@@ -30,6 +32,8 @@ int main(void)
         crypto_str = "(unrecognized)";
     }
 
-    printf("libssh2_version(0): |%s|%s|\n", libssh2_version(0), crypto_str);
+    printf("libssh2 test: |%s|%s|%s|\n", argv[0],
+                                         libssh2_version(0), crypto_str);
+
     return 0;
 }

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -8,6 +8,28 @@
 
 int main(void)
 {
-    printf("libssh2_version(0): |%s|\n", libssh2_version(0));
+    const char *crypto_str;
+
+    switch(libssh2_crypto_engine()) {
+    case libssh2_gcrypt:
+        crypto_str = "libgcrypt";
+        break;
+    case libssh2_mbedtls:
+        crypto_str = "mbedTLS";
+        break;
+    case libssh2_openssl:
+        crypto_str = "openssl compatible";
+        break;
+    case libssh2_os400qc3:
+        crypto_str = "OS400QC3";
+        break;
+    case libssh2_wincng:
+        crypto_str = "WinCNG";
+        break;
+    default:
+        crypto_str = "(unrecognized)";
+    }
+
+    printf("libssh2_version(0): |%s|%s|\n", libssh2_version(0), crypto_str);
     return 0;
 }

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -28,7 +28,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 src='../..'
 
 runres() {
-  for bin in "$1"/test-dependent*; do
+  for bin in "$1"/test-consumer*; do
     echo "Running '${bin}'...:"
     "${bin}" || true
   done

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -30,9 +30,13 @@ cmake_opts='-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DENABLE_ZLIB_COMPRESSION=O
 src='../..'
 
 runresults() {
+  set +x
   for bin in "$1"/test-consumer*; do
+    echo "---- ${bin} ----"
+    file "${bin}" || true
     "${bin}" || true
   done
+  set -x
 }
 
 if [ "${mode}" = 'ExternalProject' ]; then  # Broken

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -74,8 +74,8 @@ fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf libssh2
-  if ! ln -s "${src}" libssh2; then  # for MSYS2/Cygwin
-    rm -rf libssh2; mkdir libssh2; (cd "${src}"; git archive --format=tar HEAD) | tar -x --directory=libssh2
+  if ! ln -s "${src}" libssh2; then
+    rm -rf libssh2; mkdir libssh2; (cd "${src}"; git archive --format=tar HEAD) | tar -x --directory=libssh2  # for MSYS2/Cygwin
   fi
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -56,9 +56,11 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf libssh2; ln -s "${src}" libssh2
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" "$@" \
-    -DTEST_INTEGRATION_MODE=add_subdirectory
-  "${cmake_consumer}" --build "${bldc}" --verbose
+  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
+    "${cmake_consumer}" -B "${bldc}" "$@" \
+      -DTEST_INTEGRATION_MODE=add_subdirectory
+    "${cmake_consumer}" --build "${bldc}" --verbose
+  fi
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -66,16 +68,20 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldp="bld-libssh2-${crypto}"
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
-  "${cmake_provider}" "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${prefix}" \
-    -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
-    -DENABLE_ZLIB_COMPRESSION=ON \
-    -DCRYPTO_BACKEND="${crypto}"
-  "${cmake_provider}" --build "${bldp}"
-  "${cmake_provider}" --install "${bldp}"
+  if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
+    "${cmake_provider}" "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${prefix}" \
+      -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
+      -DENABLE_ZLIB_COMPRESSION=ON \
+      -DCRYPTO_BACKEND="${crypto}"
+    "${cmake_provider}" --build "${bldp}"
+    "${cmake_provider}" --install "${bldp}"
+  fi
   bldc='bld-find_package'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" "$@" \
-    -DTEST_INTEGRATION_MODE=find_package \
-    -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
-  "${cmake_consumer}" --build "${bldc}" --verbose
+  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
+    "${cmake_consumer}" -B "${bldc}" "$@" \
+      -DTEST_INTEGRATION_MODE=find_package \
+      -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
+    "${cmake_consumer}" --build "${bldc}" --verbose
+  fi
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -40,8 +40,9 @@ fi
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   crypto="${2:-OpenSSL}"
   bldp="bld-libssh2-${crypto}"
+  prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
-  cmake "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bldp}/_pkg" \
+  cmake "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${prefix}" \
     -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
     -DENABLE_ZLIB_COMPRESSION=ON \
     -DCRYPTO_BACKEND="${crypto}"
@@ -50,6 +51,6 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   rm -rf bld-find_package
   cmake -B bld-find_package \
     -DTEST_INTEGRATION_MODE=find_package \
-    -DCMAKE_PREFIX_PATH="${PWD}/${bldp}/_pkg/lib/cmake/libssh2"
+    -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
   cmake --build bld-find_package --verbose
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -77,15 +77,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
-  crypto="${2:-OpenSSL}"; shift
   src="${PWD}/${src}"
-  bldp="bld-libssh2-${crypto}"
+  bldp='bld-libssh2'
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
     "${cmake_provider}" -B "${bldp}" -S "${src}" -DENABLE_ZLIB_COMPRESSION=ON "$@" \
       -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
-      -DCRYPTO_BACKEND="${crypto}" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}"
     "${cmake_provider}" --install "${bldp}"
@@ -93,7 +91,6 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     mkdir "${bldp}"; cd "${bldp}"
     "${cmake_provider}" "${src}" -DENABLE_ZLIB_COMPRESSION=ON "$@" \
       -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
-      -DCRYPTO_BACKEND="${crypto}" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build .
     make install

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -54,7 +54,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
     "${cmake_consumer}" .. ${cmake_opts} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
-    "${cmake_consumer}" --verbose --build .
+    VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
   fi
   runresults "${bldc}"
@@ -88,7 +88,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     mkdir "${bldc}"; cd "${bldc}"
     "${cmake_consumer}" .. ${cmake_opts} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
-    "${cmake_consumer}" --verbose --build .
+    VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
   fi
   PATH="${bldc}/libssh2/src:${PATH}"
@@ -125,7 +125,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" .. \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
-    "${cmake_consumer}" --verbose --build .
+    VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
   fi
   PATH="${prefix}/bin:${PATH}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -20,7 +20,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
-if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
+if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -3,11 +3,12 @@
 # Copyright (C) Viktor Szakats
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Recommended options:
-#
+# Recommended option:
 # -DLIBSSH2_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
 #                              These old versions can't propagate library
 #                              directories to the consumer project.
+
+# shellcheck disable=SC2086
 
 set -eu
 
@@ -24,6 +25,8 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
 "${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
 
+cmake_opts='-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DENABLE_ZLIB_COMPRESSION=ON'
+
 src='../..'
 
 runresults() {
@@ -39,13 +42,13 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
+    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. "$@" \
+    "${cmake_consumer}" .. ${cmake_opts} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --verbose --build .
@@ -58,7 +61,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
+  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -71,12 +74,12 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
+    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. "$@" \
+    "${cmake_consumer}" .. ${cmake_opts} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --verbose --build .
     cd ..
@@ -90,15 +93,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" -DENABLE_ZLIB_COMPRESSION=ON -DCMAKE_UNITY_BUILD=ON "$@" \
-      -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}"
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" -DENABLE_ZLIB_COMPRESSION=ON "$@" \
-      -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
+    "${cmake_provider}" "${src}" ${cmake_opts} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build .
     make install

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -24,13 +24,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
   rm -rf bld-fetchcontent
   cmake -B bld-fetchcontent \
     -DTEST_INTEGRATION_MODE=FetchContent \
-    -DFROM_GIT_REPO="${PWD}/../.." \
+    -DFROM_GIT_REPO="${PWD}/${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   cmake --build bld-fetchcontent
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
-  rm -rf libssh2; ln -s ../.. libssh2
+  rm -rf libssh2; ln -s "${src}" libssh2
   rm -rf bld-add_subdirectory
   cmake -B bld-add_subdirectory \
     -DTEST_INTEGRATION_MODE=add_subdirectory
@@ -41,7 +41,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   crypto="${2:-OpenSSL}"
   bldp="bld-libssh2-${crypto}"
   rm -rf "${bldp}"
-  cmake ../.. -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bldp}/_pkg" \
+  cmake "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bldp}/_pkg" \
     -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
     -DENABLE_ZLIB_COMPRESSION=ON \
     -DCRYPTO_BACKEND="${crypto}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -22,22 +22,22 @@ src='../..'
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
   src="${PWD}/${src}"
-  bld='bld-fetchcontent'
-  rm -rf "${bld}"
-  "${cmake_consumer}" -B "${bld}" \
+  bldc='bld-fetchcontent'
+  rm -rf "${bldc}"
+  "${cmake_consumer}" -B "${bldc}" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  "${cmake_consumer}" --build "${bld}"
+  "${cmake_consumer}" --build "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf libssh2; ln -s "${src}" libssh2
-  bld='bld-add_subdirectory'
-  rm -rf "${bld}"
-  "${cmake_consumer}" -B "${bld}" \
+  bldc='bld-add_subdirectory'
+  rm -rf "${bldc}"
+  "${cmake_consumer}" -B "${bldc}" \
     -DTEST_INTEGRATION_MODE=add_subdirectory
-  "${cmake_consumer}" --build "${bld}"
+  "${cmake_consumer}" --build "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -51,10 +51,10 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     -DCRYPTO_BACKEND="${crypto}"
   "${cmake_provider}" --build "${bldp}"
   "${cmake_provider}" --install "${bldp}"
-  bld='bld-find_package'
-  rm -rf "${bld}"
-  "${cmake_consumer}" -B "${bld}" \
+  bldc='bld-find_package'
+  rm -rf "${bldc}"
+  "${cmake_consumer}" -B "${bldc}" \
     -DTEST_INTEGRATION_MODE=find_package \
     -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
-  "${cmake_consumer}" --build "${bld}" --verbose
+  "${cmake_consumer}" --build "${bldc}" --verbose
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -32,7 +32,6 @@ src='../..'
 runresults() {
   set +x
   for bin in "$1"/test-consumer*; do
-    echo "---- ${bin} ----"
     file "${bin}" || true
     "${bin}" || true
   done

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -29,7 +29,6 @@ src='../..'
 
 runresult() {
   for bin in "$1"/test-consumer*; do
-    echo "Running '${bin}'...:"
     "${bin}" || true
   done
 }

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -27,7 +27,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
-runres() {
+runresult() {
   for bin in "$1"/test-consumer*; do
     echo "Running '${bin}'...:"
     "${bin}" || true
@@ -53,7 +53,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runres "${bldc}"
+  runresult "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
@@ -65,7 +65,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}" --verbose
-  runres "${bldc}"
+  runresult "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -83,7 +83,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runres "${bldc}"
+  runresult "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -121,5 +121,5 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runres "${bldc}"
+  runresult "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -24,7 +24,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" \
+  "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -35,13 +35,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf libssh2; ln -s "${src}" libssh2
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" \
+  "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=add_subdirectory
   "${cmake_consumer}" --build "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
-  crypto="${2:-OpenSSL}"
+  crypto="${2:-OpenSSL}"; shift
   bldp="bld-libssh2-${crypto}"
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
@@ -53,7 +53,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   "${cmake_provider}" --install "${bldp}"
   bldc='bld-find_package'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" \
+  "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=find_package \
     -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
   "${cmake_consumer}" --build "${bldc}" --verbose

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -76,18 +76,18 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" -DCMAKE_INSTALL_PREFIX="${prefix}" "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" -DENABLE_ZLIB_COMPRESSION=ON "$@" \
       -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
-      -DENABLE_ZLIB_COMPRESSION=ON \
-      -DCRYPTO_BACKEND="${crypto}"
+      -DCRYPTO_BACKEND="${crypto}" \
+      -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}"
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" -DCMAKE_INSTALL_PREFIX="${prefix}" "$@" \
+    "${cmake_provider}" "${src}" -DENABLE_ZLIB_COMPRESSION=ON "$@" \
       -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
-      -DENABLE_ZLIB_COMPRESSION=ON \
-      -DCRYPTO_BACKEND="${crypto}"
+      -DCRYPTO_BACKEND="${crypto}" \
+      -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build .
     make install
     cd ..

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -69,6 +69,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}" --verbose
+  PATH="${bldc}/_deps/libssh2-build/lib:${PATH}"
   runresults "${bldc}"
 fi
 
@@ -90,6 +91,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  PATH="${bldc}/libssh2/src:${PATH}"
   runresults "${bldc}"
 fi
 
@@ -126,5 +128,6 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  PATH="${prefix}/bin:${PATH}"
   runresults "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -21,11 +21,12 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 src='../..'
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
+  src="${PWD}/${src}"
   bld='bld-fetchcontent'
   rm -rf "${bld}"
   "${cmake_consumer}" -B "${bld}" \
     -DTEST_INTEGRATION_MODE=FetchContent \
-    -DFROM_GIT_REPO="${PWD}/${src}" \
+    -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bld}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -20,6 +20,27 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
+if [ "${mode}" = 'ExternalProject' ]; then  # Broken
+  (cd "${src}"; git archive --format=tar HEAD) | gzip > source.tar.gz
+  src="${PWD}/source.tar.gz"
+  sha="$(openssl dgst -sha256 "${src}" | grep -a -i -o -E '[0-9a-f]{64}$')"
+  bldc='bld-externalproject'
+  rm -rf "${bldc}"
+  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
+    "${cmake_consumer}" -B "${bldc}" "$@" \
+      -DTEST_INTEGRATION_MODE=ExternalProject \
+      -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
+    "${cmake_consumer}" --build "${bldc}" --verbose
+  else
+    mkdir "${bldc}"; cd "${bldc}"
+    "${cmake_consumer}" .. "$@" \
+      -DTEST_INTEGRATION_MODE=ExternalProject \
+      -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
+    "${cmake_consumer}" --verbose --build .
+    cd ..
+  fi
+fi
+
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -8,7 +8,7 @@
 # -DCMAKE_UNITY_BUILD=ON
 # -DLIBSSH2_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
 #                              These old versions can't propagate library
-#                              directories back to the consumer project.
+#                              directories to the consumer project.
 
 set -eu
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -27,7 +27,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
-runresult() {
+runresults() {
   for bin in "$1"/test-consumer*; do
     "${bin}" || true
   done
@@ -52,7 +52,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runresult "${bldc}"
+  runresults "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
@@ -64,7 +64,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}" --verbose
-  runresult "${bldc}"
+  runresults "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -82,7 +82,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runresult "${bldc}"
+  runresults "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -120,5 +120,5 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runresult "${bldc}"
+  runresults "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -3,6 +3,13 @@
 # Copyright (C) Viktor Szakats
 # SPDX-License-Identifier: BSD-3-Clause
 
+# Recommended options:
+#
+# -DCMAKE_UNITY_BUILD=ON
+# -DLIBSSH2_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
+#                              These old versions can't propagate library
+#                              directories back to the consumer project.
+
 set -eu
 
 cd "$(dirname "$0")"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -22,19 +22,19 @@ src='../..'
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
   rm -rf bld-fetchcontent
-  cmake -B bld-fetchcontent \
+  "${cmake_consumer}" -B bld-fetchcontent \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${PWD}/${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  cmake --build bld-fetchcontent
+  "${cmake_consumer}" --build bld-fetchcontent
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf libssh2; ln -s "${src}" libssh2
   rm -rf bld-add_subdirectory
-  cmake -B bld-add_subdirectory \
+  "${cmake_consumer}" -B bld-add_subdirectory \
     -DTEST_INTEGRATION_MODE=add_subdirectory
-  cmake --build bld-add_subdirectory
+  "${cmake_consumer}" --build bld-add_subdirectory
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -42,15 +42,15 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldp="bld-libssh2-${crypto}"
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
-  cmake "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${prefix}" \
+  "${cmake_provider}" "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${prefix}" \
     -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
     -DENABLE_ZLIB_COMPRESSION=ON \
     -DCRYPTO_BACKEND="${crypto}"
-  cmake --build "${bldp}"
-  cmake --install "${bldp}"
+  "${cmake_provider}" --build "${bldp}"
+  "${cmake_provider}" --install "${bldp}"
   rm -rf bld-find_package
-  cmake -B bld-find_package \
+  "${cmake_consumer}" -B bld-find_package \
     -DTEST_INTEGRATION_MODE=find_package \
     -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
-  cmake --build bld-find_package --verbose
+  "${cmake_consumer}" --build bld-find_package --verbose
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -73,7 +73,10 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
-  rm -rf libssh2; ln -s "${src}" libssh2
+  rm -rf libssh2
+  if ! ln -s "${src}" libssh2; then  # for MSYS2/Cygwin
+    rm -rf libssh2; mkdir libssh2; (cd "${src}"; git archive --format=tar HEAD) | tar -x --directory=libssh2
+  fi
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -99,13 +99,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldc='bld-find_package'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" "$@" \
+    "${cmake_consumer}" -B "${bldc}" \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. "$@" \
+    "${cmake_consumer}" .. \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     "${cmake_consumer}" --verbose --build .

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -3,11 +3,6 @@
 # Copyright (C) Viktor Szakats
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Recommended option:
-# -DLIBSSH2_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
-#                              These old versions can't propagate library
-#                              directories to the consumer project.
-
 # shellcheck disable=SC2086
 
 set -eu
@@ -86,7 +81,9 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${cmake_opts} "$@" \
+    # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
+    # library directories to the consumer project.
+    "${cmake_consumer}" .. ${cmake_opts} -DCURL_USE_PKGCONFIG=OFF "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     VERBOSE=1 "${cmake_consumer}" --build .
     cd ..

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -5,7 +5,6 @@
 
 # Recommended options:
 #
-# -DCMAKE_UNITY_BUILD=ON
 # -DLIBSSH2_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
 #                              These old versions can't propagate library
 #                              directories to the consumer project.
@@ -40,7 +39,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" "$@" \
+    "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --build "${bldc}" --verbose
@@ -59,7 +58,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" "$@" \
+  "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -72,7 +71,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" "$@" \
+    "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
@@ -91,7 +90,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" -DENABLE_ZLIB_COMPRESSION=ON "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" -DENABLE_ZLIB_COMPRESSION=ON -DCMAKE_UNITY_BUILD=ON "$@" \
       -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -28,7 +28,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  "${cmake_consumer}" --build "${bldc}"
+  "${cmake_consumer}" --build "${bldc}" --verbose
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -37,7 +37,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=add_subdirectory
-  "${cmake_consumer}" --build "${bldc}"
+  "${cmake_consumer}" --build "${bldc}" --verbose
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -21,20 +21,22 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 src='../..'
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
-  rm -rf bld-fetchcontent
-  "${cmake_consumer}" -B bld-fetchcontent \
+  bld='bld-fetchcontent'
+  rm -rf "${bld}"
+  "${cmake_consumer}" -B "${bld}" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${PWD}/${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  "${cmake_consumer}" --build bld-fetchcontent
+  "${cmake_consumer}" --build "${bld}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf libssh2; ln -s "${src}" libssh2
-  rm -rf bld-add_subdirectory
-  "${cmake_consumer}" -B bld-add_subdirectory \
+  bld='bld-add_subdirectory'
+  rm -rf "${bld}"
+  "${cmake_consumer}" -B "${bld}" \
     -DTEST_INTEGRATION_MODE=add_subdirectory
-  "${cmake_consumer}" --build bld-add_subdirectory
+  "${cmake_consumer}" --build "${bld}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -48,9 +50,10 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     -DCRYPTO_BACKEND="${crypto}"
   "${cmake_provider}" --build "${bldp}"
   "${cmake_provider}" --install "${bldp}"
-  rm -rf bld-find_package
-  "${cmake_consumer}" -B bld-find_package \
+  bld='bld-find_package'
+  rm -rf "${bld}"
+  "${cmake_consumer}" -B "${bld}" \
     -DTEST_INTEGRATION_MODE=find_package \
     -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
-  "${cmake_consumer}" --build bld-find_package --verbose
+  "${cmake_consumer}" --build "${bld}" --verbose
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -27,6 +27,13 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
+runres() {
+  for bin in "$1"/test-dependent*; do
+    echo "Running '${bin}'...:"
+    "${bin}" || true
+  done
+}
+
 if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   (cd "${src}"; git archive --format=tar HEAD) | gzip > source.tar.gz
   src="${PWD}/source.tar.gz"
@@ -46,6 +53,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  runres "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
@@ -57,6 +65,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}" --verbose
+  runres "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -74,6 +83,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  runres "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -111,4 +121,5 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  runres "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -33,7 +33,7 @@ runresults() {
   set +x
   for bin in "$1"/test-consumer*; do
     file "${bin}" || true
-    "${bin}" || true
+    ${LIBSSH2_TEST_EXE_RUNNER:-} "${bin}" || true
   done
   set -x
 }


### PR DESCRIPTION
- ci/GHA: add cmake integration tests for Windows.
- ci/GHA: test `add_subdirectory` with Libgcrypt.
- make them run faster with prefill, unity, Ninja, omitting curl tool.
- add support for any build configuration.
- add old-cmake support with auto-detection.
- auto-detect Ninja.
- run consumer test apps to see if they work.
  Also show the cryptography backend.
- add support for Windows.
- make it more verbose.
- re-add `ExternalProject` cmake consumer test. It's broken.
- tidy up terminology.

Cherry-picked from #1581
