### PR TITLE
Update FindMbedTLS.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,10 +478,10 @@ endif()
 
 if(CRYPTO_BACKEND STREQUAL "mbedTLS" OR NOT CRYPTO_BACKEND)
   find_package(MbedTLS ${_specific_crypto_requirement})
-  if(MBEDTLS_FOUND)
+  if(MbedTLS_FOUND)
     set(CRYPTO_BACKEND "mbedTLS")
     set(CRYPTO_BACKEND_DEFINE "LIBSSH2_MBEDTLS")
-    list(APPEND LIBSSH2_LIBS libssh2::mbedcrypto)
+    list(APPEND LIBSSH2_LIBS MbedTLS::mbedcrypto)
   endif()
 endif()
 

--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -17,7 +17,7 @@ elseif("@CRYPTO_BACKEND@" STREQUAL "Libgcrypt")
   list(APPEND _libs libssh2::libgcrypt)
 elseif("@CRYPTO_BACKEND@" STREQUAL "mbedTLS")
   find_dependency(MbedTLS)
-  list(APPEND _libs libssh2::mbedcrypto)
+  list(APPEND _libs MbedTLS::mbedcrypto)
 endif()
 
 if(@ZLIB_FOUND@)


### PR DESCRIPTION
This module is a compatibility layer for the library version below 3.6.0, where full support of cmake configuration modules appeared. It is recommended to use the library 3.6 and higher, for which this module is redundant.

The module provides the same targets as the MbedTLS 3.6 modules, due to which the migration process to 3.6 will be very simple - just delete the local copy of this file and reinitialize the project.