### PR TITLE
Improve known_hosts parsing and harden _libssh2_base64_encode()

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -142,8 +142,8 @@ knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
     struct known_host *entry;
     size_t hostlen = strlen(host);
     int rc;
-    char *ptr;
-    size_t ptrlen;
+    char *ptr = NULL;
+    size_t ptrlen = 0;
 
     /* make sure we have a key type set */
     if(!(typemask & LIBSSH2_KNOWNHOST_KEY_MASK))
@@ -176,6 +176,12 @@ knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         if(rc)
             goto error;
 
+        if(ptr == NULL || ptrlen == 0) {
+            rc = _libssh2_error(hosts->session, LIBSSH2_ERROR_INVAL,
+                                "Base64 decoded value is invalid");
+            goto error;
+        }
+
         if(!salt) {
             rc = _libssh2_error(hosts->session, LIBSSH2_ERROR_INVAL,
                                 "Salt is NULL");
@@ -185,10 +191,19 @@ knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         entry->name = ptr;
         entry->name_len = ptrlen;
 
+        ptr = NULL;
+        ptrlen = 0;
         rc = _libssh2_base64_decode(hosts->session, &ptr, &ptrlen,
                                     salt, strlen(salt));
         if(rc)
             goto error;
+
+        if(ptr == NULL || ptrlen == 0) {
+            rc = _libssh2_error(hosts->session, LIBSSH2_ERROR_INVAL,
+                                "Base64 decoded value is invalid");
+            goto error;
+        }
+
         entry->salt = ptr;
         entry->salt_len = ptrlen;
         break;

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -176,7 +176,7 @@ knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         if(rc)
             goto error;
 
-        if(ptr == NULL || ptrlen == 0) {
+        if(!ptr || ptrlen == 0) {
             rc = _libssh2_error(hosts->session, LIBSSH2_ERROR_INVAL,
                                 "Base64 decoded value is invalid");
             goto error;
@@ -198,7 +198,7 @@ knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         if(rc)
             goto error;
 
-        if(ptr == NULL || ptrlen == 0) {
+        if(!ptr || ptrlen == 0) {
             rc = _libssh2_error(hosts->session, LIBSSH2_ERROR_INVAL,
                                 "Base64 decoded value is invalid");
             goto error;

--- a/src/misc.c
+++ b/src/misc.c
@@ -460,9 +460,6 @@ size_t _libssh2_base64_encode(LIBSSH2_SESSION *session,
                        end */
 
     if(insize == 0)
-        insize = strlen(indata);
-
-    if(insize == 0)
         return 0; /* nothing to encode */
 
     base64data = output = LIBSSH2_ALLOC(session, insize * 4 / 3 + 4);


### PR DESCRIPTION
Notes:
Added additional base64 decode validation when parsing known_hosts and no longer assume what is going into _libssh2_base64_encode() is null terminated. 

Reported by:
Dhiraj Mishra <mishra.dhiraj95@gmail.com>

Credit:
Will Cosgrove 

Reviewed by:
Michael Buckley