### PR TITLE
appveyor: disable last Windows test job, now completely broken

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,7 +131,6 @@ environment:
       PLATFORM: 'x86'
       CRYPTO_BACKEND: 'WinCNG'
       ENABLE_ECDSA_WINCNG: 'ON'
-      SKIP_CTEST: 'no'
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
After this, libssh2 is left without runtime tests on Windows in CI.

```
Waiting for SSH connection from GitHub Actions....[..].... failed.
```
Ref: https://ci.appveyor.com/project/libssh2org/libssh2/builds/53276260/job/7hom25cx4q8kf3pv (OpenSSL)
Ref: https://ci.appveyor.com/project/libssh2org/libssh2/builds/53289394/job/rxbker53liv2nqb2 (OpenSSL)
Ref: https://ci.appveyor.com/project/libssh2org/libssh2/builds/53289591/job/gf2xfpn9cq40ey0l (WinCNG)
