### PR TITLE
session.c: fix heap-buffer-overflow in session_startup()

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -850,19 +850,19 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
         buf.data = session->startup_data;
         buf.dataptr = buf.data;
         buf.len = session->startup_data_len;
-        
+
         /* advance past packet type */
         buf.dataptr++;
-        
+
         if(_libssh2_match_string(&buf, "ssh-userauth")) {
             LIBSSH2_FREE(session, session->startup_data);
             session->startup_data = NULL;
             return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                   "Invalid response received from server");
         }
-        
+
         session->startup_service_length = (sizeof("ssh-userauth") - 1);
-        
+
         LIBSSH2_FREE(session, session->startup_data);
         session->startup_data = NULL;
 


### PR DESCRIPTION
Notes:
Refactor MR #1798 to use a `string_buf` for better readability and maintainability.

Discussion:
I'm not sure why libssh2 stores off `startup_service_length`, `startup_data` and `startup_data_len` in the session since they are not used outside of this state but I wasn't comfortable outright removing them so I assigned the service length after the fact since it is no longer used.

Credit:
Oliver Chang