### PR TITLE
cmake: initialize `__runtime_dependencies` variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,8 @@ configure_file("src/libssh2_config_cmake.h.in"
 
 ## Cryptography backend choice
 
+set(__runtime_dependencies "")
+
 set(CRYPTO_BACKEND "" CACHE
   STRING "The backend to use for cryptography: OpenSSL, wolfSSL, Libgcrypt, WinCNG, mbedTLS, or empty to try any available")
 


### PR DESCRIPTION
To silence cmake `--warn-uninitialized` warning.

Follow-up to 694b9d964ba3cc3654a2d975e330256c7f2f6e5c #1610