### PR TITLE
packet: honor buffer length when passing to `_libssh2_debug()`

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -775,7 +775,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
                 _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                                "Disconnect(%d): %.*s(%.*s)", reason,
-                               message_len, message, language_len, language));
+                               (int)message_len, message,
+                               (int)language_len, language));
             }
 
             LIBSSH2_FREE(session, data);


### PR DESCRIPTION
A buffer with a length should never be handled as a string (even if it's the case this time because the next element in data-buffer is the length of language )