### PR TITLE
_WINDLL being defined doesn't mean libssh2 was built as a DLL (#1578)

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -105,7 +105,7 @@ extern "C" {
 /* Allow alternate API prefix from CFLAGS or calling app */
 #ifndef LIBSSH2_API
 # ifdef _WIN32
-#  if defined(LIBSSH2_EXPORTS)
+#  ifdef LIBSSH2_EXPORTS
 #   ifdef LIBSSH2_LIBRARY
 #    define LIBSSH2_API __declspec(dllexport)
 #   else


### PR DESCRIPTION
https://github.com/libssh2/libssh2/issues/1578
WINDLL means that the current project using this library is a DLL; not that this library was built as a DLL. This check for _WINDLL is incorrect, and the LIBSSH2_EXPORTS flag should be used instead.

Description of problem - build libssh2 as a static library to be included in a dynamic library; if libssh2 uses _WINDLL then the names generated are `__imp_*` which do not exist in the static build of the library.