### PR TITLE
cmake: drop redundant `-lws2_32` meant for `libssh2.pc`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,10 +229,6 @@ install(
 # Calculate variables for pkg-config
 set(LIBSSH2_PC_LIBS_PRIVATE "")
 
-if(WIN32)
-  list(APPEND LIBSSH2_PC_LIBS_PRIVATE "-lws2_32")
-endif()
-
 set(_ldflags "")
 
 # Avoid getting unnecessary -L options for known system directories.


### PR DESCRIPTION
The `libssh2.pc` generator logic automatically adds `-lws2_32` while
parsing `LIBSSH2_LIBS`, which contains this lib already. Then discard
the duplicate.

This change introduces a change in the position of `ws2_32` within
the lib list.

This order might in cases by significant, but:

- libssh2 no longer links against `libssl`, which was the library
  also referencing `ws2_32` and breaking picky binutils `ld` linker
  when not passed in strict dependency order.
  Ref: c84745e34e53f863ffba997ceeee7d43d1c63a4b #1128

- since switching to INTERFACE targets, cmake messes up the lib order
  anyway, adding `OpenSSL:Crypto` last, instead of `ws2_32`. This did
  not seem to cause an issue so far.
  Ref: df0563a85732fd9a33bbb116d8c07ca18ba6af38 #1535

Ref: 33b6d5f89d5328aa7677f542450cc48d825df595 #827
Ref: 31fb8860dbaae3e0b7d38f2a647ee527b4b2a95f #811
