### PR TITLE
kex: fix typos in symbol names, comment nits

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -1220,8 +1220,8 @@ static int kex_method_diffie_hellman_group14_sha256_key_exchange(
 }
 
 /* kex_method_diffie_hellman_group16_sha512_key_exchange
-* Diffie-Hellman Group16 Key Exchange using SHA512
-*/
+ * Diffie-Hellman Group16 Key Exchange using SHA512
+ */
 static int kex_method_diffie_hellman_group16_sha512_key_exchange(
     LIBSSH2_SESSION *session,
     struct key_exchange_state_low *key_state)
@@ -1312,9 +1312,9 @@ clean_exit:
     return ret;
 }
 
-/* kex_method_diffie_hellman_group16_sha512_key_exchange
-* Diffie-Hellman Group18 Key Exchange using SHA512
-*/
+/* kex_method_diffie_hellman_group18_sha512_key_exchange
+ * Diffie-Hellman Group18 Key Exchange using SHA512
+ */
 static int kex_method_diffie_hellman_group18_sha512_key_exchange(
     LIBSSH2_SESSION *session,
     struct key_exchange_state_low *key_state)
@@ -3369,35 +3369,35 @@ clean_exit:
 #define LIBSSH2_KEX_METHOD_FLAG_REQ_ENC_HOSTKEY     0x0001
 #define LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY    0x0002
 
-static const struct kex_method kex_method_diffie_helman_group1_sha1 = {
+static const struct kex_method kex_method_diffie_hellman_group1_sha1 = {
     "diffie-hellman-group1-sha1",
     kex_method_diffie_hellman_group1_sha1_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const struct kex_method kex_method_diffie_helman_group14_sha1 = {
+static const struct kex_method kex_method_diffie_hellman_group14_sha1 = {
     "diffie-hellman-group14-sha1",
     kex_method_diffie_hellman_group14_sha1_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const struct kex_method kex_method_diffie_helman_group14_sha256 = {
+static const struct kex_method kex_method_diffie_hellman_group14_sha256 = {
     "diffie-hellman-group14-sha256",
     kex_method_diffie_hellman_group14_sha256_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const struct kex_method kex_method_diffie_helman_group16_sha512 = {
+static const struct kex_method kex_method_diffie_hellman_group16_sha512 = {
     "diffie-hellman-group16-sha512",
     kex_method_diffie_hellman_group16_sha512_key_exchange,
     kex_diffie_hellman_cleanup,
     LIBSSH2_KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY,
 };
 
-static const struct kex_method kex_method_diffie_helman_group18_sha512 = {
+static const struct kex_method kex_method_diffie_hellman_group18_sha512 = {
     "diffie-hellman-group18-sha512",
     kex_method_diffie_hellman_group18_sha512_key_exchange,
     kex_diffie_hellman_cleanup,
@@ -3405,7 +3405,7 @@ static const struct kex_method kex_method_diffie_helman_group18_sha512 = {
 };
 
 static const struct kex_method
-kex_method_diffie_helman_group_exchange_sha1 = {
+kex_method_diffie_hellman_group_exchange_sha1 = {
     "diffie-hellman-group-exchange-sha1",
     kex_method_diffie_hellman_group_exchange_sha1_key_exchange,
     kex_diffie_hellman_cleanup,
@@ -3413,7 +3413,7 @@ kex_method_diffie_helman_group_exchange_sha1 = {
 };
 
 static const struct kex_method
-kex_method_diffie_helman_group_exchange_sha256 = {
+kex_method_diffie_hellman_group_exchange_sha256 = {
     "diffie-hellman-group-exchange-sha256",
     kex_method_diffie_hellman_group_exchange_sha256_key_exchange,
     kex_diffie_hellman_cleanup,
@@ -3527,13 +3527,13 @@ static const struct kex_method *libssh2_kex_methods[] = {
     &kex_method_ecdh_sha2_nistp384,
     &kex_method_ecdh_sha2_nistp521,
 #endif
-    &kex_method_diffie_helman_group_exchange_sha256,
-    &kex_method_diffie_helman_group16_sha512,
-    &kex_method_diffie_helman_group18_sha512,
-    &kex_method_diffie_helman_group14_sha256,
-    &kex_method_diffie_helman_group14_sha1,
-    &kex_method_diffie_helman_group1_sha1,
-    &kex_method_diffie_helman_group_exchange_sha1,
+    &kex_method_diffie_hellman_group_exchange_sha256,
+    &kex_method_diffie_hellman_group16_sha512,
+    &kex_method_diffie_hellman_group18_sha512,
+    &kex_method_diffie_hellman_group14_sha256,
+    &kex_method_diffie_hellman_group14_sha1,
+    &kex_method_diffie_hellman_group1_sha1,
+    &kex_method_diffie_hellman_group_exchange_sha1,
     &kex_method_extension_negotiation,
     &kex_method_strict_client_extension,
     NULL


### PR DESCRIPTION
Spotted by GitHub Code Quality