### PR TITLE
kex: fix returning error on hash calculation failures

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -2527,18 +2527,21 @@ mlkem_nistp(LIBSSH2_SESSION *session,
             case LIBSSH2_EC_CURVE_NISTP256: {
                 libssh2_sha256_ctx k_ctx;
                 if(!libssh2_sha256_init(&k_ctx)) {
-                    rc = -1;
+                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                         "kex: failed to calculate hash");
                     goto clean_exit;
                 }
 
                 if(!libssh2_sha256_update(k_ctx, shared_secret,
                                           shared_secret_len)) {
-                    rc = -1;
+                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                         "kex: failed to calculate hash");
                     goto clean_exit;
                 }
 
                 if(!libssh2_sha256_final(k_ctx, exchange_state->k_value + 4)) {
-                    rc = -1;
+                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                         "kex: failed to calculate hash");
                     goto clean_exit;
                 }
                 LIBSSH2_KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY(256);
@@ -2547,18 +2550,21 @@ mlkem_nistp(LIBSSH2_SESSION *session,
             case LIBSSH2_EC_CURVE_NISTP384: {
                 libssh2_sha384_ctx k_ctx;
                 if(!libssh2_sha384_init(&k_ctx)) {
-                    rc = -1;
+                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                         "kex: failed to calculate hash");
                     goto clean_exit;
                 }
 
                 if(!libssh2_sha384_update(k_ctx, shared_secret,
                                           shared_secret_len)) {
-                    rc = -1;
+                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                         "kex: failed to calculate hash");
                     goto clean_exit;
                 }
 
                 if(!libssh2_sha384_final(k_ctx, exchange_state->k_value + 4)) {
-                    rc = -1;
+                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                         "kex: failed to calculate hash");
                     goto clean_exit;
                 }
                 LIBSSH2_KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY(384);
@@ -3199,19 +3205,22 @@ mlkem768x25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         }
 
         if(!libssh2_sha256_init(&k_ctx)) {
-            rc = -1;
+            ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                 "kex: failed to calculate hash");
             goto clean_exit;
         }
 
         if(!libssh2_sha256_update(k_ctx, shared_secret,
                                   LIBSSH2_MLKEM_SHARED_SECRET_LEN +
                                   LIBSSH2_ED25519_KEY_LEN)) {
-            rc = -1;
+            ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                 "kex: failed to calculate hash");
             goto clean_exit;
         }
 
         if(!libssh2_sha256_final(k_ctx, exchange_state->k_value + 4)) {
-            rc = -1;
+            ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
+                                 "kex: failed to calculate hash");
             goto clean_exit;
         }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -2527,8 +2527,8 @@ mlkem_nistp(LIBSSH2_SESSION *session,
             case LIBSSH2_EC_CURVE_NISTP256: {
                 libssh2_sha256_ctx k_ctx;
                 if(!libssh2_sha256_init(&k_ctx)) {
-                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
-                                         "kex: failed to calculate hash");
+                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_INIT,
+                                         "kex: failed to initialize hash");
                     goto clean_exit;
                 }
 
@@ -2550,8 +2550,8 @@ mlkem_nistp(LIBSSH2_SESSION *session,
             case LIBSSH2_EC_CURVE_NISTP384: {
                 libssh2_sha384_ctx k_ctx;
                 if(!libssh2_sha384_init(&k_ctx)) {
-                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
-                                         "kex: failed to calculate hash");
+                    ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_INIT,
+                                         "kex: failed to initialize hash");
                     goto clean_exit;
                 }
 
@@ -3205,8 +3205,8 @@ mlkem768x25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         }
 
         if(!libssh2_sha256_init(&k_ctx)) {
-            ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
-                                 "kex: failed to calculate hash");
+            ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_INIT,
+                                 "kex: failed to initialize hash");
             goto clean_exit;
         }
 


### PR DESCRIPTION
Fixing:
```
src/kex.c:2530:21: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 2530 |                     rc = -1;
      |                     ^    ~~
src/kex.c:2536:21: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 2536 |                     rc = -1;
      |                     ^    ~~
src/kex.c:2541:21: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 2541 |                     rc = -1;
      |                     ^    ~~
src/kex.c:2550:21: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 2550 |                     rc = -1;
      |                     ^    ~~
src/kex.c:2556:21: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 2556 |                     rc = -1;
      |                     ^    ~~
src/kex.c:2561:21: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 2561 |                     rc = -1;
      |                     ^    ~~
src/kex.c:3202:13: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 3202 |             rc = -1;
      |             ^    ~~
src/kex.c:3209:13: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 3209 |             rc = -1;
      |             ^    ~~
src/kex.c:3214:13: warning: Value stored to 'rc' is never read [clang-analyzer-deadcode.DeadStores]
 3214 |             rc = -1;
      |             ^    ~~
```

Follow-up to 3ba252e2a6fe04d17ea13ad870698a4028c8ab4c #1644