### PR TITLE
sftp: Avoid need to call sftp_init again on error

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -932,6 +932,8 @@ struct _LIBSSH2_SESSION
                                            + version_id(4) */
     size_t sftpInit_sent; /* number of bytes from the buffer that have been
                              sent */
+    int sftpInit_err_code; /* saved errorcode if close_channel returns
+                              EAGAIN */
 
     /* State variables used in libssh2_scp_recv2() */
     libssh2_nonblocking_states scpRecv_state;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -842,6 +842,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         else if(ret) {
             _libssh2_error(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
                            "Unable to request SFTP subsystem");
+            session->sftpInit_state = libssh2_NB_state_error_closing;
             goto sftp_init_error;
         }
 
@@ -863,6 +864,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         if(!sftp_handle) {
             _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                            "Unable to allocate a new SFTP structure");
+            session->sftpInit_state = libssh2_NB_state_error_closing;
             goto sftp_init_error;
         }
         sftp_handle->channel = session->sftpInit_channel;
@@ -895,6 +897,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         else if(rc < 0) {
             _libssh2_error(session, LIBSSH2_ERROR_SOCKET_SEND,
                            "Unable to send SSH_FXP_INIT");
+            session->sftpInit_state = libssh2_NB_state_error_closing;
             goto sftp_init_error;
         }
         else {
@@ -910,19 +913,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
     }
 
     if(session->sftpInit_state == libssh2_NB_state_error_closing) {
-        rc = _libssh2_channel_free(session->sftpInit_channel);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
-            _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
-                           "Would block closing channel");
-            return NULL;
-        }
-        session->sftpInit_channel = NULL;
-        if(session->sftpInit_sftp) {
-            LIBSSH2_FREE(session, session->sftpInit_sftp);
-            session->sftpInit_sftp = NULL;
-        }
-        session->sftpInit_state = libssh2_NB_state_idle;
-        return NULL;
+        goto sftp_init_error;
     }
 
     rc = sftp_packet_require(sftp_handle, SSH_FXP_VERSION,
@@ -938,11 +929,13 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         }
         _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                        "Invalid SSH_FXP_VERSION response");
+        session->sftpInit_state = libssh2_NB_state_error_closing;
         goto sftp_init_error;
     }
     else if(rc) {
         _libssh2_error(session, (int)rc,
                        "Timeout waiting for response from SFTP subsystem");
+        session->sftpInit_state = libssh2_NB_state_error_closing;
         goto sftp_init_error;
     }
 
@@ -955,6 +948,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         LIBSSH2_FREE(session, data);
         _libssh2_error(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                        "Data too short when extracting version");
+        session->sftpInit_state = libssh2_NB_state_error_closing;
         goto sftp_init_error;
     }
 
@@ -993,6 +987,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
                 _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                                "Unable to allocate memory for SSH_FXP_VERSION "
                                "packet");
+                session->sftpInit_state = libssh2_NB_state_error_closing;
                 goto sftp_init_error;
             }
             memcpy(extversion_str, extdata, extdata_len);
@@ -1024,7 +1019,25 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
     return sftp_handle;
 
 sftp_init_error:
-    session->sftpInit_state = libssh2_NB_state_error_closing;
+    rc = _libssh2_channel_free(session->sftpInit_channel);
+    if(rc == LIBSSH2_ERROR_EAGAIN) {
+        session->sftpInit_err_code = session->err_code;
+        _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
+            "Would block closing channel");
+        return NULL;
+    }
+    session->sftpInit_channel = NULL;
+    if(session->sftpInit_sftp) {
+        LIBSSH2_FREE(session, session->sftpInit_sftp);
+        session->sftpInit_sftp = NULL;
+    }
+    session->sftpInit_state = libssh2_NB_state_idle;
+    if(session->sftpInit_err_code) {
+        _libssh2_error(session, session->sftpInit_err_code,
+            "Saved errorcode due to EAGAIN when "
+            "closing channel");
+    }
+
     return NULL;
 }
 


### PR DESCRIPTION
When an error is trigged in sftp_init() _libssh2_error()  is called and the state is set to "error_closing" and NULL is returned.

The caller was supposed to call again and the clean-up was done, checking for state error_closing.

This behaviour is not documented and is also wrong, the call should only be repeated on EAGAIN.

The change need a new member in SESSION struct, sftpInit_err_code, to save the previous error if channel_close() returns EAGAIN.
