### PR TITLE
userauth.c: username_len bounds checking

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -80,6 +80,12 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
         memset(&session->userauth_list_packet_requirev_state, 0,
                sizeof(session->userauth_list_packet_requirev_state));
 
+        if(username_len > UINT32_MAX - 27) {
+            _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                           "username_len out of bounds");
+            return NULL;
+        }
+
         session->userauth_list_data_len = username_len + 27;
 
         if(session->userauth_list_data) {
@@ -316,6 +322,11 @@ userauth_password(LIBSSH2_SESSION *session,
          * 40 = packet_type(1) + username_len(4) + service_len(4) +
          * service(14)"ssh-connection" + method_len(4) + method(8)"password" +
          * chgpwdbool(1) + password_len(4) */
+        if(username_len > UINT32_MAX - 40) {
+            return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                                  "username_len out of bounds");
+        }
+
         session->userauth_pswd_data_len = username_len + 40;
 
         session->userauth_pswd_data0 =
@@ -456,7 +467,7 @@ password_response:
                         }
 
                         /* basic data_len + newpw_len(4) */
-                        if(username_len + password_len + 44 <= UINT_MAX) {
+                        if(username_len <= UINT32_MAX - password_len - 44) {
                             session->userauth_pswd_data_len =
                                 username_len + password_len + 44;
                             s = session->userauth_pswd_data =


### PR DESCRIPTION
Return errors when username_len will exceed bounds, fix existing bounds check.

Credit:
[dapickle](https://github.com/dapickle)
