### PR TITLE
channel: in channel_free, find all members in session structure with the channelpointer and free and clear those entries

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2890,11 +2890,11 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
     if(session->open_channel == channel) {
         session->open_channel = NULL;
         session->open_state = libssh2_NB_state_idle;
-        if (session->open_packet) {
+        if(session->open_packet) {
             LIBSSH2_FREE(session, session->open_packet);
             session->open_packet = NULL;
         }
-        if (session->open_data) {
+        if(session->open_data) {
             LIBSSH2_FREE(session, session->open_data);
             session->open_data = NULL;
         }
@@ -2902,7 +2902,7 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
     if(session->pkeyInit_channel == channel) {
         session->pkeyInit_channel = NULL;
         session->pkeyInit_state = libssh2_NB_state_idle;
-        if (session->pkeyInit_data) {
+        if(session->pkeyInit_data) {
             LIBSSH2_FREE(session, session->pkeyInit_data);
             session->pkeyInit_data = NULL;
         }
@@ -2914,7 +2914,7 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
     if(session->scpSend_channel == channel) {
         session->scpSend_channel = NULL;
         session->scpSend_state = libssh2_NB_state_idle;
-        if (session->scpSend_command) {
+        if(session->scpSend_command) {
             LIBSSH2_FREE(session, session->scpSend_command);
             session->scpSend_command = NULL;
         }
@@ -2922,7 +2922,7 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
     if(session->scpRecv_channel == channel) {
         session->scpRecv_channel = NULL;
         session->scpRecv_state = libssh2_NB_state_idle;
-        if (session->scpRecv_command) {
+        if(session->scpRecv_command) {
             LIBSSH2_FREE(session, session->scpRecv_command);
             session->scpRecv_command = NULL;
         }


### PR DESCRIPTION
In issue #1432 the code is getting a core dump in the second call to  libssh2_scp_send64(). The reason for the coredump is that the cleanup at the end is trying to channel_free() the channel found in the session structure, but this is the old channel that is free:d is the call to channel_free. 