### PR TITLE
kex: don’t store address of stack-local hash ctx in exchange_state->exchange_hash

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -642,7 +642,6 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             }
         }
 
-        exchange_state->exchange_hash = (void *)&exchange_hash_ctx;
         if(!_libssh2_sha_algo_ctx_init(sha_algo_value, exchange_hash_ctx)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_INIT,
                                  "Unable to initialize hash context");
@@ -1723,7 +1722,6 @@ do {                                                                         \
         rc = -1;                                                             \
         break;                                                               \
     }                                                                        \
-    exchange_state->exchange_hash = (void *)&ctx;                            \
     hok = 1;                                                                 \
     if(session->local.banner) {                                              \
         _libssh2_htonu32(exchange_state->h_sig_comp,                         \

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -350,7 +350,6 @@ typedef struct kmdhgGPshakex_state_t
     size_t f_value_len;
     size_t k_value_len;
     size_t h_sig_len;
-    void *exchange_hash;
     packet_require_state_t req_state;
     libssh2_nonblocking_states burn_state;
 } kmdhgGPshakex_state_t;


### PR DESCRIPTION
No functionality change; `exchange_hash` is not used anywhere, anyways.