### PR TITLE
scp.c: handle scpSend_respons as buffer with length and not string in debug message

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -1,4 +1,4 @@
-scpSend/* Copyright (C) Daniel Stenberg
+/* Copyright (C) Daniel Stenberg
  * Copyright (C) Sara Golemon <sarag@libssh2.org>
  * All rights reserved.
  *


### PR DESCRIPTION
A buffer with a length should never be handled as a string (even if it's the case this time)