### PR TITLE
Fix small leak in base64_encode() with empty data #1627

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -463,7 +463,7 @@ size_t _libssh2_base64_encode(LIBSSH2_SESSION *session,
         insize = strlen(indata);
 
     if(insize == 0)
-        return 0; /* nothing to decode */
+        return 0; /* nothing to encode */
 
     base64data = output = LIBSSH2_ALLOC(session, insize * 4 / 3 + 4);
     if(!output)


### PR DESCRIPTION
Fix small memory leak when trying to encode base64 data with no data.

Credit:
Liu Xing Yu