### PR TITLE
Dockerfile: switch to Debian stable

### DIFF
--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM debian:testing-slim
+FROM debian:stable-slim
 
 RUN apt-get update \
  && apt-get install -y openssh-server \


### PR DESCRIPTION
To avoid failing tests in job
'linux (clang, i386, Libgcrypt, autotools, ON, --disable-static)'.
Same job with x86_64 or OpenSSL did pass without issues.

Example:
https://github.com/libssh2/libssh2/actions/runs/14703383105/job/41758988183?pr=1588
```
libssh2_session_handshake failed (-5): Unable to exchange encryption keys
```

Bug: https://github.com/libssh2/libssh2/pull/1591#issuecomment-2844417405
Fix-suggested-by: Jacob Barthelmeh
Fixes #1594
