### PR TITLE
x11: fix messages, buffer sizes, error handling

### DIFF
--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -251,11 +251,10 @@ int main(int argc, char *argv[])
                     fputc(buffer[i], stderr);
                 fprintf(stderr, "\n");
             }
-            else {
-                if(nread != LIBSSH2_ERROR_EAGAIN)
-                    /* no need to output this for the EAGAIN case */
-                    fprintf(stderr, "libssh2_channel_read returned %ld\n",
-                            (long)nread);
+            else if(nread != LIBSSH2_ERROR_EAGAIN) {
+                /* no need to output this for the EAGAIN case */
+                fprintf(stderr, "libssh2_channel_read returned %ld\n",
+                        (long)nread);
             }
         } while(nread > 0);
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
                     fputc(buffer[i], stderr);
                 fprintf(stderr, "\n");
             }
-            else if(nread != LIBSSH2_ERROR_EAGAIN) {
+            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN) {
                 /* no need to output this for the EAGAIN case */
                 fprintf(stderr, "libssh2_channel_read returned %ld\n",
                         (long)nread);

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -262,11 +262,10 @@ int main(int argc, char *argv[])
                     fputc(buffer[i], stderr);
                 fprintf(stderr, "\n");
             }
-            else {
-                if(nread != LIBSSH2_ERROR_EAGAIN)
-                    /* no need to output this for the EAGAIN case */
-                    fprintf(stderr, "libssh2_channel_read returned %ld\n",
-                            (long)nread);
+            else if(nread != LIBSSH2_ERROR_EAGAIN) {
+                /* no need to output this for the EAGAIN case */
+                fprintf(stderr, "libssh2_channel_read returned %ld\n",
+                        (long)nread);
             }
         } while(nread > 0);
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
                     fputc(buffer[i], stderr);
                 fprintf(stderr, "\n");
             }
-            else if(nread != LIBSSH2_ERROR_EAGAIN) {
+            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN) {
                 /* no need to output this for the EAGAIN case */
                 fprintf(stderr, "libssh2_channel_read returned %ld\n",
                         (long)nread);

--- a/example/x11.c
+++ b/example/x11.c
@@ -425,7 +425,8 @@ int main(int argc, char *argv[])
                 fflush(stdout);
             }
             else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN) {
-                rc = (int)nread;
+                fprintf(stderr, "libssh2_channel_read returned %ld\n",
+                        (long)nread);
             }
         }
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -1,6 +1,6 @@
 /* Copyright (C) The libssh2 project and its contributors.
  *
- * Sample showing how to makes SSH2 with X11 Forwarding works.
+ * Sample showing how to make SSH2 with X11 Forwarding works.
  *
  * $ ./x11 host user password [DEBUG]
  *
@@ -308,14 +308,14 @@ int main(int argc, char *argv[])
     sin.sin_addr.s_addr = hostaddr;
 
     if(connect(sock, (struct sockaddr*)(&sin), sizeof(struct sockaddr_in))) {
-        fprintf(stderr, "Failed to established connection.\n");
+        fprintf(stderr, "Failed to establish connection.\n");
         return 1;
     }
     /* Open a session */
     session = libssh2_session_init();
     rc      = libssh2_session_handshake(session, sock);
     if(rc) {
-        fprintf(stderr, "Failed Start the SSH session\n");
+        fprintf(stderr, "Failed to start the SSH session\n");
         return 1;
     }
 
@@ -370,7 +370,7 @@ int main(int argc, char *argv[])
 
     rc = _raw_mode();
     if(rc) {
-        fprintf(stderr, "Failed to entered in raw mode\n");
+        fprintf(stderr, "Failed to enter raw mode\n");
         goto shutdown;
     }
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -1,6 +1,6 @@
 /* Copyright (C) The libssh2 project and its contributors.
  *
- * Sample showing how to make SSH2 with X11 Forwarding works.
+ * Sample showing how to make SSH2 with X11 Forwarding work.
  *
  * $ ./x11 host user password [DEBUG]
  *

--- a/example/x11.c
+++ b/example/x11.c
@@ -418,7 +418,7 @@ int main(int argc, char *argv[])
 
         rc = libssh2_poll(fds, nfds, 0);
         if(rc > 0) {
-            libssh2_channel_read(channel, buf, bufsize);
+            libssh2_channel_read(channel, buf, bufsiz);
             fprintf(stdout, "%s", buf);
             fflush(stdout);
         }

--- a/example/x11.c
+++ b/example/x11.c
@@ -453,7 +453,7 @@ int main(int argc, char *argv[])
             /* Data in stdin */
             nread = read(fileno(stdin), buf, 1);
             if(nread > 0)
-                libssh2_channel_write(channel, buf, sizeof(buf));
+                libssh2_channel_write(channel, buf, (size_t)nread);
         }
 
         free(fds);

--- a/example/x11.c
+++ b/example/x11.c
@@ -418,7 +418,7 @@ int main(int argc, char *argv[])
 
         rc = libssh2_poll(fds, nfds, 0);
         if(rc > 0) {
-            libssh2_channel_read(channel, buf, sizeof(buf));
+            libssh2_channel_read(channel, buf, bufsize);
             fprintf(stdout, "%s", buf);
             fflush(stdout);
         }

--- a/example/x11.c
+++ b/example/x11.c
@@ -418,9 +418,15 @@ int main(int argc, char *argv[])
 
         rc = libssh2_poll(fds, nfds, 0);
         if(rc > 0) {
-            libssh2_channel_read(channel, buf, bufsiz);
-            fprintf(stdout, "%s", buf);
-            fflush(stdout);
+            ssize_t nread;
+            nread = libssh2_channel_read(channel, buf, bufsiz);
+            if(nread > 0) {
+                fwrite(buf, 1, (size_t)nread, stdout);
+                fflush(stdout);
+            }
+            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN) {
+                rc = (int)nread;
+            }
         }
 
         /* Looping on X clients */


### PR DESCRIPTION
- fix wrong data length in `libssh2_channel_write()` call.
- fix wrong buffer size in `libssh2_channel_read()` call.
- check success of `libssh2_channel_read()` call, show error on failure.
- fix writing raw data to stdout.
- fix grammar in error messages.

Also in ssh2_agent_forwarding, ssh2_exec:
- use `else if` in two other examples.
- fix to not display `libssh2_channel_read()` when zero.

Pointed out by GitHub Code Quality

Follow-up to 32080def94c3558e724e0c3e5e63de90c29194b0
