### PR TITLE
cmake: test integration with old cmake (v3.11.4 2018-03-28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin;/c/Program Files/Git/bin'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin:/c/Program Files/Git/bin'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 
@@ -132,7 +132,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin;/c/Program Files/Git/bin'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin:/c/Program Files/Git/bin'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
 
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
+          PATH=/usr/bin find /c/msys64 || true
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           path-type: inherit
           install: >-
             mingw-w64-x86_64-zlib mingw-w64-x86_64-libgcrypt mingw-w64-x86_64-openssl mingw-w64-x86_64-mbedtls
+            mingw-w64-x86_64-make
 
       - name: 'install packages'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin:/c/Program Files/Git/bin'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin:/c/mingw64/bin:/c/Program Files/Git/bin'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 
@@ -133,7 +133,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin:/c/Program Files/Git/bin'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin:/c/mingw64/bin:/c/Program Files/Git/bin'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,16 +122,16 @@ jobs:
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export CMAKE_GENERATOR='MSYS Makefiles'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }} \
             ${{ contains(matrix.image, 'macos') && '-DCMAKE_C_FLAGS="-arch arm64"' || '' }}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export CMAKE_GENERATOR='MSYS Makefiles'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }} \
             ${{ contains(matrix.image, 'macos') && '-DCMAKE_C_FLAGS="-arch arm64"' || '' }}
 
   build_linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,14 +108,14 @@ jobs:
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR="C:/mingw64/opt"'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR="C:/mingw64/opt"'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via FetchContent'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,14 +109,14 @@ jobs:
           PATH=/usr/bin find /c/msys64 || true
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt"
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt"
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via FetchContent'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,14 @@ jobs:
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
-          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL
+          [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
+          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
-          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL
+          [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
+          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         shell: ${{ contains(matrix.image, 'windows') && 'msys2 {0}' || 'bash' }}
     env:
       CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
+      old-cmake-version: 3.11.4
     strategy:
       fail-fast: false
       matrix:
@@ -79,23 +80,23 @@ jobs:
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
             cd "${HOME}" || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-              --location 'https://github.com/Kitware/CMake/releases/download/v3.7.2/cmake-3.7.2-win64-x64.zip' --output bin.zip
+              --location 'https://github.com/Kitware/CMake/releases/download/v${{ env.old-cmake-version }}/cmake-${{ env.old-cmake-version }}-win64-x64.zip' --output bin.zip
             unzip bin.zip
             rm -f bin.zip
-            printf '%s' "${HOME}/cmake-3.7.2-win64-x64/bin/cmake.exe" > "${HOME}/old-cmake-path.txt"
+            printf '%s' "${HOME}/cmake-${{ env.old-cmake-version }}-win64-x64/bin/cmake.exe" > "${HOME}/old-cmake-path.txt"
           elif [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
             sudo apt-get -o Dpkg::Use-Pty=0 install libgcrypt-dev libssl-dev libmbedtls-dev libwolfssl-dev
             cd "${HOME}" || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-              --location https://github.com/Kitware/CMake/releases/download/v3.7.2/cmake-3.7.2-Linux-x86_64.tar.gz | tar -xzf -
-            printf '%s' "$PWD/cmake-3.7.2-Linux-x86_64/bin/cmake" > "${HOME}/old-cmake-path.txt"
+              --location https://github.com/Kitware/CMake/releases/download/v${{ env.old-cmake-version }}/cmake-${{ env.old-cmake-version }}-Linux-x86_64.tar.gz | tar -xzf -
+            printf '%s' "$PWD/cmake-${{ env.old-cmake-version }}-Linux-x86_64/bin/cmake" > "${HOME}/old-cmake-path.txt"
           else
             brew install libgcrypt openssl mbedtls wolfssl
             cd "${HOME}" || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-              --location https://github.com/Kitware/CMake/releases/download/v3.7.2/cmake-3.7.2-Darwin-x86_64.tar.gz | tar -xzf -
-            printf '%s' "$PWD/cmake-3.7.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" > "${HOME}/old-cmake-path.txt"
+              --location https://github.com/Kitware/CMake/releases/download/v${{ env.old-cmake-version }}/cmake-${{ env.old-cmake-version }}-Darwin-x86_64.tar.gz | tar -xzf -
+            printf '%s' "$PWD/cmake-${{ env.old-cmake-version }}-Darwin-x86_64/CMake.app/Contents/bin/cmake" > "${HOME}/old-cmake-path.txt"
           fi
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
-          export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          export TEST_CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
             export TEST_CMAKE_GENERATOR='MSYS Makefiles'
@@ -131,7 +131,7 @@ jobs:
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
-          export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          export TEST_CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
             export TEST_CMAKE_GENERATOR='MSYS Makefiles'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH=/usr/bin;/c/Program Files/Git/bin
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin;/c/Program Files/Git/bin'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 
@@ -132,7 +132,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH=/usr/bin;/c/Program Files/Git/bin
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin;/c/Program Files/Git/bin'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,14 +109,14 @@ jobs:
           PATH=/usr/bin find /c/msys64 || true
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt"
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64"
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/mingw64/opt"
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64"
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via FetchContent'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,8 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
-            export LIBSSH2_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
             export LIBSSH2_CMAKE_GENERATOR='MSYS Makefiles'
+            export LIBSSH2_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
           fi
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
@@ -134,8 +134,8 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
-            export LIBSSH2_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
             export LIBSSH2_CMAKE_GENERATOR='MSYS Makefiles'
+            export LIBSSH2_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
           fi
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH=/usr/bin
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 
@@ -131,6 +132,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH=/usr/bin
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,13 +121,17 @@ jobs:
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          [[ '${{ matrix.image }}' = *'macos'* ]] && options+=' -DCMAKE_C_FLAGS="-arch arm64"'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export CMAKE_GENERATOR='MSYS Makefiles'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          [[ '${{ matrix.image }}' = *'macos'* ]] && options+=' -DCMAKE_C_FLAGS="-arch arm64"'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export CMAKE_GENERATOR='MSYS Makefiles'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 
   build_linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="/c/mingw64"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64"' || '' }}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
@@ -133,7 +133,7 @@ jobs:
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="/c/mingw64"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64"' || '' }}
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,32 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
+      - name: 'via add_subdirectory OpenSSL (old cmake)'
+        run: |
+          if [[ '${{ matrix.image }}' = *'windows'* ]]; then
+            echo '--------------------'
+            env
+            echo '--------------------'
+            ls -l /c || true
+            ls -l C:/mingw64 || true
+            ls -l /c/mingw64 || true
+            PATH=/usr/bin find /c/mingw64 || true
+          fi
+          export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
+          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64"' || '' }}
+
+      - name: 'via find_package OpenSSL (old cmake)'
+        run: |
+          export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
+          [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
+          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64"' || '' }}
+
       - name: 'via FetchContent'
         run: ./tests/cmake/test.sh FetchContent
       - name: 'via add_subdirectory OpenSSL'
@@ -118,22 +144,6 @@ jobs:
       - name: 'via find_package wolfSSL'
         if: ${{ !contains(matrix.image, 'windows') }}  # MSYS2 wolfSSL package not built with the OpenSSL compatibility option
         run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=wolfSSL
-
-      - name: 'via add_subdirectory OpenSSL (old cmake)'
-        run: |
-          export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
-          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64"' || '' }}
-
-      - name: 'via find_package OpenSSL (old cmake)'
-        run: |
-          export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
-          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64"' || '' }}
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH=/usr/bin
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH=/usr/bin;/c/Program Files/Git/bin
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 
@@ -132,7 +132,7 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH=/usr/bin
+          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH=/usr/bin;/c/Program Files/Git/bin
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
             ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,10 +505,7 @@ jobs:
       - name: 'autotools tests'
         if: ${{ matrix.build == 'autotools' && !matrix.target }}
         timeout-minutes: 10
-        run: |
-          export FIXTURE_TRACE_ALL_CONNECT=1
-          make -C bld check V=1 || { cat bld/tests/*.log; false; }
-
+        run: make -C bld check V=1 || { cat bld/tests/*.log; false; }
       - name: 'autotools distcheck'
         if: ${{ matrix.target == 'distcheck' }}
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,18 +121,18 @@ jobs:
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }} \
-            ${{ contains(matrix.image, 'macos') && '-DCMAKE_C_FLAGS="-arch arm64"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }} \
-            ${{ contains(matrix.image, 'macos') && '-DCMAKE_C_FLAGS="-arch arm64"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,18 @@ jobs:
             build: autotools
             zlib: 'ON'
             options: --disable-static
+          - compiler: clang
+            arch: amd64
+            crypto: Libgcrypt
+            build: autotools
+            zlib: 'ON'
+            options: --disable-static
+          - compiler: clang
+            arch: i386
+            crypto: OpenSSL
+            build: autotools
+            zlib: 'ON'
+            options: --disable-static
     env:
       CC: ${{ matrix.compiler == 'clang-tidy' && 'clang' || matrix.compiler }}
       mbedtls-version: 3.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,7 +498,10 @@ jobs:
       - name: 'autotools tests'
         if: ${{ matrix.build == 'autotools' && !matrix.target }}
         timeout-minutes: 10
-        run: make -C bld check V=1 || { cat bld/tests/*.log; false; }
+        run: |
+          export FIXTURE_TRACE_ALL_CONNECT=1
+          make -C bld check V=1 || { cat bld/tests/*.log; false; }
+
       - name: 'autotools distcheck'
         if: ${{ matrix.target == 'distcheck' }}
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,18 +121,18 @@ jobs:
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
-          [[ '${{ matrix.image }}' = *'macos'* ]] && options+=' -DCMAKE_C_FLAGS="-arch arm64"'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           [[ '${{ matrix.image }}' = *'windows'* ]] && export CMAKE_GENERATOR='MSYS Makefiles'
-          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
+          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
+            ${{ contains(matrix.image, 'macos') && '-DCMAKE_C_FLAGS="-arch arm64"' || '' }}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
-          [[ '${{ matrix.image }}' = *'macos'* ]] && options+=' -DCMAKE_C_FLAGS="-arch arm64"'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           [[ '${{ matrix.image }}' = *'windows'* ]] && export CMAKE_GENERATOR='MSYS Makefiles'
-          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
+          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
+            ${{ contains(matrix.image, 'macos') && '-DCMAKE_C_FLAGS="-arch arm64"' || '' }}
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,8 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
-            export LIBSSH2_CMAKE_GENERATOR='MSYS Makefiles'
-            export LIBSSH2_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
+            export TEST_CMAKE_GENERATOR='MSYS Makefiles'
+            export TEST_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
           fi
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
@@ -134,8 +134,8 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
-            export LIBSSH2_CMAKE_GENERATOR='MSYS Makefiles'
-            export LIBSSH2_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
+            export TEST_CMAKE_GENERATOR='MSYS Makefiles'
+            export TEST_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
           fi
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,6 @@ jobs:
 
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
-          PATH=/usr/bin find /c/msys64 || true
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,18 +124,16 @@ jobs:
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin:/c/mingw64/bin:/c/Program Files/Git/bin'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DCMAKE_IGNORE_PREFIX_PATH="C:/Program Files/"' || '' }}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && PATH='/usr/bin:/c/mingw64/bin:/c/Program Files/Git/bin'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DCMAKE_IGNORE_PREFIX_PATH="C:/Program Files/"' || '' }}
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,14 +108,20 @@ jobs:
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64"
+          if [[ '${{ matrix.image }}' = *'windows'* ]]; then
+            export LIBSSH2_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
+            export LIBSSH2_CMAKE_GENERATOR='MSYS Makefiles'
+          fi
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS="-G \"MSYS Makefiles\" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64"
+          if [[ '${{ matrix.image }}' = *'windows'* ]]; then
+            export LIBSSH2_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
+            export LIBSSH2_CMAKE_GENERATOR='MSYS Makefiles'
+          fi
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via FetchContent'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,17 +108,15 @@ jobs:
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64/opt"' || '' }}
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR="C:/mingw64/opt"'
+          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
-          [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
-          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64/opt"' || '' }}
+          [[ '${{ matrix.image }}' = *'windows'* ]] && export LIBSSH2_CMAKE_FLAGS='-G "MSYS Makefiles" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR="C:/mingw64/opt"'
+          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
 
       - name: 'via FetchContent'
         run: ./tests/cmake/test.sh FetchContent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DCMAKE_PREFIX_PATH="/c/mingw64"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="/c/mingw64"' || '' }}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
@@ -133,7 +133,7 @@ jobs:
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DCMAKE_PREFIX_PATH="/c/mingw64"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="/c/mingw64"' || '' }}
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,20 +106,11 @@ jobs:
 
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
-          if [[ '${{ matrix.image }}' = *'windows'* ]]; then
-            echo '--------------------'
-            env
-            echo '--------------------'
-            ls -l /c || true
-            ls -l C:/mingw64 || true
-            ls -l /c/mingw64 || true
-            PATH=/usr/bin find /c/mingw64 || true
-          fi
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64/opt"' || '' }}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
@@ -127,7 +118,7 @@ jobs:
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DOPENSSL_ROOT_DIR="C:/mingw64/opt"' || '' }}
 
       - name: 'via FetchContent'
         run: ./tests/cmake/test.sh FetchContent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DCMAKE_IGNORE_PREFIX_PATH="C:/Program Files/"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DCMAKE_PREFIX_PATH="/c/mingw64"' || '' }}
 
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
@@ -133,7 +133,7 @@ jobs:
           [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
           [[ '${{ matrix.image }}' = *'windows'* ]] && options+=' -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc'
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options} \
-            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DCMAKE_IGNORE_PREFIX_PATH="C:/Program Files/"' || '' }}
+            ${{ contains(matrix.image, 'windows') && '-G "MSYS Makefiles" -DCMAKE_PREFIX_PATH="/c/mingw64"' || '' }}
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
           path-type: inherit
           install: >-
             mingw-w64-x86_64-zlib mingw-w64-x86_64-libgcrypt mingw-w64-x86_64-openssl mingw-w64-x86_64-mbedtls
-            mingw-w64-x86_64-make
 
       - name: 'install packages'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,12 @@ jobs:
       - name: 'install packages'
         if: ${{ !contains(matrix.image, 'windows') }}
         run: |
-          if [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
+          if [[ '${{ matrix.image }}' = *'windows'* ]]; then
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
+              --location 'https://github.com/Kitware/CMake/releases/download/v3.7.2/cmake-3.7.2-win64-x64.zip' --output bin.zip
+            unzip bin.zip
+            rm -f bin.zip
+          elif [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
             sudo apt-get -o Dpkg::Use-Pty=0 install libgcrypt-dev libssl-dev libmbedtls-dev libwolfssl-dev
           else
@@ -102,6 +107,18 @@ jobs:
       - name: 'via find_package wolfSSL'
         if: ${{ !contains(matrix.image, 'windows') }}  # MSYS2 wolfSSL package not built with the OpenSSL compatibility option
         run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=wolfSSL
+
+      - name: 'via add_subdirectory OpenSSL (old cmake)'
+        if: ${{ contains(matrix.image, 'windows') }}
+        run: |
+          export CMAKE_CONSUMER=$PWD/cmake-3.7.2-win64-x64/bin/cmake
+          ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL
+
+      - name: 'via find_package OpenSSL (old cmake)'
+        if: ${{ contains(matrix.image, 'windows') }}
+        run: |
+          export CMAKE_CONSUMER=$PWD/cmake-3.7.2-win64-x64/bin/cmake
+          ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,18 +75,27 @@ jobs:
             mingw-w64-x86_64-zlib mingw-w64-x86_64-libgcrypt mingw-w64-x86_64-openssl mingw-w64-x86_64-mbedtls
 
       - name: 'install packages'
-        if: ${{ !contains(matrix.image, 'windows') }}
         run: |
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
-            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
+            cd "${HOME}" || exit 1
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --location 'https://github.com/Kitware/CMake/releases/download/v3.7.2/cmake-3.7.2-win64-x64.zip' --output bin.zip
             unzip bin.zip
             rm -f bin.zip
+            printf '%s' "${HOME}/cmake-3.7.2-win64-x64/bin/cmake.exe" > "${HOME}/old-cmake-path.txt"
           elif [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
             sudo apt-get -o Dpkg::Use-Pty=0 install libgcrypt-dev libssl-dev libmbedtls-dev libwolfssl-dev
+            cd "${HOME}" || exit 1
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
+              --location https://github.com/Kitware/CMake/releases/download/v3.7.2/cmake-3.7.2-Linux-x86_64.tar.gz | tar -xzf -
+            printf '%s' "$PWD/cmake-3.7.2-Linux-x86_64/bin/cmake" > "${HOME}/old-cmake-path.txt"
           else
             brew install libgcrypt openssl mbedtls wolfssl
+            cd "${HOME}" || exit 1
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
+              --location https://github.com/Kitware/CMake/releases/download/v3.7.2/cmake-3.7.2-Darwin-x86_64.tar.gz | tar -xzf -
+            printf '%s' "$PWD/cmake-3.7.2-Darwin-x86_64/CMake.app/Contents/bin/cmake" > "${HOME}/old-cmake-path.txt"
           fi
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -109,15 +118,13 @@ jobs:
         run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=wolfSSL
 
       - name: 'via add_subdirectory OpenSSL (old cmake)'
-        if: ${{ contains(matrix.image, 'windows') }}
         run: |
-          export CMAKE_CONSUMER=$PWD/cmake-3.7.2-win64-x64/bin/cmake
+          export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL
 
       - name: 'via find_package OpenSSL (old cmake)'
-        if: ${{ contains(matrix.image, 'windows') }}
         run: |
-          export CMAKE_CONSUMER=$PWD/cmake-3.7.2-win64-x64/bin/cmake
+          export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL
 
   build_linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,18 +227,6 @@ jobs:
             build: autotools
             zlib: 'ON'
             options: --disable-static
-          - compiler: clang
-            arch: amd64
-            crypto: Libgcrypt
-            build: autotools
-            zlib: 'ON'
-            options: --disable-static
-          - compiler: clang
-            arch: i386
-            crypto: OpenSSL
-            build: autotools
-            zlib: 'ON'
-            options: --disable-static
     env:
       CC: ${{ matrix.compiler == 'clang-tidy' && 'clang' || matrix.compiler }}
       mbedtls-version: 3.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 'via FetchContent'
+        run: ./tests/cmake/test.sh FetchContent
+      - name: 'via add_subdirectory OpenSSL'
+        run: ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL
+      - name: 'via add_subdirectory Libgcrypt'
+        run: ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=Libgcrypt
+      - name: 'via find_package OpenSSL'
+        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL
+      - name: 'via find_package Libgcrypt'
+        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=Libgcrypt
+      - name: 'via find_package mbedTLS'
+        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=mbedTLS
+      - name: 'via find_package wolfSSL'
+        if: ${{ !contains(matrix.image, 'windows') }}  # MSYS2 wolfSSL package not built with the OpenSSL compatibility option
+        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=wolfSSL
+
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
           export CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
@@ -123,22 +139,6 @@ jobs:
             export LIBSSH2_CMAKE_GENERATOR='MSYS Makefiles'
           fi
           ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL ${options}
-
-      - name: 'via FetchContent'
-        run: ./tests/cmake/test.sh FetchContent
-      - name: 'via add_subdirectory OpenSSL'
-        run: ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=OpenSSL
-      - name: 'via add_subdirectory Libgcrypt'
-        run: ./tests/cmake/test.sh add_subdirectory -DCRYPTO_BACKEND=Libgcrypt
-      - name: 'via find_package OpenSSL'
-        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=OpenSSL
-      - name: 'via find_package Libgcrypt'
-        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=Libgcrypt
-      - name: 'via find_package mbedTLS'
-        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=mbedTLS
-      - name: 'via find_package wolfSSL'
-        if: ${{ !contains(matrix.image, 'windows') }}  # MSYS2 wolfSSL package not built with the OpenSSL compatibility option
-        run: ./tests/cmake/test.sh find_package -DCRYPTO_BACKEND=wolfSSL
 
   build_linux:
     name: 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             cd "${HOME}" || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --location 'https://github.com/Kitware/CMake/releases/download/v${{ env.old-cmake-version }}/cmake-${{ env.old-cmake-version }}-win64-x64.zip' --output bin.zip
-            unzip bin.zip
+            unzip -q bin.zip
             rm -f bin.zip
             printf '%s' "${HOME}/cmake-${{ env.old-cmake-version }}-win64-x64/bin/cmake.exe" > "${HOME}/old-cmake-path.txt"
           elif [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -100,13 +100,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
     "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
-    "${cmake_provider}" --build "${bldp}"
+    "${cmake_provider}" --build "${bldp}" --verbose
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
     "${cmake_provider}" "${src}" ${cmake_opts} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
-    "${cmake_provider}" --build .
+    VERBOSE=1 "${cmake_provider}" --build .
     make install
     cd ..
   fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -36,7 +36,7 @@ runresults() {
   set +x
   for bin in "$1"/test-consumer*; do
     file "${bin}" || true
-    ${LIBSSH2_TEST_EXE_RUNNER:-} "${bin}" || true
+    ${TEST_CMAKE_EXE_RUNNER:-} "${bin}" || true
   done
   set -x
 }

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -18,8 +18,8 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
 "${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
 
-if [ -n "${LIBSSH2_CMAKE_GENERATOR:-}" ]; then
-  gen="${LIBSSH2_CMAKE_GENERATOR}"
+if [ -n "${TEST_CMAKE_GENERATOR:-}" ]; then
+  gen="${TEST_CMAKE_GENERATOR}"
 elif [ -n "${cmake_consumer_modern:-}" ] && \
      [ -n "${cmake_provider_modern:-}" ] && \
      command -v ninja >/dev/null; then
@@ -48,13 +48,13 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. -G "${gen}" ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_consumer}" .. -G "${gen}" ${cmake_opts} ${TEST_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     VERBOSE=1 "${cmake_consumer}" --build .
@@ -67,7 +67,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+  "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -84,14 +84,14 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
     # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
     # library directories to the consumer project.
-    "${cmake_consumer}" .. -G "${gen}" ${cmake_opts} -DLIBSSH2_USE_PKGCONFIG=OFF ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_consumer}" .. -G "${gen}" ${cmake_opts} -DLIBSSH2_USE_PKGCONFIG=OFF ${TEST_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
@@ -106,13 +106,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}" --verbose
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" -G "${gen}" ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_provider}" "${src}" -G "${gen}" ${cmake_opts} ${TEST_CMAKE_FLAGS:-} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     VERBOSE=1 "${cmake_provider}" --build .
     make install
@@ -121,13 +121,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldc='bld-find_package'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${LIBSSH2_CMAKE_FLAGS:-} \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${TEST_CMAKE_FLAGS:-} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. -G "${gen}" ${LIBSSH2_CMAKE_FLAGS:-} \
+    "${cmake_consumer}" .. -G "${gen}" ${TEST_CMAKE_FLAGS:-} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     VERBOSE=1 "${cmake_consumer}" --build .

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -18,9 +18,14 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
 "${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
 
-if [ -n "${cmake_consumer_modern:-}" ] && \
-   [ -n "${cmake_provider_modern:-}" ]; then
-  command -v ninja >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
+if [ -n "${LIBSSH2_CMAKE_GENERATOR}" ]; then
+  gen="${LIBSSH2_CMAKE_GENERATOR}"
+elif [ -n "${cmake_consumer_modern:-}" ] && \
+     [ -n "${cmake_provider_modern:-}" ] && \
+     command -v ninja >/dev/null; then
+  gen='Ninja'  # 3.17+
+else
+  gen='UNIX Makefiles'
 fi
 
 cmake_opts='-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DENABLE_ZLIB_COMPRESSION=ON'
@@ -43,13 +48,13 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_consumer}" .. -G "${gen}" ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     VERBOSE=1 "${cmake_consumer}" --build .
@@ -62,7 +67,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+  "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -79,14 +84,14 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
     # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
     # library directories to the consumer project.
-    "${cmake_consumer}" .. ${cmake_opts} -DLIBSSH2_USE_PKGCONFIG=OFF ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_consumer}" .. -G "${gen}" ${cmake_opts} -DLIBSSH2_USE_PKGCONFIG=OFF ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
@@ -101,13 +106,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}" --verbose
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
+    "${cmake_provider}" "${src}" -G "${gen}" ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     VERBOSE=1 "${cmake_provider}" --build .
     make install
@@ -116,13 +121,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldc='bld-find_package'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${LIBSSH2_CMAKE_FLAGS:-} \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${LIBSSH2_CMAKE_FLAGS:-} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${LIBSSH2_CMAKE_FLAGS:-} \
+    "${cmake_consumer}" .. -G "${gen}" ${LIBSSH2_CMAKE_FLAGS:-} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     VERBOSE=1 "${cmake_consumer}" --build .

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -25,7 +25,7 @@ elif [ -n "${cmake_consumer_modern:-}" ] && \
      command -v ninja >/dev/null; then
   gen='Ninja'  # 3.17+
 else
-  gen='UNIX Makefiles'
+  gen='Unix Makefiles'
 fi
 
 cmake_opts='-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DENABLE_ZLIB_COMPRESSION=ON'

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -9,8 +9,6 @@ set -eu
 
 cd "$(dirname "$0")"
 
-command -v ninja >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
-
 mode="${1:-all}"; shift
 
 cmake_consumer="${CMAKE_CONSUMER:-cmake}"
@@ -19,6 +17,11 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 # 'modern': supports -S/-B (3.13+), --install (3.15+)
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
 "${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
+
+if [ -n "${cmake_consumer_modern:-}" ] && \
+   [ -n "${cmake_provider_modern:-}" ]; then
+  command -v ninja >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
+fi
 
 cmake_opts='-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DENABLE_ZLIB_COMPRESSION=ON'
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -40,13 +40,13 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS} "$@" \
+    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS} "$@" \
+    "${cmake_consumer}" .. ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     VERBOSE=1 "${cmake_consumer}" --build .
@@ -59,7 +59,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS} "$@" \
+  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -76,14 +76,14 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS} "$@" \
+    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
     # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
     # library directories to the consumer project.
-    "${cmake_consumer}" .. ${cmake_opts} -DLIBSSH2_USE_PKGCONFIG=OFF ${LIBSSH2_CMAKE_FLAGS} "$@" \
+    "${cmake_consumer}" .. ${cmake_opts} -DLIBSSH2_USE_PKGCONFIG=OFF ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
@@ -98,13 +98,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS} "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}" --verbose
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS} "$@" \
+    "${cmake_provider}" "${src}" ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS:-} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     VERBOSE=1 "${cmake_provider}" --build .
     make install
@@ -113,13 +113,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldc='bld-find_package'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${LIBSSH2_CMAKE_FLAGS} \
+    "${cmake_consumer}" -B "${bldc}" ${LIBSSH2_CMAKE_FLAGS:-} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${LIBSSH2_CMAKE_FLAGS} \
+    "${cmake_consumer}" .. ${LIBSSH2_CMAKE_FLAGS:-} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     VERBOSE=1 "${cmake_consumer}" --build .

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -40,13 +40,13 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${cmake_opts} "$@" \
+    "${cmake_consumer}" .. ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     VERBOSE=1 "${cmake_consumer}" --build .
@@ -59,7 +59,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS} "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -76,14 +76,14 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
     # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
     # library directories to the consumer project.
-    "${cmake_consumer}" .. ${cmake_opts} -DLIBSSH2_USE_PKGCONFIG=OFF "$@" \
+    "${cmake_consumer}" .. ${cmake_opts} -DLIBSSH2_USE_PKGCONFIG=OFF ${LIBSSH2_CMAKE_FLAGS} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
@@ -98,13 +98,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${LIBSSH2_CMAKE_FLAGS} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}" --verbose
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" ${cmake_opts} "$@" \
+    "${cmake_provider}" "${src}" ${cmake_opts} ${LIBSSH2_CMAKE_FLAGS} "$@" \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
     VERBOSE=1 "${cmake_provider}" --build .
     make install
@@ -113,13 +113,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldc='bld-find_package'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" \
+    "${cmake_consumer}" -B "${bldc}" ${LIBSSH2_CMAKE_FLAGS} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. \
+    "${cmake_consumer}" .. ${LIBSSH2_CMAKE_FLAGS} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/libssh2"
     VERBOSE=1 "${cmake_consumer}" --build .

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -11,8 +11,8 @@ cd "$(dirname "$0")"
 
 mode="${1:-all}"; shift
 
-cmake_consumer="${CMAKE_CONSUMER:-cmake}"
-cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
+cmake_consumer="${TEST_CMAKE_CONSUMER:-cmake}"
+cmake_provider="${TEST_CMAKE_PROVIDER:-${cmake_consumer}}"
 
 # 'modern': supports -S/-B (3.13+), --install (3.15+)
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -18,7 +18,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
 "${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
 
-if [ -n "${LIBSSH2_CMAKE_GENERATOR}" ]; then
+if [ -n "${LIBSSH2_CMAKE_GENERATOR:-}" ]; then
   gen="${LIBSSH2_CMAKE_GENERATOR}"
 elif [ -n "${cmake_consumer_modern:-}" ] && \
      [ -n "${cmake_provider_modern:-}" ] && \


### PR DESCRIPTION
It was an exercise to run old cmake versions in CI and in the test suite.

It also revealed that 3.7.2 2017-01-13 is too old to consume libssh2 via
`find_package()` due to:
```
CMake Error at bld-libssh2/_pkg/lib/cmake/libssh2/libssh2-config.cmake:35 (add_library):
  add_library cannot create ALIAS target "libssh2::libssh2" because target
  "libssh2::libssh2_shared" is IMPORTED.
Call Stack (most recent call first):
  CMakeLists.txt:27 (find_package)
```
The mitigation for this issue requires 3.11.

Also:
- rename a few existing envs to use the `TEST_` prefix.
- make the `find_package` test provider stage verbose.
