### PR TITLE
src: replace typedef structs with direct struct types

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -118,18 +118,18 @@ typedef enum {
     agent_NB_state_response_received
 } agent_nonblocking_states;
 
-typedef struct agent_transaction_ctx {
+struct agent_transaction_ctx {
     unsigned char *request;
     size_t request_len;
     unsigned char *response;
     size_t response_len;
     agent_nonblocking_states state;
     size_t send_recv_total;
-} *agent_transaction_ctx_t;
+};
 
 typedef int (*agent_connect_func)(LIBSSH2_AGENT *agent);
 typedef int (*agent_transact_func)(LIBSSH2_AGENT *agent,
-                                   agent_transaction_ctx_t transctx);
+                                   struct agent_transaction_ctx *transctx);
 typedef int (*agent_disconnect_func)(LIBSSH2_AGENT *agent);
 
 struct agent_publickey {
@@ -376,8 +376,8 @@ win32_openssh_recv_all(LIBSSH2_AGENT *agent, void *buffer, size_t length,
     WIN32_RECV_SEND_ALL(ReadFile, agent, buffer, length, send_recv_total)
 }
 
-static int
-agent_transact_openssh(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
+static int agent_transact_openssh(LIBSSH2_AGENT *agent,
+                                  struct agent_transaction_ctx *transctx)
 {
     unsigned char buf[4];
     int rc;
@@ -548,8 +548,8 @@ static ssize_t _recv_all(LIBSSH2_RECV_FUNC(func), libssh2_socket_t socket,
                   flags, abstract);
 }
 
-static int
-agent_transact_unix(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
+static int agent_transact_unix(LIBSSH2_AGENT *agent,
+                               struct agent_transaction_ctx *transctx)
 {
     unsigned char buf[4];
     int rc;
@@ -661,8 +661,8 @@ agent_connect_pageant(LIBSSH2_AGENT *agent)
     return LIBSSH2_ERROR_NONE;
 }
 
-static int
-agent_transact_pageant(LIBSSH2_AGENT *agent, agent_transaction_ctx_t transctx)
+static int agent_transact_pageant(LIBSSH2_AGENT *agent,
+                                  struct agent_transaction_ctx *transctx)
 {
     HWND hwnd;
     char mapname[23];
@@ -768,7 +768,7 @@ agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
            const unsigned char *data, size_t data_len, void **abstract)
 {
     LIBSSH2_AGENT *agent = (LIBSSH2_AGENT *)(*abstract);
-    agent_transaction_ctx_t transctx = &agent->transctx;
+    struct agent_transaction_ctx *transctx = &agent->transctx;
     struct agent_publickey *identity = agent->identity;
     ssize_t len = 1 + 4 + identity->external.blob_len + 4 + data_len + 4;
     ssize_t method_len;
@@ -928,7 +928,7 @@ error:
 static int
 agent_list_identities(LIBSSH2_AGENT *agent)
 {
-    agent_transaction_ctx_t transctx = &agent->transctx;
+    struct agent_transaction_ctx *transctx = &agent->transctx;
     ssize_t len, num_identities;
     unsigned char *s;
     int rc;

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -53,10 +53,9 @@
 #define BCRYPT_BLOCKS 8
 #define BCRYPT_HASHSIZE (BCRYPT_BLOCKS * 4)
 
-static void
-bcrypt_hash(uint8_t *sha2pass, uint8_t *sha2salt, uint8_t *out)
+static void bcrypt_hash(uint8_t *sha2pass, uint8_t *sha2salt, uint8_t *out)
 {
-    blf_ctx state;
+    struct blf_ctx state;
     uint8_t ciphertext[BCRYPT_HASHSIZE] = {
         'O', 'x', 'y', 'c', 'h', 'r', 'o', 'm', 'a', 't', 'i', 'c',
         'B', 'l', 'o', 'w', 'f', 'i', 's', 'h',
@@ -97,10 +96,9 @@ bcrypt_hash(uint8_t *sha2pass, uint8_t *sha2salt, uint8_t *out)
     _libssh2_explicit_zero(&state, sizeof(state));
 }
 
-static int
-bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt,
-             size_t saltlen,
-             uint8_t *key, size_t keylen, unsigned int rounds)
+static int bcrypt_pbkdf(const char *pass, size_t passlen,
+                        const uint8_t *salt, size_t saltlen,
+                        uint8_t *key, size_t keylen, unsigned int rounds)
 {
     uint8_t sha2pass[SHA512_DIGEST_LENGTH];
     uint8_t sha2salt[SHA512_DIGEST_LENGTH];

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -434,8 +434,8 @@ static uint32_t Blowfish_stream2word(const uint8_t *data, uint16_t databytes,
     return temp;
 }
 
-static void
-Blowfish_expand0state(struct blf_ctx *c, const uint8_t *key, uint16_t keybytes)
+static void Blowfish_expand0state(struct blf_ctx *c,
+                                  const uint8_t *key, uint16_t keybytes)
 {
     int i;
     int k;

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -58,15 +58,15 @@
  * of the key affect all cipherbits.
  */
 
-#define BLF_N   16                       /* Number of Subkeys */
-#define BLF_MAXKEYLEN   ((BLF_N - 2)*4)  /* 448 bits */
-#define BLF_MAXUTILIZED ((BLF_N + 2)*4)  /* 576 bits */
+#define BLF_N   16                         /* Number of Subkeys */
+#define BLF_MAXKEYLEN   ((BLF_N - 2) * 4)  /* 448 bits */
+#define BLF_MAXUTILIZED ((BLF_N + 2) * 4)  /* 576 bits */
 
 /* Blowfish context */
-typedef struct BlowfishContext {
+struct blf_ctx {
     uint32_t S[4][256];     /* S-Boxes */
     uint32_t P[BLF_N + 2];  /* Subkeys */
-} blf_ctx;
+};
 
 /* Raw access to customized Blowfish
  *      blf_key is just:
@@ -77,15 +77,15 @@ typedef struct BlowfishContext {
 /* Standard Blowfish */
 
 /* Function for Feistel Networks */
-#define F(s, x) ((((s)[        (((x) >> 24) & 0xFF)]      \
-                 + (s)[0x100 + (((x) >> 16) & 0xFF)])     \
-                 ^ (s)[0x200 + (((x) >>  8) & 0xFF)])     \
-                 + (s)[0x300 + ( (x)        & 0xFF)])
+#define F(s, x)                           \
+    ((((s)[        (((x) >> 24) & 0xFF)]  \
+     + (s)[0x100 + (((x) >> 16) & 0xFF)]) \
+     ^ (s)[0x200 + (((x) >>  8) & 0xFF)]) \
+     + (s)[0x300 + ( (x)        & 0xFF)])
 
 #define BLFRND(s, p, i, j, n)  ((i) ^= F(s,j) ^ (p)[n])
 
-static void
-Blowfish_encipher(blf_ctx *c, uint32_t *xl, uint32_t *xr)
+static void Blowfish_encipher(struct blf_ctx *c, uint32_t *xl, uint32_t *xr)
 {
     uint32_t Xl;
     uint32_t Xr;
@@ -110,8 +110,7 @@ Blowfish_encipher(blf_ctx *c, uint32_t *xl, uint32_t *xr)
 }
 
 #ifdef _DEBUG_BLOWFISH
-static void
-Blowfish_decipher(blf_ctx *c, uint32_t *xl, uint32_t *xr)
+static void Blowfish_decipher(struct blf_ctx *c, uint32_t *xl, uint32_t *xr)
 {
     uint32_t Xl;
     uint32_t Xr;
@@ -136,12 +135,11 @@ Blowfish_decipher(blf_ctx *c, uint32_t *xl, uint32_t *xr)
 }
 #endif
 
-static void
-Blowfish_initstate(blf_ctx *c)
+static void Blowfish_initstate(struct blf_ctx *c)
 {
     /* P-box and S-box tables initialized with digits of Pi */
 
-    static const blf_ctx initstate =
+    static const struct blf_ctx initstate =
         { {
                 {
                     0xd1310ba6, 0x98dfb5ac, 0x2ffd72db, 0xd01adfb7,
@@ -416,9 +414,8 @@ Blowfish_initstate(blf_ctx *c)
 }
 
 /* Converts uint8_t to uint32_t */
-static uint32_t
-Blowfish_stream2word(const uint8_t *data, uint16_t databytes,
-                     uint16_t *current)
+static uint32_t Blowfish_stream2word(const uint8_t *data, uint16_t databytes,
+                                     uint16_t *current)
 {
     uint8_t i;
     uint16_t j;
@@ -438,7 +435,7 @@ Blowfish_stream2word(const uint8_t *data, uint16_t databytes,
 }
 
 static void
-Blowfish_expand0state(blf_ctx *c, const uint8_t *key, uint16_t keybytes)
+Blowfish_expand0state(struct blf_ctx *c, const uint8_t *key, uint16_t keybytes)
 {
     int i;
     int k;
@@ -474,9 +471,9 @@ Blowfish_expand0state(blf_ctx *c, const uint8_t *key, uint16_t keybytes)
     }
 }
 
-static void
-Blowfish_expandstate(blf_ctx *c, const uint8_t *data, uint16_t databytes,
-                     const uint8_t *key, uint16_t keybytes)
+static void Blowfish_expandstate(struct blf_ctx *c,
+                                 const uint8_t *data, uint16_t databytes,
+                                 const uint8_t *key, uint16_t keybytes)
 {
     int i;
     int k;
@@ -517,8 +514,7 @@ Blowfish_expandstate(blf_ctx *c, const uint8_t *data, uint16_t databytes,
 }
 
 #ifdef _DEBUG_BLOWFISH
-static void
-blf_key(blf_ctx *c, const uint8_t *k, uint16_t len)
+static void blf_key(struct blf_ctx *c, const uint8_t *k, uint16_t len)
 {
     /* Initialize S-boxes and subkeys with Pi */
     Blowfish_initstate(c);
@@ -528,8 +524,7 @@ blf_key(blf_ctx *c, const uint8_t *k, uint16_t len)
 }
 #endif
 
-static void
-blf_enc(blf_ctx *c, uint32_t *data, uint16_t blocks)
+static void blf_enc(struct blf_ctx *c, uint32_t *data, uint16_t blocks)
 {
     uint32_t *d;
     uint16_t i;
@@ -542,8 +537,7 @@ blf_enc(blf_ctx *c, uint32_t *data, uint16_t blocks)
 }
 
 #ifdef _DEBUG_BLOWFISH
-static void
-blf_dec(blf_ctx *c, uint32_t *data, uint16_t blocks)
+static void blf_dec(struct blf_ctx *c, uint32_t *data, uint16_t blocks)
 {
     uint32_t *d;
     uint16_t i;
@@ -555,20 +549,19 @@ blf_dec(blf_ctx *c, uint32_t *data, uint16_t blocks)
     }
 }
 
-static void
-report(uint32_t data[], uint16_t len)
+static void report(uint32_t data[], uint16_t len)
 {
     int i;
     for(i = 0; i < len; i += 2)
         printf("Block %d: 0x%08lx 0x%08lx.\n",
                i / 2, (unsigned long)data[i], (unsigned long)data[i + 1]);
 }
-int
-main(void)
+
+int main(void)
 {
-    blf_ctx c;
-    char    key[] = "AAAAA";
-    char    key2[] = "abcdefghijklmnopqrstuvwxyz";
+    struct blf_ctx c;
+    char key[] = "AAAAA";
+    char key2[] = "abcdefghijklmnopqrstuvwxyz";
 
     uint32_t data[10];
     uint32_t data2[] =

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -39,13 +39,13 @@
  * Bruce Schneier.
  */
 
-#if defined(LIBSSH2_BCRYPT_PBKDF_C) || defined(_DEBUG_BLOWFISH)
+#if defined(LIBSSH2_BCRYPT_PBKDF_C) || defined(DEBUG_BLOWFISH)
 
 #if !defined(HAVE_BCRYPT_PBKDF) && (!defined(HAVE_BLOWFISH_INITSTATE) || \
                                     !defined(HAVE_BLOWFISH_EXPAND0STATE) || \
                                     !defined(HAVE_BLF_ENC))
 
-#ifdef _DEBUG_BLOWFISH
+#ifdef DEBUG_BLOWFISH
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
@@ -109,7 +109,7 @@ static void Blowfish_encipher(struct blf_ctx *c, uint32_t *xl, uint32_t *xr)
     *xr = Xl;
 }
 
-#ifdef _DEBUG_BLOWFISH
+#ifdef DEBUG_BLOWFISH
 static void Blowfish_decipher(struct blf_ctx *c, uint32_t *xl, uint32_t *xr)
 {
     uint32_t Xl;
@@ -513,7 +513,7 @@ static void Blowfish_expandstate(struct blf_ctx *c,
     }
 }
 
-#ifdef _DEBUG_BLOWFISH
+#ifdef DEBUG_BLOWFISH
 static void blf_key(struct blf_ctx *c, const uint8_t *k, uint16_t len)
 {
     /* Initialize S-boxes and subkeys with Pi */
@@ -536,7 +536,7 @@ static void blf_enc(struct blf_ctx *c, uint32_t *data, uint16_t blocks)
     }
 }
 
-#ifdef _DEBUG_BLOWFISH
+#ifdef DEBUG_BLOWFISH
 static void blf_dec(struct blf_ctx *c, uint32_t *data, uint16_t blocks)
 {
     uint32_t *d;
@@ -598,4 +598,4 @@ int main(void)
           !defined(HAVE_BLOWFISH_EXPAND0STATE) || \
           '!defined(HAVE_BLF_ENC)) */
 
-#endif /* defined(LIBSSH2_BCRYPT_PBKDF_C) || defined(_DEBUG_BLOWFISH) */
+#endif /* defined(LIBSSH2_BCRYPT_PBKDF_C) || defined(DEBUG_BLOWFISH) */

--- a/src/kex.c
+++ b/src/kex.c
@@ -3547,10 +3547,9 @@ static const LIBSSH2_KEX_METHOD *libssh2_kex_methods[] = {
     NULL
 };
 
-typedef struct _LIBSSH2_COMMON_METHOD
-{
+struct common_method {
     const char *name;
-} LIBSSH2_COMMON_METHOD;
+};
 
 /* kex_method_strlen
  *
@@ -3560,7 +3559,7 @@ typedef struct _LIBSSH2_COMMON_METHOD
  * Another sign of bad coding practices gone mad.  Pretend you don't see this.
  */
 static size_t
-kex_method_strlen(const LIBSSH2_COMMON_METHOD **method)
+kex_method_strlen(const struct common_method **method)
 {
     size_t len = 0;
 
@@ -3581,7 +3580,7 @@ kex_method_strlen(const LIBSSH2_COMMON_METHOD **method)
  */
 static uint32_t
 kex_method_list(unsigned char *buf, uint32_t list_strlen,
-                const LIBSSH2_COMMON_METHOD **method)
+                const struct common_method **method)
 {
     _libssh2_htonu32(buf, list_strlen);
     buf += 4;
@@ -3603,20 +3602,20 @@ kex_method_list(unsigned char *buf, uint32_t list_strlen,
 
 #define LIBSSH2_METHOD_PREFS_LEN(prefvar, defaultvar)           \
     (uint32_t)((prefvar) ? strlen(prefvar) :                    \
-        kex_method_strlen((const LIBSSH2_COMMON_METHOD**)(defaultvar)))
+        kex_method_strlen((const struct common_method**)(defaultvar)))
 
-#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)        \
-    do {                                                                      \
-        if(prefvar) {                                                         \
-            _libssh2_htonu32(buf, prefvarlen);                                \
-            (buf) += 4;                                                       \
-            memcpy(buf, prefvar, prefvarlen);                                 \
-            (buf) += (prefvarlen);                                            \
-        }                                                                     \
-        else {                                                                \
-            (buf) += kex_method_list(buf, prefvarlen,                         \
-                                (const LIBSSH2_COMMON_METHOD**)(defaultvar)); \
-        }                                                                     \
+#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)       \
+    do {                                                                     \
+        if(prefvar) {                                                        \
+            _libssh2_htonu32(buf, prefvarlen);                               \
+            (buf) += 4;                                                      \
+            memcpy(buf, prefvar, prefvarlen);                                \
+            (buf) += (prefvarlen);                                           \
+        }                                                                    \
+        else {                                                               \
+            (buf) += kex_method_list(buf, prefvarlen,                        \
+                                (const struct common_method**)(defaultvar)); \
+        }                                                                    \
     } while(0)
 
 /* kexinit
@@ -3850,9 +3849,9 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
 }
 
 /* kex_get_method_by_name */
-static const LIBSSH2_COMMON_METHOD *
+static const struct common_method *
 kex_get_method_by_name(const char *name, size_t name_len,
-                       const LIBSSH2_COMMON_METHOD **methodlist)
+                       const struct common_method **methodlist)
 {
     while(*methodlist) {
         if((strlen((*methodlist)->name) == name_len) &&
@@ -3884,7 +3883,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session,
                 const LIBSSH2_HOSTKEY_METHOD *method =
                     (const LIBSSH2_HOSTKEY_METHOD *)
                     kex_get_method_by_name((char *)s, method_len,
-                                           (const LIBSSH2_COMMON_METHOD **)
+                                           (const struct common_method **)
                                            hostkeyp);
 
                 if(!method) {
@@ -3965,7 +3964,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
             if(q) {
                 const LIBSSH2_KEX_METHOD *method = (const LIBSSH2_KEX_METHOD *)
                     kex_get_method_by_name((char *)s, method_len,
-                                           (const LIBSSH2_COMMON_METHOD **)
+                                           (const struct common_method **)
                                            kexp);
 
                 if(!method) {
@@ -4043,7 +4042,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
                 const LIBSSH2_CRYPT_METHOD *method =
                     (const LIBSSH2_CRYPT_METHOD *)
                     kex_get_method_by_name((char *)s, method_len,
-                                           (const LIBSSH2_COMMON_METHOD **)
+                                           (const struct common_method **)
                                            cryptp);
 
                 if(!method) {
@@ -4104,7 +4103,7 @@ static int kex_agree_mac(LIBSSH2_SESSION *session,
             if(_libssh2_kex_agree_instr(mac, mac_len, s, method_len)) {
                 const struct mac_method *method = (const struct mac_method *)
                     kex_get_method_by_name((char *)s, method_len,
-                                           (const LIBSSH2_COMMON_METHOD**)
+                                           (const struct common_method**)
                                            macp);
 
                 if(!method) {
@@ -4157,7 +4156,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
                 const LIBSSH2_COMP_METHOD *method =
                     (const LIBSSH2_COMP_METHOD *)
                     kex_get_method_by_name((char *)s, method_len,
-                                           (const LIBSSH2_COMMON_METHOD **)
+                                           (const struct common_method **)
                                            compp);
 
                 if(!method) {
@@ -4455,47 +4454,47 @@ libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
     char **prefvar, *s, *newprefs;
     char *tmpprefs = NULL;
     size_t prefs_len = strlen(prefs);
-    const LIBSSH2_COMMON_METHOD **mlist;
+    const struct common_method **mlist;
 
     switch(method_type) {
     case LIBSSH2_METHOD_KEX:
         prefvar = &session->kex_prefs;
-        mlist = (const LIBSSH2_COMMON_METHOD **)libssh2_kex_methods;
+        mlist = (const struct common_method **)libssh2_kex_methods;
         break;
 
     case LIBSSH2_METHOD_HOSTKEY:
         prefvar = &session->hostkey_prefs;
-        mlist = (const LIBSSH2_COMMON_METHOD **)libssh2_hostkey_methods();
+        mlist = (const struct common_method **)libssh2_hostkey_methods();
         break;
 
     case LIBSSH2_METHOD_CRYPT_CS:
         prefvar = &session->local.crypt_prefs;
-        mlist = (const LIBSSH2_COMMON_METHOD **)libssh2_crypt_methods();
+        mlist = (const struct common_method **)libssh2_crypt_methods();
         break;
 
     case LIBSSH2_METHOD_CRYPT_SC:
         prefvar = &session->remote.crypt_prefs;
-        mlist = (const LIBSSH2_COMMON_METHOD **)libssh2_crypt_methods();
+        mlist = (const struct common_method **)libssh2_crypt_methods();
         break;
 
     case LIBSSH2_METHOD_MAC_CS:
         prefvar = &session->local.mac_prefs;
-        mlist = (const LIBSSH2_COMMON_METHOD **)_libssh2_mac_methods();
+        mlist = (const struct common_method **)_libssh2_mac_methods();
         break;
 
     case LIBSSH2_METHOD_MAC_SC:
         prefvar = &session->remote.mac_prefs;
-        mlist = (const LIBSSH2_COMMON_METHOD **)_libssh2_mac_methods();
+        mlist = (const struct common_method **)_libssh2_mac_methods();
         break;
 
     case LIBSSH2_METHOD_COMP_CS:
         prefvar = &session->local.comp_prefs;
-        mlist = (const LIBSSH2_COMMON_METHOD **)_libssh2_comp_methods(session);
+        mlist = (const struct common_method **)_libssh2_comp_methods(session);
         break;
 
     case LIBSSH2_METHOD_COMP_SC:
         prefvar = &session->remote.comp_prefs;
-        mlist = (const LIBSSH2_COMMON_METHOD **)_libssh2_comp_methods(session);
+        mlist = (const struct common_method **)_libssh2_comp_methods(session);
         break;
 
     case LIBSSH2_METHOD_LANG_CS:
@@ -4604,7 +4603,7 @@ LIBSSH2_API int libssh2_session_supported_algs(LIBSSH2_SESSION* session,
     unsigned int i;
     unsigned int j;
     unsigned int ialg;
-    const LIBSSH2_COMMON_METHOD **mlist;
+    const struct common_method **mlist;
 
     /* to prevent coredumps due to dereferencing of NULL */
     if(!algs)
@@ -4613,26 +4612,26 @@ LIBSSH2_API int libssh2_session_supported_algs(LIBSSH2_SESSION* session,
 
     switch(method_type) {
     case LIBSSH2_METHOD_KEX:
-        mlist = (const LIBSSH2_COMMON_METHOD **)libssh2_kex_methods;
+        mlist = (const struct common_method **)libssh2_kex_methods;
         break;
 
     case LIBSSH2_METHOD_HOSTKEY:
-        mlist = (const LIBSSH2_COMMON_METHOD **)libssh2_hostkey_methods();
+        mlist = (const struct common_method **)libssh2_hostkey_methods();
         break;
 
     case LIBSSH2_METHOD_CRYPT_CS:
     case LIBSSH2_METHOD_CRYPT_SC:
-        mlist = (const LIBSSH2_COMMON_METHOD **)libssh2_crypt_methods();
+        mlist = (const struct common_method **)libssh2_crypt_methods();
         break;
 
     case LIBSSH2_METHOD_MAC_CS:
     case LIBSSH2_METHOD_MAC_SC:
-        mlist = (const LIBSSH2_COMMON_METHOD **)_libssh2_mac_methods();
+        mlist = (const struct common_method **)_libssh2_mac_methods();
         break;
 
     case LIBSSH2_METHOD_COMP_CS:
     case LIBSSH2_METHOD_COMP_SC:
-        mlist = (const LIBSSH2_COMMON_METHOD **)_libssh2_comp_methods(session);
+        mlist = (const struct common_method **)_libssh2_comp_methods(session);
         break;
 
     case LIBSSH2_METHOD_SIGN_ALGO:

--- a/src/kex.c
+++ b/src/kex.c
@@ -4081,8 +4081,8 @@ static int kex_agree_mac(LIBSSH2_SESSION *session,
                          libssh2_endpoint_data *endpoint, unsigned char *mac,
                          size_t mac_len)
 {
-    const LIBSSH2_MAC_METHOD **macp = _libssh2_mac_methods();
-    const LIBSSH2_MAC_METHOD *override;
+    const struct mac_method **macp = _libssh2_mac_methods();
+    const struct mac_method *override;
     unsigned char *s;
     (void)session;
 
@@ -4102,9 +4102,9 @@ static int kex_agree_mac(LIBSSH2_SESSION *session,
             size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
 
             if(_libssh2_kex_agree_instr(mac, mac_len, s, method_len)) {
-                const LIBSSH2_MAC_METHOD *method = (const LIBSSH2_MAC_METHOD *)
+                const struct mac_method *method = (const struct mac_method *)
                     kex_get_method_by_name((char *)s, method_len,
-                                           (const LIBSSH2_COMMON_METHOD **)
+                                           (const LIBSSH2_COMMON_METHOD**)
                                            macp);
 
                 if(!method) {

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -595,7 +595,7 @@ typedef struct _libssh2_endpoint_data
     const LIBSSH2_CRYPT_METHOD *crypt;
     void *crypt_abstract;
 
-    const struct _LIBSSH2_MAC_METHOD *mac;
+    const struct mac_method *mac;
     uint32_t seqno;
     void *mac_abstract;
 

--- a/src/mac.c
+++ b/src/mac.c
@@ -64,7 +64,7 @@ mac_none_MAC(LIBSSH2_SESSION *session, unsigned char *buf,
     return 0;
 }
 
-static LIBSSH2_MAC_METHOD mac_method_none = {
+static const struct mac_method mac_method_none = {
     "none",
     0,
     0,
@@ -136,7 +136,7 @@ mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION *session,
     return !res;
 }
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_sha2_512 = {
+static const struct mac_method mac_method_hmac_sha2_512 = {
     "hmac-sha2-512",
     64,
     64,
@@ -146,7 +146,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_sha2_512 = {
     0
 };
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_sha2_512_etm = {
+static const struct mac_method mac_method_hmac_sha2_512_etm = {
     "hmac-sha2-512-etm@openssh.com",
     64,
     64,
@@ -191,7 +191,7 @@ mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION *session,
     return !res;
 }
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_sha2_256 = {
+static const struct mac_method mac_method_hmac_sha2_256 = {
     "hmac-sha2-256",
     32,
     32,
@@ -201,7 +201,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_sha2_256 = {
     0
 };
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_sha2_256_etm = {
+static const struct mac_method mac_method_hmac_sha2_256_etm = {
     "hmac-sha2-256-etm@openssh.com",
     32,
     32,
@@ -245,7 +245,7 @@ mac_method_hmac_sha1_hash(LIBSSH2_SESSION *session,
     return !res;
 }
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_sha1 = {
+static const struct mac_method mac_method_hmac_sha1 = {
     "hmac-sha1",
     20,
     20,
@@ -255,7 +255,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_sha1 = {
     0
 };
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_sha1_etm = {
+static const struct mac_method mac_method_hmac_sha1_etm = {
     "hmac-sha1-etm@openssh.com",
     20,
     20,
@@ -286,7 +286,7 @@ mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_sha1_96 = {
+static const struct mac_method mac_method_hmac_sha1_96 = {
     "hmac-sha1-96",
     12,
     20,
@@ -329,7 +329,7 @@ mac_method_hmac_md5_hash(LIBSSH2_SESSION *session, unsigned char *buf,
     return !res;
 }
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_md5 = {
+static const struct mac_method mac_method_hmac_md5 = {
     "hmac-md5",
     16,
     16,
@@ -360,7 +360,7 @@ mac_method_hmac_md5_96_hash(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_md5_96 = {
+static const struct mac_method mac_method_hmac_md5_96 = {
     "hmac-md5-96",
     12,
     16,
@@ -405,7 +405,7 @@ mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION *session,
     return !res;
 }
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_ripemd160 = {
+static const struct mac_method mac_method_hmac_ripemd160 = {
     "hmac-ripemd160",
     20,
     20,
@@ -415,7 +415,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_ripemd160 = {
     0
 };
 
-static const LIBSSH2_MAC_METHOD mac_method_hmac_ripemd160_openssh_com = {
+static const struct mac_method mac_method_hmac_ripemd160_openssh_com = {
     "hmac-ripemd160@openssh.com",
     20,
     20,
@@ -426,7 +426,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_ripemd160_openssh_com = {
 };
 #endif /* LIBSSH2_HMAC_RIPEMD */
 
-static const LIBSSH2_MAC_METHOD *mac_methods[] = {
+static const struct mac_method *mac_methods[] = {
 #if LIBSSH2_HMAC_SHA256
     &mac_method_hmac_sha2_256,
     &mac_method_hmac_sha2_256_etm,
@@ -452,7 +452,7 @@ static const LIBSSH2_MAC_METHOD *mac_methods[] = {
     NULL
 };
 
-const LIBSSH2_MAC_METHOD **
+const struct mac_method**
 _libssh2_mac_methods(void)
 {
     return mac_methods;
@@ -500,7 +500,7 @@ mac_method_none_dtor(LIBSSH2_SESSION *session, void **abstract)
 /* Stub for aes256-gcm@openssh.com crypto type, which has an integrated
    HMAC method. This must not be added to mac_methods[] since it cannot be
    negotiated separately. */
-static const LIBSSH2_MAC_METHOD mac_method_hmac_aesgcm = {
+static const struct mac_method mac_method_hmac_aesgcm = {
     "INTEGRATED-AES-GCM",  /* made up name for display only */
     16,
     16,
@@ -513,7 +513,7 @@ static const LIBSSH2_MAC_METHOD mac_method_hmac_aesgcm = {
 
 /* See if the negotiated crypto method has its own authentication scheme that
  * obviates the need for a separate negotiated hmac method */
-const LIBSSH2_MAC_METHOD *
+const struct mac_method *
 _libssh2_mac_override(const LIBSSH2_CRYPT_METHOD *crypt)
 {
 #if LIBSSH2_AES_GCM

--- a/src/mac.h
+++ b/src/mac.h
@@ -41,8 +41,7 @@
 
 #include "libssh2_priv.h"
 
-struct _LIBSSH2_MAC_METHOD
-{
+struct mac_method {
     const char *name;
 
     /* The length of a given MAC packet */
@@ -63,10 +62,8 @@ struct _LIBSSH2_MAC_METHOD
     int etm; /* encrypt-then-mac */
 };
 
-typedef struct _LIBSSH2_MAC_METHOD LIBSSH2_MAC_METHOD;
-
-const LIBSSH2_MAC_METHOD **_libssh2_mac_methods(void);
-const LIBSSH2_MAC_METHOD *_libssh2_mac_override(
-        const LIBSSH2_CRYPT_METHOD *crypt);
+const struct mac_method **_libssh2_mac_methods(void);
+const struct mac_method *_libssh2_mac_override(
+    const LIBSSH2_CRYPT_METHOD *crypt);
 
 #endif /* LIBSSH2_MAC_H */

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -50,16 +50,15 @@
 #define LIBSSH2_PUBLICKEY_RESPONSE_VERSION      1
 #define LIBSSH2_PUBLICKEY_RESPONSE_PUBLICKEY    2
 
-typedef struct _LIBSSH2_PUBLICKEY_CODE_LIST
-{
+struct publickey_code_list {
     const char *name;
     int name_len;
     int code;
-} LIBSSH2_PUBLICKEY_CODE_LIST;
+};
 
 #define STRLEN(s) s, sizeof(s) - 1
 
-static const LIBSSH2_PUBLICKEY_CODE_LIST publickey_response_codes[] =
+static const struct publickey_code_list publickey_response_codes[] =
 {
     {STRLEN("status"), LIBSSH2_PUBLICKEY_RESPONSE_STATUS},
     {STRLEN("version"), LIBSSH2_PUBLICKEY_RESPONSE_VERSION},
@@ -80,7 +79,7 @@ static const LIBSSH2_PUBLICKEY_CODE_LIST publickey_response_codes[] =
 
 #define LIBSSH2_PUBLICKEY_STATUS_CODE_MAX       8
 
-static const LIBSSH2_PUBLICKEY_CODE_LIST publickey_status_codes[] = {
+static const struct publickey_code_list publickey_status_codes[] = {
     {STRLEN("success"), LIBSSH2_PUBLICKEY_SUCCESS},
     {STRLEN("access denied"), LIBSSH2_PUBLICKEY_ACCESS_DENIED},
     {STRLEN("storage exceeded"), LIBSSH2_PUBLICKEY_STORAGE_EXCEEDED},
@@ -195,7 +194,7 @@ publickey_response_id(unsigned char **pdata, size_t data_len)
 {
     size_t response_len;
     unsigned char *data = *pdata;
-    const LIBSSH2_PUBLICKEY_CODE_LIST *codes = publickey_response_codes;
+    const struct publickey_code_list *codes = publickey_response_codes;
 
     if(data_len < 4) {
         /* Malformed response */

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -172,7 +172,7 @@ sftp_packet_add(LIBSSH2_SFTP *sftp, unsigned char *data,
                 size_t data_len)
 {
     LIBSSH2_SESSION *session = sftp->channel->session;
-    LIBSSH2_SFTP_PACKET *packet;
+    struct sftp_packet *packet;
     uint32_t request_id;
 
     if(data_len < 5) {
@@ -243,7 +243,7 @@ sftp_packet_add(LIBSSH2_SFTP *sftp, unsigned char *data,
         return LIBSSH2_ERROR_NONE;
     }
 
-    packet = LIBSSH2_ALLOC(session, sizeof(LIBSSH2_SFTP_PACKET));
+    packet = LIBSSH2_ALLOC(session, sizeof(struct sftp_packet));
     if(!packet) {
         return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
                               "Unable to allocate datablock for SFTP packet");
@@ -463,7 +463,7 @@ sftp_packet_ask(LIBSSH2_SFTP *sftp, unsigned char packet_type,
                 size_t *data_len)
 {
     LIBSSH2_SESSION *session = sftp->channel->session;
-    LIBSSH2_SFTP_PACKET *packet = _libssh2_list_first(&sftp->packets);
+    struct sftp_packet *packet = _libssh2_list_first(&sftp->packets);
 
     if(!packet)
         return -1;
@@ -2614,12 +2614,12 @@ static void sftp_packet_flush(LIBSSH2_SFTP *sftp)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
-    LIBSSH2_SFTP_PACKET *packet = _libssh2_list_first(&sftp->packets);
+    struct sftp_packet *packet = _libssh2_list_first(&sftp->packets);
     struct sftp_zombie_requests *zombie =
         _libssh2_list_first(&sftp->zombie_requests);
 
     while(packet) {
-        LIBSSH2_SFTP_PACKET *next;
+        struct sftp_packet *next;
 
         /* check next struct in the list */
         next = _libssh2_list_next(&packet->node);

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -68,15 +68,12 @@ struct sftp_zombie_requests {
     uint32_t request_id;
 };
 
-struct _LIBSSH2_SFTP_PACKET
-{
+struct sftp_packet {
     struct list_node node;   /* linked list header */
     uint32_t request_id;
     unsigned char *data;
     size_t data_len;              /* payload size */
 };
-
-typedef struct _LIBSSH2_SFTP_PACKET LIBSSH2_SFTP_PACKET;
 
 /* Increasing from 256 to 4092 since OpenSSH doesn't honor it. */
 #define SFTP_HANDLE_MAXLEN 4092 /* according to spec, this should be 256! */

--- a/src/transport.c
+++ b/src/transport.c
@@ -184,7 +184,7 @@ fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */ )
     struct transportpacket *p = &session->packet;
     int rc;
     int compressed;
-    const LIBSSH2_MAC_METHOD *remote_mac = NULL;
+    const struct mac_method *remote_mac = NULL;
     uint32_t seq = session->remote.seqno;
 
     memset(macbuf, '\0', sizeof(macbuf));
@@ -390,7 +390,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION *session)
     int encrypted = 1; /* whether the packet is encrypted or not */
     int firstlast = FIRST_BLOCK; /* if the first or last block to decrypt */
     unsigned int auth_len = 0; /* length of the authentication tag */
-    const LIBSSH2_MAC_METHOD *remote_mac = NULL; /* The remote MAC, if used */
+    const struct mac_method *remote_mac = NULL; /* The remote MAC, if used */
 
     block[4] = 0;
 
@@ -1022,7 +1022,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
     ssize_t ret;
     int rc;
     const unsigned char *orgdata = data;
-    const LIBSSH2_MAC_METHOD *local_mac = NULL;
+    const struct mac_method *local_mac = NULL;
     unsigned int auth_len = 0;
     size_t orgdata_len = data_len;
     size_t crypt_offset, etm_crypt_offset;
@@ -1035,7 +1035,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
      * See the similar block in _libssh2_transport_read for more details.
      */
     if(session->state & LIBSSH2_STATE_EXCHANGING_KEYS &&
-        !(session->state & LIBSSH2_STATE_KEX_ACTIVE)) {
+       !(session->state & LIBSSH2_STATE_KEX_ACTIVE)) {
         /* Don't write any new packets if we're still in the middle of a key
          * exchange. */
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Redirecting into the"


### PR DESCRIPTION
To fix checksrc TYPEDEFSTRUCT warnings.

Also:
- rename `_DEBUG_BLOWFISH` to `DEBUG_BLOWFISH` to avoid
  reserved namespace.
- some reflow/formatting along the way.
