### PR TITLE
Fix sftp_symlink when getting SSH_FXP_STATUS response

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -4012,7 +4012,7 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
         return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                               "SFTP Protocol Error (id)");
     }
- 
+
     if(packet_type == SSH_FXP_STATUS) {
         if(_libssh2_get_u32(&buf, &tmp_u32)) {
             LIBSSH2_FREE(session, data);


### PR DESCRIPTION
Move advancing past packet ID before reading the FXP_STATUS response.