### PR TITLE
CMake: Make installation optional; use `NEW` behavior for `CMP0077`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,6 @@ include(FeatureSummary)
 include(CheckFunctionExistsMayNeedLibrary)
 include(CheckNonblockingSocketSupport)
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.13)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
 project(libssh2 C)
 
 # Dump all target properties
@@ -176,12 +172,15 @@ if(NOT LIBSSH2_VERSION OR
   message(FATAL_ERROR "Unable to parse version from ${PROJECT_SOURCE_DIR}/include/libssh2.h")
 endif()
 
-include(GNUInstallDirs)
-install(
-  FILES
-    COPYING NEWS README RELEASE-NOTES
-    docs/AUTHORS docs/BINDINGS.md docs/HACKING.md
-  DESTINATION ${CMAKE_INSTALL_DOCDIR})
+option(LIBSSH2_DISABLE_INSTALL "Enable system installation of headers, libraries, CMake modules, and pkg-config files" OFF)
+if(NOT LIBSSH2_DISABLE_INSTALL)
+  include(GNUInstallDirs)
+  install(
+    FILES
+      COPYING NEWS README RELEASE-NOTES
+      docs/AUTHORS docs/BINDINGS.md docs/HACKING.md
+    DESTINATION ${CMAKE_INSTALL_DOCDIR})
+endif()
 
 include(PickyWarnings)
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -40,5 +40,7 @@ libssh2_transform_makefile_inc("Makefile.am" "${CMAKE_CURRENT_BINARY_DIR}/Makefi
 # Get dist_man_MANS variable
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.am.cmake")
 
-include(GNUInstallDirs)
-install(FILES ${dist_man_MANS} DESTINATION "${CMAKE_INSTALL_MANDIR}/man3")
+if(NOT LIBSSH2_DISABLE_INSTALL)
+  include(GNUInstallDirs)
+  install(FILES ${dist_man_MANS} DESTINATION "${CMAKE_INSTALL_MANDIR}/man3")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,9 +176,8 @@ add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_SELECTED})
 add_library(${LIB_NAME} ALIAS ${LIB_SELECTED})
 
 ## Installation
-option(ENABLE_INSTALL "Enable system installation of headers, libraries, CMake modules, and pkg-config files" ON)
 
-if(ENABLE_INSTALL)
+if(NOT LIBSSH2_DISABLE_INSTALL)
   install(FILES
     "${PROJECT_SOURCE_DIR}/include/libssh2.h"
     "${PROJECT_SOURCE_DIR}/include/libssh2_publickey.h"
@@ -206,6 +205,7 @@ if(ENABLE_INSTALL)
     "Files that must be in the same directory as the executables at runtime.")
 
   # Package config
+
   ## During package installation, install libssh2-targets.cmake
   install(EXPORT "${PROJECT_NAME}-targets"
     NAMESPACE "${PROJECT_NAME}::"


### PR DESCRIPTION
- Enables `NEW` behavior of CMake policy [`CMP0077`](https://cmake.org/cmake/help/latest/policy/CMP0077.html) so that existing variables set by dependent projects are **respected and not overridden** by the last argument to `option(...)`.
- Makes the installation phase **optional** by adding an `ENABLE_INSTALL` option variable.
  - This was breaking the build of one of my projects that uses MbedTLS. The error was along the lines of `install(...) required target "mbedcrypto" but it was not found in any export set`, same with `export(...)` calls. I don't need installation for that...

I hope this can be backported to the latest stable release 1.11.1 :slightly_smiling_face: 

---

w/o sp https://github.com/libssh2/libssh2/pull/1638/files?w=1
