### PR TITLE
agent: do not store stack pointer in transaction context

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -959,12 +959,15 @@ agent_list_identities(LIBSSH2_AGENT *agent)
                               "agent not connected");
 
     rc = agent->ops->transact(agent, transctx);
+
+    LIBSSH2_FREE(session, transctx->request);
+    transctx->request = NULL;
+
     if(rc) {
         LIBSSH2_FREE(agent->session, transctx->response);
         transctx->response = NULL;
         return rc;
     }
-    transctx->request = NULL;
 
     len = transctx->response_len;
     s = transctx->response;

--- a/src/agent.c
+++ b/src/agent.c
@@ -934,11 +934,11 @@ agent_list_identities(LIBSSH2_AGENT *agent)
     ssize_t len, num_identities;
     unsigned char *s;
     int rc;
-    static unsigned char c = SSH2_AGENTC_REQUEST_IDENTITIES;
+    static const unsigned char c = SSH2_AGENTC_REQUEST_IDENTITIES;
 
     /* Create a request to list identities */
     if(transctx->state == agent_NB_state_init) {
-        transctx->request = &c;
+        transctx->request = LIBSSH2_UNCONST(&c);
         transctx->request_len = 1;
         transctx->send_recv_total = 0;
         transctx->state = agent_NB_state_request_created;

--- a/src/agent.c
+++ b/src/agent.c
@@ -934,15 +934,11 @@ agent_list_identities(LIBSSH2_AGENT *agent)
     ssize_t len, num_identities;
     unsigned char *s;
     int rc;
+    static unsigned char c = SSH2_AGENTC_REQUEST_IDENTITIES;
 
     /* Create a request to list identities */
     if(transctx->state == agent_NB_state_init) {
-        transctx->request = LIBSSH2_ALLOC(agent->session, 1);
-        if(!transctx->request) {
-            return _libssh2_error(agent->session, LIBSSH2_ERROR_ALLOC,
-                                  "out of memory");
-        }
-        *transctx->request = SSH2_AGENTC_REQUEST_IDENTITIES;
+        transctx->request = &c;
         transctx->request_len = 1;
         transctx->send_recv_total = 0;
         transctx->state = agent_NB_state_request_created;
@@ -960,7 +956,6 @@ agent_list_identities(LIBSSH2_AGENT *agent)
 
     rc = agent->ops->transact(agent, transctx);
 
-    LIBSSH2_FREE(session, transctx->request);
     transctx->request = NULL;
 
     if(rc) {

--- a/src/agent.c
+++ b/src/agent.c
@@ -934,11 +934,15 @@ agent_list_identities(LIBSSH2_AGENT *agent)
     ssize_t len, num_identities;
     unsigned char *s;
     int rc;
-    unsigned char c = SSH2_AGENTC_REQUEST_IDENTITIES;
 
     /* Create a request to list identities */
     if(transctx->state == agent_NB_state_init) {
-        transctx->request = &c;
+        transctx->request = LIBSSH2_ALLOC(agent->session, 1);
+        if(!transctx->request) {
+            return _libssh2_error(agent->session, LIBSSH2_ERROR_ALLOC,
+                                  "out of memory");
+        }
+        *transctx->request = SSH2_AGENTC_REQUEST_IDENTITIES;
         transctx->request_len = 1;
         transctx->send_recv_total = 0;
         transctx->state = agent_NB_state_request_created;

--- a/src/agent.c
+++ b/src/agent.c
@@ -955,14 +955,12 @@ agent_list_identities(LIBSSH2_AGENT *agent)
                               "agent not connected");
 
     rc = agent->ops->transact(agent, transctx);
-
-    transctx->request = NULL;
-
     if(rc) {
         LIBSSH2_FREE(agent->session, transctx->response);
         transctx->response = NULL;
         return rc;
     }
+    transctx->request = NULL;
 
     len = transctx->response_len;
     s = transctx->response;


### PR DESCRIPTION
Fixing:
```
src/agent.c:956:9: warning: Address of stack memory associated with local variable 'c' is still referred to by the caller variable 'agent' upon returning to the caller.  This will be a dangling reference [clang-analyzer-core.StackAddressEscape]
  956 |         return _libssh2_error(agent->session, LIBSSH2_ERROR_BAD_USE,
      |         ^
src/agent.c:1164:12: note: Calling 'agent_list_identities'
 1164 |     return agent_list_identities(agent);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/agent.c:942:8: note: Assuming field 'state' is equal to agent_NB_state_init
  942 |     if(transctx->state == agent_NB_state_init) {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/agent.c:942:5: note: Taking true branch
  942 |     if(transctx->state == agent_NB_state_init) {
      |     ^
src/agent.c:950:5: note: Taking false branch
  950 |     if(*transctx->request != SSH2_AGENTC_REQUEST_IDENTITIES)
      |     ^
src/agent.c:954:8: note: Assuming field 'ops' is null
  954 |     if(!agent->ops)
      |        ^~~~~~~~~~~
src/agent.c:954:5: note: Taking true branch
  954 |     if(!agent->ops)
      |     ^
```
