### PR TITLE
Add SFTP input bounds checking

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -47,7 +47,6 @@
 #include "sftp.h"
 
 #include <assert.h>
-#include <stdint.h>
 #include <stdlib.h>  /* strtol() */
 
 /* This release of libssh2 implements Version 5 with automatic downgrade

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -3481,7 +3481,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
     packet_len = path_len + 13 + sftp_attrsize(attrs.flags);
 
-    if (packet_len > UINT32_MAX || packet_len == 0) {
+    if(packet_len > UINT32_MAX || packet_len == 0) {
         return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                               "Input too large "
                               "sftp_mkdir");


### PR DESCRIPTION
Notes:
When being passed in invalid path lengths to various public SFTP API, `uint32_t` packet length can overflow resulting in heap corruption.  This MR will compute packet length as `size_t` and bounds check it before using it.

Credit:
[Oblivionsage](https://github.com/Oblivionsage)