### PR TITLE
packet: add error checks to avoid potential runaway loop

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -890,8 +890,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
                     nr_extensions -= 1;
 
-                    _libssh2_get_string(&buf, &name, &name_len);
-                    _libssh2_get_string(&buf, &value, &value_len);
+                    if(_libssh2_get_string(&buf, &name, &name_len) != 0)
+                        break;
+                    if(_libssh2_get_string(&buf, &value, &value_len) != 0)
+                        break;
 
                     if(name && value) {
                         _libssh2_debug((session,

--- a/src/packet.c
+++ b/src/packet.c
@@ -890,9 +890,9 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
                     nr_extensions -= 1;
 
-                    if(_libssh2_get_string(&buf, &name, &name_len) != 0)
+                    if(_libssh2_get_string(&buf, &name, &name_len))
                         break;
-                    if(_libssh2_get_string(&buf, &value, &value_len) != 0)
+                    if(_libssh2_get_string(&buf, &value, &value_len))
                         break;
 
                     if(name && value) {


### PR DESCRIPTION
Report-and-patch-by: Tristan Madani
