### PR TITLE
mbedtls: add GCM support

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -324,7 +324,8 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
                 memcpy(block + blocksize - authlen, tag, authlen);
             }
             else {
-                if(memcmp(tag, block + blocksize - authlen, authlen) != 0)
+                if(_libssh2_timingsafe_bcmp(tag, block + blocksize - authlen,
+                                            authlen) != 0)
                     return MBEDTLS_ERR_GCM_AUTH_FAILED;
             }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -177,8 +177,8 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
             return -1;
         }
 
-            /* Store the context pointer */
-        *(void **)ctx = cctx;
+        /* Store the context pointer */
+        *(void **)h = cctx;
         return 0;
     }
 #endif
@@ -230,7 +230,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
         }
 
         /* Store the context pointer */
-        *(void **)ctx = cctx;
+        *(void **)h = cctx;
         return 0;
     }
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -57,6 +57,28 @@ static mbedtls_ctr_drbg_context _libssh2_mbedtls_ctr_drbg;
 
 /*******************************************************************/
 /*
+ * mbedTLS backend: Unified cipher context structure
+ *
+ * This structure handles both regular ciphers and AEAD ciphers (GCM)
+ * using a union to optimize memory usage.
+ */
+
+typedef struct {
+    mbedtls_cipher_type_t algo;
+    int encrypt;
+    union {
+        mbedtls_cipher_context_t cipher_ctx;
+#if LIBSSH2_AES_GCM
+        struct {
+            mbedtls_gcm_context gcm_ctx;
+            unsigned char iv[12];
+        } gcm;
+#endif
+    } ctx;
+} _libssh2_mbedtls_cipher_ctx;
+
+/*******************************************************************/
+/*
  * mbedTLS backend: Generic functions
  */
 
@@ -109,45 +131,107 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
                              unsigned char *secret,
                              int encrypt)
 {
-    const mbedtls_cipher_info_t *cipher_info;
-    int ret, op;
+    _libssh2_mbedtls_cipher_ctx *cctx;
+    int ret;
 
     if(!h)
         return -1;
 
-    op = encrypt ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
-
-    cipher_info = mbedtls_cipher_info_from_type(algo);
-    if(!cipher_info)
+    /* Allocate unified context structure */
+    cctx = (_libssh2_mbedtls_cipher_ctx *)
+           mbedtls_calloc(1, sizeof(_libssh2_mbedtls_cipher_ctx));
+    if(!cctx)
         return -1;
 
-    mbedtls_cipher_init(h);
-    ret = mbedtls_cipher_setup(h, cipher_info);
+    /* Store algorithm type and encryption flag */
+    cctx->algo = algo;
+    cctx->encrypt = encrypt;
 
-    /* libssh2 computes and adds SSH packet padding itself, so for CBC
-     * tell mbedTLS to expect no padding on the cipher layer. Only call
-     * set_padding_mode for CBC ciphers since other modes (CTR, stream)
-     * are not applicable and will cause an error. */
-    if(!ret) {
-        if(algo == MBEDTLS_CIPHER_AES_128_CBC ||
-           algo == MBEDTLS_CIPHER_AES_192_CBC ||
-           algo == MBEDTLS_CIPHER_AES_256_CBC ||
-           algo == MBEDTLS_CIPHER_DES_EDE3_CBC) {
-            ret = mbedtls_cipher_set_padding_mode(h, MBEDTLS_PADDING_NONE);
+#if LIBSSH2_AES_GCM
+    /* Check if this is a GCM algorithm */
+    if(algo == MBEDTLS_CIPHER_AES_128_GCM ||
+       algo == MBEDTLS_CIPHER_AES_256_GCM) {
+        unsigned int keybits;
+
+        /* Store the initial IV (will be incremented per packet) */
+        memcpy(cctx->ctx.gcm.iv, iv, 12);
+
+        /* Initialize GCM context */
+        mbedtls_gcm_init(&cctx->ctx.gcm.gcm_ctx);
+
+        /* Set key length based on algorithm */
+        if(algo == MBEDTLS_CIPHER_AES_128_GCM)
+            keybits = 128;
+        else /* MBEDTLS_CIPHER_AES_256_GCM */
+            keybits = 256;
+
+        /* Setup GCM with AES cipher and key */
+        ret = mbedtls_gcm_setkey(&cctx->ctx.gcm.gcm_ctx,
+                                 MBEDTLS_CIPHER_ID_AES,
+                                 secret,
+                                 keybits);
+
+        if(ret) {
+            mbedtls_gcm_free(&cctx->ctx.gcm.gcm_ctx);
+            mbedtls_free(cctx);
+            return -1;
         }
+
+            /* Store the context pointer */
+        *(void **)ctx = cctx;
+        return 0;
     }
+#endif
 
-    if(!ret)
-        ret = mbedtls_cipher_setkey(h,
-                  secret,
-                  (int)mbedtls_cipher_info_get_key_bitlen(cipher_info),
-                  op);
+    /* Non-GCM algorithms: use standard cipher API */
+    {
+        const mbedtls_cipher_info_t *cipher_info;
+        int op;
 
-    if(!ret)
-        ret = mbedtls_cipher_set_iv(h, iv,
-                  mbedtls_cipher_info_get_iv_size(cipher_info));
+        op = encrypt ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
 
-    return ret == 0 ? 0 : -1;
+        cipher_info = mbedtls_cipher_info_from_type(algo);
+        if(!cipher_info) {
+            mbedtls_free(cctx);
+            return -1;
+        }
+
+        mbedtls_cipher_init(&cctx->ctx.cipher_ctx);
+        ret = mbedtls_cipher_setup(&cctx->ctx.cipher_ctx, cipher_info);
+
+        /* libssh2 computes and adds SSH packet padding itself, so for CBC
+         * tell mbedTLS to expect no padding on the cipher layer. Only call
+         * set_padding_mode for CBC ciphers since other modes (CTR, stream)
+         * are not applicable and will cause an error. */
+        if(!ret) {
+            if(algo == MBEDTLS_CIPHER_AES_128_CBC ||
+               algo == MBEDTLS_CIPHER_AES_192_CBC ||
+               algo == MBEDTLS_CIPHER_AES_256_CBC ||
+               algo == MBEDTLS_CIPHER_DES_EDE3_CBC) {
+                ret = mbedtls_cipher_set_padding_mode(&cctx->ctx.cipher_ctx, MBEDTLS_PADDING_NONE);
+            }
+        }
+
+        if(!ret)
+            ret = mbedtls_cipher_setkey(&cctx->ctx.cipher_ctx,
+                      secret,
+                      (int)mbedtls_cipher_info_get_key_bitlen(cipher_info),
+                      op);
+
+        if(!ret)
+            ret = mbedtls_cipher_set_iv(&cctx->ctx.cipher_ctx, iv,
+                      mbedtls_cipher_info_get_iv_size(cipher_info));
+
+        if(ret) {
+            mbedtls_cipher_free(&cctx->ctx.cipher_ctx);
+            mbedtls_free(cctx);
+            return -1;
+        }
+
+        /* Store the context pointer */
+        *(void **)ctx = cctx;
+        return 0;
+    }
 }
 
 int
@@ -157,43 +241,156 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
                               unsigned char *block,
                               size_t blocksize, int firstlast)
 {
+    _libssh2_mbedtls_cipher_ctx *cctx;
     int ret;
-    unsigned char *output;
-    size_t osize, olen, finish_olen;
 
-    (void)encrypt;
+    cctx = *(_libssh2_mbedtls_cipher_ctx **)ctx;
+    if(!cctx)
+        return -1;
+
     (void)algo;
-    (void)firstlast;
+    (void)encrypt;
 
-    osize = blocksize + mbedtls_cipher_get_block_size(ctx);
+#if LIBSSH2_AES_GCM
+    /* Check if this is a GCM algorithm based on stored algo type */
+    if(cctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
+       cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
+        const int authlen = 16;  /* GCM authentication tag length */
+        const int aadlen = (IS_FIRST(firstlast)) ? 4 : 0;
+        const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
+        const int cryptlen = (int)blocksize - aadlen - authenticationtag;
+        unsigned char tag[16];
+        unsigned char *buf = NULL;
 
-    output = (unsigned char *)mbedtls_calloc(osize, sizeof(char));
-    if(output) {
-        ret = mbedtls_cipher_reset(ctx);
-
-        if(!ret)
-            ret = mbedtls_cipher_update(ctx, block, blocksize, output, &olen);
-
-        if(!ret)
-            ret = mbedtls_cipher_finish(ctx, output + olen, &finish_olen);
-
-        if(!ret) {
-            olen += finish_olen;
-            memcpy(block, output, olen);
+        /* Allocate temporary buffer for output */
+        if(cryptlen > 0) {
+            buf = (unsigned char *)mbedtls_calloc(cryptlen, 1);
+            if(!buf)
+                return -1;
         }
 
-        _libssh2_mbedtls_safe_free(output, osize);
-    }
-    else
-        ret = -1;
+        /* First block: start GCM operation */
+        if(IS_FIRST(firstlast)) {
+            ret = mbedtls_gcm_starts(&cctx->ctx.gcm.gcm_ctx,
+                                     cctx->encrypt ? MBEDTLS_GCM_ENCRYPT :
+                                                     MBEDTLS_GCM_DECRYPT,
+                                     cctx->ctx.gcm.iv, 12);
+            if(ret) {
+                if(buf)
+                    mbedtls_free(buf);
+                return -1;
+            }
 
-    return ret == 0 ? 0 : -1;
+            /* Process AAD (Additional Authenticated Data) */
+            if(aadlen) {
+                ret = mbedtls_gcm_update_ad(&cctx->ctx.gcm.gcm_ctx,
+                                            block, aadlen);
+                if(ret) {
+                    if(buf)
+                        mbedtls_free(buf);
+                    return -1;
+                }
+            }
+        }
+
+        /* Process payload */
+        if(cryptlen > 0) {
+            size_t olen = 0;
+            ret = mbedtls_gcm_update(&cctx->ctx.gcm.gcm_ctx,
+                                     block + aadlen, cryptlen,
+                                     buf, cryptlen, &olen);
+            if(ret) {
+                mbedtls_free(buf);
+                return -1;
+            }
+            memcpy(block + aadlen, buf, olen);
+            mbedtls_free(buf);
+        }
+
+        /* Last block: finalize and handle authentication tag */
+        if(IS_LAST(firstlast)) {
+            size_t olen_finish = 0;
+            unsigned char finish_buf[16];
+            int i;
+
+            ret = mbedtls_gcm_finish(&cctx->ctx.gcm.gcm_ctx,
+                                    finish_buf, sizeof(finish_buf),
+                                    &olen_finish, tag, authlen);
+            if(ret)
+                return -1;
+
+            if(cctx->encrypt) {
+                memcpy(block + blocksize - authlen, tag, authlen);
+            }
+            else {
+                if(memcmp(tag, block + blocksize - authlen, authlen) != 0)
+                    return MBEDTLS_ERR_GCM_AUTH_FAILED;
+            }
+
+            /* Increment IV for next packet */
+            for(i = 11; i >= 4; i--) {
+                if(++cctx->ctx.gcm.iv[i] != 0)
+                    break;
+            }
+        }
+
+        return 0;
+    }
+#endif
+
+    /* Non-GCM algorithms: use standard cipher API */
+    {
+        unsigned char *output;
+        size_t osize, olen, finish_olen;
+
+        (void)firstlast;
+
+        osize = blocksize + mbedtls_cipher_get_block_size(&cctx->ctx.cipher_ctx);
+
+        output = (unsigned char *)mbedtls_calloc(osize, sizeof(char));
+        if(output) {
+            ret = mbedtls_cipher_reset(&cctx->ctx.cipher_ctx);
+
+            if(!ret)
+                ret = mbedtls_cipher_update(&cctx->ctx.cipher_ctx, block, blocksize, output, &olen);
+
+            if(!ret)
+                ret = mbedtls_cipher_finish(&cctx->ctx.cipher_ctx, output + olen, &finish_olen);
+
+            if(!ret) {
+                olen += finish_olen;
+                memcpy(block, output, olen);
+            }
+
+            _libssh2_mbedtls_safe_free(output, osize);
+        }
+        else
+            ret = -1;
+
+        return ret == 0 ? 0 : -1;
+    }
 }
 
 void
 _libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx)
 {
-    mbedtls_cipher_free(ctx);
+    _libssh2_mbedtls_cipher_ctx *cctx = *(_libssh2_mbedtls_cipher_ctx **)ctx;
+
+    if(!cctx)
+        return;
+
+#if LIBSSH2_AES_GCM
+    if(cctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
+       cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
+        mbedtls_gcm_free(&cctx->ctx.gcm.gcm_ctx);
+        mbedtls_free(cctx);
+        return;
+    }
+#endif
+
+    /* Regular cipher context */
+    mbedtls_cipher_free(&cctx->ctx.cipher_ctx);
+    mbedtls_free(cctx);
 }
 
 int

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -208,7 +208,8 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
                algo == MBEDTLS_CIPHER_AES_192_CBC ||
                algo == MBEDTLS_CIPHER_AES_256_CBC ||
                algo == MBEDTLS_CIPHER_DES_EDE3_CBC) {
-                ret = mbedtls_cipher_set_padding_mode(&cctx->ctx.cipher_ctx, MBEDTLS_PADDING_NONE);
+                ret = mbedtls_cipher_set_padding_mode(&cctx->ctx.cipher_ctx,
+                                                      MBEDTLS_PADDING_NONE);
             }
         }
 
@@ -329,7 +330,7 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
 
             /* Increment IV for next packet */
             for(i = 11; i >= 4; i--) {
-                if(++cctx->ctx.gcm.iv[i] != 0)
+                if(++cctx->ctx.gcm.iv[i])
                     break;
             }
         }
@@ -345,17 +346,20 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
 
         (void)firstlast;
 
-        osize = blocksize + mbedtls_cipher_get_block_size(&cctx->ctx.cipher_ctx);
+        osize = blocksize +
+                mbedtls_cipher_get_block_size(&cctx->ctx.cipher_ctx);
 
         output = (unsigned char *)mbedtls_calloc(osize, sizeof(char));
         if(output) {
             ret = mbedtls_cipher_reset(&cctx->ctx.cipher_ctx);
 
             if(!ret)
-                ret = mbedtls_cipher_update(&cctx->ctx.cipher_ctx, block, blocksize, output, &olen);
+                ret = mbedtls_cipher_update(&cctx->ctx.cipher_ctx, block,
+                                            blocksize, output, &olen);
 
             if(!ret)
-                ret = mbedtls_cipher_finish(&cctx->ctx.cipher_ctx, output + olen, &finish_olen);
+                ret = mbedtls_cipher_finish(&cctx->ctx.cipher_ctx,
+                                            output + olen, &finish_olen);
 
             if(!ret) {
                 olen += finish_olen;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -379,7 +379,8 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
 void
 _libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx)
 {
-    struct _libssh2_mbedtls_cipher_ctx *cctx = *(struct _libssh2_mbedtls_cipher_ctx **)ctx;
+    struct _libssh2_mbedtls_cipher_ctx *cctx =
+        *(struct _libssh2_mbedtls_cipher_ctx **)ctx;
 
     if(!cctx)
         return;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -125,7 +125,7 @@ _libssh2_mbedtls_safe_free(void *buf, size_t len)
 }
 
 int
-_libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
+_libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
                              _libssh2_cipher_type(algo),
                              unsigned char *iv,
                              unsigned char *secret,
@@ -134,7 +134,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
     _libssh2_mbedtls_cipher_ctx *cctx;
     int ret;
 
-    if(!h)
+    if(!ctx)
         return -1;
 
     /* Allocate unified context structure */
@@ -177,8 +177,8 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
             return -1;
         }
 
-        /* Store the context pointer */
-        *(void **)h = cctx;
+            /* Store the context pointer */
+        *(void **)ctx = cctx;
         return 0;
     }
 #endif
@@ -230,7 +230,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
         }
 
         /* Store the context pointer */
-        *(void **)h = cctx;
+        *(void **)ctx = cctx;
         return 0;
     }
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -57,28 +57,6 @@ static mbedtls_ctr_drbg_context _libssh2_mbedtls_ctr_drbg;
 
 /*******************************************************************/
 /*
- * mbedTLS backend: Unified cipher context structure
- *
- * This structure handles both regular ciphers and AEAD ciphers (GCM)
- * using a union to optimize memory usage.
- */
-
-struct _libssh2_mbedtls_cipher_ctx {
-    mbedtls_cipher_type_t algo;
-    int encrypt;
-    union {
-        mbedtls_cipher_context_t cipher_ctx;
-#if LIBSSH2_AES_GCM
-        struct {
-            mbedtls_gcm_context gcm_ctx;
-            unsigned char iv[12];
-        } gcm;
-#endif
-    } ctx;
-};
-
-/*******************************************************************/
-/*
  * mbedTLS backend: Generic functions
  */
 
@@ -177,8 +155,8 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
             return -1;
         }
 
-            /* Store the context pointer */
-        *(void **)h = cctx;
+        /* Store the context pointer */
+        *h = cctx;
         return 0;
     }
 #endif
@@ -230,7 +208,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
         }
 
         /* Store the context pointer */
-        *(void **)h = cctx;
+        *h = cctx;
         return 0;
     }
 }
@@ -245,7 +223,7 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
     struct _libssh2_mbedtls_cipher_ctx *cctx;
     int ret;
 
-    cctx = *(struct _libssh2_mbedtls_cipher_ctx **)ctx;
+    cctx = *ctx;
     if(!cctx)
         return -1;
 
@@ -377,8 +355,7 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
 void
 _libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx)
 {
-    struct _libssh2_mbedtls_cipher_ctx *cctx =
-        *(struct _libssh2_mbedtls_cipher_ctx **)ctx;
+    struct _libssh2_mbedtls_cipher_ctx *cctx = *ctx;
 
     if(!cctx)
         return;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -365,6 +365,7 @@ _libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx)
        cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
         mbedtls_gcm_free(&cctx->ctx.gcm.gcm_ctx);
         mbedtls_free(cctx);
+        *ctx = NULL;
         return;
     }
 #endif
@@ -372,6 +373,7 @@ _libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx)
     /* Regular cipher context */
     mbedtls_cipher_free(&cctx->ctx.cipher_ctx);
     mbedtls_free(cctx);
+    *ctx = NULL;
 }
 
 int

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -257,7 +257,7 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
     if(cctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
        cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
         const int authlen = 16;  /* GCM authentication tag length */
-        const int aadlen = (IS_FIRST(firstlast)) ? 4 : 0;
+        const int aadlen = IS_FIRST(firstlast) ? 4 : 0;
         const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
         const int cryptlen = (int)blocksize - aadlen - authenticationtag;
         unsigned char tag[16];

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -125,7 +125,7 @@ _libssh2_mbedtls_safe_free(void *buf, size_t len)
 }
 
 int
-_libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
+_libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
                              _libssh2_cipher_type(algo),
                              unsigned char *iv,
                              unsigned char *secret,
@@ -134,7 +134,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
     _libssh2_mbedtls_cipher_ctx *cctx;
     int ret;
 
-    if(!ctx)
+    if(!h)
         return -1;
 
     /* Allocate unified context structure */
@@ -178,7 +178,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
         }
 
             /* Store the context pointer */
-        *(void **)ctx = cctx;
+        *(void **)h = cctx;
         return 0;
     }
 #endif
@@ -230,7 +230,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *ctx,
         }
 
         /* Store the context pointer */
-        *(void **)ctx = cctx;
+        *(void **)h = cctx;
         return 0;
     }
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -277,8 +277,7 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
                                                      MBEDTLS_GCM_DECRYPT,
                                      cctx->ctx.gcm.iv, 12);
             if(ret) {
-                if(buf)
-                    mbedtls_free(buf);
+                _libssh2_mbedtls_safe_free(buf, cryptlen);
                 return -1;
             }
 
@@ -287,8 +286,7 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
                 ret = mbedtls_gcm_update_ad(&cctx->ctx.gcm.gcm_ctx,
                                             block, aadlen);
                 if(ret) {
-                    if(buf)
-                        mbedtls_free(buf);
+                    _libssh2_mbedtls_safe_free(buf, cryptlen);
                     return -1;
                 }
             }
@@ -301,11 +299,11 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
                                      block + aadlen, cryptlen,
                                      buf, cryptlen, &olen);
             if(ret) {
-                mbedtls_free(buf);
+                _libssh2_mbedtls_safe_free(buf, cryptlen);
                 return -1;
             }
             memcpy(block + aadlen, buf, olen);
-            mbedtls_free(buf);
+            _libssh2_mbedtls_safe_free(buf, cryptlen);
         }
 
         /* Last block: finalize and handle authentication tag */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -63,7 +63,7 @@ static mbedtls_ctr_drbg_context _libssh2_mbedtls_ctr_drbg;
  * using a union to optimize memory usage.
  */
 
-typedef struct {
+struct _libssh2_mbedtls_cipher_ctx {
     mbedtls_cipher_type_t algo;
     int encrypt;
     union {
@@ -75,7 +75,7 @@ typedef struct {
         } gcm;
 #endif
     } ctx;
-} _libssh2_mbedtls_cipher_ctx;
+};
 
 /*******************************************************************/
 /*
@@ -131,15 +131,15 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
                              unsigned char *secret,
                              int encrypt)
 {
-    _libssh2_mbedtls_cipher_ctx *cctx;
+    struct _libssh2_mbedtls_cipher_ctx *cctx;
     int ret;
 
     if(!h)
         return -1;
 
     /* Allocate unified context structure */
-    cctx = (_libssh2_mbedtls_cipher_ctx *)
-           mbedtls_calloc(1, sizeof(_libssh2_mbedtls_cipher_ctx));
+    cctx = (struct _libssh2_mbedtls_cipher_ctx *)
+           mbedtls_calloc(1, sizeof(struct _libssh2_mbedtls_cipher_ctx));
     if(!cctx)
         return -1;
 
@@ -242,10 +242,10 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
                               unsigned char *block,
                               size_t blocksize, int firstlast)
 {
-    _libssh2_mbedtls_cipher_ctx *cctx;
+    struct _libssh2_mbedtls_cipher_ctx *cctx;
     int ret;
 
-    cctx = *(_libssh2_mbedtls_cipher_ctx **)ctx;
+    cctx = *(struct _libssh2_mbedtls_cipher_ctx **)ctx;
     if(!cctx)
         return -1;
 
@@ -379,7 +379,7 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
 void
 _libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx)
 {
-    _libssh2_mbedtls_cipher_ctx *cctx = *(_libssh2_mbedtls_cipher_ctx **)ctx;
+    struct _libssh2_mbedtls_cipher_ctx *cctx = *(struct _libssh2_mbedtls_cipher_ctx **)ctx;
 
     if(!cctx)
         return;

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -337,7 +337,26 @@ typedef enum {
  * mbedTLS backend: Cipher Context structure
  */
 
-#define _libssh2_cipher_ctx         mbedtls_cipher_context_t
+/*
+ * Unified cipher context structure.
+ * Handles both regular ciphers and AEAD ciphers (GCM)
+ * using a union to optimize memory usage.
+ */
+struct _libssh2_mbedtls_cipher_ctx {
+    mbedtls_cipher_type_t algo;
+    int encrypt;
+    union {
+        mbedtls_cipher_context_t cipher_ctx;
+#if LIBSSH2_AES_GCM
+        struct {
+            mbedtls_gcm_context gcm_ctx;
+            unsigned char iv[12];
+        } gcm;
+#endif
+    } ctx;
+};
+
+#define _libssh2_cipher_ctx         struct _libssh2_mbedtls_cipher_ctx *
 
 #define _libssh2_cipher_type(algo)  mbedtls_cipher_type_t algo
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -361,8 +361,8 @@ typedef enum {
  * mbedTLS backend: Cipher functions
  */
 
-#define _libssh2_cipher_init(ctx, type, iv, secret, encrypt) \
-    _libssh2_mbedtls_cipher_init(ctx, type, iv, secret, encrypt)
+#define _libssh2_cipher_init(h, type, iv, secret, encrypt) \
+    _libssh2_mbedtls_cipher_init(h, type, iv, secret, encrypt)
 #define _libssh2_cipher_crypt(ctx, type, encrypt, block, blocklen, fl) \
     _libssh2_mbedtls_cipher_crypt(ctx, type, encrypt, block, blocklen, fl)
 #define _libssh2_cipher_dtor(ctx) \

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -47,6 +47,7 @@
 #include <mbedtls/rsa.h>
 #include <mbedtls/bignum.h>
 #include <mbedtls/cipher.h>
+#include <mbedtls/gcm.h>
 #ifdef MBEDTLS_ECDH_C
 # include <mbedtls/ecdh.h>
 #endif
@@ -67,7 +68,7 @@
 
 #define LIBSSH2_AES_CBC         1
 #define LIBSSH2_AES_CTR         1
-#define LIBSSH2_AES_GCM         0
+#define LIBSSH2_AES_GCM         1
 #ifdef MBEDTLS_CIPHER_BLOWFISH_CBC
 # define LIBSSH2_BLOWFISH       1
 #else
@@ -373,6 +374,8 @@ struct _libssh2_mbedtls_cipher_ctx {
 #define _libssh2_cipher_arcfour   MBEDTLS_CIPHER_ARC4_128
 #endif
 #define _libssh2_cipher_3des      MBEDTLS_CIPHER_DES_EDE3_CBC
+#define _libssh2_cipher_aes128gcm MBEDTLS_CIPHER_AES_128_GCM
+#define _libssh2_cipher_aes256gcm MBEDTLS_CIPHER_AES_256_GCM
 #define _libssh2_cipher_chacha20  MBEDTLS_CIPHER_CHACHA20_POLY1305
 
 /*******************************************************************/


### PR DESCRIPTION
# Add AES-GCM support for mbedTLS backend

## Summary
This PR implements AES-128-GCM and AES-256-GCM cipher support for the mbedTLS backend, enabling connections to SSH servers that require GCM encryption algorithms.

## Problem
The mbedTLS backend had GCM support disabled (`LIBSSH2_AES_GCM = 0`) even though mbedTLS provides full GCM implementation through its `mbedtls_gcm_*` API.

## Changes

### mbedtls.h
- Enabled GCM support: `#define LIBSSH2_AES_GCM 1`
- Added `#include <mbedtls/gcm.h>`
- Defined algorithm mappings for `_libssh2_cipher_aes128gcm` and `_libssh2_cipher_aes256gcm`

### mbedtls.c
- Created unified cipher context structure `_libssh2_mbedtls_cipher_ctx` with union to handle both regular ciphers and GCM
- Modified `_libssh2_mbedtls_cipher_init()` to initialize GCM contexts with proper key setup
- Implemented GCM operations in `_libssh2_mbedtls_cipher_crypt()`:
  - AAD (Additional Authenticated Data) processing for SSH packet length
  - Encryption/decryption with proper IV management
  - Authentication tag generation and verification (16 bytes)
  - IV increment after each packet (last 8 bytes of 12-byte IV)
- Updated `_libssh2_mbedtls_cipher_dtor()` to properly free GCM contexts

## Technical Details
- GCM uses mbedTLS native API (`mbedtls_gcm_starts/update_ad/update/finish`) rather than generic cipher API
- IV structure: 4 bytes fixed + 8 bytes invocation counter (incremented per packet)
- SSH GCM packet format: 4-byte AAD + encrypted payload + 16-byte auth tag

## Testing
Tested successfully with SFTP servers requiring GCM-only encryption.

## Related
This PR has been built including bugfix of #1758 