### PR TITLE
vms: misc fixes in `man2help.c`

### DIFF
--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -491,7 +491,7 @@ void print_help(void)
 }
 /*--------------------------------------------*/
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
     int     status;
     int     i, j;

--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -546,7 +546,7 @@ int main(int argc, char **argv)
     }
 
 #if 0
-    fprintf(stderr,"manfile: %s, helpfile: %s, append: %d, base_level : %d\n",
+    fprintf(stderr, "manfile: %s, helpfile: %s, append: %d, base_level : %d\n",
             manfile, helpfile, append, base_level);
 #endif
 

--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -46,7 +46,7 @@ fpcopy(char *output, char *input, int len)
 }
 
 /*----------------------------------------------------------*/
-/* give part of ilename in partname. See code for proper
+/* give part of filename in partname. See code for proper
    value of i ( 0 = node, 1 = dev, 2 = dir, 3 = name etc.
 */
 

--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -433,10 +433,10 @@ int convertman(char *filespec, FILE *hlp, int base_level, int add_parentheses)
         }
     }
 
-    /*
-     printf("read %d from %s, written %d to helpfile, return_status = %d\n",
-        len, filespec, strlen(uit), return_status);
-    */
+#if 0
+    printf("read %d from %s, written %d to helpfile, return_status = %d\n",
+           len, filespec, strlen(uit), return_status);
+#endif
 
     free(in);
     free(uit);
@@ -545,10 +545,10 @@ int main(int argc, char **argv)
         }
     }
 
-    /*
+#if 0
     fprintf(stderr,"manfile: %s, helpfile: %s, append: %d, base_level : %d\n",
             manfile, helpfile, append, base_level);
-    */
+#endif
 
     status = convertmans(manfile, helpfile, base_level, append,
                          add_parentheses);

--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -438,8 +438,8 @@ int convertman(char *filespec, FILE *hlp, int base_level, int add_parentheses)
         len, filespec, strlen(uit), return_status);
     */
 
-    free(m);
-    free(h);
+    free(in);
+    free(uit);
 
     return 1;
 }


### PR DESCRIPTION
- fix to free the correct pointers in `convertman()`.
- declare `main()` to return `int`.
- fix typo in comment.
- replace commented code with `#if 0`.

Spotted by GitHub Code Quality
