### PR TITLE
Fix mbedTLS AES-CBC backend: avoid BAD_INPUT_DATA during cipher_finish() in SSH handshake

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -135,10 +135,10 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
     if(!ret) {
         mbedtls_cipher_type_t ctype =
             mbedtls_cipher_info_get_type(cipher_info);
-        if( ctype == MBEDTLS_CIPHER_AES_128_CBC ||
-            ctype == MBEDTLS_CIPHER_AES_192_CBC ||
-            ctype == MBEDTLS_CIPHER_AES_256_CBC ||
-            ctype == MBEDTLS_CIPHER_DES_EDE3_CBC) {
+        if(ctype == MBEDTLS_CIPHER_AES_128_CBC ||
+           ctype == MBEDTLS_CIPHER_AES_192_CBC ||
+           ctype == MBEDTLS_CIPHER_AES_256_CBC ||
+           ctype == MBEDTLS_CIPHER_DES_EDE3_CBC) {
             ret = mbedtls_cipher_set_padding_mode(ctx, MBEDTLS_PADDING_NONE);
         }
     }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -133,12 +133,10 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
      * set_padding_mode for CBC ciphers since other modes (CTR, stream)
      * are not applicable and will cause an error. */
     if(!ret) {
-        mbedtls_cipher_type_t ctype =
-            mbedtls_cipher_info_get_type(cipher_info);
-        if(ctype == MBEDTLS_CIPHER_AES_128_CBC ||
-           ctype == MBEDTLS_CIPHER_AES_192_CBC ||
-           ctype == MBEDTLS_CIPHER_AES_256_CBC ||
-           ctype == MBEDTLS_CIPHER_DES_EDE3_CBC) {
+        if(algo == MBEDTLS_CIPHER_AES_128_CBC ||
+           algo == MBEDTLS_CIPHER_AES_192_CBC ||
+           algo == MBEDTLS_CIPHER_AES_256_CBC ||
+           algo == MBEDTLS_CIPHER_DES_EDE3_CBC) {
             ret = mbedtls_cipher_set_padding_mode(ctx, MBEDTLS_PADDING_NONE);
         }
     }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -133,7 +133,11 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
      * set_padding_mode for CBC ciphers since other modes (CTR, stream)
      * are not applicable and will cause an error. */
     if (!ret) {
-        if (mbedtls_cipher_info_get_mode(cipher_info) == MBEDTLS_MODE_CBC) {
+        mbedtls_cipher_type_t ctype = mbedtls_cipher_info_get_type(cipher_info);
+        if (ctype == MBEDTLS_CIPHER_AES_128_CBC ||
+            ctype == MBEDTLS_CIPHER_AES_192_CBC ||
+            ctype == MBEDTLS_CIPHER_AES_256_CBC ||
+            ctype == MBEDTLS_CIPHER_DES_EDE3_CBC) {
             ret = mbedtls_cipher_set_padding_mode(ctx, MBEDTLS_PADDING_NONE);
         }
     }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -143,7 +143,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
         }
     }
 
-    if (!ret)
+    if(!ret)
         ret = mbedtls_cipher_setkey(ctx,
                   secret,
                   (int)mbedtls_cipher_info_get_key_bitlen(cipher_info),

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -132,9 +132,10 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
      * tell mbedTLS to expect no padding on the cipher layer. Only call
      * set_padding_mode for CBC ciphers since other modes (CTR, stream)
      * are not applicable and will cause an error. */
-    if (!ret) {
-        mbedtls_cipher_type_t ctype = mbedtls_cipher_info_get_type(cipher_info);
-        if (ctype == MBEDTLS_CIPHER_AES_128_CBC ||
+    if(!ret) {
+        mbedtls_cipher_type_t ctype =
+            mbedtls_cipher_info_get_type(cipher_info);
+        if( ctype == MBEDTLS_CIPHER_AES_128_CBC ||
             ctype == MBEDTLS_CIPHER_AES_192_CBC ||
             ctype == MBEDTLS_CIPHER_AES_256_CBC ||
             ctype == MBEDTLS_CIPHER_DES_EDE3_CBC) {

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -119,7 +119,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
     if(!ctx)
         return -1;
 
-    op = encrypt == 0 ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
+    op = encrypt ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
 
     cipher_info = mbedtls_cipher_info_from_type(algo);
     if(!cipher_info)
@@ -127,6 +127,11 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
 
     mbedtls_cipher_init(ctx);
     ret = mbedtls_cipher_setup(ctx, cipher_info);
+    /* libssh2 computes and adds SSH packet padding itself, so tell mbedTLS
+     * to expect no padding on the cipher layer. If this call fails, treat
+     * it as an init error so we don't end up with get_padding == NULL. */
+    if(!ret)
+        ret = mbedtls_cipher_set_padding_mode(ctx, MBEDTLS_PADDING_NONE);
     if(!ret)
         ret = mbedtls_cipher_setkey(ctx,
                   secret,


### PR DESCRIPTION
# Description

This PR fixes a reproducible failure in the mbedTLS backend of libssh2 when negotiating AES-CBC ciphers with certain SSH servers.

When libssh2 is built with mbedTLS (tested with mbedTLS 3.6.2), the library fails to encrypt the very first SSH packet after NEWKEYS when the chosen cipher is AES-XXX-CBC. The failure manifests as:

```shell
Failure establishing SSH session: -44
libssh2 last error: Unable to ask for ssh-userauth service
```

Tracing the mbedTLS backend reveals the root cause:

```shell
mbedTLS cipher_finish failed: ret = -24832 (MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA)
mbedTLS cipher_crypt failed
crypt name = aes256-cbc
```

This happens during the encryption of SSH_MSG_SERVICE_REQUEST (seqno=0), right after the KEX exchange succeeds.
The server → client traffic is irrelevant at that point; this is a pure client-side mbedTLS cipher failure.

# Reproduction steps

The issue can be reproduced with:

   - libssh2 master
   - mbedTLS 3.6.2
   - any SSH server that negotiates AES-128-CBC or AES-256-CBC
(confirmed with OpenSSH and a proprietary embedded SSH server)

Steps:

   1. Build libssh2 with mbedTLS backend.
   2. Connect to a server offering CBC ciphers.
   3. Let the negotiation select AES-CBC.
   4. Observe handshake failure right after NEWKEYS.

# Root cause analysis

1. Wrong interpretation of the `encrypt` flag

The code used:

```c
op = encrypt == 0 ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
```

which inverted the intended direction.
The fix correctly maps the flag:

```c
op = encrypt ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
```

2. Missing explicit padding configuration for mbedTLS

libssh2 handles SSH packet padding internally, so the cipher must operate with no padding.
Without explicitly setting this, mbedTLS rejects CBC operations during `cipher_finish()`.

The fix adds:

```c
mbedtls_cipher_set_padding_mode(ctx, MBEDTLS_PADDING_NONE);
```

This ensures that mbedTLS does not attempt to validate or add padding at the cipher layer.

# Related issues

Probably, this PR fixes #793

