### PR TITLE
appveyor: test tidy-ups

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,11 +74,13 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       CMAKE_GENERATOR: 'Visual Studio 12 2013'
       CMAKE_GENERATE: '-A x64 -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=C:/OpenSSL-v111-Win64 -DBUILD_SHARED_LIBS=OFF'
+      #SKIP_CTEST: 'yes'
 
     - job_name: 'VS2010, WinCNG, x64, Build-only, non-unity'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       CMAKE_GENERATOR: 'Visual Studio 10 2010'
       CMAKE_GENERATE: '-A x64 -DCRYPTO_BACKEND=WinCNG -DENABLE_ECDSA_WINCNG=ON -DCMAKE_UNITY_BUILD=OFF'
+      #SKIP_CTEST: 'yes'
 
     - job_name: 'VS2022, WinCNG, x64, Server 2019, Debug-logging'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
@@ -89,6 +91,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       CMAKE_GENERATOR: 'Visual Studio 17 2022'
       CMAKE_GENERATE: '-A ARM64 -DCRYPTO_BACKEND=WinCNG -DENABLE_ECDSA_WINCNG=ON'
+      #SKIP_CTEST: 'yes'
 
     - job_name: 'VS2015, WinCNG, x64, Server 2012 R2'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
@@ -105,18 +108,13 @@ matrix:
 
 install:
   - ps: $env:PATH = "C:/my-cmake/bin;C:/my-docker/docker;$env:PATH"
-  # prepare local SSH server for reverse tunneling from GitHub Actions hosting our docker container
   - ps: |
+      # prepare local SSH server for reverse tunneling from GitHub Actions hosting our docker container
       $env:OPENSSH_SERVER_PORT = Get-Random -Minimum 2000 -Maximum 2300
       [System.Environment]::SetEnvironmentVariable('OPENSSH_SERVER_PORT', $env:OPENSSH_SERVER_PORT)
       ./scripts/appveyor/docker-bridge.ps1
 
-build_script:
-  - cmd: sh -c ./appveyor.sh
-
-test_script:
-  - ps: |
-      if($env:SKIP_CTEST -ne 'yes' -and $env:CMAKE_GENERATE -notlike '*ARM64*') {
+      if($env:SKIP_CTEST -ne 'yes') {
         Write-Host 'Waiting for SSH connection from GitHub Actions' -NoNewline
         $endDate = (Get-Date).AddMinutes(5)
         while((Get-Process -Name 'sshd' -ErrorAction SilentlyContinue).Count -eq 1 -and (Get-Date) -lt $endDate) {
@@ -131,6 +129,14 @@ test_script:
         else {
           Write-Host '... failed.'
         }
+      }
+
+build_script:
+  - cmd: sh -c ./appveyor.sh
+
+test_script:
+  - ps: |
+      if($env:SKIP_CTEST -ne 'yes') {
         if($env:CMAKE_GENERATE -like '*WinCNG*') {
           $env:FIXTURE_TRACE_ALL_CONNECT = '1'
         }

--- a/scripts/appveyor/docker-bridge.sh
+++ b/scripts/appveyor/docker-bridge.sh
@@ -7,6 +7,7 @@ set -eu
 netsh interface portproxy add v4tov4 listenport=3389 listenaddress="$1" connectport=22 connectaddress=127.0.0.1
 netsh interface portproxy show all
 
+# ssh-keygen -b 2048 -t rsa -f auth -q -N '' && mkdir .ssh && mv auth.pub .ssh/authorized_keys
 ssh-keygen -t ed25519 -f auth -q -N '' && mkdir .ssh && mv auth.pub .ssh/authorized_keys
 ssh-keygen -A
 "$(command -v sshd)" &


### PR DESCRIPTION
- wait for sshd before the build, to ease testing.
- restore the RSA 2048 hostkey generator line, commented, to ease tests.
- keep per-job `SKIP_CTEST` settings, commented, to ease tests.
- drop automatism to disable tests for ARM64, for simplicity.

Note: This has been tested with tests enabled, but they remain
a hit-or-miss (mostly a miss) due to failed sshd connection, and this
patch does not re-enable them.

FTR:
- a CI run when tests worked without issues (2023-12-04):
  https://ci.appveyor.com/project/libssh2org/libssh2/builds/48673013/job/79lywpm3pfvq7hn5
- a fresh CI run when the first job successfully waited for sshd:
  https://ci.appveyor.com/project/libssh2org/libssh2/builds/53941135/job/yu9jf5hvp3grse0g

Ref: #1856 #1857
Follow-up to c71ff14f3b956d65b86707e025b831a80579dba2 #1894
Follow-up to c321b324d65e0d5d4a74a36a39cd9887ec24eeae #1768
Follow-up to b5e68bdc37c6afa0dc777794dda8307167919d04 #1461
Follow-up to f36edf94e7af2797fd431a7dc7bbe31213dac7d7 #997
