### PR TITLE
tests: fix sleep durations

### DIFF
--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -282,7 +282,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
            https://github.com/docker/machine/issues/2612), so we retry a few
            times with exponential backoff if it fails */
         int attempt_no = 0;
-        unsigned int wait_time = 500;
+        unsigned int wait_time = 1;
         for(;;) {
             int ret = run_command(ip_address_out, "docker-machine ip %s",
                                   active_docker_machine);

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -267,7 +267,7 @@ static int is_running_inside_a_container(void)
 static void portable_sleep(unsigned int seconds)
 {
 #ifdef _WIN32
-    Sleep(seconds);
+    Sleep(seconds * 1000);
 #else
     sleep(seconds);
 #endif

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -34,7 +34,7 @@ static const char *password = "password";
 static void portable_sleep(unsigned int seconds)
 {
 #ifdef _WIN32
-    Sleep(seconds);
+    Sleep(seconds * 1000);
 #else
     sleep(seconds);
 #endif


### PR DESCRIPTION
- openssh_fixture: fix overly long retry delay on non-Windows, when
  acquiring docker machine IP.

- test_ssh2: fix overly short retry delay on Windows, on connect.

Follow-up to a459a25302a31f6e2aba3c4e15b1472b83b596fc #996
Follow-up to a88a727c2a1840f979b34f12bcce3d55dcd7ea6e
Follow-up to 984d008106b2d950a6f16ce84a5c0a0ef96d3f93 #490
Follow-up to cf80f2f4b5255cc85a04ee43b27a29c678c1edb1
