### PR TITLE
os400qc3: open PEM files in binary mode

### DIFF
--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2139,6 +2139,8 @@ load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
     if(ret) {
         /* Try DER encoding. */
         fp = fopen(filename, "rb");
+        if(!fp)
+            return -1;
         fseek(fp, 0L, SEEK_END);
         filesize = ftell(fp);
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -313,7 +313,6 @@ static const char   beginprivkeyhdr[] = "-----BEGIN PRIVATE KEY-----";
 static const char   endprivkeyhdr[] = "-----END PRIVATE KEY-----";
 static const char   beginrsaprivkeyhdr[] = "-----BEGIN RSA PRIVATE KEY-----";
 static const char   endrsaprivkeyhdr[] = "-----END RSA PRIVATE KEY-----";
-static const char   fopenrbmode[] = "rb";
 
 /* The rest of character literals in this module are in EBCDIC. */
 #pragma convert(37)
@@ -2110,7 +2109,7 @@ load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
                       unsigned const char *passphrase,
                       loadkeyproc proc1, loadkeyproc proc8, void *loadkeydata)
 {
-    FILE *fp = fopen(filename, fopenrbmode);
+    FILE *fp = fopen(filename, "rb");
     unsigned char *data = NULL;
     size_t datalen = 0;
     int ret;
@@ -2139,7 +2138,7 @@ load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
 
     if(ret) {
         /* Try DER encoding. */
-        fp = fopen(filename, fopenrbmode);
+        fp = fopen(filename, "rb");
         fseek(fp, 0L, SEEK_END);
         filesize = ftell(fp);
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -313,7 +313,6 @@ static const char   beginprivkeyhdr[] = "-----BEGIN PRIVATE KEY-----";
 static const char   endprivkeyhdr[] = "-----END PRIVATE KEY-----";
 static const char   beginrsaprivkeyhdr[] = "-----BEGIN RSA PRIVATE KEY-----";
 static const char   endrsaprivkeyhdr[] = "-----END RSA PRIVATE KEY-----";
-static const char   fopenrmode[] = "r";
 static const char   fopenrbmode[] = "rb";
 
 /* The rest of character literals in this module are in EBCDIC. */
@@ -2111,7 +2110,7 @@ load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
                       unsigned const char *passphrase,
                       loadkeyproc proc1, loadkeyproc proc8, void *loadkeydata)
 {
-    FILE *fp = fopen(filename, fopenrmode);
+    FILE *fp = fopen(filename, fopenrbmode);
     unsigned char *data = NULL;
     size_t datalen = 0;
     int ret;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -313,6 +313,7 @@ static const char   beginprivkeyhdr[] = "-----BEGIN PRIVATE KEY-----";
 static const char   endprivkeyhdr[] = "-----END PRIVATE KEY-----";
 static const char   beginrsaprivkeyhdr[] = "-----BEGIN RSA PRIVATE KEY-----";
 static const char   endrsaprivkeyhdr[] = "-----END RSA PRIVATE KEY-----";
+static const char   fopenrbmode[] = "rb";
 
 /* The rest of character literals in this module are in EBCDIC. */
 #pragma convert(37)
@@ -2109,7 +2110,7 @@ load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
                       unsigned const char *passphrase,
                       loadkeyproc proc1, loadkeyproc proc8, void *loadkeydata)
 {
-    FILE *fp = fopen(filename, "rb");
+    FILE *fp = fopen(filename, fopenrbmode);
     unsigned char *data = NULL;
     size_t datalen = 0;
     int ret;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2140,7 +2140,8 @@ load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
         fseek(fp, 0L, SEEK_END);
         filesize = ftell(fp);
 
-        if(filesize <= 32768) {        /* Limit to a reasonable size. */
+        if(filesize > 0 &&
+           filesize <= 32768) {  /* Limit to a reasonable size. */
             datalen = filesize;
             data = (unsigned char *) alloca(datalen);
             if(data) {

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2134,13 +2134,9 @@ load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
     if(ret)
         ret = try_pem_load(session, fp, passphrase, beginrsaprivkeyhdr,
                            endrsaprivkeyhdr, proc1, loadkeydata);
-    fclose(fp);
 
+    /* Try DER encoding. */
     if(ret) {
-        /* Try DER encoding. */
-        fp = fopen(filename, "rb");
-        if(!fp)
-            return -1;
         fseek(fp, 0L, SEEK_END);
         filesize = ftell(fp);
 
@@ -2163,8 +2159,9 @@ load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
                                    loadkeydata);
             }
         }
-        fclose(fp);
     }
+
+    fclose(fp);
 
     return ret;
 }


### PR DESCRIPTION
To make `ftell()` return a byte offset.

Also:
- handle `ftell()` returning -1 when loading DER format.

Follow-up to 0ca33b61b65e57fc52e580294d036c9575d455ec #1883
