### PR TITLE
Revert "openssl: Add OPENSSL_cleanup in crypto_exit if used with OpenSSL 4.x"

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1146,12 +1146,7 @@ void _libssh2_openssl_crypto_init(void)
 #endif
 }
 
-void _libssh2_openssl_crypto_exit(void)
-{
-#if OPENSSL_VERSION_NUMBER >= 0x40000000L
-    OPENSSL_cleanup();
-#endif
-}
+void _libssh2_openssl_crypto_exit(void) {}
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA || LIBSSH2_ED25519
 /* TODO: Optionally call a passphrase callback specified by the


### PR DESCRIPTION
Notes:
Reverts libssh2/libssh2#1830 per the conversation and unintended consequences of cleaning up OpenSSL from under a running application.