### PR TITLE
GHA: replace deprecated `set-output` command with `$GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -56,7 +56,7 @@ jobs:
 
       - shell: bash
         id: hash
-        run: echo "::set-output name=hash::$(git rev-parse --short=20 HEAD:tests/openssh_server)"
+        run: echo "hash=$(git rev-parse --short=20 HEAD:tests/openssh_server)" >> "$GITHUB_OUTPUT"
 
       - shell: bash
         id: poll


### PR DESCRIPTION
Fixing:
```
Image build and push
The `set-output` command is deprecated and will be disabled soon. Please upgrade
to using Environment Files. For more information
see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
Ref: https://github.com/libssh2/libssh2/actions/runs/18667440406

Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#environment-files
