### PR TITLE
cmake: make `clean-coverage` target portable

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -168,7 +168,7 @@ add_custom_target(coverage
     --output "${CMAKE_CURRENT_BINARY_DIR}/coverage/index.html")
 
 add_custom_target(clean-coverage
-  COMMAND rm -rf "${CMAKE_CURRENT_BINARY_DIR}/coverage")
+  COMMAND ${CMAKE_COMMAND} rm -rf "${CMAKE_CURRENT_BINARY_DIR}/coverage")
 
 libssh2_add_target_to_copy_dependencies(
   TARGET copy_test_dependencies


### PR DESCRIPTION
By using cmake's `rm` command instead of expecting the shell to support
it.
