### PR TITLE
ci/GHA: move CI checks to Linux, other CI tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     steps:
       - name: 'install prereqs'
         run: /home/linuxbrew/.linuxbrew/bin/brew install shellcheck zizmor
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 'checksrc'
-        run: ./ci/checksrc.sh
+        run: ci/checksrc.sh
 
   reuse:
     name: 'REUSE check'
@@ -42,24 +42,49 @@ jobs:
     name: 'spellcheck'
     runs-on: ubuntu-latest
     steps:
-      - name: 'install tools'
+      - name: 'install prereqs'
         run: pip install --break-system-packages -U codespell
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: 'spellcheck'
-        run: ./ci/spellcheck.sh
+        run: ci/spellcheck.sh
 
-  shellcheck:
-    name: 'shellcheck'
+  miscchecks:
+    name: 'misc checks'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install shellcheck zizmor
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
+      - name: 'zizmor GHA'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          zizmor --pedantic .github/workflows/*.yml
+
+      - name: 'shellcheck GHA'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          shellcheck --version
+          export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
+          git ls-files '.github/workflows/*.yml' | while read -r f; do
+            echo "Verifying ${f}..."
+            {
+              echo '#!/usr/bin/env bash'
+              echo 'set -eu'
+              yq eval '.. | select(has("run") and (.run | type == "!!str")) | .run + "\ntrue\n"' "${f}"
+            } | sed -E 's|\$\{\{ .+ \}\}|GHA_EXPRESSION|g' | shellcheck -
+          done
+
       - name: 'shellcheck'
-        run: ./ci/shellcheck.sh
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          shellcheck --version
+          ci/shellcheck.sh
 
   cmakelint:
     name: 'cmakelint'
@@ -72,31 +97,6 @@ jobs:
         run: |
           python3 -m pip install --break-system-packages cmakelang==0.6.13
           ci/cmakelint.sh
-
-  cicheck:
-    name: 'CI checks'
-    runs-on: macos-latest
-    timeout-minutes: 1
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-      - name: 'install prereqs'
-        run: brew install shellcheck zizmor
-      - name: 'zizmor GHA'
-        run: zizmor --pedantic .github/workflows/*.yml
-      - name: 'shellcheck'
-        run: |
-          shellcheck --version
-          export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
-          git ls-files '.github/workflows/*.yml' | while read -r f; do
-            echo "Verifying ${f}..."
-            {
-              echo '#!/usr/bin/env bash'
-              echo 'set -eu'
-              yq eval '.. | select(has("run") and (.run | type == "!!str")) | .run + "\ntrue\n"' "${f}"
-            } | sed -E 's|\$\{\{ .+ \}\}|GHA_EXPRESSION|g' | shellcheck -
-          done
 
   build_integration:
     name: 'CM integration ${{ matrix.image }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,7 +575,7 @@ jobs:
           [ -d "$HOME"/usr ] && options+=" -DCMAKE_PREFIX_PATH=$HOME/usr"
           [ "${MATRIX_ARCH}" = 'i386' ] && options+=" -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=${MATRIX_ARCH} -DCMAKE_C_FLAGS=-m32"
           [ "${MATRIX_COMPILER}" = 'clang-tidy' ] && options+=' -DLIBSSH2_CLANG_TIDY=ON'
-          cmake -B bld -G Ninja ${options} $TOOLCHAIN_OPTION \
+          cmake -B bld -G Ninja ${options} \
             -DCMAKE_UNITY_BUILD=ON \
             -DENABLE_WERROR=ON \
             -DCRYPTO_BACKEND=${crypto} \

--- a/ci/appveyor/docker-bridge.sh
+++ b/ci/appveyor/docker-bridge.sh
@@ -2,7 +2,7 @@
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
-set -e
+set -eu
 
 netsh interface portproxy add v4tov4 listenport=3389 listenaddress="$1" connectport=22 connectaddress=127.0.0.1
 netsh interface portproxy show all
@@ -12,16 +12,16 @@ ssh-keygen -A
 "$(command -v sshd)" &
 
 curl \
-  -F "account=${APPVEYOR_ACCOUNT_NAME}" \
-  -F "project=${APPVEYOR_PROJECT_SLUG}" \
-  -F "buildid=${APPVEYOR_BUILD_VERSION}" \
-  -F "base=${APPVEYOR_REPO_BRANCH}" \
-  -F "hash=${APPVEYOR_REPO_COMMIT}" \
-  -F "repo=${APPVEYOR_REPO_NAME}" \
-  -F "ssh_host=$2" \
-  -F "ssh_port=$3" \
-  -F "ssh_user=$(whoami)" \
-  -F "ssh_forward=127.0.0.1:${OPENSSH_SERVER_PORT} 127.0.0.1:${OPENSSH_SERVER_PORT},127.0.0.1:2375 /var/run/docker.sock" \
-  -F "ssh_hostkey=$(paste -d , /etc/ssh/ssh_host_*_key.pub)" \
-  -F "ssh_privkey=$(paste -sd , auth)" \
+  -F account="${APPVEYOR_ACCOUNT_NAME}" \
+  -F project="${APPVEYOR_PROJECT_SLUG}" \
+  -F buildid="${APPVEYOR_BUILD_VERSION}" \
+  -F base="${APPVEYOR_REPO_BRANCH}" \
+  -F hash="${APPVEYOR_REPO_COMMIT}" \
+  -F repo="${APPVEYOR_REPO_NAME}" \
+  -F ssh_host="$2" \
+  -F ssh_port="$3" \
+  -F ssh_user="$(whoami)" \
+  -F ssh_forward="127.0.0.1:${OPENSSH_SERVER_PORT} 127.0.0.1:${OPENSSH_SERVER_PORT},127.0.0.1:2375 /var/run/docker.sock" \
+  -F ssh_hostkey="$(paste -d , /etc/ssh/ssh_host_*_key.pub)" \
+  -F ssh_privkey="$(paste -sd , auth)" \
   -s 'https://stuff.marc-hoersken.de/libssh2/dispatch.php'

--- a/ci/checksrc.sh
+++ b/ci/checksrc.sh
@@ -2,9 +2,9 @@
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
-set -e
+set -eu
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")"/..
 
 git ls-files "*.[ch]" "*.cc" | xargs -n1 \
-./ci/checksrc.pl -i4 -m79 -AFOPENMODE -ASNPRINTF -ATYPEDEFSTRUCT
+ci/checksrc.pl -i4 -m79 -AFOPENMODE -ASNPRINTF -ATYPEDEFSTRUCT

--- a/ci/cmakelint.sh
+++ b/ci/cmakelint.sh
@@ -18,8 +18,13 @@
 # If such a file is ever added, then this can be portably fixed by switching to
 # "xargs -I{}" and appending {} to the end of the xargs arguments (which will
 # call cmakelint once per file) or by using the GNU extension "xargs -d'\n'".
+
+set -eu
+
+cd "$(dirname "$0")"/..
+
 {
-  if [ -n "$1" ]; then
+  if [ -n "${1:-}" ]; then
     for A in "$@"; do printf "%s\n" "$A"; done
   elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     git ls-files

--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -3,7 +3,10 @@
 #
 # SPDX-License-Identifier: curl
 
-shellcheck --version
+set -eu
+
+cd "$(dirname "$0")"/..
+
 # shellcheck disable=SC2046
 shellcheck --exclude=1091 \
   --enable=avoid-nullary-conditions,deprecate-which \

--- a/ci/spellcheck.sh
+++ b/ci/spellcheck.sh
@@ -2,9 +2,9 @@
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
-set -e
+set -eu
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")"/..
 
 # shellcheck disable=SC2046
 codespell --skip='docs/AUTHORS' \

--- a/tests/gen_keys.sh
+++ b/tests/gen_keys.sh
@@ -3,8 +3,7 @@
 # Copyright (C) Viktor Szakats
 # SPDX-License-Identifier: BSD-3-Clause
 
-set -e
-set -u
+set -eu
 
 # Generate test keys
 

--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -2,8 +2,7 @@
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
-set -e
-set -u
+set -eu
 
 # Written by Mikhail Gusarov
 #

--- a/tests/test_read_algos.test
+++ b/tests/test_read_algos.test
@@ -2,8 +2,7 @@
 # Copyright (C) Viktor Szakats
 # SPDX-License-Identifier: BSD-3-Clause
 
-set -e
-set -u
+set -eu
 
 # https://testanything.org/tap-specification.html
 

--- a/tests/test_sshd.test
+++ b/tests/test_sshd.test
@@ -6,8 +6,7 @@
 # Start sshd, invoke test(s), saving exit code, kill sshd, and
 # return exit code.
 
-set -e
-set -u
+set -eu
 
 # https://testanything.org/tap-specification.html
 


### PR DESCRIPTION
Also:
- merge CI check and shellcheck jobs into a single one.
  To share the same shellcheck version and less overhead.
- use `set -eu` in more scripts.
- make sure CI scripts run from any cwd.
  To make it easy to run them on local machine.
- drop reference to unused `TOOLCHAIN_OPTION` variable.
  Follow-up to 201c368aa16c9b262f6579b3c0829cfa5d178e7d #1598
- minor tidy-ups.
