### PR TITLE
packet: authagent_open: fix failure packet length

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -464,7 +464,7 @@ packet_authagent_open(LIBSSH2_SESSION * session,
 {
     int failure_code = SSH_OPEN_CONNECT_FAILED;
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */
-    size_t packet_len = 17 + strlen(X11FwdUnAvil);
+    size_t packet_len = 17 + strlen(AuthAgentUnavail);
     unsigned char *p;
     LIBSSH2_CHANNEL *channel = authagent_state->channel;
     int rc;


### PR DESCRIPTION
Compute packet_len using strlen(AuthAgentUnavail) (not X11FwdUnAvil). The mismatch could send extra uninitialized bytes on the wire or truncate the failure payload.