### PR TITLE
Implemented gssapi-with-mic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,18 @@ if(HIDE_SYMBOLS)
   endif()
 endif()
 
+# GSSAPI
+option(LIBSSH2_GSSAPI_ENABLE "Build libssh2 with GSSAPI support" OFF)
+if(LIBSSH2_GSSAPI_ENABLE)
+    list(APPEND C_MAKE_FLAGS "-DUSE_GSSAPI")
+    if(WIN32)
+        list(APPEND LIBSSH2_LIBS "secur32")
+	    list(APPEND LIBSSH2_PICKY_C_FLAGS "-DUSE_GSSAPI")
+    else()
+        list(APPEND LIBSSH2_LIBS "gssapi_krb5")
+    endif()
+endif()
+
 # Options
 
 # Enable debugging logging by default if the user configured a debug build

--- a/docs/libssh2_userauth_gssapi_with_mic.md
+++ b/docs/libssh2_userauth_gssapi_with_mic.md
@@ -1,0 +1,37 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_userauth_gssapi_with_mic
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_userauth_gssapi_with_mic_ex(3)
+---
+
+# NAME
+
+libssh2_userauth_gsspi_with_mic - convenience macro for *libssh2_userauth_gsspi_with_mic_ex(3)* calls
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+int
+libssh2_userauth_gsspi_with_mic(LIBSSH2_SESSION *session,
+                          const char *username,
+                          const char *hostname);
+~~~
+
+# DESCRIPTION
+
+This is a macro defined in a public libssh2 header file that is using the
+underlying function *libssh2_userauth_gsspi_with_mic_ex(3)*.
+
+# RETURN VALUE
+
+See *libssh2_userauth_gsspi_with_mic_ex(3)*
+
+# ERRORS
+
+See *libssh2_userauth_gsspi_with_mic_ex(3)*

--- a/docs/libssh2_userauth_gssapi_with_mic_ex.md
+++ b/docs/libssh2_userauth_gssapi_with_mic_ex.md
@@ -1,0 +1,74 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_userauth_gsspi_with_mic_ex
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_session_init_ex(3)
+---
+
+# NAME
+
+libssh2_userauth_gsspi_with_mic_ex - authenticate a session with gssapi-with-mic
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+int
+libssh2_userauth_gsspi_with_mcic_ex(LIBSSH2_SESSION *session,
+                                    const char *username,
+                                    unsigned int username_len,
+                                    const char *hostname,
+                                    unsigned int hostname_len,
+                                    int delegation_flag);
+
+#define libssh2_userauth_gssapi_with_mic(session, username, hostname \
+     libssh2_userauth_gssapi_with_mic_ex((session), (username), \
+                                         strlen(username), \
+                                         (hostname, strlen(hostname, 0)
+~~~
+
+# DESCRIPTION
+
+*session* - Session instance as returned by libssh2_session_init_ex(3)
+
+*username* - Name of user to attempt gssapi-with-mic authentication for.
+
+*username_len* - Length of username parameter.
+
+*hostname* - Hostname for connection.
+
+*hostname_len* - Length of hostname parameter.
+
+*delegation_flag - Flag to indicate the delegated credential can be used on the host.
+
+Attempt gssapi-with-mic authentication. Note that username must be user@REALM
+where REALM is the FQDN of the Windows domain and must be in upper case.
+hostname must be FQDN. The client and the SSH-server must have joined the domain
+and have a valid Kerberos ticket.
+
+# RETURN VALUE
+
+Return 0 on success or negative on failure. A partial successful 
+authentication returns LIBSSH2_ERROR_PARTIAL_SUCCESS and further 
+authentication is needed. It returns LIBSSH2_ERROR_EAGAIN when it
+would otherwise block. While LIBSSH2_ERROR_PARTIAL_SUCCESS and
+LIBSSH2_ERROR_EAGAIN are negative numbers, they are not really failures per se.
+
+# ERRORS
+
+Some of the errors this function may return include:
+
+*LIBSSH2_ERROR_ALLOC* - An internal memory allocation call failed.
+
+*LIBSSH2_ERROR_SOCKET_SEND* - Unable to send data on socket.
+
+*LIBSSH2_ERROR_PASSWORD_EXPIRED* -
+
+*LIBSSH2_ERROR_AUTHENTICATION_FAILED* - failed, invalid username
+or Kerberos ticket invalid.
+
+*LIBSSH2_ERROR_GSSAPI_FAILURE* - An error during the GSSAPI exchange.

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -593,6 +593,10 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_MAC_FAILURE               -52
 #define LIBSSH2_ERROR_HASH_INIT                 -53
 #define LIBSSH2_ERROR_HASH_CALC                 -54
+#define LIBSSH2_ERROR_PARTIAL_SUCCESS           -55
+#ifdef LIBSSH2_GSSAPI
+#define LIBSSH2_ERROR_GSSAPI_FAILURE            -56
+#endif
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV
@@ -819,6 +823,22 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
                               LIBSSH2_USERAUTH_SK_SIGN_FUNC
                                   ((*sign_callback)),
                               void **abstract);
+
+#ifdef LIBSSH2_GSSAPI
+LIBSSH2_API int
+libssh2_userauth_gssapi_with_mic_ex(LIBSSH2_SESSION *session,
+                                 const char *username,
+                                 size_t username_len,
+                                 const char *hostname,
+                                 size_t hostname_len,
+                                 int delegation_flag);
+#define libssh2_userauth_gssapi_with_mic(session, username, hostname) \
+    libssh2_userauth_gssapi_with_mic_ex((session), (username), \
+                                 (size_t)strlen(username), \
+                                 (hostname), \
+                                 (size_t)strlen(hostname), \
+                                 0)
+#endif
 
 LIBSSH2_API int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds,
                              long timeout);

--- a/src/misc.c
+++ b/src/misc.c
@@ -302,6 +302,34 @@ int _libssh2_store_str(unsigned char **buf, const char *str, size_t len)
     assert(len_stored == len);
     return len_stored == len;
 }
+#ifdef LIBSSH2_GSSAPI
+/* _libssh2_store_u8
+ */
+void _libssh2_store_u8(unsigned char **buf, uint8_t value)
+{
+    unsigned char *ptr = *buf;
+
+    ptr[0] = (unsigned char)value;
+    *buf += sizeof(uint8_t);
+}
+
+/* _libssh2_store_bytes
+ */
+int _libssh2_store_bytes(unsigned char **buf,
+                         const unsigned char *mem,
+                         size_t len)
+{
+    uint32_t len_stored = (uint32_t)len;
+
+    if(len_stored) {
+        memcpy(*buf, mem, len_stored);
+        *buf += len_stored;
+    }
+
+    assert(len_stored == len);
+    return len_stored == len;
+}
+#endif
 
 /* _libssh2_store_bignum2_bytes
  */

--- a/src/misc.h
+++ b/src/misc.h
@@ -114,6 +114,12 @@ void _libssh2_htonu32(unsigned char *buf, uint32_t val);
 void _libssh2_store_u32(unsigned char **buf, uint32_t value);
 void _libssh2_store_u64(unsigned char **buf, libssh2_uint64_t value);
 int _libssh2_store_str(unsigned char **buf, const char *str, size_t len);
+#ifdef LIBSSH2_GSSAPI
+void _libssh2_store_u8(unsigned char **buf, uint8_t value);
+int _libssh2_store_bytes(unsigned char **buf,
+                         const unsigned char *mem,
+                         size_t len);
+#endif
 int _libssh2_store_bignum2_bytes(unsigned char **buf,
                                  const unsigned char *bytes,
                                  size_t len);


### PR DESCRIPTION
I have implemented authentication gssapi-with-mic (Issue #707) as described by RFC4462, without gssapi KEX implementation. The implementation also handles partial success (new error LIBSSH2_ERROR_PARTIAL_SUCCESS, the same as pull request #1757) and USERAUTH_BANNER during message exchange. Errors in GSSAPI handling are returned as LIBSSH2_ERROR_GSSAPI_FAILURE. I have a working example/ssh2 on both Linux and Windows (I only add call to libssh2_userauth_gssapi_with_mic() in ssh2.c) Test have been made on Linux (with command kinit first) and Windows (logged in as domain user aduser01). The domain is SYSTEM.SE (uppercase is needed for Kerberos to work…) and the name of the SSH-server is sl.system.se. The linux client and the linux SSH-server is a member of the domain. example/ssh2 sl.system.se aduser01@SYSTEM.SE "" -K date and the date of the server is displayed.
The new functions are
```
int libssh2_userauth_gssapi_with_mic(LIBSSH2_SESSION *session,
                                                                      const char *username,
                                                                      const char *hostname)
int libssh2_userauth_gssapi_with_mic_ex(LIBSSH2_SESSION *session,
                                                                             const char *username,
                                                                             size_t username_len,
                                                                             const char *hostname,
                                                                             size_t hostname_len,
                                                                             int delegation_flag);
```
where hostname is the host (not IP) used in the connection. Delegation_flag is set to false (0) when libssh2_userauth_gssapi_with_mic() is called Changes are made in the following files (all with “#ifdef LIBSSH2_GSSAPI” for the added code): src/misc.[ch]:
added function void _libssh2_store_u8(unsigned char **buf, uint8_t value) and int _libssh2_store_bytes(unsigned char **buf, const unsigned char *mem, size_t len) _libssh2_store_bytes() is needed due to the length in one message is u8 (and not u32) src/userauth.c: Main implementation (approx. 1200 lines) src/libssh2_priv.h: additional members of session structure and new MSG-definitions include/libssh2.h: function definition and new error codes examples/ssh2.c: code to use new function incl. handling of hostname instead of IP-address (attached) docs/libssh2_userauth_gssapi_with_mic.md and /libssh2_userauth_gssapi_with_mic_ex.md; New man-pages CMakeLists.txt: option -DLIBSSH2_GSSAPI_ENABLE=ON enables this function and additional libraries needed are added.
