### PR TITLE
tidy-up: add missing, and drop redundant parentheses

### DIFF
--- a/docs/libssh2_session_init_ex.md
+++ b/docs/libssh2_session_init_ex.md
@@ -19,9 +19,9 @@ libssh2_session_init_ex - initializes an SSH session object
 #include <libssh2.h>
 
 LIBSSH2_SESSION *
-libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC((*myalloc)),
-                        LIBSSH2_FREE_FUNC((*myfree)),
-                        LIBSSH2_REALLOC_FUNC((*myrealloc)),
+libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*myalloc),
+                        LIBSSH2_FREE_FUNC(*myfree),
+                        LIBSSH2_REALLOC_FUNC(*myrealloc),
                         void *abstract);
 
 LIBSSH2_SESSION *

--- a/docs/libssh2_sftp_fstat_ex.md
+++ b/docs/libssh2_sftp_fstat_ex.md
@@ -23,9 +23,9 @@ libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
                       LIBSSH2_SFTP_ATTRIBUTES *attrs, int setstat)
 
 #define libssh2_sftp_fstat(handle, attrs) \
-    libssh2_sftp_fstat_ex((handle), (attrs), 0)
+    libssh2_sftp_fstat_ex(handle, attrs, 0)
 #define libssh2_sftp_fsetstat(handle, attrs) \
-    libssh2_sftp_fstat_ex((handle), (attrs), 1)
+    libssh2_sftp_fstat_ex(handle, attrs, 1)
 ~~~
 
 # DESCRIPTION

--- a/docs/libssh2_sftp_readlink.md
+++ b/docs/libssh2_sftp_readlink.md
@@ -19,8 +19,8 @@ libssh2_sftp_readlink - convenience macro for *libssh2_sftp_symlink_ex(3)*
 #include <libssh2_sftp.h>
 
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), (path), strlen(path), \
-                            (target), (maxlen), \
+    libssh2_sftp_symlink_ex(sftp, path, strlen(path), \
+                            target, maxlen, \
                             LIBSSH2_SFTP_READLINK)
 ~~~
 

--- a/docs/libssh2_sftp_realpath.md
+++ b/docs/libssh2_sftp_realpath.md
@@ -19,8 +19,8 @@ libssh2_sftp_realpath - convenience macro for *libssh2_sftp_symlink_ex(3)*
 #include <libssh2_sftp.h>
 
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), (path), strlen(path), \
-                            (target), (maxlen), \
+    libssh2_sftp_symlink_ex(sftp, path, strlen(path), \
+                            target, maxlen, \
                             LIBSSH2_SFTP_REALPATH)
 ~~~
 

--- a/docs/libssh2_sftp_rmdir.md
+++ b/docs/libssh2_sftp_rmdir.md
@@ -19,7 +19,7 @@ libssh2_sftp_rmdir - convenience macro for *libssh2_sftp_rmdir_ex(3)*
 #include <libssh2_sftp.h>
 
 #define libssh2_sftp_rmdir(sftp, path) \
-    libssh2_sftp_rmdir_ex((sftp), (path), strlen(path))
+    libssh2_sftp_rmdir_ex(sftp, path, strlen(path))
 ~~~
 
 # DESCRIPTION

--- a/docs/libssh2_sftp_symlink.md
+++ b/docs/libssh2_sftp_symlink.md
@@ -19,7 +19,7 @@ libssh2_sftp_symlink - convenience macro for *libssh2_sftp_symlink_ex(3)*
 #include <libssh2_sftp.h>
 
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \
-    libssh2_sftp_symlink_ex((sftp), (orig), strlen(orig), (linkpath), \
+    libssh2_sftp_symlink_ex(sftp, orig, strlen(orig), linkpath, \
                             strlen(linkpath), LIBSSH2_SFTP_SYMLINK)
 ~~~
 

--- a/docs/libssh2_sign_sk.md
+++ b/docs/libssh2_sign_sk.md
@@ -32,7 +32,7 @@ typedef struct _LIBSSH2_PRIVKEY_SK {
     const char *application;
     const unsigned char *key_handle;
     size_t handle_len;
-    LIBSSH2_USERAUTH_SK_SIGN_FUNC((*sign_callback));
+    LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback);
     void **orig_abstract;
 } LIBSSH2_PRIVKEY_SK;
 ~~~

--- a/docs/libssh2_userauth_keyboard_interactive.md
+++ b/docs/libssh2_userauth_keyboard_interactive.md
@@ -20,7 +20,7 @@ libssh2_userauth_keyboard_interactive - convenience macro for *libssh2_userauth_
 int
 libssh2_userauth_keyboard_interactive(LIBSSH2_SESSION* session,
                                       const char *username,
-                 LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC((*response_callback)));
+                    LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback));
 ~~~
 
 # DESCRIPTION

--- a/docs/libssh2_userauth_password_ex.md
+++ b/docs/libssh2_userauth_password_ex.md
@@ -23,7 +23,7 @@ libssh2_userauth_password_ex(LIBSSH2_SESSION *session,
                              unsigned int username_len,
                              const char *password,
                              unsigned int password_len,
-                           LIBSSH2_PASSWD_CHANGEREQ_FUNC((*passwd_change_cb)));
+                             LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb));
 
 #define libssh2_userauth_password(session, username, password) \
      libssh2_userauth_password_ex(session, \

--- a/docs/libssh2_userauth_password_ex.md
+++ b/docs/libssh2_userauth_password_ex.md
@@ -26,9 +26,9 @@ libssh2_userauth_password_ex(LIBSSH2_SESSION *session,
                            LIBSSH2_PASSWD_CHANGEREQ_FUNC((*passwd_change_cb)));
 
 #define libssh2_userauth_password(session, username, password) \
-     libssh2_userauth_password_ex((session), (username), \
-                                  strlen(username), \
-                                  (password), strlen(password), NULL)
+     libssh2_userauth_password_ex(session, \
+                                  username, strlen(username), \
+                                  password, strlen(password), NULL)
 ~~~
 
 # DESCRIPTION

--- a/docs/libssh2_userauth_publickey_sk.md
+++ b/docs/libssh2_userauth_publickey_sk.md
@@ -26,7 +26,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
                               const char *passphrase,
-                              LIBSSH2_USERAUTH_SK_SIGN_FUNC((*sign_callback)),
+                              LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback),
                               void **abstract);
 ~~~
 

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
     }
     else
         libssh2_sftp_seek64(sftp_handle, attrs.filesize);
-    fprintf(stderr, "Did a seek to position %ld\n", (long) attrs.filesize);
+    fprintf(stderr, "Did a seek to position %ld\n", (long)attrs.filesize);
 
     fprintf(stderr, "libssh2_sftp_open() a handle for APPEND\n");
     if(!sftp_handle) {

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -618,8 +618,8 @@ LIBSSH2_API int libssh2_session_disconnect_ex(LIBSSH2_SESSION *session,
                                               const char *description,
                                               const char *lang);
 #define libssh2_session_disconnect(session, description) \
-    libssh2_session_disconnect_ex((session), SSH_DISCONNECT_BY_APPLICATION, \
-                                  (description), "")
+    libssh2_session_disconnect_ex(session, SSH_DISCONNECT_BY_APPLICATION, \
+                                  description, "")
 
 LIBSSH2_API int libssh2_session_free(LIBSSH2_SESSION *session);
 
@@ -665,9 +665,9 @@ libssh2_userauth_password_ex(LIBSSH2_SESSION *session,
                                  ((*passwd_change_cb)));
 
 #define libssh2_userauth_password(session, username, password) \
-    libssh2_userauth_password_ex((session), (username), \
+    libssh2_userauth_password_ex(session, username, \
                                  (unsigned int)strlen(username), \
-                                 (password), (unsigned int)strlen(password), \
+                                 password, (unsigned int)strlen(password), \
                                  NULL)
 
 LIBSSH2_API int
@@ -680,10 +680,10 @@ libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
 
 #define libssh2_userauth_publickey_fromfile(session, username, publickey,  \
                                             privatekey, passphrase)        \
-    libssh2_userauth_publickey_fromfile_ex((session), (username),          \
+    libssh2_userauth_publickey_fromfile_ex(session, username,              \
                                            (unsigned int)strlen(username), \
-                                           (publickey),                    \
-                                           (privatekey), (passphrase))
+                                           publickey,                      \
+                                           privatekey, passphrase)
 
 LIBSSH2_API int
 libssh2_userauth_publickey(LIBSSH2_SESSION *session,
@@ -708,13 +708,13 @@ libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
 
 #define libssh2_userauth_hostbased_fromfile(session, username, publickey,     \
                                             privatekey, passphrase, hostname) \
-    libssh2_userauth_hostbased_fromfile_ex((session), (username),             \
+    libssh2_userauth_hostbased_fromfile_ex(session, username,                 \
                                            (unsigned int)strlen(username),    \
-                                           (publickey),                       \
-                                           (privatekey), (passphrase),        \
-                                           (hostname),                        \
+                                           publickey,                         \
+                                           privatekey, passphrase,            \
+                                           hostname,                          \
                                            (unsigned int)strlen(hostname),    \
-                                           (username),                        \
+                                           username,                          \
                                            (unsigned int)strlen(username))
 
 LIBSSH2_API int
@@ -742,9 +742,9 @@ libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION* session,
 
 #define libssh2_userauth_keyboard_interactive(session, username,             \
                                               response_callback)             \
-    libssh2_userauth_keyboard_interactive_ex((session), (username),          \
+    libssh2_userauth_keyboard_interactive_ex(session, username,              \
                                              (unsigned int)strlen(username), \
-                                             (response_callback))
+                                             response_callback)
 
 LIBSSH2_API int
 libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
@@ -787,7 +787,7 @@ libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *channel_type,
                         const char *message, unsigned int message_len);
 
 #define libssh2_channel_open_session(session) \
-    libssh2_channel_open_ex((session), "session", sizeof("session") - 1, \
+    libssh2_channel_open_ex(session, "session", sizeof("session") - 1, \
                             LIBSSH2_CHANNEL_WINDOW_DEFAULT, \
                             LIBSSH2_CHANNEL_PACKET_DEFAULT, NULL, 0)
 
@@ -795,7 +795,7 @@ LIBSSH2_API LIBSSH2_CHANNEL *
 libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
                                 int port, const char *shost, int sport);
 #define libssh2_channel_direct_tcpip(session, host, port) \
-    libssh2_channel_direct_tcpip_ex((session), (host), (port), "127.0.0.1", 22)
+    libssh2_channel_direct_tcpip_ex(session, host, port, "127.0.0.1", 22)
 
 LIBSSH2_API LIBSSH2_CHANNEL *
 libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
@@ -807,7 +807,7 @@ libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session, const char *host,
                                   int port, int *bound_port,
                                   int queue_maxsize);
 #define libssh2_channel_forward_listen(session, port) \
-    libssh2_channel_forward_listen_ex((session), NULL, (port), NULL, 16)
+    libssh2_channel_forward_listen_ex(session, NULL, port, NULL, 16)
 
 LIBSSH2_API int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener);
 
@@ -821,8 +821,8 @@ LIBSSH2_API int libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
                                           unsigned int value_len);
 
 #define libssh2_channel_setenv(channel, varname, value)                 \
-    libssh2_channel_setenv_ex((channel), (varname),                     \
-                              (unsigned int)strlen(varname), (value),   \
+    libssh2_channel_setenv_ex(channel, varname,                         \
+                              (unsigned int)strlen(varname), value,     \
                               (unsigned int)strlen(value))
 
 LIBSSH2_API int libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel);
@@ -835,7 +835,7 @@ LIBSSH2_API int libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel,
                                                int width, int height,
                                                int width_px, int height_px);
 #define libssh2_channel_request_pty(channel, term)                      \
-    libssh2_channel_request_pty_ex((channel), (term),                   \
+    libssh2_channel_request_pty_ex(channel, term,                       \
                                    (unsigned int)strlen(term),          \
                                    NULL, 0,                             \
                                    LIBSSH2_TERM_WIDTH,                  \
@@ -848,7 +848,7 @@ LIBSSH2_API int libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel,
                                                     int width_px,
                                                     int height_px);
 #define libssh2_channel_request_pty_size(channel, width, height) \
-    libssh2_channel_request_pty_size_ex((channel), (width), (height), 0, 0)
+    libssh2_channel_request_pty_size_ex(channel, width, height, 0, 0)
 
 LIBSSH2_API int libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel,
                                            int single_connection,
@@ -856,13 +856,13 @@ LIBSSH2_API int libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel,
                                            const char *auth_cookie,
                                            int screen_number);
 #define libssh2_channel_x11_req(channel, screen_number) \
-    libssh2_channel_x11_req_ex((channel), 0, NULL, NULL, (screen_number))
+    libssh2_channel_x11_req_ex(channel, 0, NULL, NULL, screen_number)
 
 LIBSSH2_API int libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
                                           const char *signame,
                                           size_t signame_len);
 #define libssh2_channel_signal(channel, signame) \
-    libssh2_channel_signal_ex((channel), signame, strlen(signame))
+    libssh2_channel_signal_ex(channel, signame, strlen(signame))
 
 LIBSSH2_API int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                                 const char *request,
@@ -870,25 +870,25 @@ LIBSSH2_API int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                                 const char *message,
                                                 unsigned int message_len);
 #define libssh2_channel_shell(channel) \
-    libssh2_channel_process_startup((channel), "shell", sizeof("shell") - 1, \
+    libssh2_channel_process_startup(channel, "shell", sizeof("shell") - 1, \
                                     NULL, 0)
 #define libssh2_channel_exec(channel, command) \
-    libssh2_channel_process_startup((channel), "exec", sizeof("exec") - 1, \
-                                    (command), (unsigned int)strlen(command))
+    libssh2_channel_process_startup(channel, "exec", sizeof("exec") - 1, \
+                                    command, (unsigned int)strlen(command))
 #define libssh2_channel_subsystem(channel, subsystem) \
-    libssh2_channel_process_startup((channel), "subsystem", \
-                                    sizeof("subsystem") - 1, (subsystem), \
+    libssh2_channel_process_startup(channel, "subsystem", \
+                                    sizeof("subsystem") - 1, subsystem, \
                                     (unsigned int)strlen(subsystem))
 
 LIBSSH2_API ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel,
                                             int stream_id, char *buf,
                                             size_t buflen);
 #define libssh2_channel_read(channel, buf, buflen) \
-    libssh2_channel_read_ex((channel), 0, \
-                            (buf), (buflen))
+    libssh2_channel_read_ex(channel, 0, \
+                            buf, buflen)
 #define libssh2_channel_read_stderr(channel, buf, buflen) \
-    libssh2_channel_read_ex((channel), SSH_EXTENDED_DATA_STDERR, \
-                            (buf), (buflen))
+    libssh2_channel_read_ex(channel, SSH_EXTENDED_DATA_STDERR, \
+                            buf, buflen)
 
 LIBSSH2_API int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel,
                                           int extended);
@@ -898,7 +898,7 @@ libssh2_channel_window_read_ex(LIBSSH2_CHANNEL *channel,
                                unsigned long *read_avail,
                                unsigned long *window_size_initial);
 #define libssh2_channel_window_read(channel) \
-    libssh2_channel_window_read_ex((channel), NULL, NULL)
+    libssh2_channel_window_read_ex(channel, NULL, NULL)
 
 #ifndef LIBSSH2_NO_DEPRECATED
 LIBSSH2_DEPRECATED(1.1.0, "Use libssh2_channel_receive_window_adjust2()")
@@ -918,17 +918,17 @@ LIBSSH2_API ssize_t libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel,
                                              size_t buflen);
 
 #define libssh2_channel_write(channel, buf, buflen) \
-    libssh2_channel_write_ex((channel), 0, \
-                             (buf), (buflen))
+    libssh2_channel_write_ex(channel, 0, \
+                             buf, buflen)
 #define libssh2_channel_write_stderr(channel, buf, buflen) \
-    libssh2_channel_write_ex((channel), SSH_EXTENDED_DATA_STDERR, \
-                             (buf), (buflen))
+    libssh2_channel_write_ex(channel, SSH_EXTENDED_DATA_STDERR, \
+                             buf, buflen)
 
 LIBSSH2_API unsigned long
 libssh2_channel_window_write_ex(LIBSSH2_CHANNEL *channel,
                                 unsigned long *window_size_initial);
 #define libssh2_channel_window_write(channel) \
-    libssh2_channel_window_write_ex((channel), NULL)
+    libssh2_channel_window_write_ex(channel, NULL)
 
 LIBSSH2_API void libssh2_session_set_blocking(LIBSSH2_SESSION* session,
                                               int blocking);
@@ -963,7 +963,7 @@ LIBSSH2_API int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
  */
 /* DEPRECATED since 0.3.0. Use libssh2_channel_handle_extended_data2(). */
 #define libssh2_channel_ignore_extended_data(channel, ignore)                 \
-    libssh2_channel_handle_extended_data((channel), (ignore) ?                \
+    libssh2_channel_handle_extended_data(channel, (ignore) ?                  \
                                        LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE : \
                                        LIBSSH2_CHANNEL_EXTENDED_DATA_NORMAL)
 #endif
@@ -972,9 +972,9 @@ LIBSSH2_API int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
 #define LIBSSH2_CHANNEL_FLUSH_ALL               (-2)
 LIBSSH2_API int libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel,
                                          int streamid);
-#define libssh2_channel_flush(channel) libssh2_channel_flush_ex((channel), 0)
+#define libssh2_channel_flush(channel) libssh2_channel_flush_ex(channel, 0)
 #define libssh2_channel_flush_stderr(channel) \
-    libssh2_channel_flush_ex((channel), SSH_EXTENDED_DATA_STDERR)
+    libssh2_channel_flush_ex(channel, SSH_EXTENDED_DATA_STDERR)
 
 LIBSSH2_API int libssh2_channel_get_exit_status(LIBSSH2_CHANNEL* channel);
 LIBSSH2_API int libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL* channel,
@@ -1008,7 +1008,7 @@ LIBSSH2_API LIBSSH2_CHANNEL *libssh2_scp_send_ex(LIBSSH2_SESSION *session,
                                                  size_t size, long mtime,
                                                  long atime);
 #define libssh2_scp_send(session, path, mode, size) \
-    libssh2_scp_send_ex((session), (path), (mode), (size), 0, 0)
+    libssh2_scp_send_ex(session, path, mode, size, 0, 0)
 #endif
 LIBSSH2_API LIBSSH2_CHANNEL *
 libssh2_scp_send64(LIBSSH2_SESSION *session, const char *path, int mode,

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -246,7 +246,8 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
 
 /* 'publickey' authentication callback */
 #define LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(name) \
-    int (name)(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, \
+    int (name)(LIBSSH2_SESSION *session, \
+               unsigned char **sig, size_t *sig_len, \
                const unsigned char *data, size_t data_len, void **abstract)
 
 /* 'keyboard-interactive' authentication callback */
@@ -274,8 +275,8 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
 
 /* Callbacks for special SSH packets */
 #define LIBSSH2_IGNORE_FUNC(name) \
-    void (name)(LIBSSH2_SESSION *session, const char *message, int message_len, \
-                void **abstract)
+    void (name)(LIBSSH2_SESSION *session, \
+                const char *message, int message_len, void **abstract)
 
 #define LIBSSH2_DEBUG_FUNC(name) \
     void (name)(LIBSSH2_SESSION *session, int always_display, \

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -246,25 +246,25 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
 
 /* 'publickey' authentication callback */
 #define LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(name) \
-    int name(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, \
-             const unsigned char *data, size_t data_len, void **abstract)
+    int (name)(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, \
+               const unsigned char *data, size_t data_len, void **abstract)
 
 /* 'keyboard-interactive' authentication callback */
 /* FIXME: name_len, instruction_len -> size_t, num_prompts -> unsigned int? */
 #define LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(name_) \
-    void name_(const char *name, int name_len, const char *instruction, \
-               int instruction_len, int num_prompts, \
-               const LIBSSH2_USERAUTH_KBDINT_PROMPT *prompts, \
-               LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses, void **abstract)
+    void (name_)(const char *name, int name_len, const char *instruction, \
+                 int instruction_len, int num_prompts, \
+                 const LIBSSH2_USERAUTH_KBDINT_PROMPT *prompts, \
+                 LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses, void **abstract)
 
 /* SK authentication callback */
 #define LIBSSH2_USERAUTH_SK_SIGN_FUNC(name) \
-    int name(LIBSSH2_SESSION *session, LIBSSH2_SK_SIG_INFO *sig_info, \
-             const unsigned char *data, size_t data_len, \
-             int algorithm, uint8_t flags, \
-             const char *application, const unsigned char *key_handle, \
-             size_t handle_len, \
-             void **abstract)
+    int (name)(LIBSSH2_SESSION *session, LIBSSH2_SK_SIG_INFO *sig_info, \
+               const unsigned char *data, size_t data_len, \
+               int algorithm, uint8_t flags, \
+               const char *application, const unsigned char *key_handle, \
+               size_t handle_len, \
+               void **abstract)
 
 /* Flags for SK authentication */
 #define LIBSSH2_SK_PRESENCE_REQUIRED     0x01
@@ -274,62 +274,62 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
 
 /* Callbacks for special SSH packets */
 #define LIBSSH2_IGNORE_FUNC(name) \
-    void name(LIBSSH2_SESSION *session, const char *message, int message_len, \
-              void **abstract)
+    void (name)(LIBSSH2_SESSION *session, const char *message, int message_len, \
+                void **abstract)
 
 #define LIBSSH2_DEBUG_FUNC(name) \
-    void name(LIBSSH2_SESSION *session, int always_display, \
-              const char *message, int message_len, \
-              const char *language, int language_len, \
-              void **abstract)
+    void (name)(LIBSSH2_SESSION *session, int always_display, \
+                const char *message, int message_len, \
+                const char *language, int language_len, \
+                void **abstract)
 
 #define LIBSSH2_DISCONNECT_FUNC(name) \
-    void name(LIBSSH2_SESSION *session, int reason, \
-              const char *message, int message_len, \
-              const char *language, int language_len, \
-              void **abstract)
+    void (name)(LIBSSH2_SESSION *session, int reason, \
+                const char *message, int message_len, \
+                const char *language, int language_len, \
+                void **abstract)
 
 #define LIBSSH2_PASSWD_CHANGEREQ_FUNC(name) \
-    void name(LIBSSH2_SESSION *session, char **newpw, int *newpw_len, \
-              void **abstract)
+    void (name)(LIBSSH2_SESSION *session, char **newpw, int *newpw_len, \
+                void **abstract)
 
 #define LIBSSH2_MACERROR_FUNC(name) \
-    int name(LIBSSH2_SESSION *session, const char *packet, int packet_len, \
-             void **abstract)
+    int (name)(LIBSSH2_SESSION *session, const char *packet, int packet_len, \
+               void **abstract)
 
 #define LIBSSH2_X11_OPEN_FUNC(name) \
-    void name(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel, \
-              const char *shost, int sport, void **abstract)
+    void (name)(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel, \
+                const char *shost, int sport, void **abstract)
 
 #define LIBSSH2_AUTHAGENT_FUNC(name) \
-    void name(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel, \
-              void **abstract)
+    void (name)(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel, \
+                void **abstract)
 
 #define LIBSSH2_ADD_IDENTITIES_FUNC(name) \
-    void name(LIBSSH2_SESSION *session, void *buffer, \
-              const char *agent_path, void **abstract)
+    void (name)(LIBSSH2_SESSION *session, void *buffer, \
+                const char *agent_path, void **abstract)
 
 #define LIBSSH2_AUTHAGENT_SIGN_FUNC(name) \
-    int name(LIBSSH2_SESSION* session, \
-             unsigned char *blob, unsigned int blen, \
-             const unsigned char *data, unsigned int dlen, \
-             unsigned char **signature, unsigned int *sigLen, \
-             const char *agentPath, \
-             void **abstract)
+    int (name)(LIBSSH2_SESSION* session, \
+               unsigned char *blob, unsigned int blen, \
+               const unsigned char *data, unsigned int dlen, \
+               unsigned char **signature, unsigned int *sigLen, \
+               const char *agentPath, \
+               void **abstract)
 
 #define LIBSSH2_CHANNEL_CLOSE_FUNC(name) \
-    void name(LIBSSH2_SESSION *session, void **session_abstract, \
-              LIBSSH2_CHANNEL *channel, void **channel_abstract)
+    void (name)(LIBSSH2_SESSION *session, void **session_abstract, \
+                LIBSSH2_CHANNEL *channel, void **channel_abstract)
 
 /* I/O callbacks */
 #define LIBSSH2_RECV_FUNC(name)                                         \
-    ssize_t name(libssh2_socket_t socket,                               \
-                 void *buffer, size_t length,                           \
-                 int flags, void **abstract)
+    ssize_t (name)(libssh2_socket_t socket,                             \
+                   void *buffer, size_t length,                         \
+                   int flags, void **abstract)
 #define LIBSSH2_SEND_FUNC(name)                                         \
-    ssize_t name(libssh2_socket_t socket,                               \
-                 const void *buffer, size_t length,                     \
-                 int flags, void **abstract)
+    ssize_t (name)(libssh2_socket_t socket,                             \
+                   const void *buffer, size_t length,                   \
+                   int flags, void **abstract)
 
 /* libssh2_session_callback_set() constants */
 #define LIBSSH2_CALLBACK_IGNORE               0

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -585,9 +585,9 @@ LIBSSH2_API int libssh2_session_supported_algs(LIBSSH2_SESSION* session,
 
 /* Session API */
 LIBSSH2_API LIBSSH2_SESSION *
-libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC((*my_alloc)),
-                        LIBSSH2_FREE_FUNC((*my_free)),
-                        LIBSSH2_REALLOC_FUNC((*my_realloc)), void *abstract);
+libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
+                        LIBSSH2_FREE_FUNC(*my_free),
+                        LIBSSH2_REALLOC_FUNC(*my_realloc), void *abstract);
 #define libssh2_session_init() libssh2_session_init_ex(NULL, NULL, NULL, NULL)
 
 LIBSSH2_API void **libssh2_session_abstract(LIBSSH2_SESSION *session);

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -374,7 +374,7 @@ typedef struct _LIBSSH2_PRIVKEY_SK {
     const char *application;
     const unsigned char *key_handle;
     size_t handle_len;
-    LIBSSH2_USERAUTH_SK_SIGN_FUNC((*sign_callback));
+    LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback);
     void **orig_abstract;
 } LIBSSH2_PRIVKEY_SK;
 
@@ -661,8 +661,7 @@ libssh2_userauth_password_ex(LIBSSH2_SESSION *session,
                              unsigned int username_len,
                              const char *password,
                              unsigned int password_len,
-                             LIBSSH2_PASSWD_CHANGEREQ_FUNC
-                                 ((*passwd_change_cb)));
+                             LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb));
 
 #define libssh2_userauth_password(session, username, password) \
     libssh2_userauth_password_ex(session, username, \
@@ -690,8 +689,7 @@ libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                            const char *username,
                            const unsigned char *pubkeydata,
                            size_t pubkeydata_len,
-                           LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC
-                               ((*sign_callback)),
+                          LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(*sign_callback),
                            void **abstract);
 
 LIBSSH2_API int
@@ -737,8 +735,7 @@ LIBSSH2_API int
 libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION* session,
                                          const char *username,
                                          unsigned int username_len,
-                                         LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC
-                                             ((*response_callback)));
+                    LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback));
 
 #define libssh2_userauth_keyboard_interactive(session, username,             \
                                               response_callback)             \
@@ -755,8 +752,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
                               const char *passphrase,
-                              LIBSSH2_USERAUTH_SK_SIGN_FUNC
-                                  ((*sign_callback)),
+                              LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback),
                               void **abstract);
 
 #ifndef LIBSSH2_NO_DEPRECATED

--- a/include/libssh2_publickey.h
+++ b/include/libssh2_publickey.h
@@ -96,10 +96,8 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
                          const libssh2_publickey_attribute attrs[]);
 #define libssh2_publickey_add(pkey, name, blob, blob_len, overwrite, \
                               num_attrs, attrs) \
-    libssh2_publickey_add_ex((pkey), \
-                             (name), strlen(name), \
-                             (blob), (blob_len), \
-                             (overwrite), (num_attrs), (attrs))
+    libssh2_publickey_add_ex(pkey, name, strlen(name), blob, blob_len, \
+                             overwrite, num_attrs, attrs)
 
 LIBSSH2_API int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
                                             const unsigned char *name,
@@ -107,9 +105,7 @@ LIBSSH2_API int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
                                             const unsigned char *blob,
                                             unsigned long blob_len);
 #define libssh2_publickey_remove(pkey, name, blob, blob_len) \
-    libssh2_publickey_remove_ex((pkey), \
-                                (name), strlen(name), \
-                                (blob), (blob_len))
+    libssh2_publickey_remove_ex(pkey, name, strlen(name), blob, blob_len)
 
 LIBSSH2_API int
 libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -233,12 +233,12 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
                      unsigned long flags,
                      long mode, int open_type);
 #define libssh2_sftp_open(sftp, filename, flags, mode) \
-    libssh2_sftp_open_ex((sftp), \
-                         (filename), (unsigned int)strlen(filename), \
-                         (flags), (mode), LIBSSH2_SFTP_OPENFILE)
+    libssh2_sftp_open_ex(sftp, \
+                         filename, (unsigned int)strlen(filename), \
+                         flags, mode, LIBSSH2_SFTP_OPENFILE)
 #define libssh2_sftp_opendir(sftp, path) \
-    libssh2_sftp_open_ex((sftp), \
-                         (path), (unsigned int)strlen(path), \
+    libssh2_sftp_open_ex(sftp, \
+                         path, (unsigned int)strlen(path), \
                          0, 0, LIBSSH2_SFTP_OPENDIR)
 LIBSSH2_API LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
@@ -248,9 +248,9 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
                        long mode, int open_type,
                        LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs) \
-    libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), \
-                           (flags), (mode), LIBSSH2_SFTP_OPENFILE, \
-                           (attrs))
+    libssh2_sftp_open_ex_r(sftp, filename, strlen(filename), \
+                           flags, mode, LIBSSH2_SFTP_OPENFILE, \
+                           attrs)
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                                       char *buffer, size_t buffer_maxlen);
@@ -261,8 +261,8 @@ LIBSSH2_API int libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle, \
                                         size_t longentry_maxlen,
                                         LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_readdir(handle, buffer, buffer_maxlen, attrs) \
-    libssh2_sftp_readdir_ex((handle), (buffer), (buffer_maxlen), NULL, 0, \
-                            (attrs))
+    libssh2_sftp_readdir_ex(handle, buffer, buffer_maxlen, NULL, 0, \
+                            attrs)
 
 LIBSSH2_API ssize_t libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle,
                                        const char *buffer, size_t count);
@@ -275,7 +275,7 @@ LIBSSH2_API int libssh2_sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle);
 LIBSSH2_API void libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset);
 LIBSSH2_API void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle,
                                      libssh2_uint64_t offset);
-#define libssh2_sftp_rewind(handle) libssh2_sftp_seek64((handle), 0)
+#define libssh2_sftp_rewind(handle) libssh2_sftp_seek64(handle, 0)
 
 LIBSSH2_API size_t libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle);
 LIBSSH2_API libssh2_uint64_t libssh2_sftp_tell64(LIBSSH2_SFTP_HANDLE *handle);
@@ -284,9 +284,9 @@ LIBSSH2_API int libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
                                       LIBSSH2_SFTP_ATTRIBUTES *attrs,
                                       int setstat);
 #define libssh2_sftp_fstat(handle, attrs) \
-    libssh2_sftp_fstat_ex((handle), (attrs), 0)
+    libssh2_sftp_fstat_ex(handle, attrs, 0)
 #define libssh2_sftp_fsetstat(handle, attrs) \
-    libssh2_sftp_fstat_ex((handle), (attrs), 1)
+    libssh2_sftp_fstat_ex(handle, attrs, 1)
 
 /* Miscellaneous Ops */
 LIBSSH2_API int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
@@ -296,9 +296,9 @@ LIBSSH2_API int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
                                        unsigned int dest_filename_len,
                                        long flags);
 #define libssh2_sftp_rename(sftp, sourcefile, destfile) \
-    libssh2_sftp_rename_ex((sftp), \
-                           (sourcefile), (unsigned int)strlen(sourcefile), \
-                           (destfile), (unsigned int)strlen(destfile), \
+    libssh2_sftp_rename_ex(sftp, \
+                           sourcefile, (unsigned int)strlen(sourcefile), \
+                           destfile, (unsigned int)strlen(destfile), \
                            LIBSSH2_SFTP_RENAME_OVERWRITE | \
                            LIBSSH2_SFTP_RENAME_ATOMIC | \
                            LIBSSH2_SFTP_RENAME_NATIVE)
@@ -309,14 +309,14 @@ LIBSSH2_API int libssh2_sftp_posix_rename_ex(LIBSSH2_SFTP *sftp,
                                              const char *dest_filename,
                                              size_t dest_filename_len);
 #define libssh2_sftp_posix_rename(sftp, sourcefile, destfile) \
-    libssh2_sftp_posix_rename_ex((sftp), (sourcefile), strlen(sourcefile), \
-                                 (destfile), strlen(destfile))
+    libssh2_sftp_posix_rename_ex(sftp, sourcefile, strlen(sourcefile), \
+                                 destfile, strlen(destfile))
 
 LIBSSH2_API int libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp,
                                        const char *filename,
                                        unsigned int filename_len);
 #define libssh2_sftp_unlink(sftp, filename) \
-    libssh2_sftp_unlink_ex((sftp), (filename), (unsigned int)strlen(filename))
+    libssh2_sftp_unlink_ex(sftp, filename, (unsigned int)strlen(filename))
 
 LIBSSH2_API int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
                                       LIBSSH2_SFTP_STATVFS *st);
@@ -330,13 +330,13 @@ LIBSSH2_API int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path,
                                       unsigned int path_len, long mode);
 #define libssh2_sftp_mkdir(sftp, path, mode) \
-    libssh2_sftp_mkdir_ex((sftp), (path), (unsigned int)strlen(path), (mode))
+    libssh2_sftp_mkdir_ex(sftp, path, (unsigned int)strlen(path), mode)
 
 LIBSSH2_API int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path,
                                       unsigned int path_len);
 #define libssh2_sftp_rmdir(sftp, path) \
-    libssh2_sftp_rmdir_ex((sftp), (path), (unsigned int)strlen(path))
+    libssh2_sftp_rmdir_ex(sftp, path, (unsigned int)strlen(path))
 
 LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                                      const char *path,
@@ -344,14 +344,14 @@ LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                                      int stat_type,
                                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_stat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
-                         LIBSSH2_SFTP_STAT, (attrs))
+    libssh2_sftp_stat_ex(sftp, path, (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_STAT, attrs)
 #define libssh2_sftp_lstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
-                         LIBSSH2_SFTP_LSTAT, (attrs))
+    libssh2_sftp_stat_ex(sftp, path, (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_LSTAT, attrs)
 #define libssh2_sftp_setstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
-                         LIBSSH2_SFTP_SETSTAT, (attrs))
+    libssh2_sftp_stat_ex(sftp, path, (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_SETSTAT, attrs)
 
 LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         const char *path,
@@ -360,19 +360,19 @@ LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         unsigned int target_len,
                                         int link_type);
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \
-    libssh2_sftp_symlink_ex((sftp), \
-                            (orig), (unsigned int)strlen(orig), \
-                            (linkpath), (unsigned int)strlen(linkpath), \
+    libssh2_sftp_symlink_ex(sftp, \
+                            orig, (unsigned int)strlen(orig), \
+                            linkpath, (unsigned int)strlen(linkpath), \
                             LIBSSH2_SFTP_SYMLINK)
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), \
-                            (path), (unsigned int)strlen(path), \
-                            (target), (maxlen), \
+    libssh2_sftp_symlink_ex(sftp, \
+                            path, (unsigned int)strlen(path), \
+                            target, maxlen, \
                             LIBSSH2_SFTP_READLINK)
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), \
-                            (path), (unsigned int)strlen(path), \
-                            (target), (maxlen), \
+    libssh2_sftp_symlink_ex(sftp, \
+                            path, (unsigned int)strlen(path), \
+                            target, maxlen, \
                             LIBSSH2_SFTP_REALPATH)
 
 #ifdef __cplusplus

--- a/os400/include/sys/socket.h
+++ b/os400/include/sys/socket.h
@@ -69,7 +69,7 @@ extern int  _libssh2_os400_connect(int sd,
                                    struct sockaddr *destaddr, int addrlen);
 
 #ifndef LIBSSH2_DISABLE_QADRT_EXT
-#define connect(sd, addr, len)  _libssh2_os400_connect((sd), (addr), (len))
+#define connect(sd, addr, len)  _libssh2_os400_connect(sd, addr, len)
 #endif
 
 #endif

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -82,7 +82,7 @@ typedef struct BlowfishContext {
                  ^ (s)[0x200 + (((x) >>  8) & 0xFF)])     \
                  + (s)[0x300 + ( (x)        & 0xFF)])
 
-#define BLFRND(s,p,i,j,n) ((i) ^= F(s,j) ^ (p)[n])
+#define BLFRND(s, p, i, j, n)  ((i) ^= F(s,j) ^ (p)[n])
 
 static void
 Blowfish_encipher(blf_ctx *c, uint32_t *xl, uint32_t *xr)

--- a/src/chacha.c
+++ b/src/chacha.c
@@ -20,7 +20,7 @@
 #define U32V(v) ((u32)(v) & U32C(0xFFFFFFFF))
 
 #define ROTL32(v, n) \
-  (U32V((v) << (n)) | ((v) >> (32 - (n))))
+  U32V((v) << (n)) | ((v) >> (32 - (n)))
 
 #define U8TO32_LITTLE(p) \
   (((u32)((p)[0])      ) | \
@@ -36,10 +36,10 @@
     (p)[3] = U8V((v) >> 24); \
   } while (0)
 
-#define ROTATE(v, c) (ROTL32(v,c))
+#define ROTATE(v, c) ROTL32(v, c)
 #define XOR(v, w) ((v) ^ (w))
-#define PLUS(v, w) (U32V((v) + (w)))
-#define PLUSONE(v) (PLUS((v),1))
+#define PLUS(v, w) U32V((v) + (w))
+#define PLUSONE(v) PLUS(v, 1)
 
 #define QUARTERROUND(a, b, c, d) \
   (a) = PLUS(a, b); (d) = ROTATE(XOR(d, a), 16); \

--- a/src/kex.c
+++ b/src/kex.c
@@ -3608,13 +3608,13 @@ kex_method_list(unsigned char *buf, uint32_t list_strlen,
 #define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)        \
     do {                                                                      \
         if(prefvar) {                                                         \
-            _libssh2_htonu32((buf), (prefvarlen));                            \
+            _libssh2_htonu32(buf, prefvarlen);                                \
             (buf) += 4;                                                       \
-            memcpy((buf), (prefvar), (prefvarlen));                           \
+            memcpy(buf, prefvar, prefvarlen);                                 \
             (buf) += (prefvarlen);                                            \
         }                                                                     \
         else {                                                                \
-            (buf) += kex_method_list((buf), (prefvarlen),                     \
+            (buf) += kex_method_list(buf, prefvarlen,                         \
                                 (const LIBSSH2_COMMON_METHOD**)(defaultvar)); \
         }                                                                     \
     } while(0)

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -80,7 +80,7 @@
 #define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
 #define _libssh2_random(buf, len) \
-    (gcry_randomize((buf), (len), GCRY_STRONG_RANDOM), 0)
+    (gcry_randomize(buf, len, GCRY_STRONG_RANDOM), 0)
 
 #define libssh2_prepare_iovec(vec, len)  /* Empty. */
 
@@ -92,7 +92,7 @@
     (gcry_md_write(ctx, data, len), 1)
 #define libssh2_sha1_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), SHA_DIGEST_LENGTH), \
-    gcry_md_close(ctx), 1)
+     gcry_md_close(ctx), 1)
 #define libssh2_sha1(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA1, out, message, len), 0)
 
@@ -103,7 +103,7 @@
     (gcry_md_write(ctx, data, len), 1)
 #define libssh2_sha256_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), SHA256_DIGEST_LENGTH), \
-    gcry_md_close(ctx), 1)
+     gcry_md_close(ctx), 1)
 #define libssh2_sha256(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA256, out, message, len), 0)
 
@@ -114,7 +114,7 @@
     (gcry_md_write(ctx, data, len), 1)
 #define libssh2_sha384_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), SHA384_DIGEST_LENGTH), \
-    gcry_md_close(ctx), 1)
+     gcry_md_close(ctx), 1)
 #define libssh2_sha384(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA384, out, message, len), 0)
 
@@ -125,7 +125,7 @@
     (gcry_md_write(ctx, data, len), 1)
 #define libssh2_sha512_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), SHA512_DIGEST_LENGTH), \
-    gcry_md_close(ctx), 1)
+     gcry_md_close(ctx), 1)
 #define libssh2_sha512(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA512, out, message, len), 0)
 
@@ -137,7 +137,7 @@
     (gcry_md_write(ctx, data, len), 1)
 #define libssh2_md5_final(ctx, out) \
     (memcpy(out, gcry_md_read(ctx, 0), MD5_DIGEST_LENGTH), \
-    gcry_md_close(ctx), 1)
+     gcry_md_close(ctx), 1)
 #endif
 
 #define libssh2_hmac_ctx gcry_md_hd_t
@@ -199,7 +199,7 @@
                                              new bignum */
 #define _libssh2_bn_set_word(bn, val) gcry_mpi_set_ui(bn, val)
 #define _libssh2_bn_from_bin(bn, len, val) \
-    gcry_mpi_scan(&((bn)), GCRYMPI_FMT_USG, val, len, NULL)
+    gcry_mpi_scan(&(bn), GCRYMPI_FMT_USG, val, len, NULL)
 #define _libssh2_bn_to_bin(bn, val) \
     gcry_mpi_print(GCRYMPI_FMT_USG, val, _libssh2_bn_bytes(bn), NULL, bn)
 #define _libssh2_bn_bytes(bn) \

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -688,9 +688,9 @@ struct _LIBSSH2_SESSION
     /* Memory management callbacks */
     void *abstract;
 
-    LIBSSH2_ALLOC_FUNC((*alloc));
-    LIBSSH2_REALLOC_FUNC((*realloc));
-    LIBSSH2_FREE_FUNC((*free));
+    LIBSSH2_ALLOC_FUNC(*alloc);
+    LIBSSH2_REALLOC_FUNC(*realloc);
+    LIBSSH2_FREE_FUNC(*free);
 
     /* Other callbacks */
     LIBSSH2_IGNORE_FUNC((*ssh_msg_ignore));

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -482,7 +482,7 @@ struct _LIBSSH2_CHANNEL
     LIBSSH2_SESSION *session;
 
     void *abstract;
-      LIBSSH2_CHANNEL_CLOSE_FUNC((*close_cb));
+    LIBSSH2_CHANNEL_CLOSE_FUNC(*close_cb);
 
     /* State variables used in libssh2_channel_setenv_ex() */
     libssh2_nonblocking_states setenv_state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -693,16 +693,16 @@ struct _LIBSSH2_SESSION
     LIBSSH2_FREE_FUNC(*free);
 
     /* Other callbacks */
-    LIBSSH2_IGNORE_FUNC((*ssh_msg_ignore));
-    LIBSSH2_DEBUG_FUNC((*ssh_msg_debug));
-    LIBSSH2_DISCONNECT_FUNC((*ssh_msg_disconnect));
-    LIBSSH2_MACERROR_FUNC((*macerror));
-    LIBSSH2_X11_OPEN_FUNC((*x11));
-    LIBSSH2_AUTHAGENT_FUNC((*authagent));
-    LIBSSH2_ADD_IDENTITIES_FUNC((*addLocalIdentities));
-    LIBSSH2_AUTHAGENT_SIGN_FUNC((*agentSignCallback));
-    LIBSSH2_SEND_FUNC((*send));
-    LIBSSH2_RECV_FUNC((*recv));
+    LIBSSH2_IGNORE_FUNC(*ssh_msg_ignore);
+    LIBSSH2_DEBUG_FUNC(*ssh_msg_debug);
+    LIBSSH2_DISCONNECT_FUNC(*ssh_msg_disconnect);
+    LIBSSH2_MACERROR_FUNC(*macerror);
+    LIBSSH2_X11_OPEN_FUNC(*x11);
+    LIBSSH2_AUTHAGENT_FUNC(*authagent);
+    LIBSSH2_ADD_IDENTITIES_FUNC(*addLocalIdentities);
+    LIBSSH2_AUTHAGENT_SIGN_FUNC(*agentSignCallback);
+    LIBSSH2_SEND_FUNC(*send);
+    LIBSSH2_RECV_FUNC(*recv);
 
     /* Method preferences -- NULL yields "load order" */
     char *kex_prefs;

--- a/src/mac.c
+++ b/src/mac.c
@@ -282,7 +282,7 @@ mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION * session,
                                  addtl, addtl_len, abstract))
         return 1;
 
-    memcpy(buf, (char *) temp, 96 / 8);
+    memcpy(buf, (char *)temp, 96 / 8);
     return 0;
 }
 
@@ -356,7 +356,7 @@ mac_method_hmac_md5_96_hash(LIBSSH2_SESSION * session,
                                 addtl, addtl_len, abstract))
         return 1;
 
-    memcpy(buf, (char *) temp, 96 / 8);
+    memcpy(buf, (char *)temp, 96 / 8);
     return 0;
 }
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -225,8 +225,7 @@
 
 #define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
-#define _libssh2_random(buf, len) \
-    _libssh2_openssl_random((buf), (len))
+#define _libssh2_random(buf, len)  _libssh2_openssl_random(buf, len)
 
 #define libssh2_prepare_iovec(vec, len)  /* Empty. */
 

--- a/src/session.c
+++ b/src/session.c
@@ -440,13 +440,13 @@ libssh2_banner_set(LIBSSH2_SESSION * session, const char *banner)
  * to the callbacks (so they know who's asking)
  */
 LIBSSH2_API LIBSSH2_SESSION *
-libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC((*my_alloc)),
-                        LIBSSH2_FREE_FUNC((*my_free)),
-                        LIBSSH2_REALLOC_FUNC((*my_realloc)), void *abstract)
+libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
+                        LIBSSH2_FREE_FUNC(*my_free),
+                        LIBSSH2_REALLOC_FUNC(*my_realloc), void *abstract)
 {
-    LIBSSH2_ALLOC_FUNC((*local_alloc)) = libssh2_default_alloc;
-    LIBSSH2_FREE_FUNC((*local_free)) = libssh2_default_free;
-    LIBSSH2_REALLOC_FUNC((*local_realloc)) = libssh2_default_realloc;
+    LIBSSH2_ALLOC_FUNC(*local_alloc) = libssh2_default_alloc;
+    LIBSSH2_FREE_FUNC(*local_free) = libssh2_default_free;
+    LIBSSH2_REALLOC_FUNC(*local_realloc) = libssh2_default_realloc;
     LIBSSH2_SESSION *session;
 
     if(my_alloc) {

--- a/src/session.c
+++ b/src/session.c
@@ -502,54 +502,52 @@ libssh2_session_callback_set2(LIBSSH2_SESSION *session, int cbtype,
     switch(cbtype) {
     case LIBSSH2_CALLBACK_IGNORE:
         oldcb = (libssh2_cb_generic *)session->ssh_msg_ignore;
-        session->ssh_msg_ignore = (LIBSSH2_IGNORE_FUNC((*)))callback;
+        session->ssh_msg_ignore = (LIBSSH2_IGNORE_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_DEBUG:
         oldcb = (libssh2_cb_generic *)session->ssh_msg_debug;
-        session->ssh_msg_debug = (LIBSSH2_DEBUG_FUNC((*)))callback;
+        session->ssh_msg_debug = (LIBSSH2_DEBUG_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_DISCONNECT:
         oldcb = (libssh2_cb_generic *)session->ssh_msg_disconnect;
-        session->ssh_msg_disconnect = (LIBSSH2_DISCONNECT_FUNC((*)))callback;
+        session->ssh_msg_disconnect = (LIBSSH2_DISCONNECT_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_MACERROR:
         oldcb = (libssh2_cb_generic *)session->macerror;
-        session->macerror = (LIBSSH2_MACERROR_FUNC((*)))callback;
+        session->macerror = (LIBSSH2_MACERROR_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_X11:
         oldcb = (libssh2_cb_generic *)session->x11;
-        session->x11 = (LIBSSH2_X11_OPEN_FUNC((*)))callback;
+        session->x11 = (LIBSSH2_X11_OPEN_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_SEND:
         oldcb = (libssh2_cb_generic *)session->send;
-        session->send = (LIBSSH2_SEND_FUNC((*)))callback;
+        session->send = (LIBSSH2_SEND_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_RECV:
         oldcb = (libssh2_cb_generic *)session->recv;
-        session->recv = (LIBSSH2_RECV_FUNC((*)))callback;
+        session->recv = (LIBSSH2_RECV_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_AUTHAGENT:
         oldcb = (libssh2_cb_generic *)session->authagent;
-        session->authagent = (LIBSSH2_AUTHAGENT_FUNC((*)))callback;
+        session->authagent = (LIBSSH2_AUTHAGENT_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_AUTHAGENT_IDENTITIES:
         oldcb = (libssh2_cb_generic *)session->addLocalIdentities;
-        session->addLocalIdentities =
-            (LIBSSH2_ADD_IDENTITIES_FUNC((*)))callback;
+        session->addLocalIdentities = (LIBSSH2_ADD_IDENTITIES_FUNC(*))callback;
         return oldcb;
 
     case LIBSSH2_CALLBACK_AUTHAGENT_SIGN:
         oldcb = (libssh2_cb_generic *)session->agentSignCallback;
-        session->agentSignCallback =
-            (LIBSSH2_AUTHAGENT_SIGN_FUNC((*)))callback;
+        session->agentSignCallback = (LIBSSH2_AUTHAGENT_SIGN_FUNC(*))callback;
         return oldcb;
     }
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Setting Callback %d",

--- a/src/transport.c
+++ b/src/transport.c
@@ -93,7 +93,7 @@ debugdump(LIBSSH2_SESSION * session,
             }
 
             buffer[used++] = ' ';
-            if((width/2) - 1 == c)
+            if((width / 2) - 1 == c)
                 buffer[used++] = ' ';
         }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -302,7 +302,7 @@ static int
 userauth_password(LIBSSH2_SESSION *session,
                   const char *username, unsigned int username_len,
                   const unsigned char *password, unsigned int password_len,
-                  LIBSSH2_PASSWD_CHANGEREQ_FUNC((*passwd_change_cb)))
+                  LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb))
 {
     unsigned char *s;
     static const unsigned char reply_codes[4] = {
@@ -569,8 +569,7 @@ LIBSSH2_API int
 libssh2_userauth_password_ex(LIBSSH2_SESSION *session, const char *username,
                              unsigned int username_len, const char *password,
                              unsigned int password_len,
-                             LIBSSH2_PASSWD_CHANGEREQ_FUNC
-                             ((*passwd_change_cb)))
+                             LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb))
 {
     int rc;
     BLOCK_ADJUST(rc, session,
@@ -1547,8 +1546,7 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                             size_t username_len,
                             const unsigned char *pubkeydata,
                             size_t pubkeydata_len,
-                            LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC
-                            ((*sign_callback)),
+                          LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(*sign_callback),
                             void *abstract)
 {
     unsigned char reply_codes[4] = {
@@ -2112,8 +2110,7 @@ libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                            const char *username,
                            const unsigned char *pubkeydata,
                            size_t pubkeydata_len,
-                           LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC
-                               ((*sign_callback)),
+                          LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(*sign_callback),
                            void **abstract)
 {
     int rc;
@@ -2138,8 +2135,7 @@ static int
 userauth_keyboard_interactive(LIBSSH2_SESSION * session,
                               const char *username,
                               unsigned int username_len,
-                              LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC
-                                  ((*response_callback)))
+                     LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback))
 {
     unsigned char *s;
 
@@ -2412,8 +2408,7 @@ LIBSSH2_API int
 libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION *session,
                                          const char *username,
                                          unsigned int username_len,
-                                         LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC
-                                             ((*response_callback)))
+                     LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback))
 {
     int rc;
     BLOCK_ADJUST(rc, session,
@@ -2436,8 +2431,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
                               const char *passphrase,
-                              LIBSSH2_USERAUTH_SK_SIGN_FUNC
-                                  ((*sign_callback)),
+                              LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback),
                               void **abstract)
 {
     int rc = LIBSSH2_ERROR_NONE;

--- a/src/userauth.h
+++ b/src/userauth.h
@@ -46,8 +46,7 @@ _libssh2_userauth_publickey(LIBSSH2_SESSION *session,
                             size_t username_len,
                             const unsigned char *pubkeydata,
                             size_t pubkeydata_len,
-                            LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC
-                                ((*sign_callback)),
+                          LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(*sign_callback),
                             void *abstract);
 
 #endif /* LIBSSH2_USERAUTH_H */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -632,7 +632,7 @@ int _libssh2_wincng_hash_init(_libssh2_wincng_hash_ctx *ctx,
                             (unsigned char *)&dwHash,
                             sizeof(dwHash),
                             &cbData, 0);
-    if((!BCRYPT_SUCCESS(ret)) || dwHash != hashlen) {
+    if(!BCRYPT_SUCCESS(ret) || dwHash != hashlen) {
         return -1;
     }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -766,7 +766,7 @@ int _libssh2_hmac_sha512_init(libssh2_hmac_ctx *ctx,
 int _libssh2_hmac_update(libssh2_hmac_ctx *ctx,
                          const void *data, size_t datalen)
 {
-    int ret = _libssh2_wincng_hash_update(ctx, data, (ULONG) datalen);
+    int ret = _libssh2_wincng_hash_update(ctx, data, (ULONG)datalen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -3549,7 +3549,7 @@ _libssh2_wincng_bignum_rand(_libssh2_bn *rnd, int bits, int top, int bottom)
     if(!rnd)
         return -1;
 
-    length = (ULONG) (ceil(((double)bits) / 8.0) * sizeof(unsigned char));
+    length = (ULONG)(ceil(((double)bits) / 8.0) * sizeof(unsigned char));
     if(_libssh2_wincng_bignum_resize(rnd, length))
         return -1;
 
@@ -3671,7 +3671,7 @@ _libssh2_wincng_bignum_set_word(_libssh2_bn *bn, ULONG word)
         bits++;
     bits++;
 
-    length = (ULONG) (ceil(((double)bits) / 8.0) * sizeof(unsigned char));
+    length = (ULONG)(ceil(((double)bits) / 8.0) * sizeof(unsigned char));
     if(_libssh2_wincng_bignum_resize(bn, length))
         return -1;
 
@@ -3720,7 +3720,7 @@ _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
     memcpy(bn->bignum, bin, len);
 
     bits = _libssh2_wincng_bignum_bits(bn);
-    length = (ULONG) (ceil(((double)bits) / 8.0) * sizeof(unsigned char));
+    length = (ULONG)(ceil(((double)bits) / 8.0) * sizeof(unsigned char));
 
     offset = bn->length - length;
     if(offset > 0) {

--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -193,15 +193,13 @@ int listofmans(char *filespec, manPtr *manroot)
     for(;;) {
         status = find_file(filespec, gevonden, &ffindex);
 
-        if((status&1)) {
+        if((status & 1) != 0) {
             r = addman(manroot, gevonden);
             if(!r)
                 return 2;
         }
-        else {
-            if(!(status&1))
-                break;
-        }
+        else
+            break;
     }
 
     lib$find_file_end(&ffindex);


### PR DESCRIPTION
Also:
- apply minor whitespace fixes.
- VMS/man2help.c: clarify `if` expression, drop redundant `else` 
  expression.

Follow-up to 6e47049cff4f8d2a0067a0909ab9df3954a5a92f #1844

---

https://github.com/libssh2/libssh2/pull/1898/files?w=1
