### PR TITLE
build: fix to omit libcrypto.pc from libssh2.pc for BoringSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,13 @@ if(CRYPTO_BACKEND STREQUAL "OpenSSL" OR NOT CRYPTO_BACKEND)
     set(CRYPTO_BACKEND_DEFINE "LIBSSH2_OPENSSL")
     list(APPEND LIBSSH2_LIBS OpenSSL::Crypto)
 
+    if(NOT DEFINED HAVE_BORINGSSL)
+      cmake_push_check_state()
+      list(APPEND CMAKE_REQUIRED_LIBRARIES OpenSSL::Crypto)
+      check_symbol_exists("OPENSSL_IS_BORINGSSL" "openssl/base.h" HAVE_BORINGSSL)
+      cmake_pop_check_state()
+    endif()
+
     if(WIN32)
       # Statically linking to OpenSSL requires crypt32 for some Windows APIs.
       # This should really be handled by FindOpenSSL.cmake.

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -876,6 +876,8 @@ m4_case([$1],
 [openssl], [
   LIBSSH2_LIB_HAVE_LINKFLAGS([ssl], [crypto], [#include <openssl/ssl.h>], [
     AC_DEFINE(LIBSSH2_OPENSSL, 1, [Use $1])
+    found_crypto="$1"
+    found_crypto_str="OpenSSL"
 
     AC_MSG_CHECKING([for BoringSSL])
     AC_COMPILE_IFELSE([
@@ -888,7 +890,7 @@ m4_case([$1],
       ]])
     ],[
       AC_MSG_RESULT([yes])
-      ssl_msg="BoringSSL"
+      found_crypto_str="BoringSSL"
       OPENSSL_IS_BORINGSSL=1
     ],[
       AC_MSG_RESULT([no])
@@ -897,8 +899,6 @@ m4_case([$1],
     if test "$OPENSSL_IS_BORINGSSL" != "1"; then  dnl BoringSSL does not provide libcrypto.pc
       LIBSSH2_PC_REQUIRES_PRIVATE="$LIBSSH2_PC_REQUIRES_PRIVATE${LIBSSH2_PC_REQUIRES_PRIVATE:+,}libcrypto"
     fi
-    found_crypto="$1"
-    found_crypto_str="OpenSSL"
   ])
 ],
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -876,7 +876,27 @@ m4_case([$1],
 [openssl], [
   LIBSSH2_LIB_HAVE_LINKFLAGS([ssl], [crypto], [#include <openssl/ssl.h>], [
     AC_DEFINE(LIBSSH2_OPENSSL, 1, [Use $1])
-    LIBSSH2_PC_REQUIRES_PRIVATE="$LIBSSH2_PC_REQUIRES_PRIVATE${LIBSSH2_PC_REQUIRES_PRIVATE:+,}libcrypto"
+
+    AC_MSG_CHECKING([for BoringSSL])
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
+        #include <openssl/base.h>
+        ]],[[
+        #ifndef OPENSSL_IS_BORINGSSL
+        #error not BoringSSL
+        #endif
+      ]])
+    ],[
+      AC_MSG_RESULT([yes])
+      ssl_msg="BoringSSL"
+      OPENSSL_IS_BORINGSSL=1
+    ],[
+      AC_MSG_RESULT([no])
+    ])
+
+    if test "$OPENSSL_IS_BORINGSSL" != "1"; then  dnl BoringSSL does not provide libcrypto.pc
+      LIBSSH2_PC_REQUIRES_PRIVATE="$LIBSSH2_PC_REQUIRES_PRIVATE${LIBSSH2_PC_REQUIRES_PRIVATE:+,}libcrypto"
+    fi
     found_crypto="$1"
     found_crypto_str="OpenSSL"
   ])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -256,7 +256,7 @@ if(NOT LIBSSH2_DISABLE_INSTALL)
       if(NOT _libname AND NOT _libs AND NOT _libdirs)
         message(WARNING "Bad lib in library list: ${_lib}")
       endif()
-      if(_lib STREQUAL OpenSSL::Crypto)
+      if(_lib STREQUAL OpenSSL::Crypto AND NOT HAVE_BORINGSSL)  # BoringSSL does not provide libcrypto.pc
         set(_modules "libcrypto")
       elseif(_lib STREQUAL ZLIB::ZLIB)
         set(_modules "zlib")


### PR DESCRIPTION
BoringSSL does not provide .pc files.