### PR TITLE
Fix possible heap overflow in SSH_MSG_CHANNEL_REQUEST #1815

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -1246,7 +1246,7 @@ libssh2_packet_add_jump_point4:
                 }
             }
 
-            clean_exit:
+clean_exit:
 
             LIBSSH2_FREE(session, data);
             session->packAdd_state = libssh2_NB_state_idle;


### PR DESCRIPTION
Add additional validation to `len` value to avoid possible heap overflow in SSH_MSG_CHANNEL_REQUEST when calling `_libssh2_debug()`. 


Credit:
[Chen Zhengzhe](https://github.com/BreakingBad6)