### PR TITLE
userauth: various fixes to `_libssh2_key_sign_algorithm()` (cont.)

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1469,7 +1469,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
         s = p ? (p + 1) : NULL;
     }
 
-    filtered_algs[i - filtered_algs] = '\0';
+    *i = '\0';
 
     if(session->sign_algo_prefs) {
         s = session->sign_algo_prefs;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1435,7 +1435,8 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
         }
     }
 
-    filtered_algs = LIBSSH2_ALLOC(session, strlen(supported_algs) + 1);
+    filtered_algs = LIBSSH2_ALLOC(session,
+                                  strlen(session->server_sign_algorithms) + 1);
     if(!filtered_algs) {
         rc = _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate filtered algs");

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1471,12 +1471,7 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
 
     *i = '\0';
 
-    if(session->sign_algo_prefs) {
-        s = session->sign_algo_prefs;
-    }
-    else {
-        s = supported_algs;
-    }
+    s = session->sign_algo_prefs ? session->sign_algo_prefs : supported_algs;
 
     /* now that we have the possible supported algos, match based on the prefs
        or what is supported by the crypto backend, look for a match */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1451,12 +1451,12 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
 
     while(s && *s) {
         p = strchr(s, ',');
-        p_len = (p ? (size_t)(p - s) : strlen(s));
+        p_len = p ? (size_t)(p - s) : strlen(s);
         a = supported_algs;
 
         while(a && *a) {
             f = strchr(a, ',');
-            f_len = (f ? (size_t)(f - a) : strlen(a));
+            f_len = f ? (size_t)(f - a) : strlen(a);
 
             if(f_len == p_len && memcmp(a, s, p_len) == 0) {
 
@@ -1484,12 +1484,12 @@ _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
 
     while(s && *s && !match) {
         p = strchr(s, ',');
-        p_len = (p ? (size_t)(p - s) : strlen(s));
+        p_len = p ? (size_t)(p - s) : strlen(s);
         a = filtered_algs;
 
         while(a && *a && !match) {
             f = strchr(a, ',');
-            f_len = (f ? (size_t)(f - a) : strlen(a));
+            f_len = f ? (size_t)(f - a) : strlen(a);
 
             if(f_len == p_len && memcmp(a, s, p_len) == 0) {
                 /* found a match, upgrade key method */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1350,17 +1350,17 @@ size_t plain_method(char *method, size_t method_len)
  */
 static int is_version_less_than_78(const char *version)
 {
-    const char *endptr = NULL;
+    const char *endptr_major = NULL;
     long major = 0;
     int minor = 0;
 
     if(!version)
         return 0;
 
-    major = strtol(version, &endptr, 10);
-    if(!endptr || *endptr != '.')
+    major = strtol(version, &endptr_major, 10);
+    if(!endptr_major || *endptr_major != '.')
         return 0; /* Not a valid number */
-    minor = (endptr + 1)[0] - '0';
+    minor = (endptr_major + 1)[0] - '0';
     if((major >= 1 && major <= 6) ||
        (major == 7 && minor >= 0 && minor <= 7)) {
         return 1; /* Version is in the specified range */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1351,8 +1351,9 @@ size_t plain_method(char *method, size_t method_len)
 static int is_version_less_than_78(const char *version)
 {
     const char *endptr_major = NULL;
+    const char *endptr_minor = NULL;
     long major = 0;
-    int minor = 0;
+    long minor = 0;
 
     if(!version)
         return 0;
@@ -1360,7 +1361,11 @@ static int is_version_less_than_78(const char *version)
     major = strtol(version, &endptr_major, 10);
     if(!endptr_major || *endptr_major != '.')
         return 0; /* Not a valid number */
-    minor = (endptr_major + 1)[0] - '0';
+
+    minor = strtol(endptr_major + 1, &minor_endptr, 10);
+    if(!minor_endptr || minor_endptr == endptr_major + 1)
+        return 0; /* Not a valid number */
+
     if((major >= 1 && major <= 6) ||
        (major == 7 && minor >= 0 && minor <= 7)) {
         return 1; /* Version is in the specified range */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1350,8 +1350,8 @@ size_t plain_method(char *method, size_t method_len)
  */
 static int is_version_less_than_78(const char *version)
 {
-    const char *endptr_major = NULL;
-    const char *endptr_minor = NULL;
+    char *endptr_major = NULL;
+    char *endptr_minor = NULL;
     long major = 0;
     long minor = 0;
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1362,8 +1362,8 @@ static int is_version_less_than_78(const char *version)
     if(!endptr_major || *endptr_major != '.')
         return 0; /* Not a valid number */
 
-    minor = strtol(endptr_major + 1, &minor_endptr, 10);
-    if(!minor_endptr || minor_endptr == endptr_major + 1)
+    minor = strtol(endptr_major + 1, &endptr_minor, 10);
+    if(!endptr_minor || endptr_minor == endptr_major + 1)
         return 0; /* Not a valid number */
 
     if((major >= 1 && major <= 6) ||

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1350,7 +1350,7 @@ size_t plain_method(char *method, size_t method_len)
  */
 static int is_version_less_than_78(const char *version)
 {
-    char *endptr = NULL;
+    const char *endptr = NULL;
     long major = 0;
     int minor = 0;
 


### PR DESCRIPTION
- size the `filtered-algs` buffer by the server list rather than the 
  supported list, since the output is always a subset of the server list
  byte-for-byte.
  Report-and-patch-by: Kit Knox

- use `strttol()` to extract minor version too.
  Pointed out by GitHub Code Quality.

Also:
- rename a variable.
- simplify an expression.
- inline an `if` block.
- drop redundant parentheses.

Follow-up to ba2a7ff9cbc0212d85e42a4986ace17bfe20837e #1881
Follow-up to 3a6ab70dcfeb87a3acbb5af7ea6fc783c3981e04 #1314
