### PR TITLE
agent: pageant backend, bound reply copy, handle missing reply

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -721,7 +721,7 @@ agent_transact_pageant(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
         UnmapViewOfFile(p);
         CloseHandle(filemap);
         return _libssh2_error(agent->session, LIBSSH2_ERROR_AGENT_PROTOCOL,
-                              "pagent did not handle message");
+                              "pageant did not handle message");
     }
 
     UnmapViewOfFile(p);


### PR DESCRIPTION
The Pageant transact path trusted the 32-bit length in the shared memory
mapping and could memcpy past the mapped view. It also treated
a non-positive SendMessage(WM_COPYDATA) result as success.

Changes:

Reject replies when SendMessage returns ≤ 0 and report
LIBSSH2_ERROR_AGENT_PROTOCOL.

Bound the copy by validating response_len <= PAGEANT_MAX_MSGLEN - 4
(accounting for the length prefix) to avoid OOB reads.

Impact: prevents potential out-of-bounds read and use of uninitialized
mapping contents when Pageant misbehaves or is malicious.
