### PR TITLE
comp: check and avoid overflow in `comp_method_zlib_alloc()`

### DIFF
--- a/src/comp.c
+++ b/src/comp.c
@@ -127,7 +127,7 @@ comp_method_zlib_alloc(voidpf opaque, uInt items, uInt size)
     if(items && (SIZE_MAX / (size_t)items) < (size_t)size)
         return NULL;
 
-    return (voidpf)LIBSSH2_ALLOC(session, items * size);
+    return (voidpf)LIBSSH2_ALLOC(session, items * (size_t)size);
 }
 
 static void

--- a/src/comp.c
+++ b/src/comp.c
@@ -124,7 +124,7 @@ comp_method_zlib_alloc(voidpf opaque, uInt items, uInt size)
     LIBSSH2_SESSION *session = (LIBSSH2_SESSION *)opaque;
 
     /* Make sure (items * size) does not overflow */
-    if(items && (SIZE_MAX / items) < size)
+    if(items && (SIZE_MAX / (size_t)items) < (size_t)size)
         return NULL;
 
     return (voidpf)LIBSSH2_ALLOC(session, items * size);

--- a/src/comp.c
+++ b/src/comp.c
@@ -123,6 +123,10 @@ comp_method_zlib_alloc(voidpf opaque, uInt items, uInt size)
 {
     LIBSSH2_SESSION *session = (LIBSSH2_SESSION *)opaque;
 
+    /* Make sure (items * size) does not overflow */
+    if(items && (SIZE_MAX / items) < size)
+        return NULL;
+
     return (voidpf)LIBSSH2_ALLOC(session, items * size);
 }
 


### PR DESCRIPTION
Detected by CodeQL