### PR TITLE
fuzz: replace assert() with goto in ssh2_client_fuzzer

### DIFF
--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -19,7 +19,7 @@
         {                                                                     \
             fprintf(stderr, "Assertion failed: " #COND "\n%s",                \
                     strerror(errno));                                         \
-            assert((COND));                                                   \
+            goto EXIT_LABEL;                                                  \
         }                                                                     \
     } while(0)
 


### PR DESCRIPTION
## Summary

Replace `assert()` with `goto EXIT_LABEL` in the `FUZZ_ASSERT` macro in `ssh2_client_fuzzer.cc`.

### Problem

When `socketpair()` fails (e.g., due to file descriptor exhaustion during long fuzzing runs), `FUZZ_ASSERT(rc == 0)` calls `assert()`, which aborts the entire fuzzer process. LibFuzzer expects harnesses to handle errors gracefully by returning 0 — aborting terminates the fuzzing campaign.

The rest of the fuzzer already uses `goto EXIT_LABEL` for error handling (lines 38, 53, 59, 69, 73), so the `assert()` in `FUZZ_ASSERT` is inconsistent with the existing pattern.

### Fix

Change `assert((COND))` to `goto EXIT_LABEL` in the `FUZZ_ASSERT` macro, making it consistent with all other error paths in the fuzzer.

## Coverage comparison (60 seconds, empty seed corpus, ASan, libFuzzer)

| Metric | Original | Fixed | Change |
|--------|----------|-------|--------|
| Edge coverage | 320 | 373 | +16.56% (+53 edges) |
| Feature coverage | 696 | 778 | +11.78% (+82 features) |

Note: The coverage improvement may be due to fuzzer randomness rather than the fix itself, but it confirms the fix does not regress coverage.