### PR TITLE
userauth: various fixes to `_libssh2_key_sign_algorithm()`

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1429,7 +1429,8 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
         if(remote_ver_start) {
             const char *remote_ver = remote_ver_start + strlen(remote_ver_pre);
             int SSH_BUG_SIGTYPE = is_version_less_than_78(remote_ver);
-            if(SSH_BUG_SIGTYPE && *key_method_len == method_len &&
+            if(SSH_BUG_SIGTYPE &&
+               *key_method && *key_method_len == method_len &&
                memcmp(*key_method, method, method_len) == 0) {
                 LIBSSH2_FREE(session, filtered_algs);
                 return LIBSSH2_ERROR_NONE;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1431,7 +1431,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
             const char *remote_ver = remote_ver_start + strlen(remote_ver_pre);
             int SSH_BUG_SIGTYPE = is_version_less_than_78(remote_ver);
             if(SSH_BUG_SIGTYPE && *key_method_len == method_len &&
-               memcmp(key_method, method, method_len)) {
+               memcmp(*key_method, method, method_len)) {
                 LIBSSH2_FREE(session, filtered_algs);
                 return LIBSSH2_ERROR_NONE;
             }
@@ -1505,8 +1505,8 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
     }
 
     if(match) {
-        if(*key_method_len == method_len &&
-           memcmp(key_method, method, method_len)) {
+        if(*key_method && *key_method_len == method_len &&
+           memcmp(*key_method, method, method_len)) {
             if(*key_method)
                 LIBSSH2_FREE(session, *key_method);
             *key_method = LIBSSH2_ALLOC(session, match_len + suffix_len);

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1396,7 +1396,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
     size_t match_len = 0;
     char *filtered_algs = NULL;
     const size_t suffix_len = sizeof("-cert-v01@openssh.com") - 1;
-    const char * const certSuffix = "-cert-v01@openssh.com";
+    const char * const suffix = "-cert-v01@openssh.com";
     const size_t method_len = sizeof("ssh-rsa-cert-v01@openssh.com") - 1;
     const char * const method = "ssh-rsa-cert-v01@openssh.com";
     const char *remote_banner = NULL;
@@ -1510,7 +1510,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
             *key_method = LIBSSH2_ALLOC(session, match_len + suffix_len);
             if(*key_method) {
                 memcpy(*key_method, match, match_len);
-                memcpy(*key_method + match_len, certSuffix, suffix_len);
+                memcpy(*key_method + match_len, suffix, suffix_len);
                 *key_method_len = match_len + suffix_len;
             }
         }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1379,7 +1379,6 @@ static int is_version_less_than_78(const char *version)
  * @param key_method_len length of the key method buffer
  * @result error code or zero on success
  */
-
 static int
 _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
                             unsigned char **key_method,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1411,13 +1411,6 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
         return LIBSSH2_ERROR_NONE;
     }
 
-    filtered_algs = LIBSSH2_ALLOC(session, strlen(supported_algs) + 1);
-    if(!filtered_algs) {
-        rc = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                            "Unable to allocate filtered algs");
-        return rc;
-    }
-
     /* Set "SSH_BUG_SIGTYPE" flag when the remote server version is OpenSSH 7.7
        or lower and when the RSA key in question is a certificate to ignore
        "server-sig-algs" and only offer ssh-rsa signature algorithm for
@@ -1432,10 +1425,16 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
             if(SSH_BUG_SIGTYPE &&
                *key_method && *key_method_len == method_len &&
                memcmp(*key_method, method, method_len) == 0) {
-                LIBSSH2_FREE(session, filtered_algs);
                 return LIBSSH2_ERROR_NONE;
             }
         }
+    }
+
+    filtered_algs = LIBSSH2_ALLOC(session, strlen(supported_algs) + 1);
+    if(!filtered_algs) {
+        rc = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
+                            "Unable to allocate filtered algs");
+        return rc;
     }
 
     s = session->server_sign_algorithms;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1395,14 +1395,13 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
     size_t f_len = 0;
     int rc = 0;
     size_t match_len = 0;
-    const size_t suffix_len = 21;
     char *filtered_algs = NULL;
+    const size_t suffix_len = sizeof("-cert-v01@openssh.com") - 1;
     const char * const certSuffix = "-cert-v01@openssh.com";
+    const size_t method_len = sizeof("ssh-rsa-cert-v01@openssh.com") - 1;
+    const char * const method = "ssh-rsa-cert-v01@openssh.com";
     const char *remote_banner = NULL;
     const char * const remote_ver_pre = "OpenSSH_";
-    const char *remote_ver_start = NULL;
-    const char *remote_ver = NULL;
-    int SSH_BUG_SIGTYPE = 0;
 
     const char *supported_algs =
     _libssh2_supported_key_sign_algorithms(session,
@@ -1428,13 +1427,13 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
     remote_banner = libssh2_session_banner_get(session);
     /* Extract version information from the banner */
     if(remote_banner) {
-        remote_ver_start = strstr(remote_banner, remote_ver_pre);
+        const char *remote_ver_start = strstr(remote_banner, remote_ver_pre);
         if(remote_ver_start) {
-            remote_ver = remote_ver_start + strlen(remote_ver_pre);
-            SSH_BUG_SIGTYPE = is_version_less_than_78(remote_ver);
-            if(SSH_BUG_SIGTYPE && *key_method_len == 28 &&
-               memcmp(key_method, "ssh-rsa-cert-v01@openssh.com",
-                      *key_method_len)) {
+            const char *remote_ver = remote_ver_start + strlen(remote_ver_pre);
+            int SSH_BUG_SIGTYPE = is_version_less_than_78(remote_ver);
+            if(SSH_BUG_SIGTYPE && *key_method_len == method_len &&
+               memcmp(key_method, method, method_len)) {
+                LIBSSH2_FREE(session, filtered_algs);
                 return LIBSSH2_ERROR_NONE;
             }
         }
@@ -1507,9 +1506,8 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
     }
 
     if(match) {
-        if(*key_method_len == 28 &&
-           memcmp(key_method,
-                  "ssh-rsa-cert-v01@openssh.com", *key_method_len)) {
+        if(*key_method_len == method_len &&
+           memcmp(key_method, method, method_len)) {
             if(*key_method)
                 LIBSSH2_FREE(session, *key_method);
             *key_method = LIBSSH2_ALLOC(session, match_len + suffix_len);
@@ -1540,8 +1538,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
                             "No signing signature matched");
     }
 
-    if(filtered_algs)
-        LIBSSH2_FREE(session, filtered_algs);
+    LIBSSH2_FREE(session, filtered_algs);
 
     return rc;
 }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1431,7 +1431,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
             const char *remote_ver = remote_ver_start + strlen(remote_ver_pre);
             int SSH_BUG_SIGTYPE = is_version_less_than_78(remote_ver);
             if(SSH_BUG_SIGTYPE && *key_method_len == method_len &&
-               memcmp(*key_method, method, method_len)) {
+               memcmp(*key_method, method, method_len) == 0) {
                 LIBSSH2_FREE(session, filtered_algs);
                 return LIBSSH2_ERROR_NONE;
             }
@@ -1506,7 +1506,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
 
     if(match) {
         if(*key_method && *key_method_len == method_len &&
-           memcmp(*key_method, method, method_len)) {
+           memcmp(*key_method, method, method_len) == 0) {
             LIBSSH2_FREE(session, *key_method);
             *key_method = LIBSSH2_ALLOC(session, match_len + suffix_len);
             if(*key_method) {

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1404,9 +1404,8 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
     const char * const remote_ver_pre = "OpenSSH_";
 
     const char *supported_algs =
-    _libssh2_supported_key_sign_algorithms(session,
-                                           *key_method,
-                                           *key_method_len);
+        _libssh2_supported_key_sign_algorithms(session,
+                                               *key_method, *key_method_len);
 
     if(!supported_algs || !session->server_sign_algorithms) {
         /* no upgrading key algorithm supported, do nothing */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1507,8 +1507,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
     if(match) {
         if(*key_method && *key_method_len == method_len &&
            memcmp(*key_method, method, method_len)) {
-            if(*key_method)
-                LIBSSH2_FREE(session, *key_method);
+            LIBSSH2_FREE(session, *key_method);
             *key_method = LIBSSH2_ALLOC(session, match_len + suffix_len);
             if(*key_method) {
                 memcpy(*key_method, match, match_len);


### PR DESCRIPTION
- dedupe constant, and replace magic number with `sizeof()`.
- drop useless check for non-NULL `filtered_algs` on exit.
- fix leaking `filtered_algs` on an error path.
- fix to pass `*key_method` to `memcmp()` (was: `key_method`).
- fix to compare `memcmp()` against `0` (was: non-zero).
- add missing NULL-check before using `*key_method`.
- drop redundant `*key_method` NULL-check after use.
- scope variables.
- avoid camelcase in variable name.
- fix formatting.

Ref: https://github.com/libssh2/libssh2/pull/1314#discussion_r3125784577
Ref: https://github.com/libssh2/libssh2/pull/1877#discussion_r3133769919
Ref: https://github.com/libssh2/libssh2/pull/1877#discussion_r3133769820
Follow-up to 3a6ab70dcfeb87a3acbb5af7ea6fc783c3981e04 #1314

---

FIXME?: The comment and code about `SSH_BUG_SIGTYPE` seem to be
not in sync with each other.

/cc @Tejaswikandula
