### PR TITLE
src: misc tidy-ups

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -525,7 +525,7 @@ packet_authagent_open(LIBSSH2_SESSION * session,
 
     if(session->authagent) {
         if(authagent_state->state == libssh2_NB_state_allocated) {
-            channel = LIBSSH2_ALLOC(session, sizeof(LIBSSH2_CHANNEL));
+            channel = LIBSSH2_CALLOC(session, sizeof(LIBSSH2_CHANNEL));
             authagent_state->channel = channel;
 
             if(!channel) {
@@ -534,7 +534,6 @@ packet_authagent_open(LIBSSH2_SESSION * session,
                 failure_code = SSH_OPEN_RESOURCE_SHORTAGE;
                 goto authagent_exit;
             }
-            memset(channel, 0, sizeof(LIBSSH2_CHANNEL));
 
             channel->session = session;
             channel->channel_type_len = strlen("auth agent");

--- a/src/packet.c
+++ b/src/packet.c
@@ -321,7 +321,7 @@ packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
         }
         if(_libssh2_get_u32(&buf, &(x11open_state->packet_size))) {
             _libssh2_error(session, LIBSSH2_ERROR_INVAL,
-                           "unexpected window size");
+                           "unexpected packet size");
             failure_code = SSH_OPEN_CONNECT_FAILED;
             goto x11_exit;
         }
@@ -447,7 +447,7 @@ packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
     }
     else
         failure_code = SSH_OPEN_RESOURCE_SHORTAGE;
-    /* fall-trough */
+    /* fall-through */
 x11_exit:
     LIBSSH2_FREE(session, x11open_state->shost);
     x11open_state->shost = NULL;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -174,7 +174,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                 LIBSSH2_FREE(session, session->userauth_list_data);
                 session->userauth_list_data = NULL;
                 _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                              "Unable to allocate memory for userauth_banner");
+                              "Unable to allocate memory for userauth banner");
                 return NULL;
             }
             memcpy(session->userauth_banner, session->userauth_list_data + 5,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -944,8 +944,6 @@ static int _libssh2_wincng_load_private_memory(LIBSSH2_SESSION *session,
     size_t datalen = 0;
     int ret = -1;
 
-    (void)passphrase;
-
     if(ret && tryLoadRSA) {
         ret = _libssh2_pem_parse_memory(session,
                                         PEM_RSA_HEADER, PEM_RSA_FOOTER,
@@ -1364,8 +1362,6 @@ _libssh2_wincng_rsa_new_private(libssh2_rsa_ctx **rsa,
     size_t cbEncoded;
     int ret;
 
-    (void)session;
-
     ret = _libssh2_wincng_load_private(session, filename, passphrase,
                                        &pbEncoded, &cbEncoded, 1, 0);
     if(ret) {
@@ -1396,8 +1392,6 @@ _libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
     unsigned char *pbEncoded;
     size_t cbEncoded;
     int ret;
-
-    (void)session;
 
     ret = _libssh2_wincng_load_private_memory(session, filedata, filedata_len,
                                               passphrase,


### PR DESCRIPTION
- packet: replace ALLOC + memset with CALLOC. Also syncing usage with
  similar code nearby.
- packet: fix error message.
- packet: fix typo in comment.
- userauth: make a error message consistent with others.
- wincng: drop redundant unused variable silencers.

Pointed out by GitHub Code Quality
