### PR TITLE
Dockerfile: pin Debian trixie image, enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,19 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    commit-message:
+      prefix: 'GHA:'
 
   - package-ecosystem: 'pip'
     directory: '/.github/workflows'
     schedule:
       interval: 'monthly'
+    commit-message:
+      prefix: 'GHA:'
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: 'GHA:'

--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright (C) Alexander Lamaison <alexander.lamaison@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM debian:stable-slim
+# To update, get the latest digest e.g. from https://hub.docker.com/_/debian/tags
+FROM debian:trixie-slim@sha256:c99c73388e005d98f2f131b15fa9389f2a8eec2888a35dc30455e5936467803b
 
 RUN apt-get update \
  && apt-get install -y openssh-server \


### PR DESCRIPTION
- pin Debian trixie Docker image to hash.
- set Dependabot to update the pin once every month.
- set Dependabot commit message prefixes to `GHA:` (to match curl).
