### PR TITLE
checksrc: stop disabling TYPEDEFSTRUCT globally

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -222,6 +222,8 @@ typedef off_t libssh2_struct_stat_size;
                                                  void **abstract))
 #define LIBSSH2_FREE_FUNC(name)    void ((name)(void *ptr, void **abstract))
 
+/* for pre-existing ones: !checksrc! disable TYPEDEFSTRUCT all */
+
 typedef struct _LIBSSH2_USERAUTH_KBDINT_PROMPT
 {
     unsigned char *text;

--- a/include/libssh2_publickey.h
+++ b/include/libssh2_publickey.h
@@ -52,6 +52,7 @@
 
 typedef struct _LIBSSH2_PUBLICKEY               LIBSSH2_PUBLICKEY;
 
+/* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct _libssh2_publickey_attribute {
     const char *name;
     unsigned long name_len;
@@ -60,6 +61,7 @@ typedef struct _libssh2_publickey_attribute {
     char mandatory;
 } libssh2_publickey_attribute;
 
+/* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct _libssh2_publickey_list {
     unsigned char *packet; /* For freeing */
 

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -12,7 +12,7 @@ use Cwd 'abs_path';
 
 my @options = (
     "-i4", "-m79",
-    "-AFIXME", "-AERRNOVAR", "-ATYPEDEFSTRUCT",
+    "-AFIXME", "-AERRNOVAR",
     "-aaccept",
     "-aatoi",
     "-acalloc",


### PR DESCRIPTION
Silence locally in public headers. They are part of the documented
public interface, removing them would be a breaking change.
                                                          
Follow-up to 35aa0b2cd732ef460e027a1a85bea56b5c7b1b33 #1910
Follow-up to 7dd7e626292a7eacac442cac2db76ad48972c71a #1909
Follow-up to c07e953a2f04df1ec1cc267bdc43cf4c1659ed14 #1908
Follow-up to 967647c4daec2ff132aec9bf8021a3245747c09e #1907
