### PR TITLE
cmake: save and restore `CMAKE_MODULE_PATH` in `libssh2-config.cmake`

### DIFF
--- a/cmake/libssh2-config.cmake.in
+++ b/cmake/libssh2-config.cmake.in
@@ -5,7 +5,7 @@ option(LIBSSH2_USE_PKGCONFIG "Enable pkg-config to detect @PROJECT_NAME@ depende
 
 include(CMakeFindDependencyMacro)
 
-set(_cmake_module_path_save ${CMAKE_MODULE_PATH})
+set(_libssh2_cmake_module_path_save ${CMAKE_MODULE_PATH})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
 set(_libs "")
@@ -26,7 +26,7 @@ if(@ZLIB_FOUND@)
   find_dependency(ZLIB)
 endif()
 
-set(CMAKE_MODULE_PATH ${_cmake_module_path_save})
+set(CMAKE_MODULE_PATH ${_libssh2_cmake_module_path_save})
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 


### PR DESCRIPTION
Bug: https://github.com/curl/curl/pull/16973#discussion_r2572957270
Follow-up to 82b09f9b3aae97f641fbcc2d746d2a6383abe857 #1322