### PR TITLE
src: open key files in binary mode

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -325,7 +325,7 @@ _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
     unsigned char *n, *e, *d, *p, *q, *e1, *e2, *coeff;
     unsigned int nlen, elen, dlen, plen, qlen, e1len, e2len, coefflen;
 
-    fp = fopen(filename, FOPEN_READTEXT);
+    fp = fopen(filename, "rb");
     if(!fp) {
         return -1;
     }
@@ -445,7 +445,7 @@ _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
     unsigned char *p, *q, *g, *y, *x;
     unsigned int plen, qlen, glen, ylen, xlen;
 
-    fp = fopen(filename, FOPEN_READTEXT);
+    fp = fopen(filename, "rb");
     if(!fp) {
         return -1;
     }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -680,7 +680,7 @@ file_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH, "Loading public key file: %s",
                    pubkeyfile));
     /* Read Public Key */
-    fd = fopen(pubkeyfile, FOPEN_READTEXT);
+    fd = fopen(pubkeyfile, "rb");
     if(!fd) {
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                               "Unable to open public key file");

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -887,7 +887,7 @@ static int _libssh2_wincng_load_pem(LIBSSH2_SESSION *session,
     FILE *fp;
     int ret;
 
-    fp = fopen(filename, FOPEN_READTEXT);
+    fp = fopen(filename, "rb");
     if(!fp) {
         return -1;
     }
@@ -2648,7 +2648,7 @@ _libssh2_wincng_ecdsa_new_private(OUT _libssh2_wincng_ecdsa_key **key,
             "Passphrase-protected ECDSA private key files are unsupported");
     }
 
-    file_handle = fopen(filename, FOPEN_READTEXT);
+    file_handle = fopen(filename, "rb");
     if(!file_handle) {
         result = _libssh2_error(
             session,


### PR DESCRIPTION
To fix `ftell()` returning the size in bytes in `_libssh2_pem_parse()`.

Ref: https://github.com/libssh2/libssh2/pull/1880#discussion_r3134532395
Follow-up to ef6eaadba51985319ad18661ef54a273a3867c59 #235
