### PR TITLE
tidy-up: parenthesis in macros (OS400)

### DIFF
--- a/os400/ccsid.c
+++ b/os400/ccsid.c
@@ -58,8 +58,7 @@
 #define OFFSET_OF(t, f) ((size_t) ((char *) &((t *) 0)->f - (char *) 0))
 
 #define ALLOC(s, sz)        ((s) ? LIBSSH2_ALLOC(s, sz) : malloc(sz))
-#define REALLOC(s, p, sz)   ((s) ? LIBSSH2_REALLOC(s, p, sz)          \
-                                 : realloc(p, sz))
+#define REALLOC(s, p, sz)   ((s) ? LIBSSH2_REALLOC(s, p, sz) : realloc(p, sz))
 #define FREE(s, p)          ((s) ? LIBSSH2_FREE(s, p) : free(p))
 
 struct _libssh2_string_cache {


### PR DESCRIPTION
Follow-up to d97d8e31980a514c50c289836c4489ee8ffec634 #1773
