### PR TITLE
mbedtls: fix using garbage value (reported by clang-tidy)

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -760,6 +760,8 @@ _libssh2_mbedtls_pub_priv_key(LIBSSH2_SESSION *session,
                               "Key type not supported");
     }
 
+    ret = 0;
+
     /* write method */
     mthlen = 7;
     mth = LIBSSH2_ALLOC(session, mthlen);


### PR DESCRIPTION
In `_libssh2_mbedtls_pub_priv_key()` on a NON-error code path, a stack
variable was checked without initializing it first.

I found it interesting that clang-tidy did not find this when building
against the system mbedtls (2.x) with 2.x compatibility code still in.
Then it did find it when using a manual build of mbedtls 3.1.0 with
2.x compatibility code deleted from libssh2. Being such a trivial error
I wonder why no compiler ever detected it as a regular warning.

linux (clang-tidy, amd64, mbedTLS-prev [3.1.0], cmake, ON):
```
src/mbedtls.c:744:8: error: Branch condition evaluates to a garbage value [clang-analyzer-core.uninitialized.Branch,-warnings-as-errors]
  744 |     if(ret) {
      |        ^
```
Ref: https://github.com/libssh2/libssh2/actions/runs/18620615649/job/53091295760#step:22:44

Follow-up to 186f1a2d75560d960bc9ec0e727c14328f51ca4a #132
Cherry-picked from #1727
