### PR TITLE
Buffer overread vulnerability fix

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2337,6 +2337,13 @@ ssize_t
 _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
                        const unsigned char *buf, size_t buflen)
 {
+    if (buflen > strlen((const char *)buf)) {
+        /* Length mismatch */
+        return _libssh2_error(channel->session,
+                                  LIBSSH2_ERROR_INVAL,
+                                  "Malicious buffer passed.");
+    }
+    
     int rc = 0;
     LIBSSH2_SESSION *session = channel->session;
     ssize_t wrote = 0; /* counter for this specific this call */


### PR DESCRIPTION
If Address Sanitization (asan) is enabled when building libssh2 and any encapsulating code, attempts to call the vulnerable functions using mismatched lengths will cause the application to panic and crash. If asan is not enabled during the build process, the application will continue running with the malicious buffer. The affected functions send the data to the connected SSH server, leaking memory from the server running libssh2. Due to the nature of libssh2, and code using the library, there is a high probability of sensitive information such as authentication material being leaked to the remote server.