### PR TITLE
Fix returning a pointer to stack memory

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -831,7 +831,10 @@ _libssh2_mbedtls_pub_priv_keyfile(LIBSSH2_SESSION *session,
     if(ret) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));
         mbedtls_pk_free(&pkey);
-        return _libssh2_error(session, LIBSSH2_ERROR_FILE, buf);
+        return _libssh2_error_flags(session,
+                                    LIBSSH2_ERROR_FILE,
+                                    buf,
+                                    LIBSSH2_ERR_FLAG_DUP);
     }
 
     ret = _libssh2_mbedtls_pub_priv_key(session, method, method_len,
@@ -889,7 +892,10 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     if(ret) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));
         mbedtls_pk_free(&pkey);
-        return _libssh2_error(session, LIBSSH2_ERROR_FILE, buf);
+        return _libssh2_error_flags(session,
+                                    LIBSSH2_ERROR_FILE,
+                                    buf,
+                                    LIBSSH2_ERR_FLAG_DUP);
     }
 
     ret = _libssh2_mbedtls_pub_priv_key(session, method, method_len,


### PR DESCRIPTION
[Upstream patch](https://github.com/SFML/SFML/pull/3675) to fix returning of a pointer to stack memory by having libssh2 make a copy of `buf`.