### PR TITLE
Corrected non-blocking code and fixed sftp_RW_nonblock.c

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -1,5 +1,13 @@
 /* Copyright (C) The libssh2 project and its contributors.
  *
+ * Sample showing how to do TCP forward in non-blocking manner.
+ *
+ * The sample code has default values for host name, user name, password
+ * listenip, listenport and remoteip and remoteport, but you can specify
+ * them on the command line like:
+ *
+ * $ ./direct_tcpip 192.168.0.1 user password 127.0.0.1 2222 192.168.1.1 22
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -51,6 +59,43 @@ enum {
     AUTH_PASSWORD = 1,
     AUTH_PUBLICKEY = 2
 };
+
+static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
+{
+    struct timeval timeout;
+    int rc;
+    fd_set fd;
+    fd_set *writefd = NULL;
+    fd_set *readfd = NULL;
+    int dir;
+
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+
+    FD_ZERO(&fd);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+    FD_SET(socket_fd, &fd);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+    /* now make sure we wait in the correct direction */
+    dir = libssh2_session_block_directions(session);
+
+    if(dir & LIBSSH2_SESSION_BLOCK_INBOUND)
+        readfd = &fd;
+
+    if(dir & LIBSSH2_SESSION_BLOCK_OUTBOUND)
+        writefd = &fd;
+
+    rc = select((int)(socket_fd + 1), readfd, writefd, NULL, &timeout);
+
+    return rc;
+}
 
 int main(int argc, char *argv[])
 {
@@ -335,12 +380,30 @@ shutdown:
         LIBSSH2_SOCKET_CLOSE(listensock);
     }
 
-    if(channel)
-        libssh2_channel_free(channel);
+    if(channel) {
+        fprintf(stderr, "Sending EOF\n");
+        while(libssh2_channel_send_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for EOF\n");
+        while(libssh2_channel_wait_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for channel to close\n");
+        while(libssh2_channel_wait_closed(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        while(libssh2_channel_free(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        channel = NULL;
+    }
 
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_CHANNEL *channel;
+    LIBSSH2_CHANNEL *channel = NULL;
     libssh2_struct_stat fileinfo;
 #ifdef HAVE_GETTIMEOFDAY
     struct timeval start;
@@ -174,7 +174,8 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-          LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN)
+        waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -195,7 +196,8 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -206,7 +208,8 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
                                                         pubkey, privkey,
                                                         password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
@@ -223,16 +226,16 @@ int main(int argc, char *argv[])
         channel = libssh2_scp_recv2(session, scppath, &fileinfo);
 
         if(!channel) {
-            if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
+                fprintf(stderr, "libssh2_scp_recv2() spin\n");
+                waitsocket(sock, session);
+            }
+            else {
                 char *err_msg;
 
                 libssh2_session_last_error(session, &err_msg, NULL, 0);
                 fprintf(stderr, "%s\n", err_msg);
                 goto shutdown;
-            }
-            else {
-                fprintf(stderr, "libssh2_scp_recv2() spin\n");
-                waitsocket(sock, session);
             }
         }
     } while(!channel);
@@ -280,14 +283,32 @@ int main(int argc, char *argv[])
     fprintf(stderr, "Got %ld bytes spin: %d\n", (long)total, spin);
 #endif
 
-    libssh2_channel_free(channel);
-    channel = NULL;
-
 shutdown:
 
+    if(channel) {
+        fprintf(stderr, "Sending EOF\n");
+        while(libssh2_channel_send_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for EOF\n");
+        while(libssh2_channel_wait_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for channel to close\n");
+        while(libssh2_channel_wait_closed(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        while(libssh2_channel_free(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        channel = NULL;
+    }
+
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_CHANNEL *channel;
+    LIBSSH2_CHANNEL *channel = NULL;
     FILE *local;
     char mem[1024 * 100];
     size_t nread;
@@ -177,7 +177,8 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-          LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN)
+        waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -198,7 +199,8 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -209,7 +211,8 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
                                                         pubkey, privkey,
                                                         password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
@@ -221,13 +224,18 @@ int main(int argc, char *argv[])
         channel = libssh2_scp_send64(session, scppath, fileinfo.st_mode & 0777,
                                      fileinfo.st_size, 0, 0);
 
-        if(!channel &&
-           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            char *err_msg;
+        if(!channel) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
+                fprintf(stderr, "non-blocking scp_send64\n");
+                waitsocket(sock, session); /* now we wait */
+            }
+            else {
+                char *err_msg;
 
-            libssh2_session_last_error(session, &err_msg, NULL, 0);
-            fprintf(stderr, "%s\n", err_msg);
-            goto shutdown;
+                libssh2_session_last_error(session, &err_msg, NULL, 0);
+                fprintf(stderr, "%s\n", err_msg);
+                goto shutdown;
+            }
         }
     } while(!channel);
 
@@ -272,27 +280,36 @@ int main(int argc, char *argv[])
     fprintf(stderr, "%ld bytes in %d seconds makes %.1f bytes/sec\n",
            (long)total, duration, (double)total / duration);
 
-    fprintf(stderr, "Sending EOF\n");
-    while(libssh2_channel_send_eof(channel) == LIBSSH2_ERROR_EAGAIN);
-
-    fprintf(stderr, "Waiting for EOF\n");
-    while(libssh2_channel_wait_eof(channel) == LIBSSH2_ERROR_EAGAIN);
-
-    fprintf(stderr, "Waiting for channel to close\n");
-    while(libssh2_channel_wait_closed(channel) == LIBSSH2_ERROR_EAGAIN);
-
-    libssh2_channel_free(channel);
-    channel = NULL;
-
 shutdown:
+
+    if(channel) {
+        fprintf(stderr, "Sending EOF\n");
+        while(libssh2_channel_send_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for EOF\n");
+        while(libssh2_channel_wait_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for channel to close\n");
+        while(libssh2_channel_wait_closed(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        while(libssh2_channel_free(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        channel = NULL;
+    }
 
     fclose(local);
 
     if(session) {
         while(libssh2_session_disconnect(session, "Normal Shutdown") ==
-              LIBSSH2_ERROR_EAGAIN);
-        libssh2_session_free(session);
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
+
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
         shutdown(sock, 2);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_SFTP *sftp_session;
-    LIBSSH2_SFTP_HANDLE *sftp_handle;
+    LIBSSH2_SFTP *sftp_session = NULL;
+    LIBSSH2_SFTP_HANDLE *sftp_handle = NULL;
     FILE *tempstorage = NULL;
     char mem[1000];
     struct timeval timeout;
@@ -151,7 +151,9 @@ int main(int argc, char *argv[])
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
      */
-    rc = libssh2_session_handshake(session, sock);
+    while((rc = libssh2_session_handshake(session, sock)) ==
+          LIBSSH2_ERROR_EAGAIN)
+          waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -180,7 +182,8 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -192,7 +195,8 @@ int main(int argc, char *argv[])
               libssh2_userauth_publickey_fromfile(session, username,
                                                   pubkey, privkey,
                                                   password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
@@ -278,7 +282,9 @@ int main(int argc, char *argv[])
         }
     } while(1);
 
-    libssh2_sftp_close(sftp_handle);
+    while(libssh2_sftp_close(sftp_handle) == LIBSSH2_ERROR_EAGAIN)
+        waitsocket(sock, session);
+
     fclose(tempstorage);
 
     tempstorage = fopen(storage, "rb");
@@ -290,13 +296,28 @@ int main(int argc, char *argv[])
 
     /* we're done downloading, now reverse the process and upload the
        temporarily stored data to the destination path */
-    sftp_handle = libssh2_sftp_open(sftp_session, dest,
-                                    LIBSSH2_FXF_WRITE |
-                                    LIBSSH2_FXF_CREAT,
-                                    LIBSSH2_SFTP_S_IRUSR |
-                                    LIBSSH2_SFTP_S_IWUSR |
-                                    LIBSSH2_SFTP_S_IRGRP |
-                                    LIBSSH2_SFTP_S_IROTH);
+    do {
+        sftp_handle = libssh2_sftp_open(sftp_session, dest,
+                                        LIBSSH2_FXF_WRITE |
+                                        LIBSSH2_FXF_CREAT |
+                                        LIBSSH2_FXF_TRUNC,
+                                        LIBSSH2_SFTP_S_IRUSR |
+                                        LIBSSH2_SFTP_S_IWUSR |
+                                        LIBSSH2_SFTP_S_IRGRP |
+                                        LIBSSH2_SFTP_S_IROTH);
+        if(!sftp_handle) {
+            if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
+                fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                        libssh2_sftp_last_error(sftp_session));
+                goto shutdown;
+            }
+            else {
+                fprintf(stderr, "non-blocking open\n");
+                waitsocket(sock, session); /* now we wait */
+            }
+        }
+    } while(!sftp_handle);
+
     if(sftp_handle) {
         size_t nread;
         char *ptr;
@@ -313,13 +334,17 @@ int main(int argc, char *argv[])
                 /* write data in a loop until we block */
                 nwritten = libssh2_sftp_write(sftp_handle, ptr,
                                               nread);
+                if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+                    waitsocket(sock, session);
+                    continue;
+                }
                 if(nwritten < 0)
                     break;
                 ptr += nwritten;
                 nread -= (size_t)nwritten;
-            } while(nwritten >= 0);
+            } while(nread > 0);
 
-            if(nwritten != LIBSSH2_ERROR_EAGAIN) {
+            if(nwritten < 0 && nwritten != LIBSSH2_ERROR_EAGAIN) {
                 /* error or end of file */
                 break;
             }
@@ -355,13 +380,21 @@ int main(int argc, char *argv[])
                 dest);
     }
 
-    libssh2_sftp_shutdown(sftp_session);
-
 shutdown:
 
+    if(sftp_handle)
+        while(libssh2_sftp_close(sftp_handle) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+    if(sftp_session)
+        while(libssh2_sftp_shutdown(sftp_session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -35,6 +35,43 @@ static const char *username = "username";
 static const char *password = "password";
 static const char *sftppath = "/tmp/sftp_mkdir_nonblock";
 
+static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
+{
+    struct timeval timeout;
+    int rc;
+    fd_set fd;
+    fd_set *writefd = NULL;
+    fd_set *readfd = NULL;
+    int dir;
+
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+
+    FD_ZERO(&fd);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+    FD_SET(socket_fd, &fd);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+    /* now make sure we wait in the correct direction */
+    dir = libssh2_session_block_directions(session);
+
+    if(dir & LIBSSH2_SESSION_BLOCK_INBOUND)
+        readfd = &fd;
+
+    if(dir & LIBSSH2_SESSION_BLOCK_OUTBOUND)
+        writefd = &fd;
+
+    rc = select((int)(socket_fd + 1), readfd, writefd, NULL, &timeout);
+
+    return rc;
+}
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -44,7 +81,7 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_SFTP *sftp_session;
+    LIBSSH2_SFTP *sftp_session = NULL;
 
 #ifdef _WIN32
     WSADATA wsadata;
@@ -106,7 +143,9 @@ int main(int argc, char *argv[])
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
      */
-    rc = libssh2_session_handshake(session, sock);
+    while((rc = libssh2_session_handshake(session, sock)) ==
+          LIBSSH2_ERROR_EAGAIN)
+        waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -126,16 +165,22 @@ int main(int argc, char *argv[])
 
     if(auth_pw) {
         /* We could authenticate via password */
-        if(libssh2_userauth_password(session, username, password)) {
+        while((rc = libssh2_userauth_password(session, username, password)) ==
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
+        if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
         }
     }
     else {
         /* Or by public key */
-        if(libssh2_userauth_publickey_fromfile(session, username,
-                                               pubkey, privkey,
-                                               password)) {
+        while((rc = libssh2_userauth_publickey_fromfile(session, username,
+                                                        pubkey, privkey,
+                                                        password)) ==
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
+        if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
         }
@@ -158,15 +203,21 @@ int main(int argc, char *argv[])
                              LIBSSH2_SFTP_S_IXGRP |
                              LIBSSH2_SFTP_S_IROTH |
                              LIBSSH2_SFTP_S_IXOTH) ==
-          LIBSSH2_ERROR_EAGAIN);
-
-    libssh2_sftp_shutdown(sftp_session);
+          LIBSSH2_ERROR_EAGAIN)
+        waitsocket(sock, session);
 
 shutdown:
 
+    if(sftp_session)
+        while(libssh2_sftp_shutdown(sftp_session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -97,8 +97,8 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_SFTP *sftp_session;
-    LIBSSH2_SFTP_HANDLE *sftp_handle;
+    LIBSSH2_SFTP *sftp_session = NULL;
+    LIBSSH2_SFTP_HANDLE *sftp_handle = NULL;
 #ifdef HAVE_GETTIMEOFDAY
     struct timeval start;
     struct timeval end;
@@ -175,7 +175,8 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-          LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN)
+          waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -196,7 +197,8 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -204,11 +206,11 @@ int main(int argc, char *argv[])
     }
     else {
         /* Or by public key */
-        while((rc =
-              libssh2_userauth_publickey_fromfile(session, username,
-                                                  pubkey, privkey,
-                                                  password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+        while((rc = libssh2_userauth_publickey_fromfile(session, username,
+                                                        pubkey, privkey,
+                                                        password)) ==
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
@@ -281,16 +283,22 @@ int main(int argc, char *argv[])
     fprintf(stderr, "Got %ld bytes spin: %d\n", (long)total, spin);
 #endif
 
-    libssh2_sftp_close(sftp_handle);
-    libssh2_sftp_shutdown(sftp_session);
+ shutdown:
 
-shutdown:
+    if(sftp_handle)
+        while(libssh2_sftp_closedir(sftp_handle) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+    if(sftp_session)
+        while(libssh2_sftp_shutdown(sftp_session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
 
     if(session) {
-        fprintf(stderr, "libssh2_session_disconnect\n");
         while(libssh2_session_disconnect(session, "Normal Shutdown") ==
-              LIBSSH2_ERROR_EAGAIN);
-        libssh2_session_free(session);
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_SFTP *sftp_session;
-    LIBSSH2_SFTP_HANDLE *sftp_handle;
+    LIBSSH2_SFTP *sftp_session = NULL;
+    LIBSSH2_SFTP_HANDLE *sftp_handle = NULL;
     FILE *local;
     char mem[1024 * 1000];
     size_t nread;
@@ -171,7 +171,8 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-          LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN)
+          waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -192,7 +193,8 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -203,7 +205,8 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
                                                         pubkey, privkey,
                                                         password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
@@ -214,10 +217,15 @@ int main(int argc, char *argv[])
     do {
         sftp_session = libssh2_sftp_init(session);
 
-        if(!sftp_session &&
-           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            fprintf(stderr, "Unable to init SFTP session\n");
-            goto shutdown;
+        if(!sftp_session) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
+                fprintf(stderr, "non-blocking init\n");
+                waitsocket(sock, session); /* now we wait */
+            }
+            else {
+                fprintf(stderr, "Unable to init SFTP session\n");
+                goto shutdown;
+            }
         }
     } while(!sftp_session);
 
@@ -232,11 +240,15 @@ int main(int argc, char *argv[])
                                         LIBSSH2_SFTP_S_IWUSR |
                                         LIBSSH2_SFTP_S_IRGRP |
                                         LIBSSH2_SFTP_S_IROTH);
-        if(!sftp_handle &&
-           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            fprintf(stderr, "Unable to open file with SFTP: %ld\n",
-                    libssh2_sftp_last_error(sftp_session));
-            goto shutdown;
+        if(!sftp_session) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
+                fprintf(stderr, "non-blocking init\n");
+                waitsocket(sock, session); /* now we wait */
+            }
+            else {
+                fprintf(stderr, "Unable to init SFTP session\n");
+                goto shutdown;
+            }
         }
     } while(!sftp_handle);
 
@@ -280,17 +292,23 @@ int main(int argc, char *argv[])
     fprintf(stderr, "%ld bytes in %d seconds makes %.1f bytes/sec\n",
             (long)total, duration, (double)total / duration);
 
-    libssh2_sftp_close(sftp_handle);
-    libssh2_sftp_shutdown(sftp_session);
-
 shutdown:
+
+    if(sftp_handle)
+        while(libssh2_sftp_close(sftp_handle) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+    if(sftp_session)
+        while(libssh2_sftp_shutdown(sftp_session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
 
     fclose(local);
 
     if(session) {
         while(libssh2_session_disconnect(session, "Normal Shutdown") ==
-              LIBSSH2_ERROR_EAGAIN);
-        libssh2_session_free(session);
+              LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -41,6 +41,43 @@ static const char *username = "username";
 static const char *password = "password";
 static const char *sftppath = "/tmp/secretdir";
 
+static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
+{
+    struct timeval timeout;
+    int rc;
+    fd_set fd;
+    fd_set *writefd = NULL;
+    fd_set *readfd = NULL;
+    int dir;
+
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+
+    FD_ZERO(&fd);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+    FD_SET(socket_fd, &fd);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+    /* now make sure we wait in the correct direction */
+    dir = libssh2_session_block_directions(session);
+
+    if(dir & LIBSSH2_SESSION_BLOCK_INBOUND)
+        readfd = &fd;
+
+    if(dir & LIBSSH2_SESSION_BLOCK_OUTBOUND)
+        writefd = &fd;
+
+    rc = select((int)(socket_fd + 1), readfd, writefd, NULL, &timeout);
+
+    return rc;
+}
+
 int main(int argc, char *argv[])
 {
     uint32_t hostaddr;
@@ -50,8 +87,8 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_SFTP *sftp_session;
-    LIBSSH2_SFTP_HANDLE *sftp_handle;
+    LIBSSH2_SFTP *sftp_session = NULL;
+    LIBSSH2_SFTP_HANDLE *sftp_handle = NULL;
 
 #ifdef _WIN32
     WSADATA wsadata;
@@ -116,8 +153,9 @@ int main(int argc, char *argv[])
     /* ... start it up. This will trade welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
      */
-    while((rc = libssh2_session_handshake(session, sock)) ==
-          LIBSSH2_ERROR_EAGAIN);
+   while((rc = libssh2_session_handshake(session, sock)) ==
+          LIBSSH2_ERROR_EAGAIN)
+        waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -138,7 +176,8 @@ int main(int argc, char *argv[])
     if(auth_pw) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -149,7 +188,8 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
                                                         pubkey, privkey,
                                                         password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
@@ -160,10 +200,15 @@ int main(int argc, char *argv[])
     do {
         sftp_session = libssh2_sftp_init(session);
 
-        if(!sftp_session &&
-           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            fprintf(stderr, "Unable to init SFTP session\n");
-            goto shutdown;
+        if(!sftp_handle) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
+                fprintf(stderr, "non-blocking init\n");
+                waitsocket(sock, session); /* now we wait */
+           }
+           else {
+                fprintf(stderr, "Unable to init SFTP session\n");
+                goto shutdown;
+            }
         }
     } while(!sftp_session);
 
@@ -172,10 +217,15 @@ int main(int argc, char *argv[])
     do {
         sftp_handle = libssh2_sftp_opendir(sftp_session, sftppath);
 
-        if(!sftp_handle &&
-           libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            fprintf(stderr, "Unable to open dir with SFTP\n");
-            goto shutdown;
+        if(!sftp_handle) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
+                fprintf(stderr, "non-blocking init\n");
+                waitsocket(sock, session); /* now we wait */
+           }
+           else {
+                fprintf(stderr, "Unable to opendir in SFTP session\n");
+                goto shutdown;
+            }
         }
     } while(!sftp_handle);
 
@@ -186,7 +236,8 @@ int main(int argc, char *argv[])
 
         /* loop until we fail */
         while((rc = libssh2_sftp_readdir(sftp_handle, mem, sizeof(mem),
-                                         &attrs)) == LIBSSH2_ERROR_EAGAIN);
+                                         &attrs)) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
         if(rc > 0) {
             /* rc is the length of the file name in the mem
                buffer */
@@ -223,14 +274,22 @@ int main(int argc, char *argv[])
 
     } while(1);
 
-    libssh2_sftp_closedir(sftp_handle);
-    libssh2_sftp_shutdown(sftp_session);
-
 shutdown:
 
+    if(sftp_handle)
+        while(libssh2_sftp_closedir(sftp_handle) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+    if(sftp_session)
+        while(libssh2_sftp_shutdown(sftp_session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     struct sockaddr_in sin;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_CHANNEL *channel;
+    LIBSSH2_CHANNEL *channel = NULL;
     LIBSSH2_AGENT *agent = NULL;
     struct libssh2_agent_publickey *identity, *prev_identity = NULL;
     int exitcode;
@@ -282,14 +282,33 @@ int main(int argc, char *argv[])
                 exitcode, (long)bytecount);
     }
 
-    libssh2_channel_free(channel);
-    channel = NULL;
 
 shutdown:
 
+    if(channel) {
+        fprintf(stderr, "Sending EOF\n");
+        while(libssh2_channel_send_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for EOF\n");
+        while(libssh2_channel_wait_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for channel to close\n");
+        while(libssh2_channel_wait_closed(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        while(libssh2_channel_free(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        channel = NULL;
+    }
+
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_CHANNEL *channel;
+    LIBSSH2_CHANNEL *channel = NULL;
     int exitcode = 0;
     char *exitsignal = NULL;
     size_t len;
@@ -146,7 +146,8 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-          LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN)
+          waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -193,7 +194,8 @@ int main(int argc, char *argv[])
     if(strlen(password) != 0) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             return 1;
@@ -360,8 +362,11 @@ int main(int argc, char *argv[])
 shutdown:
 
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     const char *fingerprint;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_CHANNEL *channel;
+    LIBSSH2_CHANNEL *channel = NULL;
     int exitcode;
     char *exitsignal = NULL;
     ssize_t bytecount = 0;
@@ -152,7 +152,8 @@ int main(int argc, char *argv[])
      * and setup crypto, compression, and MAC layers
      */
     while((rc = libssh2_session_handshake(session, sock)) ==
-          LIBSSH2_ERROR_EAGAIN);
+          LIBSSH2_ERROR_EAGAIN)
+          waitsocket(sock, session);
     if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
         goto shutdown;
@@ -199,7 +200,8 @@ int main(int argc, char *argv[])
     if(strlen(password) != 0) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
             goto shutdown;
@@ -210,7 +212,8 @@ int main(int argc, char *argv[])
         while((rc = libssh2_userauth_publickey_fromfile(session, username,
                                                         pubkey, privkey,
                                                         password)) ==
-              LIBSSH2_ERROR_EAGAIN);
+              LIBSSH2_ERROR_EAGAIN)
+              waitsocket(sock, session);
         if(rc) {
             fprintf(stderr, "Authentication by public key failed.\n");
             goto shutdown;
@@ -289,14 +292,32 @@ int main(int argc, char *argv[])
         fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
                 exitcode, (long)bytecount);
 
-    libssh2_channel_free(channel);
-    channel = NULL;
-
 shutdown:
 
+    if(channel) {
+        fprintf(stderr, "Sending EOF\n");
+        while(libssh2_channel_send_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for EOF\n");
+        while(libssh2_channel_wait_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for channel to close\n");
+        while(libssh2_channel_wait_closed(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        while(libssh2_channel_free(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        channel = NULL;
+    }
+
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+                waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -55,6 +55,43 @@ enum {
     AUTH_PUBLICKEY = 2
 };
 
+static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
+{
+    struct timeval timeout;
+    int rc;
+    fd_set fd;
+    fd_set *writefd = NULL;
+    fd_set *readfd = NULL;
+    int dir;
+
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+
+    FD_ZERO(&fd);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+    FD_SET(socket_fd, &fd);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+    /* now make sure we wait in the correct direction */
+    dir = libssh2_session_block_directions(session);
+
+    if(dir & LIBSSH2_SESSION_BLOCK_INBOUND)
+        readfd = &fd;
+
+    if(dir & LIBSSH2_SESSION_BLOCK_OUTBOUND)
+        writefd = &fd;
+
+    rc = select((int)(socket_fd + 1), readfd, writefd, NULL, &timeout);
+
+    return rc;
+}
+
 int main(int argc, char *argv[])
 {
     int i, auth = AUTH_NONE;
@@ -325,15 +362,35 @@ shutdown:
         LIBSSH2_SOCKET_CLOSE(forwardsock);
     }
 
-    if(channel)
-        libssh2_channel_free(channel);
+    if(channel) {
+        fprintf(stderr, "Sending EOF\n");
+        while(libssh2_channel_send_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
 
-    if(listener)
-        libssh2_channel_forward_cancel(listener);
+        fprintf(stderr, "Waiting for EOF\n");
+        while(libssh2_channel_wait_eof(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        fprintf(stderr, "Waiting for channel to close\n");
+        while(libssh2_channel_wait_closed(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+
+        while(libssh2_channel_free(channel) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        channel = NULL;
+    }
+
+    if(listener) {
+        while(libssh2_channel_forward_cancel(listener) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+    }
 
     if(session) {
-        libssh2_session_disconnect(session, "Normal Shutdown");
-        libssh2_session_free(session);
+        while(libssh2_session_disconnect(session, "Normal Shutdown") ==
+              LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
+        while(libssh2_session_free(session) == LIBSSH2_ERROR_EAGAIN)
+            waitsocket(sock, session);
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {


### PR DESCRIPTION
All non-blocking examples are not handling EAGAIN while close channels and sessions.

Also addad waitsocket() when EAGIN is returned.

sftp_RW_nonblock.c was not working, looping when  libssh2_sftp_write() returned zero and not hanling file over the size of 1000 bytes.