### PR TITLE
comp.c: Add defensive code if src buffer is empty/null

### DIFF
--- a/src/comp.c
+++ b/src/comp.c
@@ -281,6 +281,16 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
         }
         else if(status == Z_BUF_ERROR) {
             /* the input data has been exhausted so we are done */
+
+            if((out_maxlen - strm->avail_out) == 0) {
+                /* nothing was decompressed */
+                LIBSSH2_FREE(session, out);
+                _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
+                                "zlib empty src error %d", status));
+                return _libssh2_error(session, LIBSSH2_ERROR_ZLIB,
+                                      "decompression failure");
+            }
+
             break;
         }
         else {


### PR DESCRIPTION
If `src` is NULL a 25 byte buffer is still allocated and returned but with a length of zero and no error. This causes error handling to be a bit tricky on the other side of this call so we should clean up on this side and return an error. 

Reviewed: 
Michael Buckley