### PR TITLE
src: replace typedef structs with direct struct types (cont.)

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1670,14 +1670,14 @@ int
 _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
 {
     if(channel->flush_state == libssh2_NB_state_idle) {
-        LIBSSH2_PACKET *packet =
+        struct packet *packet =
             _libssh2_list_first(&channel->session->packets);
         channel->flush_refund_bytes = 0;
         channel->flush_flush_bytes = 0;
 
         while(packet) {
             unsigned char packet_type;
-            LIBSSH2_PACKET *next = _libssh2_list_next(&packet->node);
+            struct packet *next = _libssh2_list_next(&packet->node);
 
             if(packet->data_len < 1) {
                 packet = next;
@@ -2079,8 +2079,8 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
     size_t bytes_read = 0;
     size_t bytes_want;
     int unlink_packet;
-    LIBSSH2_PACKET *read_packet;
-    LIBSSH2_PACKET *read_next;
+    struct packet *read_packet;
+    struct packet *read_next;
 
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
                    "channel_read() wants %ld bytes from channel %u/%u "
@@ -2128,7 +2128,7 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
            makes us flush buffers prematurely and loose data.
         */
 
-        LIBSSH2_PACKET *readpkt = read_packet;
+        struct packet *readpkt = read_packet;
 
         /* In case packet gets destroyed during this iteration */
         read_next = _libssh2_list_next(&readpkt->node);
@@ -2274,8 +2274,8 @@ size_t
 _libssh2_channel_packet_data_len(LIBSSH2_CHANNEL *channel, int stream_id)
 {
     LIBSSH2_SESSION *session = channel->session;
-    LIBSSH2_PACKET *read_packet;
-    LIBSSH2_PACKET *next_packet;
+    struct packet *read_packet;
+    struct packet *next_packet;
     uint32_t read_local_id;
 
     read_packet = _libssh2_list_first(&session->packets);
@@ -2545,8 +2545,8 @@ LIBSSH2_API int
 libssh2_channel_eof(LIBSSH2_CHANNEL *channel)
 {
     LIBSSH2_SESSION *session;
-    LIBSSH2_PACKET *packet;
-    LIBSSH2_PACKET *next_packet;
+    struct packet *packet;
+    struct packet *next_packet;
 
     if(!channel)
         return LIBSSH2_ERROR_BAD_USE;
@@ -2972,8 +2972,8 @@ libssh2_channel_window_read_ex(LIBSSH2_CHANNEL *channel,
 
     if(read_avail) {
         size_t bytes_queued = 0;
-        LIBSSH2_PACKET *next_packet;
-        LIBSSH2_PACKET *packet =
+        struct packet *next_packet;
+        struct packet *packet =
             _libssh2_list_first(&channel->session->packets);
 
         while(packet) {

--- a/src/comp.c
+++ b/src/comp.c
@@ -98,7 +98,7 @@ comp_method_none_decomp(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static const LIBSSH2_COMP_METHOD comp_method_none = {
+static const struct comp_method comp_method_none = {
     "none",
     0, /* not really compressing */
     0, /* isn't used in userauth, go figure */
@@ -348,7 +348,7 @@ comp_method_zlib_dtor(LIBSSH2_SESSION *session, int compr, void **abstract)
     return 0;
 }
 
-static const LIBSSH2_COMP_METHOD comp_method_zlib = {
+static const struct comp_method comp_method_zlib = {
     "zlib",
     1, /* yes, this compresses */
     1, /* do compression during userauth */
@@ -358,7 +358,7 @@ static const LIBSSH2_COMP_METHOD comp_method_zlib = {
     comp_method_zlib_dtor,
 };
 
-static const LIBSSH2_COMP_METHOD comp_method_zlib_openssh = {
+static const struct comp_method comp_method_zlib_openssh = {
     "zlib@openssh.com",
     1, /* yes, this compresses */
     0, /* don't use compression during userauth */
@@ -371,7 +371,7 @@ static const LIBSSH2_COMP_METHOD comp_method_zlib_openssh = {
 
 /* If compression is enabled by the API, then this array is used which then
    may allow compression if zlib is available at build time */
-static const LIBSSH2_COMP_METHOD *comp_methods[] = {
+static const struct comp_method *comp_methods[] = {
 #ifdef LIBSSH2_HAVE_ZLIB
     &comp_method_zlib,
     &comp_method_zlib_openssh,
@@ -381,12 +381,12 @@ static const LIBSSH2_COMP_METHOD *comp_methods[] = {
 };
 
 /* If compression is disabled by the API, then this array is used */
-static const LIBSSH2_COMP_METHOD *no_comp_methods[] = {
+static const struct comp_method *no_comp_methods[] = {
     &comp_method_none,
     NULL
 };
 
-const LIBSSH2_COMP_METHOD **
+const struct comp_method **
 _libssh2_comp_methods(LIBSSH2_SESSION *session)
 {
     if(session->flag.compress)

--- a/src/comp.h
+++ b/src/comp.h
@@ -40,6 +40,6 @@
 
 #include "libssh2_priv.h"
 
-const LIBSSH2_COMP_METHOD **_libssh2_comp_methods(LIBSSH2_SESSION *session);
+const struct comp_method **_libssh2_comp_methods(LIBSSH2_SESSION *session);
 
 #endif /* LIBSSH2_COMP_H */

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -69,7 +69,7 @@ crypt_none_crypt(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_none = {
+static const struct crypt_method libssh2_crypt_method_none = {
     "none",
     "DEK-Info: NONE",
     8,                /* blocksize (SSH2 defines minimum blocksize as 8) */
@@ -92,7 +92,7 @@ struct crypt_ctx
 
 static int
 crypt_init(LIBSSH2_SESSION *session,
-           const LIBSSH2_CRYPT_METHOD *method,
+           const struct crypt_method *method,
            unsigned char *iv, int *free_iv,
            unsigned char *secret, int *free_secret,
            int encrypt, void **abstract)
@@ -142,7 +142,7 @@ crypt_dtor(LIBSSH2_SESSION *session, void **abstract)
 }
 
 #if LIBSSH2_AES_GCM
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes256_gcm = {
+static const struct crypt_method libssh2_crypt_method_aes256_gcm = {
     "aes256-gcm@openssh.com",
     "",
     16,                         /* blocksize */
@@ -157,7 +157,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes256_gcm = {
     _libssh2_cipher_aes256gcm
 };
 
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes128_gcm = {
+static const struct crypt_method libssh2_crypt_method_aes128_gcm = {
     "aes128-gcm@openssh.com",
     "",
     16,                         /* blocksize */
@@ -174,7 +174,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes128_gcm = {
 #endif
 
 #if LIBSSH2_AES_CTR
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes128_ctr = {
+static const struct crypt_method libssh2_crypt_method_aes128_ctr = {
     "aes128-ctr",
     "",
     16,                         /* blocksize */
@@ -189,7 +189,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes128_ctr = {
     _libssh2_cipher_aes128ctr
 };
 
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes192_ctr = {
+static const struct crypt_method libssh2_crypt_method_aes192_ctr = {
     "aes192-ctr",
     "",
     16,                         /* blocksize */
@@ -204,7 +204,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes192_ctr = {
     _libssh2_cipher_aes192ctr
 };
 
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes256_ctr = {
+static const struct crypt_method libssh2_crypt_method_aes256_ctr = {
     "aes256-ctr",
     "",
     16,                         /* blocksize */
@@ -221,7 +221,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes256_ctr = {
 #endif
 
 #if LIBSSH2_AES_CBC
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes128_cbc = {
+static const struct crypt_method libssh2_crypt_method_aes128_cbc = {
     "aes128-cbc",
     "DEK-Info: AES-128-CBC",
     16,                         /* blocksize */
@@ -236,7 +236,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes128_cbc = {
     _libssh2_cipher_aes128
 };
 
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes192_cbc = {
+static const struct crypt_method libssh2_crypt_method_aes192_cbc = {
     "aes192-cbc",
     "DEK-Info: AES-192-CBC",
     16,                         /* blocksize */
@@ -251,7 +251,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes192_cbc = {
     _libssh2_cipher_aes192
 };
 
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes256_cbc = {
+static const struct crypt_method libssh2_crypt_method_aes256_cbc = {
     "aes256-cbc",
     "DEK-Info: AES-256-CBC",
     16,                         /* blocksize */
@@ -267,7 +267,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_aes256_cbc = {
 };
 
 /* rijndael-cbc@lysator.liu.se == aes256-cbc */
-static const LIBSSH2_CRYPT_METHOD
+static const struct crypt_method
     libssh2_crypt_method_rijndael_cbc_lysator_liu_se = {
     "rijndael-cbc@lysator.liu.se",
     "DEK-Info: AES-256-CBC",
@@ -285,7 +285,7 @@ static const LIBSSH2_CRYPT_METHOD
 #endif /* LIBSSH2_AES_CBC */
 
 #if LIBSSH2_BLOWFISH
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_blowfish_cbc = {
+static const struct crypt_method libssh2_crypt_method_blowfish_cbc = {
     "blowfish-cbc",
     "",
     8,                          /* blocksize */
@@ -302,7 +302,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_blowfish_cbc = {
 #endif /* LIBSSH2_BLOWFISH */
 
 #if LIBSSH2_RC4
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_arcfour = {
+static const struct crypt_method libssh2_crypt_method_arcfour = {
     "arcfour",
     "DEK-Info: RC4",
     8,                          /* blocksize */
@@ -319,7 +319,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_arcfour = {
 
 static int
 crypt_init_arcfour128(LIBSSH2_SESSION *session,
-                      const LIBSSH2_CRYPT_METHOD *method,
+                      const struct crypt_method *method,
                       unsigned char *iv, int *free_iv,
                       unsigned char *secret, int *free_secret,
                       int encrypt, void **abstract)
@@ -341,7 +341,7 @@ crypt_init_arcfour128(LIBSSH2_SESSION *session,
     return rc;
 }
 
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_arcfour128 = {
+static const struct crypt_method libssh2_crypt_method_arcfour128 = {
     "arcfour128",
     "",
     8,                          /* blocksize */
@@ -358,7 +358,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_arcfour128 = {
 #endif /* LIBSSH2_RC4 */
 
 #if LIBSSH2_CAST
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_cast128_cbc = {
+static const struct crypt_method libssh2_crypt_method_cast128_cbc = {
     "cast128-cbc",
     "",
     8,                          /* blocksize */
@@ -375,7 +375,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_cast128_cbc = {
 #endif /* LIBSSH2_CAST */
 
 #if LIBSSH2_3DES
-static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_3des_cbc = {
+static const struct crypt_method libssh2_crypt_method_3des_cbc = {
     "3des-cbc",
     "DEK-Info: DES-EDE3-CBC",
     8,                          /* blocksize */
@@ -393,7 +393,7 @@ static const LIBSSH2_CRYPT_METHOD libssh2_crypt_method_3des_cbc = {
 
 static int
 crypt_init_chacha20_poly(LIBSSH2_SESSION *session,
-           const LIBSSH2_CRYPT_METHOD *method,
+           const struct crypt_method *method,
            unsigned char *iv, int *free_iv,
            unsigned char *secret, int *free_secret,
            int encrypt, void **abstract)
@@ -486,7 +486,7 @@ crypt_dtor_chacha20_poly(LIBSSH2_SESSION *session, void **abstract)
     return 0;
 }
 
-static const LIBSSH2_CRYPT_METHOD
+static const struct crypt_method
     libssh2_crypt_method_chacha20_poly1305_openssh = {
     "chacha20-poly1305@openssh.com",
     "",
@@ -504,7 +504,7 @@ static const LIBSSH2_CRYPT_METHOD
 
 /* These are the crypt methods that are available to be negotiated. Methods
    towards the start are chosen in preference to ones further down the list. */
-static const LIBSSH2_CRYPT_METHOD *_libssh2_crypt_methods[] = {
+static const struct crypt_method *_libssh2_crypt_methods[] = {
     &libssh2_crypt_method_chacha20_poly1305_openssh,
 #if LIBSSH2_AES_GCM
     &libssh2_crypt_method_aes256_gcm,
@@ -541,7 +541,7 @@ static const LIBSSH2_CRYPT_METHOD *_libssh2_crypt_methods[] = {
 };
 
 /* Expose to kex.c */
-const LIBSSH2_CRYPT_METHOD **
+const struct crypt_method **
 libssh2_crypt_methods(void)
 {
     return _libssh2_crypt_methods;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -437,7 +437,7 @@ hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session, void **abstract)
 
 #if LIBSSH2_RSA_SHA1
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa = {
+static const struct hostkey_method hostkey_method_ssh_rsa = {
     "ssh-rsa",
     SHA_DIGEST_LENGTH,
     hostkey_method_ssh_rsa_init,
@@ -453,7 +453,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa = {
 
 #if LIBSSH2_RSA_SHA2
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_256 = {
+static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256 = {
     "rsa-sha2-256",
     SHA256_DIGEST_LENGTH,
     hostkey_method_ssh_rsa_init,
@@ -465,7 +465,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_256 = {
     hostkey_method_ssh_rsa_dtor,
 };
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_512 = {
+static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512 = {
     "rsa-sha2-512",
     SHA512_DIGEST_LENGTH,
     hostkey_method_ssh_rsa_init,
@@ -481,7 +481,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_512 = {
 
 #if LIBSSH2_RSA_SHA1
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_cert = {
+static const struct hostkey_method hostkey_method_ssh_rsa_cert = {
     "ssh-rsa-cert-v01@openssh.com",
     SHA_DIGEST_LENGTH,
     NULL,
@@ -497,28 +497,28 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_cert = {
 
 #if LIBSSH2_RSA_SHA2
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_256_cert = {
-     "rsa-sha2-256-cert-v01@openssh.com",
-     SHA256_DIGEST_LENGTH,
-     NULL,
-     hostkey_method_ssh_rsa_initPEM,
-     hostkey_method_ssh_rsa_initPEMFromMemory,
-     NULL,
-     hostkey_method_ssh_rsa_sha2_256_signv,
-     NULL,                       /* encrypt */
-     hostkey_method_ssh_rsa_dtor,
+static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256_cert = {
+    "rsa-sha2-256-cert-v01@openssh.com",
+    SHA256_DIGEST_LENGTH,
+    NULL,
+    hostkey_method_ssh_rsa_initPEM,
+    hostkey_method_ssh_rsa_initPEMFromMemory,
+    NULL,
+    hostkey_method_ssh_rsa_sha2_256_signv,
+    NULL,                       /* encrypt */
+    hostkey_method_ssh_rsa_dtor,
 };
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_rsa_sha2_512_cert = {
-     "rsa-sha2-512-cert-v01@openssh.com",
-     SHA512_DIGEST_LENGTH,
-     NULL,
-     hostkey_method_ssh_rsa_initPEM,
-     hostkey_method_ssh_rsa_initPEMFromMemory,
-     NULL,
-     hostkey_method_ssh_rsa_sha2_512_signv,
-     NULL,                       /* encrypt */
-     hostkey_method_ssh_rsa_dtor,
+static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512_cert = {
+    "rsa-sha2-512-cert-v01@openssh.com",
+    SHA512_DIGEST_LENGTH,
+    NULL,
+    hostkey_method_ssh_rsa_initPEM,
+    hostkey_method_ssh_rsa_initPEMFromMemory,
+    NULL,
+    hostkey_method_ssh_rsa_sha2_512_signv,
+    NULL,                       /* encrypt */
+    hostkey_method_ssh_rsa_dtor,
 };
 
 #endif /* LIBSSH2_RSA_SHA2 */
@@ -750,7 +750,7 @@ hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session, void **abstract)
     return 0;
 }
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_dss = {
+static const struct hostkey_method hostkey_method_ssh_dss = {
     "ssh-dss",
     SHA_DIGEST_LENGTH,
     hostkey_method_ssh_dss_init,
@@ -1041,7 +1041,7 @@ hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session, void **abstract)
     return 0;
 }
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp256 = {
+static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256 = {
     "ecdsa-sha2-nistp256",
     SHA256_DIGEST_LENGTH,
     hostkey_method_ssh_ecdsa_init,
@@ -1053,7 +1053,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp256 = {
     hostkey_method_ssh_ecdsa_dtor,
 };
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp384 = {
+static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp384 = {
     "ecdsa-sha2-nistp384",
     SHA384_DIGEST_LENGTH,
     hostkey_method_ssh_ecdsa_init,
@@ -1065,7 +1065,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp384 = {
     hostkey_method_ssh_ecdsa_dtor,
 };
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp521 = {
+static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521 = {
     "ecdsa-sha2-nistp521",
     SHA512_DIGEST_LENGTH,
     hostkey_method_ssh_ecdsa_init,
@@ -1077,7 +1077,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp521 = {
     hostkey_method_ssh_ecdsa_dtor,
 };
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp256_cert = {
+static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256_cert = {
     "ecdsa-sha2-nistp256-cert-v01@openssh.com",
     SHA256_DIGEST_LENGTH,
     NULL,
@@ -1089,7 +1089,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp256_cert = {
     hostkey_method_ssh_ecdsa_dtor,
 };
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp384_cert = {
+static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp384_cert = {
     "ecdsa-sha2-nistp384-cert-v01@openssh.com",
     SHA384_DIGEST_LENGTH,
     NULL,
@@ -1101,7 +1101,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp384_cert = {
     hostkey_method_ssh_ecdsa_dtor,
 };
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ecdsa_ssh_nistp521_cert = {
+static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521_cert = {
     "ecdsa-sha2-nistp521-cert-v01@openssh.com",
     SHA512_DIGEST_LENGTH,
     NULL,
@@ -1310,7 +1310,7 @@ hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session, void **abstract)
     return 0;
 }
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_ed25519 = {
+static const struct hostkey_method hostkey_method_ssh_ed25519 = {
     "ssh-ed25519",
     SHA256_DIGEST_LENGTH,
     hostkey_method_ssh_ed25519_init,
@@ -1322,7 +1322,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_ed25519 = {
     hostkey_method_ssh_ed25519_dtor,
 };
 
-static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_ed25519_cert = {
+static const struct hostkey_method hostkey_method_ssh_ed25519_cert = {
     "ssh-ed25519-cert-v01@openssh.com",
     SHA256_DIGEST_LENGTH,
     hostkey_method_ssh_ed25519_init,
@@ -1341,7 +1341,7 @@ static const LIBSSH2_HOSTKEY_METHOD hostkey_method_ssh_ed25519_cert = {
  *
  * Host Key order matches OpenSSH for compatibility
  */
-static const LIBSSH2_HOSTKEY_METHOD *hostkey_methods[] = {
+static const struct hostkey_method *hostkey_methods[] = {
 #if LIBSSH2_ED25519
     &hostkey_method_ssh_ed25519_cert,
 #endif
@@ -1380,8 +1380,7 @@ static const LIBSSH2_HOSTKEY_METHOD *hostkey_methods[] = {
     NULL
 };
 
-const LIBSSH2_HOSTKEY_METHOD **
-libssh2_hostkey_methods(void)
+const struct hostkey_method **libssh2_hostkey_methods(void)
 {
     return hostkey_methods;
 }

--- a/src/kex.c
+++ b/src/kex.c
@@ -3377,42 +3377,42 @@ clean_exit:
 #define LIBSSH2_KEX_METHOD_FLAG_REQ_ENC_HOSTKEY     0x0001
 #define LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY    0x0002
 
-static const LIBSSH2_KEX_METHOD kex_method_diffie_helman_group1_sha1 = {
+static const struct kex_method kex_method_diffie_helman_group1_sha1 = {
     "diffie-hellman-group1-sha1",
     kex_method_diffie_hellman_group1_sha1_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const LIBSSH2_KEX_METHOD kex_method_diffie_helman_group14_sha1 = {
+static const struct kex_method kex_method_diffie_helman_group14_sha1 = {
     "diffie-hellman-group14-sha1",
     kex_method_diffie_hellman_group14_sha1_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const LIBSSH2_KEX_METHOD kex_method_diffie_helman_group14_sha256 = {
+static const struct kex_method kex_method_diffie_helman_group14_sha256 = {
     "diffie-hellman-group14-sha256",
     kex_method_diffie_hellman_group14_sha256_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const LIBSSH2_KEX_METHOD kex_method_diffie_helman_group16_sha512 = {
+static const struct kex_method kex_method_diffie_helman_group16_sha512 = {
     "diffie-hellman-group16-sha512",
     kex_method_diffie_hellman_group16_sha512_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const LIBSSH2_KEX_METHOD kex_method_diffie_helman_group18_sha512 = {
+static const struct kex_method kex_method_diffie_helman_group18_sha512 = {
     "diffie-hellman-group18-sha512",
     kex_method_diffie_hellman_group18_sha512_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_diffie_helman_group_exchange_sha1 = {
     "diffie-hellman-group-exchange-sha1",
     kex_method_diffie_hellman_group_exchange_sha1_key_exchange,
@@ -3420,7 +3420,7 @@ kex_method_diffie_helman_group_exchange_sha1 = {
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_diffie_helman_group_exchange_sha256 = {
     "diffie-hellman-group-exchange-sha256",
     kex_method_diffie_hellman_group_exchange_sha256_key_exchange,
@@ -3429,7 +3429,7 @@ kex_method_diffie_helman_group_exchange_sha256 = {
 };
 
 #if LIBSSH2_ECDSA
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_ecdh_sha2_nistp256 = {
     "ecdh-sha2-nistp256",
     kex_method_ecdh_key_exchange,
@@ -3437,7 +3437,7 @@ kex_method_ecdh_sha2_nistp256 = {
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_ecdh_sha2_nistp384 = {
     "ecdh-sha2-nistp384",
     kex_method_ecdh_key_exchange,
@@ -3445,7 +3445,7 @@ kex_method_ecdh_sha2_nistp384 = {
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_ecdh_sha2_nistp521 = {
     "ecdh-sha2-nistp521",
     kex_method_ecdh_key_exchange,
@@ -3453,14 +3453,14 @@ kex_method_ecdh_sha2_nistp521 = {
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 #if LIBSSH2_MLKEM
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_ssh_mlkem768_nistp256_sha256 = {
     "mlkem768nistp256-sha256",
     kex_method_mlkem_nistp_key_exchange,
     kex_method_mlkem_nistp_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_ssh_mlkem1024_nistp384_sha384 = {
     "mlkem1024nistp384-sha384",
     kex_method_mlkem_nistp_key_exchange,
@@ -3471,14 +3471,14 @@ kex_method_ssh_mlkem1024_nistp384_sha384 = {
 #endif
 
 #if LIBSSH2_ED25519
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_ssh_curve25519_sha256_libssh = {
     "curve25519-sha256@libssh.org",
     kex_method_curve25519_key_exchange,
     kex_method_curve25519_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_ssh_curve25519_sha256 = {
     "curve25519-sha256",
     kex_method_curve25519_key_exchange,
@@ -3486,7 +3486,7 @@ kex_method_ssh_curve25519_sha256 = {
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 #if LIBSSH2_MLKEM
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_ssh_mlkem768_x25519_sha256 = {
     "mlkem768x25519-sha256",
     kex_method_mlkem768x25519_key_exchange,
@@ -3500,7 +3500,7 @@ kex_method_ssh_mlkem768_x25519_sha256 = {
  * as described in https://datatracker.ietf.org/doc/html/rfc8308
 */
 
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_extension_negotiation = {
     "ext-info-c",
     NULL,
@@ -3508,7 +3508,7 @@ kex_method_extension_negotiation = {
     0,
 };
 
-static const LIBSSH2_KEX_METHOD
+static const struct kex_method
 kex_method_strict_client_extension = {
     "kex-strict-c-v00@openssh.com",
     NULL,
@@ -3516,7 +3516,7 @@ kex_method_strict_client_extension = {
     0,
 };
 
-static const LIBSSH2_KEX_METHOD *libssh2_kex_methods[] = {
+static const struct kex_method *libssh2_kex_methods[] = {
 #if LIBSSH2_MLKEM
 #if LIBSSH2_ED25519
     &kex_method_ssh_mlkem768_x25519_sha256,
@@ -3945,7 +3945,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
                                  size_t kex_len, unsigned char *hostkey,
                                  size_t hostkey_len)
 {
-    const LIBSSH2_KEX_METHOD **kexp = libssh2_kex_methods;
+    const struct kex_method **kexp = libssh2_kex_methods;
     unsigned char *s;
     const unsigned char *strict =
         (const unsigned char *)"kex-strict-s-v00@openssh.com";
@@ -3962,7 +3962,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
             size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
             q = _libssh2_kex_agree_instr(kex, kex_len, s, method_len);
             if(q) {
-                const LIBSSH2_KEX_METHOD *method = (const LIBSSH2_KEX_METHOD *)
+                const struct kex_method *method = (const struct kex_method *)
                     kex_get_method_by_name((char *)s, method_len,
                                            (const struct common_method **)
                                            kexp);

--- a/src/kex.c
+++ b/src/kex.c
@@ -4141,7 +4141,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
                           struct endpoint_data *endpoint, unsigned char *comp,
                           size_t comp_len)
 {
-    const LIBSSH2_COMP_METHOD **compp = _libssh2_comp_methods(session);
+    const struct comp_method **compp = _libssh2_comp_methods(session);
     unsigned char *s;
     (void)session;
 
@@ -4153,8 +4153,8 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
             size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
 
             if(_libssh2_kex_agree_instr(comp, comp_len, s, method_len)) {
-                const LIBSSH2_COMP_METHOD *method =
-                    (const LIBSSH2_COMP_METHOD *)
+                const struct comp_method *method =
+                    (const struct comp_method *)
                     kex_get_method_by_name((char *)s, method_len,
                                            (const struct common_method **)
                                            compp);

--- a/src/kex.c
+++ b/src/kex.c
@@ -4022,7 +4022,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
  * Agree on a cipher algo
  */
 static int kex_agree_crypt(LIBSSH2_SESSION *session,
-                           libssh2_endpoint_data *endpoint,
+                           struct endpoint_data *endpoint,
                            unsigned char *crypt,
                            size_t crypt_len)
 {
@@ -4077,7 +4077,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
  * Agree on a message authentication hash
  */
 static int kex_agree_mac(LIBSSH2_SESSION *session,
-                         libssh2_endpoint_data *endpoint, unsigned char *mac,
+                         struct endpoint_data *endpoint, unsigned char *mac,
                          size_t mac_len)
 {
     const struct mac_method **macp = _libssh2_mac_methods();
@@ -4138,7 +4138,7 @@ static int kex_agree_mac(LIBSSH2_SESSION *session,
  * Agree on a compression scheme
  */
 static int kex_agree_comp(LIBSSH2_SESSION *session,
-                          libssh2_endpoint_data *endpoint, unsigned char *comp,
+                          struct endpoint_data *endpoint, unsigned char *comp,
                           size_t comp_len)
 {
     const LIBSSH2_COMP_METHOD **compp = _libssh2_comp_methods(session);

--- a/src/kex.c
+++ b/src/kex.c
@@ -4300,7 +4300,7 @@ static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,
  */
 int
 _libssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
-                      key_exchange_state_t *key_state)
+                      struct key_exchange_state *key_state)
 {
     int rc = 0;
     int retcode;

--- a/src/kex.c
+++ b/src/kex.c
@@ -3870,7 +3870,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session,
                              size_t kex_flags,
                              unsigned char *hostkey, size_t hostkey_len)
 {
-    const LIBSSH2_HOSTKEY_METHOD **hostkeyp = libssh2_hostkey_methods();
+    const struct hostkey_method **hostkeyp = libssh2_hostkey_methods();
     unsigned char *s;
 
     if(session->hostkey_prefs) {
@@ -3880,8 +3880,8 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session,
             unsigned char *p = (unsigned char *)strchr((char *)s, ',');
             size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
             if(_libssh2_kex_agree_instr(hostkey, hostkey_len, s, method_len)) {
-                const LIBSSH2_HOSTKEY_METHOD *method =
-                    (const LIBSSH2_HOSTKEY_METHOD *)
+                const struct hostkey_method *method =
+                    (const struct hostkey_method *)
                     kex_get_method_by_name((char *)s, method_len,
                                            (const struct common_method **)
                                            hostkeyp);

--- a/src/kex.c
+++ b/src/kex.c
@@ -684,7 +684,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                                    p */
 
         /* Zero the whole thing out */
-        memset(&exchange_state->req_state, 0, sizeof(packet_require_state_t));
+        memset(&exchange_state->req_state, 0,
+               sizeof(exchange_state->req_state));
 
         /* Generate x and e */
         if(_libssh2_bn_bits(p) > LIBSSH2_DH_MAX_MODULUS_BITS) {

--- a/src/kex.c
+++ b/src/kex.c
@@ -187,11 +187,12 @@ static int _libssh2_sha_algo_ctx_final(int sha_algo, void *ctx,
     return 0;
 }
 
-static void _libssh2_sha_algo_value_hash(int sha_algo,
-                                         LIBSSH2_SESSION *session,
-                                         kmdhgGPshakex_state_t *exchange_state,
-                                         unsigned char **data, size_t data_len,
-                                         const unsigned char *version)
+static void _libssh2_sha_algo_value_hash(
+    int sha_algo,
+    LIBSSH2_SESSION *session,
+    struct kmdhgGPshakex_state *exchange_state,
+    unsigned char **data, size_t data_len,
+    const unsigned char *version)
 {
     if(sha_algo == 512) {
         LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(512, *data, data_len, version);
@@ -212,11 +213,10 @@ static void _libssh2_sha_algo_value_hash(int sha_algo,
     }
 }
 
-static int
-process_host_key(LIBSSH2_SESSION *session,
-                 struct string_buf *buf,
-                 const kmdhgGPshakex_state_t *exchange_state,
-                 unsigned char *data, size_t data_len)
+static int process_host_key(LIBSSH2_SESSION *session,
+                            struct string_buf *buf,
+                            const struct kmdhgGPshakex_state *exchange_state,
+                            unsigned char *data, size_t data_len)
 {
     size_t host_key_len;
 
@@ -355,10 +355,9 @@ process_host_key(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static int
-finish_kex(LIBSSH2_SESSION *session,
-           kmdhgGPshakex_state_t *exchange_state,
-           int digest_len, int sha_algo_value)
+static int finish_kex(LIBSSH2_SESSION *session,
+                      struct kmdhgGPshakex_state *exchange_state,
+                      int digest_len, int sha_algo_value)
 {
     int rc;
     rc = _libssh2_packet_require(session, SSH_MSG_NEWKEYS,
@@ -580,9 +579,9 @@ finish_kex(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static void
-diffie_hellman_state_cleanup(LIBSSH2_SESSION *session,
-                             kmdhgGPshakex_state_t *exchange_state)
+static void diffie_hellman_state_cleanup(
+    LIBSSH2_SESSION *session,
+    struct kmdhgGPshakex_state *exchange_state)
 {
     libssh2_dh_dtor(&exchange_state->x);
     _libssh2_bn_free(exchange_state->e);
@@ -649,7 +648,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                    unsigned char packet_type_reply,
                                    unsigned char *midhash,
                                    size_t midhash_len,
-                                   kmdhgGPshakex_state_t *exchange_state)
+                                   struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc;
@@ -1097,25 +1096,25 @@ clean_exit:
 /* kex_method_diffie_hellman_group14_key_exchange
  * Diffie-Hellman Group14 Key Exchange with hash function callback
  */
-typedef int (*diffie_hellman_hash_func_t)(LIBSSH2_SESSION *,
-                                          _libssh2_bn *,
-                                          _libssh2_bn *,
-                                          int,
-                                          int,
-                                          void *,
-                                          unsigned char,
-                                          unsigned char,
-                                          unsigned char *,
-                                          size_t,
-                                          kmdhgGPshakex_state_t *);
-static int
-kex_method_diffie_hellman_group14_key_exchange(LIBSSH2_SESSION *session,
-                                               key_exchange_state_low_t
-                                               * key_state,
-                                               int sha_algo_value,
-                                               void *exchange_hash_ctx,
-                                               diffie_hellman_hash_func_t
-                                               hashfunc)
+typedef int (*diffie_hellman_hash_func_t)(
+    LIBSSH2_SESSION *session,
+    _libssh2_bn *g,
+    _libssh2_bn *p,
+    int group_order,
+    int sha_algo_value,
+    void *exchange_hash_ctx,
+    unsigned char packet_type_init,
+    unsigned char packet_type_reply,
+    unsigned char *midhash,
+    size_t midhash_len,
+    struct kmdhgGPshakex_state *exchange_state);
+
+static int kex_method_diffie_hellman_group14_key_exchange(
+    LIBSSH2_SESSION *session,
+    key_exchange_state_low_t *key_state,
+    int sha_algo_value,
+    void *exchange_hash_ctx,
+    diffie_hellman_hash_func_t hashfunc)
 {
     static const unsigned char p_value[256] = {
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -2005,9 +2004,9 @@ kex_session_ecdh_curve_type(const char *name, libssh2_curve_type *out_type)
     return 0;
 }
 
-static void
-ecdh_exchange_state_cleanup(LIBSSH2_SESSION *session,
-                            kmdhgGPshakex_state_t *exchange_state)
+static void ecdh_exchange_state_cleanup(
+    LIBSSH2_SESSION *session,
+    struct kmdhgGPshakex_state *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
@@ -2053,7 +2052,7 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                            unsigned char *data, size_t data_len,
                            unsigned char *public_key,
                            size_t public_key_len, _libssh2_ec_key *private_key,
-                           kmdhgGPshakex_state_t *exchange_state)
+                           struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc;
@@ -2328,9 +2327,9 @@ ecdh_clean_exit:
 
 #if LIBSSH2_MLKEM
 
-static void
-mlkem_nistp_exchange_state_cleanup(LIBSSH2_SESSION *session,
-                                   kmdhgGPshakex_state_t *exchange_state)
+static void mlkem_nistp_exchange_state_cleanup(
+    LIBSSH2_SESSION *session,
+    struct kmdhgGPshakex_state *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
@@ -2383,15 +2382,14 @@ kex_method_mlkem_nistp_cleanup
     }
 }
 
-static int
-mlkem_nistp(LIBSSH2_SESSION *session,
-            unsigned char *data, size_t data_len,
-            unsigned char *public_t_key,
-            size_t public_t_key_len,
-            _libssh2_ec_key *private_t_key,
-            unsigned char *public_pq_key,
-            unsigned char *private_pq_key,
-            kmdhgGPshakex_state_t *exchange_state)
+static int mlkem_nistp(LIBSSH2_SESSION *session,
+                       unsigned char *data, size_t data_len,
+                       unsigned char *public_t_key,
+                       size_t public_t_key_len,
+                       _libssh2_ec_key *private_t_key,
+                       unsigned char *public_pq_key,
+                       unsigned char *private_pq_key,
+                       struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc, ml_kem_size, sha_algo_value;
@@ -2751,9 +2749,9 @@ clean_exit:
 
 #if LIBSSH2_ED25519
 
-static void
-curve25519_exchange_state_cleanup(LIBSSH2_SESSION *session,
-                                  kmdhgGPshakex_state_t *exchange_state)
+static void curve25519_exchange_state_cleanup(
+    LIBSSH2_SESSION *session,
+    struct kmdhgGPshakex_state *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
@@ -2799,12 +2797,12 @@ kex_method_curve25519_cleanup
 /* curve25519_sha256
  * Elliptic Curve Key Exchange
  */
-static int
-curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
-                  size_t data_len,
-                  unsigned char public_key[LIBSSH2_ED25519_KEY_LEN],
-                  unsigned char private_key[LIBSSH2_ED25519_KEY_LEN],
-                  kmdhgGPshakex_state_t *exchange_state)
+static int curve25519_sha256(
+    LIBSSH2_SESSION *session, unsigned char *data,
+    size_t data_len,
+    unsigned char public_key[LIBSSH2_ED25519_KEY_LEN],
+    unsigned char private_key[LIBSSH2_ED25519_KEY_LEN],
+    struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc;
@@ -3045,9 +3043,9 @@ clean_exit:
 
 #if LIBSSH2_MLKEM
 
-static void
-mlkem768x25519_exchange_state_cleanup(LIBSSH2_SESSION *session,
-                                  kmdhgGPshakex_state_t *exchange_state)
+static void mlkem768x25519_exchange_state_cleanup(
+    LIBSSH2_SESSION *session,
+    struct kmdhgGPshakex_state *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
@@ -3104,16 +3102,14 @@ kex_method_mlkem768x25519_cleanup
     }
 }
 
-static int
-mlkem768x25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
-                      size_t data_len,
-                      unsigned char public_t_key[LIBSSH2_ED25519_KEY_LEN],
-                      unsigned char private_t_key[LIBSSH2_ED25519_KEY_LEN],
-                      unsigned char public_pq_key
-                        [LIBSSH2_MLKEM_768_PUBLIC_KEY_LEN],
-                      unsigned char private_pq_key
-                        [LIBSSH2_MLKEM_768_PRIVATE_KEY_LEN],
-                      kmdhgGPshakex_state_t *exchange_state)
+static int mlkem768x25519_sha256(
+    LIBSSH2_SESSION *session,
+    unsigned char *data, size_t data_len,
+    unsigned char public_t_key[LIBSSH2_ED25519_KEY_LEN],
+    unsigned char private_t_key[LIBSSH2_ED25519_KEY_LEN],
+    unsigned char public_pq_key[LIBSSH2_MLKEM_768_PUBLIC_KEY_LEN],
+    unsigned char private_pq_key[LIBSSH2_MLKEM_768_PRIVATE_KEY_LEN],
+    struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc;

--- a/src/kex.c
+++ b/src/kex.c
@@ -611,9 +611,10 @@ static void diffie_hellman_state_cleanup(
     exchange_state->state = libssh2_NB_state_idle;
 }
 
-static void
-kex_diffie_hellman_cleanup(LIBSSH2_SESSION *session,
-                           key_exchange_state_low_t *key_state) {
+static void kex_diffie_hellman_cleanup(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
+{
     if(key_state->state != libssh2_NB_state_idle) {
         _libssh2_bn_free(key_state->p);
         key_state->p = NULL;
@@ -1028,10 +1029,9 @@ clean_exit:
 /* kex_method_diffie_hellman_group1_sha1_key_exchange
  * Diffie-Hellman Group1 (Actually Group2) Key Exchange using SHA1
  */
-static int
-kex_method_diffie_hellman_group1_sha1_key_exchange(LIBSSH2_SESSION *session,
-                                                   key_exchange_state_low_t
-                                                   *key_state)
+static int kex_method_diffie_hellman_group1_sha1_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     static const unsigned char p_value[128] = {
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -1111,7 +1111,7 @@ typedef int (*diffie_hellman_hash_func_t)(
 
 static int kex_method_diffie_hellman_group14_key_exchange(
     LIBSSH2_SESSION *session,
-    key_exchange_state_low_t *key_state,
+    struct key_exchange_state_low *key_state,
     int sha_algo_value,
     void *exchange_hash_ctx,
     diffie_hellman_hash_func_t hashfunc)
@@ -1192,10 +1192,9 @@ clean_exit:
 /* kex_method_diffie_hellman_group14_sha1_key_exchange
  * Diffie-Hellman Group14 Key Exchange using SHA1
  */
-static int
-kex_method_diffie_hellman_group14_sha1_key_exchange(LIBSSH2_SESSION *session,
-                                                    key_exchange_state_low_t
-                                                    * key_state)
+static int kex_method_diffie_hellman_group14_sha1_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     libssh2_sha1_ctx ctx;
     return kex_method_diffie_hellman_group14_key_exchange(session,
@@ -1207,10 +1206,9 @@ kex_method_diffie_hellman_group14_sha1_key_exchange(LIBSSH2_SESSION *session,
 /* kex_method_diffie_hellman_group14_sha256_key_exchange
  * Diffie-Hellman Group14 Key Exchange using SHA256
  */
-static int
-kex_method_diffie_hellman_group14_sha256_key_exchange(LIBSSH2_SESSION *session,
-                                                      key_exchange_state_low_t
-                                                      * key_state)
+static int kex_method_diffie_hellman_group14_sha256_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     libssh2_sha256_ctx ctx;
     return kex_method_diffie_hellman_group14_key_exchange(session,
@@ -1222,10 +1220,9 @@ kex_method_diffie_hellman_group14_sha256_key_exchange(LIBSSH2_SESSION *session,
 /* kex_method_diffie_hellman_group16_sha512_key_exchange
 * Diffie-Hellman Group16 Key Exchange using SHA512
 */
-static int
-kex_method_diffie_hellman_group16_sha512_key_exchange(LIBSSH2_SESSION *session,
-                                                      key_exchange_state_low_t
-                                                      * key_state)
+static int kex_method_diffie_hellman_group16_sha512_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     static const unsigned char p_value[512] = {
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC9, 0x0F, 0xDA, 0xA2,
@@ -1316,10 +1313,9 @@ clean_exit:
 /* kex_method_diffie_hellman_group16_sha512_key_exchange
 * Diffie-Hellman Group18 Key Exchange using SHA512
 */
-static int
-kex_method_diffie_hellman_group18_sha512_key_exchange(LIBSSH2_SESSION *session,
-                                                      key_exchange_state_low_t
-                                                      * key_state)
+static int kex_method_diffie_hellman_group18_sha512_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     static const unsigned char p_value[1024] = {
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC9, 0x0F, 0xDA, 0xA2,
@@ -1455,10 +1451,9 @@ clean_exit:
  * Diffie-Hellman Group Exchange Key Exchange using SHA1
  * Negotiates random(ish) group for secret derivation
  */
-static int
-kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
-                                          LIBSSH2_SESSION *session,
-                                          key_exchange_state_low_t *key_state)
+static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc;
@@ -1583,10 +1578,9 @@ dh_gex_clean_exit:
  * Diffie-Hellman Group Exchange Key Exchange using SHA256
  * Negotiates random(ish) group for secret derivation
  */
-static int
-kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
-                                          LIBSSH2_SESSION *session,
-                                          key_exchange_state_low_t *key_state)
+static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc;
@@ -2019,9 +2013,8 @@ static void ecdh_exchange_state_cleanup(
     exchange_state->state = libssh2_NB_state_idle;
 }
 
-static void
-kex_method_ecdh_cleanup
-(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
+static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
+                                    struct key_exchange_state_low *key_state)
 {
     if(key_state->public_key_oct) {
         LIBSSH2_FREE(session, key_state->public_key_oct);
@@ -2219,9 +2212,9 @@ clean_exit:
  * supports SHA256/384/512 hashes based on negotiated ecdh method
  *
  */
-static int
-kex_method_ecdh_key_exchange
-(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
+static int kex_method_ecdh_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -2342,9 +2335,9 @@ static void mlkem_nistp_exchange_state_cleanup(
     exchange_state->state = libssh2_NB_state_idle;
 }
 
-static void
-kex_method_mlkem_nistp_cleanup
-(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
+static void kex_method_mlkem_nistp_cleanup(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     if(key_state->public_key_oct) {
         LIBSSH2_FREE(session, key_state->public_key_oct);
@@ -2617,9 +2610,9 @@ clean_exit:
     return ret;
 }
 
-static int
-kex_method_mlkem_nistp_key_exchange
-(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
+static int kex_method_mlkem_nistp_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -2764,9 +2757,9 @@ static void curve25519_exchange_state_cleanup(
     exchange_state->state = libssh2_NB_state_idle;
 }
 
-static void
-kex_method_curve25519_cleanup
-(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
+static void kex_method_curve25519_cleanup(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     if(key_state->curve25519_public_key) {
         _libssh2_explicit_zero(key_state->curve25519_public_key,
@@ -2943,9 +2936,9 @@ clean_exit:
  * Elliptic Curve X25519 Key Exchange with SHA256 hash
  *
  */
-static int
-kex_method_curve25519_key_exchange
-(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
+static int kex_method_curve25519_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -3058,9 +3051,9 @@ static void mlkem768x25519_exchange_state_cleanup(
     exchange_state->state = libssh2_NB_state_idle;
 }
 
-static void
-kex_method_mlkem768x25519_cleanup
-(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
+static void kex_method_mlkem768x25519_cleanup(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     if(key_state->curve25519_public_key) {
         _libssh2_explicit_zero(key_state->curve25519_public_key,
@@ -3262,9 +3255,9 @@ clean_exit:
     return ret;
 }
 
-static int
-kex_method_mlkem768x25519_key_exchange
-(LIBSSH2_SESSION *session, key_exchange_state_low_t *key_state)
+static int kex_method_mlkem768x25519_key_exchange(
+    LIBSSH2_SESSION *session,
+    struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc = 0;

--- a/src/kex.c
+++ b/src/kex.c
@@ -4026,7 +4026,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
                            unsigned char *crypt,
                            size_t crypt_len)
 {
-    const LIBSSH2_CRYPT_METHOD **cryptp = libssh2_crypt_methods();
+    const struct crypt_method **cryptp = libssh2_crypt_methods();
     unsigned char *s;
 
     (void)session;
@@ -4039,8 +4039,8 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
             size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
 
             if(_libssh2_kex_agree_instr(crypt, crypt_len, s, method_len)) {
-                const LIBSSH2_CRYPT_METHOD *method =
-                    (const LIBSSH2_CRYPT_METHOD *)
+                const struct crypt_method *method =
+                    (const struct crypt_method *)
                     kex_get_method_by_name((char *)s, method_len,
                                            (const struct common_method **)
                                            cryptp);

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -315,10 +315,9 @@ struct packet_require_state {
     time_t start;
 };
 
-typedef struct packet_requirev_state_t
-{
+struct packet_requirev_state {
     time_t start;
-} packet_requirev_state_t;
+};
 
 typedef struct kmdhgGPshakex_state_t
 {
@@ -479,7 +478,7 @@ struct _LIBSSH2_CHANNEL
     unsigned char *setenv_packet;
     size_t setenv_packet_len;
     unsigned char setenv_local_channel[4];
-    packet_requirev_state_t setenv_packet_requirev_state;
+    struct packet_requirev_state setenv_packet_requirev_state;
 
     /* State variables used in libssh2_channel_request_pty_ex()
        libssh2_channel_request_pty_size_ex() */
@@ -487,21 +486,21 @@ struct _LIBSSH2_CHANNEL
     unsigned char reqPTY_packet[41 + 256];
     size_t reqPTY_packet_len;
     unsigned char reqPTY_local_channel[4];
-    packet_requirev_state_t reqPTY_packet_requirev_state;
+    struct packet_requirev_state reqPTY_packet_requirev_state;
 
     /* State variables used in libssh2_channel_x11_req_ex() */
     libssh2_nonblocking_states reqX11_state;
     unsigned char *reqX11_packet;
     size_t reqX11_packet_len;
     unsigned char reqX11_local_channel[4];
-    packet_requirev_state_t reqX11_packet_requirev_state;
+    struct packet_requirev_state reqX11_packet_requirev_state;
 
     /* State variables used in libssh2_channel_process_startup() */
     libssh2_nonblocking_states process_state;
     unsigned char *process_packet;
     size_t process_packet_len;
     unsigned char process_local_channel[4];
-    packet_requirev_state_t process_packet_requirev_state;
+    struct packet_requirev_state process_packet_requirev_state;
 
     /* State variables used in libssh2_channel_flush_ex() */
     libssh2_nonblocking_states flush_state;
@@ -546,7 +545,7 @@ struct _LIBSSH2_CHANNEL
     unsigned char req_auth_agent_packet[36];
     size_t req_auth_agent_packet_len;
     unsigned char req_auth_agent_local_channel[4];
-    packet_requirev_state_t req_auth_agent_requirev_state;
+    struct packet_requirev_state req_auth_agent_requirev_state;
 
     /* State variables used in libssh2_channel_signal_ex() */
     libssh2_nonblocking_states sendsignal_state;
@@ -818,7 +817,7 @@ struct _LIBSSH2_SESSION
     unsigned char *userauth_list_data;
     size_t userauth_list_data_len;
     char *userauth_banner;
-    packet_requirev_state_t userauth_list_packet_requirev_state;
+    struct packet_requirev_state userauth_list_packet_requirev_state;
 
     /* State variables used in libssh2_userauth_password_ex() */
     libssh2_nonblocking_states userauth_pswd_state;
@@ -827,7 +826,7 @@ struct _LIBSSH2_SESSION
     size_t userauth_pswd_data_len;
     char *userauth_pswd_newpw;
     int userauth_pswd_newpw_len;
-    packet_requirev_state_t userauth_pswd_packet_requirev_state;
+    struct packet_requirev_state userauth_pswd_packet_requirev_state;
 
     /* State variables used in libssh2_userauth_hostbased_fromfile_ex() */
     libssh2_nonblocking_states userauth_host_state;
@@ -838,7 +837,7 @@ struct _LIBSSH2_SESSION
     unsigned char *userauth_host_method;
     size_t userauth_host_method_len;
     unsigned char *userauth_host_s;
-    packet_requirev_state_t userauth_host_packet_requirev_state;
+    struct packet_requirev_state userauth_host_packet_requirev_state;
 
     /* State variables used in libssh2_userauth_publickey_fromfile_ex() */
     libssh2_nonblocking_states userauth_pblc_state;
@@ -850,7 +849,7 @@ struct _LIBSSH2_SESSION
     size_t userauth_pblc_method_len;
     unsigned char *userauth_pblc_s;
     unsigned char *userauth_pblc_b;
-    packet_requirev_state_t userauth_pblc_packet_requirev_state;
+    struct packet_requirev_state userauth_pblc_packet_requirev_state;
 
     /* State variables used in libssh2_userauth_keyboard_interactive_ex() */
     libssh2_nonblocking_states userauth_kybd_state;
@@ -866,11 +865,11 @@ struct _LIBSSH2_SESSION
     int userauth_kybd_auth_failure;
     LIBSSH2_USERAUTH_KBDINT_PROMPT *userauth_kybd_prompts;
     LIBSSH2_USERAUTH_KBDINT_RESPONSE *userauth_kybd_responses;
-    packet_requirev_state_t userauth_kybd_packet_requirev_state;
+    struct packet_requirev_state userauth_kybd_packet_requirev_state;
 
     /* State variables used in libssh2_channel_open_ex() */
     libssh2_nonblocking_states open_state;
-    packet_requirev_state_t open_packet_requirev_state;
+    struct packet_requirev_state open_packet_requirev_state;
     LIBSSH2_CHANNEL *open_channel;
     unsigned char *open_packet;
     size_t open_packet_len;
@@ -890,7 +889,7 @@ struct _LIBSSH2_SESSION
     unsigned char *fwdLstn_packet;
     uint32_t fwdLstn_host_len;
     uint32_t fwdLstn_packet_len;
-    packet_requirev_state_t fwdLstn_packet_requirev_state;
+    struct packet_requirev_state fwdLstn_packet_requirev_state;
 
     /* State variables used in libssh2_publickey_init() */
     libssh2_nonblocking_states pkeyInit_state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -380,8 +380,7 @@ struct key_exchange_state {
 
 #define FwdNotReq "Forward not requested"
 
-typedef struct packet_queue_listener_state_t
-{
+struct packet_queue_listener_state {
     libssh2_nonblocking_states state;
     unsigned char packet[17 + (sizeof(FwdNotReq) - 1)];
     unsigned char *host;
@@ -394,7 +393,7 @@ typedef struct packet_queue_listener_state_t
     uint32_t host_len;
     uint32_t shost_len;
     LIBSSH2_CHANNEL *channel;
-} packet_queue_listener_state_t;
+};
 
 #define X11FwdUnAvil "X11 Forward Unavailable"
 
@@ -902,7 +901,7 @@ struct _LIBSSH2_SESSION
     libssh2_nonblocking_states packAdd_state;
     LIBSSH2_CHANNEL *packAdd_channelp; /* keeper of the channel during EAGAIN
                                           states */
-    packet_queue_listener_state_t packAdd_Qlstn_state;
+    struct packet_queue_listener_state packAdd_Qlstn_state;
     packet_x11_open_state_t packAdd_x11open_state;
     packet_authagent_state_t packAdd_authagent_state;
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -397,8 +397,7 @@ struct packet_queue_listener_state {
 
 #define X11FwdUnAvil "X11 Forward Unavailable"
 
-typedef struct packet_x11_open_state_t
-{
+struct packet_x11_open_state {
     libssh2_nonblocking_states state;
     unsigned char packet[17 + (sizeof(X11FwdUnAvil) - 1)];
     unsigned char *shost;
@@ -408,7 +407,7 @@ typedef struct packet_x11_open_state_t
     uint32_t sport;
     uint32_t shost_len;
     LIBSSH2_CHANNEL *channel;
-} packet_x11_open_state_t;
+};
 
 #define AuthAgentUnavail "Auth Agent unavailable"
 
@@ -902,7 +901,7 @@ struct _LIBSSH2_SESSION
     LIBSSH2_CHANNEL *packAdd_channelp; /* keeper of the channel during EAGAIN
                                           states */
     struct packet_queue_listener_state packAdd_Qlstn_state;
-    packet_x11_open_state_t packAdd_x11open_state;
+    struct packet_x11_open_state packAdd_x11open_state;
     packet_authagent_state_t packAdd_authagent_state;
 
     /* State variables used in fullpacket() */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -440,8 +440,7 @@ struct packet {
     size_t data_head;
 };
 
-typedef struct _libssh2_channel_data
-{
+struct channel_data {
     /* Identifier */
     uint32_t id;
 
@@ -450,7 +449,7 @@ typedef struct _libssh2_channel_data
 
     /* Set to 1 when CHANNEL_CLOSE / CHANNEL_EOF sent/received */
     char close, eof, extended_data_ignore_mode;
-} libssh2_channel_data;
+};
 
 struct _LIBSSH2_CHANNEL
 {
@@ -465,7 +464,7 @@ struct _LIBSSH2_CHANNEL
     /* channel's program exit signal (without the SIG prefix) */
     char *exit_signal;
 
-    libssh2_channel_data local, remote;
+    struct channel_data local, remote;
     /* Amount of bytes to be refunded to receive window (but not yet sent) */
     uint32_t adjust_queue;
     /* Data immediately available for reading */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -287,8 +287,6 @@ struct iovec {
 #define LIBSSH2_RECV(session, buffer, length, flags) \
     LIBSSH2_RECV_FD(session, (session)->socket_fd, buffer, length, flags)
 
-typedef struct _LIBSSH2_COMP_METHOD LIBSSH2_COMP_METHOD;
-
 typedef struct _LIBSSH2_PACKET LIBSSH2_PACKET;
 
 typedef enum
@@ -595,7 +593,7 @@ struct endpoint_data {
     uint32_t seqno;
     void *mac_abstract;
 
-    const LIBSSH2_COMP_METHOD *comp;
+    const struct comp_method *comp;
     void *comp_abstract;
 
     /* Method Preferences -- NULL yields "load order" */
@@ -1081,8 +1079,7 @@ struct crypt_method {
 #define IS_FIRST(firstlast) ((firstlast) & FIRST_BLOCK)
 #define IS_LAST(firstlast)  ((firstlast) & LAST_BLOCK)
 
-struct _LIBSSH2_COMP_METHOD
-{
+struct comp_method {
     const char *name;
     int compress; /* 1 if it does compress, 0 if it doesn't */
     int use_in_auth; /* 1 if compression should be used in userauth */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -287,8 +287,6 @@ struct iovec {
 #define LIBSSH2_RECV(session, buffer, length, flags) \
     LIBSSH2_RECV_FD(session, (session)->socket_fd, buffer, length, flags)
 
-typedef struct _LIBSSH2_PACKET LIBSSH2_PACKET;
-
 typedef enum
 {
     libssh2_NB_state_idle = 0,
@@ -430,8 +428,7 @@ typedef struct packet_authagent_state_t
     LIBSSH2_CHANNEL *channel;
 } packet_authagent_state_t;
 
-struct _LIBSSH2_PACKET
-{
+struct packet {
     struct list_node node; /* linked list header */
 
     /* the raw unencrypted payload */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -585,8 +585,7 @@ struct _LIBSSH2_LISTENER
     size_t chanFwdCncl_data_len;
 };
 
-typedef struct _libssh2_endpoint_data
-{
+struct endpoint_data {
     unsigned char *banner;
 
     unsigned char *kexinit;
@@ -607,7 +606,7 @@ typedef struct _libssh2_endpoint_data
     char *mac_prefs;
     char *comp_prefs;
     char *lang_prefs;
-} libssh2_endpoint_data;
+};
 
 #define PACKETBUFSIZE MAX_SSH_PACKET_LEN
 
@@ -755,10 +754,10 @@ struct _LIBSSH2_SESSION
     int kex_strict;
 
     /* (remote as source of data -- packet_read ) */
-    libssh2_endpoint_data remote;
+    struct endpoint_data remote;
 
     /* (local as source of data -- packet_write ) */
-    libssh2_endpoint_data local;
+    struct endpoint_data local;
 
     /* Inbound Data linked list -- Sometimes the packet that comes in isn't the
        packet we're ready for */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -411,15 +411,14 @@ struct packet_x11_open_state {
 
 #define AuthAgentUnavail "Auth Agent unavailable"
 
-typedef struct packet_authagent_state_t
-{
+struct packet_authagent_state {
     libssh2_nonblocking_states state;
     unsigned char packet[17 + (sizeof(AuthAgentUnavail) - 1)];
     uint32_t sender_channel;
     uint32_t initial_window_size;
     uint32_t packet_size;
     LIBSSH2_CHANNEL *channel;
-} packet_authagent_state_t;
+};
 
 struct packet {
     struct list_node node; /* linked list header */
@@ -902,7 +901,7 @@ struct _LIBSSH2_SESSION
                                           states */
     struct packet_queue_listener_state packAdd_Qlstn_state;
     struct packet_x11_open_state packAdd_x11open_state;
-    packet_authagent_state_t packAdd_authagent_state;
+    struct packet_authagent_state packAdd_authagent_state;
 
     /* State variables used in fullpacket() */
     libssh2_nonblocking_states fullpacket_state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -368,8 +368,7 @@ struct key_exchange_state_low {
     unsigned char *mlkem_private_key; /* ML-KEM private key */
 };
 
-typedef struct key_exchange_state_t
-{
+struct key_exchange_state {
     libssh2_nonblocking_states state;
     struct packet_require_state req_state;
     struct key_exchange_state_low key_state_low;
@@ -377,7 +376,7 @@ typedef struct key_exchange_state_t
     size_t data_len;
     unsigned char *oldlocal;
     size_t oldlocal_len;
-} key_exchange_state_t;
+};
 
 #define FwdNotReq "Forward not requested"
 
@@ -796,7 +795,7 @@ struct _LIBSSH2_SESSION
     unsigned char startup_service[sizeof("ssh-userauth") + 5 - 1];
     size_t startup_service_length;
     struct packet_require_state startup_req_state;
-    key_exchange_state_t startup_key_state;
+    struct key_exchange_state startup_key_state;
 
     /* State variables used in libssh2_session_free() */
     libssh2_nonblocking_states free_state;
@@ -1193,7 +1192,7 @@ ssize_t _libssh2_send(libssh2_socket_t socket, const void *buffer,
                                            waiting for more data to arrive */
 
 int _libssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
-                          key_exchange_state_t *key_state);
+                          struct key_exchange_state *key_state);
 
 unsigned char *_libssh2_kex_agree_instr(unsigned char *haystack,
                                         size_t haystack_len,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -287,7 +287,6 @@ struct iovec {
 #define LIBSSH2_RECV(session, buffer, length, flags) \
     LIBSSH2_RECV_FD(session, (session)->socket_fd, buffer, length, flags)
 
-typedef struct _LIBSSH2_HOSTKEY_METHOD LIBSSH2_HOSTKEY_METHOD;
 typedef struct _LIBSSH2_CRYPT_METHOD LIBSSH2_CRYPT_METHOD;
 typedef struct _LIBSSH2_COMP_METHOD LIBSSH2_COMP_METHOD;
 
@@ -725,7 +724,7 @@ struct _LIBSSH2_SESSION
     long api_timeout;
 
     /* Server's public key */
-    const LIBSSH2_HOSTKEY_METHOD *hostkey;
+    const struct hostkey_method *hostkey;
     void *server_hostkey_abstract;
 
     /* Either set with libssh2_session_hostkey() (for server mode)
@@ -1002,8 +1001,7 @@ struct kex_method {
     long flags;
 };
 
-struct _LIBSSH2_HOSTKEY_METHOD
-{
+struct hostkey_method {
     const char *name;
     size_t hash_len;
 
@@ -1217,7 +1215,7 @@ unsigned char *_libssh2_kex_agree_instr(unsigned char *haystack,
 
 /* Let crypt.c/hostkey.c expose their method structs */
 const LIBSSH2_CRYPT_METHOD **libssh2_crypt_methods(void);
-const LIBSSH2_HOSTKEY_METHOD **libssh2_hostkey_methods(void);
+const struct hostkey_method **libssh2_hostkey_methods(void);
 
 int _libssh2_bcrypt_pbkdf(const char *pass,
                           size_t passlen,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -287,7 +287,6 @@ struct iovec {
 #define LIBSSH2_RECV(session, buffer, length, flags) \
     LIBSSH2_RECV_FD(session, (session)->socket_fd, buffer, length, flags)
 
-typedef struct _LIBSSH2_CRYPT_METHOD LIBSSH2_CRYPT_METHOD;
 typedef struct _LIBSSH2_COMP_METHOD LIBSSH2_COMP_METHOD;
 
 typedef struct _LIBSSH2_PACKET LIBSSH2_PACKET;
@@ -589,7 +588,7 @@ struct endpoint_data {
     unsigned char *kexinit;
     size_t kexinit_len;
 
-    const LIBSSH2_CRYPT_METHOD *crypt;
+    const struct crypt_method *crypt;
     void *crypt_abstract;
 
     const struct mac_method *mac;
@@ -1026,8 +1025,7 @@ struct hostkey_method {
     int (*dtor)(LIBSSH2_SESSION *session, void **abstract);
 };
 
-struct _LIBSSH2_CRYPT_METHOD
-{
+struct crypt_method {
     const char *name;
     const char *pem_annotation;
 
@@ -1043,7 +1041,7 @@ struct _LIBSSH2_CRYPT_METHOD
     long flags;
 
     int (*init)(LIBSSH2_SESSION *session,
-                const LIBSSH2_CRYPT_METHOD *method, unsigned char *iv,
+                const struct crypt_method *method, unsigned char *iv,
                 int *free_iv, unsigned char *secret, int *free_secret,
                 int encrypt, void **abstract);
     int (*get_len)(LIBSSH2_SESSION *session, unsigned int seqno,
@@ -1057,7 +1055,7 @@ struct _LIBSSH2_CRYPT_METHOD
     _libssh2_cipher_type(algo);
 };
 
-/* Bit flags for _LIBSSH2_CRYPT_METHOD */
+/* Bit flags for struct crypt_method */
 
 /* Crypto method has integrated message authentication */
 #define LIBSSH2_CRYPT_FLAG_INTEGRATED_MAC            1
@@ -1214,7 +1212,7 @@ unsigned char *_libssh2_kex_agree_instr(unsigned char *haystack,
                                         size_t needle_len);
 
 /* Let crypt.c/hostkey.c expose their method structs */
-const LIBSSH2_CRYPT_METHOD **libssh2_crypt_methods(void);
+const struct crypt_method **libssh2_crypt_methods(void);
 const struct hostkey_method **libssh2_hostkey_methods(void);
 
 int _libssh2_bcrypt_pbkdf(const char *pass,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -310,11 +310,10 @@ typedef enum
     libssh2_NB_state_jumpauthagent
 } libssh2_nonblocking_states;
 
-typedef struct packet_require_state_t
-{
+struct packet_require_state {
     libssh2_nonblocking_states state;
     time_t start;
-} packet_require_state_t;
+};
 
 typedef struct packet_requirev_state_t
 {
@@ -343,14 +342,14 @@ typedef struct kmdhgGPshakex_state_t
     size_t f_value_len;
     size_t k_value_len;
     size_t h_sig_len;
-    packet_require_state_t req_state;
+    struct packet_require_state req_state;
     libssh2_nonblocking_states burn_state;
 } kmdhgGPshakex_state_t;
 
 typedef struct key_exchange_state_low_t
 {
     libssh2_nonblocking_states state;
-    packet_require_state_t req_state;
+    struct packet_require_state req_state;
     kmdhgGPshakex_state_t exchange_state;
     _libssh2_bn *p;             /* SSH2 defined value (p_value) */
     _libssh2_bn *g;             /* SSH2 defined value (2) */
@@ -375,7 +374,7 @@ typedef struct key_exchange_state_low_t
 typedef struct key_exchange_state_t
 {
     libssh2_nonblocking_states state;
-    packet_require_state_t req_state;
+    struct packet_require_state req_state;
     key_exchange_state_low_t key_state_low;
     unsigned char *data;
     size_t data_len;
@@ -799,7 +798,7 @@ struct _LIBSSH2_SESSION
     size_t startup_data_len;
     unsigned char startup_service[sizeof("ssh-userauth") + 5 - 1];
     size_t startup_service_length;
-    packet_require_state_t startup_req_state;
+    struct packet_require_state startup_req_state;
     key_exchange_state_t startup_key_state;
 
     /* State variables used in libssh2_session_free() */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -287,7 +287,6 @@ struct iovec {
 #define LIBSSH2_RECV(session, buffer, length, flags) \
     LIBSSH2_RECV_FD(session, (session)->socket_fd, buffer, length, flags)
 
-typedef struct _LIBSSH2_KEX_METHOD LIBSSH2_KEX_METHOD;
 typedef struct _LIBSSH2_HOSTKEY_METHOD LIBSSH2_HOSTKEY_METHOD;
 typedef struct _LIBSSH2_CRYPT_METHOD LIBSSH2_CRYPT_METHOD;
 typedef struct _LIBSSH2_COMP_METHOD LIBSSH2_COMP_METHOD;
@@ -713,7 +712,7 @@ struct _LIBSSH2_SESSION
     struct flags flag;
 
     /* Agreed Key Exchange Method */
-    const LIBSSH2_KEX_METHOD *kex;
+    const struct kex_method *kex;
     unsigned int burn_optimistic_kexinit;
 
     unsigned char *session_id;
@@ -989,8 +988,7 @@ struct _LIBSSH2_SESSION
 /* libssh2 extensible ssh api, ultimately I'd like to allow loading additional
    methods via .so/.dll */
 
-struct _LIBSSH2_KEX_METHOD
-{
+struct kex_method {
     const char *name;
 
     /* Key exchange, populates session->* and returns 0 on success, non-0 on

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -344,8 +344,7 @@ struct kmdhgGPshakex_state {
     libssh2_nonblocking_states burn_state;
 };
 
-typedef struct key_exchange_state_low_t
-{
+struct key_exchange_state_low {
     libssh2_nonblocking_states state;
     struct packet_require_state req_state;
     struct kmdhgGPshakex_state exchange_state;
@@ -367,13 +366,13 @@ typedef struct key_exchange_state_low_t
                                               bytes */
     unsigned char *mlkem_public_key; /* ML-KEM public key */
     unsigned char *mlkem_private_key; /* ML-KEM private key */
-} key_exchange_state_low_t;
+};
 
 typedef struct key_exchange_state_t
 {
     libssh2_nonblocking_states state;
     struct packet_require_state req_state;
-    key_exchange_state_low_t key_state_low;
+    struct key_exchange_state_low key_state_low;
     unsigned char *data;
     size_t data_len;
     unsigned char *oldlocal;
@@ -983,10 +982,10 @@ struct kex_method {
     /* Key exchange, populates session->* and returns 0 on success, non-0 on
        error */
     int (*exchange_keys)(LIBSSH2_SESSION *session,
-                         key_exchange_state_low_t *key_state);
+                         struct key_exchange_state_low *key_state);
 
     void (*cleanup)(LIBSSH2_SESSION *session,
-                    key_exchange_state_low_t *key_state);
+                    struct key_exchange_state_low *key_state);
 
     long flags;
 };

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -319,8 +319,7 @@ struct packet_requirev_state {
     time_t start;
 };
 
-typedef struct kmdhgGPshakex_state_t
-{
+struct kmdhgGPshakex_state {
     libssh2_nonblocking_states state;
     unsigned char *e_packet;
     unsigned char *s_packet;
@@ -343,13 +342,13 @@ typedef struct kmdhgGPshakex_state_t
     size_t h_sig_len;
     struct packet_require_state req_state;
     libssh2_nonblocking_states burn_state;
-} kmdhgGPshakex_state_t;
+};
 
 typedef struct key_exchange_state_low_t
 {
     libssh2_nonblocking_states state;
     struct packet_require_state req_state;
-    kmdhgGPshakex_state_t exchange_state;
+    struct kmdhgGPshakex_state exchange_state;
     _libssh2_bn *p;             /* SSH2 defined value (p_value) */
     _libssh2_bn *g;             /* SSH2 defined value (2) */
     /* Request must fit mlkem1024nistp384 keys + 5 bytes overhead */

--- a/src/mac.c
+++ b/src/mac.c
@@ -513,8 +513,8 @@ static const struct mac_method mac_method_hmac_aesgcm = {
 
 /* See if the negotiated crypto method has its own authentication scheme that
  * obviates the need for a separate negotiated hmac method */
-const struct mac_method *
-_libssh2_mac_override(const LIBSSH2_CRYPT_METHOD *crypt)
+const struct mac_method *_libssh2_mac_override(
+    const struct crypt_method *crypt)
 {
 #if LIBSSH2_AES_GCM
     if(!strcmp(crypt->name, "aes256-gcm@openssh.com") ||

--- a/src/mac.h
+++ b/src/mac.h
@@ -64,6 +64,6 @@ struct mac_method {
 
 const struct mac_method **_libssh2_mac_methods(void);
 const struct mac_method *_libssh2_mac_override(
-    const LIBSSH2_CRYPT_METHOD *crypt);
+    const struct crypt_method *crypt);
 
 #endif /* LIBSSH2_MAC_H */

--- a/src/packet.c
+++ b/src/packet.c
@@ -1674,7 +1674,7 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
                          unsigned char **data, size_t *data_len,
                          int match_ofs,
                          const unsigned char *match_buf, size_t match_len,
-                         packet_requirev_state_t *state)
+                         struct packet_requirev_state *state)
 {
     if(_libssh2_packet_askv(session, packet_types, data, data_len, match_ofs,
                             match_buf, match_len) == 0) {

--- a/src/packet.c
+++ b/src/packet.c
@@ -1547,7 +1547,7 @@ _libssh2_packet_require(LIBSSH2_SESSION *session, unsigned char packet_type,
                         int match_ofs,
                         const unsigned char *match_buf,
                         size_t match_len,
-                        packet_require_state_t *state)
+                        struct packet_require_state *state)
 {
     if(state->start == 0) {
         if(_libssh2_packet_ask(session, packet_type, data, data_len,

--- a/src/packet.c
+++ b/src/packet.c
@@ -279,7 +279,7 @@ packet_queue_listener(LIBSSH2_SESSION *session, unsigned char *data,
 static inline int
 packet_x11_open(LIBSSH2_SESSION *session, unsigned char *data,
                 size_t datalen,
-                packet_x11_open_state_t *x11open_state)
+                struct packet_x11_open_state *x11open_state)
 {
     uint32_t failure_code = SSH_OPEN_CONNECT_FAILED;
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */

--- a/src/packet.c
+++ b/src/packet.c
@@ -480,7 +480,7 @@ x11_exit:
 static inline int
 packet_authagent_open(LIBSSH2_SESSION *session,
                       unsigned char *data, size_t datalen,
-                      packet_authagent_state_t *authagent_state)
+                      struct packet_authagent_state *authagent_state)
 {
     uint32_t failure_code = SSH_OPEN_CONNECT_FAILED;
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */

--- a/src/packet.c
+++ b/src/packet.c
@@ -1418,8 +1418,9 @@ libssh2_packet_add_jump_authagent:
     }
 
     if((msg == SSH_MSG_KEXINIT &&
-         !(session->state & LIBSSH2_STATE_EXCHANGING_KEYS)) ||
+        !(session->state & LIBSSH2_STATE_EXCHANGING_KEYS)) ||
         (session->packAdd_state == libssh2_NB_state_sent2)) {
+
         if(session->packAdd_state == libssh2_NB_state_sent1) {
             /*
              * Remote wants new keys
@@ -1443,7 +1444,8 @@ libssh2_packet_add_jump_authagent:
         session->packAdd_state = libssh2_NB_state_idle;
         session->fullpacket_state = libssh2_NB_state_idle;
 
-        memset(&session->startup_key_state, 0, sizeof(key_exchange_state_t));
+        memset(&session->startup_key_state, 0,
+               sizeof(session->startup_key_state));
 
         /*
          * If there was a key reexchange failure, let's just hope we didn't

--- a/src/packet.c
+++ b/src/packet.c
@@ -1399,8 +1399,8 @@ libssh2_packet_add_jump_authagent:
     }
 
     if(session->packAdd_state == libssh2_NB_state_sent) {
-        LIBSSH2_PACKET *packetp =
-            LIBSSH2_ALLOC(session, sizeof(LIBSSH2_PACKET));
+        struct packet *packetp =
+            LIBSSH2_ALLOC(session, sizeof(struct packet));
         if(!packetp) {
             _libssh2_debug((session, LIBSSH2_ERROR_ALLOC,
                            "memory for packet"));
@@ -1470,7 +1470,7 @@ _libssh2_packet_ask(LIBSSH2_SESSION *session, unsigned char packet_type,
                     int match_ofs, const unsigned char *match_buf,
                     size_t match_len)
 {
-    LIBSSH2_PACKET *packet = _libssh2_list_first(&session->packets);
+    struct packet *packet = _libssh2_list_first(&session->packets);
 
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
                    "Looking for packet of type: %u",

--- a/src/packet.c
+++ b/src/packet.c
@@ -65,7 +65,7 @@
 static inline int
 packet_queue_listener(LIBSSH2_SESSION *session, unsigned char *data,
                       size_t datalen,
-                      packet_queue_listener_state_t *listen_state)
+                      struct packet_queue_listener_state *listen_state)
 {
     /*
      * Look for a matching listener

--- a/src/packet.h
+++ b/src/packet.h
@@ -59,7 +59,7 @@ int _libssh2_packet_require(LIBSSH2_SESSION *session,
                             size_t *data_len, int match_ofs,
                             const unsigned char *match_buf,
                             size_t match_len,
-                            packet_require_state_t *state);
+                            struct packet_require_state *state);
 int _libssh2_packet_requirev(LIBSSH2_SESSION *session,
                              const unsigned char *packet_types,
                              unsigned char **data, size_t *data_len,

--- a/src/packet.h
+++ b/src/packet.h
@@ -66,7 +66,7 @@ int _libssh2_packet_requirev(LIBSSH2_SESSION *session,
                              int match_ofs,
                              const unsigned char *match_buf,
                              size_t match_len,
-                             packet_requirev_state_t *state);
+                             struct packet_requirev_state *state);
 int _libssh2_packet_burn(LIBSSH2_SESSION *session,
                          libssh2_nonblocking_states *state);
 int _libssh2_packet_write(LIBSSH2_SESSION *session, unsigned char *data,

--- a/src/pem.c
+++ b/src/pem.c
@@ -184,7 +184,7 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION *session,
     size_t b64datalen = 0;
     size_t off = 0;
     int ret;
-    const LIBSSH2_CRYPT_METHOD* method = NULL;
+    const struct crypt_method* method = NULL;
 
     do {
         *line = '\0';
@@ -203,7 +203,7 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION *session,
 
     if(passphrase &&
        memcmp(line, crypt_annotation, strlen(crypt_annotation)) == 0) {
-        const LIBSSH2_CRYPT_METHOD** all_methods, * cur_method;
+        const struct crypt_method** all_methods, * cur_method;
         int i;
 
         if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
@@ -420,7 +420,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION *session,
                                 const char *b64data, size_t b64datalen,
                                 struct string_buf **decrypted_buf)
 {
-    const LIBSSH2_CRYPT_METHOD *method = NULL;
+    const struct crypt_method *method = NULL;
     struct string_buf decoded, decrypted, kdf_buf;
     unsigned char *ciphername = NULL;
     unsigned char *kdfname = NULL;
@@ -538,7 +538,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION *session,
     decrypted.len = tmp_len;
 
     if(ciphername && strcmp((const char *)ciphername, "none") != 0) {
-        const LIBSSH2_CRYPT_METHOD **all_methods, *cur_method;
+        const struct crypt_method **all_methods, *cur_method;
 
         all_methods = libssh2_crypt_methods();
         /* !checksrc! disable EQUALSNULL 1 */

--- a/src/pem.c
+++ b/src/pem.c
@@ -184,7 +184,7 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION *session,
     size_t b64datalen = 0;
     size_t off = 0;
     int ret;
-    const struct crypt_method* method = NULL;
+    const struct crypt_method *method = NULL;
 
     do {
         *line = '\0';
@@ -203,7 +203,7 @@ _libssh2_pem_parse_memory(LIBSSH2_SESSION *session,
 
     if(passphrase &&
        memcmp(line, crypt_annotation, strlen(crypt_annotation)) == 0) {
-        const struct crypt_method** all_methods, * cur_method;
+        const struct crypt_method **all_methods, *cur_method;
         int i;
 
         if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {

--- a/src/session.c
+++ b/src/session.c
@@ -1275,7 +1275,7 @@ LIBSSH2_API const char *
 libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
 {
     /* All methods have char *name as their first element */
-    const LIBSSH2_KEX_METHOD *method = NULL;
+    const struct kex_method *method = NULL;
 
     switch(method_type) {
     case LIBSSH2_METHOD_KEX:
@@ -1283,31 +1283,31 @@ libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
         break;
 
     case LIBSSH2_METHOD_HOSTKEY:
-        method = (const LIBSSH2_KEX_METHOD *)session->hostkey;
+        method = (const struct kex_method *)session->hostkey;
         break;
 
     case LIBSSH2_METHOD_CRYPT_CS:
-        method = (const LIBSSH2_KEX_METHOD *)session->local.crypt;
+        method = (const struct kex_method *)session->local.crypt;
         break;
 
     case LIBSSH2_METHOD_CRYPT_SC:
-        method = (const LIBSSH2_KEX_METHOD *)session->remote.crypt;
+        method = (const struct kex_method *)session->remote.crypt;
         break;
 
     case LIBSSH2_METHOD_MAC_CS:
-        method = (const LIBSSH2_KEX_METHOD *)session->local.mac;
+        method = (const struct kex_method *)session->local.mac;
         break;
 
     case LIBSSH2_METHOD_MAC_SC:
-        method = (const LIBSSH2_KEX_METHOD *)session->remote.mac;
+        method = (const struct kex_method *)session->remote.mac;
         break;
 
     case LIBSSH2_METHOD_COMP_CS:
-        method = (const LIBSSH2_KEX_METHOD *)session->local.comp;
+        method = (const struct kex_method *)session->local.comp;
         break;
 
     case LIBSSH2_METHOD_COMP_SC:
-        method = (const LIBSSH2_KEX_METHOD *)session->remote.comp;
+        method = (const struct kex_method *)session->remote.comp;
         break;
 
     case LIBSSH2_METHOD_LANG_CS:

--- a/src/session.c
+++ b/src/session.c
@@ -920,7 +920,7 @@ static int
 session_free(LIBSSH2_SESSION *session)
 {
     int rc;
-    LIBSSH2_PACKET *pkg;
+    struct packet *pkg;
     LIBSSH2_CHANNEL *ch;
     LIBSSH2_LISTENER *l;
     int packets_left = 0;
@@ -1542,7 +1542,7 @@ LIBSSH2_API int
 libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
 {
     LIBSSH2_SESSION *session;
-    LIBSSH2_PACKET *packet;
+    struct packet *packet;
 
     if(!channel)
         return LIBSSH2_ERROR_BAD_USE;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -759,13 +759,13 @@ file_read_publickey(LIBSSH2_SESSION *session, unsigned char **method,
 
 static int
 memory_read_privatekey(LIBSSH2_SESSION *session,
-                       const LIBSSH2_HOSTKEY_METHOD **hostkey_method,
+                       const struct hostkey_method **hostkey_method,
                        void **hostkey_abstract,
                        const unsigned char *method, size_t method_len,
                        const char *privkeyfiledata, size_t privkeyfiledata_len,
                        const char *passphrase)
 {
-    const LIBSSH2_HOSTKEY_METHOD **hostkey_methods_avail =
+    const struct hostkey_method **hostkey_methods_avail =
         libssh2_hostkey_methods();
 
     *hostkey_method = NULL;
@@ -800,12 +800,12 @@ memory_read_privatekey(LIBSSH2_SESSION *session,
  */
 static int
 file_read_privatekey(LIBSSH2_SESSION *session,
-                     const LIBSSH2_HOSTKEY_METHOD **hostkey_method,
+                     const struct hostkey_method **hostkey_method,
                      void **hostkey_abstract,
                      const unsigned char *method, size_t method_len,
                      const char *privkeyfile, const char *passphrase)
 {
-    const LIBSSH2_HOSTKEY_METHOD **hostkey_methods_avail =
+    const struct hostkey_method **hostkey_methods_avail =
         libssh2_hostkey_methods();
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
@@ -852,7 +852,7 @@ sign_frommemory(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
                 const unsigned char *data, size_t data_len, void **abstract)
 {
     struct privkey_mem *pk_mem = (struct privkey_mem *)(*abstract);
-    const LIBSSH2_HOSTKEY_METHOD *privkeyobj;
+    const struct hostkey_method *privkeyobj;
     void *hostkey_abstract;
     struct iovec datavec;
     int rc;
@@ -892,7 +892,7 @@ sign_fromfile(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
               const unsigned char *data, size_t data_len, void **abstract)
 {
     struct privkey_file *privkey_file = (struct privkey_file *)(*abstract);
-    const LIBSSH2_HOSTKEY_METHOD *privkeyobj;
+    const struct hostkey_method *privkeyobj;
     void *hostkey_abstract;
     struct iovec datavec;
     int rc;
@@ -1042,7 +1042,7 @@ userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
     int rc;
 
     if(session->userauth_host_state == libssh2_NB_state_idle) {
-        const LIBSSH2_HOSTKEY_METHOD *privkeyobj;
+        const struct hostkey_method *privkeyobj;
         unsigned char *pubkeydata = NULL;
         unsigned char *sig = NULL;
         size_t pubkeydata_len = 0;


### PR DESCRIPTION
To fix checksrc TYPEDEFSTRUCT warnings.

Also:
- use target variable instead of resolved type in memset size argument
  for robustness.
- add missing arg names to a typedef func.
- some reflow/formatting/indenting fixes along the way.
