### PR TITLE
src: drop leading underscore from internal macro constants

### DIFF
--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -341,15 +341,15 @@ LIBSSH2_AES
 #define as 1 if the crypto library supports AES in CBC mode, else 0.
 If defined as 0, the rest of this section can be omitted.
 
-_libssh2_cipher_aes128
+libssh2_cipher_aes128
 AES-128-CBC algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
-_libssh2_cipher_aes192
+libssh2_cipher_aes192
 AES-192-CBC algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
-_libssh2_cipher_aes256
+libssh2_cipher_aes256
 AES-256-CBC algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
@@ -358,15 +358,15 @@ LIBSSH2_AES_CTR
 #define as 1 if the crypto library supports AES in CTR mode, else 0.
 If defined as 0, the rest of this section can be omitted.
 
-_libssh2_cipher_aes128ctr
+libssh2_cipher_aes128ctr
 AES-128-CTR algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
-_libssh2_cipher_aes192ctr
+libssh2_cipher_aes192ctr
 AES-192-CTR algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
-_libssh2_cipher_aes256ctr
+libssh2_cipher_aes256ctr
 AES-256-CTR algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
@@ -375,7 +375,7 @@ LIBSSH2_BLOWFISH
 #define as 1 if the crypto library supports blowfish in CBC mode, else 0.
 If defined as 0, the rest of this section can be omitted.
 
-_libssh2_cipher_blowfish
+libssh2_cipher_blowfish
 Blowfish-CBC algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
@@ -384,7 +384,7 @@ LIBSSH2_RC4
 #define as 1 if the crypto library supports RC4 (arcfour), else 0.
 If defined as 0, the rest of this section can be omitted.
 
-_libssh2_cipher_arcfour
+libssh2_cipher_arcfour
 RC4 algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
@@ -393,7 +393,7 @@ LIBSSH2_CAST
 #define 1 if the crypto library supports cast, else 0.
 If defined as 0, the rest of this section can be omitted.
 
-_libssh2_cipher_cast5
+libssh2_cipher_cast5
 CAST5-CBC algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 
@@ -402,7 +402,7 @@ LIBSSH2_3DES
 #define as 1 if the crypto library supports TripleDES in CBC mode, else 0.
 If defined as 0, the rest of this section can be omitted.
 
-_libssh2_cipher_3des
+libssh2_cipher_3des
 TripleDES-CBC algorithm identifier initializer.
 #define with constant value of type LIBSSH2_CIPHER_T().
 

--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -424,16 +424,16 @@ The maximum Diffie-Hellman modulus bit count accepted from the server. This
 value must be supported by the backend.  Usually 16384.
 
 5.1) Diffie-Hellman context.
-_libssh2_dh_ctx
+libssh2_dh_ctx
 Type of a Diffie-Hellman computation context.
 Must always be defined.
 
 5.2) Diffie-Hellman computation procedures.
-void libssh2_dh_init(_libssh2_dh_ctx *dhctx);
+void libssh2_dh_init(libssh2_dh_ctx *dhctx);
 Initializes the Diffie-Hellman context at `dhctx'. No effective context
 creation needed here.
 
-int libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+int libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
                         _libssh2_bn *g, _libssh2_bn *p, int group_order,
                         _libssh2_bn_ctx *bnctx);
 Generates a Diffie-Hellman key pair using base `g', prime `p' and the given
@@ -442,14 +442,14 @@ The private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
 the public key is returned in `public'.
 0 is returned upon success, else -1.
 
-int libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+int libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                       _libssh2_bn *f, _libssh2_bn *p, _libssh2_bn_ctx * bnctx)
 Computes the Diffie-Hellman secret from the previously created context `*dhctx',
 the public key `f' from the other party and the same prime `p' used at
 context creation. The result is stored in `secret'.
 0 is returned upon success, else -1.
 
-void libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
+void libssh2_dh_dtor(libssh2_dh_ctx *dhctx)
 Destroys Diffie-Hellman context at `dhctx' and resets its storage.
 
 6) Big numbers.

--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -303,14 +303,14 @@ Returns 1 for success and 0 for failure.
 
 4) Bidirectional key ciphers.
 
-_libssh2_cipher_ctx
+libssh2_cipher_ctx
 Type of a cipher computation context.
 
 _libssh2_cipher_type(name);
 Macro defining name as storage identifying a cipher algorithm for
 the crypto library interface. No trailing semicolon.
 
-int _libssh2_cipher_init(_libssh2_cipher_ctx *h,
+int _libssh2_cipher_init(libssh2_cipher_ctx *h,
                          _libssh2_cipher_type(algo),
                          unsigned char *iv,
                          unsigned char *secret,
@@ -321,7 +321,7 @@ encrypt.
 Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int _libssh2_cipher_crypt(_libssh2_cipher_ctx *ctx,
+int _libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
                           _libssh2_cipher_type(algo),
                           int encrypt,
                           unsigned char *block,
@@ -332,7 +332,7 @@ context and/or algorithm.
 Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-void _libssh2_cipher_dtor(_libssh2_cipher_ctx *ctx);
+void _libssh2_cipher_dtor(libssh2_cipher_ctx *ctx);
 Release cipher context at ctx.
 
 4.1) AES

--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -306,12 +306,12 @@ Returns 1 for success and 0 for failure.
 libssh2_cipher_ctx
 Type of a cipher computation context.
 
-_libssh2_cipher_type(name);
+LIBSSH2_CIPHER_T(name);
 Macro defining name as storage identifying a cipher algorithm for
 the crypto library interface. No trailing semicolon.
 
 int _libssh2_cipher_init(libssh2_cipher_ctx *h,
-                         _libssh2_cipher_type(algo),
+                         LIBSSH2_CIPHER_T(algo),
                          unsigned char *iv,
                          unsigned char *secret,
                          int encrypt);
@@ -322,7 +322,7 @@ Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
 int _libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
-                          _libssh2_cipher_type(algo),
+                          LIBSSH2_CIPHER_T(algo),
                           int encrypt,
                           unsigned char *block,
                           size_t blocksize,
@@ -343,15 +343,15 @@ If defined as 0, the rest of this section can be omitted.
 
 _libssh2_cipher_aes128
 AES-128-CBC algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 _libssh2_cipher_aes192
 AES-192-CBC algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 _libssh2_cipher_aes256
 AES-256-CBC algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 4.1.2) AES in CTR block mode.
 LIBSSH2_AES_CTR
@@ -360,15 +360,15 @@ If defined as 0, the rest of this section can be omitted.
 
 _libssh2_cipher_aes128ctr
 AES-128-CTR algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 _libssh2_cipher_aes192ctr
 AES-192-CTR algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 _libssh2_cipher_aes256ctr
 AES-256-CTR algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 4.2) Blowfish in CBC block mode.
 LIBSSH2_BLOWFISH
@@ -377,7 +377,7 @@ If defined as 0, the rest of this section can be omitted.
 
 _libssh2_cipher_blowfish
 Blowfish-CBC algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 4.3) RC4.
 LIBSSH2_RC4
@@ -386,7 +386,7 @@ If defined as 0, the rest of this section can be omitted.
 
 _libssh2_cipher_arcfour
 RC4 algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 4.4) CAST5 in CBC block mode.
 LIBSSH2_CAST
@@ -395,7 +395,7 @@ If defined as 0, the rest of this section can be omitted.
 
 _libssh2_cipher_cast5
 CAST5-CBC algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 4.5) Triple DES in CBC block mode.
 LIBSSH2_3DES
@@ -404,7 +404,7 @@ If defined as 0, the rest of this section can be omitted.
 
 _libssh2_cipher_3des
 TripleDES-CBC algorithm identifier initializer.
-#define with constant value of type _libssh2_cipher_type().
+#define with constant value of type LIBSSH2_CIPHER_T().
 
 5) Diffie-Hellman support.
 

--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -435,7 +435,7 @@ creation needed here.
 
 int libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
                         libssh2_bn *g, libssh2_bn *p, int group_order,
-                        _libssh2_bn_ctx *bnctx);
+                        libssh2_bn_ctx *bnctx);
 Generates a Diffie-Hellman key pair using base `g', prime `p' and the given
 `group_order'. Can use the given big number context `bnctx' if needed.
 The private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
@@ -443,7 +443,7 @@ the public key is returned in `public'.
 0 is returned upon success, else -1.
 
 int libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
-                      libssh2_bn *f, libssh2_bn *p, _libssh2_bn_ctx * bnctx)
+                      libssh2_bn *f, libssh2_bn *p, libssh2_bn_ctx * bnctx)
 Computes the Diffie-Hellman secret from the previously created context `*dhctx',
 the public key `f' from the other party and the same prime `p' used at
 context creation. The result is stored in `secret'.
@@ -459,14 +459,14 @@ Positive multi-byte integers support is sufficient.
 This has a real meaning if the big numbers computations need some context
 storage. If not, use a dummy type and functions (macros).
 
-_libssh2_bn_ctx
+libssh2_bn_ctx
 Type of multiple precision computation context. May not be empty. if not used,
 #define as char, for example.
 
-_libssh2_bn_ctx _libssh2_bn_ctx_new(void);
+libssh2_bn_ctx _libssh2_bn_ctx_new(void);
 Returns a new multiple precision computation context.
 
-void _libssh2_bn_ctx_free(_libssh2_bn_ctx ctx);
+void _libssh2_bn_ctx_free(libssh2_bn_ctx ctx);
 Releases a multiple precision computation context.
 
 6.2) Computation support.

--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -433,8 +433,8 @@ void libssh2_dh_init(libssh2_dh_ctx *dhctx);
 Initializes the Diffie-Hellman context at `dhctx'. No effective context
 creation needed here.
 
-int libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
-                        _libssh2_bn *g, _libssh2_bn *p, int group_order,
+int libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
+                        libssh2_bn *g, libssh2_bn *p, int group_order,
                         _libssh2_bn_ctx *bnctx);
 Generates a Diffie-Hellman key pair using base `g', prime `p' and the given
 `group_order'. Can use the given big number context `bnctx' if needed.
@@ -442,8 +442,8 @@ The private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
 the public key is returned in `public'.
 0 is returned upon success, else -1.
 
-int libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
-                      _libssh2_bn *f, _libssh2_bn *p, _libssh2_bn_ctx * bnctx)
+int libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
+                      libssh2_bn *f, libssh2_bn *p, _libssh2_bn_ctx * bnctx)
 Computes the Diffie-Hellman secret from the previously created context `*dhctx',
 the public key `f' from the other party and the same prime `p' used at
 context creation. The result is stored in `secret'.
@@ -470,41 +470,41 @@ void _libssh2_bn_ctx_free(_libssh2_bn_ctx ctx);
 Releases a multiple precision computation context.
 
 6.2) Computation support.
-_libssh2_bn
+libssh2_bn
 Type of multiple precision numbers (aka bignumbers or huge integers) for the
 crypto library.
 
-_libssh2_bn * _libssh2_bn_init(void);
+libssh2_bn * _libssh2_bn_init(void);
 Creates a multiple precision number (preset to zero).
 
-_libssh2_bn * _libssh2_bn_init_from_bin(void);
+libssh2_bn * _libssh2_bn_init_from_bin(void);
 Create a multiple precision number intended to be set by the
 _libssh2_bn_from_bin() function (see below). Unlike _libssh2_bn_init(), this
 code may be a dummy initializer if the _libssh2_bn_from_bin() actually
-allocates the number. Returns a value of type _libssh2_bn *.
+allocates the number. Returns a value of type libssh2_bn *.
 
-void _libssh2_bn_free(_libssh2_bn *bn);
+void _libssh2_bn_free(libssh2_bn *bn);
 Destroys the multiple precision number at bn.
 
-unsigned long _libssh2_bn_bytes(_libssh2_bn *bn);
+unsigned long _libssh2_bn_bytes(libssh2_bn *bn);
 Get the number of bytes needed to store the bits of the multiple precision
 number at bn.
 
-unsigned long _libssh2_bn_bits(_libssh2_bn *bn);
+unsigned long _libssh2_bn_bits(libssh2_bn *bn);
 Returns the number of bits of multiple precision number at bn.
 
-int _libssh2_bn_set_word(_libssh2_bn *bn, unsigned long val);
+int _libssh2_bn_set_word(libssh2_bn *bn, unsigned long val);
 Sets the value of bn to val.
 Returns 1 on success, 0 otherwise.
 
-_libssh2_bn * _libssh2_bn_from_bin(_libssh2_bn *bn, int len,
+libssh2_bn * _libssh2_bn_from_bin(libssh2_bn *bn, int len,
                                    const unsigned char *val);
 Converts the positive integer in big-endian form of length len at val
-into a _libssh2_bn and place it in bn. If bn is NULL, a new _libssh2_bn is
+into a libssh2_bn and place it in bn. If bn is NULL, a new libssh2_bn is
 created.
-Returns a pointer to target _libssh2_bn or NULL if error.
+Returns a pointer to target libssh2_bn or NULL if error.
 
-int _libssh2_bn_to_bin(_libssh2_bn *bn, unsigned char *val);
+int _libssh2_bn_to_bin(libssh2_bn *bn, unsigned char *val);
 Converts the absolute value of bn into big-endian form and store it at
 val. val must point to _libssh2_bn_bytes(bn) bytes of memory.
 Returns the length of the big-endian number.
@@ -939,7 +939,7 @@ Verify (s, s_len) signature of (m, m_len) using the given ED25519 context.
 Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int _libssh2_curve25519_gen_k(_libssh2_bn **k,
+int _libssh2_curve25519_gen_k(libssh2_bn **k,
                               uint8_t private_key[LIBSSH2_ED25519_KEY_LEN],
                               uint8_t srvr_public_key[LIBSSH2_ED25519_KEY_LEN]);
 Computes a shared ED25519 secret key from the given raw server public key and

--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -772,7 +772,7 @@ Releases the DSA computation context at dsactx.
 7.3) ECDSA
 LIBSSH2_ECDSA
 #define as 1 if the crypto library supports ECDSA, else 0.
-If defined as 0, _libssh2_ec_key should be defined as void and the rest of
+If defined as 0, libssh2_ec_key should be defined as void and the rest of
 this section can be omitted.
 
 EC_MAX_POINT_LEN
@@ -781,7 +781,7 @@ Maximum point length. Usually defined as ((528 * 2 / 8) + 1) (= 133).
 libssh2_ecdsa_ctx
 Type of an ECDSA computation context. Generally a struct.
 
-_libssh2_ec_key
+libssh2_ec_key
 Type of an elliptic curve key.
 
 libssh2_curve_type
@@ -790,7 +790,7 @@ An enum type defining curve types. Current supported identifiers are:
     LIBSSH2_EC_CURVE_NISTP384
     LIBSSH2_EC_CURVE_NISTP521
 
-int _libssh2_ecdsa_create_key(_libssh2_ec_key **out_private_key,
+int _libssh2_ecdsa_create_key(libssh2_ec_key **out_private_key,
                               unsigned char **out_public_key_octal,
                               size_t *out_public_key_octal_len,
                               libssh2_curve_type curve_type);

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -85,7 +85,7 @@ static const struct crypt_method libssh2_crypt_method_none = {
 struct crypt_ctx
 {
     int encrypt;
-    _libssh2_cipher_type(algo);
+    LIBSSH2_CIPHER_T(algo);
     libssh2_cipher_ctx h;
     struct chachapoly_ctx chachapoly_ctx;
 };

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -154,7 +154,7 @@ static const struct crypt_method libssh2_crypt_method_aes256_gcm = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes256gcm
+    libssh2_cipher_aes256gcm
 };
 
 static const struct crypt_method libssh2_crypt_method_aes128_gcm = {
@@ -169,7 +169,7 @@ static const struct crypt_method libssh2_crypt_method_aes128_gcm = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes128gcm
+    libssh2_cipher_aes128gcm
 };
 #endif
 
@@ -186,7 +186,7 @@ static const struct crypt_method libssh2_crypt_method_aes128_ctr = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes128ctr
+    libssh2_cipher_aes128ctr
 };
 
 static const struct crypt_method libssh2_crypt_method_aes192_ctr = {
@@ -201,7 +201,7 @@ static const struct crypt_method libssh2_crypt_method_aes192_ctr = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes192ctr
+    libssh2_cipher_aes192ctr
 };
 
 static const struct crypt_method libssh2_crypt_method_aes256_ctr = {
@@ -216,7 +216,7 @@ static const struct crypt_method libssh2_crypt_method_aes256_ctr = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes256ctr
+    libssh2_cipher_aes256ctr
 };
 #endif
 
@@ -233,7 +233,7 @@ static const struct crypt_method libssh2_crypt_method_aes128_cbc = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes128
+    libssh2_cipher_aes128
 };
 
 static const struct crypt_method libssh2_crypt_method_aes192_cbc = {
@@ -248,7 +248,7 @@ static const struct crypt_method libssh2_crypt_method_aes192_cbc = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes192
+    libssh2_cipher_aes192
 };
 
 static const struct crypt_method libssh2_crypt_method_aes256_cbc = {
@@ -263,7 +263,7 @@ static const struct crypt_method libssh2_crypt_method_aes256_cbc = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes256
+    libssh2_cipher_aes256
 };
 
 /* rijndael-cbc@lysator.liu.se == aes256-cbc */
@@ -280,7 +280,7 @@ static const struct crypt_method
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_aes256
+    libssh2_cipher_aes256
 };
 #endif /* LIBSSH2_AES_CBC */
 
@@ -297,7 +297,7 @@ static const struct crypt_method libssh2_crypt_method_blowfish_cbc = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_blowfish
+    libssh2_cipher_blowfish
 };
 #endif /* LIBSSH2_BLOWFISH */
 
@@ -314,7 +314,7 @@ static const struct crypt_method libssh2_crypt_method_arcfour = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_arcfour
+    libssh2_cipher_arcfour
 };
 
 static int
@@ -353,7 +353,7 @@ static const struct crypt_method libssh2_crypt_method_arcfour128 = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_arcfour
+    libssh2_cipher_arcfour
 };
 #endif /* LIBSSH2_RC4 */
 
@@ -370,7 +370,7 @@ static const struct crypt_method libssh2_crypt_method_cast128_cbc = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_cast5
+    libssh2_cipher_cast5
 };
 #endif /* LIBSSH2_CAST */
 
@@ -387,7 +387,7 @@ static const struct crypt_method libssh2_crypt_method_3des_cbc = {
     NULL,
     &crypt_encrypt,
     &crypt_dtor,
-    _libssh2_cipher_3des
+    libssh2_cipher_3des
 };
 #endif
 
@@ -499,7 +499,7 @@ static const struct crypt_method
     &crypt_get_length_chacha20_poly,
     &crypt_encrypt_chacha20_poly_buffer,
     &crypt_dtor_chacha20_poly,
-    _libssh2_cipher_chacha20                    /* not actually used */
+    libssh2_cipher_chacha20                     /* not actually used */
 };
 
 /* These are the crypt methods that are available to be negotiated. Methods

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -86,7 +86,7 @@ struct crypt_ctx
 {
     int encrypt;
     _libssh2_cipher_type(algo);
-    _libssh2_cipher_ctx h;
+    libssh2_cipher_ctx h;
     struct chachapoly_ctx chachapoly_ctx;
 };
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -320,12 +320,12 @@ _libssh2_mlkem_get_sk(unsigned char *out_shared_key,
 
 #endif /* LIBSSH2_MLKEM */
 
-int _libssh2_cipher_init(_libssh2_cipher_ctx *h,
+int _libssh2_cipher_init(libssh2_cipher_ctx *h,
                          _libssh2_cipher_type(algo),
                          unsigned char *iv,
                          unsigned char *secret, int encrypt);
 
-int _libssh2_cipher_crypt(_libssh2_cipher_ctx *ctx,
+int _libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
                           _libssh2_cipher_type(algo),
                           int encrypt, unsigned char *block, size_t blocksize,
                           int firstlast);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -210,7 +210,7 @@ _libssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
                           libssh2_curve_type curve_type);
 
 int
-_libssh2_ecdh_gen_k(_libssh2_bn **k, _libssh2_ec_key *private_key,
+_libssh2_ecdh_gen_k(libssh2_bn **k, _libssh2_ec_key *private_key,
                     const unsigned char *server_public_key,
                     size_t server_public_key_len);
 
@@ -251,7 +251,7 @@ _libssh2_curve25519_new(LIBSSH2_SESSION *session, uint8_t **out_public_key,
                         uint8_t **out_private_key);
 
 int
-_libssh2_curve25519_gen_k(_libssh2_bn **k,
+_libssh2_curve25519_gen_k(libssh2_bn **k,
                           uint8_t private_key[LIBSSH2_ED25519_KEY_LEN],
                           uint8_t server_public_key[LIBSSH2_ED25519_KEY_LEN]);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -204,13 +204,13 @@ _libssh2_ecdsa_verify(libssh2_ecdsa_ctx *ec_ctx,
 
 int
 _libssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
-                          _libssh2_ec_key **out_private_key,
+                          libssh2_ec_key **out_private_key,
                           unsigned char **out_public_key_octal,
                           size_t *out_public_key_octal_len,
                           libssh2_curve_type curve_type);
 
 int
-_libssh2_ecdh_gen_k(libssh2_bn **k, _libssh2_ec_key *private_key,
+_libssh2_ecdh_gen_k(libssh2_bn **k, libssh2_ec_key *private_key,
                     const unsigned char *server_public_key,
                     size_t server_public_key_len);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -321,12 +321,12 @@ _libssh2_mlkem_get_sk(unsigned char *out_shared_key,
 #endif /* LIBSSH2_MLKEM */
 
 int _libssh2_cipher_init(libssh2_cipher_ctx *h,
-                         _libssh2_cipher_type(algo),
+                         LIBSSH2_CIPHER_T(algo),
                          unsigned char *iv,
                          unsigned char *secret, int encrypt);
 
 int _libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
-                          _libssh2_cipher_type(algo),
+                          LIBSSH2_CIPHER_T(algo),
                           int encrypt, unsigned char *block, size_t blocksize,
                           int firstlast);
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -640,8 +640,8 @@ static void kex_diffie_hellman_cleanup(
  * @result 0 on success, error code on failure
  */
 static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
-                                   _libssh2_bn *g,
-                                   _libssh2_bn *p,
+                                   libssh2_bn *g,
+                                   libssh2_bn *p,
                                    int group_order,
                                    int sha_algo_value,
                                    void *exchange_hash_ctx,
@@ -1098,8 +1098,8 @@ clean_exit:
  */
 typedef int (*diffie_hellman_hash_func_t)(
     LIBSSH2_SESSION *session,
-    _libssh2_bn *g,
-    _libssh2_bn *p,
+    libssh2_bn *g,
+    libssh2_bn *p,
     int group_order,
     int sha_algo_value,
     void *exchange_hash_ctx,

--- a/src/kex.c
+++ b/src/kex.c
@@ -2044,7 +2044,7 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
 static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
                            unsigned char *data, size_t data_len,
                            unsigned char *public_key,
-                           size_t public_key_len, _libssh2_ec_key *private_key,
+                           size_t public_key_len, libssh2_ec_key *private_key,
                            struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
@@ -2379,7 +2379,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                        unsigned char *data, size_t data_len,
                        unsigned char *public_t_key,
                        size_t public_t_key_len,
-                       _libssh2_ec_key *private_t_key,
+                       libssh2_ec_key *private_t_key,
                        unsigned char *public_pq_key,
                        unsigned char *private_pq_key,
                        struct kmdhgGPshakex_state *exchange_state)

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -733,7 +733,7 @@ _libssh2_dsa_sha1_verify(libssh2_dsa_ctx *dsactx,
 #endif
 
 int
-_libssh2_cipher_init(_libssh2_cipher_ctx *h,
+_libssh2_cipher_init(libssh2_cipher_ctx *h,
                      _libssh2_cipher_type(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
@@ -771,7 +771,7 @@ _libssh2_cipher_init(_libssh2_cipher_ctx *h,
 }
 
 int
-_libssh2_cipher_crypt(_libssh2_cipher_ctx *ctx,
+_libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
                       _libssh2_cipher_type(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -734,7 +734,7 @@ _libssh2_dsa_sha1_verify(libssh2_dsa_ctx *dsactx,
 
 int
 _libssh2_cipher_init(libssh2_cipher_ctx *h,
-                     _libssh2_cipher_type(algo),
+                     LIBSSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
     int ret;
@@ -772,7 +772,7 @@ _libssh2_cipher_init(libssh2_cipher_ctx *h,
 
 int
 _libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
-                      _libssh2_cipher_type(algo),
+                      LIBSSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)
 {

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -880,8 +880,8 @@ _libssh2_dh_init(libssh2_dh_ctx *dhctx)
 }
 
 int
-_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
-                     _libssh2_bn *g, _libssh2_bn *p, int group_order)
+_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
+                     libssh2_bn *g, libssh2_bn *p, int group_order)
 {
     /* Generate x and e */
     gcry_mpi_randomize(*dhctx, group_order * 8 - 1, GCRY_WEAK_RANDOM);
@@ -890,8 +890,8 @@ _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
 }
 
 int
-_libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
-                   _libssh2_bn *f, _libssh2_bn *p)
+_libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
+                   libssh2_bn *f, libssh2_bn *p)
 {
     /* Compute the shared secret */
     gcry_mpi_powm(secret, f, *dhctx, p);

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -874,13 +874,13 @@ void _libssh2_init_aes_ctr(void)
 }
 
 void
-_libssh2_dh_init(_libssh2_dh_ctx *dhctx)
+_libssh2_dh_init(libssh2_dh_ctx *dhctx)
 {
     *dhctx = gcry_mpi_new(0);                   /* Random from client */
 }
 
 int
-_libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
                      _libssh2_bn *g, _libssh2_bn *p, int group_order)
 {
     /* Generate x and e */
@@ -890,7 +890,7 @@ _libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
 }
 
 int
-_libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+_libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                    _libssh2_bn *f, _libssh2_bn *p)
 {
     /* Compute the shared secret */
@@ -899,7 +899,7 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
 }
 
 void
-_libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
+_libssh2_dh_dtor(libssh2_dh_ctx *dhctx)
 {
     gcry_mpi_release(*dhctx);
     *dhctx = NULL;

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -158,7 +158,7 @@
 #define _libssh2_ec_key void
 #endif
 
-#define _libssh2_cipher_type(name) int name
+#define LIBSSH2_CIPHER_T(name) int name
 #define libssh2_cipher_ctx gcry_cipher_hd_t
 
 #define _libssh2_gcry_ciphermode(c,m) (((c) << 8) | (m))

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -191,7 +191,7 @@
 #define _libssh2_cipher_dtor(ctx) gcry_cipher_close(*(ctx))
 
 #define libssh2_bn struct gcry_mpi
-#define _libssh2_bn_ctx int
+#define libssh2_bn_ctx int
 #define _libssh2_bn_ctx_new() 0
 #define _libssh2_bn_ctx_free(bnctx) ((void)0)
 #define _libssh2_bn_init() gcry_mpi_new(0)

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -165,27 +165,27 @@
 #define _libssh2_gcry_cipher(c) ((c) >> 8)
 #define _libssh2_gcry_mode(m) ((m) & 0xFF)
 
-#define _libssh2_cipher_aes256ctr \
+#define libssh2_cipher_aes256ctr \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_AES256, GCRY_CIPHER_MODE_CTR)
-#define _libssh2_cipher_aes192ctr \
+#define libssh2_cipher_aes192ctr \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_AES192, GCRY_CIPHER_MODE_CTR)
-#define _libssh2_cipher_aes128ctr \
+#define libssh2_cipher_aes128ctr \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_AES128, GCRY_CIPHER_MODE_CTR)
-#define _libssh2_cipher_aes256 \
+#define libssh2_cipher_aes256 \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_AES256, GCRY_CIPHER_MODE_CBC)
-#define _libssh2_cipher_aes192 \
+#define libssh2_cipher_aes192 \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_AES192, GCRY_CIPHER_MODE_CBC)
-#define _libssh2_cipher_aes128 \
+#define libssh2_cipher_aes128 \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_AES128, GCRY_CIPHER_MODE_CBC)
-#define _libssh2_cipher_blowfish \
+#define libssh2_cipher_blowfish \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_BLOWFISH, GCRY_CIPHER_MODE_CBC)
-#define _libssh2_cipher_arcfour \
+#define libssh2_cipher_arcfour \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_ARCFOUR, GCRY_CIPHER_MODE_STREAM)
-#define _libssh2_cipher_cast5 \
+#define libssh2_cipher_cast5 \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_CAST5, GCRY_CIPHER_MODE_CBC)
-#define _libssh2_cipher_3des \
+#define libssh2_cipher_3des \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_3DES, GCRY_CIPHER_MODE_CBC)
-#define _libssh2_cipher_chacha20 \
+#define libssh2_cipher_chacha20 \
     _libssh2_gcry_ciphermode(GCRY_CIPHER_CHACHA20, GCRY_CIPHER_MODE_STREAM)
 
 #define _libssh2_cipher_dtor(ctx) gcry_cipher_close(*(ctx))

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -216,7 +216,7 @@
 
 #define LIBSSH2_DH_MAX_MODULUS_BITS 16384
 
-#define _libssh2_dh_ctx struct gcry_mpi *
+#define libssh2_dh_ctx struct gcry_mpi *
 #define libssh2_dh_init(dhctx) _libssh2_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     _libssh2_dh_key_pair(dhctx, public, g, p, group_order)
@@ -224,12 +224,12 @@
     _libssh2_dh_secret(dhctx, secret, f, p)
 #define libssh2_dh_dtor(dhctx) _libssh2_dh_dtor(dhctx)
 extern void _libssh2_init_aes_ctr(void);
-extern void _libssh2_dh_init(_libssh2_dh_ctx *dhctx);
-extern int _libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+extern void _libssh2_dh_init(libssh2_dh_ctx *dhctx);
+extern int _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
                                 _libssh2_bn *g, _libssh2_bn *p,
                                 int group_order);
-extern int _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+extern int _libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                               _libssh2_bn *f, _libssh2_bn *p);
-extern void _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
+extern void _libssh2_dh_dtor(libssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_LIBGCRYPT_H */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -190,7 +190,7 @@
 
 #define _libssh2_cipher_dtor(ctx) gcry_cipher_close(*(ctx))
 
-#define _libssh2_bn struct gcry_mpi
+#define libssh2_bn struct gcry_mpi
 #define _libssh2_bn_ctx int
 #define _libssh2_bn_ctx_new() 0
 #define _libssh2_bn_ctx_free(bnctx) ((void)0)
@@ -225,11 +225,11 @@
 #define libssh2_dh_dtor(dhctx) _libssh2_dh_dtor(dhctx)
 extern void _libssh2_init_aes_ctr(void);
 extern void _libssh2_dh_init(libssh2_dh_ctx *dhctx);
-extern int _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
-                                _libssh2_bn *g, _libssh2_bn *p,
+extern int _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
+                                libssh2_bn *g, libssh2_bn *p,
                                 int group_order);
-extern int _libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
-                              _libssh2_bn *f, _libssh2_bn *p);
+extern int _libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
+                              libssh2_bn *f, libssh2_bn *p);
 extern void _libssh2_dh_dtor(libssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_LIBGCRYPT_H */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -159,7 +159,7 @@
 #endif
 
 #define _libssh2_cipher_type(name) int name
-#define _libssh2_cipher_ctx gcry_cipher_hd_t
+#define libssh2_cipher_ctx gcry_cipher_hd_t
 
 #define _libssh2_gcry_ciphermode(c,m) (((c) << 8) | (m))
 #define _libssh2_gcry_cipher(c) ((c) >> 8)

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -155,7 +155,7 @@
 
 #if LIBSSH2_ECDSA
 #else
-#define _libssh2_ec_key void
+#define libssh2_ec_key void
 #endif
 
 #define LIBSSH2_CIPHER_T(name) int name

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -356,7 +356,7 @@ struct key_exchange_state_low {
     unsigned char *data;
     size_t request_len;
     size_t data_len;
-    _libssh2_ec_key *private_key;   /* SSH2 ecdh private key */
+    libssh2_ec_key *private_key;    /* SSH2 ecdh private key */
     unsigned char *public_key_oct;  /* SSH2 ecdh public key octal value */
     size_t public_key_oct_len;      /* SSH2 ecdh public key octal value
                                        length */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -330,7 +330,7 @@ struct kmdhgGPshakex_state {
     size_t s_packet_len;
     size_t tmp_len;
     _libssh2_bn_ctx *ctx;
-    _libssh2_dh_ctx x;
+    libssh2_dh_ctx x;
     _libssh2_bn *e;
     _libssh2_bn *f;
     _libssh2_bn *k;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1038,7 +1038,7 @@ struct crypt_method {
                  int firstlast);
     int (*dtor)(LIBSSH2_SESSION *session, void **abstract);
 
-    _libssh2_cipher_type(algo);
+    LIBSSH2_CIPHER_T(algo);
 };
 
 /* Bit flags for struct crypt_method */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -331,9 +331,9 @@ struct kmdhgGPshakex_state {
     size_t tmp_len;
     _libssh2_bn_ctx *ctx;
     libssh2_dh_ctx x;
-    _libssh2_bn *e;
-    _libssh2_bn *f;
-    _libssh2_bn *k;
+    libssh2_bn *e;
+    libssh2_bn *f;
+    libssh2_bn *k;
     unsigned char *f_value;
     unsigned char *k_value;
     unsigned char *h_sig;
@@ -348,8 +348,8 @@ struct key_exchange_state_low {
     libssh2_nonblocking_states state;
     struct packet_require_state req_state;
     struct kmdhgGPshakex_state exchange_state;
-    _libssh2_bn *p;             /* SSH2 defined value (p_value) */
-    _libssh2_bn *g;             /* SSH2 defined value (2) */
+    libssh2_bn *p;             /* SSH2 defined value (p_value) */
+    libssh2_bn *g;             /* SSH2 defined value (2) */
     /* Request must fit mlkem1024nistp384 keys + 5 bytes overhead */
     unsigned char request[LIBSSH2_MLKEM_1024_PUBLIC_KEY_LEN +
                           LIBSSH2_EC_P384_PUBLIC_KEY_LEN + 5];

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -329,7 +329,7 @@ struct kmdhgGPshakex_state {
     size_t e_packet_len;
     size_t s_packet_len;
     size_t tmp_len;
-    _libssh2_bn_ctx *ctx;
+    libssh2_bn_ctx *ctx;
     libssh2_dh_ctx x;
     libssh2_bn *e;
     libssh2_bn *f;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -906,13 +906,13 @@ void _libssh2_init_aes_ctr(void)
  */
 
 void
-_libssh2_dh_init(_libssh2_dh_ctx *dhctx)
+_libssh2_dh_init(libssh2_dh_ctx *dhctx)
 {
     *dhctx = _libssh2_mbedtls_bignum_init();    /* Random from client */
 }
 
 int
-_libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
                      _libssh2_bn *g, _libssh2_bn *p, int group_order)
 {
     /* Generate x and e */
@@ -922,7 +922,7 @@ _libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
 }
 
 int
-_libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+_libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                    _libssh2_bn *f, _libssh2_bn *p)
 {
     /* Compute the shared secret */
@@ -931,7 +931,7 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
 }
 
 void
-_libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
+_libssh2_dh_dtor(libssh2_dh_ctx *dhctx)
 {
     _libssh2_mbedtls_bignum_free(*dhctx);
     *dhctx = NULL;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -314,12 +314,12 @@ void _libssh2_hmac_cleanup(libssh2_hmac_ctx *ctx)
  * mbedTLS backend: BigNumber functions
  */
 
-_libssh2_bn *
+libssh2_bn *
 _libssh2_mbedtls_bignum_init(void)
 {
-    _libssh2_bn *bignum;
+    libssh2_bn *bignum;
 
-    bignum = (_libssh2_bn *)mbedtls_calloc(1, sizeof(_libssh2_bn));
+    bignum = (libssh2_bn *)mbedtls_calloc(1, sizeof(libssh2_bn));
     if(bignum) {
         mbedtls_mpi_init(bignum);
     }
@@ -328,7 +328,7 @@ _libssh2_mbedtls_bignum_init(void)
 }
 
 void
-_libssh2_mbedtls_bignum_free(_libssh2_bn *bn)
+_libssh2_mbedtls_bignum_free(libssh2_bn *bn)
 {
     if(bn) {
         mbedtls_mpi_free(bn);
@@ -337,7 +337,7 @@ _libssh2_mbedtls_bignum_free(_libssh2_bn *bn)
 }
 
 static int
-_libssh2_mbedtls_bignum_random(_libssh2_bn *bn, int bits, int top, int bottom)
+_libssh2_mbedtls_bignum_random(libssh2_bn *bn, int bits, int top, int bottom)
 {
     size_t len;
     int err;
@@ -912,8 +912,8 @@ _libssh2_dh_init(libssh2_dh_ctx *dhctx)
 }
 
 int
-_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
-                     _libssh2_bn *g, _libssh2_bn *p, int group_order)
+_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
+                     libssh2_bn *g, libssh2_bn *p, int group_order)
 {
     /* Generate x and e */
     _libssh2_mbedtls_bignum_random(*dhctx, group_order * 8 - 1, 0, -1);
@@ -922,8 +922,8 @@ _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
 }
 
 int
-_libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
-                   _libssh2_bn *f, _libssh2_bn *p)
+_libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
+                   libssh2_bn *f, libssh2_bn *p)
 {
     /* Compute the shared secret */
     mbedtls_mpi_exp_mod(secret, f, *dhctx, p, NULL);
@@ -1040,7 +1040,7 @@ failed:
  * remote public key and length
  */
 int
-_libssh2_mbedtls_ecdh_gen_k(_libssh2_bn **k,
+_libssh2_mbedtls_ecdh_gen_k(libssh2_bn **k,
                             _libssh2_ec_key *private_key,
                             const unsigned char *server_public_key,
                             size_t server_public_key_len)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -103,7 +103,7 @@ _libssh2_mbedtls_safe_free(void *buf, size_t len)
 }
 
 int
-_libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
+_libssh2_mbedtls_cipher_init(libssh2_cipher_ctx *h,
                              _libssh2_cipher_type(algo),
                              unsigned char *iv,
                              unsigned char *secret,
@@ -151,7 +151,7 @@ _libssh2_mbedtls_cipher_init(_libssh2_cipher_ctx *h,
 }
 
 int
-_libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
+_libssh2_mbedtls_cipher_crypt(libssh2_cipher_ctx *ctx,
                               _libssh2_cipher_type(algo),
                               int encrypt,
                               unsigned char *block,
@@ -191,7 +191,7 @@ _libssh2_mbedtls_cipher_crypt(_libssh2_cipher_ctx *ctx,
 }
 
 void
-_libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx)
+_libssh2_mbedtls_cipher_dtor(libssh2_cipher_ctx *ctx)
 {
     mbedtls_cipher_free(ctx);
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -104,7 +104,7 @@ _libssh2_mbedtls_safe_free(void *buf, size_t len)
 
 int
 _libssh2_mbedtls_cipher_init(libssh2_cipher_ctx *h,
-                             _libssh2_cipher_type(algo),
+                             LIBSSH2_CIPHER_T(algo),
                              unsigned char *iv,
                              unsigned char *secret,
                              int encrypt)
@@ -152,7 +152,7 @@ _libssh2_mbedtls_cipher_init(libssh2_cipher_ctx *h,
 
 int
 _libssh2_mbedtls_cipher_crypt(libssh2_cipher_ctx *ctx,
-                              _libssh2_cipher_type(algo),
+                              LIBSSH2_CIPHER_T(algo),
                               int encrypt,
                               unsigned char *block,
                               size_t blocksize, int firstlast)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -953,7 +953,7 @@ _libssh2_dh_dtor(libssh2_dh_ctx *dhctx)
  */
 int
 _libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
-                                  _libssh2_ec_key **out_private_key,
+                                  libssh2_ec_key **out_private_key,
                                   unsigned char **out_public_key_octal,
                                   size_t *out_public_key_octal_len,
                                   libssh2_curve_type curve_type)
@@ -1041,7 +1041,7 @@ failed:
  */
 int
 _libssh2_mbedtls_ecdh_gen_k(libssh2_bn **k,
-                            _libssh2_ec_key *private_key,
+                            libssh2_ec_key *private_key,
                             const unsigned char *server_public_key,
                             size_t server_public_key_len)
 {

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -337,7 +337,7 @@ typedef enum {
  * mbedTLS backend: Cipher Context structure
  */
 
-#define _libssh2_cipher_ctx         mbedtls_cipher_context_t
+#define libssh2_cipher_ctx          mbedtls_cipher_context_t
 
 #define _libssh2_cipher_type(algo)  mbedtls_cipher_type_t algo
 
@@ -432,7 +432,7 @@ int
 _libssh2_mbedtls_random(unsigned char *buf, size_t len);
 
 void
-_libssh2_mbedtls_cipher_dtor(_libssh2_cipher_ctx *ctx);
+_libssh2_mbedtls_cipher_dtor(libssh2_cipher_ctx *ctx);
 
 int
 _libssh2_mbedtls_hash_init(mbedtls_md_context_t *ctx,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -341,20 +341,20 @@ typedef enum {
 
 #define LIBSSH2_CIPHER_T(algo)    mbedtls_cipher_type_t algo
 
-#define _libssh2_cipher_aes256ctr MBEDTLS_CIPHER_AES_256_CTR
-#define _libssh2_cipher_aes192ctr MBEDTLS_CIPHER_AES_192_CTR
-#define _libssh2_cipher_aes128ctr MBEDTLS_CIPHER_AES_128_CTR
-#define _libssh2_cipher_aes256    MBEDTLS_CIPHER_AES_256_CBC
-#define _libssh2_cipher_aes192    MBEDTLS_CIPHER_AES_192_CBC
-#define _libssh2_cipher_aes128    MBEDTLS_CIPHER_AES_128_CBC
+#define libssh2_cipher_aes256ctr  MBEDTLS_CIPHER_AES_256_CTR
+#define libssh2_cipher_aes192ctr  MBEDTLS_CIPHER_AES_192_CTR
+#define libssh2_cipher_aes128ctr  MBEDTLS_CIPHER_AES_128_CTR
+#define libssh2_cipher_aes256     MBEDTLS_CIPHER_AES_256_CBC
+#define libssh2_cipher_aes192     MBEDTLS_CIPHER_AES_192_CBC
+#define libssh2_cipher_aes128     MBEDTLS_CIPHER_AES_128_CBC
 #ifdef MBEDTLS_CIPHER_BLOWFISH_CBC
-#define _libssh2_cipher_blowfish  MBEDTLS_CIPHER_BLOWFISH_CBC
+#define libssh2_cipher_blowfish   MBEDTLS_CIPHER_BLOWFISH_CBC
 #endif
 #ifdef MBEDTLS_CIPHER_ARC4_128
-#define _libssh2_cipher_arcfour   MBEDTLS_CIPHER_ARC4_128
+#define libssh2_cipher_arcfour    MBEDTLS_CIPHER_ARC4_128
 #endif
-#define _libssh2_cipher_3des      MBEDTLS_CIPHER_DES_EDE3_CBC
-#define _libssh2_cipher_chacha20  MBEDTLS_CIPHER_CHACHA20_POLY1305
+#define libssh2_cipher_3des       MBEDTLS_CIPHER_DES_EDE3_CBC
+#define libssh2_cipher_chacha20   MBEDTLS_CIPHER_CHACHA20_POLY1305
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -337,9 +337,9 @@ typedef enum {
  * mbedTLS backend: Cipher Context structure
  */
 
-#define libssh2_cipher_ctx          mbedtls_cipher_context_t
+#define libssh2_cipher_ctx        mbedtls_cipher_context_t
 
-#define _libssh2_cipher_type(algo)  mbedtls_cipher_type_t algo
+#define LIBSSH2_CIPHER_T(algo)    mbedtls_cipher_type_t algo
 
 #define _libssh2_cipher_aes256ctr MBEDTLS_CIPHER_AES_256_CTR
 #define _libssh2_cipher_aes192ctr MBEDTLS_CIPHER_AES_192_CTR

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -269,9 +269,9 @@ typedef enum {
 #endif
 } libssh2_curve_type;
 
-# define _libssh2_ec_key mbedtls_ecp_keypair
+# define libssh2_ec_key mbedtls_ecp_keypair
 #else
-# define _libssh2_ec_key void
+# define libssh2_ec_key void
 #endif /* LIBSSH2_ECDSA */
 
 /*******************************************************************/

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -409,7 +409,7 @@ typedef enum {
 
 #define LIBSSH2_DH_MAX_MODULUS_BITS 16384
 
-#define _libssh2_dh_ctx mbedtls_mpi *
+#define libssh2_dh_ctx mbedtls_mpi *
 #define libssh2_dh_init(dhctx) _libssh2_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     _libssh2_dh_key_pair(dhctx, public, g, p, group_order)
@@ -467,14 +467,14 @@ _libssh2_mbedtls_ecdsa_free(libssh2_ecdsa_ctx *ctx);
 extern void
 _libssh2_init_aes_ctr(void);
 extern void
-_libssh2_dh_init(_libssh2_dh_ctx *dhctx);
+_libssh2_dh_init(libssh2_dh_ctx *dhctx);
 extern int
-_libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
                      _libssh2_bn *g, _libssh2_bn *p, int group_order);
 extern int
-_libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+_libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                    _libssh2_bn *f, _libssh2_bn *p);
 extern void
-_libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
+_libssh2_dh_dtor(libssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_MBEDTLS_H */

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -373,7 +373,7 @@ typedef enum {
  * mbedTLS backend: BigNumber Support
  */
 
-#define _libssh2_bn_ctx int /* not used */
+#define libssh2_bn_ctx int /* not used */
 #define _libssh2_bn_ctx_new() 0 /* not used */
 #define _libssh2_bn_ctx_free(bnctx) ((void)0) /* not used */
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -377,7 +377,7 @@ typedef enum {
 #define _libssh2_bn_ctx_new() 0 /* not used */
 #define _libssh2_bn_ctx_free(bnctx) ((void)0) /* not used */
 
-#define _libssh2_bn mbedtls_mpi
+#define libssh2_bn mbedtls_mpi
 
 #define _libssh2_bn_init() \
     _libssh2_mbedtls_bignum_init()
@@ -445,11 +445,11 @@ int
 _libssh2_mbedtls_hash(const unsigned char *data, size_t datalen,
                       mbedtls_md_type_t mdtype, unsigned char *hash);
 
-_libssh2_bn *
+libssh2_bn *
 _libssh2_mbedtls_bignum_init(void);
 
 void
-_libssh2_mbedtls_bignum_free(_libssh2_bn *bn);
+_libssh2_mbedtls_bignum_free(libssh2_bn *bn);
 
 void
 _libssh2_mbedtls_rsa_free(libssh2_rsa_ctx *ctx);
@@ -469,11 +469,11 @@ _libssh2_init_aes_ctr(void);
 extern void
 _libssh2_dh_init(libssh2_dh_ctx *dhctx);
 extern int
-_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
-                     _libssh2_bn *g, _libssh2_bn *p, int group_order);
+_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
+                     libssh2_bn *g, libssh2_bn *p, int group_order);
 extern int
-_libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
-                   _libssh2_bn *f, _libssh2_bn *p);
+_libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
+                   libssh2_bn *f, libssh2_bn *p);
 extern void
 _libssh2_dh_dtor(libssh2_dh_ctx *dhctx);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5298,13 +5298,13 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 }
 
 void
-_libssh2_dh_init(_libssh2_dh_ctx *dhctx)
+_libssh2_dh_init(libssh2_dh_ctx *dhctx)
 {
     *dhctx = BN_new();                          /* Random from client */
 }
 
 int
-_libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
                      _libssh2_bn *g, _libssh2_bn *p, int group_order,
                      _libssh2_bn_ctx *bnctx)
 {
@@ -5315,7 +5315,7 @@ _libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
 }
 
 int
-_libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+_libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                    _libssh2_bn *f, _libssh2_bn *p,
                    _libssh2_bn_ctx *bnctx)
 {
@@ -5325,7 +5325,7 @@ _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
 }
 
 void
-_libssh2_dh_dtor(_libssh2_dh_ctx *dhctx)
+_libssh2_dh_dtor(libssh2_dh_ctx *dhctx)
 {
     BN_clear_free(*dhctx);
     *dhctx = NULL;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5306,7 +5306,7 @@ _libssh2_dh_init(libssh2_dh_ctx *dhctx)
 int
 _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
                      libssh2_bn *g, libssh2_bn *p, int group_order,
-                     _libssh2_bn_ctx *bnctx)
+                     libssh2_bn_ctx *bnctx)
 {
     /* Generate x and e */
     BN_rand(*dhctx, group_order * 8 - 1, 0, -1);
@@ -5317,7 +5317,7 @@ _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
 int
 _libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
                    libssh2_bn *f, libssh2_bn *p,
-                   _libssh2_bn_ctx *bnctx)
+                   libssh2_bn_ctx *bnctx)
 {
     /* Compute the shared secret */
     BN_mod_exp(secret, f, *dhctx, p, bnctx);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -989,7 +989,7 @@ cleanup:
 #endif /* LIBSSH2_ECDSA */
 
 int
-_libssh2_cipher_init(_libssh2_cipher_ctx *h,
+_libssh2_cipher_init(libssh2_cipher_ctx *h,
                      _libssh2_cipher_type(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
@@ -1024,7 +1024,7 @@ _libssh2_cipher_init(_libssh2_cipher_ctx *h,
 #endif
 
 int
-_libssh2_cipher_crypt(_libssh2_cipher_ctx *ctx,
+_libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
                       _libssh2_cipher_type(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4229,7 +4229,7 @@ _libssh2_ecdsa_new_private_sk(libssh2_ecdsa_ctx **ec_ctx,
 
 int
 _libssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
-                          _libssh2_ec_key **out_private_key,
+                          libssh2_ec_key **out_private_key,
                           unsigned char **out_public_key_octal,
                           size_t *out_public_key_octal_len,
                           libssh2_curve_type curve_type)
@@ -4237,7 +4237,7 @@ _libssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
     int ret = 1;
     size_t octal_len = 0;
     unsigned char octal_value[EC_MAX_POINT_LEN];
-    _libssh2_ec_key *private_key = NULL;
+    libssh2_ec_key *private_key = NULL;
 
 #ifdef USE_OPENSSL_3
     EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
@@ -4347,7 +4347,7 @@ clean_exit:
  */
 
 int
-_libssh2_ecdh_gen_k(libssh2_bn **k, _libssh2_ec_key *private_key,
+_libssh2_ecdh_gen_k(libssh2_bn **k, libssh2_ec_key *private_key,
                     const unsigned char *server_public_key,
                     size_t server_public_key_len)
 {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4347,7 +4347,7 @@ clean_exit:
  */
 
 int
-_libssh2_ecdh_gen_k(_libssh2_bn **k, _libssh2_ec_key *private_key,
+_libssh2_ecdh_gen_k(libssh2_bn **k, _libssh2_ec_key *private_key,
                     const unsigned char *server_public_key,
                     size_t server_public_key_len)
 {
@@ -4577,7 +4577,7 @@ clean_exit:
 }
 
 int
-_libssh2_curve25519_gen_k(_libssh2_bn **k,
+_libssh2_curve25519_gen_k(libssh2_bn **k,
                           uint8_t private_key[LIBSSH2_ED25519_KEY_LEN],
                           uint8_t server_public_key[LIBSSH2_ED25519_KEY_LEN])
 {
@@ -5304,8 +5304,8 @@ _libssh2_dh_init(libssh2_dh_ctx *dhctx)
 }
 
 int
-_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
-                     _libssh2_bn *g, _libssh2_bn *p, int group_order,
+_libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
+                     libssh2_bn *g, libssh2_bn *p, int group_order,
                      _libssh2_bn_ctx *bnctx)
 {
     /* Generate x and e */
@@ -5315,8 +5315,8 @@ _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
 }
 
 int
-_libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
-                   _libssh2_bn *f, _libssh2_bn *p,
+_libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
+                   libssh2_bn *f, libssh2_bn *p,
                    _libssh2_bn_ctx *bnctx)
 {
     /* Compute the shared secret */
@@ -5332,7 +5332,7 @@ _libssh2_dh_dtor(libssh2_dh_ctx *dhctx)
 }
 
 int
-_libssh2_bn_from_bin(_libssh2_bn *bn, size_t len, const unsigned char *val)
+_libssh2_bn_from_bin(libssh2_bn *bn, size_t len, const unsigned char *val)
 {
     if(!BN_bin2bn(val, (int)len, bn)) {
         return -1;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -990,7 +990,7 @@ cleanup:
 
 int
 _libssh2_cipher_init(libssh2_cipher_ctx *h,
-                     _libssh2_cipher_type(algo),
+                     LIBSSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -1025,7 +1025,7 @@ _libssh2_cipher_init(libssh2_cipher_ctx *h,
 
 int
 _libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
-                      _libssh2_cipher_type(algo),
+                      LIBSSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)
 {

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -365,11 +365,11 @@ extern void _libssh2_openssl_crypto_exit(void);
 #ifdef USE_OPENSSL_3
 #define libssh2_ecdsa_ctx EVP_PKEY
 #define _libssh2_ecdsa_free(ecdsactx) EVP_PKEY_free(ecdsactx)
-#define _libssh2_ec_key EVP_PKEY
+#define libssh2_ec_key EVP_PKEY
 #else
 #define libssh2_ecdsa_ctx EC_KEY
 #define _libssh2_ecdsa_free(ecdsactx) EC_KEY_free(ecdsactx)
-#define _libssh2_ec_key EC_KEY
+#define libssh2_ec_key EC_KEY
 #endif
 
 typedef enum {
@@ -379,7 +379,7 @@ typedef enum {
 }
 libssh2_curve_type;
 #else /* !LIBSSH2_ECDSA */
-#define _libssh2_ec_key void
+#define libssh2_ec_key void
 #endif /* LIBSSH2_ECDSA */
 
 #if LIBSSH2_ED25519

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -416,7 +416,7 @@ libssh2_curve_type;
 #endif
 
 #define libssh2_bn BIGNUM
-#define _libssh2_bn_ctx BN_CTX
+#define libssh2_bn_ctx BN_CTX
 #define _libssh2_bn_ctx_new() BN_CTX_new()
 #define _libssh2_bn_ctx_free(bnctx) BN_CTX_free(bnctx)
 #define _libssh2_bn_init() BN_new()
@@ -448,10 +448,10 @@ extern void _libssh2_dh_init(libssh2_dh_ctx *dhctx);
 extern int _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
                                 libssh2_bn *g, libssh2_bn *p,
                                 int group_order,
-                                _libssh2_bn_ctx *bnctx);
+                                libssh2_bn_ctx *bnctx);
 extern int _libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
                               libssh2_bn *f, libssh2_bn *p,
-                              _libssh2_bn_ctx *bnctx);
+                              libssh2_bn_ctx *bnctx);
 extern void _libssh2_dh_dtor(libssh2_dh_ctx *dhctx);
 
 extern int _libssh2_openssl_random(void *buf, size_t len);

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -415,14 +415,14 @@ libssh2_curve_type;
 #define _libssh2_cipher_dtor(ctx) EVP_CIPHER_CTX_cleanup(ctx)
 #endif
 
-#define _libssh2_bn BIGNUM
+#define libssh2_bn BIGNUM
 #define _libssh2_bn_ctx BN_CTX
 #define _libssh2_bn_ctx_new() BN_CTX_new()
 #define _libssh2_bn_ctx_free(bnctx) BN_CTX_free(bnctx)
 #define _libssh2_bn_init() BN_new()
 #define _libssh2_bn_init_from_bin() _libssh2_bn_init()
 #define _libssh2_bn_set_word(bn, val) !BN_set_word(bn, val)
-extern int _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
+extern int _libssh2_bn_from_bin(libssh2_bn *bn, size_t len,
                                 const unsigned char *val);
 #define _libssh2_bn_to_bin(bn, val) (BN_bn2bin(bn, val) <= 0)
 #define _libssh2_bn_bytes(bn) BN_num_bytes(bn)
@@ -445,12 +445,12 @@ extern int _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
     _libssh2_dh_secret(dhctx, secret, f, p, bnctx)
 #define libssh2_dh_dtor(dhctx) _libssh2_dh_dtor(dhctx)
 extern void _libssh2_dh_init(libssh2_dh_ctx *dhctx);
-extern int _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
-                                _libssh2_bn *g, _libssh2_bn *p,
+extern int _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
+                                libssh2_bn *g, libssh2_bn *p,
                                 int group_order,
                                 _libssh2_bn_ctx *bnctx);
-extern int _libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
-                              _libssh2_bn *f, _libssh2_bn *p,
+extern int _libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
+                              libssh2_bn *f, libssh2_bn *p,
                               _libssh2_bn_ctx *bnctx);
 extern void _libssh2_dh_dtor(libssh2_dh_ctx *dhctx);
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -437,22 +437,22 @@ extern int _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
 
 #define LIBSSH2_DH_MAX_MODULUS_BITS 16384
 
-#define _libssh2_dh_ctx BIGNUM *
+#define libssh2_dh_ctx BIGNUM *
 #define libssh2_dh_init(dhctx) _libssh2_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     _libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx)
 #define libssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     _libssh2_dh_secret(dhctx, secret, f, p, bnctx)
 #define libssh2_dh_dtor(dhctx) _libssh2_dh_dtor(dhctx)
-extern void _libssh2_dh_init(_libssh2_dh_ctx *dhctx);
-extern int _libssh2_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
+extern void _libssh2_dh_init(libssh2_dh_ctx *dhctx);
+extern int _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, _libssh2_bn *public,
                                 _libssh2_bn *g, _libssh2_bn *p,
                                 int group_order,
                                 _libssh2_bn_ctx *bnctx);
-extern int _libssh2_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
+extern int _libssh2_dh_secret(libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
                               _libssh2_bn *f, _libssh2_bn *p,
                               _libssh2_bn_ctx *bnctx);
-extern void _libssh2_dh_dtor(_libssh2_dh_ctx *dhctx);
+extern void _libssh2_dh_dtor(libssh2_dh_ctx *dhctx);
 
 extern int _libssh2_openssl_random(void *buf, size_t len);
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -394,20 +394,20 @@ libssh2_curve_type;
 #define libssh2_cipher_ctx EVP_CIPHER_CTX
 #endif
 
-#define _libssh2_cipher_aes256gcm EVP_aes_256_gcm
-#define _libssh2_cipher_aes128gcm EVP_aes_128_gcm
+#define libssh2_cipher_aes256gcm EVP_aes_256_gcm
+#define libssh2_cipher_aes128gcm EVP_aes_128_gcm
 
-#define _libssh2_cipher_aes256 EVP_aes_256_cbc
-#define _libssh2_cipher_aes192 EVP_aes_192_cbc
-#define _libssh2_cipher_aes128 EVP_aes_128_cbc
-#define _libssh2_cipher_aes128ctr EVP_aes_128_ctr
-#define _libssh2_cipher_aes192ctr EVP_aes_192_ctr
-#define _libssh2_cipher_aes256ctr EVP_aes_256_ctr
-#define _libssh2_cipher_blowfish EVP_bf_cbc
-#define _libssh2_cipher_arcfour EVP_rc4
-#define _libssh2_cipher_cast5 EVP_cast5_cbc
-#define _libssh2_cipher_3des EVP_des_ede3_cbc
-#define _libssh2_cipher_chacha20 NULL
+#define libssh2_cipher_aes256 EVP_aes_256_cbc
+#define libssh2_cipher_aes192 EVP_aes_192_cbc
+#define libssh2_cipher_aes128 EVP_aes_128_cbc
+#define libssh2_cipher_aes128ctr EVP_aes_128_ctr
+#define libssh2_cipher_aes192ctr EVP_aes_192_ctr
+#define libssh2_cipher_aes256ctr EVP_aes_256_ctr
+#define libssh2_cipher_blowfish EVP_bf_cbc
+#define libssh2_cipher_arcfour EVP_rc4
+#define libssh2_cipher_cast5 EVP_cast5_cbc
+#define libssh2_cipher_3des EVP_des_ede3_cbc
+#define libssh2_cipher_chacha20 NULL
 
 #ifdef HAVE_OPAQUE_STRUCTS
 #define _libssh2_cipher_dtor(ctx) EVP_CIPHER_CTX_free(*(ctx))

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -389,9 +389,9 @@ libssh2_curve_type;
 
 #define _libssh2_cipher_type(name) const EVP_CIPHER *(*(name))(void)
 #ifdef HAVE_OPAQUE_STRUCTS
-#define _libssh2_cipher_ctx EVP_CIPHER_CTX *
+#define libssh2_cipher_ctx EVP_CIPHER_CTX *
 #else
-#define _libssh2_cipher_ctx EVP_CIPHER_CTX
+#define libssh2_cipher_ctx EVP_CIPHER_CTX
 #endif
 
 #define _libssh2_cipher_aes256gcm EVP_aes_256_gcm

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -387,7 +387,7 @@ libssh2_curve_type;
 #define _libssh2_ed25519_free(ctx) EVP_PKEY_free(ctx)
 #endif /* LIBSSH2_ED25519 */
 
-#define _libssh2_cipher_type(name) const EVP_CIPHER *(*(name))(void)
+#define LIBSSH2_CIPHER_T(name) const EVP_CIPHER *(*(name))(void)
 #ifdef HAVE_OPAQUE_STRUCTS
 #define libssh2_cipher_ctx EVP_CIPHER_CTX *
 #else

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1111,7 +1111,7 @@ void _libssh2_hmac_cleanup(libssh2_hmac_ctx *ctx)
  *******************************************************************/
 
 int
-_libssh2_cipher_init(_libssh2_cipher_ctx *h, _libssh2_cipher_type(algo),
+_libssh2_cipher_init(libssh2_cipher_ctx *h, _libssh2_cipher_type(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
     Qc3_Format_ALGD0200_T algd;
@@ -1151,7 +1151,7 @@ _libssh2_cipher_init(_libssh2_cipher_ctx *h, _libssh2_cipher_type(algo),
 }
 
 int
-_libssh2_cipher_crypt(_libssh2_cipher_ctx *ctx,
+_libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
                       _libssh2_cipher_type(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -364,12 +364,12 @@ _libssh2_random(unsigned char *buf, size_t len)
     return errcode.Bytes_Available ? -1 : 0;
 }
 
-_libssh2_bn *
+libssh2_bn *
 _libssh2_bn_init(void)
 {
-    _libssh2_bn *bignum;
+    libssh2_bn *bignum;
 
-    bignum = (_libssh2_bn *) malloc(sizeof(*bignum));
+    bignum = (libssh2_bn *) malloc(sizeof(*bignum));
     if(bignum) {
         bignum->bignum = NULL;
         bignum->length = 0;
@@ -379,7 +379,7 @@ _libssh2_bn_init(void)
 }
 
 void
-_libssh2_bn_free(_libssh2_bn *bn)
+_libssh2_bn_free(libssh2_bn *bn)
 {
     if(bn) {
         if(bn->bignum) {
@@ -394,7 +394,7 @@ _libssh2_bn_free(_libssh2_bn *bn)
 }
 
 static int
-_libssh2_bn_resize(_libssh2_bn *bn, size_t newlen)
+_libssh2_bn_resize(libssh2_bn *bn, size_t newlen)
 {
     unsigned char *bignum;
 
@@ -430,7 +430,7 @@ _libssh2_bn_resize(_libssh2_bn *bn, size_t newlen)
 }
 
 unsigned long
-_libssh2_bn_bits(_libssh2_bn *bn)
+_libssh2_bn_bits(libssh2_bn *bn)
 {
     unsigned int i;
     unsigned char b;
@@ -452,7 +452,7 @@ _libssh2_bn_bits(_libssh2_bn *bn)
 }
 
 int
-_libssh2_bn_from_bin(_libssh2_bn *bn, size_t len, const unsigned char *val)
+_libssh2_bn_from_bin(libssh2_bn *bn, size_t len, const unsigned char *val)
 {
     size_t i;
 
@@ -472,14 +472,14 @@ _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len, const unsigned char *val)
 }
 
 int
-_libssh2_bn_set_word(_libssh2_bn *bn, unsigned long val)
+_libssh2_bn_set_word(libssh2_bn *bn, unsigned long val)
 {
     val = htonl(val);
     return _libssh2_bn_from_bin(bn, sizeof(val), (unsigned char *) &val);
 }
 
 int
-_libssh2_bn_to_bin(_libssh2_bn *bn, unsigned char *val)
+_libssh2_bn_to_bin(libssh2_bn *bn, unsigned char *val)
 {
     int i;
 
@@ -493,7 +493,7 @@ _libssh2_bn_to_bin(_libssh2_bn *bn, unsigned char *val)
 }
 
 static int
-_libssh2_bn_from_bn(_libssh2_bn *to, _libssh2_bn *from)
+_libssh2_bn_from_bn(libssh2_bn *to, libssh2_bn *from)
 {
     int i;
 
@@ -655,7 +655,7 @@ asn1delete(struct asn1Element *e)
 }
 
 static struct asn1Element *
-asn1uint(_libssh2_bn *bn)
+asn1uint(libssh2_bn *bn)
 {
     struct asn1Element *e;
     int bits;
@@ -728,7 +728,7 @@ asn1bytes(unsigned int type, const unsigned char *bytes, unsigned int length)
 }
 
 static struct asn1Element *
-rsapublickey(_libssh2_bn *e, _libssh2_bn *m)
+rsapublickey(libssh2_bn *e, libssh2_bn *m)
 {
     struct asn1Element *publicexponent;
     struct asn1Element *modulus;
@@ -752,9 +752,9 @@ rsapublickey(_libssh2_bn *e, _libssh2_bn *m)
 }
 
 static struct asn1Element *
-rsaprivatekey(_libssh2_bn *e, _libssh2_bn *m, _libssh2_bn *d,
-              _libssh2_bn *p, _libssh2_bn *q,
-              _libssh2_bn *exp1, _libssh2_bn *exp2, _libssh2_bn *coeff)
+rsaprivatekey(libssh2_bn *e, libssh2_bn *m, libssh2_bn *d,
+              libssh2_bn *p, libssh2_bn *q,
+              libssh2_bn *exp1, libssh2_bn *exp2, libssh2_bn *coeff)
 {
     struct asn1Element *version;
     struct asn1Element *modulus;
@@ -1195,14 +1195,14 @@ _libssh2_rsa_new(libssh2_rsa_ctx **rsa,
                  const unsigned char *coeffdata, unsigned long coefflen)
 {
     libssh2_rsa_ctx *ctx;
-    _libssh2_bn *e = _libssh2_bn_init_from_bin();
-    _libssh2_bn *n = _libssh2_bn_init_from_bin();
-    _libssh2_bn *d = NULL;
-    _libssh2_bn *p = NULL;
-    _libssh2_bn *q = NULL;
-    _libssh2_bn *e1 = NULL;
-    _libssh2_bn *e2 = NULL;
-    _libssh2_bn *coeff = NULL;
+    libssh2_bn *e = _libssh2_bn_init_from_bin();
+    libssh2_bn *n = _libssh2_bn_init_from_bin();
+    libssh2_bn *d = NULL;
+    libssh2_bn *p = NULL;
+    libssh2_bn *q = NULL;
+    libssh2_bn *e1 = NULL;
+    libssh2_bn *e2 = NULL;
+    libssh2_bn *coeff = NULL;
     struct asn1Element *key = NULL;
     struct asn1Element *structkey = NULL;
     int keytype;
@@ -1294,8 +1294,8 @@ _libssh2_os400qc3_dh_init(_libssh2_dh_ctx *dhctx)
 }
 
 int
-_libssh2_os400qc3_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
-                              _libssh2_bn *g, _libssh2_bn *p, int group_order)
+_libssh2_os400qc3_dh_key_pair(_libssh2_dh_ctx *dhctx, libssh2_bn *public,
+                              libssh2_bn *g, libssh2_bn *p, int group_order)
 {
     struct asn1Element *prime;
     struct asn1Element *base;
@@ -1342,8 +1342,8 @@ _libssh2_os400qc3_dh_key_pair(_libssh2_dh_ctx *dhctx, _libssh2_bn *public,
 }
 
 int
-_libssh2_os400qc3_dh_secret(_libssh2_dh_ctx *dhctx, _libssh2_bn *secret,
-                            _libssh2_bn *f, _libssh2_bn *p)
+_libssh2_os400qc3_dh_secret(_libssh2_dh_ctx *dhctx, libssh2_bn *secret,
+                            libssh2_bn *f, libssh2_bn *p)
 {
     char *pubkey;
     int pubkeysize;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1111,7 +1111,7 @@ void _libssh2_hmac_cleanup(libssh2_hmac_ctx *ctx)
  *******************************************************************/
 
 int
-_libssh2_cipher_init(libssh2_cipher_ctx *h, _libssh2_cipher_type(algo),
+_libssh2_cipher_init(libssh2_cipher_ctx *h, LIBSSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
     Qc3_Format_ALGD0200_T algd;
@@ -1152,7 +1152,7 @@ _libssh2_cipher_init(libssh2_cipher_ctx *h, _libssh2_cipher_type(algo),
 
 int
 _libssh2_cipher_crypt(libssh2_cipher_ctx *ctx,
-                      _libssh2_cipher_type(algo),
+                      LIBSSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)
 {

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -343,7 +343,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 
 #define LIBSSH2_DH_MAX_MODULUS_BITS 2048
 
-#define _libssh2_dh_ctx         struct os400qc3_dh_ctx
+#define libssh2_dh_ctx          struct os400qc3_dh_ctx
 #define libssh2_dh_init(dhctx)  _libssh2_os400qc3_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx)        \
             _libssh2_os400qc3_dh_key_pair(dhctx, public, g, p, group_order)
@@ -382,15 +382,15 @@ extern int      _libssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
                                             int veccount,
                                             const struct iovec vector[],
                                             libssh2_rsa_ctx *ctx);
-extern void     _libssh2_os400qc3_dh_init(_libssh2_dh_ctx *dhctx);
-extern int      _libssh2_os400qc3_dh_key_pair(_libssh2_dh_ctx *dhctx,
+extern void     _libssh2_os400qc3_dh_init(libssh2_dh_ctx *dhctx);
+extern int      _libssh2_os400qc3_dh_key_pair(libssh2_dh_ctx *dhctx,
                                               _libssh2_bn *public,
                                               _libssh2_bn *g,
                                               _libssh2_bn *p, int group_order);
-extern int      _libssh2_os400qc3_dh_secret(_libssh2_dh_ctx *dhctx,
+extern int      _libssh2_os400qc3_dh_secret(libssh2_dh_ctx *dhctx,
                                             _libssh2_bn *secret,
                                             _libssh2_bn *f, _libssh2_bn *p);
-extern void     _libssh2_os400qc3_dh_dtor(_libssh2_dh_ctx *dhctx);
+extern void     _libssh2_os400qc3_dh_dtor(libssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_OS400QC3_H */
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -249,7 +249,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define libssh2_sha384_ctx      Qc3_Format_ALGD0100_T
 #define libssh2_sha512_ctx      Qc3_Format_ALGD0100_T
 #define libssh2_hmac_ctx        struct os400qc3_crypto_ctx
-#define _libssh2_cipher_ctx     struct os400qc3_crypto_ctx
+#define libssh2_cipher_ctx      struct os400qc3_crypto_ctx
 
 #define libssh2_sha1_init(x)    _libssh2_os400qc3_hash_init(x, Qc3_SHA1)
 #define libssh2_sha1_update(ctx, data, len)                                 \

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -299,7 +299,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define _libssh2_bn_init_from_bin() _libssh2_bn_init()
 #define _libssh2_bn_bytes(bn)   ((bn)->length)
 
-#define _libssh2_cipher_type(name)  struct os400qc3_cipher name
+#define LIBSSH2_CIPHER_T(name)  struct os400qc3_cipher name
 #define _libssh2_cipher_aes128 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \
                                 Qc3_CBC, 16}
 #define _libssh2_cipher_aes192 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -300,23 +300,20 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define _libssh2_bn_bytes(bn)   ((bn)->length)
 
 #define LIBSSH2_CIPHER_T(name)  struct os400qc3_cipher name
-#define _libssh2_cipher_aes128 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \
-                                Qc3_CBC, 16}
-#define _libssh2_cipher_aes192 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \
-                                Qc3_CBC, 24}
-#define _libssh2_cipher_aes256 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \
-                                Qc3_CBC, 32}
-#define _libssh2_cipher_aes128ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
-                                   Qc3_CTR, 16}
-#define _libssh2_cipher_aes192ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
-                                   Qc3_CTR, 24}
-#define _libssh2_cipher_aes256ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
-                                   Qc3_CTR, 32}
-#define _libssh2_cipher_3des {Qc3_Alg_Block_Cipher, Qc3_TDES, 8,            \
-                              Qc3_CBC, 24}
+#define libssh2_cipher_aes128 {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 16}
+#define libssh2_cipher_aes192 {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 24}
+#define libssh2_cipher_aes256 {Qc3_Alg_Block_Cipher, Qc3_AES, 16,          \
+                               Qc3_CBC, 32}
+#define libssh2_cipher_aes128ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
+                                  Qc3_CTR, 16}
+#define libssh2_cipher_aes192ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
+                                  Qc3_CTR, 24}
+#define libssh2_cipher_aes256ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16,       \
+                                  Qc3_CTR, 32}
+#define libssh2_cipher_3des {Qc3_Alg_Block_Cipher, Qc3_TDES, 8, Qc3_CBC, 24}
 /* Nonsense values for chacha20-poly1305 */
-#define _libssh2_cipher_chacha20 {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
-#define _libssh2_cipher_arcfour {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
+#define libssh2_cipher_chacha20 {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
+#define libssh2_cipher_arcfour  {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
 
 #define _libssh2_cipher_dtor(ctx) _libssh2_os400qc3_crypto_dtor(ctx)
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -291,7 +291,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
                                 _libssh2_os400qc3_hash_final(&(ctx), out)
 #endif
 
-#define _libssh2_bn_ctx         int                 /* Not used. */
+#define libssh2_bn_ctx         int                 /* Not used. */
 
 #define _libssh2_bn_ctx_new()           0
 #define _libssh2_bn_ctx_free(bnctx)     ((void) 0)

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -221,7 +221,7 @@ struct os400qc3_bn {    /* Big number. */
     unsigned int            length;         /* Length of bignum (# bytes). */
 };
 
-#define _libssh2_bn struct os400qc3_bn
+#define libssh2_bn struct os400qc3_bn
 
 struct os400qc3_cipher {  /* Algorithm description. */
     char *                  fmt;            /* Format of Qc3 structure. */
@@ -357,13 +357,13 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
  *
  *******************************************************************/
 
-extern _libssh2_bn *    _libssh2_bn_init(void);
-extern void     _libssh2_bn_free(_libssh2_bn *bn);
-extern unsigned long    _libssh2_bn_bits(_libssh2_bn *bn);
-extern int      _libssh2_bn_from_bin(_libssh2_bn *bn, size_t len,
+extern libssh2_bn *    _libssh2_bn_init(void);
+extern void     _libssh2_bn_free(libssh2_bn *bn);
+extern unsigned long    _libssh2_bn_bits(libssh2_bn *bn);
+extern int      _libssh2_bn_from_bin(libssh2_bn *bn, size_t len,
                                      const unsigned char *v);
-extern int      _libssh2_bn_set_word(_libssh2_bn *bn, unsigned long val);
-extern int      _libssh2_bn_to_bin(_libssh2_bn *bn, unsigned char *val);
+extern int      _libssh2_bn_set_word(libssh2_bn *bn, unsigned long val);
+extern int      _libssh2_bn_to_bin(libssh2_bn *bn, unsigned char *val);
 extern int      _libssh2_random(unsigned char *buf, size_t len);
 extern void     _libssh2_os400qc3_crypto_dtor(struct os400qc3_crypto_ctx *x);
 extern int      _libssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x,
@@ -384,12 +384,12 @@ extern int      _libssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
                                             libssh2_rsa_ctx *ctx);
 extern void     _libssh2_os400qc3_dh_init(libssh2_dh_ctx *dhctx);
 extern int      _libssh2_os400qc3_dh_key_pair(libssh2_dh_ctx *dhctx,
-                                              _libssh2_bn *public,
-                                              _libssh2_bn *g,
-                                              _libssh2_bn *p, int group_order);
+                                              libssh2_bn *public,
+                                              libssh2_bn *g,
+                                              libssh2_bn *p, int group_order);
 extern int      _libssh2_os400qc3_dh_secret(libssh2_dh_ctx *dhctx,
-                                            _libssh2_bn *secret,
-                                            _libssh2_bn *f, _libssh2_bn *p);
+                                            libssh2_bn *secret,
+                                            libssh2_bn *f, libssh2_bn *p);
 extern void     _libssh2_os400qc3_dh_dtor(libssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_OS400QC3_H */

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -200,7 +200,7 @@
 
 #if LIBSSH2_ECDSA
 #else
-#define _libssh2_ec_key void
+#define libssh2_ec_key void
 #endif
 
 /*******************************************************************

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3298,7 +3298,7 @@ _libssh2_wincng_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
  * Windows CNG backend: Cipher functions
  */
 int
-_libssh2_wincng_cipher_init(_libssh2_cipher_ctx *h,
+_libssh2_wincng_cipher_init(libssh2_cipher_ctx *h,
                             _libssh2_cipher_type(algo),
                             unsigned char *iv,
                             unsigned char *secret,
@@ -3414,7 +3414,7 @@ static void _libssh2_aes_ctr_increment(unsigned char *ctr,
 }
 
 int
-_libssh2_wincng_cipher_crypt(_libssh2_cipher_ctx *ctx,
+_libssh2_wincng_cipher_crypt(libssh2_cipher_ctx *ctx,
                              _libssh2_cipher_type(algo),
                              int encrypt,
                              unsigned char *block,
@@ -3478,7 +3478,7 @@ _libssh2_wincng_cipher_crypt(_libssh2_cipher_ctx *ctx,
 }
 
 void
-_libssh2_wincng_cipher_dtor(_libssh2_cipher_ctx *ctx)
+_libssh2_wincng_cipher_dtor(libssh2_cipher_ctx *ctx)
 {
     BCryptDestroyKey(ctx->hKey);
     ctx->hKey = NULL;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -247,7 +247,7 @@
 #define PKCS_RSA_PRIVATE_KEY ((LPCSTR)(size_t)43)
 #endif
 
-static int _libssh2_wincng_bignum_resize(_libssh2_bn* bn, ULONG length);
+static int _libssh2_wincng_bignum_resize(libssh2_bn* bn, ULONG length);
 
 /*******************************************************************/
 /*
@@ -2376,7 +2376,7 @@ cleanup:
  * remote public key and length
  */
 int
-_libssh2_wincng_ecdh_gen_k(OUT _libssh2_bn **secret,
+_libssh2_wincng_ecdh_gen_k(OUT libssh2_bn **secret,
                            IN struct wincng_ecdsa_ctx *privatekey,
                            IN const unsigned char *server_publickey_encoded,
                            IN size_t server_publickey_encoded_len)
@@ -3501,12 +3501,12 @@ _libssh2_wincng_cipher_dtor(_libssh2_cipher_ctx *ctx)
  * Windows CNG backend: BigNumber functions
  */
 
-_libssh2_bn *
+libssh2_bn *
 _libssh2_wincng_bignum_init(void)
 {
-    _libssh2_bn *bignum;
+    libssh2_bn *bignum;
 
-    bignum = (_libssh2_bn *)malloc(sizeof(_libssh2_bn));
+    bignum = (libssh2_bn *)malloc(sizeof(libssh2_bn));
     if(bignum) {
         bignum->bignum = NULL;
         bignum->length = 0;
@@ -3516,7 +3516,7 @@ _libssh2_wincng_bignum_init(void)
 }
 
 static int
-_libssh2_wincng_bignum_resize(_libssh2_bn *bn, ULONG length)
+_libssh2_wincng_bignum_resize(libssh2_bn *bn, ULONG length)
 {
     unsigned char *bignum;
 
@@ -3541,7 +3541,7 @@ _libssh2_wincng_bignum_resize(_libssh2_bn *bn, ULONG length)
 }
 
 static int
-_libssh2_wincng_bignum_rand(_libssh2_bn *rnd, int bits, int top, int bottom)
+_libssh2_wincng_bignum_rand(libssh2_bn *rnd, int bits, int top, int bottom)
 {
     unsigned char *bignum;
     ULONG length;
@@ -3583,10 +3583,10 @@ _libssh2_wincng_bignum_rand(_libssh2_bn *rnd, int bits, int top, int bottom)
 }
 
 static int
-_libssh2_wincng_bignum_mod_exp(_libssh2_bn *r,
-                               _libssh2_bn *a,
-                               _libssh2_bn *p,
-                               _libssh2_bn *m)
+_libssh2_wincng_bignum_mod_exp(libssh2_bn *r,
+                               libssh2_bn *a,
+                               libssh2_bn *p,
+                               libssh2_bn *m)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_RSAKEY_BLOB *rsakey;
@@ -3658,7 +3658,7 @@ _libssh2_wincng_bignum_mod_exp(_libssh2_bn *r,
 }
 
 int
-_libssh2_wincng_bignum_set_word(_libssh2_bn *bn, ULONG word)
+_libssh2_wincng_bignum_set_word(libssh2_bn *bn, ULONG word)
 {
     ULONG offset, number, bits, length;
 
@@ -3682,7 +3682,7 @@ _libssh2_wincng_bignum_set_word(_libssh2_bn *bn, ULONG word)
 }
 
 ULONG
-_libssh2_wincng_bignum_bits(const _libssh2_bn *bn)
+_libssh2_wincng_bignum_bits(const libssh2_bn *bn)
 {
     unsigned char number;
     ULONG offset, length, bits;
@@ -3705,7 +3705,7 @@ _libssh2_wincng_bignum_bits(const _libssh2_bn *bn)
 }
 
 int
-_libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
+_libssh2_wincng_bignum_from_bin(libssh2_bn *bn, ULONG len,
                                 const unsigned char *bin)
 {
     unsigned char *bignum;
@@ -3742,7 +3742,7 @@ _libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
 }
 
 int
-_libssh2_wincng_bignum_to_bin(const _libssh2_bn *bn, unsigned char *bin)
+_libssh2_wincng_bignum_to_bin(const libssh2_bn *bn, unsigned char *bin)
 {
     if(bin && bn && bn->bignum && bn->length > 0) {
         memcpy(bin, bn->bignum, bn->length);
@@ -3753,7 +3753,7 @@ _libssh2_wincng_bignum_to_bin(const _libssh2_bn *bn, unsigned char *bin)
 }
 
 void
-_libssh2_wincng_bignum_free(_libssh2_bn *bn)
+_libssh2_wincng_bignum_free(libssh2_bn *bn)
 {
     if(bn) {
         if(bn->bignum) {
@@ -3761,7 +3761,7 @@ _libssh2_wincng_bignum_free(_libssh2_bn *bn)
             bn->bignum = NULL;
         }
         bn->length = 0;
-        _libssh2_wincng_safe_free(bn, sizeof(_libssh2_bn));
+        _libssh2_wincng_safe_free(bn, sizeof(libssh2_bn));
     }
 }
 
@@ -3810,8 +3810,8 @@ round_down(int number, int multiple)
  * the public key is returned in `public'.  0 is returned upon success, else
  * -1.  */
 int
-_libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, _libssh2_bn *public,
-                     _libssh2_bn *g, _libssh2_bn *p, int group_order)
+_libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
+                     libssh2_bn *g, libssh2_bn *p, int group_order)
 {
     const int hasAlgDHwithKDF = _libssh2_wincng.hasAlgDHwithKDF;
 
@@ -4000,8 +4000,8 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, _libssh2_bn *public,
  * used at context creation. The result is stored in `secret'.  0 is returned
  * upon success, else -1.  */
 int
-_libssh2_dh_secret(struct wincng_dh_ctx *dhctx, _libssh2_bn *secret,
-                   _libssh2_bn *f, _libssh2_bn *p)
+_libssh2_dh_secret(struct wincng_dh_ctx *dhctx, libssh2_bn *secret,
+                   libssh2_bn *f, libssh2_bn *p)
 {
     if(_libssh2_wincng.hAlgDH && _libssh2_wincng.hasAlgDHwithKDF != -1 &&
        dhctx->dh_handle && dhctx->dh_params && f) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3299,7 +3299,7 @@ _libssh2_wincng_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
  */
 int
 _libssh2_wincng_cipher_init(libssh2_cipher_ctx *h,
-                            _libssh2_cipher_type(algo),
+                            LIBSSH2_CIPHER_T(algo),
                             unsigned char *iv,
                             unsigned char *secret,
                             int encrypt)
@@ -3415,7 +3415,7 @@ static void _libssh2_aes_ctr_increment(unsigned char *ctr,
 
 int
 _libssh2_wincng_cipher_crypt(libssh2_cipher_ctx *ctx,
-                             _libssh2_cipher_type(algo),
+                             LIBSSH2_CIPHER_T(algo),
                              int encrypt,
                              unsigned char *block,
                              size_t blocksize, int firstlast)

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -404,15 +404,15 @@ struct _libssh2_wincng_cipher_type {
 
 #define LIBSSH2_CIPHER_T(type) struct _libssh2_wincng_cipher_type type
 
-#define _libssh2_cipher_aes256ctr { &_libssh2_wincng.hAlgAES_ECB, 32, 0, 1 }
-#define _libssh2_cipher_aes192ctr { &_libssh2_wincng.hAlgAES_ECB, 24, 0, 1 }
-#define _libssh2_cipher_aes128ctr { &_libssh2_wincng.hAlgAES_ECB, 16, 0, 1 }
-#define _libssh2_cipher_aes256    { &_libssh2_wincng.hAlgAES_CBC, 32, 1, 0 }
-#define _libssh2_cipher_aes192    { &_libssh2_wincng.hAlgAES_CBC, 24, 1, 0 }
-#define _libssh2_cipher_aes128    { &_libssh2_wincng.hAlgAES_CBC, 16, 1, 0 }
-#define _libssh2_cipher_arcfour   { &_libssh2_wincng.hAlgRC4_NA, 16, 0, 0 }
-#define _libssh2_cipher_3des      { &_libssh2_wincng.hAlg3DES_CBC, 24, 1, 0 }
-#define _libssh2_cipher_chacha20  { &_libssh2_wincng.hAlgChacha20, 24, 1, 0 }
+#define libssh2_cipher_aes256ctr { &_libssh2_wincng.hAlgAES_ECB, 32, 0, 1 }
+#define libssh2_cipher_aes192ctr { &_libssh2_wincng.hAlgAES_ECB, 24, 0, 1 }
+#define libssh2_cipher_aes128ctr { &_libssh2_wincng.hAlgAES_ECB, 16, 0, 1 }
+#define libssh2_cipher_aes256    { &_libssh2_wincng.hAlgAES_CBC, 32, 1, 0 }
+#define libssh2_cipher_aes192    { &_libssh2_wincng.hAlgAES_CBC, 24, 1, 0 }
+#define libssh2_cipher_aes128    { &_libssh2_wincng.hAlgAES_CBC, 16, 1, 0 }
+#define libssh2_cipher_arcfour   { &_libssh2_wincng.hAlgRC4_NA, 16, 0, 0 }
+#define libssh2_cipher_3des      { &_libssh2_wincng.hAlg3DES_CBC, 24, 1, 0 }
+#define libssh2_cipher_chacha20  { &_libssh2_wincng.hAlgChacha20, 24, 1, 0 }
 
 /*
  * Windows CNG backend: Cipher functions

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -402,7 +402,7 @@ struct _libssh2_wincng_cipher_type {
     int ctrMode;
 };
 
-#define _libssh2_cipher_type(type) struct _libssh2_wincng_cipher_type type
+#define LIBSSH2_CIPHER_T(type) struct _libssh2_wincng_cipher_type type
 
 #define _libssh2_cipher_aes256ctr { &_libssh2_wincng.hAlgAES_ECB, 32, 0, 1 }
 #define _libssh2_cipher_aes192ctr { &_libssh2_wincng.hAlgAES_ECB, 24, 0, 1 }

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -108,7 +108,7 @@
 
 #if LIBSSH2_ECDSA
 #else
-#define _libssh2_ec_key void
+#define libssh2_ec_key void
 #endif
 
 /*******************************************************************/
@@ -320,7 +320,7 @@ struct wincng_ecdsa_ctx {
 #define libssh2_ecdsa_ctx struct wincng_ecdsa_ctx
 
 #if LIBSSH2_ECDSA
-#define _libssh2_ec_key struct wincng_ecdsa_ctx
+#define libssh2_ec_key struct wincng_ecdsa_ctx
 #endif
 
 void

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -388,7 +388,7 @@ struct _libssh2_wincng_cipher_ctx {
     ULONG dwCtrLength;
 };
 
-#define _libssh2_cipher_ctx struct _libssh2_wincng_cipher_ctx
+#define libssh2_cipher_ctx struct _libssh2_wincng_cipher_ctx
 
 /*
  * Windows CNG backend: Cipher Type structure
@@ -530,7 +530,7 @@ _libssh2_wincng_dsa_free(libssh2_dsa_ctx *dsa);
 #endif
 
 void
-_libssh2_wincng_cipher_dtor(_libssh2_cipher_ctx *ctx);
+_libssh2_wincng_cipher_dtor(libssh2_cipher_ctx *ctx);
 
 libssh2_bn *
 _libssh2_wincng_bignum_init(void);

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -444,7 +444,7 @@ struct _libssh2_wincng_bignum {
     ULONG length;
 };
 
-#define _libssh2_bn struct _libssh2_wincng_bignum
+#define libssh2_bn struct _libssh2_wincng_bignum
 
 /*
  * Windows CNG backend: BigNumber functions
@@ -532,27 +532,27 @@ _libssh2_wincng_dsa_free(libssh2_dsa_ctx *dsa);
 void
 _libssh2_wincng_cipher_dtor(_libssh2_cipher_ctx *ctx);
 
-_libssh2_bn *
+libssh2_bn *
 _libssh2_wincng_bignum_init(void);
 int
-_libssh2_wincng_bignum_set_word(_libssh2_bn *bn, ULONG word);
+_libssh2_wincng_bignum_set_word(libssh2_bn *bn, ULONG word);
 ULONG
-_libssh2_wincng_bignum_bits(const _libssh2_bn *bn);
+_libssh2_wincng_bignum_bits(const libssh2_bn *bn);
 int
-_libssh2_wincng_bignum_from_bin(_libssh2_bn *bn, ULONG len,
+_libssh2_wincng_bignum_from_bin(libssh2_bn *bn, ULONG len,
                                 const unsigned char *bin);
 int
-_libssh2_wincng_bignum_to_bin(const _libssh2_bn *bn, unsigned char *bin);
+_libssh2_wincng_bignum_to_bin(const libssh2_bn *bn, unsigned char *bin);
 void
-_libssh2_wincng_bignum_free(_libssh2_bn *bn);
+_libssh2_wincng_bignum_free(libssh2_bn *bn);
 extern void
 _libssh2_dh_init(struct wincng_dh_ctx *dhctx);
 extern int
-_libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, _libssh2_bn *public,
-                     _libssh2_bn *g, _libssh2_bn *p, int group_order);
+_libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
+                     libssh2_bn *g, libssh2_bn *p, int group_order);
 extern int
-_libssh2_dh_secret(struct wincng_dh_ctx *dhctx, _libssh2_bn *secret,
-                   _libssh2_bn *f, _libssh2_bn *p);
+_libssh2_dh_secret(struct wincng_dh_ctx *dhctx, libssh2_bn *secret,
+                   libssh2_bn *f, libssh2_bn *p);
 extern void
 _libssh2_dh_dtor(struct wincng_dh_ctx *dhctx);
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -489,7 +489,7 @@ struct wincng_dh_ctx {
     struct _libssh2_wincng_bignum *dh_privbn;
 };
 
-#define _libssh2_dh_ctx struct wincng_dh_ctx
+#define libssh2_dh_ctx struct wincng_dh_ctx
 
 #define libssh2_dh_init(dhctx) _libssh2_dh_init(dhctx)
 #define libssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -430,7 +430,7 @@ struct _libssh2_wincng_cipher_type {
  * Windows CNG backend: BigNumber Context
  */
 
-#define _libssh2_bn_ctx int /* not used */
+#define libssh2_bn_ctx int /* not used */
 #define _libssh2_bn_ctx_new() 0 /* not used */
 #define _libssh2_bn_ctx_free(bnctx) ((void)0) /* not used */
 


### PR DESCRIPTION
To make the code easier to read and write.

Also rename special type macro `_libssh2_cipher_type()` to
`LIBSSH2_CIPHER_T()` for a more macro-like name.

---

- [ ] replace leading underscore from internal functions, macros and variables.
  To make them stand out of public functions, use a leading uppercase,
  e.g. `Libssh2_cipher_init()`. → Possibly separate PR.
- [x] drop leading underscores from structs/unions. (sftp, wincng) → Possibly separate PR. → #1931
