### PR TITLE
packet: fix bounds checks

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -85,7 +85,7 @@ packet_queue_listener(LIBSSH2_SESSION *session, unsigned char *data,
         buf.dataptr = buf.data;
         buf.len = datalen;
 
-        if(datalen < offset + 12) {
+        if(datalen < offset + 12) {  /* 3 * 4-byte */
             return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                   "Unexpected packet size");
         }

--- a/src/packet.c
+++ b/src/packet.c
@@ -85,7 +85,7 @@ packet_queue_listener(LIBSSH2_SESSION *session, unsigned char *data,
         buf.dataptr = buf.data;
         buf.len = datalen;
 
-        if(datalen < offset) {
+        if(datalen < offset + 12) {
             return _libssh2_error(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                   "Unexpected packet size");
         }
@@ -298,7 +298,7 @@ packet_x11_open(LIBSSH2_SESSION *session, unsigned char *data,
         buf.dataptr = buf.data;
         buf.len = datalen;
 
-        if(datalen < offset) {
+        if(datalen < offset + 12) {
             _libssh2_error(session, LIBSSH2_ERROR_INVAL,
                            "unexpected data length");
             failure_code = SSH_OPEN_CONNECT_FAILED;

--- a/src/packet.c
+++ b/src/packet.c
@@ -298,7 +298,7 @@ packet_x11_open(LIBSSH2_SESSION *session, unsigned char *data,
         buf.dataptr = buf.data;
         buf.len = datalen;
 
-        if(datalen < offset + 12) {
+        if(datalen < offset + 12) {  /* 3 * 4-byte */
             _libssh2_error(session, LIBSSH2_ERROR_INVAL,
                            "unexpected data length");
             failure_code = SSH_OPEN_CONNECT_FAILED;


### PR DESCRIPTION
The bounds check in packet_queue_listener() and packet_x11_open() only
verifies that datalen >= offset, but both functions read three additional
uint32 fields (12 bytes) immediately after advancing the buffer pointer.

Update the check to datalen < offset + 12 to account for these reads,
following the same pattern applied in #1895 for packet_authagent_open().

Reported via libssh2-security@haxx.se, discussed with @bagder and Will.

Follow-up to 456b9b9473087161247b8ecb5d6c75b7833f63d0 #1895
