### PR TITLE
packet.c: check _libssh2_get_string() return in EXT_INFO handler

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -890,8 +890,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
                     nr_extensions -= 1;
 
-                    _libssh2_get_string(&buf, &name, &name_len);
-                    _libssh2_get_string(&buf, &value, &value_len);
+                    if(_libssh2_get_string(&buf, &name, &name_len))
+                        break;
+                    if(_libssh2_get_string(&buf, &value, &value_len))
+                        break;
 
                     if(name && value) {
                         _libssh2_debug((session,


### PR DESCRIPTION
The `SSH_MSG_EXT_INFO` handler discards the return values from `_libssh2_get_string()` when parsing extension name/value pairs. When the buffer is exhausted before all claimed extensions are parsed, the loop continues with no-op iterations until `nr_extensions` reaches zero.

The `nr_extensions >= 1024` cap limits the worst case, but the loop should still break on parse failure for correctness and consistency with other parsers in this file (e.g. `SSH_MSG_CHANNEL_OPEN`, `SSH_MSG_KEXINIT`) that check `_libssh2_get_string()` return values.
