### PR TITLE
scp: fix NULL dereference in path arg of send/recv

### DIFF
--- a/docs/libssh2_scp_recv.3
+++ b/docs/libssh2_scp_recv.3
@@ -28,6 +28,8 @@ Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 .SH ERRORS
 \fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
+\fILIBSSH2_ERROR_INVAL\fP - Invalid argument used in function call.
+
 \fILIBSSH2_ERROR_SCP_PROTOCOL\fP -
 
 \fILIBSSH2_ERROR_EAGAIN\fP - Marked for non-blocking I/O but the call would

--- a/docs/libssh2_scp_recv2.3
+++ b/docs/libssh2_scp_recv2.3
@@ -25,6 +25,8 @@ Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 .SH ERRORS
 \fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
+\fILIBSSH2_ERROR_INVAL\fP - Invalid argument used in function call.
+
 \fILIBSSH2_ERROR_SCP_PROTOCOL\fP -
 
 \fILIBSSH2_ERROR_EAGAIN\fP - Marked for non-blocking I/O but the call would

--- a/docs/libssh2_scp_send64.3
+++ b/docs/libssh2_scp_send64.3
@@ -37,6 +37,8 @@ Pointer to a newly allocated LIBSSH2_CHANNEL instance, or NULL on errors.
 .SH ERRORS
 \fILIBSSH2_ERROR_ALLOC\fP - An internal memory allocation call failed.
 
+\fILIBSSH2_ERROR_INVAL\fP - Invalid argument used in function call.
+
 \fILIBSSH2_ERROR_SOCKET_SEND\fP - Unable to send data on socket.
 
 \fILIBSSH2_ERROR_SCP_PROTOCOL\fP -

--- a/src/scp.c
+++ b/src/scp.c
@@ -285,9 +285,9 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
     const char *tmp_err_msg;
 
     if(!path) {
-	 _libssh2_error(session, LIBSSH2_ERROR_INVAL,
-                           "Path argument can not be null");
-	 return NULL;
+        _libssh2_error(session, LIBSSH2_ERROR_INVAL,
+                       "Path argument can not be null");
+        return NULL;
     }
 
     if(session->scpRecv_state == libssh2_NB_state_idle) {
@@ -867,9 +867,9 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
     const char *tmp_err_msg;
 
     if(!path) {
-	 _libssh2_error(session, LIBSSH2_ERROR_INVAL,
-                           "Path argument can not be null");
-	 return NULL;
+        _libssh2_error(session, LIBSSH2_ERROR_INVAL,
+                       "Path argument can not be null");
+        return NULL;
     }
 
     if(session->scpSend_state == libssh2_NB_state_idle) {

--- a/src/scp.c
+++ b/src/scp.c
@@ -284,6 +284,12 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
     int tmp_err_code;
     const char *tmp_err_msg;
 
+    if(!path) {
+	 _libssh2_error(session, LIBSSH2_ERROR_INVAL,
+                           "Path argument can not be null");
+	 return NULL;
+    }
+
     if(session->scpRecv_state == libssh2_NB_state_idle) {
         session->scpRecv_mode = 0;
         session->scpRecv_size = 0;
@@ -859,6 +865,12 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
     int rc;
     int tmp_err_code;
     const char *tmp_err_msg;
+
+    if(!path) {
+	 _libssh2_error(session, LIBSSH2_ERROR_INVAL,
+                           "Path argument can not be null");
+	 return NULL;
+    }
 
     if(session->scpSend_state == libssh2_NB_state_idle) {
         session->scpSend_command_len =


### PR DESCRIPTION
As described in #1624 there is a crash when the path argument is set
to NULL. In addition to the send function I also found that receive
function to have the same issue and applied the fix to both functions.

Reported-by: Liu Xing Yu
Fixes #1624