### PR TITLE
libgcrypt: bump weak random to very strong in `_libssh2_dh_key_pair()`

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -884,7 +884,7 @@ _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
                      libssh2_bn *g, libssh2_bn *p, int group_order)
 {
     /* Generate x and e */
-    gcry_mpi_randomize(*dhctx, group_order * 8 - 1, GCRY_WEAK_RANDOM);
+    gcry_mpi_randomize(*dhctx, group_order * 8 - 1, GCRY_VERY_STRONG_RANDOM);
     gcry_mpi_powm(public, g, *dhctx, p);
     return 0;
 }


### PR DESCRIPTION
Used in an obsolete algo, and no longer CI tested because recent OpenSSH
no longer supports it.                                         

Reported-by: Joshua Rogers

Follow-up to f7daf3185a4e889fcd5272858db97764a279da1e #149
