### PR TITLE
session: fix heap-buffer-overflow in session_startup()

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -854,7 +854,8 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
         session->startup_service_length =
             _libssh2_ntohu32(session->startup_data + 1);
 
-        if((session->startup_service_length != (sizeof("ssh-userauth") - 1)) ||
+        if((session->startup_service_length > session->startup_data_len - 5) ||
+           (session->startup_service_length != (sizeof("ssh-userauth") - 1)) ||
            strncmp("ssh-userauth",
                    (const char *) session->startup_data + 5,
                    session->startup_service_length)) {


### PR DESCRIPTION
When parsing the `SSH_MSG_SERVICE_ACCEPT` packet, the code failed to verify that the `startup_data` buffer was large enough to contain the service name string of length `startup_service_length`.

Specifically, `startup_service_length` is extracted from the packet and used as the length parameter in `strncmp` starting at an offset of 5 bytes into `startup_data`. If `startup_data_len` is small (e.g., 5) but `startup_service_length` is large, `strncmp` reads past the end of the allocated heap buffer.

Fix this by adding a bounds check to ensure `startup_service_length` does not exceed the remaining bytes in `startup_data_len`. The subtraction `session->startup_data_len - 5` is safe because `startup_data_len` is guaranteed to be at least 5 by preceding logic.

This fixes an OSS-Fuzz issue
(https://issues.oss-fuzz.com/issues/474401005).