### PR TITLE
GHA: drop FreeBSD arm64 job, it is broken upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1081,7 +1081,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['x86_64', 'arm64']
+        arch: ['x86_64']
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION
Broken since 2026-01-11:
```
The process will require 71 MiB more space.
18 MiB to be downloaded.
pkg: Failed to fetch https://pkg.FreeBSD.org/FreeBSD:14:aarch64/quarterly/All/Hashed/libtool-2.5.4_1~f2b07c18ac.pkg: Not found
pkg: Failed to fetch https://pkg.FreeBSD.org/FreeBSD:14:aarch64/quarterly/All/Hashed/libtool-2.5.4_1~f2b07c18ac.pkg: Not found
```
Ref: https://github.com/libssh2/libssh2/actions/runs/21008063627/job/60395548917?pr=1789#step:3:130
