### PR TITLE
GHA: move config log dumps to their separate steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,6 +843,9 @@ jobs:
     name: 'msvc'
     runs-on: windows-2022
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -858,8 +861,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+
       - name: 'configure'
-        shell: bash
         env:
           MATRIX_ARCH: '${{ matrix.arch }}'
           MATRIX_CRYPTO: '${{ matrix.crypto }}'
@@ -900,6 +903,7 @@ jobs:
 
       - name: 'build'
         run: cmake --build bld --parallel 5 --target package --config Release
+
       - name: 'tests'
         # UWP binaries require a CRT DLL that is not found. Static CRT not supported.
         if: ${{ matrix.arch != 'arm64' && matrix.plat != 'uwp' }}


### PR DESCRIPTION
To make configure step output more readable in case of a build error.
To expose configure logs for successful builds without adding clutter.

Also:
- set shell globally for Windows jobs.
- move all Cygwin files to `D:`.
