### PR TITLE
kex.c, packet.c: Validate DH prime range, validate server extensions count

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -1541,7 +1541,7 @@ kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
         }
 
         bits = (int)_libssh2_bn_bits(key_state->p);
-        if(bits < 0 || bits < LIBSSH2_DH_GEX_MINGROUP ||
+        if(bits < LIBSSH2_DH_GEX_MINGROUP ||
            bits > LIBSSH2_DH_GEX_MAXGROUP) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "DH-SHA1 p out of range");
@@ -1670,7 +1670,7 @@ kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
         }
 
         bits = (int)_libssh2_bn_bits(key_state->p);
-        if(bits < 0 || bits < LIBSSH2_DH_GEX_MINGROUP ||
+        if(bits < LIBSSH2_DH_GEX_MINGROUP ||
            bits > LIBSSH2_DH_GEX_MAXGROUP) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                  "DH-SHA256 p out of range");

--- a/src/packet.c
+++ b/src/packet.c
@@ -880,7 +880,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                 buf.dataptr += 1; /* advance past type */
 
                 if(_libssh2_get_u32(&buf, &nr_extensions) != 0 ||
-                                    nr_extensions > 1024) {
+                                    nr_extensions >= 1024) {
                     rc = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                                         "Invalid extension info received");
                 }


### PR DESCRIPTION
1) In DH sha1 and sha256 we request a min/max group value but then don't validate the reply from the server is within the requested range which could lead to insecure connections.

2) When we get back the server extension list, cap the server extension list count to prevent a possible DOS.

credit:
Joren Afman