### PR TITLE
packet: bound-safe logging for SSH_MSG_DEBUG/DISCONNECT

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -339,7 +339,8 @@ packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "X11 Connection Received from %s:%u on channel %u",
+                       "X11 Connection Received from %.*s:%u on channel %u",
+                       (int)x11open_state->shost_len,
                        x11open_state->shost, x11open_state->sport,
                        x11open_state->sender_channel));
 


### PR DESCRIPTION
Use %.*s with parsed lengths and NULL guards when printing message/language in _libssh2_packet_add(). These fields are not NUL-terminated and may be absent; previous %s usage risked OOB reads or NULL deref (debug builds).