### PR TITLE
hostkey: prefer ED25519 over ECDSA in hostkey algorithm negotiation

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -1337,6 +1337,10 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_ed25519_cert = {
 #endif /* LIBSSH2_ED25519 */
 
 static const LIBSSH2_HOSTKEY_METHOD *hostkey_methods[] = {
+#if LIBSSH2_ED25519
+    &hostkey_method_ssh_ed25519,
+    &hostkey_method_ssh_ed25519_cert,
+#endif
 #if LIBSSH2_ECDSA
     &hostkey_method_ecdsa_ssh_nistp256,
     &hostkey_method_ecdsa_ssh_nistp384,
@@ -1344,10 +1348,6 @@ static const LIBSSH2_HOSTKEY_METHOD *hostkey_methods[] = {
     &hostkey_method_ecdsa_ssh_nistp256_cert,
     &hostkey_method_ecdsa_ssh_nistp384_cert,
     &hostkey_method_ecdsa_ssh_nistp521_cert,
-#endif
-#if LIBSSH2_ED25519
-    &hostkey_method_ssh_ed25519,
-    &hostkey_method_ssh_ed25519_cert,
 #endif
 #if LIBSSH2_RSA
 #if LIBSSH2_RSA_SHA2


### PR DESCRIPTION
Reorders the hostkey_methods array to prioritize ED25519 host keys over ECDSA curves, aligning libssh2 with OpenSSH's default behavior. 

As noted in issue #1782, industry usage has shifted to prefer ED25519

Previous order:
ECDSA (nistp256/384/521 + certificates)
**ED25519 (ssh-ed25519 + certificates)**
RSA (SHA2-512, SHA2-256, SHA1)
DSA

New order:
**ED25519 (ssh-ed25519 + certificates)**
ECDSA (nistp256/384/521 + certificates)
RSA (SHA2-512, SHA2-256, SHA1)
DSA

Testing:
Existing test suites should pass without modification

References:
OpenSSH HostKeyAlgorithms default order: 
- https://man.openbsd.org/sshd_config#HostKeyAlgorithms
- https://man.openbsd.org/ssh_config#HostKeyAlgorithms

Fixes #1782
