### PR TITLE
Add input bounds checking to SFTP API

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -47,7 +47,6 @@
 #include "sftp.h"
 
 #include <assert.h>
-#include <stdint.h>
 #include <stdlib.h>  /* strtol() */
 
 /* This release of libssh2 implements Version 5 with automatic downgrade

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1170,7 +1170,7 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
         return NULL;
     }
 
-    packet_len += filename_len;
+    packet_len += (uint32_t)filename_len;
 
     if(sftp->open_state == libssh2_NB_state_idle) {
 
@@ -2808,7 +2808,7 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename,
                               "Input too large "
                               "sftp_unlink");
     }
-    packet_len += filename_len;
+    packet_len += (uint32_t)filename_len;
 
     if(sftp->unlink_state == libssh2_NB_state_idle) {
         sftp->last_errno = LIBSSH2_FX_OK;
@@ -2924,7 +2924,7 @@ static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
                               "Input too large "
                               "sftp_rename");
     }
-    packet_len += source_filename_len;
+    packet_len += (uint32_t)source_filename_len;
 
     if(packet_len + dest_filename_len < packet_len) {
         return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
@@ -3087,14 +3087,14 @@ sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
                               "Input too large "
                               "posix-rename@openssh.com");
     }
-    packet_len += source_filename_len;
+    packet_len += (uint32_t)source_filename_len;
 
     if(packet_len + dest_filename_len < packet_len) {
         return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                               "Input too large (2) "
                               "posix-rename@openssh.com");
     }
-    packet_len += dest_filename_len;
+    packet_len += (uint32_t)dest_filename_len;
 
     if(sftp->posix_rename_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
@@ -3217,7 +3217,7 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
                               "Input too large "
                               "sftp_fstatvfs");
     }
-    packet_len += handle->handle_len;
+    packet_len += (uint32_t)handle->handle_len;
 
     if(sftp->fstatvfs_state == libssh2_NB_state_idle) {
         sftp->last_errno = LIBSSH2_FX_OK;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -3548,7 +3548,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
             sftp->mkdir_packet = packet;
             return (int)nwritten;
         }
-        if(ssize_t)packet_len != nwritten) {
+        if((ssize_t)packet_len != nwritten) {
             LIBSSH2_FREE(session, packet);
             sftp->mkdir_state = libssh2_NB_state_idle;
             return _libssh2_error(session, LIBSSH2_ERROR_SOCKET_SEND,

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -2919,16 +2919,14 @@ static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
        source_filename_len(4) + dest_filename_len(4) + flags(4){SFTP5+) */
     packet_len = 17 + (sftp->version >= 5 ? 4 : 0);
 
-    if(packet_len + source_filename_len < packet_len)
-    {
+    if(packet_len + source_filename_len < packet_len) {
         return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                               "Input too large "
                               "sftp_rename");
     }
     packet_len += source_filename_len;
 
-    if(packet_len + dest_filename_len < packet_len)
-    {
+    if(packet_len + dest_filename_len < packet_len) {
         return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                               "Input too large (2) "
                               "sftp_rename");
@@ -3902,7 +3900,8 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
             return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                   "Input too large (2)"
                                   "sftp_symlink");
-        } else {
+        }
+        else {
             packet_len += (4 + target_len);
         }
     }

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -3548,7 +3548,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
             sftp->mkdir_packet = packet;
             return (int)nwritten;
         }
-        if(packet_len != nwritten) {
+        if(ssize_t)packet_len != nwritten) {
             LIBSSH2_FREE(session, packet);
             sftp->mkdir_state = libssh2_NB_state_idle;
             return _libssh2_error(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -3658,7 +3658,7 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
         if(nwritten == LIBSSH2_ERROR_EAGAIN) {
             return (int)nwritten;
         }
-        else if(packet_len != nwritten) {
+        else if((ssize_t)packet_len != nwritten) {
             LIBSSH2_FREE(session, sftp->rmdir_packet);
             sftp->rmdir_packet = NULL;
             sftp->rmdir_state = libssh2_NB_state_idle;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -3481,7 +3481,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
     packet_len = path_len + 13 + sftp_attrsize(attrs.flags);
 
-    if (packet_len > UINT32_MAX || packet_len == 0) {
+    if(packet_len > UINT32_MAX || packet_len == 0) {
         return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                               "Input too large "
                               "sftp_mkdir");


### PR DESCRIPTION
Add bounds checking to public SFTP API input to avoid possible heap corruption when passing in invalid values.

Credit:
[Oblivionsage](https://github.com/Oblivionsage)