### PR TITLE
channel: fix off-by-one write in X11 cookie generation

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1427,6 +1427,7 @@ channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
                the trailing zero at the LIBSSH2_X11_RANDOM_COOKIE_LEN/2
                border */
             unsigned char buffer[(LIBSSH2_X11_RANDOM_COOKIE_LEN / 2) + 1];
+            char hex[3];
 
             if(_libssh2_random(buffer, LIBSSH2_X11_RANDOM_COOKIE_LEN / 2)) {
                 return _libssh2_error(session, LIBSSH2_ERROR_RANDGEN,
@@ -1434,7 +1435,8 @@ channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
                                       "for x11-req cookie");
             }
             for(i = 0; i < (LIBSSH2_X11_RANDOM_COOKIE_LEN / 2); i++) {
-                snprintf((char *)&s[i*2], 3, "%02X", buffer[i]);
+                snprintf(hex, sizeof(hex), "%02X", buffer[i]);
+                memcpy(&s[i*2], hex, 2);
             }
         }
         s += cookie_len;


### PR DESCRIPTION
The loop hex-encodes 16 random bytes into a 32-byte cookie but used snprintf directly into the output buffer s, writing 3 bytes per iteration (2 hex + NUL) and overflowing by 1 byte on the last write. Hex-encode into a small temp and memcpy 2 bytes per iteration so exactly cookie_len bytes are written with no trailing NUL.