### PR TITLE
examples: readd `sys/time.h` where necessary

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -27,6 +27,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>  /* for timeval */
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -33,7 +33,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif
 
 #include <stdio.h>

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -24,7 +24,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#include <sys/time.h>  /* for timeval */
 #endif
 
 #include <stdio.h>

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -31,7 +31,7 @@
 #include <netinet/in.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#include <sys/time.h>  /* for timeval */
 #endif
 
 #include <stdio.h>

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -34,7 +34,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif
 
 #include <stdio.h>

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -30,7 +30,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#include <sys/time.h>  /* for timeval */
 #endif
 
 #include <stdio.h>

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -30,7 +30,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#include <sys/time.h>  /* for timeval */
 #endif
 
 #include <stdio.h>

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -31,6 +31,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>  /* for timeval */
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -32,6 +32,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>  /* for timeval */
+#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -28,6 +28,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>  /* for timeval */
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -27,6 +27,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>  /* for timeval */
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/example/x11.c
+++ b/example/x11.c
@@ -34,6 +34,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>  /* for timeval */
+#endif
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif


### PR DESCRIPTION
Also add comments saying why `sys/time.h` is included.

Reported-by: nnarayanamurthy on github
Fixes #1792
Follow-up to e53aae0e16dbf53ddd1a4fcfc50e365a15fcb8b9 #1001
