### PR TITLE
tidy-up: formatting

### DIFF
--- a/example/x11.c
+++ b/example/x11.c
@@ -58,8 +58,8 @@ struct chan_X11_list {
     struct chan_X11_list *next;
 };
 
-static struct chan_X11_list * gp_x11_chan = NULL;
-static struct termios         _saved_tio;
+static struct chan_X11_list *gp_x11_chan = NULL;
+static struct termios        _saved_tio;
 
 static int _raw_mode(void)
 {

--- a/example/x11.c
+++ b/example/x11.c
@@ -132,7 +132,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
             addr.sun_family = AF_UNIX;
             snprintf(addr.sun_path, sizeof(addr.sun_path),
                      _PATH_UNIX_X, display_port);
-            rc = connect(sock, (struct sockaddr *) &addr, sizeof(addr));
+            rc = connect(sock, (struct sockaddr *)&addr, sizeof(addr));
 
             if(rc != -1) {
                 /* Connection Successful */

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -795,7 +795,7 @@ libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
     libssh2_channel_direct_tcpip_ex(session, host, port, "127.0.0.1", 22)
 
 LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION *session,
                                       const char *socket_path,
                                       const char *shost, int sport);
 

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -329,8 +329,7 @@ LIBSSH2_API int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
     libssh2_sftp_rmdir_ex(sftp, path, (unsigned int)strlen(path))
 
 LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
-                                     const char *path,
-                                     unsigned int path_len,
+                                     const char *path, unsigned int path_len,
                                      int stat_type,
                                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_stat(sftp, path, attrs) \
@@ -346,8 +345,7 @@ LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
 LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         const char *path,
                                         unsigned int path_len,
-                                        char *target,
-                                        unsigned int target_len,
+                                        char *target, unsigned int target_len,
                                         int link_type);
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \
     libssh2_sftp_symlink_ex(sftp, \
@@ -355,15 +353,11 @@ LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                             linkpath, (unsigned int)strlen(linkpath), \
                             LIBSSH2_SFTP_SYMLINK)
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex(sftp, \
-                            path, (unsigned int)strlen(path), \
-                            target, maxlen, \
-                            LIBSSH2_SFTP_READLINK)
+    libssh2_sftp_symlink_ex(sftp, path, (unsigned int)strlen(path), \
+                            target, maxlen, LIBSSH2_SFTP_READLINK)
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex(sftp, \
-                            path, (unsigned int)strlen(path), \
-                            target, maxlen, \
-                            LIBSSH2_SFTP_REALPATH)
+    libssh2_sftp_symlink_ex(sftp, path, (unsigned int)strlen(path), \
+                            target, maxlen, LIBSSH2_SFTP_REALPATH)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -314,19 +314,17 @@ LIBSSH2_API int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
                                       LIBSSH2_SFTP_STATVFS *st);
 
 LIBSSH2_API int libssh2_sftp_statvfs(LIBSSH2_SFTP *sftp,
-                                     const char *path,
-                                     size_t path_len,
+                                     const char *path, size_t path_len,
                                      LIBSSH2_SFTP_STATVFS *st);
 
 LIBSSH2_API int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
-                                      const char *path,
-                                      unsigned int path_len, long mode);
+                                      const char *path, unsigned int path_len,
+                                      long mode);
 #define libssh2_sftp_mkdir(sftp, path, mode) \
     libssh2_sftp_mkdir_ex(sftp, path, (unsigned int)strlen(path), mode)
 
 LIBSSH2_API int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
-                                      const char *path,
-                                      unsigned int path_len);
+                                      const char *path, unsigned int path_len);
 #define libssh2_sftp_rmdir(sftp, path) \
     libssh2_sftp_rmdir_ex(sftp, path, (unsigned int)strlen(path))
 

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -228,29 +228,22 @@ LIBSSH2_API LIBSSH2_CHANNEL *libssh2_sftp_get_channel(LIBSSH2_SFTP *sftp);
 /* File / Directory Ops */
 LIBSSH2_API LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
-                     const char *filename,
-                     unsigned int filename_len,
-                     unsigned long flags,
-                     long mode, int open_type);
+                     const char *filename, unsigned int filename_len,
+                     unsigned long flags, long mode, int open_type);
 #define libssh2_sftp_open(sftp, filename, flags, mode) \
-    libssh2_sftp_open_ex(sftp, \
-                         filename, (unsigned int)strlen(filename), \
+    libssh2_sftp_open_ex(sftp, filename, (unsigned int)strlen(filename), \
                          flags, mode, LIBSSH2_SFTP_OPENFILE)
 #define libssh2_sftp_opendir(sftp, path) \
-    libssh2_sftp_open_ex(sftp, \
-                         path, (unsigned int)strlen(path), \
+    libssh2_sftp_open_ex(sftp, path, (unsigned int)strlen(path), \
                          0, 0, LIBSSH2_SFTP_OPENDIR)
 LIBSSH2_API LIBSSH2_SFTP_HANDLE *
 libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
-                       const char *filename,
-                       size_t filename_len,
-                       unsigned long flags,
-                       long mode, int open_type,
+                       const char *filename, size_t filename_len,
+                       unsigned long flags, long mode, int open_type,
                        LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs) \
     libssh2_sftp_open_ex_r(sftp, filename, strlen(filename), \
-                           flags, mode, LIBSSH2_SFTP_OPENFILE, \
-                           attrs)
+                           flags, mode, LIBSSH2_SFTP_OPENFILE, attrs)
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                                       char *buffer, size_t buffer_maxlen);
@@ -261,8 +254,7 @@ LIBSSH2_API int libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle, \
                                         size_t longentry_maxlen,
                                         LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_readdir(handle, buffer, buffer_maxlen, attrs) \
-    libssh2_sftp_readdir_ex(handle, buffer, buffer_maxlen, NULL, 0, \
-                            attrs)
+    libssh2_sftp_readdir_ex(handle, buffer, buffer_maxlen, NULL, 0, attrs)
 
 LIBSSH2_API ssize_t libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle,
                                        const char *buffer, size_t count);

--- a/src/agent.c
+++ b/src/agent.c
@@ -704,7 +704,7 @@ agent_transact_pageant(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
     cds.cbData = (DWORD)(1 + strlen(mapname));
     cds.lpData = mapname;
 
-    id = SendMessage(hwnd, WM_COPYDATA, (WPARAM) NULL, (LPARAM) &cds);
+    id = SendMessage(hwnd, WM_COPYDATA, (WPARAM)NULL, (LPARAM)&cds);
     if(id > 0) {
         transctx->response_len = _libssh2_ntohu32(p);
         if(transctx->response_len > PAGEANT_MAX_MSGLEN - 4) {

--- a/src/agent.c
+++ b/src/agent.c
@@ -767,7 +767,7 @@ static int
 agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
            const unsigned char *data, size_t data_len, void **abstract)
 {
-    LIBSSH2_AGENT *agent = (LIBSSH2_AGENT *) (*abstract);
+    LIBSSH2_AGENT *agent = (LIBSSH2_AGENT *)(*abstract);
     agent_transaction_ctx_t transctx = &agent->transctx;
     struct agent_publickey *identity = agent->identity;
     ssize_t len = 1 + 4 + identity->external.blob_len + 4 + data_len + 4;

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -580,7 +580,7 @@ main(void)
     for(i = 0; i < 10; i++)
         data[i] = i;
 
-    blf_key(&c, (uint8_t *) key, 5);
+    blf_key(&c, (uint8_t *)key, 5);
     blf_enc(&c, data, 5);
     blf_dec(&c, data, 1);
     blf_dec(&c, data + 2, 4);
@@ -588,7 +588,7 @@ main(void)
     report(data, 10);
 
     /* Second test */
-    blf_key(&c, (uint8_t *) key2, (uint16_t)strlen(key2));
+    blf_key(&c, (uint8_t *)key2, (uint16_t)strlen(key2));
     blf_enc(&c, data2, 1);
     printf("\nShould read as: 0x324ed0fe 0xf413a203.\n");
     report(data2, 2);

--- a/src/channel.c
+++ b/src/channel.c
@@ -1286,7 +1286,7 @@ libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel, const char *term,
 }
 
 static int
-channel_request_pty_size(LIBSSH2_CHANNEL * channel, int width,
+channel_request_pty_size(LIBSSH2_CHANNEL *channel, int width,
                          int height, int width_px, int height_px)
 {
     LIBSSH2_SESSION *session = channel->session;
@@ -1654,7 +1654,7 @@ libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
  * blocking.
  */
 LIBSSH2_API void
-libssh2_channel_set_blocking(LIBSSH2_CHANNEL * channel, int blocking)
+libssh2_channel_set_blocking(LIBSSH2_CHANNEL *channel, int blocking)
 {
     if(channel)
         (void)_libssh2_session_set_blocking(channel->session, blocking);
@@ -1866,7 +1866,7 @@ libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
  * Calls _libssh2_error() !
  */
 int
-_libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL * channel,
+_libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
                                        uint32_t adjustment,
                                        unsigned char force,
                                        unsigned int *store)
@@ -2271,7 +2271,7 @@ libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id, char *buf,
  * isn't a packet.
  */
 size_t
-_libssh2_channel_packet_data_len(LIBSSH2_CHANNEL * channel, int stream_id)
+_libssh2_channel_packet_data_len(LIBSSH2_CHANNEL *channel, int stream_id)
 {
     LIBSSH2_SESSION *session = channel->session;
     LIBSSH2_PACKET *read_packet;
@@ -2542,7 +2542,7 @@ libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel)
  * Read channel's eof status
  */
 LIBSSH2_API int
-libssh2_channel_eof(LIBSSH2_CHANNEL * channel)
+libssh2_channel_eof(LIBSSH2_CHANNEL *channel)
 {
     LIBSSH2_SESSION *session;
     LIBSSH2_PACKET *packet;
@@ -2644,7 +2644,7 @@ libssh2_channel_wait_eof(LIBSSH2_CHANNEL *channel)
     return rc;
 }
 
-int _libssh2_channel_close(LIBSSH2_CHANNEL * channel)
+int _libssh2_channel_close(LIBSSH2_CHANNEL *channel)
 {
     LIBSSH2_SESSION *session = channel->session;
     int rc = 0;

--- a/src/channel.c
+++ b/src/channel.c
@@ -61,7 +61,7 @@
  * Determine the next channel ID we can use at our end
  */
 uint32_t
-_libssh2_channel_nextid(LIBSSH2_SESSION * session)
+_libssh2_channel_nextid(LIBSSH2_SESSION *session)
 {
     uint32_t id = session->next_channel;
     LIBSSH2_CHANNEL *channel;
@@ -128,7 +128,7 @@ _libssh2_channel_locate(LIBSSH2_SESSION *session, uint32_t channel_id)
  * Establish a generic session channel
  */
 LIBSSH2_CHANNEL *
-_libssh2_channel_open(LIBSSH2_SESSION * session, const char *channel_type,
+_libssh2_channel_open(LIBSSH2_SESSION *session, const char *channel_type,
                       uint32_t channel_type_len,
                       uint32_t window_size,
                       uint32_t packet_size,
@@ -379,7 +379,7 @@ libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *channel_type,
  * Tunnel TCP/IP connect through the SSH session to direct host/port
  */
 static LIBSSH2_CHANNEL *
-channel_direct_tcpip(LIBSSH2_SESSION * session, const char *host,
+channel_direct_tcpip(LIBSSH2_SESSION *session, const char *host,
                      int port, const char *shost, int sport)
 {
     LIBSSH2_CHANNEL *channel;
@@ -460,7 +460,7 @@ libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
 static LIBSSH2_CHANNEL *
-channel_direct_streamlocal(LIBSSH2_SESSION * session, const char *socket_path,
+channel_direct_streamlocal(LIBSSH2_SESSION *session, const char *socket_path,
                            const char *shost, int sport)
 {
     LIBSSH2_CHANNEL *channel;
@@ -518,7 +518,7 @@ channel_direct_streamlocal(LIBSSH2_SESSION * session, const char *socket_path,
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
 LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
+libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION *session,
                                       const char *socket_path,
                                       const char *shost, int sport)
 {
@@ -539,7 +539,7 @@ libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION * session,
  * Bind a port on the remote host and listen for connections
  */
 static LIBSSH2_LISTENER *
-channel_forward_listen(LIBSSH2_SESSION * session, const char *host,
+channel_forward_listen(LIBSSH2_SESSION *session, const char *host,
                        int port, int *bound_port, int queue_maxsize)
 {
     unsigned char *s;

--- a/src/channel.h
+++ b/src/channel.h
@@ -90,7 +90,7 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
  * Establish a generic session channel
  */
 LIBSSH2_CHANNEL *
-_libssh2_channel_open(LIBSSH2_SESSION * session, const char *channel_type,
+_libssh2_channel_open(LIBSSH2_SESSION *session, const char *channel_type,
                       uint32_t channel_type_len,
                       uint32_t window_size,
                       uint32_t packet_size,
@@ -118,9 +118,9 @@ _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
 ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
                               char *buf, size_t buflen);
 
-uint32_t _libssh2_channel_nextid(LIBSSH2_SESSION * session);
+uint32_t _libssh2_channel_nextid(LIBSSH2_SESSION *session);
 
-LIBSSH2_CHANNEL *_libssh2_channel_locate(LIBSSH2_SESSION * session,
+LIBSSH2_CHANNEL *_libssh2_channel_locate(LIBSSH2_SESSION *session,
                                          uint32_t channel_id);
 
 size_t _libssh2_channel_packet_data_len(LIBSSH2_CHANNEL * channel,

--- a/src/channel.h
+++ b/src/channel.h
@@ -49,7 +49,7 @@
  *
  * Always non-blocking.
  */
-int _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL * channel,
+int _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
                                            uint32_t adjustment,
                                            unsigned char force,
                                            unsigned int *store);
@@ -123,10 +123,10 @@ uint32_t _libssh2_channel_nextid(LIBSSH2_SESSION *session);
 LIBSSH2_CHANNEL *_libssh2_channel_locate(LIBSSH2_SESSION *session,
                                          uint32_t channel_id);
 
-size_t _libssh2_channel_packet_data_len(LIBSSH2_CHANNEL * channel,
+size_t _libssh2_channel_packet_data_len(LIBSSH2_CHANNEL *channel,
                                         int stream_id);
 
-int _libssh2_channel_close(LIBSSH2_CHANNEL * channel);
+int _libssh2_channel_close(LIBSSH2_CHANNEL *channel);
 
 /*
  * _libssh2_channel_forward_cancel

--- a/src/comp.c
+++ b/src/comp.c
@@ -121,15 +121,15 @@ static const LIBSSH2_COMP_METHOD comp_method_none = {
 static voidpf
 comp_method_zlib_alloc(voidpf opaque, uInt items, uInt size)
 {
-    LIBSSH2_SESSION *session = (LIBSSH2_SESSION *) opaque;
+    LIBSSH2_SESSION *session = (LIBSSH2_SESSION *)opaque;
 
-    return (voidpf) LIBSSH2_ALLOC(session, items * size);
+    return (voidpf)LIBSSH2_ALLOC(session, items * size);
 }
 
 static void
 comp_method_zlib_free(voidpf opaque, voidpf address)
 {
-    LIBSSH2_SESSION *session = (LIBSSH2_SESSION *) opaque;
+    LIBSSH2_SESSION *session = (LIBSSH2_SESSION *)opaque;
 
     LIBSSH2_FREE(session, address);
 }
@@ -151,9 +151,9 @@ comp_method_zlib_init(LIBSSH2_SESSION * session, int compr,
                               "zlib compression/decompression");
     }
 
-    strm->opaque = (voidpf) session;
-    strm->zalloc = (alloc_func) comp_method_zlib_alloc;
-    strm->zfree = (free_func) comp_method_zlib_free;
+    strm->opaque = (voidpf)session;
+    strm->zalloc = (alloc_func)comp_method_zlib_alloc;
+    strm->zfree = (free_func)comp_method_zlib_free;
     if(compr) {
         /* deflate */
         status = deflateInit(strm, Z_DEFAULT_COMPRESSION);
@@ -259,7 +259,7 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
 #endif
     strm->avail_in = (uInt)src_len;
     strm->next_out = (Bytef *)LIBSSH2_ALLOC(session, (uInt)out_maxlen);
-    out = (char *) strm->next_out;
+    out = (char *)strm->next_out;
     strm->avail_out = (uInt)out_maxlen;
     if(!strm->next_out)
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -322,7 +322,7 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
         strm->avail_out = (uInt)(out_maxlen - out_ofs);
     }
 
-    *dest = (unsigned char *) out;
+    *dest = (unsigned char *)out;
     *dest_len = out_maxlen - strm->avail_out;
 
     return 0;

--- a/src/comp.c
+++ b/src/comp.c
@@ -80,7 +80,7 @@ comp_method_none_comp(LIBSSH2_SESSION *session,
  * Minimalist decompression: Absolutely none
  */
 static int
-comp_method_none_decomp(LIBSSH2_SESSION * session,
+comp_method_none_decomp(LIBSSH2_SESSION *session,
                         unsigned char **dest,
                         size_t *dest_len,
                         size_t payload_limit,
@@ -138,7 +138,7 @@ comp_method_zlib_free(voidpf opaque, voidpf address)
  * All your bandwidth are belong to us (so save some)
  */
 static int
-comp_method_zlib_init(LIBSSH2_SESSION * session, int compr,
+comp_method_zlib_init(LIBSSH2_SESSION *session, int compr,
                       void **abstract)
 {
     z_stream *strm;
@@ -222,7 +222,7 @@ comp_method_zlib_comp(LIBSSH2_SESSION *session,
  * Decompresses source to destination. Allocates the output memory.
  */
 static int
-comp_method_zlib_decomp(LIBSSH2_SESSION * session,
+comp_method_zlib_decomp(LIBSSH2_SESSION *session,
                         unsigned char **dest,
                         size_t *dest_len,
                         size_t payload_limit,

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -58,7 +58,7 @@
  *
  */
 static int
-crypt_none_crypt(LIBSSH2_SESSION * session,
+crypt_none_crypt(LIBSSH2_SESSION *session,
                  unsigned int seqno,
                  unsigned char *buf,
                  size_t buf_len,
@@ -91,7 +91,7 @@ struct crypt_ctx
 };
 
 static int
-crypt_init(LIBSSH2_SESSION * session,
+crypt_init(LIBSSH2_SESSION *session,
            const LIBSSH2_CRYPT_METHOD * method,
            unsigned char *iv, int *free_iv,
            unsigned char *secret, int *free_secret,
@@ -115,7 +115,7 @@ crypt_init(LIBSSH2_SESSION * session,
 }
 
 static int
-crypt_encrypt(LIBSSH2_SESSION * session,
+crypt_encrypt(LIBSSH2_SESSION *session,
               unsigned int seqno,
               unsigned char *buf,
               size_t buf_len,
@@ -130,7 +130,7 @@ crypt_encrypt(LIBSSH2_SESSION * session,
 }
 
 static int
-crypt_dtor(LIBSSH2_SESSION * session, void **abstract)
+crypt_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     struct crypt_ctx **cctx = (struct crypt_ctx **) abstract;
     if(cctx && *cctx) {
@@ -318,7 +318,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_arcfour = {
 };
 
 static int
-crypt_init_arcfour128(LIBSSH2_SESSION * session,
+crypt_init_arcfour128(LIBSSH2_SESSION *session,
                       const LIBSSH2_CRYPT_METHOD * method,
                       unsigned char *iv, int *free_iv,
                       unsigned char *secret, int *free_secret,
@@ -392,7 +392,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_3des_cbc = {
 #endif
 
 static int
-crypt_init_chacha20_poly(LIBSSH2_SESSION * session,
+crypt_init_chacha20_poly(LIBSSH2_SESSION *session,
            const LIBSSH2_CRYPT_METHOD * method,
            unsigned char *iv, int *free_iv,
            unsigned char *secret, int *free_secret,
@@ -421,7 +421,7 @@ crypt_init_chacha20_poly(LIBSSH2_SESSION * session,
 }
 
 static int
-crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION * session,
+crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
                                    unsigned int seqno,
                                    unsigned char *buf,
                                    size_t buf_len,
@@ -463,7 +463,7 @@ crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION * session,
 }
 
 static int
-crypt_get_length_chacha20_poly(LIBSSH2_SESSION * session, unsigned int seqno,
+crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session, unsigned int seqno,
                                unsigned char *data, size_t data_size,
                                unsigned int *len, void **abstract)
 {
@@ -476,7 +476,7 @@ crypt_get_length_chacha20_poly(LIBSSH2_SESSION * session, unsigned int seqno,
 }
 
 static int
-crypt_dtor_chacha20_poly(LIBSSH2_SESSION * session, void **abstract)
+crypt_dtor_chacha20_poly(LIBSSH2_SESSION *session, void **abstract)
 {
     struct crypt_ctx **cctx = (struct crypt_ctx **) abstract;
     if(cctx && *cctx) {

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -123,8 +123,8 @@ crypt_encrypt(LIBSSH2_SESSION * session,
               int firstlast)
 {
     struct crypt_ctx *cctx = *(struct crypt_ctx **) abstract;
-    (void) session;
-    (void) seqno;
+    (void)session;
+    (void)seqno;
     return _libssh2_cipher_crypt(&cctx->h, cctx->algo, cctx->encrypt, buf,
                                  buf_len, firstlast);
 }

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -122,7 +122,7 @@ crypt_encrypt(LIBSSH2_SESSION *session,
               void **abstract,
               int firstlast)
 {
-    struct crypt_ctx *cctx = *(struct crypt_ctx **) abstract;
+    struct crypt_ctx *cctx = *(struct crypt_ctx **)abstract;
     (void)session;
     (void)seqno;
     return _libssh2_cipher_crypt(&cctx->h, cctx->algo, cctx->encrypt, buf,
@@ -132,7 +132,7 @@ crypt_encrypt(LIBSSH2_SESSION *session,
 static int
 crypt_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
-    struct crypt_ctx **cctx = (struct crypt_ctx **) abstract;
+    struct crypt_ctx **cctx = (struct crypt_ctx **)abstract;
     if(cctx && *cctx) {
         _libssh2_cipher_dtor(&(*cctx)->h);
         LIBSSH2_FREE(session, *cctx);
@@ -329,7 +329,7 @@ crypt_init_arcfour128(LIBSSH2_SESSION *session,
     rc = crypt_init(session, method, iv, free_iv, secret, free_secret,
                     encrypt, abstract);
     if(rc == 0) {
-        struct crypt_ctx *cctx = *(struct crypt_ctx **) abstract;
+        struct crypt_ctx *cctx = *(struct crypt_ctx **)abstract;
         unsigned char block[8];
         size_t discard = 1536;
         for(; discard; discard -= 8)
@@ -429,7 +429,7 @@ crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
                                    int firstlast)
 {
     int ret = 1;
-    struct crypt_ctx *ctx = *(struct crypt_ctx **) abstract;
+    struct crypt_ctx *ctx = *(struct crypt_ctx **)abstract;
 
     (void)session;
     (void)firstlast;
@@ -467,7 +467,7 @@ crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session, unsigned int seqno,
                                unsigned char *data, size_t data_size,
                                unsigned int *len, void **abstract)
 {
-    struct crypt_ctx *ctx = *(struct crypt_ctx **) abstract;
+    struct crypt_ctx *ctx = *(struct crypt_ctx **)abstract;
 
     (void)session;
 
@@ -478,7 +478,7 @@ crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session, unsigned int seqno,
 static int
 crypt_dtor_chacha20_poly(LIBSSH2_SESSION *session, void **abstract)
 {
-    struct crypt_ctx **cctx = (struct crypt_ctx **) abstract;
+    struct crypt_ctx **cctx = (struct crypt_ctx **)abstract;
     if(cctx && *cctx) {
         LIBSSH2_FREE(session, *cctx);
         *abstract = NULL;

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -92,7 +92,7 @@ struct crypt_ctx
 
 static int
 crypt_init(LIBSSH2_SESSION *session,
-           const LIBSSH2_CRYPT_METHOD * method,
+           const LIBSSH2_CRYPT_METHOD *method,
            unsigned char *iv, int *free_iv,
            unsigned char *secret, int *free_secret,
            int encrypt, void **abstract)
@@ -319,7 +319,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_arcfour = {
 
 static int
 crypt_init_arcfour128(LIBSSH2_SESSION *session,
-                      const LIBSSH2_CRYPT_METHOD * method,
+                      const LIBSSH2_CRYPT_METHOD *method,
                       unsigned char *iv, int *free_iv,
                       unsigned char *secret, int *free_secret,
                       int encrypt, void **abstract)
@@ -393,7 +393,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_3des_cbc = {
 
 static int
 crypt_init_chacha20_poly(LIBSSH2_SESSION *session,
-           const LIBSSH2_CRYPT_METHOD * method,
+           const LIBSSH2_CRYPT_METHOD *method,
            unsigned char *iv, int *free_iv,
            unsigned char *secret, int *free_secret,
            int encrypt, void **abstract)

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -93,7 +93,7 @@ void _libssh2_hmac_cleanup(libssh2_hmac_ctx *ctx);
 #define LIBSSH2_MLKEM_1024_CIPHERTEXT 1568
 
 #if LIBSSH2_RSA
-int _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
+int _libssh2_rsa_new(libssh2_rsa_ctx **rsa,
                      const unsigned char *edata,
                      unsigned long elen,
                      const unsigned char *ndata,
@@ -109,44 +109,44 @@ int _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
                      const unsigned char *e2data,
                      unsigned long e2len,
                      const unsigned char *coeffdata, unsigned long coefflen);
-int _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
-                             LIBSSH2_SESSION * session,
+int _libssh2_rsa_new_private(libssh2_rsa_ctx **rsa,
+                             LIBSSH2_SESSION *session,
                              const char *filename,
                              const unsigned char *passphrase);
 #if LIBSSH2_RSA_SHA1
-int _libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
-                           libssh2_rsa_ctx * rsactx,
+int _libssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
+                           libssh2_rsa_ctx *rsactx,
                            const unsigned char *hash,
                            size_t hash_len,
                            unsigned char **signature,
                            size_t *signature_len);
-int _libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
+int _libssh2_rsa_sha1_verify(libssh2_rsa_ctx *rsactx,
                              const unsigned char *sig,
                              size_t sig_len,
                              const unsigned char *m, size_t m_len);
 #endif
 #if LIBSSH2_RSA_SHA2
-int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
-                           libssh2_rsa_ctx * rsactx,
+int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
+                           libssh2_rsa_ctx *rsactx,
                            const unsigned char *hash,
                            size_t hash_len,
                            unsigned char **signature,
                            size_t *signature_len);
-int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx *rsactx,
                              size_t hash_len,
                              const unsigned char *sig,
                              size_t sig_len,
                              const unsigned char *m, size_t m_len);
 #endif
-int _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
-                                        LIBSSH2_SESSION * session,
+int _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
+                                        LIBSSH2_SESSION *session,
                                         const char *filedata,
                                         size_t filedata_len,
                                         const unsigned char *passphrase);
 #endif
 
 #if LIBSSH2_DSA
-int _libssh2_dsa_new(libssh2_dsa_ctx ** dsa,
+int _libssh2_dsa_new(libssh2_dsa_ctx **dsa,
                      const unsigned char *pdata,
                      unsigned long plen,
                      const unsigned char *qdata,
@@ -156,18 +156,18 @@ int _libssh2_dsa_new(libssh2_dsa_ctx ** dsa,
                      const unsigned char *ydata,
                      unsigned long ylen,
                      const unsigned char *x, unsigned long x_len);
-int _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
-                             LIBSSH2_SESSION * session,
+int _libssh2_dsa_new_private(libssh2_dsa_ctx **dsa,
+                             LIBSSH2_SESSION *session,
                              const char *filename,
                              const unsigned char *passphrase);
-int _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
+int _libssh2_dsa_sha1_verify(libssh2_dsa_ctx *dsactx,
                              const unsigned char *sig,
                              const unsigned char *m, size_t m_len);
-int _libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
+int _libssh2_dsa_sha1_sign(libssh2_dsa_ctx *dsactx,
                            const unsigned char *hash,
                            size_t hash_len, unsigned char *sig);
-int _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
-                                        LIBSSH2_SESSION * session,
+int _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx **dsa,
+                                        LIBSSH2_SESSION *session,
                                         const char *filedata,
                                         size_t filedata_len,
                                         const unsigned char *passphrase);
@@ -175,29 +175,29 @@ int _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
 
 #if LIBSSH2_ECDSA
 int
-_libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx ** ec_ctx,
+_libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx **ec_ctx,
                                          const unsigned char *k,
                                          size_t k_len,
                                          libssh2_curve_type curve);
 
 int
-_libssh2_ecdsa_new_private(libssh2_ecdsa_ctx ** ec_ctx,
-                           LIBSSH2_SESSION * session,
+_libssh2_ecdsa_new_private(libssh2_ecdsa_ctx **ec_ctx,
+                           LIBSSH2_SESSION *session,
                            const char *filename,
                            const unsigned char *passphrase);
 
 int
-_libssh2_ecdsa_new_private_sk(libssh2_ecdsa_ctx ** ec_ctx,
+_libssh2_ecdsa_new_private_sk(libssh2_ecdsa_ctx **ec_ctx,
                               unsigned char *flags,
                               const char **application,
                               const unsigned char **key_handle,
                               size_t *handle_len,
-                              LIBSSH2_SESSION * session,
+                              LIBSSH2_SESSION *session,
                               const char *filename,
                               const unsigned char *passphrase);
 
 int
-_libssh2_ecdsa_verify(libssh2_ecdsa_ctx * ec_ctx,
+_libssh2_ecdsa_verify(libssh2_ecdsa_ctx *ec_ctx,
                       const unsigned char *r, size_t r_len,
                       const unsigned char *s, size_t s_len,
                       const unsigned char *m, size_t m_len);
@@ -219,18 +219,18 @@ _libssh2_ecdsa_sign(LIBSSH2_SESSION *session, libssh2_ecdsa_ctx *ec_ctx,
                     const unsigned char *hash, size_t hash_len,
                     unsigned char **signature, size_t *signature_len);
 
-int _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx ** ec_ctx,
-                                          LIBSSH2_SESSION * session,
+int _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ec_ctx,
+                                          LIBSSH2_SESSION *session,
                                           const char *filedata,
                                           size_t filedata_len,
                                           const unsigned char *passphrase);
 
-int _libssh2_ecdsa_new_private_frommemory_sk(libssh2_ecdsa_ctx ** ec_ctx,
+int _libssh2_ecdsa_new_private_frommemory_sk(libssh2_ecdsa_ctx **ec_ctx,
                                              unsigned char *flags,
                                              const char **application,
                                              const unsigned char **key_handle,
                                              size_t *handle_len,
-                                             LIBSSH2_SESSION * session,
+                                             LIBSSH2_SESSION *session,
                                              const char *filedata,
                                              size_t filedata_len,
                                              const unsigned char *passphrase);
@@ -320,12 +320,12 @@ _libssh2_mlkem_get_sk(unsigned char *out_shared_key,
 
 #endif /* LIBSSH2_MLKEM */
 
-int _libssh2_cipher_init(_libssh2_cipher_ctx * h,
+int _libssh2_cipher_init(_libssh2_cipher_ctx *h,
                          _libssh2_cipher_type(algo),
                          unsigned char *iv,
                          unsigned char *secret, int encrypt);
 
-int _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
+int _libssh2_cipher_crypt(_libssh2_cipher_ctx *ctx,
                           _libssh2_cipher_type(algo),
                           int encrypt, unsigned char *block, size_t blocksize,
                           int firstlast);

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -206,7 +206,7 @@ hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION * session,
                                   const unsigned char *m,
                                   size_t m_len, void **abstract)
 {
-    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
 
     /* Skip past keyname_len(4) + keyname(7){"ssh-rsa"} + signature_len(4) */
@@ -231,7 +231,7 @@ hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION * session,
                              const struct iovec datavec[],
                              void **abstract)
 {
-    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
 
 #ifdef _libssh2_rsa_sha1_signv
     return _libssh2_rsa_sha1_signv(session, signature, signature_len,
@@ -280,7 +280,7 @@ hostkey_method_ssh_rsa_sha2_256_sig_verify(LIBSSH2_SESSION * session,
                                            const unsigned char *m,
                                            size_t m_len, void **abstract)
 {
-    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
 
     /* Skip past keyname_len(4) + keyname(12){"rsa-sha2-256"} +
@@ -308,7 +308,7 @@ hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION * session,
                                       const struct iovec datavec[],
                                       void **abstract)
 {
-    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
 
 #ifdef _libssh2_rsa_sha2_256_signv
     return _libssh2_rsa_sha2_256_signv(session, signature, signature_len,
@@ -354,7 +354,7 @@ hostkey_method_ssh_rsa_sha2_512_sig_verify(LIBSSH2_SESSION * session,
                                            const unsigned char *m,
                                            size_t m_len, void **abstract)
 {
-    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
 
     /* Skip past keyname_len(4) + keyname(12){"rsa-sha2-512"} +
@@ -381,7 +381,7 @@ hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION * session,
                                       const struct iovec datavec[],
                                       void **abstract)
 {
-    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
 
 #ifdef _libssh2_rsa_sha2_512_signv
     return _libssh2_rsa_sha2_512_signv(session, signature, signature_len,
@@ -425,7 +425,7 @@ hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION * session,
 static int
 hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION * session, void **abstract)
 {
-    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *) (*abstract);
+    libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
 
     _libssh2_rsa_free(rsactx);
@@ -669,7 +669,7 @@ hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION * session,
                                   const unsigned char *m,
                                   size_t m_len, void **abstract)
 {
-    libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *) (*abstract);
+    libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *)(*abstract);
 
     /* Skip past keyname_len(4) + keyname(7){"ssh-dss"} + signature_len(4) */
     if(sig_len != 55) {
@@ -696,7 +696,7 @@ hostkey_method_ssh_dss_signv(LIBSSH2_SESSION * session,
                              const struct iovec datavec[],
                              void **abstract)
 {
-    libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *) (*abstract);
+    libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *)(*abstract);
     unsigned char hash[SHA_DIGEST_LENGTH];
     libssh2_sha1_ctx ctx;
     int i;
@@ -740,7 +740,7 @@ hostkey_method_ssh_dss_signv(LIBSSH2_SESSION * session,
 static int
 hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION * session, void **abstract)
 {
-    libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *) (*abstract);
+    libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *)(*abstract);
     (void)session;
 
     _libssh2_dsa_free(dsactx);
@@ -808,13 +808,13 @@ hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION * session,
     if(_libssh2_get_string(&buf, &type_str, &len) || len != 19)
         return -1;
 
-    if(strncmp((char *) type_str, "ecdsa-sha2-nistp256", 19) == 0) {
+    if(strncmp((char *)type_str, "ecdsa-sha2-nistp256", 19) == 0) {
         type = LIBSSH2_EC_CURVE_NISTP256;
     }
-    else if(strncmp((char *) type_str, "ecdsa-sha2-nistp384", 19) == 0) {
+    else if(strncmp((char *)type_str, "ecdsa-sha2-nistp384", 19) == 0) {
         type = LIBSSH2_EC_CURVE_NISTP384;
     }
-    else if(strncmp((char *) type_str, "ecdsa-sha2-nistp521", 19) == 0) {
+    else if(strncmp((char *)type_str, "ecdsa-sha2-nistp521", 19) == 0) {
         type = LIBSSH2_EC_CURVE_NISTP521;
     }
     else {
@@ -932,7 +932,7 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
     size_t r_len, s_len, name_len;
     uint32_t len;
     struct string_buf buf;
-    libssh2_ecdsa_ctx *ctx = (libssh2_ecdsa_ctx *) (*abstract);
+    libssh2_ecdsa_ctx *ctx = (libssh2_ecdsa_ctx *)(*abstract);
 
     (void)session;
 
@@ -1002,7 +1002,7 @@ hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION * session,
                                const struct iovec datavec[],
                                void **abstract)
 {
-    libssh2_ecdsa_ctx *ec_ctx = (libssh2_ecdsa_ctx *) (*abstract);
+    libssh2_ecdsa_ctx *ec_ctx = (libssh2_ecdsa_ctx *)(*abstract);
     libssh2_curve_type type = _libssh2_ecdsa_get_curve_type(ec_ctx);
     int ret = 0;
 
@@ -1030,7 +1030,7 @@ hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION * session,
 static int
 hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION * session, void **abstract)
 {
-    libssh2_ecdsa_ctx *keyctx = (libssh2_ecdsa_ctx *) (*abstract);
+    libssh2_ecdsa_ctx *keyctx = (libssh2_ecdsa_ctx *)(*abstract);
     (void)session;
 
     if(keyctx)
@@ -1250,7 +1250,7 @@ hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION * session,
                                       const unsigned char *m,
                                       size_t m_len, void **abstract)
 {
-    libssh2_ed25519_ctx *ctx = (libssh2_ed25519_ctx *) (*abstract);
+    libssh2_ed25519_ctx *ctx = (libssh2_ed25519_ctx *)(*abstract);
     (void)session;
 
     if(sig_len < 19)
@@ -1280,7 +1280,7 @@ hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION * session,
                                  const struct iovec datavec[],
                                  void **abstract)
 {
-    libssh2_ed25519_ctx *ctx = (libssh2_ed25519_ctx *) (*abstract);
+    libssh2_ed25519_ctx *ctx = (libssh2_ed25519_ctx *)(*abstract);
 
     if(veccount != 1) {
         return -1;
@@ -1299,7 +1299,7 @@ hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION * session,
 static int
 hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION * session, void **abstract)
 {
-    libssh2_ed25519_ctx *keyctx = (libssh2_ed25519_ctx*) (*abstract);
+    libssh2_ed25519_ctx *keyctx = (libssh2_ed25519_ctx*)(*abstract);
     (void)session;
 
     if(keyctx)
@@ -1401,16 +1401,16 @@ libssh2_hostkey_hash(LIBSSH2_SESSION * session, int hash_type)
 #if LIBSSH2_MD5
     case LIBSSH2_HOSTKEY_HASH_MD5:
         return (session->server_hostkey_md5_valid)
-          ? (char *) session->server_hostkey_md5
+          ? (char *)session->server_hostkey_md5
           : NULL;
 #endif /* LIBSSH2_MD5 */
     case LIBSSH2_HOSTKEY_HASH_SHA1:
         return (session->server_hostkey_sha1_valid)
-          ? (char *) session->server_hostkey_sha1
+          ? (char *)session->server_hostkey_sha1
           : NULL;
     case LIBSSH2_HOSTKEY_HASH_SHA256:
         return (session->server_hostkey_sha256_valid)
-          ? (char *) session->server_hostkey_sha256
+          ? (char *)session->server_hostkey_sha256
           : NULL;
     default:
         return NULL;
@@ -1490,7 +1490,7 @@ libssh2_session_hostkey(LIBSSH2_SESSION *session, size_t *len, int *type)
         if(type)
             *type = hostkey_type(session->server_hostkey,
                                  session->server_hostkey_len);
-        return (char *) session->server_hostkey;
+        return (char *)session->server_hostkey;
     }
     if(len)
         *len = 0;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -50,7 +50,7 @@
  * ssh-rsa *
  *********** */
 
-static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION * session,
+static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
                                        void **abstract);
 
 /*
@@ -59,7 +59,7 @@ static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION * session,
  * Initialize the server hostkey working area with e/n pair
  */
 static int
-hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
                             const unsigned char *hostkey_data,
                             size_t hostkey_data_len,
                             void **abstract)
@@ -138,7 +138,7 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
  * Load a Private Key from a PEM file
  */
 static int
-hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION *session,
                                const char *privkeyfile,
                                const unsigned char *passphrase,
                                void **abstract)
@@ -167,7 +167,7 @@ hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION * session,
  * Load a Private Key from a memory
  */
 static int
-hostkey_method_ssh_rsa_initPEMFromMemory(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_initPEMFromMemory(LIBSSH2_SESSION *session,
                                          const char *privkeyfiledata,
                                          size_t privkeyfiledata_len,
                                          const unsigned char *passphrase,
@@ -200,7 +200,7 @@ hostkey_method_ssh_rsa_initPEMFromMemory(LIBSSH2_SESSION * session,
  * Verify signature created by remote
  */
 static int
-hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION *session,
                                   const unsigned char *sig,
                                   size_t sig_len,
                                   const unsigned char *m,
@@ -224,7 +224,7 @@ hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION * session,
  * Construct a signature from an array of vectors
  */
 static int
-hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
                              unsigned char **signature,
                              size_t *signature_len,
                              int veccount,
@@ -274,7 +274,7 @@ hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION * session,
 #if LIBSSH2_RSA_SHA2
 
 static int
-hostkey_method_ssh_rsa_sha2_256_sig_verify(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_sha2_256_sig_verify(LIBSSH2_SESSION *session,
                                            const unsigned char *sig,
                                            size_t sig_len,
                                            const unsigned char *m,
@@ -301,7 +301,7 @@ hostkey_method_ssh_rsa_sha2_256_sig_verify(LIBSSH2_SESSION * session,
  */
 
 static int
-hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
                                       unsigned char **signature,
                                       size_t *signature_len,
                                       int veccount,
@@ -348,7 +348,7 @@ hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION * session,
  * Verify signature created by remote
  */
 static int
-hostkey_method_ssh_rsa_sha2_512_sig_verify(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_sha2_512_sig_verify(LIBSSH2_SESSION *session,
                                            const unsigned char *sig,
                                            size_t sig_len,
                                            const unsigned char *m,
@@ -374,7 +374,7 @@ hostkey_method_ssh_rsa_sha2_512_sig_verify(LIBSSH2_SESSION * session,
  * Construct a signature from an array of vectors
  */
 static int
-hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION * session,
+hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
                                       unsigned char **signature,
                                       size_t *signature_len,
                                       int veccount,
@@ -423,7 +423,7 @@ hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION * session,
  * Shutdown the hostkey
  */
 static int
-hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION * session, void **abstract)
+hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
@@ -530,7 +530,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_512_cert = {
  * ssh-dss *
  *********** */
 
-static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION * session,
+static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
                                        void **abstract);
 
 /*
@@ -539,7 +539,7 @@ static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION * session,
  * Initialize the server hostkey working area with p/q/g/y set
  */
 static int
-hostkey_method_ssh_dss_init(LIBSSH2_SESSION * session,
+hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
                             const unsigned char *hostkey_data,
                             size_t hostkey_data_len,
                             void **abstract)
@@ -602,7 +602,7 @@ hostkey_method_ssh_dss_init(LIBSSH2_SESSION * session,
  * Load a Private Key from a PEM file
  */
 static int
-hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION * session,
+hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION *session,
                                const char *privkeyfile,
                                const unsigned char *passphrase,
                                void **abstract)
@@ -631,7 +631,7 @@ hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION * session,
  * Load a Private Key from memory
  */
 static int
-hostkey_method_ssh_dss_initPEMFromMemory(LIBSSH2_SESSION * session,
+hostkey_method_ssh_dss_initPEMFromMemory(LIBSSH2_SESSION *session,
                                          const char *privkeyfiledata,
                                          size_t privkeyfiledata_len,
                                          const unsigned char *passphrase,
@@ -663,7 +663,7 @@ hostkey_method_ssh_dss_initPEMFromMemory(LIBSSH2_SESSION * session,
  * Verify signature created by remote
  */
 static int
-hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION * session,
+hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION *session,
                                   const unsigned char *sig,
                                   size_t sig_len,
                                   const unsigned char *m,
@@ -689,7 +689,7 @@ hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION * session,
  * Construct a signature from an array of vectors
  */
 static int
-hostkey_method_ssh_dss_signv(LIBSSH2_SESSION * session,
+hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
                              unsigned char **signature,
                              size_t *signature_len,
                              int veccount,
@@ -738,7 +738,7 @@ hostkey_method_ssh_dss_signv(LIBSSH2_SESSION * session,
  * Shutdown the hostkey method
  */
 static int
-hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION * session, void **abstract)
+hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *)(*abstract);
     (void)session;
@@ -770,7 +770,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_dss = {
  *********** */
 
 static int
-hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
                               void **abstract);
 
 /*
@@ -779,7 +779,7 @@ hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION * session,
  * Initialize the server hostkey working area with e/n pair
  */
 static int
-hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
                               const unsigned char *hostkey_data,
                               size_t hostkey_data_len,
                               void **abstract)
@@ -860,7 +860,7 @@ hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION * session,
  * Load a Private Key from a PEM file
  */
 static int
-hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION *session,
                                  const char *privkeyfile,
                                  const unsigned char *passphrase,
                                  void **abstract)
@@ -888,7 +888,7 @@ hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION * session,
  * Load a Private Key from memory
  */
 static int
-hostkey_method_ssh_ecdsa_initPEMFromMemory(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ecdsa_initPEMFromMemory(LIBSSH2_SESSION *session,
                                            const char *privkeyfiledata,
                                            size_t privkeyfiledata_len,
                                            const unsigned char *passphrase,
@@ -922,7 +922,7 @@ hostkey_method_ssh_ecdsa_initPEMFromMemory(LIBSSH2_SESSION * session,
  * Verify signature created by remote
  */
 static int
-hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
                                     const unsigned char *sig,
                                     size_t sig_len,
                                     const unsigned char *m,
@@ -995,7 +995,7 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
  * Construct a signature from an array of vectors
  */
 static int
-hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
                                unsigned char **signature,
                                size_t *signature_len,
                                int veccount,
@@ -1028,7 +1028,7 @@ hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION * session,
  * Shutdown the hostkey by freeing EC_KEY context
  */
 static int
-hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION * session, void **abstract)
+hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     libssh2_ecdsa_ctx *keyctx = (libssh2_ecdsa_ctx *)(*abstract);
     (void)session;
@@ -1121,7 +1121,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp521_cert = {
  * ed25519 *
  *********** */
 
-static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION * session,
+static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
                                            void **abstract);
 
 /*
@@ -1130,7 +1130,7 @@ static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION * session,
  * Initialize the server hostkey working area with e/n pair
  */
 static int
-hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
                                 const unsigned char *hostkey_data,
                                 size_t hostkey_data_len,
                                 void **abstract)
@@ -1180,7 +1180,7 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
  * Load a Private Key from a PEM file
  */
 static int
-hostkey_method_ssh_ed25519_initPEM(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ed25519_initPEM(LIBSSH2_SESSION *session,
                                    const char *privkeyfile,
                                    const unsigned char *passphrase,
                                    void **abstract)
@@ -1210,7 +1210,7 @@ hostkey_method_ssh_ed25519_initPEM(LIBSSH2_SESSION * session,
  * Load a Private Key from memory
  */
 static int
-hostkey_method_ssh_ed25519_initPEMFromMemory(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ed25519_initPEMFromMemory(LIBSSH2_SESSION *session,
                                              const char *privkeyfiledata,
                                              size_t privkeyfiledata_len,
                                              const unsigned char *passphrase,
@@ -1244,7 +1244,7 @@ hostkey_method_ssh_ed25519_initPEMFromMemory(LIBSSH2_SESSION * session,
  * Verify signature created by remote
  */
 static int
-hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION *session,
                                       const unsigned char *sig,
                                       size_t sig_len,
                                       const unsigned char *m,
@@ -1273,7 +1273,7 @@ hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION * session,
  * Construct a signature from an array of vectors
  */
 static int
-hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION * session,
+hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
                                  unsigned char **signature,
                                  size_t *signature_len,
                                  int veccount,
@@ -1297,7 +1297,7 @@ hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION * session,
  * Shutdown the hostkey by freeing key context
  */
 static int
-hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION * session, void **abstract)
+hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     libssh2_ed25519_ctx *keyctx = (libssh2_ed25519_ctx*)(*abstract);
     (void)session;
@@ -1395,7 +1395,7 @@ libssh2_hostkey_methods(void)
  * i.e. MD5 == 16, SHA1 == 20, SHA256 == 32
  */
 LIBSSH2_API const char *
-libssh2_hostkey_hash(LIBSSH2_SESSION * session, int hash_type)
+libssh2_hostkey_hash(LIBSSH2_SESSION *session, int hash_type)
 {
     switch(hash_type) {
 #if LIBSSH2_MD5

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -93,7 +93,7 @@ libssh2_keepalive_send(LIBSSH2_SESSION *session,
             *seconds_to_next = session->keepalive_interval;
     }
     else if(seconds_to_next) {
-        *seconds_to_next = (int) (session->keepalive_last_sent - now)
+        *seconds_to_next = (int)(session->keepalive_last_sent - now)
             + session->keepalive_interval;
     }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -356,7 +356,7 @@ process_host_key(LIBSSH2_SESSION *session,
 }
 
 static int
-finish_kex(LIBSSH2_SESSION * session,
+finish_kex(LIBSSH2_SESSION *session,
            kmdhgGPshakex_state_t *exchange_state,
            int digest_len, int sha_algo_value)
 {
@@ -581,7 +581,7 @@ finish_kex(LIBSSH2_SESSION * session,
 }
 
 static void
-diffie_hellman_state_cleanup(LIBSSH2_SESSION * session,
+diffie_hellman_state_cleanup(LIBSSH2_SESSION *session,
                              kmdhgGPshakex_state_t *exchange_state)
 {
     libssh2_dh_dtor(&exchange_state->x);
@@ -613,7 +613,7 @@ diffie_hellman_state_cleanup(LIBSSH2_SESSION * session,
 }
 
 static void
-kex_diffie_hellman_cleanup(LIBSSH2_SESSION * session,
+kex_diffie_hellman_cleanup(LIBSSH2_SESSION *session,
                            key_exchange_state_low_t * key_state) {
     if(key_state->state != libssh2_NB_state_idle) {
         _libssh2_bn_free(key_state->p);
@@ -1457,7 +1457,7 @@ clean_exit:
  */
 static int
 kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
-                                          LIBSSH2_SESSION * session,
+                                          LIBSSH2_SESSION *session,
                                           key_exchange_state_low_t * key_state)
 {
     int ret = 0;
@@ -1585,7 +1585,7 @@ dh_gex_clean_exit:
  */
 static int
 kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
-                                          LIBSSH2_SESSION * session,
+                                          LIBSSH2_SESSION *session,
                                           key_exchange_state_low_t * key_state)
 {
     int ret = 0;
@@ -2005,7 +2005,7 @@ kex_session_ecdh_curve_type(const char *name, libssh2_curve_type *out_type)
 }
 
 static void
-ecdh_exchange_state_cleanup(LIBSSH2_SESSION * session,
+ecdh_exchange_state_cleanup(LIBSSH2_SESSION *session,
                             kmdhgGPshakex_state_t *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
@@ -2021,7 +2021,7 @@ ecdh_exchange_state_cleanup(LIBSSH2_SESSION * session,
 
 static void
 kex_method_ecdh_cleanup
-(LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
 {
     if(key_state->public_key_oct) {
         LIBSSH2_FREE(session, key_state->public_key_oct);
@@ -2221,7 +2221,7 @@ clean_exit:
  */
 static int
 kex_method_ecdh_key_exchange
-(LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -2328,7 +2328,7 @@ ecdh_clean_exit:
 #if LIBSSH2_MLKEM
 
 static void
-mlkem_nistp_exchange_state_cleanup(LIBSSH2_SESSION * session,
+mlkem_nistp_exchange_state_cleanup(LIBSSH2_SESSION *session,
                                    kmdhgGPshakex_state_t *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
@@ -2344,7 +2344,7 @@ mlkem_nistp_exchange_state_cleanup(LIBSSH2_SESSION * session,
 
 static void
 kex_method_mlkem_nistp_cleanup
-(LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
 {
     if(key_state->public_key_oct) {
         LIBSSH2_FREE(session, key_state->public_key_oct);
@@ -2620,7 +2620,7 @@ clean_exit:
 
 static int
 kex_method_mlkem_nistp_key_exchange
-(LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -2751,7 +2751,7 @@ clean_exit:
 #if LIBSSH2_ED25519
 
 static void
-curve25519_exchange_state_cleanup(LIBSSH2_SESSION * session,
+curve25519_exchange_state_cleanup(LIBSSH2_SESSION *session,
                                   kmdhgGPshakex_state_t *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
@@ -2767,7 +2767,7 @@ curve25519_exchange_state_cleanup(LIBSSH2_SESSION * session,
 
 static void
 kex_method_curve25519_cleanup
-(LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
 {
     if(key_state->curve25519_public_key) {
         _libssh2_explicit_zero(key_state->curve25519_public_key,
@@ -2946,7 +2946,7 @@ clean_exit:
  */
 static int
 kex_method_curve25519_key_exchange
-(LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -3045,7 +3045,7 @@ clean_exit:
 #if LIBSSH2_MLKEM
 
 static void
-mlkem768x25519_exchange_state_cleanup(LIBSSH2_SESSION * session,
+mlkem768x25519_exchange_state_cleanup(LIBSSH2_SESSION *session,
                                   kmdhgGPshakex_state_t *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
@@ -3061,7 +3061,7 @@ mlkem768x25519_exchange_state_cleanup(LIBSSH2_SESSION * session,
 
 static void
 kex_method_mlkem768x25519_cleanup
-(LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
 {
     if(key_state->curve25519_public_key) {
         _libssh2_explicit_zero(key_state->curve25519_public_key,
@@ -3267,7 +3267,7 @@ clean_exit:
 
 static int
 kex_method_mlkem768x25519_key_exchange
-(LIBSSH2_SESSION * session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -3622,7 +3622,7 @@ kex_method_list(unsigned char *buf, uint32_t list_strlen,
 /* kexinit
  * Send SSH_MSG_KEXINIT packet
  */
-static int kexinit(LIBSSH2_SESSION * session)
+static int kexinit(LIBSSH2_SESSION *session)
 {
     /* 62 = packet_type(1) + cookie(16) + first_packet_follows(1) +
        reserved(4) + length longs(40) */
@@ -3867,7 +3867,7 @@ kex_get_method_by_name(const char *name, size_t name_len,
 /* kex_agree_hostkey
  * Agree on a Hostkey which works with this kex
  */
-static int kex_agree_hostkey(LIBSSH2_SESSION * session,
+static int kex_agree_hostkey(LIBSSH2_SESSION *session,
                              size_t kex_flags,
                              unsigned char *hostkey, size_t hostkey_len)
 {
@@ -3942,7 +3942,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION * session,
 /* kex_agree_kex_hostkey
  * Agree on a Key Exchange method and a hostkey encoding type
  */
-static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
+static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
                                  size_t kex_len, unsigned char *hostkey,
                                  size_t hostkey_len)
 {
@@ -4022,7 +4022,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
 /* kex_agree_crypt
  * Agree on a cipher algo
  */
-static int kex_agree_crypt(LIBSSH2_SESSION * session,
+static int kex_agree_crypt(LIBSSH2_SESSION *session,
                            libssh2_endpoint_data *endpoint,
                            unsigned char *crypt,
                            size_t crypt_len)
@@ -4077,7 +4077,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION * session,
 /* kex_agree_mac
  * Agree on a message authentication hash
  */
-static int kex_agree_mac(LIBSSH2_SESSION * session,
+static int kex_agree_mac(LIBSSH2_SESSION *session,
                          libssh2_endpoint_data * endpoint, unsigned char *mac,
                          size_t mac_len)
 {
@@ -4195,7 +4195,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
 /* kex_agree_methods
  * Decide which specific method to use of the methods offered by each party
  */
-static int kex_agree_methods(LIBSSH2_SESSION * session, unsigned char *data,
+static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,
                              size_t data_len)
 {
     unsigned char *kex, *hostkey, *crypt_cs, *crypt_sc, *comp_cs, *comp_sc,
@@ -4310,7 +4310,7 @@ static int kex_agree_methods(LIBSSH2_SESSION * session, unsigned char *data,
  * Returns some errors without _libssh2_error()
  */
 int
-_libssh2_kex_exchange(LIBSSH2_SESSION * session, int reexchange,
+_libssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
                       key_exchange_state_t * key_state)
 {
     int rc = 0;
@@ -4449,7 +4449,7 @@ _libssh2_kex_exchange(LIBSSH2_SESSION * session, int reexchange,
  * Set preferred method
  */
 LIBSSH2_API int
-libssh2_session_method_pref(LIBSSH2_SESSION * session, int method_type,
+libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
                             const char *prefs)
 {
     char **prefvar, *s, *newprefs;

--- a/src/kex.c
+++ b/src/kex.c
@@ -614,7 +614,7 @@ diffie_hellman_state_cleanup(LIBSSH2_SESSION *session,
 
 static void
 kex_diffie_hellman_cleanup(LIBSSH2_SESSION *session,
-                           key_exchange_state_low_t * key_state) {
+                           key_exchange_state_low_t *key_state) {
     if(key_state->state != libssh2_NB_state_idle) {
         _libssh2_bn_free(key_state->p);
         key_state->p = NULL;
@@ -1458,7 +1458,7 @@ clean_exit:
 static int
 kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
                                           LIBSSH2_SESSION *session,
-                                          key_exchange_state_low_t * key_state)
+                                          key_exchange_state_low_t *key_state)
 {
     int ret = 0;
     int rc;
@@ -1586,7 +1586,7 @@ dh_gex_clean_exit:
 static int
 kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
                                           LIBSSH2_SESSION *session,
-                                          key_exchange_state_low_t * key_state)
+                                          key_exchange_state_low_t *key_state)
 {
     int ret = 0;
     int rc;
@@ -2021,7 +2021,7 @@ ecdh_exchange_state_cleanup(LIBSSH2_SESSION *session,
 
 static void
 kex_method_ecdh_cleanup
-(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
 {
     if(key_state->public_key_oct) {
         LIBSSH2_FREE(session, key_state->public_key_oct);
@@ -2221,7 +2221,7 @@ clean_exit:
  */
 static int
 kex_method_ecdh_key_exchange
-(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -2344,7 +2344,7 @@ mlkem_nistp_exchange_state_cleanup(LIBSSH2_SESSION *session,
 
 static void
 kex_method_mlkem_nistp_cleanup
-(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
 {
     if(key_state->public_key_oct) {
         LIBSSH2_FREE(session, key_state->public_key_oct);
@@ -2620,7 +2620,7 @@ clean_exit:
 
 static int
 kex_method_mlkem_nistp_key_exchange
-(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -2767,7 +2767,7 @@ curve25519_exchange_state_cleanup(LIBSSH2_SESSION *session,
 
 static void
 kex_method_curve25519_cleanup
-(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
 {
     if(key_state->curve25519_public_key) {
         _libssh2_explicit_zero(key_state->curve25519_public_key,
@@ -2946,7 +2946,7 @@ clean_exit:
  */
 static int
 kex_method_curve25519_key_exchange
-(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -3061,7 +3061,7 @@ mlkem768x25519_exchange_state_cleanup(LIBSSH2_SESSION *session,
 
 static void
 kex_method_mlkem768x25519_cleanup
-(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
 {
     if(key_state->curve25519_public_key) {
         _libssh2_explicit_zero(key_state->curve25519_public_key,
@@ -3267,7 +3267,7 @@ clean_exit:
 
 static int
 kex_method_mlkem768x25519_key_exchange
-(LIBSSH2_SESSION *session, key_exchange_state_low_t * key_state)
+(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -4078,7 +4078,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
  * Agree on a message authentication hash
  */
 static int kex_agree_mac(LIBSSH2_SESSION *session,
-                         libssh2_endpoint_data * endpoint, unsigned char *mac,
+                         libssh2_endpoint_data *endpoint, unsigned char *mac,
                          size_t mac_len)
 {
     const LIBSSH2_MAC_METHOD **macp = _libssh2_mac_methods();
@@ -4311,7 +4311,7 @@ static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,
  */
 int
 _libssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
-                      key_exchange_state_t * key_state)
+                      key_exchange_state_t *key_state)
 {
     int rc = 0;
     int retcode;

--- a/src/kex.c
+++ b/src/kex.c
@@ -739,7 +739,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX, "Sending KEX packet %u",
-                       (unsigned int) packet_type_init));
+                       (unsigned int)packet_type_init));
         exchange_state->state = libssh2_NB_state_created;
     }
 
@@ -782,7 +782,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
                            "Burnt packet of type: %02x",
-                           (unsigned int) burn_type));
+                           (unsigned int)burn_type));
         }
 
         exchange_state->state = libssh2_NB_state_sent1;

--- a/src/kex.c
+++ b/src/kex.c
@@ -877,14 +877,14 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         hok = 1;
         if(session->local.banner) {
             _libssh2_htonu32(exchange_state->h_sig_comp,
-                (uint32_t)(strlen((char *) session->local.banner) - 2));
+                (uint32_t)(strlen((char *)session->local.banner) - 2));
             hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
                                                 exchange_hash_ctx,
                                                 exchange_state->h_sig_comp, 4);
             hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
                                                 exchange_hash_ctx,
                                                 session->local.banner,
-                                   strlen((char *) session->local.banner) - 2);
+                                   strlen((char *)session->local.banner) - 2);
         }
         else {
             _libssh2_htonu32(exchange_state->h_sig_comp,
@@ -899,7 +899,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
 
         _libssh2_htonu32(exchange_state->h_sig_comp,
-                         (uint32_t)strlen((char *) session->remote.banner));
+                         (uint32_t)strlen((char *)session->remote.banner));
         hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
                                             exchange_state->h_sig_comp, 4);
         hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
@@ -1768,7 +1768,7 @@ do {                                                                         \
     hok = 1;                                                                 \
     if(session->local.banner) {                                              \
         _libssh2_htonu32(exchange_state->h_sig_comp,                         \
-            (uint32_t)(strlen((char *) session->local.banner) - 2));         \
+            (uint32_t)(strlen((char *)session->local.banner) - 2));          \
         hok &= libssh2_sha##digest_type##_update(ctx,                        \
                                                  exchange_state->h_sig_comp, \
                                                  4);                         \
@@ -1789,7 +1789,7 @@ do {                                                                         \
     }                                                                        \
                                                                              \
     _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-        (uint32_t)strlen((char *) session->remote.banner));                  \
+        (uint32_t)strlen((char *)session->remote.banner));                   \
     hok &= libssh2_sha##digest_type##_update(ctx,                            \
                                              exchange_state->h_sig_comp, 4); \
     hok &= libssh2_sha##digest_type##_update(ctx, session->remote.banner,    \
@@ -1884,7 +1884,7 @@ do {                                                                         \
     hok = 1;                                                                 \
     if(session->local.banner) {                                              \
         _libssh2_htonu32(exchange_state->h_sig_comp,                         \
-            (uint32_t)(strlen((char *) session->local.banner) - 2));         \
+            (uint32_t)(strlen((char *)session->local.banner) - 2));          \
         hok &= libssh2_sha##digest_type##_update(ctx,                        \
                                                  exchange_state->h_sig_comp, \
                                                  4);                         \
@@ -1905,7 +1905,7 @@ do {                                                                         \
     }                                                                        \
                                                                              \
     _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-        (uint32_t)strlen((char *) session->remote.banner));                  \
+        (uint32_t)strlen((char *)session->remote.banner));                   \
     hok &= libssh2_sha##digest_type##_update(ctx,                            \
                                              exchange_state->h_sig_comp, 4); \
     hok &= libssh2_sha##digest_type##_update(ctx, session->remote.banner,    \
@@ -3819,7 +3819,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
     left = end_haystack - s;
 
     /* Needle at start of haystack */
-    if((strncmp((char *) haystack, (const char *) needle, needle_len) == 0) &&
+    if((strncmp((char *)haystack, (const char *)needle, needle_len) == 0) &&
         (needle_len == haystack_len || haystack[needle_len] == ',')) {
         return haystack;
     }
@@ -3827,7 +3827,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
     /* Search until we run out of comas or we run out of haystack,
        whichever comes first */
     /* !checksrc! disable EQUALSNULL 1 */
-    while((s = (unsigned char *) memchr((char *) s, ',', left)) != NULL) {
+    while((s = (unsigned char *)memchr((char *)s, ',', left)) != NULL) {
         /* Advance buffer past coma if we can */
         left = end_haystack - s;
         if((left >= 1) && (left <= haystack_len) && (left > needle_len)) {
@@ -3839,7 +3839,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
         }
 
         /* Needle at X position */
-        if((strncmp((char *) s, (const char *) needle, needle_len) == 0) &&
+        if((strncmp((char *)s, (const char *)needle, needle_len) == 0) &&
             (((s - haystack) + needle_len) == haystack_len ||
              s[needle_len] == ',')) {
             return s;
@@ -3875,15 +3875,15 @@ static int kex_agree_hostkey(LIBSSH2_SESSION * session,
     unsigned char *s;
 
     if(session->hostkey_prefs) {
-        s = (unsigned char *) session->hostkey_prefs;
+        s = (unsigned char *)session->hostkey_prefs;
 
         while(s && *s) {
-            unsigned char *p = (unsigned char *) strchr((char *) s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *) s));
+            unsigned char *p = (unsigned char *)strchr((char *)s, ',');
+            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
             if(_libssh2_kex_agree_instr(hostkey, hostkey_len, s, method_len)) {
                 const LIBSSH2_HOSTKEY_METHOD *method =
                     (const LIBSSH2_HOSTKEY_METHOD *)
-                    kex_get_method_by_name((char *) s, method_len,
+                    kex_get_method_by_name((char *)s, method_len,
                                            (const LIBSSH2_COMMON_METHOD **)
                                            hostkeyp);
 
@@ -3915,7 +3915,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION * session,
 
     while(hostkeyp && (*hostkeyp) && (*hostkeyp)->name) {
         s = _libssh2_kex_agree_instr(hostkey, hostkey_len,
-                                     (const unsigned char *) (*hostkeyp)->name,
+                                     (const unsigned char *)(*hostkeyp)->name,
                                      strlen((*hostkeyp)->name));
         if(s) {
             /* So far so good, but does it suit our purposes? (Encrypting vs
@@ -3956,15 +3956,15 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
     }
 
     if(session->kex_prefs) {
-        s = (unsigned char *) session->kex_prefs;
+        s = (unsigned char *)session->kex_prefs;
 
         while(s && *s) {
-            unsigned char *q, *p = (unsigned char *) strchr((char *) s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *) s));
+            unsigned char *q, *p = (unsigned char *)strchr((char *)s, ',');
+            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
             q = _libssh2_kex_agree_instr(kex, kex_len, s, method_len);
             if(q) {
                 const LIBSSH2_KEX_METHOD *method = (const LIBSSH2_KEX_METHOD *)
-                    kex_get_method_by_name((char *) s, method_len,
+                    kex_get_method_by_name((char *)s, method_len,
                                            (const LIBSSH2_COMMON_METHOD **)
                                            kexp);
 
@@ -3996,7 +3996,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
 
     while(*kexp && (*kexp)->name) {
         s = _libssh2_kex_agree_instr(kex, kex_len,
-                                     (const unsigned char *) (*kexp)->name,
+                                     (const unsigned char *)(*kexp)->name,
                                      strlen((*kexp)->name));
         if(s) {
             /* We've agreed on a key exchange method,
@@ -4033,16 +4033,16 @@ static int kex_agree_crypt(LIBSSH2_SESSION * session,
     (void)session;
 
     if(endpoint->crypt_prefs) {
-        s = (unsigned char *) endpoint->crypt_prefs;
+        s = (unsigned char *)endpoint->crypt_prefs;
 
         while(s && *s) {
-            unsigned char *p = (unsigned char *) strchr((char *) s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *) s));
+            unsigned char *p = (unsigned char *)strchr((char *)s, ',');
+            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
 
             if(_libssh2_kex_agree_instr(crypt, crypt_len, s, method_len)) {
                 const LIBSSH2_CRYPT_METHOD *method =
                     (const LIBSSH2_CRYPT_METHOD *)
-                    kex_get_method_by_name((char *) s, method_len,
+                    kex_get_method_by_name((char *)s, method_len,
                                            (const LIBSSH2_COMMON_METHOD **)
                                            cryptp);
 
@@ -4062,7 +4062,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION * session,
 
     while(*cryptp && (*cryptp)->name) {
         s = _libssh2_kex_agree_instr(crypt, crypt_len,
-                                     (const unsigned char *) (*cryptp)->name,
+                                     (const unsigned char *)(*cryptp)->name,
                                      strlen((*cryptp)->name));
         if(s) {
             endpoint->crypt = *cryptp;
@@ -4095,15 +4095,15 @@ static int kex_agree_mac(LIBSSH2_SESSION * session,
     }
 
     if(endpoint->mac_prefs) {
-        s = (unsigned char *) endpoint->mac_prefs;
+        s = (unsigned char *)endpoint->mac_prefs;
 
         while(s && *s) {
-            unsigned char *p = (unsigned char *) strchr((char *) s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *) s));
+            unsigned char *p = (unsigned char *)strchr((char *)s, ',');
+            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
 
             if(_libssh2_kex_agree_instr(mac, mac_len, s, method_len)) {
                 const LIBSSH2_MAC_METHOD *method = (const LIBSSH2_MAC_METHOD *)
-                    kex_get_method_by_name((char *) s, method_len,
+                    kex_get_method_by_name((char *)s, method_len,
                                            (const LIBSSH2_COMMON_METHOD **)
                                            macp);
 
@@ -4123,7 +4123,7 @@ static int kex_agree_mac(LIBSSH2_SESSION * session,
 
     while(*macp && (*macp)->name) {
         s = _libssh2_kex_agree_instr(mac, mac_len,
-                                     (const unsigned char *) (*macp)->name,
+                                     (const unsigned char *)(*macp)->name,
                                      strlen((*macp)->name));
         if(s) {
             endpoint->mac = *macp;
@@ -4147,16 +4147,16 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
     (void)session;
 
     if(endpoint->comp_prefs) {
-        s = (unsigned char *) endpoint->comp_prefs;
+        s = (unsigned char *)endpoint->comp_prefs;
 
         while(s && *s) {
-            unsigned char *p = (unsigned char *) strchr((char *) s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *) s));
+            unsigned char *p = (unsigned char *)strchr((char *)s, ',');
+            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
 
             if(_libssh2_kex_agree_instr(comp, comp_len, s, method_len)) {
                 const LIBSSH2_COMP_METHOD *method =
                     (const LIBSSH2_COMP_METHOD *)
-                    kex_get_method_by_name((char *) s, method_len,
+                    kex_get_method_by_name((char *)s, method_len,
                                            (const LIBSSH2_COMMON_METHOD **)
                                            compp);
 
@@ -4176,7 +4176,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
 
     while(*compp && (*compp)->name) {
         s = _libssh2_kex_agree_instr(comp, comp_len,
-                                     (const unsigned char *) (*compp)->name,
+                                     (const unsigned char *)(*compp)->name,
                                      strlen((*compp)->name));
         if(s) {
             endpoint->comp = *compp;

--- a/src/kex.c
+++ b/src/kex.c
@@ -3560,7 +3560,7 @@ typedef struct _LIBSSH2_COMMON_METHOD
  * Another sign of bad coding practices gone mad.  Pretend you don't see this.
  */
 static size_t
-kex_method_strlen(const LIBSSH2_COMMON_METHOD ** method)
+kex_method_strlen(const LIBSSH2_COMMON_METHOD **method)
 {
     size_t len = 0;
 
@@ -3581,7 +3581,7 @@ kex_method_strlen(const LIBSSH2_COMMON_METHOD ** method)
  */
 static uint32_t
 kex_method_list(unsigned char *buf, uint32_t list_strlen,
-                const LIBSSH2_COMMON_METHOD ** method)
+                const LIBSSH2_COMMON_METHOD **method)
 {
     _libssh2_htonu32(buf, list_strlen);
     buf += 4;
@@ -3852,7 +3852,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
 /* kex_get_method_by_name */
 static const LIBSSH2_COMMON_METHOD *
 kex_get_method_by_name(const char *name, size_t name_len,
-                       const LIBSSH2_COMMON_METHOD ** methodlist)
+                       const LIBSSH2_COMMON_METHOD **methodlist)
 {
     while(*methodlist) {
         if((strlen((*methodlist)->name) == name_len) &&

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -186,7 +186,7 @@ _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
 }
 
 int
-_libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+_libssh2_rsa_sha2_verify(libssh2_rsa_ctx *rsactx,
                          size_t hash_len,
                          const unsigned char *sig,
                          size_t sig_len,
@@ -250,7 +250,7 @@ out:
 
 #if LIBSSH2_RSA_SHA1
 int
-_libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
+_libssh2_rsa_sha1_verify(libssh2_rsa_ctx *rsactx,
                          const unsigned char *sig,
                          size_t sig_len,
                          const unsigned char *m, size_t m_len)
@@ -610,7 +610,7 @@ _libssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_DSA
 int
-_libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
+_libssh2_dsa_sha1_sign(libssh2_dsa_ctx *dsactx,
                        const unsigned char *hash,
                        size_t hash_len, unsigned char *sig)
 {
@@ -700,7 +700,7 @@ out:
 }
 
 int
-_libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
+_libssh2_dsa_sha1_verify(libssh2_dsa_ctx *dsactx,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len)
 {
@@ -733,7 +733,7 @@ _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
 #endif
 
 int
-_libssh2_cipher_init(_libssh2_cipher_ctx * h,
+_libssh2_cipher_init(_libssh2_cipher_ctx *h,
                      _libssh2_cipher_type(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
@@ -771,7 +771,7 @@ _libssh2_cipher_init(_libssh2_cipher_ctx * h,
 }
 
 int
-_libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
+_libssh2_cipher_crypt(_libssh2_cipher_ctx *ctx,
                       _libssh2_cipher_type(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -299,7 +299,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
 #if LIBSSH2_RSA
 int
 _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
-                                    LIBSSH2_SESSION * session,
+                                    LIBSSH2_SESSION *session,
                                     const char *filedata, size_t filedata_len,
                                     const unsigned char *passphrase)
 {
@@ -315,7 +315,7 @@ _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
 
 int
 _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
-                         LIBSSH2_SESSION * session,
+                         LIBSSH2_SESSION *session,
                          const char *filename, const unsigned char *passphrase)
 {
     FILE *fp;
@@ -419,7 +419,7 @@ fail:
 #if LIBSSH2_DSA
 int
 _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
-                                    LIBSSH2_SESSION * session,
+                                    LIBSSH2_SESSION *session,
                                     const char *filedata, size_t filedata_len,
                                     const unsigned char *passphrase)
 {
@@ -435,7 +435,7 @@ _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
 
 int
 _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
-                         LIBSSH2_SESSION * session,
+                         LIBSSH2_SESSION *session,
                          const char *filename, const unsigned char *passphrase)
 {
     FILE *fp;
@@ -524,8 +524,8 @@ fail:
 
 #if LIBSSH2_RSA
 int
-_libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
-                       libssh2_rsa_ctx * rsactx,
+_libssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
+                       libssh2_rsa_ctx *rsactx,
                        const unsigned char *hash,
                        size_t hash_len,
                        unsigned char **signature,
@@ -595,8 +595,8 @@ out:
 
 #if LIBSSH2_RSA_SHA1
 int
-_libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
-                       libssh2_rsa_ctx * rsactx,
+_libssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
+                       libssh2_rsa_ctx *rsactx,
                        const unsigned char *hash,
                        size_t hash_len,
                        unsigned char **signature,

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -143,7 +143,7 @@ void _libssh2_hmac_cleanup(libssh2_hmac_ctx *ctx)
 
 #if LIBSSH2_RSA
 int
-_libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
+_libssh2_rsa_new(libssh2_rsa_ctx **rsa,
                  const unsigned char *edata,
                  unsigned long elen,
                  const unsigned char *ndata,
@@ -263,7 +263,7 @@ _libssh2_rsa_sha1_verify(libssh2_rsa_ctx *rsactx,
 
 #if LIBSSH2_DSA
 int
-_libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
+_libssh2_dsa_new(libssh2_dsa_ctx **dsactx,
                  const unsigned char *p,
                  unsigned long p_len,
                  const unsigned char *q,
@@ -298,7 +298,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
 
 #if LIBSSH2_RSA
 int
-_libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
+_libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *filedata, size_t filedata_len,
                                     const unsigned char *passphrase)
@@ -314,7 +314,7 @@ _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
 }
 
 int
-_libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
+_libssh2_rsa_new_private(libssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename, const unsigned char *passphrase)
 {
@@ -418,7 +418,7 @@ fail:
 
 #if LIBSSH2_DSA
 int
-_libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
+_libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx **dsa,
                                     LIBSSH2_SESSION *session,
                                     const char *filedata, size_t filedata_len,
                                     const unsigned char *passphrase)
@@ -434,7 +434,7 @@ _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
 }
 
 int
-_libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
+_libssh2_dsa_new_private(libssh2_dsa_ctx **dsa,
                          LIBSSH2_SESSION *session,
                          const char *filename, const unsigned char *passphrase)
 {

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -997,10 +997,10 @@ struct _LIBSSH2_KEX_METHOD
     /* Key exchange, populates session->* and returns 0 on success, non-0 on
        error */
     int (*exchange_keys) (LIBSSH2_SESSION *session,
-                          key_exchange_state_low_t * key_state);
+                          key_exchange_state_low_t *key_state);
 
     void (*cleanup) (LIBSSH2_SESSION *session,
-                     key_exchange_state_low_t * key_state);
+                     key_exchange_state_low_t *key_state);
 
     long flags;
 };
@@ -1047,17 +1047,17 @@ struct _LIBSSH2_CRYPT_METHOD
 
     long flags;
 
-    int (*init) (LIBSSH2_SESSION *session,
-                 const LIBSSH2_CRYPT_METHOD * method, unsigned char *iv,
-                 int *free_iv, unsigned char *secret, int *free_secret,
-                 int encrypt, void **abstract);
-    int (*get_len) (LIBSSH2_SESSION *session, unsigned int seqno,
-                    unsigned char *data, size_t data_size, unsigned int *len,
-                    void **abstract);
-    int (*crypt) (LIBSSH2_SESSION *session, unsigned int seqno,
-                  unsigned char *block, size_t blocksize, void **abstract,
-                  int firstlast);
-    int (*dtor) (LIBSSH2_SESSION *session, void **abstract);
+    int (*init)(LIBSSH2_SESSION *session,
+                const LIBSSH2_CRYPT_METHOD *method, unsigned char *iv,
+                int *free_iv, unsigned char *secret, int *free_secret,
+                int encrypt, void **abstract);
+    int (*get_len)(LIBSSH2_SESSION *session, unsigned int seqno,
+                   unsigned char *data, size_t data_size, unsigned int *len,
+                   void **abstract);
+    int (*crypt)(LIBSSH2_SESSION *session, unsigned int seqno,
+                 unsigned char *block, size_t blocksize, void **abstract,
+                 int firstlast);
+    int (*dtor)(LIBSSH2_SESSION *session, void **abstract);
 
     _libssh2_cipher_type(algo);
 };
@@ -1211,7 +1211,7 @@ ssize_t _libssh2_send(libssh2_socket_t socket, const void *buffer,
                                            waiting for more data to arrive */
 
 int _libssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
-                          key_exchange_state_t * key_state);
+                          key_exchange_state_t *key_state);
 
 unsigned char *_libssh2_kex_agree_instr(unsigned char *haystack,
                                         size_t haystack_len,
@@ -1235,7 +1235,7 @@ int _libssh2_pem_parse(LIBSSH2_SESSION *session,
                        const char *headerbegin,
                        const char *headerend,
                        const unsigned char *passphrase,
-                       FILE * fp, unsigned char **data, size_t *datalen);
+                       FILE *fp, unsigned char **data, size_t *datalen);
 int _libssh2_pem_parse_memory(LIBSSH2_SESSION *session,
                               const char *headerbegin,
                               const char *headerend,
@@ -1246,7 +1246,7 @@ int _libssh2_pem_parse_memory(LIBSSH2_SESSION *session,
 int
 _libssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
                            const unsigned char *passphrase,
-                           FILE * fp, struct string_buf **decrypted_buf);
+                           FILE *fp, struct string_buf **decrypted_buf);
 int
 _libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
                                   const unsigned char *passphrase,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -996,10 +996,10 @@ struct _LIBSSH2_KEX_METHOD
 
     /* Key exchange, populates session->* and returns 0 on success, non-0 on
        error */
-    int (*exchange_keys) (LIBSSH2_SESSION * session,
+    int (*exchange_keys) (LIBSSH2_SESSION *session,
                           key_exchange_state_low_t * key_state);
 
-    void (*cleanup) (LIBSSH2_SESSION * session,
+    void (*cleanup) (LIBSSH2_SESSION *session,
                      key_exchange_state_low_t * key_state);
 
     long flags;
@@ -1010,25 +1010,25 @@ struct _LIBSSH2_HOSTKEY_METHOD
     const char *name;
     size_t hash_len;
 
-    int (*init) (LIBSSH2_SESSION * session, const unsigned char *hostkey_data,
+    int (*init) (LIBSSH2_SESSION *session, const unsigned char *hostkey_data,
                  size_t hostkey_data_len, void **abstract);
-    int (*initPEM) (LIBSSH2_SESSION * session, const char *privkeyfile,
+    int (*initPEM) (LIBSSH2_SESSION *session, const char *privkeyfile,
                     const unsigned char *passphrase, void **abstract);
-    int (*initPEMFromMemory) (LIBSSH2_SESSION * session,
+    int (*initPEMFromMemory) (LIBSSH2_SESSION *session,
                               const char *privkeyfiledata,
                               size_t privkeyfiledata_len,
                               const unsigned char *passphrase,
                               void **abstract);
-    int (*sig_verify) (LIBSSH2_SESSION * session, const unsigned char *sig,
+    int (*sig_verify) (LIBSSH2_SESSION *session, const unsigned char *sig,
                        size_t sig_len, const unsigned char *m,
                        size_t m_len, void **abstract);
-    int (*signv) (LIBSSH2_SESSION * session, unsigned char **signature,
+    int (*signv) (LIBSSH2_SESSION *session, unsigned char **signature,
                   size_t *signature_len, int veccount,
                   const struct iovec datavec[], void **abstract);
-    int (*encrypt) (LIBSSH2_SESSION * session, unsigned char **dst,
+    int (*encrypt) (LIBSSH2_SESSION *session, unsigned char **dst,
                     size_t *dst_len, const unsigned char *src,
                     size_t src_len, void **abstract);
-    int (*dtor) (LIBSSH2_SESSION * session, void **abstract);
+    int (*dtor) (LIBSSH2_SESSION *session, void **abstract);
 };
 
 struct _LIBSSH2_CRYPT_METHOD
@@ -1047,17 +1047,17 @@ struct _LIBSSH2_CRYPT_METHOD
 
     long flags;
 
-    int (*init) (LIBSSH2_SESSION * session,
+    int (*init) (LIBSSH2_SESSION *session,
                  const LIBSSH2_CRYPT_METHOD * method, unsigned char *iv,
                  int *free_iv, unsigned char *secret, int *free_secret,
                  int encrypt, void **abstract);
-    int (*get_len) (LIBSSH2_SESSION * session, unsigned int seqno,
+    int (*get_len) (LIBSSH2_SESSION *session, unsigned int seqno,
                     unsigned char *data, size_t data_size, unsigned int *len,
                     void **abstract);
-    int (*crypt) (LIBSSH2_SESSION * session, unsigned int seqno,
+    int (*crypt) (LIBSSH2_SESSION *session, unsigned int seqno,
                   unsigned char *block, size_t blocksize, void **abstract,
                   int firstlast);
-    int (*dtor) (LIBSSH2_SESSION * session, void **abstract);
+    int (*dtor) (LIBSSH2_SESSION *session, void **abstract);
 
     _libssh2_cipher_type(algo);
 };
@@ -1107,12 +1107,12 @@ struct _LIBSSH2_COMP_METHOD
                    const unsigned char *src,
                    size_t src_len,
                    void **abstract);
-    int (*dtor) (LIBSSH2_SESSION * session, int compress, void **abstract);
+    int (*dtor) (LIBSSH2_SESSION *session, int compress, void **abstract);
 };
 
 #ifdef LIBSSH2DEBUG
 void
-_libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
+_libssh2_debug_low(LIBSSH2_SESSION *session, int context, const char *format,
                    ...) LIBSSH2_PRINTF(3, 4);
 #define _libssh2_debug(x) _libssh2_debug_low x
 #else
@@ -1210,7 +1210,7 @@ ssize_t _libssh2_send(libssh2_socket_t socket, const void *buffer,
 #define LIBSSH2_DEFAULT_READ_TIMEOUT 60 /* generic timeout in seconds used when
                                            waiting for more data to arrive */
 
-int _libssh2_kex_exchange(LIBSSH2_SESSION * session, int reexchange,
+int _libssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
                           key_exchange_state_t * key_state);
 
 unsigned char *_libssh2_kex_agree_instr(unsigned char *haystack,
@@ -1231,12 +1231,12 @@ int _libssh2_bcrypt_pbkdf(const char *pass,
                           unsigned int rounds);
 
 /* pem.c */
-int _libssh2_pem_parse(LIBSSH2_SESSION * session,
+int _libssh2_pem_parse(LIBSSH2_SESSION *session,
                        const char *headerbegin,
                        const char *headerend,
                        const unsigned char *passphrase,
                        FILE * fp, unsigned char **data, size_t *datalen);
-int _libssh2_pem_parse_memory(LIBSSH2_SESSION * session,
+int _libssh2_pem_parse_memory(LIBSSH2_SESSION *session,
                               const char *headerbegin,
                               const char *headerend,
                               const unsigned char *passphrase,
@@ -1244,11 +1244,11 @@ int _libssh2_pem_parse_memory(LIBSSH2_SESSION * session,
                               unsigned char **data, size_t *datalen);
  /* OpenSSL keys */
 int
-_libssh2_openssh_pem_parse(LIBSSH2_SESSION * session,
+_libssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
                            const unsigned char *passphrase,
                            FILE * fp, struct string_buf **decrypted_buf);
 int
-_libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
+_libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
                                   const unsigned char *passphrase,
                                   const char *filedata, size_t filedata_len,
                                   struct string_buf **decrypted_buf);

--- a/src/mac.c
+++ b/src/mac.c
@@ -521,7 +521,7 @@ _libssh2_mac_override(const LIBSSH2_CRYPT_METHOD *crypt)
        !strcmp(crypt->name, "aes128-gcm@openssh.com"))
         return &mac_method_hmac_aesgcm;
 #else
-    (void) crypt;
+    (void)crypt;
 #endif /* LIBSSH2_AES_GCM */
     return NULL;
 }

--- a/src/mac.c
+++ b/src/mac.c
@@ -56,7 +56,7 @@
  *
  */
 static int
-mac_none_MAC(LIBSSH2_SESSION * session, unsigned char *buf,
+mac_none_MAC(LIBSSH2_SESSION *session, unsigned char *buf,
              uint32_t seqno, const unsigned char *packet,
              size_t packet_len, const unsigned char *addtl,
              size_t addtl_len, void **abstract)
@@ -79,7 +79,7 @@ static LIBSSH2_MAC_METHOD mac_method_none = {
  * Initialize simple mac methods
  */
 static int
-mac_method_common_init(LIBSSH2_SESSION * session, unsigned char *key,
+mac_method_common_init(LIBSSH2_SESSION *session, unsigned char *key,
                        int *free_key, void **abstract)
 {
     *abstract = key;
@@ -93,7 +93,7 @@ mac_method_common_init(LIBSSH2_SESSION * session, unsigned char *key,
  * Cleanup simple mac methods
  */
 static int
-mac_method_common_dtor(LIBSSH2_SESSION * session, void **abstract)
+mac_method_common_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     if(*abstract) {
         LIBSSH2_FREE(session, *abstract);
@@ -108,7 +108,7 @@ mac_method_common_dtor(LIBSSH2_SESSION * session, void **abstract)
  * Calculate hash using full sha512 value
  */
 static int
-mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION * session,
+mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION *session,
                               unsigned char *buf, uint32_t seqno,
                               const unsigned char *packet,
                               size_t packet_len,
@@ -163,7 +163,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_sha2_512_etm = {
  * Calculate hash using full sha256 value
  */
 static int
-mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION * session,
+mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION *session,
                               unsigned char *buf, uint32_t seqno,
                               const unsigned char *packet,
                               size_t packet_len,
@@ -217,7 +217,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_sha2_256_etm = {
  * Calculate hash using full sha1 value
  */
 static int
-mac_method_hmac_sha1_hash(LIBSSH2_SESSION * session,
+mac_method_hmac_sha1_hash(LIBSSH2_SESSION *session,
                           unsigned char *buf, uint32_t seqno,
                           const unsigned char *packet,
                           size_t packet_len,
@@ -269,7 +269,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_sha1_etm = {
  * Calculate hash using first 96 bits of sha1 value
  */
 static int
-mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION * session,
+mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
                              unsigned char *buf, uint32_t seqno,
                              const unsigned char *packet,
                              size_t packet_len,
@@ -301,7 +301,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_sha1_96 = {
  * Calculate hash using full md5 value
  */
 static int
-mac_method_hmac_md5_hash(LIBSSH2_SESSION * session, unsigned char *buf,
+mac_method_hmac_md5_hash(LIBSSH2_SESSION *session, unsigned char *buf,
                          uint32_t seqno,
                          const unsigned char *packet,
                          size_t packet_len,
@@ -343,7 +343,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_md5 = {
  * Calculate hash using first 96 bits of md5 value
  */
 static int
-mac_method_hmac_md5_96_hash(LIBSSH2_SESSION * session,
+mac_method_hmac_md5_96_hash(LIBSSH2_SESSION *session,
                             unsigned char *buf, uint32_t seqno,
                             const unsigned char *packet,
                             size_t packet_len,
@@ -376,7 +376,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_md5_96 = {
  * Calculate hash using ripemd160 value
  */
 static int
-mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION * session,
+mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION *session,
                                unsigned char *buf, uint32_t seqno,
                                const unsigned char *packet,
                                size_t packet_len,
@@ -460,7 +460,7 @@ _libssh2_mac_methods(void)
 
 #if LIBSSH2_AES_GCM
 static int
-mac_method_none_init(LIBSSH2_SESSION * session, unsigned char *key,
+mac_method_none_init(LIBSSH2_SESSION *session, unsigned char *key,
                      int *free_key, void **abstract)
 {
     (void)session;
@@ -471,7 +471,7 @@ mac_method_none_init(LIBSSH2_SESSION * session, unsigned char *key,
 }
 
 static int
-mac_method_hmac_none_hash(LIBSSH2_SESSION * session,
+mac_method_hmac_none_hash(LIBSSH2_SESSION *session,
                           unsigned char *buf, uint32_t seqno,
                           const unsigned char *packet,
                           size_t packet_len,
@@ -490,7 +490,7 @@ mac_method_hmac_none_hash(LIBSSH2_SESSION * session,
 }
 
 static int
-mac_method_none_dtor(LIBSSH2_SESSION * session, void **abstract)
+mac_method_none_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     (void)session;
     (void)abstract;

--- a/src/mac.h
+++ b/src/mac.h
@@ -52,13 +52,13 @@ struct _LIBSSH2_MAC_METHOD
     int key_len;
 
     /* Message Authentication Code Hashing algo */
-    int (*init) (LIBSSH2_SESSION * session, unsigned char *key, int *free_key,
+    int (*init) (LIBSSH2_SESSION *session, unsigned char *key, int *free_key,
                  void **abstract);
-    int (*hash) (LIBSSH2_SESSION * session, unsigned char *buf,
+    int (*hash) (LIBSSH2_SESSION *session, unsigned char *buf,
                  uint32_t seqno, const unsigned char *packet,
                  size_t packet_len, const unsigned char *addtl,
                  size_t addtl_len, void **abstract);
-    int (*dtor) (LIBSSH2_SESSION * session, void **abstract);
+    int (*dtor) (LIBSSH2_SESSION *session, void **abstract);
 
     int etm; /* encrypt-then-mac */
 };

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -554,7 +554,7 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
 }
 
 int
-_libssh2_mbedtls_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+_libssh2_mbedtls_rsa_sha2_verify(libssh2_rsa_ctx *rsactx,
                                  size_t hash_len,
                                  const unsigned char *sig,
                                  size_t sig_len,
@@ -601,7 +601,7 @@ _libssh2_mbedtls_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
 }
 
 int
-_libssh2_mbedtls_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
+_libssh2_mbedtls_rsa_sha1_verify(libssh2_rsa_ctx *rsactx,
                                  const unsigned char *sig,
                                  size_t sig_len,
                                  const unsigned char *m,
@@ -662,8 +662,8 @@ _libssh2_mbedtls_rsa_sha2_sign(LIBSSH2_SESSION *session,
 }
 
 int
-_libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION * session,
-                               libssh2_rsa_ctx * rsactx,
+_libssh2_mbedtls_rsa_sha1_sign(LIBSSH2_SESSION *session,
+                               libssh2_rsa_ctx *rsactx,
                                const unsigned char *hash,
                                size_t hash_len,
                                unsigned char **signature,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -470,7 +470,7 @@ _libssh2_mbedtls_rsa_new_private(libssh2_rsa_ctx **rsa,
     mbedtls_pk_context pkey;
     mbedtls_rsa_context *pk_rsa;
 
-    *rsa = (libssh2_rsa_ctx *) LIBSSH2_ALLOC(session, sizeof(libssh2_rsa_ctx));
+    *rsa = (libssh2_rsa_ctx *)LIBSSH2_ALLOC(session, sizeof(libssh2_rsa_ctx));
     if(!*rsa)
         return -1;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -410,7 +410,7 @@ _libssh2_mbedtls_rsa_new(libssh2_rsa_ctx **rsa,
     int ret;
     libssh2_rsa_ctx *ctx;
 
-    ctx = (libssh2_rsa_ctx *) mbedtls_calloc(1, sizeof(libssh2_rsa_ctx));
+    ctx = (libssh2_rsa_ctx *)mbedtls_calloc(1, sizeof(libssh2_rsa_ctx));
     if(ctx)
         mbedtls_rsa_init(ctx);
     else
@@ -508,7 +508,7 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
     void *filedata_nullterm;
     size_t pwd_len;
 
-    *rsa = (libssh2_rsa_ctx *) mbedtls_calloc(1, sizeof(libssh2_rsa_ctx));
+    *rsa = (libssh2_rsa_ctx *)mbedtls_calloc(1, sizeof(libssh2_rsa_ctx));
     if(!*rsa)
         return -1;
 
@@ -1146,7 +1146,7 @@ _libssh2_mbedtls_parse_eckey(libssh2_ecdsa_ctx **ctx,
 {
     size_t pwd_len;
 
-    pwd_len = pwd ? strlen((const char *) pwd) : 0;
+    pwd_len = pwd ? strlen((const char *)pwd) : 0;
 
     if(mbedtls_pk_parse_key(pkey, data, data_len, pwd, pwd_len,
                             mbedtls_ctr_drbg_random,

--- a/src/misc.c
+++ b/src/misc.c
@@ -496,12 +496,12 @@ size_t _libssh2_base64_encode(LIBSSH2_SESSION *session,
                 ibuf[i] = 0;
         }
 
-        obuf[0] = (unsigned char)  ((ibuf[0] & 0xFC) >> 2);
-        obuf[1] = (unsigned char) (((ibuf[0] & 0x03) << 4) | \
-                                   ((ibuf[1] & 0xF0) >> 4));
-        obuf[2] = (unsigned char) (((ibuf[1] & 0x0F) << 2) | \
-                                   ((ibuf[2] & 0xC0) >> 6));
-        obuf[3] = (unsigned char)   (ibuf[2] & 0x3F);
+        obuf[0] = (unsigned char) ((ibuf[0] & 0xFC) >> 2);
+        obuf[1] = (unsigned char)(((ibuf[0] & 0x03) << 4) | \
+                                  ((ibuf[1] & 0xF0) >> 4));
+        obuf[2] = (unsigned char)(((ibuf[1] & 0x0F) << 2) | \
+                                  ((ibuf[2] & 0xC0) >> 6));
+        obuf[3] = (unsigned char)  (ibuf[2] & 0x3F);
 
         switch(inputparts) {
         case 1: /* only one byte read */

--- a/src/misc.c
+++ b/src/misc.c
@@ -542,7 +542,7 @@ libssh2_free(LIBSSH2_SESSION *session, void *ptr)
 #include <stdarg.h>
 
 LIBSSH2_API int
-libssh2_trace(LIBSSH2_SESSION * session, int bitmask)
+libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     session->showmask = bitmask;
     return 0;
@@ -558,7 +558,7 @@ libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
 }
 
 void
-_libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
+_libssh2_debug_low(LIBSSH2_SESSION *session, int context, const char *format,
                    ...)
 {
     char buffer[1536];
@@ -631,7 +631,7 @@ _libssh2_debug_low(LIBSSH2_SESSION * session, int context, const char *format,
 
 #else
 LIBSSH2_API int
-libssh2_trace(LIBSSH2_SESSION * session, int bitmask)
+libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     (void)session;
     (void)bitmask;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -370,29 +370,29 @@ _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
     BIGNUM * iqmp = 0;
 
     e = BN_new();
-    BN_bin2bn(edata, (int) elen, e);
+    BN_bin2bn(edata, (int)elen, e);
 
     n = BN_new();
-    BN_bin2bn(ndata, (int) nlen, n);
+    BN_bin2bn(ndata, (int)nlen, n);
 
     if(ddata) {
         d = BN_new();
-        BN_bin2bn(ddata, (int) dlen, d);
+        BN_bin2bn(ddata, (int)dlen, d);
 
         p = BN_new();
-        BN_bin2bn(pdata, (int) plen, p);
+        BN_bin2bn(pdata, (int)plen, p);
 
         q = BN_new();
-        BN_bin2bn(qdata, (int) qlen, q);
+        BN_bin2bn(qdata, (int)qlen, q);
 
         dmp1 = BN_new();
-        BN_bin2bn(e1data, (int) e1len, dmp1);
+        BN_bin2bn(e1data, (int)e1len, dmp1);
 
         dmq1 = BN_new();
-        BN_bin2bn(e2data, (int) e2len, dmq1);
+        BN_bin2bn(e2data, (int)e2len, dmq1);
 
         iqmp = BN_new();
-        BN_bin2bn(coeffdata, (int) coefflen, iqmp);
+        BN_bin2bn(coeffdata, (int)coefflen, iqmp);
     }
 
     *rsa = RSA_new();
@@ -495,7 +495,7 @@ _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
 #else
 
     ret = RSA_verify(nid_type, hash, (unsigned int) hash_len,
-                     (const unsigned char *) sig,
+                     (const unsigned char *)sig,
                      (unsigned int) sig_len, rsactx);
 #endif
 
@@ -628,20 +628,20 @@ _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
     BIGNUM * priv_key = NULL;
 
     p_bn = BN_new();
-    BN_bin2bn(p, (int) p_len, p_bn);
+    BN_bin2bn(p, (int)p_len, p_bn);
 
     q_bn = BN_new();
-    BN_bin2bn(q, (int) q_len, q_bn);
+    BN_bin2bn(q, (int)q_len, q_bn);
 
     g_bn = BN_new();
-    BN_bin2bn(g, (int) g_len, g_bn);
+    BN_bin2bn(g, (int)g_len, g_bn);
 
     pub_key = BN_new();
-    BN_bin2bn(y, (int) y_len, pub_key);
+    BN_bin2bn(y, (int)y_len, pub_key);
 
     if(x_len) {
         priv_key = BN_new();
-        BN_bin2bn(x, (int) x_len, priv_key);
+        BN_bin2bn(x, (int)x_len, priv_key);
     }
 
     *dsactx = DSA_new();
@@ -927,16 +927,16 @@ _libssh2_ecdsa_verify(libssh2_ecdsa_ctx * ec_ctx,
     BIGNUM *pr = BN_new();
     BIGNUM *ps = BN_new();
 
-    BN_bin2bn(r, (int) r_len, pr);
-    BN_bin2bn(s, (int) s_len, ps);
+    BN_bin2bn(r, (int)r_len, pr);
+    BN_bin2bn(s, (int)s_len, ps);
     ECDSA_SIG_set0(ecdsa_sig, pr, ps);
 #else
     ECDSA_SIG ecdsa_sig_;
     ECDSA_SIG *ecdsa_sig = &ecdsa_sig_;
     ecdsa_sig_.r = BN_new();
-    BN_bin2bn(r, (int) r_len, ecdsa_sig_.r);
+    BN_bin2bn(r, (int)r_len, ecdsa_sig_.r);
     ecdsa_sig_.s = BN_new();
-    BN_bin2bn(s, (int) s_len, ecdsa_sig_.s);
+    BN_bin2bn(s, (int)s_len, ecdsa_sig_.s);
 #endif
 
 #ifdef USE_OPENSSL_3
@@ -1156,7 +1156,7 @@ void _libssh2_openssl_crypto_exit(void) {}
 static int
 passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
 {
-    int passphrase_len = (int) strlen(passphrase);
+    int passphrase_len = (int)strlen(passphrase);
 
     (void)rwflag;
 
@@ -1193,8 +1193,8 @@ read_private_key_from_memory(void **key_ctx,
         return -1;
     }
 
-    *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
-                                (void *) LIBSSH2_UNCONST(passphrase));
+    *key_ctx = read_private_key(bp, NULL, (pem_password_cb *)passphrase_cb,
+                                (void *)LIBSSH2_UNCONST(passphrase));
 
     BIO_free(bp);
     return (*key_ctx) ? 0 : -1;
@@ -1217,8 +1217,8 @@ read_private_key_from_file(void **key_ctx,
         return -1;
     }
 
-    *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
-                                (void *) LIBSSH2_UNCONST(passphrase));
+    *key_ctx = read_private_key(bp, NULL, (pem_password_cb *)passphrase_cb,
+                                (void *)LIBSSH2_UNCONST(passphrase));
 
     BIO_free(bp);
     return (*key_ctx) ? 0 : -1;
@@ -2200,7 +2200,7 @@ gen_publickey_from_ed_evp(LIBSSH2_SESSION *session,
     }
 
     _libssh2_store_str(&bufPos, methodName, sizeof(methodName) - 1);
-    _libssh2_store_u32(&bufPos, (uint32_t) rawKeyLen);
+    _libssh2_store_u32(&bufPos, (uint32_t)rawKeyLen);
 
     if(EVP_PKEY_get_raw_public_key(pk, bufPos, &rawKeyLen) != 1) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
@@ -3837,7 +3837,7 @@ gen_publickey_from_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
         goto fail;
     }
 
-    BN_bin2bn(exponent, (int) exponentlen, bn_exponent);
+    BN_bin2bn(exponent, (int)exponentlen, bn_exponent);
     rc = (EC_KEY_set_private_key(ec_key, bn_exponent) != 1);
 #endif
 
@@ -4497,7 +4497,7 @@ _libssh2_ecdh_gen_k(_libssh2_bn **k, _libssh2_ec_key *private_key,
         goto clean_exit;
     }
 
-    BN_bin2bn(secret, (int) secret_len, *k);
+    BN_bin2bn(secret, (int)secret_len, *k);
 #endif
 
 clean_exit:

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -271,7 +271,7 @@ _libssh2_openssl_random(void *buf, size_t len)
 
 #if LIBSSH2_RSA
 int
-_libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
+_libssh2_rsa_new(libssh2_rsa_ctx **rsa,
                  const unsigned char *edata,
                  unsigned long elen,
                  const unsigned char *ndata,
@@ -519,7 +519,7 @@ _libssh2_rsa_sha1_verify(libssh2_rsa_ctx *rsactx,
 
 #if LIBSSH2_DSA
 int
-_libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
+_libssh2_dsa_new(libssh2_dsa_ctx **dsactx,
                  const unsigned char *p,
                  unsigned long p_len,
                  const unsigned char *q,
@@ -793,7 +793,7 @@ _libssh2_ecdsa_curve_type_from_name(const char *name,
  *
  */
 int
-_libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx ** ec_ctx,
+_libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx **ec_ctx,
      const unsigned char *k,
      size_t k_len, libssh2_curve_type curve)
 {
@@ -1227,7 +1227,7 @@ read_private_key_from_file(void **key_ctx,
 
 #if LIBSSH2_RSA
 int
-_libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
+_libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *filedata,
                                     size_t filedata_len,
@@ -1583,7 +1583,7 @@ fail:
 }
 
 static int
-_libssh2_rsa_new_openssh_private(libssh2_rsa_ctx ** rsa,
+_libssh2_rsa_new_openssh_private(libssh2_rsa_ctx **rsa,
                                  LIBSSH2_SESSION *session,
                                  const char *filename,
                                  const unsigned char *passphrase)
@@ -1639,7 +1639,7 @@ _libssh2_rsa_new_openssh_private(libssh2_rsa_ctx ** rsa,
 }
 
 int
-_libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
+_libssh2_rsa_new_private(libssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename, const unsigned char *passphrase)
 {
@@ -1669,7 +1669,7 @@ _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
 
 #if LIBSSH2_DSA
 int
-_libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
+_libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx **dsa,
                                     LIBSSH2_SESSION *session,
                                     const char *filedata,
                                     size_t filedata_len,
@@ -1940,7 +1940,7 @@ fail:
 }
 
 static int
-_libssh2_dsa_new_openssh_private(libssh2_dsa_ctx ** dsa,
+_libssh2_dsa_new_openssh_private(libssh2_dsa_ctx **dsa,
                                  LIBSSH2_SESSION *session,
                                  const char *filename,
                                  const unsigned char *passphrase)
@@ -1996,7 +1996,7 @@ _libssh2_dsa_new_openssh_private(libssh2_dsa_ctx ** dsa,
 }
 
 int
-_libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
+_libssh2_dsa_new_private(libssh2_dsa_ctx **dsa,
                          LIBSSH2_SESSION *session,
                          const char *filename, const unsigned char *passphrase)
 {
@@ -2026,7 +2026,7 @@ _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
 
 #if LIBSSH2_ECDSA
 int
-_libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx ** ec_ctx,
+_libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ec_ctx,
                                       LIBSSH2_SESSION *session,
                                       const char *filedata,
                                       size_t filedata_len,
@@ -2059,7 +2059,7 @@ _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx ** ec_ctx,
     return rc;
 }
 
-int _libssh2_ecdsa_new_private_frommemory_sk(libssh2_ecdsa_ctx ** ec_ctx,
+int _libssh2_ecdsa_new_private_frommemory_sk(libssh2_ecdsa_ctx **ec_ctx,
                                              unsigned char *flags,
                                              const char **application,
                                              const unsigned char **key_handle,
@@ -2526,7 +2526,7 @@ clean_exit:
 }
 
 int
-_libssh2_ed25519_new_private(libssh2_ed25519_ctx ** ed_ctx,
+_libssh2_ed25519_new_private(libssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename, const uint8_t *passphrase)
 {
@@ -2664,7 +2664,7 @@ _libssh2_ed25519_new_private_sk(libssh2_ed25519_ctx **ed_ctx,
 }
 
 int
-_libssh2_ed25519_new_private_frommemory(libssh2_ed25519_ctx ** ed_ctx,
+_libssh2_ed25519_new_private_frommemory(libssh2_ed25519_ctx **ed_ctx,
                                         LIBSSH2_SESSION *session,
                                         const char *filedata,
                                         size_t filedata_len,
@@ -2726,7 +2726,7 @@ _libssh2_ed25519_new_private_frommemory_sk(libssh2_ed25519_ctx **ed_ctx,
 }
 
 int
-_libssh2_ed25519_new_public(libssh2_ed25519_ctx ** ed_ctx,
+_libssh2_ed25519_new_public(libssh2_ed25519_ctx **ed_ctx,
                             LIBSSH2_SESSION *session,
                             const unsigned char *raw_pub_key,
                             const size_t key_len)
@@ -4027,7 +4027,7 @@ fail:
 }
 
 static int
-_libssh2_ecdsa_new_openssh_private(libssh2_ecdsa_ctx ** ec_ctx,
+_libssh2_ecdsa_new_openssh_private(libssh2_ecdsa_ctx **ec_ctx,
                                    LIBSSH2_SESSION *session,
                                    const char *filename,
                                    const unsigned char *passphrase)
@@ -4087,7 +4087,7 @@ _libssh2_ecdsa_new_openssh_private(libssh2_ecdsa_ctx ** ec_ctx,
 }
 
 static int
-_libssh2_ecdsa_new_openssh_private_sk(libssh2_ecdsa_ctx ** ec_ctx,
+_libssh2_ecdsa_new_openssh_private_sk(libssh2_ecdsa_ctx **ec_ctx,
                                       uint8_t *flags,
                                       const char **application,
                                       const unsigned char **key_handle,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1228,7 +1228,7 @@ read_private_key_from_file(void **key_ctx,
 #if LIBSSH2_RSA
 int
 _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
-                                    LIBSSH2_SESSION * session,
+                                    LIBSSH2_SESSION *session,
                                     const char *filedata,
                                     size_t filedata_len,
                                     const unsigned char *passphrase)
@@ -1584,7 +1584,7 @@ fail:
 
 static int
 _libssh2_rsa_new_openssh_private(libssh2_rsa_ctx ** rsa,
-                                 LIBSSH2_SESSION * session,
+                                 LIBSSH2_SESSION *session,
                                  const char *filename,
                                  const unsigned char *passphrase)
 {
@@ -1640,7 +1640,7 @@ _libssh2_rsa_new_openssh_private(libssh2_rsa_ctx ** rsa,
 
 int
 _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
-                         LIBSSH2_SESSION * session,
+                         LIBSSH2_SESSION *session,
                          const char *filename, const unsigned char *passphrase)
 {
     int rc;
@@ -1670,7 +1670,7 @@ _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
 #if LIBSSH2_DSA
 int
 _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
-                                    LIBSSH2_SESSION * session,
+                                    LIBSSH2_SESSION *session,
                                     const char *filedata,
                                     size_t filedata_len,
                                     const unsigned char *passphrase)
@@ -1941,7 +1941,7 @@ fail:
 
 static int
 _libssh2_dsa_new_openssh_private(libssh2_dsa_ctx ** dsa,
-                                 LIBSSH2_SESSION * session,
+                                 LIBSSH2_SESSION *session,
                                  const char *filename,
                                  const unsigned char *passphrase)
 {
@@ -1997,7 +1997,7 @@ _libssh2_dsa_new_openssh_private(libssh2_dsa_ctx ** dsa,
 
 int
 _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
-                         LIBSSH2_SESSION * session,
+                         LIBSSH2_SESSION *session,
                          const char *filename, const unsigned char *passphrase)
 {
     int rc;
@@ -2027,7 +2027,7 @@ _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
 #if LIBSSH2_ECDSA
 int
 _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx ** ec_ctx,
-                                      LIBSSH2_SESSION * session,
+                                      LIBSSH2_SESSION *session,
                                       const char *filedata,
                                       size_t filedata_len,
                                       const unsigned char *passphrase)
@@ -2064,7 +2064,7 @@ int _libssh2_ecdsa_new_private_frommemory_sk(libssh2_ecdsa_ctx ** ec_ctx,
                                              const char **application,
                                              const unsigned char **key_handle,
                                              size_t *handle_len,
-                                             LIBSSH2_SESSION * session,
+                                             LIBSSH2_SESSION *session,
                                              const char *filedata,
                                              size_t filedata_len,
                                              const unsigned char *passphrase)
@@ -2527,7 +2527,7 @@ clean_exit:
 
 int
 _libssh2_ed25519_new_private(libssh2_ed25519_ctx ** ed_ctx,
-                             LIBSSH2_SESSION * session,
+                             LIBSSH2_SESSION *session,
                              const char *filename, const uint8_t *passphrase)
 {
     int rc;
@@ -2665,7 +2665,7 @@ _libssh2_ed25519_new_private_sk(libssh2_ed25519_ctx **ed_ctx,
 
 int
 _libssh2_ed25519_new_private_frommemory(libssh2_ed25519_ctx ** ed_ctx,
-                                        LIBSSH2_SESSION * session,
+                                        LIBSSH2_SESSION *session,
                                         const char *filedata,
                                         size_t filedata_len,
                                         const unsigned char *passphrase)
@@ -2727,7 +2727,7 @@ _libssh2_ed25519_new_private_frommemory_sk(libssh2_ed25519_ctx **ed_ctx,
 
 int
 _libssh2_ed25519_new_public(libssh2_ed25519_ctx ** ed_ctx,
-                            LIBSSH2_SESSION * session,
+                            LIBSSH2_SESSION *session,
                             const unsigned char *raw_pub_key,
                             const size_t key_len)
 {
@@ -2921,7 +2921,7 @@ clean_exit:
 
 #if LIBSSH2_RSA
 int
-_libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
+_libssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
                        libssh2_rsa_ctx * rsactx,
                        const unsigned char *hash,
                        size_t hash_len,
@@ -3008,7 +3008,7 @@ _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
 
 #if LIBSSH2_RSA_SHA1
 int
-_libssh2_rsa_sha1_sign(LIBSSH2_SESSION * session,
+_libssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
                        libssh2_rsa_ctx * rsactx,
                        const unsigned char *hash,
                        size_t hash_len,
@@ -3096,7 +3096,7 @@ _libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
 #if LIBSSH2_ECDSA
 
 int
-_libssh2_ecdsa_sign(LIBSSH2_SESSION * session, libssh2_ecdsa_ctx * ec_ctx,
+_libssh2_ecdsa_sign(LIBSSH2_SESSION *session, libssh2_ecdsa_ctx * ec_ctx,
                     const unsigned char *hash, size_t hash_len,
                     unsigned char **signature, size_t *signature_len)
 {
@@ -4028,7 +4028,7 @@ fail:
 
 static int
 _libssh2_ecdsa_new_openssh_private(libssh2_ecdsa_ctx ** ec_ctx,
-                                   LIBSSH2_SESSION * session,
+                                   LIBSSH2_SESSION *session,
                                    const char *filename,
                                    const unsigned char *passphrase)
 {
@@ -4092,7 +4092,7 @@ _libssh2_ecdsa_new_openssh_private_sk(libssh2_ecdsa_ctx ** ec_ctx,
                                       const char **application,
                                       const unsigned char **key_handle,
                                       size_t *handle_len,
-                                      LIBSSH2_SESSION * session,
+                                      LIBSSH2_SESSION *session,
                                       const char *filename,
                                       const unsigned char *passphrase)
 {
@@ -4153,8 +4153,8 @@ _libssh2_ecdsa_new_openssh_private_sk(libssh2_ecdsa_ctx ** ec_ctx,
 }
 
 int
-_libssh2_ecdsa_new_private(libssh2_ecdsa_ctx ** ec_ctx,
-       LIBSSH2_SESSION * session,
+_libssh2_ecdsa_new_private(libssh2_ecdsa_ctx **ec_ctx,
+       LIBSSH2_SESSION *session,
        const char *filename, const unsigned char *passphrase)
 {
     int rc;
@@ -4169,7 +4169,7 @@ _libssh2_ecdsa_new_private(libssh2_ecdsa_ctx ** ec_ctx,
 
     _libssh2_init_if_needed();
 
-    rc = read_private_key_from_file((void **) ec_ctx, read_ec,
+    rc = read_private_key_from_file((void **)ec_ctx, read_ec,
                                     filename, passphrase);
 
     if(rc) {
@@ -4181,12 +4181,12 @@ _libssh2_ecdsa_new_private(libssh2_ecdsa_ctx ** ec_ctx,
 }
 
 int
-_libssh2_ecdsa_new_private_sk(libssh2_ecdsa_ctx ** ec_ctx,
+_libssh2_ecdsa_new_private_sk(libssh2_ecdsa_ctx **ec_ctx,
                               unsigned char *flags,
                               const char **application,
                               const unsigned char **key_handle,
                               size_t *handle_len,
-                              LIBSSH2_SESSION * session,
+                              LIBSSH2_SESSION *session,
                               const char *filename,
                               const unsigned char *passphrase)
 {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -360,14 +360,14 @@ _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
 
     return (ret == 1) ? 0 : -1;
 #else
-    BIGNUM * e;
-    BIGNUM * n;
-    BIGNUM * d = 0;
-    BIGNUM * p = 0;
-    BIGNUM * q = 0;
-    BIGNUM * dmp1 = 0;
-    BIGNUM * dmq1 = 0;
-    BIGNUM * iqmp = 0;
+    BIGNUM *e;
+    BIGNUM *n;
+    BIGNUM *d = 0;
+    BIGNUM *p = 0;
+    BIGNUM *q = 0;
+    BIGNUM *dmp1 = 0;
+    BIGNUM *dmq1 = 0;
+    BIGNUM *iqmp = 0;
 
     e = BN_new();
     BN_bin2bn(edata, (int)elen, e);
@@ -424,7 +424,7 @@ _libssh2_rsa_new(libssh2_rsa_ctx ** rsa,
 }
 
 int
-_libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+_libssh2_rsa_sha2_verify(libssh2_rsa_ctx *rsactx,
                          size_t hash_len,
                          const unsigned char *sig,
                          size_t sig_len,
@@ -506,7 +506,7 @@ _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
 
 #if LIBSSH2_RSA_SHA1
 int
-_libssh2_rsa_sha1_verify(libssh2_rsa_ctx * rsactx,
+_libssh2_rsa_sha1_verify(libssh2_rsa_ctx *rsactx,
                          const unsigned char *sig,
                          size_t sig_len,
                          const unsigned char *m, size_t m_len)
@@ -621,11 +621,11 @@ _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
 
 #else
 
-    BIGNUM * p_bn;
-    BIGNUM * q_bn;
-    BIGNUM * g_bn;
-    BIGNUM * pub_key;
-    BIGNUM * priv_key = NULL;
+    BIGNUM *p_bn;
+    BIGNUM *q_bn;
+    BIGNUM *g_bn;
+    BIGNUM *pub_key;
+    BIGNUM *priv_key = NULL;
 
     p_bn = BN_new();
     BN_bin2bn(p, (int)p_len, p_bn);
@@ -666,7 +666,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx ** dsactx,
 }
 
 int
-_libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
+_libssh2_dsa_sha1_verify(libssh2_dsa_ctx *dsactx,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len)
 {
@@ -677,9 +677,9 @@ _libssh2_dsa_sha1_verify(libssh2_dsa_ctx * dsactx,
 #endif
 
     unsigned char hash[SHA_DIGEST_LENGTH];
-    DSA_SIG * dsasig;
-    BIGNUM * r;
-    BIGNUM * s;
+    DSA_SIG *dsasig;
+    BIGNUM *r;
+    BIGNUM *s;
     int ret = -1;
 
     r = BN_new();
@@ -906,7 +906,7 @@ _libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx ** ec_ctx,
 #endif
 
 int
-_libssh2_ecdsa_verify(libssh2_ecdsa_ctx * ec_ctx,
+_libssh2_ecdsa_verify(libssh2_ecdsa_ctx *ec_ctx,
                       const unsigned char *r, size_t r_len,
                       const unsigned char *s, size_t s_len,
                       const unsigned char *m, size_t m_len)
@@ -989,7 +989,7 @@ cleanup:
 #endif /* LIBSSH2_ECDSA */
 
 int
-_libssh2_cipher_init(_libssh2_cipher_ctx * h,
+_libssh2_cipher_init(_libssh2_cipher_ctx *h,
                      _libssh2_cipher_type(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
@@ -1024,7 +1024,7 @@ _libssh2_cipher_init(_libssh2_cipher_ctx * h,
 #endif
 
 int
-_libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
+_libssh2_cipher_crypt(_libssh2_cipher_ctx *ctx,
                       _libssh2_cipher_type(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)
@@ -1184,7 +1184,7 @@ read_private_key_from_memory(void **key_ctx,
                              size_t filedata_len,
                              const unsigned char *passphrase)
 {
-    BIO * bp;
+    BIO *bp;
 
     *key_ctx = NULL;
 
@@ -1208,7 +1208,7 @@ read_private_key_from_file(void **key_ctx,
                            const char *filename,
                            const unsigned char *passphrase)
 {
-    BIO * bp;
+    BIO *bp;
 
     *key_ctx = NULL;
 
@@ -1270,14 +1270,14 @@ gen_publickey_from_rsa(LIBSSH2_SESSION *session, libssh2_rsa_ctx *rsa,
     unsigned char *p;
 
 #ifdef USE_OPENSSL_3
-    BIGNUM * e = NULL;
-    BIGNUM * n = NULL;
+    BIGNUM *e = NULL;
+    BIGNUM *n = NULL;
 
     EVP_PKEY_get_bn_param(rsa, OSSL_PKEY_PARAM_RSA_E, &e);
     EVP_PKEY_get_bn_param(rsa, OSSL_PKEY_PARAM_RSA_N, &n);
 #else
-    const BIGNUM * e;
-    const BIGNUM * n;
+    const BIGNUM *e;
+    const BIGNUM *n;
 #ifdef HAVE_OPAQUE_STRUCTS
     e = NULL;
     n = NULL;
@@ -1712,20 +1712,20 @@ gen_publickey_from_dsa(LIBSSH2_SESSION* session, libssh2_dsa_ctx *dsa,
     unsigned char *p;
 
 #ifdef USE_OPENSSL_3
-    BIGNUM * p_bn = NULL;
-    BIGNUM * q = NULL;
-    BIGNUM * g = NULL;
-    BIGNUM * pub_key = NULL;
+    BIGNUM *p_bn = NULL;
+    BIGNUM *q = NULL;
+    BIGNUM *g = NULL;
+    BIGNUM *pub_key = NULL;
 
     EVP_PKEY_get_bn_param(dsa, OSSL_PKEY_PARAM_FFC_P, &p_bn);
     EVP_PKEY_get_bn_param(dsa, OSSL_PKEY_PARAM_FFC_Q, &q);
     EVP_PKEY_get_bn_param(dsa, OSSL_PKEY_PARAM_FFC_G, &g);
     EVP_PKEY_get_bn_param(dsa, OSSL_PKEY_PARAM_PUB_KEY, &pub_key);
 #else
-    const BIGNUM * p_bn;
-    const BIGNUM * q;
-    const BIGNUM * g;
-    const BIGNUM * pub_key;
+    const BIGNUM *p_bn;
+    const BIGNUM *q;
+    const BIGNUM *g;
+    const BIGNUM *pub_key;
 #ifdef HAVE_OPAQUE_STRUCTS
     DSA_get0_pqg(dsa, &p_bn, &q, &g);
 #else
@@ -2922,7 +2922,7 @@ clean_exit:
 #if LIBSSH2_RSA
 int
 _libssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
-                       libssh2_rsa_ctx * rsactx,
+                       libssh2_rsa_ctx *rsactx,
                        const unsigned char *hash,
                        size_t hash_len,
                        unsigned char **signature, size_t *signature_len)
@@ -3027,8 +3027,8 @@ _libssh2_dsa_sha1_sign(libssh2_dsa_ctx *dsactx,
                        size_t hash_len, unsigned char *signature)
 {
     DSA_SIG *sig = NULL;
-    const BIGNUM * r;
-    const BIGNUM * s;
+    const BIGNUM *r;
+    const BIGNUM *s;
     int r_len, s_len;
 
 #ifdef USE_OPENSSL_3
@@ -3096,7 +3096,7 @@ _libssh2_dsa_sha1_sign(libssh2_dsa_ctx *dsactx,
 #if LIBSSH2_ECDSA
 
 int
-_libssh2_ecdsa_sign(LIBSSH2_SESSION *session, libssh2_ecdsa_ctx * ec_ctx,
+_libssh2_ecdsa_sign(LIBSSH2_SESSION *session, libssh2_ecdsa_ctx *ec_ctx,
                     const unsigned char *hash, size_t hash_len,
                     unsigned char **signature, size_t *signature_len)
 {
@@ -3249,7 +3249,7 @@ _libssh2_sha1(const unsigned char *message, size_t len,
               unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_MD_CTX * ctx = EVP_MD_CTX_new();
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
     if(!ctx)
         return 1; /* error */
@@ -3325,7 +3325,7 @@ _libssh2_sha256(const unsigned char *message, size_t len,
                 unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_MD_CTX * ctx = EVP_MD_CTX_new();
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
     if(!ctx)
         return 1; /* error */
@@ -3401,7 +3401,7 @@ _libssh2_sha384(const unsigned char *message, size_t len,
                 unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_MD_CTX * ctx = EVP_MD_CTX_new();
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
     if(!ctx)
         return 1; /* error */
@@ -3477,7 +3477,7 @@ _libssh2_sha512(const unsigned char *message, size_t len,
                 unsigned char *out)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
-    EVP_MD_CTX * ctx = EVP_MD_CTX_new();
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
     if(!ctx)
         return 1; /* error */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -494,9 +494,9 @@ _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
 
 #else
 
-    ret = RSA_verify(nid_type, hash, (unsigned int) hash_len,
+    ret = RSA_verify(nid_type, hash, (unsigned int)hash_len,
                      (const unsigned char *)sig,
-                     (unsigned int) sig_len, rsactx);
+                     (unsigned int)sig_len, rsactx);
 #endif
 
     free(hash);
@@ -1237,10 +1237,10 @@ _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx ** rsa,
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
     pem_read_bio_func read_rsa =
-        (pem_read_bio_func) &PEM_read_bio_PrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
 #else
     pem_read_bio_func read_rsa =
-        (pem_read_bio_func) &PEM_read_bio_RSAPrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_RSAPrivateKey;
 #endif
 
     _libssh2_init_if_needed();
@@ -1647,15 +1647,15 @@ _libssh2_rsa_new_private(libssh2_rsa_ctx ** rsa,
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
     pem_read_bio_func read_rsa =
-        (pem_read_bio_func) &PEM_read_bio_PrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
 #else
     pem_read_bio_func read_rsa =
-        (pem_read_bio_func) &PEM_read_bio_RSAPrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_RSAPrivateKey;
 #endif
 
     _libssh2_init_if_needed();
 
-    rc = read_private_key_from_file((void **) rsa, read_rsa,
+    rc = read_private_key_from_file((void **)rsa, read_rsa,
                                     filename, passphrase);
 
     if(rc) {
@@ -1679,10 +1679,10 @@ _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx ** dsa,
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
     pem_read_bio_func read_dsa =
-        (pem_read_bio_func) &PEM_read_bio_PrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
 #else
     pem_read_bio_func read_dsa =
-        (pem_read_bio_func) &PEM_read_bio_DSAPrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_DSAPrivateKey;
 #endif
 
     _libssh2_init_if_needed();
@@ -2004,15 +2004,15 @@ _libssh2_dsa_new_private(libssh2_dsa_ctx ** dsa,
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
     pem_read_bio_func read_dsa =
-        (pem_read_bio_func) &PEM_read_bio_PrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
 #else
     pem_read_bio_func read_dsa =
-        (pem_read_bio_func) &PEM_read_bio_DSAPrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_DSAPrivateKey;
 #endif
 
     _libssh2_init_if_needed();
 
-    rc = read_private_key_from_file((void **) dsa, read_dsa,
+    rc = read_private_key_from_file((void **)dsa, read_dsa,
                                     filename, passphrase);
 
     if(rc) {
@@ -2036,10 +2036,10 @@ _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx ** ec_ctx,
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
     pem_read_bio_func read_ec =
-        (pem_read_bio_func) &PEM_read_bio_PrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
 #else
     pem_read_bio_func read_ec =
-        (pem_read_bio_func) &PEM_read_bio_ECPrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_ECPrivateKey;
 #endif
 
     _libssh2_init_if_needed();
@@ -2981,13 +2981,13 @@ _libssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
 #else
     if(hash_len == SHA_DIGEST_LENGTH)
         ret = RSA_sign(NID_sha1,
-                       hash, (unsigned int) hash_len, sig, &sig_len, rsactx);
+                       hash, (unsigned int)hash_len, sig, &sig_len, rsactx);
     else if(hash_len == SHA256_DIGEST_LENGTH)
         ret = RSA_sign(NID_sha256,
-                       hash, (unsigned int) hash_len, sig, &sig_len, rsactx);
+                       hash, (unsigned int)hash_len, sig, &sig_len, rsactx);
     else if(hash_len == SHA512_DIGEST_LENGTH)
         ret = RSA_sign(NID_sha512,
-                       hash, (unsigned int) hash_len, sig, &sig_len, rsactx);
+                       hash, (unsigned int)hash_len, sig, &sig_len, rsactx);
     else {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                        "Unsupported hash digest length");
@@ -3009,7 +3009,7 @@ _libssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
 #if LIBSSH2_RSA_SHA1
 int
 _libssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
-                       libssh2_rsa_ctx * rsactx,
+                       libssh2_rsa_ctx *rsactx,
                        const unsigned char *hash,
                        size_t hash_len,
                        unsigned char **signature, size_t *signature_len)
@@ -3022,7 +3022,7 @@ _libssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_DSA
 int
-_libssh2_dsa_sha1_sign(libssh2_dsa_ctx * dsactx,
+_libssh2_dsa_sha1_sign(libssh2_dsa_ctx *dsactx,
                        const unsigned char *hash,
                        size_t hash_len, unsigned char *signature)
 {
@@ -4161,10 +4161,10 @@ _libssh2_ecdsa_new_private(libssh2_ecdsa_ctx **ec_ctx,
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
     pem_read_bio_func read_ec =
-        (pem_read_bio_func) &PEM_read_bio_PrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
 #else
     pem_read_bio_func read_ec =
-        (pem_read_bio_func) &PEM_read_bio_ECPrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_ECPrivateKey;
 #endif
 
     _libssh2_init_if_needed();
@@ -4194,15 +4194,15 @@ _libssh2_ecdsa_new_private_sk(libssh2_ecdsa_ctx **ec_ctx,
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
     pem_read_bio_func read_ec =
-        (pem_read_bio_func) &PEM_read_bio_PrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
 #else
     pem_read_bio_func read_ec =
-        (pem_read_bio_func) &PEM_read_bio_ECPrivateKey;
+        (pem_read_bio_func)&PEM_read_bio_ECPrivateKey;
 #endif
 
     _libssh2_init_if_needed();
 
-    rc = read_private_key_from_file((void **) ec_ctx, read_ec,
+    rc = read_private_key_from_file((void **)ec_ctx, read_ec,
                                     filename, passphrase);
 
     if(rc) {

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -321,18 +321,18 @@ typedef struct {        /* Diffie-Hellman context. */
 
 #define libssh2_rsa_ctx         _libssh2_os400qc3_crypto_ctx
 #define _libssh2_rsa_free(ctx)  (_libssh2_os400qc3_crypto_dtor(ctx),        \
-                                 free((char *) ctx))
-#define libssh2_prepare_iovec(vec, len) memset((char *) (vec), 0,           \
+                                 free((char *)ctx))
+#define libssh2_prepare_iovec(vec, len) memset((char *)(vec), 0,            \
                                                (len) * sizeof(struct iovec))
 #define _libssh2_rsa_sha1_signv(session, sig, siglen, count, vector, ctx)   \
             _libssh2_os400qc3_rsa_signv(session, Qc3_SHA1, sig, siglen,     \
-                                             count, vector, ctx)
+                                        count, vector, ctx)
 #define _libssh2_rsa_sha2_256_signv(session, sig, siglen, cnt, vector, ctx) \
             _libssh2_os400qc3_rsa_signv(session, Qc3_SHA256, sig, siglen,   \
-                                             cnt, vector, ctx)
+                                        cnt, vector, ctx)
 #define _libssh2_rsa_sha2_512_signv(session, sig, siglen, cnt, vector, ctx) \
             _libssh2_os400qc3_rsa_signv(session, Qc3_SHA512, sig, siglen,   \
-                                             cnt, vector, ctx)
+                                        cnt, vector, ctx)
 
 /* Default generate and safe prime sizes for diffie-hellman-group-exchange-sha1
    Qc3 is limited to a maximum 2048-bit modulus/key size. */

--- a/src/packet.c
+++ b/src/packet.c
@@ -668,7 +668,7 @@ _libssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
     case libssh2_NB_state_idle:
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                        "Packet type %u received, length=%ld",
-                       (unsigned int) msg, (long)datalen));
+                       (unsigned int)msg, (long)datalen));
 
         if((macstate == LIBSSH2_MAC_INVALID) &&
             (!session->macerror ||

--- a/src/packet.c
+++ b/src/packet.c
@@ -63,7 +63,7 @@
  * Queue a connection request for a listener
  */
 static inline int
-packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
+packet_queue_listener(LIBSSH2_SESSION *session, unsigned char *data,
                       size_t datalen,
                       packet_queue_listener_state_t *listen_state)
 {
@@ -137,7 +137,7 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
 
     if(listen_state->state != libssh2_NB_state_sent) {
         while(listn) {
-            if((listn->port == (int) listen_state->port) &&
+            if((listn->port == (int)listen_state->port) &&
                 (strlen(listn->host) == listen_state->host_len) &&
                 (memcmp(listn->host, listen_state->host,
                         listen_state->host_len) == 0)) {
@@ -277,7 +277,7 @@ packet_queue_listener(LIBSSH2_SESSION * session, unsigned char *data,
  * Accept a forwarded X11 connection
  */
 static inline int
-packet_x11_open(LIBSSH2_SESSION * session, unsigned char *data,
+packet_x11_open(LIBSSH2_SESSION *session, unsigned char *data,
                 size_t datalen,
                 packet_x11_open_state_t *x11open_state)
 {
@@ -478,7 +478,7 @@ x11_exit:
  * Open a connection to authentication agent
  */
 static inline int
-packet_authagent_open(LIBSSH2_SESSION * session,
+packet_authagent_open(LIBSSH2_SESSION *session,
                       unsigned char *data, size_t datalen,
                       packet_authagent_state_t *authagent_state)
 {
@@ -668,11 +668,11 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
     case libssh2_NB_state_idle:
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                        "Packet type %u received, length=%ld",
-                       (unsigned int) msg, (long) datalen));
+                       (unsigned int) msg, (long)datalen));
 
         if((macstate == LIBSSH2_MAC_INVALID) &&
             (!session->macerror ||
-             LIBSSH2_MACERROR(session, (char *) data, datalen))) {
+             LIBSSH2_MACERROR(session, (char *)data, datalen))) {
             /* Bad MAC input, but no callback set or non-zero return from the
                callback */
 
@@ -811,7 +811,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
         case SSH_MSG_IGNORE:
             if(datalen >= 2) {
                 if(session->ssh_msg_ignore) {
-                    LIBSSH2_IGNORE(session, (char *) data + 1, datalen - 1);
+                    LIBSSH2_IGNORE(session, (char *)data + 1, datalen - 1);
                 }
             }
             else if(session->ssh_msg_ignore) {
@@ -1006,7 +1006,7 @@ libssh2_packet_add_jump_point5:
 
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                "%ld bytes packet_add() for %u/%u/%u",
-                               (long) (datalen - data_head),
+                               (long)(datalen - data_head),
                                channelp->local.id,
                                channelp->remote.id,
                                stream_id));
@@ -1020,7 +1020,7 @@ libssh2_packet_add_jump_point5:
 
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                               "Ignoring extended data and refunding %ld bytes",
-                               (long) (datalen - 13)));
+                               (long)(datalen - 13)));
                 if(channelp->read_avail + datalen - data_head >=
                     channelp->remote.window_size)
                     datalen = channelp->remote.window_size -
@@ -1031,9 +1031,9 @@ libssh2_packet_add_jump_point5:
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                                "shrinking window size by %ld bytes to %u, "
                                "read_avail %ld",
-                               (long) (datalen - data_head),
+                               (long)(datalen - data_head),
                                channelp->remote.window_size,
-                               (long) channelp->read_avail));
+                               (long)channelp->read_avail));
 
                 session->packAdd_channelp = channelp;
 
@@ -1519,7 +1519,7 @@ _libssh2_packet_askv(LIBSSH2_SESSION * session,
                      const unsigned char *match_buf,
                      size_t match_len)
 {
-    size_t i, packet_types_len = strlen((const char *) packet_types);
+    size_t i, packet_types_len = strlen((const char *)packet_types);
 
     for(i = 0; i < packet_types_len; i++) {
         if(_libssh2_packet_ask(session, packet_types[i], data,
@@ -1674,7 +1674,7 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
                          unsigned char **data, size_t *data_len,
                          int match_ofs,
                          const unsigned char *match_buf, size_t match_len,
-                         packet_requirev_state_t * state)
+                         packet_requirev_state_t *state)
 {
     if(_libssh2_packet_askv(session, packet_types, data, data_len, match_ofs,
                             match_buf, match_len) == 0) {
@@ -1706,7 +1706,7 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
             }
         }
 
-        if(strchr((const char *) packet_types, ret)) {
+        if(strchr((const char *)packet_types, ret)) {
             /* Be lazy, let packet_ask pull it out of the brigade */
             ret = _libssh2_packet_askv(session, packet_types, data,
                                        data_len, match_ofs, match_buf,

--- a/src/packet.c
+++ b/src/packet.c
@@ -648,7 +648,7 @@ authagent_exit:
  * This function will always be called with 'datalen' greater than zero.
  */
 int
-_libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+_libssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                     size_t datalen, int macstate, uint32_t seq)
 {
     int rc = 0;
@@ -1465,7 +1465,7 @@ libssh2_packet_add_jump_authagent:
  * a packet first
  */
 int
-_libssh2_packet_ask(LIBSSH2_SESSION * session, unsigned char packet_type,
+_libssh2_packet_ask(LIBSSH2_SESSION *session, unsigned char packet_type,
                     unsigned char **data, size_t *data_len,
                     int match_ofs, const unsigned char *match_buf,
                     size_t match_len)
@@ -1512,7 +1512,7 @@ _libssh2_packet_ask(LIBSSH2_SESSION * session, unsigned char packet_type,
  * socket for a packet first
  */
 int
-_libssh2_packet_askv(LIBSSH2_SESSION * session,
+_libssh2_packet_askv(LIBSSH2_SESSION *session,
                      const unsigned char *packet_types,
                      unsigned char **data, size_t *data_len,
                      int match_ofs,
@@ -1542,7 +1542,7 @@ _libssh2_packet_askv(LIBSSH2_SESSION * session,
  * Returns 0 when it has taken care of the requested packet.
  */
 int
-_libssh2_packet_require(LIBSSH2_SESSION * session, unsigned char packet_type,
+_libssh2_packet_require(LIBSSH2_SESSION *session, unsigned char packet_type,
                         unsigned char **data, size_t *data_len,
                         int match_ofs,
                         const unsigned char *match_buf,
@@ -1604,8 +1604,8 @@ _libssh2_packet_require(LIBSSH2_SESSION * session, unsigned char packet_type,
  * Used during KEX exchange to discard badly guessed KEX_INIT packets
  */
 int
-_libssh2_packet_burn(LIBSSH2_SESSION * session,
-                     libssh2_nonblocking_states * state)
+_libssh2_packet_burn(LIBSSH2_SESSION *session,
+                     libssh2_nonblocking_states *state)
 {
     unsigned char *data;
     size_t data_len;

--- a/src/packet.h
+++ b/src/packet.h
@@ -40,38 +40,38 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-int _libssh2_packet_read(LIBSSH2_SESSION * session);
+int _libssh2_packet_read(LIBSSH2_SESSION *session);
 
-int _libssh2_packet_ask(LIBSSH2_SESSION * session, unsigned char packet_type,
+int _libssh2_packet_ask(LIBSSH2_SESSION *session, unsigned char packet_type,
                         unsigned char **data, size_t *data_len,
                         int match_ofs,
                         const unsigned char *match_buf,
                         size_t match_len);
 
-int _libssh2_packet_askv(LIBSSH2_SESSION * session,
+int _libssh2_packet_askv(LIBSSH2_SESSION *session,
                          const unsigned char *packet_types,
                          unsigned char **data, size_t *data_len,
                          int match_ofs,
                          const unsigned char *match_buf,
                          size_t match_len);
-int _libssh2_packet_require(LIBSSH2_SESSION * session,
+int _libssh2_packet_require(LIBSSH2_SESSION *session,
                             unsigned char packet_type, unsigned char **data,
                             size_t *data_len, int match_ofs,
                             const unsigned char *match_buf,
                             size_t match_len,
-                            packet_require_state_t * state);
+                            packet_require_state_t *state);
 int _libssh2_packet_requirev(LIBSSH2_SESSION *session,
                              const unsigned char *packet_types,
                              unsigned char **data, size_t *data_len,
                              int match_ofs,
                              const unsigned char *match_buf,
                              size_t match_len,
-                             packet_requirev_state_t * state);
-int _libssh2_packet_burn(LIBSSH2_SESSION * session,
-                         libssh2_nonblocking_states * state);
-int _libssh2_packet_write(LIBSSH2_SESSION * session, unsigned char *data,
+                             packet_requirev_state_t *state);
+int _libssh2_packet_burn(LIBSSH2_SESSION *session,
+                         libssh2_nonblocking_states *state);
+int _libssh2_packet_write(LIBSSH2_SESSION *session, unsigned char *data,
                           unsigned long data_len);
-int _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+int _libssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                         size_t datalen, int macstate, uint32_t seq);
 
 #endif /* LIBSSH2_PACKET_H */

--- a/src/pem.c
+++ b/src/pem.c
@@ -457,7 +457,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
         goto out;
     }
 
-    if(strncmp((const char *) decoded.dataptr, AUTH_MAGIC,
+    if(strncmp((const char *)decoded.dataptr, AUTH_MAGIC,
                strlen(AUTH_MAGIC)) != 0) {
         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
                              "key auth magic mismatch");

--- a/src/pem.c
+++ b/src/pem.c
@@ -41,7 +41,7 @@
 #include "libssh2_priv.h"
 
 static int
-readline(char *line, int line_size, FILE * fp)
+readline(char *line, int line_size, FILE *fp)
 {
     size_t len;
 
@@ -111,7 +111,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
                    const unsigned char *passphrase,
-                   FILE * fp, unsigned char **data, size_t *datalen)
+                   FILE *fp, unsigned char **data, size_t *datalen)
 {
     int ret = -1;
     char *filedata = NULL;
@@ -752,7 +752,7 @@ out:
 int
 _libssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
                            const unsigned char *passphrase,
-                           FILE * fp, struct string_buf **decrypted_buf)
+                           FILE *fp, struct string_buf **decrypted_buf)
 {
     char line[LINE_SIZE];
     char *b64data = NULL;

--- a/src/pem.c
+++ b/src/pem.c
@@ -107,7 +107,7 @@ static unsigned char hex_decode(char digit)
 }
 
 int
-_libssh2_pem_parse(LIBSSH2_SESSION * session,
+_libssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
                    const unsigned char *passphrase,
@@ -171,7 +171,7 @@ out:
 }
 
 int
-_libssh2_pem_parse_memory(LIBSSH2_SESSION * session,
+_libssh2_pem_parse_memory(LIBSSH2_SESSION *session,
                           const char *headerbegin,
                           const char *headerend,
                           const unsigned char *passphrase,
@@ -415,7 +415,7 @@ out:
 #define OPENSSH_HEADER_END "-----END OPENSSH PRIVATE KEY-----"
 
 static int
-_libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
+_libssh2_openssh_pem_parse_data(LIBSSH2_SESSION *session,
                                 const unsigned char *passphrase,
                                 const char *b64data, size_t b64datalen,
                                 struct string_buf **decrypted_buf)
@@ -750,7 +750,7 @@ out:
 }
 
 int
-_libssh2_openssh_pem_parse(LIBSSH2_SESSION * session,
+_libssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
                            const unsigned char *passphrase,
                            FILE * fp, struct string_buf **decrypted_buf)
 {
@@ -820,7 +820,7 @@ out:
 }
 
 int
-_libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION * session,
+_libssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
                                   const unsigned char *passphrase,
                                   const char *filedata, size_t filedata_len,
                                   struct string_buf **decrypted_buf)

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -388,7 +388,7 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
 
         _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
                        "Sending publickey advertising version %d support",
-                       (int) LIBSSH2_PUBLICKEY_VERSION));
+                       (int)LIBSSH2_PUBLICKEY_VERSION));
 
         session->pkeyInit_state = libssh2_NB_state_sent2;
     }

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -127,7 +127,7 @@ publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
  * Read a packet from the subsystem
  */
 static int
-publickey_packet_receive(LIBSSH2_PUBLICKEY * pkey,
+publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
                          unsigned char **data, size_t *data_len)
 {
     LIBSSH2_CHANNEL *channel = pkey->channel;
@@ -226,7 +226,7 @@ publickey_response_id(unsigned char **pdata, size_t data_len)
  * Generic helper routine to wait for success response and nothing else
  */
 static int
-publickey_response_success(LIBSSH2_PUBLICKEY * pkey)
+publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
 {
     LIBSSH2_SESSION *session = pkey->channel->session;
     unsigned char *data, *s;
@@ -729,7 +729,7 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
  * performed using it
  */
 LIBSSH2_API int
-libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY * pkey,
+libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
                             const unsigned char *name, unsigned long name_len,
                             const unsigned char *blob, unsigned long blob_len)
 {
@@ -814,8 +814,8 @@ libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY * pkey,
  * Fetch a list of supported public key from a server
  */
 LIBSSH2_API int
-libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY * pkey, unsigned long *num_keys,
-                             libssh2_publickey_list ** pkey_list)
+libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey, unsigned long *num_keys,
+                             libssh2_publickey_list **pkey_list)
 {
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_SESSION *session;
@@ -1214,8 +1214,8 @@ err_exit:
  * Free a previously fetched list of public keys
  */
 LIBSSH2_API void
-libssh2_publickey_list_free(LIBSSH2_PUBLICKEY * pkey,
-                            libssh2_publickey_list * pkey_list)
+libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
+                            libssh2_publickey_list *pkey_list)
 {
     LIBSSH2_SESSION *session;
     libssh2_publickey_list *p = pkey_list;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -138,7 +138,7 @@ publickey_packet_receive(LIBSSH2_PUBLICKEY * pkey,
     *data_len = 0;
 
     if(pkey->receive_state == libssh2_NB_state_idle) {
-        rc = _libssh2_channel_read(channel, 0, (char *) buffer, 4);
+        rc = _libssh2_channel_read(channel, 0, (char *)buffer, 4);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             return (int)rc;
         }
@@ -160,7 +160,7 @@ publickey_packet_receive(LIBSSH2_PUBLICKEY * pkey,
     }
 
     if(pkey->receive_state == libssh2_NB_state_sent) {
-        rc = _libssh2_channel_read(channel, 0, (char *) pkey->receive_packet,
+        rc = _libssh2_channel_read(channel, 0, (char *)pkey->receive_packet,
                                    pkey->receive_packet_len);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             return (int)rc;
@@ -211,7 +211,7 @@ publickey_response_id(unsigned char **pdata, size_t data_len)
 
     while(codes->name) {
         if((unsigned long)codes->name_len == response_len &&
-            strncmp(codes->name, (char *) data, response_len) == 0) {
+            strncmp(codes->name, (char *)data, response_len) == 0) {
             *pdata = data + response_len;
             return codes->code;
         }
@@ -614,7 +614,7 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
                 if(attrs[i].name_len == (sizeof("comment") - 1) &&
                     strncmp(attrs[i].name, "comment",
                             sizeof("comment") - 1) == 0) {
-                    comment = (const unsigned char *) attrs[i].value;
+                    comment = (const unsigned char *)attrs[i].value;
                     comment_len = attrs[i].value_len;
                     break;
                 }
@@ -995,7 +995,7 @@ libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY * pkey, unsigned long *num_keys,
                     }
                     list[keys].attrs[0].name = "comment";
                     list[keys].attrs[0].name_len = sizeof("comment") - 1;
-                    list[keys].attrs[0].value = (char *) pkey->listFetch_s;
+                    list[keys].attrs[0].value = (char *)pkey->listFetch_s;
                     list[keys].attrs[0].value_len = comment_len;
                     list[keys].attrs[0].mandatory = 0;
 
@@ -1136,7 +1136,7 @@ libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY * pkey, unsigned long *num_keys,
                         if(pkey->listFetch_s + list[keys].attrs[i].name_len <=
                            pkey->listFetch_data + pkey->listFetch_data_len) {
                             list[keys].attrs[i].name =
-                                (char *) pkey->listFetch_s;
+                                (char *)pkey->listFetch_s;
                             pkey->listFetch_s += list[keys].attrs[i].name_len;
                         }
                         else {
@@ -1163,7 +1163,7 @@ libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY * pkey, unsigned long *num_keys,
                            list[keys].attrs[i].value_len <=
                            pkey->listFetch_data + pkey->listFetch_data_len) {
                             list[keys].attrs[i].value =
-                                (char *) pkey->listFetch_s;
+                                (char *)pkey->listFetch_s;
                             pkey->listFetch_s += list[keys].attrs[i].value_len;
                         }
                         else {

--- a/src/scp.c
+++ b/src/scp.c
@@ -277,7 +277,7 @@ shell_quotearg(const char *path, unsigned char *buf,
  *
  */
 static LIBSSH2_CHANNEL *
-scp_recv(LIBSSH2_SESSION *session, const char *path, libssh2_struct_stat * sb)
+scp_recv(LIBSSH2_SESSION *session, const char *path, libssh2_struct_stat *sb)
 {
     size_t cmd_len;
     int rc;

--- a/src/scp.c
+++ b/src/scp.c
@@ -277,7 +277,7 @@ shell_quotearg(const char *path, unsigned char *buf,
  *
  */
 static LIBSSH2_CHANNEL *
-scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
+scp_recv(LIBSSH2_SESSION *session, const char *path, libssh2_struct_stat * sb)
 {
     size_t cmd_len;
     int rc;
@@ -857,7 +857,7 @@ libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
  *
  */
 static LIBSSH2_CHANNEL *
-scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
+scp_send(LIBSSH2_SESSION *session, const char *path, int mode,
          libssh2_int64_t size, time_t mtime, time_t atime)
 {
     size_t cmd_len;

--- a/src/scp.c
+++ b/src/scp.c
@@ -416,7 +416,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
 
             if(session->scpRecv_state == libssh2_NB_state_sent2) {
                 rc = (int)_libssh2_channel_read(session->scpRecv_channel, 0,
-                                                (char *) session->
+                                                (char *)session->
                                                 scpRecv_response +
                                                 session->scpRecv_response_len,
                                                 1);
@@ -534,7 +534,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
 
                 s = session->scpRecv_response + 1;
 
-                p = (unsigned char *) strchr((char *) s, ' ');
+                p = (unsigned char *)strchr((char *)s, ' ');
                 if(!p || ((p - s) <= 0)) {
                     /* No spaces or space in the wrong spot */
                     _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
@@ -545,9 +545,9 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
 
                 *(p++) = '\0';
                 /* Make sure we don't get fooled by leftover values */
-                session->scpRecv_mtime = strtol((char *) s, NULL, 10);
+                session->scpRecv_mtime = strtol((char *)s, NULL, 10);
 
-                s = (unsigned char *) strchr((char *) p, ' ');
+                s = (unsigned char *)strchr((char *)p, ' ');
                 if(!s || ((s - p) <= 0)) {
                     /* No spaces or space in the wrong spot */
                     _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
@@ -558,7 +558,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
 
                 /* Ignore mtime.usec */
                 s++;
-                p = (unsigned char *) strchr((char *) s, ' ');
+                p = (unsigned char *)strchr((char *)s, ' ');
                 if(!p || ((p - s) <= 0)) {
                     /* No spaces or space in the wrong spot */
                     _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
@@ -569,7 +569,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
 
                 *p = '\0';
                 /* Make sure we don't get fooled by leftover values */
-                session->scpRecv_atime = strtol((char *) s, NULL, 10);
+                session->scpRecv_atime = strtol((char *)s, NULL, 10);
 
                 /* SCP ACK */
                 session->scpRecv_response[0] = '\0';
@@ -616,7 +616,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
 
             if(session->scpRecv_state == libssh2_NB_state_sent5) {
                 rc = (int)_libssh2_channel_read(session->scpRecv_channel, 0,
-                                                (char *) session->
+                                                (char *)session->
                                                 scpRecv_response +
                                                 session->scpRecv_response_len,
                                                 1);
@@ -694,7 +694,7 @@ scp_recv(LIBSSH2_SESSION * session, const char *path, libssh2_struct_stat * sb)
                     goto scp_recv_error;
                 }
 
-                s = (char *) session->scpRecv_response + 1;
+                s = (char *)session->scpRecv_response + 1;
 
                 p = strchr(s, ' ');
                 if(!p || ((p - s) <= 0)) {
@@ -969,7 +969,7 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
     if(session->scpSend_state == libssh2_NB_state_sent1) {
         /* Wait for ACK */
         rc = (int)_libssh2_channel_read(session->scpSend_channel, 0,
-                                        (char *) session->scpSend_response, 1);
+                                        (char *)session->scpSend_response, 1);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
                            "Would block waiting for response from remote");
@@ -990,7 +990,7 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
         if(mtime || atime) {
             /* Send mtime and atime to be used for file */
             session->scpSend_response_len =
-                snprintf((char *) session->scpSend_response,
+                snprintf((char *)session->scpSend_response,
                          LIBSSH2_SCP_RESPONSE_BUFLEN, "T%ld 0 %ld 0\n",
                          (long)mtime, (long)atime);
             _libssh2_debug((session, LIBSSH2_TRACE_SCP, "Sent %s",
@@ -1023,7 +1023,7 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
         if(session->scpSend_state == libssh2_NB_state_sent3) {
             /* Wait for ACK */
             rc = (int)_libssh2_channel_read(session->scpSend_channel, 0,
-                                            (char *) session->scpSend_response,
+                                            (char *)session->scpSend_response,
                                             1);
             if(rc == LIBSSH2_ERROR_EAGAIN) {
                 _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
@@ -1061,7 +1061,7 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
             base = path;
 
         session->scpSend_response_len =
-            snprintf((char *) session->scpSend_response,
+            snprintf((char *)session->scpSend_response,
                      LIBSSH2_SCP_RESPONSE_BUFLEN, "C0%o %"
                      LIBSSH2_INT64_T_FORMAT " %s\n", mode,
                      size, base);
@@ -1092,7 +1092,7 @@ scp_send(LIBSSH2_SESSION * session, const char *path, int mode,
     if(session->scpSend_state == libssh2_NB_state_sent6) {
         /* Wait for ACK */
         rc = (int)_libssh2_channel_read(session->scpSend_channel, 0,
-                                        (char *) session->scpSend_response,
+                                        (char *)session->scpSend_response,
                                         1);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,

--- a/src/session.c
+++ b/src/session.c
@@ -219,8 +219,8 @@ banner_send(LIBSSH2_SESSION * session)
     if(session->banner_TxRx_state == libssh2_NB_state_idle) {
         if(session->local.banner) {
             /* setopt_string will have given us our \r\n characters */
-            banner_len = strlen((char *) session->local.banner);
-            banner = (char *) session->local.banner;
+            banner_len = strlen((char *)session->local.banner);
+            banner = (char *)session->local.banner;
         }
 #ifdef LIBSSH2DEBUG
         {
@@ -310,7 +310,7 @@ session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
     return ioctl(sockfd, FIONBIO, &flags);
 #elif defined(HAVE_IOCTLSOCKET_CASE)
     /* presumably for Amiga */
-    return IoctlSocket(sockfd, FIONBIO, (long) nonblock);
+    return IoctlSocket(sockfd, FIONBIO, (long)nonblock);
 #elif defined(HAVE_SO_NONBLOCK)
     /* BeOS */
     long b = nonblock ? 1 : 0;
@@ -351,7 +351,7 @@ get_socket_nonblocking(libssh2_socket_t sockfd)
         /* Assume blocking on error */
         return 1;
     }
-    return (int) b;
+    return (int)b;
 #elif defined(SO_STATE) && defined(__VMS)
     /* VMS TCP/IP Services */
 
@@ -373,11 +373,11 @@ get_socket_nonblocking(libssh2_socket_t sockfd)
     socklen_t option_len = sizeof(option_value);
 
     if(getsockopt(sockfd, SOL_SOCKET, SO_ERROR,
-                  (void *) &option_value, &option_len)) {
+                  (void *)&option_value, &option_len)) {
         /* Assume blocking on error */
         return 1;
     }
-    return (int) option_value;
+    return (int)option_value;
 #else
     (void)sockfd;
     return 1;                   /* returns blocking */
@@ -906,7 +906,7 @@ libssh2_session_handshake(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 LIBSSH2_API int
 libssh2_session_startup(LIBSSH2_SESSION *session, int sock)
 {
-    return libssh2_session_handshake(session, (libssh2_socket_t) sock);
+    return libssh2_session_handshake(session, (libssh2_socket_t)sock);
 }
 #endif
 
@@ -1283,31 +1283,31 @@ libssh2_session_methods(LIBSSH2_SESSION * session, int method_type)
         break;
 
     case LIBSSH2_METHOD_HOSTKEY:
-        method = (const LIBSSH2_KEX_METHOD *) session->hostkey;
+        method = (const LIBSSH2_KEX_METHOD *)session->hostkey;
         break;
 
     case LIBSSH2_METHOD_CRYPT_CS:
-        method = (const LIBSSH2_KEX_METHOD *) session->local.crypt;
+        method = (const LIBSSH2_KEX_METHOD *)session->local.crypt;
         break;
 
     case LIBSSH2_METHOD_CRYPT_SC:
-        method = (const LIBSSH2_KEX_METHOD *) session->remote.crypt;
+        method = (const LIBSSH2_KEX_METHOD *)session->remote.crypt;
         break;
 
     case LIBSSH2_METHOD_MAC_CS:
-        method = (const LIBSSH2_KEX_METHOD *) session->local.mac;
+        method = (const LIBSSH2_KEX_METHOD *)session->local.mac;
         break;
 
     case LIBSSH2_METHOD_MAC_SC:
-        method = (const LIBSSH2_KEX_METHOD *) session->remote.mac;
+        method = (const LIBSSH2_KEX_METHOD *)session->remote.mac;
         break;
 
     case LIBSSH2_METHOD_COMP_CS:
-        method = (const LIBSSH2_KEX_METHOD *) session->local.comp;
+        method = (const LIBSSH2_KEX_METHOD *)session->local.comp;
         break;
 
     case LIBSSH2_METHOD_COMP_SC:
-        method = (const LIBSSH2_KEX_METHOD *) session->remote.comp;
+        method = (const LIBSSH2_KEX_METHOD *)session->remote.comp;
         break;
 
     case LIBSSH2_METHOD_LANG_CS:
@@ -1962,5 +1962,5 @@ libssh2_session_banner_get(LIBSSH2_SESSION *session)
     if(!session->remote.banner)
         return NULL;
 
-    return (const char *) session->remote.banner;
+    return (const char *)session->remote.banner;
 }

--- a/src/session.c
+++ b/src/session.c
@@ -1581,7 +1581,7 @@ libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
  * non-0 if data can be written without blocking
  */
 static inline int
-poll_channel_write(LIBSSH2_CHANNEL * channel)
+poll_channel_write(LIBSSH2_CHANNEL *channel)
 {
     return channel->local.window_size ? 1 : 0;
 }
@@ -1592,7 +1592,7 @@ poll_channel_write(LIBSSH2_CHANNEL * channel)
  * non-0 if one or more connections are available
  */
 static inline int
-poll_listener_queued(LIBSSH2_LISTENER * listener)
+poll_listener_queued(LIBSSH2_LISTENER *listener)
 {
     return _libssh2_list_first(&listener->queue) ? 1 : 0;
 }
@@ -1604,7 +1604,7 @@ poll_listener_queued(LIBSSH2_LISTENER * listener)
  * Poll sockets, channels, and listeners for activity
  */
 LIBSSH2_API int
-libssh2_poll(LIBSSH2_POLLFD * fds, unsigned int nfds, long timeout)
+libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 {
     long timeout_remaining;
     unsigned int i, active_fds;

--- a/src/session.c
+++ b/src/session.c
@@ -104,7 +104,7 @@ LIBSSH2_REALLOC_FUNC(libssh2_default_realloc)
  * on failure
  */
 static int
-banner_receive(LIBSSH2_SESSION * session)
+banner_receive(LIBSSH2_SESSION *session)
 {
     ssize_t ret;
     size_t banner_len;
@@ -210,7 +210,7 @@ banner_receive(LIBSSH2_SESSION * session)
  * (same data pointer and same data_len) until zero or failure is returned.
  */
 static int
-banner_send(LIBSSH2_SESSION * session)
+banner_send(LIBSSH2_SESSION *session)
 {
     const char *banner = LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
     size_t banner_len = sizeof(LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF) - 1;
@@ -388,7 +388,7 @@ get_socket_nonblocking(libssh2_socket_t sockfd)
  * Set the local banner to use in the server handshake.
  */
 LIBSSH2_API int
-libssh2_session_banner_set(LIBSSH2_SESSION * session, const char *banner)
+libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
 {
     size_t banner_len = banner ? strlen(banner) : 0;
 
@@ -424,7 +424,7 @@ libssh2_session_banner_set(LIBSSH2_SESSION * session, const char *banner)
  * Set the local banner. DEPRECATED VERSION
  */
 LIBSSH2_API int
-libssh2_banner_set(LIBSSH2_SESSION * session, const char *banner)
+libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner)
 {
     return libssh2_session_banner_set(session, banner);
 }
@@ -579,7 +579,7 @@ libssh2_session_callback_set2(LIBSSH2_SESSION *session, int cbtype,
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 LIBSSH2_API void *
-libssh2_session_callback_set(LIBSSH2_SESSION * session,
+libssh2_session_callback_set(LIBSSH2_SESSION *session,
                              int cbtype, void *callback)
 {
     return (void *)libssh2_session_callback_set2(session, cbtype,
@@ -1184,7 +1184,7 @@ session_free(LIBSSH2_SESSION *session)
  * Also closes and frees any channels attached to this session
  */
 LIBSSH2_API int
-libssh2_session_free(LIBSSH2_SESSION * session)
+libssh2_session_free(LIBSSH2_SESSION *session)
 {
     int rc;
 
@@ -1272,7 +1272,7 @@ libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
  * regardless of actual negotiation Strings should NOT be freed
  */
 LIBSSH2_API const char *
-libssh2_session_methods(LIBSSH2_SESSION * session, int method_type)
+libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
 {
     /* All methods have char *name as their first element */
     const LIBSSH2_KEX_METHOD *method = NULL;
@@ -1335,7 +1335,7 @@ libssh2_session_methods(LIBSSH2_SESSION * session, int method_type)
  * Retrieve a pointer to the abstract property
  */
 LIBSSH2_API void **
-libssh2_session_abstract(LIBSSH2_SESSION * session)
+libssh2_session_abstract(LIBSSH2_SESSION *session)
 {
     return &session->abstract;
 }
@@ -1347,7 +1347,7 @@ libssh2_session_abstract(LIBSSH2_SESSION * session)
  * program. Otherwise it is assumed to be owned by libssh2
  */
 LIBSSH2_API int
-libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
+libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
                            int *errmsg_len, int want_buf)
 {
     size_t msglen = 0;
@@ -1400,7 +1400,7 @@ libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
  * Returns error code
  */
 LIBSSH2_API int
-libssh2_session_last_errno(LIBSSH2_SESSION * session)
+libssh2_session_last_errno(LIBSSH2_SESSION *session)
 {
     return session->err_code;
 }
@@ -1429,7 +1429,7 @@ libssh2_session_set_last_error(LIBSSH2_SESSION* session,
  * Return error code.
  */
 LIBSSH2_API int
-libssh2_session_flag(LIBSSH2_SESSION * session, int flag, int value)
+libssh2_session_flag(LIBSSH2_SESSION *session, int flag, int value)
 {
     switch(flag) {
     case LIBSSH2_FLAG_SIGPIPE:
@@ -1472,7 +1472,7 @@ _libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
  * fcntl(fd, F_SETFL, O_NONBLOCK); type command
  */
 LIBSSH2_API void
-libssh2_session_set_blocking(LIBSSH2_SESSION * session, int blocking)
+libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
 {
     (void)_libssh2_session_set_blocking(session, blocking);
 }
@@ -1482,7 +1482,7 @@ libssh2_session_set_blocking(LIBSSH2_SESSION * session, int blocking)
  * Returns a session's blocking mode on or off
  */
 LIBSSH2_API int
-libssh2_session_get_blocking(LIBSSH2_SESSION * session)
+libssh2_session_get_blocking(LIBSSH2_SESSION *session)
 {
     return session->api_block_mode;
 }
@@ -1493,7 +1493,7 @@ libssh2_session_get_blocking(LIBSSH2_SESSION * session)
  * or 0 to disable timeouts.
  */
 LIBSSH2_API void
-libssh2_session_set_timeout(LIBSSH2_SESSION * session, long timeout)
+libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
 {
     session->api_timeout = timeout;
 }
@@ -1503,7 +1503,7 @@ libssh2_session_set_timeout(LIBSSH2_SESSION * session, long timeout)
  * Returns a session's timeout, or 0 if disabled
  */
 LIBSSH2_API long
-libssh2_session_get_timeout(LIBSSH2_SESSION * session)
+libssh2_session_get_timeout(LIBSSH2_SESSION *session)
 {
     return session->api_timeout;
 }
@@ -1514,7 +1514,7 @@ libssh2_session_get_timeout(LIBSSH2_SESSION * session)
  * or 0 to use default of 60 seconds.
  */
 LIBSSH2_API void
-libssh2_session_set_read_timeout(LIBSSH2_SESSION * session, long timeout)
+libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
 {
     if(timeout <= 0) {
         timeout = LIBSSH2_DEFAULT_READ_TIMEOUT;
@@ -1527,7 +1527,7 @@ libssh2_session_set_read_timeout(LIBSSH2_SESSION * session, long timeout)
  * Returns a session's timeout. Default is 60 seconds.
  */
 LIBSSH2_API long
-libssh2_session_get_read_timeout(LIBSSH2_SESSION * session)
+libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
 {
     return session->packet_read_timeout;
 }

--- a/src/session.h
+++ b/src/session.h
@@ -89,6 +89,6 @@
 int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time);
 
 /* this is the lib-internal set blocking function */
-int _libssh2_session_set_blocking(LIBSSH2_SESSION * session, int blocking);
+int _libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking);
 
 #endif /* LIBSSH2_SESSION_H */

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -626,7 +626,7 @@ static int sftp_attrsize(unsigned long flags)
  * Populate attributes into an SFTP block
  */
 static ssize_t
-sftp_attr2bin(unsigned char *p, const LIBSSH2_SFTP_ATTRIBUTES * attrs)
+sftp_attr2bin(unsigned char *p, const LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
     unsigned char *s = p;
     uint32_t flag_mask =
@@ -1409,7 +1409,7 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
 /* sftp_read
  * Read from an SFTP file handle
  */
-static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE * handle, char *buffer,
+static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                          size_t buffer_size)
 {
     LIBSSH2_SFTP *sftp = handle->sftp;
@@ -3718,7 +3718,7 @@ libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp, const char *path,
  */
 static int sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
                      unsigned int path_len, int stat_type,
-                     LIBSSH2_SFTP_ATTRIBUTES * attrs)
+                     LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -507,12 +507,12 @@ sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
     }
 
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Requiring packet %u id %u",
-                   (unsigned int) packet_type, request_id));
+                   (unsigned int)packet_type, request_id));
 
     if(sftp_packet_ask(sftp, packet_type, request_id, data, data_len) == 0) {
         /* The right packet was available in the packet brigade */
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %u",
-                       (unsigned int) packet_type));
+                       (unsigned int)packet_type));
 
         if(*data_len < required_size) {
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
@@ -530,7 +530,7 @@ sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
         if(!sftp_packet_ask(sftp, packet_type, request_id, data, data_len)) {
             /* The right packet was available in the packet brigade */
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %d",
-                           (unsigned int) packet_type));
+                           (unsigned int)packet_type));
 
             if(*data_len < required_size) {
                 return LIBSSH2_ERROR_BUFFER_TOO_SMALL;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -754,7 +754,7 @@ LIBSSH2_CHANNEL_CLOSE_FUNC(libssh2_sftp_dtor);
  */
 LIBSSH2_CHANNEL_CLOSE_FUNC(libssh2_sftp_dtor)
 {
-    LIBSSH2_SFTP *sftp = (LIBSSH2_SFTP *) (*channel_abstract);
+    LIBSSH2_SFTP *sftp = (LIBSSH2_SFTP *)(*channel_abstract);
 
     (void)session_abstract;
     (void)channel;
@@ -1854,7 +1854,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
             ssize_t attr_len = 0;
 
             if(names_packet_len >= 4) {
-                s = (unsigned char *) handle->u.dir.next_name;
+                s = (unsigned char *)handle->u.dir.next_name;
                 real_filename_len = _libssh2_ntohu32(s);
                 s += 4;
                 names_packet_len -= 4;
@@ -1929,7 +1929,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                 goto end;
             }
 
-            handle->u.dir.next_name = (char *) s;
+            handle->u.dir.next_name = (char *)s;
             handle->u.dir.names_packet_len = names_packet_len;
 
             if((--handle->u.dir.names_left) == 0)
@@ -2027,7 +2027,7 @@ end:
 
     handle->u.dir.names_left = num_names;
     handle->u.dir.names_packet = data;
-    handle->u.dir.next_name = (char *) data + 9;
+    handle->u.dir.next_name = (char *)data + 9;
     handle->u.dir.names_packet_len = data_len - 9;
 
     /* use the name popping mechanism from the start of the function */

--- a/src/transport.c
+++ b/src/transport.c
@@ -54,7 +54,7 @@
 #ifdef LIBSSH2DEBUG
 #define UNPRINTABLE_CHAR '.'
 static void
-debugdump(LIBSSH2_SESSION * session,
+debugdump(LIBSSH2_SESSION *session,
           const char *desc, const unsigned char *ptr, size_t size)
 {
     size_t i;
@@ -123,7 +123,7 @@ debugdump(LIBSSH2_SESSION * session,
  * returns 0 on success and negative on failure
  */
 static int
-decrypt(LIBSSH2_SESSION * session, unsigned char *source,
+decrypt(LIBSSH2_SESSION *session, unsigned char *source,
         unsigned char *dest, ssize_t len, int firstlast)
 {
     struct transportpacket *p = &session->packet;
@@ -178,7 +178,7 @@ decrypt(LIBSSH2_SESSION * session, unsigned char *source,
  * collected.
  */
 static int
-fullpacket(LIBSSH2_SESSION * session, int encrypted /* 1 or 0 */ )
+fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */ )
 {
     unsigned char macbuf[MAX_MACSIZE];
     struct transportpacket *p = &session->packet;
@@ -372,7 +372,7 @@ fullpacket(LIBSSH2_SESSION * session, int encrypted /* 1 or 0 */ )
  *
  * DOES NOT call _libssh2_error() for ANY error case.
  */
-int _libssh2_transport_read(LIBSSH2_SESSION * session)
+int _libssh2_transport_read(LIBSSH2_SESSION *session)
 {
     int rc;
     struct transportpacket *p = &session->packet;

--- a/src/transport.c
+++ b/src/transport.c
@@ -70,7 +70,7 @@ debugdump(LIBSSH2_SESSION *session,
     }
 
     used = snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
-                    desc, (unsigned long) size);
+                    desc, (unsigned long)size);
     if(session->tracehandler)
         (session->tracehandler)(session, session->tracehandler_context,
                                 buffer, used);

--- a/src/transport.c
+++ b/src/transport.c
@@ -696,7 +696,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
                     /* copy the data from index 5 to the end of
                        the blocksize from the temporary buffer to
                        the start of the decrypted buffer */
-                    if(blocksize - 5 <= (int) total_num) {
+                    if(blocksize - 5 <= (int)total_num) {
                         memcpy(p->wptr, &block[5], blocksize - 5);
                         p->wptr += blocksize - 5; /* advance write pointer */
                         if(etm) {

--- a/src/transport.h
+++ b/src/transport.h
@@ -82,6 +82,6 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
  * This function reads the binary stream as specified in chapter 6 of RFC4253
  * "The Secure Shell (SSH) Transport Layer Protocol"
  */
-int _libssh2_transport_read(LIBSSH2_SESSION * session);
+int _libssh2_transport_read(LIBSSH2_SESSION *session);
 
 #endif /* LIBSSH2_TRANSPORT_H */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -759,7 +759,7 @@ file_read_publickey(LIBSSH2_SESSION *session, unsigned char **method,
 
 static int
 memory_read_privatekey(LIBSSH2_SESSION *session,
-                       const LIBSSH2_HOSTKEY_METHOD ** hostkey_method,
+                       const LIBSSH2_HOSTKEY_METHOD **hostkey_method,
                        void **hostkey_abstract,
                        const unsigned char *method, size_t method_len,
                        const char *privkeyfiledata, size_t privkeyfiledata_len,
@@ -800,7 +800,7 @@ memory_read_privatekey(LIBSSH2_SESSION *session,
  */
 static int
 file_read_privatekey(LIBSSH2_SESSION *session,
-                     const LIBSSH2_HOSTKEY_METHOD ** hostkey_method,
+                     const LIBSSH2_HOSTKEY_METHOD **hostkey_method,
                      void **hostkey_abstract,
                      const unsigned char *method, size_t method_len,
                      const char *privkeyfile, const char *passphrase)

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -250,7 +250,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
  * username should be NULL, or a null terminated string
  */
 LIBSSH2_API char *
-libssh2_userauth_list(LIBSSH2_SESSION * session, const char *username,
+libssh2_userauth_list(LIBSSH2_SESSION *session, const char *username,
                       unsigned int username_len)
 {
     char *ptr;
@@ -290,7 +290,7 @@ libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
  *          1 if already authenticated
  */
 LIBSSH2_API int
-libssh2_userauth_authenticated(LIBSSH2_SESSION * session)
+libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
 {
     return (session->state & LIBSSH2_STATE_AUTHENTICATED) ? 1 : 0;
 }
@@ -581,7 +581,7 @@ libssh2_userauth_password_ex(LIBSSH2_SESSION *session, const char *username,
 }
 
 static int
-memory_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
+memory_read_publickey(LIBSSH2_SESSION *session, unsigned char **method,
                       size_t *method_len,
                       unsigned char **pubkeydata,
                       size_t *pubkeydata_len,
@@ -664,7 +664,7 @@ memory_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
  * in method on success.
  */
 static int
-file_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
+file_read_publickey(LIBSSH2_SESSION *session, unsigned char **method,
                     size_t *method_len,
                     unsigned char **pubkeydata,
                     size_t *pubkeydata_len,
@@ -758,7 +758,7 @@ file_read_publickey(LIBSSH2_SESSION * session, unsigned char **method,
 }
 
 static int
-memory_read_privatekey(LIBSSH2_SESSION * session,
+memory_read_privatekey(LIBSSH2_SESSION *session,
                        const LIBSSH2_HOSTKEY_METHOD ** hostkey_method,
                        void **hostkey_abstract,
                        const unsigned char *method, size_t method_len,
@@ -799,7 +799,7 @@ memory_read_privatekey(LIBSSH2_SESSION * session,
  * Read a PEM encoded private key from an id_??? style file
  */
 static int
-file_read_privatekey(LIBSSH2_SESSION * session,
+file_read_privatekey(LIBSSH2_SESSION *session,
                      const LIBSSH2_HOSTKEY_METHOD ** hostkey_method,
                      void **hostkey_abstract,
                      const unsigned char *method, size_t method_len,
@@ -2123,7 +2123,7 @@ libssh2_userauth_publickey(LIBSSH2_SESSION *session,
  * Authenticate using a challenge-response authentication
  */
 static int
-userauth_keyboard_interactive(LIBSSH2_SESSION * session,
+userauth_keyboard_interactive(LIBSSH2_SESSION *session,
                               const char *username,
                               unsigned int username_len,
                      LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback))

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -772,7 +772,7 @@ memory_read_privatekey(LIBSSH2_SESSION * session,
     *hostkey_abstract = NULL;
     while(*hostkey_methods_avail && (*hostkey_methods_avail)->name) {
         if((*hostkey_methods_avail)->initPEMFromMemory &&
-           strncmp((*hostkey_methods_avail)->name, (const char *) method,
+           strncmp((*hostkey_methods_avail)->name, (const char *)method,
                    method_len) == 0) {
             *hostkey_method = *hostkey_methods_avail;
             break;
@@ -786,7 +786,7 @@ memory_read_privatekey(LIBSSH2_SESSION * session,
 
     if((*hostkey_method)->
         initPEMFromMemory(session, privkeyfiledata, privkeyfiledata_len,
-                          (const unsigned char *) passphrase,
+                          (const unsigned char *)passphrase,
                           hostkey_abstract)) {
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                               "Unable to initialize private key from memory");
@@ -814,7 +814,7 @@ file_read_privatekey(LIBSSH2_SESSION * session,
     *hostkey_abstract = NULL;
     while(*hostkey_methods_avail && (*hostkey_methods_avail)->name) {
         if((*hostkey_methods_avail)->initPEM &&
-           strncmp((*hostkey_methods_avail)->name, (const char *) method,
+           strncmp((*hostkey_methods_avail)->name, (const char *)method,
                    method_len) == 0) {
             *hostkey_method = *hostkey_methods_avail;
             break;
@@ -827,7 +827,7 @@ file_read_privatekey(LIBSSH2_SESSION * session,
     }
 
     if((*hostkey_method)->
-        initPEM(session, privkeyfile, (const unsigned char *) passphrase,
+        initPEM(session, privkeyfile, (const unsigned char *)passphrase,
                 hostkey_abstract)) {
         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
                               "Unable to initialize private key from file");
@@ -851,7 +851,7 @@ static int
 sign_frommemory(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
                 const unsigned char *data, size_t data_len, void **abstract)
 {
-    struct privkey_mem *pk_mem = (struct privkey_mem *) (*abstract);
+    struct privkey_mem *pk_mem = (struct privkey_mem *)(*abstract);
     const LIBSSH2_HOSTKEY_METHOD *privkeyobj;
     void *hostkey_abstract;
     struct iovec datavec;
@@ -891,7 +891,7 @@ static int
 sign_fromfile(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
               const unsigned char *data, size_t data_len, void **abstract)
 {
-    struct privkey_file *privkey_file = (struct privkey_file *) (*abstract);
+    struct privkey_file *privkey_file = (struct privkey_file *)(*abstract);
     const LIBSSH2_HOSTKEY_METHOD *privkeyobj;
     void *hostkey_abstract;
     struct iovec datavec;
@@ -931,7 +931,7 @@ libssh2_sign_sk(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
                 const unsigned char *data, size_t data_len, void **abstract)
 {
     int rc = LIBSSH2_ERROR_DECRYPT;
-    LIBSSH2_PRIVKEY_SK *sk_info = (LIBSSH2_PRIVKEY_SK *) (*abstract);
+    LIBSSH2_PRIVKEY_SK *sk_info = (LIBSSH2_PRIVKEY_SK *)(*abstract);
     LIBSSH2_SK_SIG_INFO sig_info = { 0 };
 
     if(sk_info->handle_len <= 0) {

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1289,41 +1289,33 @@ libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
 size_t plain_method(char *method, size_t method_len)
 {
     if(!strncmp("ssh-rsa-cert-v01@openssh.com",
-                method,
-                method_len)) {
+                method, method_len)) {
         return 7;
     }
 
     if(!strncmp("rsa-sha2-256-cert-v01@openssh.com",
-                method,
-                method_len) ||
+                method, method_len) ||
        !strncmp("rsa-sha2-512-cert-v01@openssh.com",
-                method,
-                method_len)) {
+                method, method_len)) {
         return 12;
     }
 
     if(!strncmp("ecdsa-sha2-nistp256-cert-v01@openssh.com",
-                method,
-                method_len) ||
+                method, method_len) ||
        !strncmp("ecdsa-sha2-nistp384-cert-v01@openssh.com",
-                method,
-                method_len) ||
+                method, method_len) ||
        !strncmp("ecdsa-sha2-nistp521-cert-v01@openssh.com",
-                method,
-                method_len)) {
+                method, method_len)) {
         return 19;
     }
 
     if(!strncmp("ssh-ed25519-cert-v01@openssh.com",
-                method,
-                method_len)) {
+                method, method_len)) {
         return 11;
     }
 
     if(!strncmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com",
-                method,
-                method_len)) {
+                method, method_len)) {
         const char *new_method = "sk-ecdsa-sha2-nistp256@openssh.com";
         /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
         memcpy(method, new_method, strlen(new_method));
@@ -1331,8 +1323,7 @@ size_t plain_method(char *method, size_t method_len)
     }
 
     if(!strncmp("sk-ssh-ed25519-cert-v01@openssh.com",
-                method,
-                method_len)) {
+                method, method_len)) {
         const char *new_method = "sk-ssh-ed25519@openssh.com";
         /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
         memcpy(method, new_method, strlen(new_method));

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -727,7 +727,7 @@ int _libssh2_hmac_md5_init(libssh2_hmac_ctx *ctx,
 {
     int ret = _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacMD5,
                                         MD5_DIGEST_LENGTH,
-                                        key, (ULONG) keylen);
+                                        key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -738,7 +738,7 @@ int _libssh2_hmac_sha1_init(libssh2_hmac_ctx *ctx,
 {
     int ret = _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacSHA1,
                                         SHA_DIGEST_LENGTH,
-                                        key, (ULONG) keylen);
+                                        key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -748,7 +748,7 @@ int _libssh2_hmac_sha256_init(libssh2_hmac_ctx *ctx,
 {
     int ret = _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacSHA256,
                                         SHA256_DIGEST_LENGTH,
-                                        key, (ULONG) keylen);
+                                        key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -758,7 +758,7 @@ int _libssh2_hmac_sha512_init(libssh2_hmac_ctx *ctx,
 {
     int ret = _libssh2_wincng_hash_init(ctx, _libssh2_wincng.hAlgHmacSHA512,
                                         SHA512_DIGEST_LENGTH,
-                                        key, (ULONG) keylen);
+                                        key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }


### PR DESCRIPTION
- reflow a few lines.
- drop space between cast and value. To match majority of code.
- drop space between `*` and variable in declarations and argument
  lists. To match majority of code.

---

https://github.com/libssh2/libssh2/pull/1899/files?w=1
