### PR TITLE
src: drop 'libssh2' prefix from static symbols

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -69,7 +69,7 @@ crypt_none_crypt(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static const struct crypt_method libssh2_crypt_method_none = {
+static const struct crypt_method crypt_method_none = {
     "none",
     "DEK-Info: NONE",
     8,                /* blocksize (SSH2 defines minimum blocksize as 8) */
@@ -142,7 +142,7 @@ crypt_dtor(LIBSSH2_SESSION *session, void **abstract)
 }
 
 #if LIBSSH2_AES_GCM
-static const struct crypt_method libssh2_crypt_method_aes256_gcm = {
+static const struct crypt_method crypt_method_aes256_gcm = {
     "aes256-gcm@openssh.com",
     "",
     16,                         /* blocksize */
@@ -157,7 +157,7 @@ static const struct crypt_method libssh2_crypt_method_aes256_gcm = {
     libssh2_cipher_aes256gcm
 };
 
-static const struct crypt_method libssh2_crypt_method_aes128_gcm = {
+static const struct crypt_method crypt_method_aes128_gcm = {
     "aes128-gcm@openssh.com",
     "",
     16,                         /* blocksize */
@@ -174,7 +174,7 @@ static const struct crypt_method libssh2_crypt_method_aes128_gcm = {
 #endif
 
 #if LIBSSH2_AES_CTR
-static const struct crypt_method libssh2_crypt_method_aes128_ctr = {
+static const struct crypt_method crypt_method_aes128_ctr = {
     "aes128-ctr",
     "",
     16,                         /* blocksize */
@@ -189,7 +189,7 @@ static const struct crypt_method libssh2_crypt_method_aes128_ctr = {
     libssh2_cipher_aes128ctr
 };
 
-static const struct crypt_method libssh2_crypt_method_aes192_ctr = {
+static const struct crypt_method crypt_method_aes192_ctr = {
     "aes192-ctr",
     "",
     16,                         /* blocksize */
@@ -204,7 +204,7 @@ static const struct crypt_method libssh2_crypt_method_aes192_ctr = {
     libssh2_cipher_aes192ctr
 };
 
-static const struct crypt_method libssh2_crypt_method_aes256_ctr = {
+static const struct crypt_method crypt_method_aes256_ctr = {
     "aes256-ctr",
     "",
     16,                         /* blocksize */
@@ -221,7 +221,7 @@ static const struct crypt_method libssh2_crypt_method_aes256_ctr = {
 #endif
 
 #if LIBSSH2_AES_CBC
-static const struct crypt_method libssh2_crypt_method_aes128_cbc = {
+static const struct crypt_method crypt_method_aes128_cbc = {
     "aes128-cbc",
     "DEK-Info: AES-128-CBC",
     16,                         /* blocksize */
@@ -236,7 +236,7 @@ static const struct crypt_method libssh2_crypt_method_aes128_cbc = {
     libssh2_cipher_aes128
 };
 
-static const struct crypt_method libssh2_crypt_method_aes192_cbc = {
+static const struct crypt_method crypt_method_aes192_cbc = {
     "aes192-cbc",
     "DEK-Info: AES-192-CBC",
     16,                         /* blocksize */
@@ -251,7 +251,7 @@ static const struct crypt_method libssh2_crypt_method_aes192_cbc = {
     libssh2_cipher_aes192
 };
 
-static const struct crypt_method libssh2_crypt_method_aes256_cbc = {
+static const struct crypt_method crypt_method_aes256_cbc = {
     "aes256-cbc",
     "DEK-Info: AES-256-CBC",
     16,                         /* blocksize */
@@ -268,7 +268,7 @@ static const struct crypt_method libssh2_crypt_method_aes256_cbc = {
 
 /* rijndael-cbc@lysator.liu.se == aes256-cbc */
 static const struct crypt_method
-    libssh2_crypt_method_rijndael_cbc_lysator_liu_se = {
+    crypt_method_rijndael_cbc_lysator_liu_se = {
     "rijndael-cbc@lysator.liu.se",
     "DEK-Info: AES-256-CBC",
     16,                         /* blocksize */
@@ -285,7 +285,7 @@ static const struct crypt_method
 #endif /* LIBSSH2_AES_CBC */
 
 #if LIBSSH2_BLOWFISH
-static const struct crypt_method libssh2_crypt_method_blowfish_cbc = {
+static const struct crypt_method crypt_method_blowfish_cbc = {
     "blowfish-cbc",
     "",
     8,                          /* blocksize */
@@ -302,7 +302,7 @@ static const struct crypt_method libssh2_crypt_method_blowfish_cbc = {
 #endif /* LIBSSH2_BLOWFISH */
 
 #if LIBSSH2_RC4
-static const struct crypt_method libssh2_crypt_method_arcfour = {
+static const struct crypt_method crypt_method_arcfour = {
     "arcfour",
     "DEK-Info: RC4",
     8,                          /* blocksize */
@@ -341,7 +341,7 @@ crypt_init_arcfour128(LIBSSH2_SESSION *session,
     return rc;
 }
 
-static const struct crypt_method libssh2_crypt_method_arcfour128 = {
+static const struct crypt_method crypt_method_arcfour128 = {
     "arcfour128",
     "",
     8,                          /* blocksize */
@@ -358,7 +358,7 @@ static const struct crypt_method libssh2_crypt_method_arcfour128 = {
 #endif /* LIBSSH2_RC4 */
 
 #if LIBSSH2_CAST
-static const struct crypt_method libssh2_crypt_method_cast128_cbc = {
+static const struct crypt_method crypt_method_cast128_cbc = {
     "cast128-cbc",
     "",
     8,                          /* blocksize */
@@ -375,7 +375,7 @@ static const struct crypt_method libssh2_crypt_method_cast128_cbc = {
 #endif /* LIBSSH2_CAST */
 
 #if LIBSSH2_3DES
-static const struct crypt_method libssh2_crypt_method_3des_cbc = {
+static const struct crypt_method crypt_method_3des_cbc = {
     "3des-cbc",
     "DEK-Info: DES-EDE3-CBC",
     8,                          /* blocksize */
@@ -487,7 +487,7 @@ crypt_dtor_chacha20_poly(LIBSSH2_SESSION *session, void **abstract)
 }
 
 static const struct crypt_method
-    libssh2_crypt_method_chacha20_poly1305_openssh = {
+    crypt_method_chacha20_poly1305_openssh = {
     "chacha20-poly1305@openssh.com",
     "",
     8,                                          /* blocksize */
@@ -505,37 +505,37 @@ static const struct crypt_method
 /* These are the crypt methods that are available to be negotiated. Methods
    towards the start are chosen in preference to ones further down the list. */
 static const struct crypt_method *_libssh2_crypt_methods[] = {
-    &libssh2_crypt_method_chacha20_poly1305_openssh,
+    &crypt_method_chacha20_poly1305_openssh,
 #if LIBSSH2_AES_GCM
-    &libssh2_crypt_method_aes256_gcm,
-    &libssh2_crypt_method_aes128_gcm,
+    &crypt_method_aes256_gcm,
+    &crypt_method_aes128_gcm,
 #endif /* LIBSSH2_AES_GCM */
 #if LIBSSH2_AES_CTR
-    &libssh2_crypt_method_aes256_ctr,
-    &libssh2_crypt_method_aes192_ctr,
-    &libssh2_crypt_method_aes128_ctr,
+    &crypt_method_aes256_ctr,
+    &crypt_method_aes192_ctr,
+    &crypt_method_aes128_ctr,
 #endif /* LIBSSH2_AES_CTR */
 #if LIBSSH2_AES_CBC
-    &libssh2_crypt_method_aes256_cbc,
-    &libssh2_crypt_method_rijndael_cbc_lysator_liu_se,  /* == aes256-cbc */
-    &libssh2_crypt_method_aes192_cbc,
-    &libssh2_crypt_method_aes128_cbc,
+    &crypt_method_aes256_cbc,
+    &crypt_method_rijndael_cbc_lysator_liu_se,  /* == aes256-cbc */
+    &crypt_method_aes192_cbc,
+    &crypt_method_aes128_cbc,
 #endif /* LIBSSH2_AES_CBC */
 #if LIBSSH2_BLOWFISH
-    &libssh2_crypt_method_blowfish_cbc,
+    &crypt_method_blowfish_cbc,
 #endif /* LIBSSH2_BLOWFISH */
 #if LIBSSH2_RC4
-    &libssh2_crypt_method_arcfour128,
-    &libssh2_crypt_method_arcfour,
+    &crypt_method_arcfour128,
+    &crypt_method_arcfour,
 #endif /* LIBSSH2_RC4 */
 #if LIBSSH2_CAST
-    &libssh2_crypt_method_cast128_cbc,
+    &crypt_method_cast128_cbc,
 #endif /* LIBSSH2_CAST */
 #if LIBSSH2_3DES
-    &libssh2_crypt_method_3des_cbc,
+    &crypt_method_3des_cbc,
 #endif /*  LIBSSH2_DES */
 #if defined(LIBSSH2DEBUG) && defined(LIBSSH2_CRYPT_NONE_INSECURE)
-    &libssh2_crypt_method_none,
+    &crypt_method_none,
 #endif
     NULL
 };

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -504,7 +504,7 @@ static const struct crypt_method
 
 /* These are the crypt methods that are available to be negotiated. Methods
    towards the start are chosen in preference to ones further down the list. */
-static const struct crypt_method *_libssh2_crypt_methods[] = {
+static const struct crypt_method *crypt_methods[] = {
     &crypt_method_chacha20_poly1305_openssh,
 #if LIBSSH2_AES_GCM
     &crypt_method_aes256_gcm,
@@ -541,8 +541,7 @@ static const struct crypt_method *_libssh2_crypt_methods[] = {
 };
 
 /* Expose to kex.c */
-const struct crypt_method **
-libssh2_crypt_methods(void)
+const struct crypt_method **libssh2_crypt_methods(void)
 {
-    return _libssh2_crypt_methods;
+    return crypt_methods;
 }

--- a/src/global.c
+++ b/src/global.c
@@ -40,39 +40,36 @@
 
 #include "libssh2_priv.h"
 
-static int _libssh2_initialized = 0;
-static int _libssh2_init_flags = 0;
+static int s_initialized = 0;
+static int s_init_flags = 0;
 
-LIBSSH2_API int
-libssh2_init(int flags)
+LIBSSH2_API int libssh2_init(int flags)
 {
-    if(_libssh2_initialized == 0 && !(flags & LIBSSH2_INIT_NO_CRYPTO)) {
+    if(s_initialized == 0 && !(flags & LIBSSH2_INIT_NO_CRYPTO)) {
         libssh2_crypto_init();
     }
 
-    _libssh2_initialized++;
-    _libssh2_init_flags |= flags;
+    s_initialized++;
+    s_init_flags |= flags;
 
     return 0;
 }
 
-LIBSSH2_API void
-libssh2_exit(void)
+LIBSSH2_API void libssh2_exit(void)
 {
-    if(_libssh2_initialized == 0)
+    if(s_initialized == 0)
         return;
 
-    _libssh2_initialized--;
+    s_initialized--;
 
-    if(_libssh2_initialized == 0 &&
-       !(_libssh2_init_flags & LIBSSH2_INIT_NO_CRYPTO)) {
+    if(s_initialized == 0 &&
+       !(s_init_flags & LIBSSH2_INIT_NO_CRYPTO)) {
         libssh2_crypto_exit();
     }
 }
 
-void
-_libssh2_init_if_needed(void)
+void _libssh2_init_if_needed(void)
 {
-    if(_libssh2_initialized == 0)
+    if(s_initialized == 0)
         (void)libssh2_init(0);
 }

--- a/src/kex.c
+++ b/src/kex.c
@@ -1702,8 +1702,8 @@ dh_gex_clean_exit:
  * returns the EC curve type by name used in hybrid key exchange
  */
 
-static int
-kex_session_hybrid_curve_type(const char *name, libssh2_curve_type *out_type)
+static int kex_session_hybrid_curve_type(const char *name,
+                                         libssh2_curve_type *out_type)
 {
     libssh2_curve_type type;
 
@@ -1967,8 +1967,8 @@ do {                                                                         \
  * returns the EC curve type by name used in key exchange
  */
 
-static int
-kex_session_ecdh_curve_type(const char *name, libssh2_curve_type *out_type)
+static int kex_session_ecdh_curve_type(const char *name,
+                                       libssh2_curve_type *out_type)
 {
     libssh2_curve_type type;
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -187,12 +187,11 @@ static int sha_algo_ctx_final(int sha_algo, void *ctx,
     return 0;
 }
 
-static void _libssh2_sha_algo_value_hash(
-    int sha_algo,
-    LIBSSH2_SESSION *session,
-    struct kmdhgGPshakex_state *exchange_state,
-    unsigned char **data, size_t data_len,
-    const unsigned char *version)
+static void sha_algo_value_hash(int sha_algo,
+                                LIBSSH2_SESSION *session,
+                                struct kmdhgGPshakex_state *exchange_state,
+                                unsigned char **data, size_t data_len,
+                                 const unsigned char *version)
 {
     if(sha_algo == 512) {
         LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(512, *data, data_len, version);
@@ -409,18 +408,18 @@ static int finish_kex(LIBSSH2_SESSION *session,
         unsigned char *iv = NULL, *secret = NULL;
         int free_iv = 0, free_secret = 0;
 
-        _libssh2_sha_algo_value_hash(sha_algo_value, session,
-                                     exchange_state, &iv,
-                                     session->local.crypt->iv_len,
-                                     (const unsigned char *)"A");
+        sha_algo_value_hash(sha_algo_value, session,
+                            exchange_state, &iv,
+                            session->local.crypt->iv_len,
+                            (const unsigned char *)"A");
 
         if(!iv) {
             return -1;
         }
-        _libssh2_sha_algo_value_hash(sha_algo_value, session,
-                                     exchange_state, &secret,
-                                     session->local.crypt->secret_len,
-                                     (const unsigned char *)"C");
+        sha_algo_value_hash(sha_algo_value, session,
+                            exchange_state, &secret,
+                            session->local.crypt->secret_len,
+                            (const unsigned char *)"C");
 
         if(!secret) {
             LIBSSH2_FREE(session, iv);
@@ -458,17 +457,17 @@ static int finish_kex(LIBSSH2_SESSION *session,
         unsigned char *iv = NULL, *secret = NULL;
         int free_iv = 0, free_secret = 0;
 
-        _libssh2_sha_algo_value_hash(sha_algo_value, session,
-                                     exchange_state, &iv,
-                                     session->remote.crypt->iv_len,
-                                     (const unsigned char *)"B");
+        sha_algo_value_hash(sha_algo_value, session,
+                            exchange_state, &iv,
+                            session->remote.crypt->iv_len,
+                            (const unsigned char *)"B");
         if(!iv) {
             return LIBSSH2_ERROR_KEX_FAILURE;
         }
-        _libssh2_sha_algo_value_hash(sha_algo_value, session,
-                                     exchange_state, &secret,
-                                     session->remote.crypt->secret_len,
-                                     (const unsigned char *)"D");
+        sha_algo_value_hash(sha_algo_value, session,
+                            exchange_state, &secret,
+                            session->remote.crypt->secret_len,
+                            (const unsigned char *)"D");
         if(!secret) {
             LIBSSH2_FREE(session, iv);
             return LIBSSH2_ERROR_KEX_FAILURE;
@@ -503,10 +502,10 @@ static int finish_kex(LIBSSH2_SESSION *session,
         unsigned char *key = NULL;
         int free_key = 0;
 
-        _libssh2_sha_algo_value_hash(sha_algo_value, session,
-                                     exchange_state, &key,
-                                     session->local.mac->key_len,
-                                     (const unsigned char *)"E");
+        sha_algo_value_hash(sha_algo_value, session,
+                            exchange_state, &key,
+                            session->local.mac->key_len,
+                            (const unsigned char *)"E");
         if(!key) {
             return LIBSSH2_ERROR_KEX_FAILURE;
         }
@@ -529,10 +528,10 @@ static int finish_kex(LIBSSH2_SESSION *session,
         unsigned char *key = NULL;
         int free_key = 0;
 
-        _libssh2_sha_algo_value_hash(sha_algo_value, session,
-                                     exchange_state, &key,
-                                     session->remote.mac->key_len,
-                                     (const unsigned char *)"F");
+        sha_algo_value_hash(sha_algo_value, session,
+                            exchange_state, &key,
+                            session->remote.mac->key_len,
+                            (const unsigned char *)"F");
         if(!key) {
             return LIBSSH2_ERROR_KEX_FAILURE;
         }

--- a/src/kex.c
+++ b/src/kex.c
@@ -160,8 +160,8 @@ static int sha_algo_ctx_update(int sha_algo, void *ctx,
     return 0;
 }
 
-static int _libssh2_sha_algo_ctx_final(int sha_algo, void *ctx,
-                                       void *hash)
+static int sha_algo_ctx_final(int sha_algo, void *ctx,
+                              void *hash)
 {
     if(sha_algo == 512) {
         libssh2_sha512_ctx *_ctx = (libssh2_sha512_ctx*)ctx;
@@ -963,7 +963,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                    exchange_state->k_value_len);
 
         if(!hok ||
-           !_libssh2_sha_algo_ctx_final(sha_algo_value, exchange_hash_ctx,
+           !sha_algo_ctx_final(sha_algo_value, exchange_hash_ctx,
                                exchange_state->h_sig_comp)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
                                  "kex: failed to calculate hash");

--- a/src/kex.c
+++ b/src/kex.c
@@ -3500,7 +3500,7 @@ kex_method_strict_client_extension = {
     0,
 };
 
-static const struct kex_method *libssh2_kex_methods[] = {
+static const struct kex_method *kex_methods[] = {
 #if LIBSSH2_MLKEM
 #if LIBSSH2_ED25519
     &kex_method_ssh_mlkem768_x25519_sha256,
@@ -3621,7 +3621,7 @@ static int kexinit(LIBSSH2_SESSION *session)
         uint32_t lang_cs_len, lang_sc_len;
 
         kex_len =
-            LIBSSH2_METHOD_PREFS_LEN(session->kex_prefs, libssh2_kex_methods);
+            LIBSSH2_METHOD_PREFS_LEN(session->kex_prefs, kex_methods);
         hostkey_len =
             LIBSSH2_METHOD_PREFS_LEN(session->hostkey_prefs,
                                      libssh2_hostkey_methods());
@@ -3672,7 +3672,7 @@ static int kexinit(LIBSSH2_SESSION *session)
            inefficient from a CPU standpoint, but it saves multiple
            malloc/realloc calls */
         LIBSSH2_METHOD_PREFS_STR(s, kex_len, session->kex_prefs,
-                                 libssh2_kex_methods);
+                                 kex_methods);
         LIBSSH2_METHOD_PREFS_STR(s, hostkey_len, session->hostkey_prefs,
                                  libssh2_hostkey_methods());
         LIBSSH2_METHOD_PREFS_STR(s, crypt_cs_len, session->local.crypt_prefs,
@@ -3929,7 +3929,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
                                  size_t kex_len, unsigned char *hostkey,
                                  size_t hostkey_len)
 {
-    const struct kex_method **kexp = libssh2_kex_methods;
+    const struct kex_method **kexp = kex_methods;
     unsigned char *s;
     const unsigned char *strict =
         (const unsigned char *)"kex-strict-s-v00@openssh.com";
@@ -4443,7 +4443,7 @@ libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
     switch(method_type) {
     case LIBSSH2_METHOD_KEX:
         prefvar = &session->kex_prefs;
-        mlist = (const struct common_method **)libssh2_kex_methods;
+        mlist = (const struct common_method **)kex_methods;
         break;
 
     case LIBSSH2_METHOD_HOSTKEY:
@@ -4596,7 +4596,7 @@ LIBSSH2_API int libssh2_session_supported_algs(LIBSSH2_SESSION* session,
 
     switch(method_type) {
     case LIBSSH2_METHOD_KEX:
-        mlist = (const struct common_method **)libssh2_kex_methods;
+        mlist = (const struct common_method **)kex_methods;
         break;
 
     case LIBSSH2_METHOD_HOSTKEY:

--- a/src/kex.c
+++ b/src/kex.c
@@ -111,7 +111,7 @@ do {                                                                          \
  * don't allow it so we have to wrap them up in helper functions
  */
 
-static int _libssh2_sha_algo_ctx_init(int sha_algo, void *ctx)
+static int sha_algo_ctx_init(int sha_algo, void *ctx)
 {
     if(sha_algo == 512) {
         return libssh2_sha512_init((libssh2_sha512_ctx*)ctx);
@@ -872,7 +872,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             }
         }
 
-        if(!_libssh2_sha_algo_ctx_init(sha_algo_value, exchange_hash_ctx)) {
+        if(!sha_algo_ctx_init(sha_algo_value, exchange_hash_ctx)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_INIT,
                                  "Unable to initialize hash context");
             goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -133,8 +133,8 @@ static int sha_algo_ctx_init(int sha_algo, void *ctx)
     return 0;
 }
 
-static int _libssh2_sha_algo_ctx_update(int sha_algo, void *ctx,
-                                        const void *data, size_t len)
+static int sha_algo_ctx_update(int sha_algo, void *ctx,
+                               const void *data, size_t len)
 {
     if(sha_algo == 512) {
         libssh2_sha512_ctx *_ctx = (libssh2_sha512_ctx*)ctx;
@@ -881,57 +881,53 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         if(session->local.banner) {
             _libssh2_htonu32(exchange_state->h_sig_comp,
                 (uint32_t)(strlen((char *)session->local.banner) - 2));
-            hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
-                                                exchange_hash_ctx,
-                                                exchange_state->h_sig_comp, 4);
-            hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
-                                                exchange_hash_ctx,
-                                                session->local.banner,
-                                   strlen((char *)session->local.banner) - 2);
+            hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                       exchange_state->h_sig_comp, 4);
+            hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                       session->local.banner,
+                                    strlen((char *)session->local.banner) - 2);
         }
         else {
             _libssh2_htonu32(exchange_state->h_sig_comp,
                              sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
-            hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
-                                                exchange_hash_ctx,
-                                                exchange_state->h_sig_comp, 4);
-            hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
-                                                exchange_hash_ctx,
+            hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                       exchange_state->h_sig_comp, 4);
+            hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
                                       (const void *)LIBSSH2_SSH_DEFAULT_BANNER,
                                        sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
         }
 
         _libssh2_htonu32(exchange_state->h_sig_comp,
                          (uint32_t)strlen((char *)session->remote.banner));
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            exchange_state->h_sig_comp, 4);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            session->remote.banner,
-                                       strlen((char *)session->remote.banner));
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   exchange_state->h_sig_comp, 4);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   session->remote.banner,
+                                   strlen((char *)session->remote.banner));
 
         _libssh2_htonu32(exchange_state->h_sig_comp,
                          (uint32_t)session->local.kexinit_len);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            exchange_state->h_sig_comp, 4);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            session->local.kexinit,
-                                            session->local.kexinit_len);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   exchange_state->h_sig_comp, 4);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   session->local.kexinit,
+                                   session->local.kexinit_len);
 
         _libssh2_htonu32(exchange_state->h_sig_comp,
                          (uint32_t)session->remote.kexinit_len);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            exchange_state->h_sig_comp, 4);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            session->remote.kexinit,
-                                            session->remote.kexinit_len);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   exchange_state->h_sig_comp, 4);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   session->remote.kexinit,
+                                   session->remote.kexinit_len);
 
         _libssh2_htonu32(exchange_state->h_sig_comp,
                          session->server_hostkey_len);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            exchange_state->h_sig_comp, 4);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            session->server_hostkey,
-                                            session->server_hostkey_len);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   exchange_state->h_sig_comp, 4);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   session->server_hostkey,
+                                   session->server_hostkey_len);
 
         if(packet_type_init == SSH_MSG_KEX_DH_GEX_INIT) {
             /* diffie-hellman-group-exchange hashes additional fields */
@@ -941,37 +937,34 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                              LIBSSH2_DH_GEX_OPTGROUP);
             _libssh2_htonu32(exchange_state->h_sig_comp + 8,
                              LIBSSH2_DH_GEX_MAXGROUP);
-            hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
-                                                exchange_hash_ctx,
-                                                exchange_state->h_sig_comp,
-                                                12);
+            hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                       exchange_state->h_sig_comp, 12);
         }
 
         if(midhash) {
-            hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
-                                                exchange_hash_ctx,
-                                                midhash, midhash_len);
+            hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                       midhash, midhash_len);
         }
 
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            exchange_state->e_packet + 1,
-                                            exchange_state->e_packet_len - 1);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   exchange_state->e_packet + 1,
+                                   exchange_state->e_packet_len - 1);
 
         _libssh2_htonu32(exchange_state->h_sig_comp,
                          (uint32_t)exchange_state->f_value_len);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            exchange_state->h_sig_comp, 4);
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            exchange_state->f_value,
-                                            exchange_state->f_value_len);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   exchange_state->h_sig_comp, 4);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   exchange_state->f_value,
+                                   exchange_state->f_value_len);
 
-        hok &= _libssh2_sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
-                                            exchange_state->k_value,
-                                            exchange_state->k_value_len);
+        hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
+                                   exchange_state->k_value,
+                                   exchange_state->k_value_len);
 
         if(!hok ||
            !_libssh2_sha_algo_ctx_final(sha_algo_value, exchange_hash_ctx,
-                                        exchange_state->h_sig_comp)) {
+                               exchange_state->h_sig_comp)) {
             ret = _libssh2_error(session, LIBSSH2_ERROR_HASH_CALC,
                                  "kex: failed to calculate hash");
             goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -191,7 +191,7 @@ static void sha_algo_value_hash(int sha_algo,
                                 LIBSSH2_SESSION *session,
                                 struct kmdhgGPshakex_state *exchange_state,
                                 unsigned char **data, size_t data_len,
-                                 const unsigned char *version)
+                                const unsigned char *version)
 {
     if(sha_algo == 512) {
         LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(512, *data, data_len, version);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1344,10 +1344,9 @@ cleanup:
     return *ec_ctx ? 0 : -1;
 }
 
-static unsigned char *
-_libssh2_mbedtls_mpi_write_binary(unsigned char *buf,
-                                  const mbedtls_mpi *mpi,
-                                  size_t bytes)
+static unsigned char *mbed_mpi_write_binary(unsigned char *buf,
+                                            const mbedtls_mpi *mpi,
+                                            size_t bytes)
 {
     unsigned char *p = buf;
     uint32_t size = (uint32_t)bytes;
@@ -1411,8 +1410,8 @@ _libssh2_mbedtls_ecdsa_sign(LIBSSH2_SESSION *session,
         goto cleanup;
 
     sp = tmp_sign;
-    sp = _libssh2_mbedtls_mpi_write_binary(sp, &pr, r_len);
-    sp = _libssh2_mbedtls_mpi_write_binary(sp, &ps, s_len);
+    sp = mbed_mpi_write_binary(sp, &pr, r_len);
+    sp = mbed_mpi_write_binary(sp, &ps, s_len);
 
     *signature_len = (size_t)(sp - tmp_sign);
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -335,8 +335,7 @@ _libssh2_mbedtls_bignum_free(libssh2_bn *bn)
     }
 }
 
-static int
-_libssh2_mbedtls_bignum_random(libssh2_bn *bn, int bits, int top, int bottom)
+static int mbed_bignum_random(libssh2_bn *bn, int bits, int top, int bottom)
 {
     size_t len;
     int err;
@@ -915,7 +914,7 @@ _libssh2_dh_key_pair(libssh2_dh_ctx *dhctx, libssh2_bn *public,
                      libssh2_bn *g, libssh2_bn *p, int group_order)
 {
     /* Generate x and e */
-    _libssh2_mbedtls_bignum_random(*dhctx, group_order * 8 - 1, 0, -1);
+    mbed_bignum_random(*dhctx, group_order * 8 - 1, 0, -1);
     mbedtls_mpi_exp_mod(public, g, *dhctx, p, NULL);
     return 0;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -52,8 +52,8 @@
  * mbedTLS backend: Global context handles
  */
 
-static mbedtls_entropy_context  s_mbedtls_entropy;
-static mbedtls_ctr_drbg_context s_mbedtls_ctr_drbg;
+static mbedtls_entropy_context  mbed_entropy;
+static mbedtls_ctr_drbg_context mbed_ctr_drbg;
 
 /*******************************************************************/
 /*
@@ -65,28 +65,28 @@ _libssh2_mbedtls_init(void)
 {
     int ret;
 
-    mbedtls_entropy_init(&s_mbedtls_entropy);
-    mbedtls_ctr_drbg_init(&s_mbedtls_ctr_drbg);
+    mbedtls_entropy_init(&mbed_entropy);
+    mbedtls_ctr_drbg_init(&mbed_ctr_drbg);
 
-    ret = mbedtls_ctr_drbg_seed(&s_mbedtls_ctr_drbg,
+    ret = mbedtls_ctr_drbg_seed(&mbed_ctr_drbg,
                                 mbedtls_entropy_func,
-                                &s_mbedtls_entropy, NULL, 0);
+                                &mbed_entropy, NULL, 0);
     if(ret)
-        mbedtls_ctr_drbg_free(&s_mbedtls_ctr_drbg);
+        mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
 }
 
 void
 _libssh2_mbedtls_free(void)
 {
-    mbedtls_ctr_drbg_free(&s_mbedtls_ctr_drbg);
-    mbedtls_entropy_free(&s_mbedtls_entropy);
+    mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
+    mbedtls_entropy_free(&mbed_entropy);
 }
 
 int
 _libssh2_mbedtls_random(unsigned char *buf, size_t len)
 {
     int ret;
-    ret = mbedtls_ctr_drbg_random(&s_mbedtls_ctr_drbg, buf, len);
+    ret = mbedtls_ctr_drbg_random(&mbed_ctr_drbg, buf, len);
     return ret == 0 ? 0 : -1;
 }
 
@@ -348,7 +348,7 @@ _libssh2_mbedtls_bignum_random(libssh2_bn *bn, int bits, int top, int bottom)
 
     len = (bits + 7) >> 3;
     err = mbedtls_mpi_fill_random(bn, len, mbedtls_ctr_drbg_random,
-                                  &s_mbedtls_ctr_drbg);
+                                  &mbed_ctr_drbg);
     if(err)
         return -1;
 
@@ -479,7 +479,7 @@ _libssh2_mbedtls_rsa_new_private(libssh2_rsa_ctx **rsa,
 
     ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase,
                                    mbedtls_ctr_drbg_random,
-                                   &s_mbedtls_ctr_drbg);
+                                   &mbed_ctr_drbg);
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);
         mbedtls_rsa_free(*rsa);
@@ -535,7 +535,7 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
                                filedata_len + 1,
                                passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
-                               &s_mbedtls_ctr_drbg);
+                               &mbed_ctr_drbg);
     _libssh2_mbedtls_safe_free(filedata_nullterm, filedata_len);
 
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
@@ -647,7 +647,7 @@ _libssh2_mbedtls_rsa_sha2_sign(LIBSSH2_SESSION *session,
     if(ret == 0)
         ret = mbedtls_rsa_pkcs1_sign(rsactx,
                                      mbedtls_ctr_drbg_random,
-                                     &s_mbedtls_ctr_drbg,
+                                     &mbed_ctr_drbg,
                                      md_type, (unsigned int)hash_len,
                                      hash, sig);
     if(ret) {
@@ -794,7 +794,7 @@ _libssh2_mbedtls_pub_priv_keyfile(LIBSSH2_SESSION *session,
     mbedtls_pk_init(&pkey);
     ret = mbedtls_pk_parse_keyfile(&pkey, privatekey, passphrase,
                                    mbedtls_ctr_drbg_random,
-                                   &s_mbedtls_ctr_drbg);
+                                   &mbed_ctr_drbg);
     if(ret) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));
         mbedtls_pk_free(&pkey);
@@ -844,7 +844,7 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                privatekeydata_len + 1,
                                (const unsigned char *)passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
-                               &s_mbedtls_ctr_drbg);
+                               &mbed_ctr_drbg);
     _libssh2_mbedtls_safe_free(privatekeydata_nullterm, privatekeydata_len);
 
     if(ret) {
@@ -969,7 +969,7 @@ _libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
 
     if(mbedtls_ecdsa_genkey(*out_private_key, (mbedtls_ecp_group_id)curve_type,
                             mbedtls_ctr_drbg_random,
-                            &s_mbedtls_ctr_drbg))
+                            &mbed_ctr_drbg))
         goto failed;
 
     plen = 2 * mbedtls_mpi_size(
@@ -1065,7 +1065,7 @@ _libssh2_mbedtls_ecdh_gen_k(libssh2_bn **k,
                                    &pubkey,
                                    &private_key->MBEDTLS_PRIVATE(d),
                                    mbedtls_ctr_drbg_random,
-                                   &s_mbedtls_ctr_drbg)) {
+                                   &mbed_ctr_drbg)) {
         rc = -1;
         goto cleanup;
     }
@@ -1150,7 +1150,7 @@ _libssh2_mbedtls_parse_eckey(libssh2_ecdsa_ctx **ctx,
 
     if(mbedtls_pk_parse_key(pkey, data, data_len, pwd, pwd_len,
                             mbedtls_ctr_drbg_random,
-                            &s_mbedtls_ctr_drbg))
+                            &mbed_ctr_drbg))
 
         goto failed;
 
@@ -1229,7 +1229,7 @@ _libssh2_mbedtls_parse_openssh_key(libssh2_ecdsa_ctx **ctx,
                        &(*ctx)->MBEDTLS_PRIVATE(d),
                        &(*ctx)->MBEDTLS_PRIVATE(grp).G,
                        mbedtls_ctr_drbg_random,
-                       &s_mbedtls_ctr_drbg))
+                       &mbed_ctr_drbg))
         goto failed;
 
     if(mbedtls_ecp_check_privkey(&(*ctx)->MBEDTLS_PRIVATE(grp),
@@ -1403,7 +1403,7 @@ _libssh2_mbedtls_ecdsa_sign(LIBSSH2_SESSION *session,
                           &ec_ctx->MBEDTLS_PRIVATE(d),
                           hash, hash_len,
                           mbedtls_ctr_drbg_random,
-                          &s_mbedtls_ctr_drbg))
+                          &mbed_ctr_drbg))
         goto cleanup;
 
     r_len = mbedtls_mpi_size(&pr) + 1;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1170,12 +1170,11 @@ failed:
     return -1;
 }
 
-static int
-_libssh2_mbedtls_parse_openssh_key(libssh2_ecdsa_ctx **ctx,
-                                   LIBSSH2_SESSION *session,
-                                   const unsigned char *data,
-                                   size_t data_len,
-                                   const unsigned char *pwd)
+static int mbed_parse_openssh_key(libssh2_ecdsa_ctx **ctx,
+                                  LIBSSH2_SESSION *session,
+                                  const unsigned char *data,
+                                  size_t data_len,
+                                  const unsigned char *pwd)
 {
     libssh2_curve_type type;
     unsigned char *name = NULL;
@@ -1287,8 +1286,8 @@ _libssh2_mbedtls_ecdsa_new_private(libssh2_ecdsa_ctx **ec_ctx,
                         data, data_len, passphrase) == 0)
         goto cleanup;
 
-    _libssh2_mbedtls_parse_openssh_key(ec_ctx, session, data, data_len,
-                                       passphrase);
+    mbed_parse_openssh_key(ec_ctx, session, data, data_len,
+                           passphrase);
 
 cleanup:
 
@@ -1332,8 +1331,8 @@ _libssh2_mbedtls_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ec_ctx,
                         ntdata, filedata_len + 1, passphrase) == 0)
         goto cleanup;
 
-    _libssh2_mbedtls_parse_openssh_key(ec_ctx, session,
-                                       ntdata, filedata_len + 1, passphrase);
+    mbed_parse_openssh_key(ec_ctx, session,
+                           ntdata, filedata_len + 1, passphrase);
 
 cleanup:
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -678,10 +678,9 @@ _libssh2_mbedtls_rsa_free(libssh2_rsa_ctx *ctx)
     mbedtls_free(ctx);
 }
 
-static unsigned char *
-gen_publickey_from_rsa(LIBSSH2_SESSION *session,
-                       mbedtls_rsa_context *rsa,
-                       size_t *keylen)
+static unsigned char *gen_publickey_from_rsa(LIBSSH2_SESSION *session,
+                                             mbedtls_rsa_context *rsa,
+                                             size_t *keylen)
 {
     uint32_t e_bytes, n_bytes;
     uint32_t len;
@@ -722,13 +721,12 @@ gen_publickey_from_rsa(LIBSSH2_SESSION *session,
     return key;
 }
 
-static int
-_libssh2_mbedtls_pub_priv_key(LIBSSH2_SESSION *session,
-                              unsigned char **method,
-                              size_t *method_len,
-                              unsigned char **pubkeydata,
-                              size_t *pubkeydata_len,
-                              mbedtls_pk_context *pkey)
+static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
+                             unsigned char **method,
+                             size_t *method_len,
+                             unsigned char **pubkeydata,
+                             size_t *pubkeydata_len,
+                             mbedtls_pk_context *pkey)
 {
     unsigned char *key = NULL, *mth = NULL;
     size_t keylen = 0, mthlen = 0;
@@ -800,8 +798,8 @@ _libssh2_mbedtls_pub_priv_keyfile(LIBSSH2_SESSION *session,
                                     LIBSSH2_ERR_FLAG_DUP);
     }
 
-    ret = _libssh2_mbedtls_pub_priv_key(session, method, method_len,
-                                        pubkeydata, pubkeydata_len, &pkey);
+    ret = mbed_pub_priv_key(session, method, method_len,
+                            pubkeydata, pubkeydata_len, &pkey);
 
     mbedtls_pk_free(&pkey);
 
@@ -852,8 +850,8 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                     LIBSSH2_ERR_FLAG_DUP);
     }
 
-    ret = _libssh2_mbedtls_pub_priv_key(session, method, method_len,
-                                        pubkeydata, pubkeydata_len, &pkey);
+    ret = mbed_pub_priv_key(session, method, method_len,
+                            pubkeydata, pubkeydata_len, &pkey);
 
     mbedtls_pk_free(&pkey);
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -90,8 +90,7 @@ _libssh2_mbedtls_random(unsigned char *buf, size_t len)
     return ret == 0 ? 0 : -1;
 }
 
-static void
-_libssh2_mbedtls_safe_free(void *buf, size_t len)
+static void mbed_safe_free(void *buf, size_t len)
 {
     if(!buf)
         return;
@@ -182,7 +181,7 @@ _libssh2_mbedtls_cipher_crypt(libssh2_cipher_ctx *ctx,
             memcpy(block, output, olen);
         }
 
-        _libssh2_mbedtls_safe_free(output, osize);
+        mbed_safe_free(output, osize);
     }
     else
         ret = -1;
@@ -536,7 +535,7 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
                                passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
                                &mbed_ctr_drbg);
-    _libssh2_mbedtls_safe_free(filedata_nullterm, filedata_len);
+    mbed_safe_free(filedata_nullterm, filedata_len);
 
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);
@@ -845,7 +844,7 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                (const unsigned char *)passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
                                &mbed_ctr_drbg);
-    _libssh2_mbedtls_safe_free(privatekeydata_nullterm, privatekeydata_len);
+    mbed_safe_free(privatekeydata_nullterm, privatekeydata_len);
 
     if(ret) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));
@@ -989,7 +988,7 @@ _libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
 failed:
 
     _libssh2_mbedtls_ecdsa_free(*out_private_key);
-    _libssh2_mbedtls_safe_free(*out_public_key_octal, plen);
+    mbed_safe_free(*out_public_key_octal, plen);
     *out_private_key = NULL;
 
     return -1;
@@ -1344,7 +1343,7 @@ cleanup:
 
     mbedtls_pk_free(&pkey);
 
-    _libssh2_mbedtls_safe_free(ntdata, filedata_len);
+    mbed_safe_free(ntdata, filedata_len);
 
     return *ec_ctx ? 0 : -1;
 }
@@ -1433,7 +1432,7 @@ cleanup:
     mbedtls_mpi_free(&pr);
     mbedtls_mpi_free(&ps);
 
-    _libssh2_mbedtls_safe_free(tmp_sign, tmp_sign_len);
+    mbed_safe_free(tmp_sign, tmp_sign_len);
 
     return *signature ? 0 : -1;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -52,8 +52,8 @@
  * mbedTLS backend: Global context handles
  */
 
-static mbedtls_entropy_context  _libssh2_mbedtls_entropy;
-static mbedtls_ctr_drbg_context _libssh2_mbedtls_ctr_drbg;
+static mbedtls_entropy_context  s_mbedtls_entropy;
+static mbedtls_ctr_drbg_context s_mbedtls_ctr_drbg;
 
 /*******************************************************************/
 /*
@@ -65,28 +65,28 @@ _libssh2_mbedtls_init(void)
 {
     int ret;
 
-    mbedtls_entropy_init(&_libssh2_mbedtls_entropy);
-    mbedtls_ctr_drbg_init(&_libssh2_mbedtls_ctr_drbg);
+    mbedtls_entropy_init(&s_mbedtls_entropy);
+    mbedtls_ctr_drbg_init(&s_mbedtls_ctr_drbg);
 
-    ret = mbedtls_ctr_drbg_seed(&_libssh2_mbedtls_ctr_drbg,
+    ret = mbedtls_ctr_drbg_seed(&s_mbedtls_ctr_drbg,
                                 mbedtls_entropy_func,
-                                &_libssh2_mbedtls_entropy, NULL, 0);
+                                &s_mbedtls_entropy, NULL, 0);
     if(ret)
-        mbedtls_ctr_drbg_free(&_libssh2_mbedtls_ctr_drbg);
+        mbedtls_ctr_drbg_free(&s_mbedtls_ctr_drbg);
 }
 
 void
 _libssh2_mbedtls_free(void)
 {
-    mbedtls_ctr_drbg_free(&_libssh2_mbedtls_ctr_drbg);
-    mbedtls_entropy_free(&_libssh2_mbedtls_entropy);
+    mbedtls_ctr_drbg_free(&s_mbedtls_ctr_drbg);
+    mbedtls_entropy_free(&s_mbedtls_entropy);
 }
 
 int
 _libssh2_mbedtls_random(unsigned char *buf, size_t len)
 {
     int ret;
-    ret = mbedtls_ctr_drbg_random(&_libssh2_mbedtls_ctr_drbg, buf, len);
+    ret = mbedtls_ctr_drbg_random(&s_mbedtls_ctr_drbg, buf, len);
     return ret == 0 ? 0 : -1;
 }
 
@@ -348,7 +348,7 @@ _libssh2_mbedtls_bignum_random(libssh2_bn *bn, int bits, int top, int bottom)
 
     len = (bits + 7) >> 3;
     err = mbedtls_mpi_fill_random(bn, len, mbedtls_ctr_drbg_random,
-                                  &_libssh2_mbedtls_ctr_drbg);
+                                  &s_mbedtls_ctr_drbg);
     if(err)
         return -1;
 
@@ -479,7 +479,7 @@ _libssh2_mbedtls_rsa_new_private(libssh2_rsa_ctx **rsa,
 
     ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase,
                                    mbedtls_ctr_drbg_random,
-                                   &_libssh2_mbedtls_ctr_drbg);
+                                   &s_mbedtls_ctr_drbg);
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);
         mbedtls_rsa_free(*rsa);
@@ -535,7 +535,7 @@ _libssh2_mbedtls_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
                                filedata_len + 1,
                                passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
-                               &_libssh2_mbedtls_ctr_drbg);
+                               &s_mbedtls_ctr_drbg);
     _libssh2_mbedtls_safe_free(filedata_nullterm, filedata_len);
 
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
@@ -647,7 +647,7 @@ _libssh2_mbedtls_rsa_sha2_sign(LIBSSH2_SESSION *session,
     if(ret == 0)
         ret = mbedtls_rsa_pkcs1_sign(rsactx,
                                      mbedtls_ctr_drbg_random,
-                                     &_libssh2_mbedtls_ctr_drbg,
+                                     &s_mbedtls_ctr_drbg,
                                      md_type, (unsigned int)hash_len,
                                      hash, sig);
     if(ret) {
@@ -794,7 +794,7 @@ _libssh2_mbedtls_pub_priv_keyfile(LIBSSH2_SESSION *session,
     mbedtls_pk_init(&pkey);
     ret = mbedtls_pk_parse_keyfile(&pkey, privatekey, passphrase,
                                    mbedtls_ctr_drbg_random,
-                                   &_libssh2_mbedtls_ctr_drbg);
+                                   &s_mbedtls_ctr_drbg);
     if(ret) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));
         mbedtls_pk_free(&pkey);
@@ -844,7 +844,7 @@ _libssh2_mbedtls_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                privatekeydata_len + 1,
                                (const unsigned char *)passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
-                               &_libssh2_mbedtls_ctr_drbg);
+                               &s_mbedtls_ctr_drbg);
     _libssh2_mbedtls_safe_free(privatekeydata_nullterm, privatekeydata_len);
 
     if(ret) {
@@ -969,7 +969,7 @@ _libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
 
     if(mbedtls_ecdsa_genkey(*out_private_key, (mbedtls_ecp_group_id)curve_type,
                             mbedtls_ctr_drbg_random,
-                            &_libssh2_mbedtls_ctr_drbg))
+                            &s_mbedtls_ctr_drbg))
         goto failed;
 
     plen = 2 * mbedtls_mpi_size(
@@ -1065,7 +1065,7 @@ _libssh2_mbedtls_ecdh_gen_k(libssh2_bn **k,
                                    &pubkey,
                                    &private_key->MBEDTLS_PRIVATE(d),
                                    mbedtls_ctr_drbg_random,
-                                   &_libssh2_mbedtls_ctr_drbg)) {
+                                   &s_mbedtls_ctr_drbg)) {
         rc = -1;
         goto cleanup;
     }
@@ -1150,7 +1150,7 @@ _libssh2_mbedtls_parse_eckey(libssh2_ecdsa_ctx **ctx,
 
     if(mbedtls_pk_parse_key(pkey, data, data_len, pwd, pwd_len,
                             mbedtls_ctr_drbg_random,
-                            &_libssh2_mbedtls_ctr_drbg))
+                            &s_mbedtls_ctr_drbg))
 
         goto failed;
 
@@ -1229,7 +1229,7 @@ _libssh2_mbedtls_parse_openssh_key(libssh2_ecdsa_ctx **ctx,
                        &(*ctx)->MBEDTLS_PRIVATE(d),
                        &(*ctx)->MBEDTLS_PRIVATE(grp).G,
                        mbedtls_ctr_drbg_random,
-                       &_libssh2_mbedtls_ctr_drbg))
+                       &s_mbedtls_ctr_drbg))
         goto failed;
 
     if(mbedtls_ecp_check_privkey(&(*ctx)->MBEDTLS_PRIVATE(grp),
@@ -1403,7 +1403,7 @@ _libssh2_mbedtls_ecdsa_sign(LIBSSH2_SESSION *session,
                           &ec_ctx->MBEDTLS_PRIVATE(d),
                           hash, hash_len,
                           mbedtls_ctr_drbg_random,
-                          &_libssh2_mbedtls_ctr_drbg))
+                          &s_mbedtls_ctr_drbg))
         goto cleanup;
 
     r_len = mbedtls_mpi_size(&pr) + 1;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1132,13 +1132,12 @@ cleanup:
     return (rc == 0) ? 0 : -1;
 }
 
-static int
-_libssh2_mbedtls_parse_eckey(libssh2_ecdsa_ctx **ctx,
-                             mbedtls_pk_context *pkey,
-                             LIBSSH2_SESSION *session,
-                             const unsigned char *data,
-                             size_t data_len,
-                             const unsigned char *pwd)
+static int mbed_parse_eckey(libssh2_ecdsa_ctx **ctx,
+                            mbedtls_pk_context *pkey,
+                            LIBSSH2_SESSION *session,
+                            const unsigned char *data,
+                            size_t data_len,
+                            const unsigned char *pwd)
 {
     size_t pwd_len;
 
@@ -1284,8 +1283,8 @@ _libssh2_mbedtls_ecdsa_new_private(libssh2_ecdsa_ctx **ec_ctx,
     if(fread(data, 1, data_len, fp) != data_len)
         goto cleanup;
 
-    if(_libssh2_mbedtls_parse_eckey(ec_ctx, &pkey, session,
-                                    data, data_len, passphrase) == 0)
+    if(mbed_parse_eckey(ec_ctx, &pkey, session,
+                        data, data_len, passphrase) == 0)
         goto cleanup;
 
     _libssh2_mbedtls_parse_openssh_key(ec_ctx, session, data, data_len,
@@ -1329,8 +1328,8 @@ _libssh2_mbedtls_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ec_ctx,
 
     memcpy(ntdata, filedata, filedata_len);
 
-    if(_libssh2_mbedtls_parse_eckey(ec_ctx, &pkey, session,
-                                    ntdata, filedata_len + 1, passphrase) == 0)
+    if(mbed_parse_eckey(ec_ctx, &pkey, session,
+                        ntdata, filedata_len + 1, passphrase) == 0)
         goto cleanup;
 
     _libssh2_mbedtls_parse_openssh_key(ec_ctx, session,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1694,9 +1694,9 @@ _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx **dsa,
     return rc;
 }
 
-static unsigned char *
-gen_publickey_from_dsa(LIBSSH2_SESSION* session, libssh2_dsa_ctx *dsa,
-                       size_t *key_len)
+static unsigned char *gen_publickey_from_dsa(LIBSSH2_SESSION* session,
+                                             libssh2_dsa_ctx *dsa,
+                                             size_t *key_len)
 {
     int            p_bytes, q_bytes, g_bytes, k_bytes;
     unsigned long  len;
@@ -1769,13 +1769,12 @@ fail:
     return key;
 }
 
-static int
-gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
-                           unsigned char **method,
-                           size_t *method_len,
-                           unsigned char **pubkeydata,
-                           size_t *pubkeydata_len,
-                           EVP_PKEY *pk)
+static int gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
+                                      unsigned char **method,
+                                      size_t *method_len,
+                                      unsigned char **pubkeydata,
+                                      size_t *pubkeydata_len,
+                                      EVP_PKEY *pk)
 {
     libssh2_dsa_ctx *dsa = NULL;
     unsigned char *key;
@@ -2149,13 +2148,12 @@ clean_exit:
     return rc;
 }
 
-static int
-gen_publickey_from_ed_evp(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
-                          unsigned char **pubkeydata,
-                          size_t *pubkeydata_len,
-                          EVP_PKEY *pk)
+static int gen_publickey_from_ed_evp(LIBSSH2_SESSION *session,
+                                     unsigned char **method,
+                                     size_t *method_len,
+                                     unsigned char **pubkeydata,
+                                     size_t *pubkeydata_len,
+                                     EVP_PKEY *pk)
 {
     const char methodName[] = "ssh-ed25519";
     unsigned char *methodBuf = NULL;
@@ -3556,14 +3554,13 @@ _libssh2_md5_final(libssh2_md5_ctx *ctx,
 
 #if LIBSSH2_ECDSA
 
-static int
-gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
-                          unsigned char **pubkeydata,
-                          size_t *pubkeydata_len,
-                          int is_sk,
-                          EVP_PKEY *pk)
+static int gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
+                                     unsigned char **method,
+                                     size_t *method_len,
+                                     unsigned char **pubkeydata,
+                                     size_t *pubkeydata_len,
+                                     int is_sk,
+                                     EVP_PKEY *pk)
 {
     int rc = 0;
     unsigned char *p;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1932,11 +1932,10 @@ fail:
                           "Unable to allocate memory for private key data");
 }
 
-static int
-_libssh2_dsa_new_openssh_private(libssh2_dsa_ctx **dsa,
-                                 LIBSSH2_SESSION *session,
-                                 const char *filename,
-                                 const unsigned char *passphrase)
+static int dsa_new_openssh_private(libssh2_dsa_ctx **dsa,
+                                   LIBSSH2_SESSION *session,
+                                   const char *filename,
+                                   const unsigned char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -2009,8 +2008,8 @@ _libssh2_dsa_new_private(libssh2_dsa_ctx **dsa,
                                     filename, passphrase);
 
     if(rc) {
-        rc = _libssh2_dsa_new_openssh_private(dsa, session,
-                                              filename, passphrase);
+        rc = dsa_new_openssh_private(dsa, session,
+                                     filename, passphrase);
     }
 
     return rc;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1575,11 +1575,10 @@ fail:
                           "Unable to allocate memory for private key data");
 }
 
-static int
-_libssh2_rsa_new_openssh_private(libssh2_rsa_ctx **rsa,
-                                 LIBSSH2_SESSION *session,
-                                 const char *filename,
-                                 const unsigned char *passphrase)
+static int rsa_new_openssh_private(libssh2_rsa_ctx **rsa,
+                                   LIBSSH2_SESSION *session,
+                                   const char *filename,
+                                   const unsigned char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -1652,8 +1651,8 @@ _libssh2_rsa_new_private(libssh2_rsa_ctx **rsa,
                                     filename, passphrase);
 
     if(rc) {
-        rc = _libssh2_rsa_new_openssh_private(rsa, session,
-                                              filename, passphrase);
+        rc = rsa_new_openssh_private(rsa, session,
+                                     filename, passphrase);
     }
 
     return rc;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4014,11 +4014,10 @@ fail:
     return rc;
 }
 
-static int
-_libssh2_ecdsa_new_openssh_private(libssh2_ecdsa_ctx **ec_ctx,
-                                   LIBSSH2_SESSION *session,
-                                   const char *filename,
-                                   const unsigned char *passphrase)
+static int ecdsa_new_openssh_private(libssh2_ecdsa_ctx **ec_ctx,
+                                     LIBSSH2_SESSION *session,
+                                     const char *filename,
+                                     const unsigned char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -4161,8 +4160,8 @@ _libssh2_ecdsa_new_private(libssh2_ecdsa_ctx **ec_ctx,
                                     filename, passphrase);
 
     if(rc) {
-        return _libssh2_ecdsa_new_openssh_private(ec_ctx, session,
-                                                  filename, passphrase);
+        return ecdsa_new_openssh_private(ec_ctx, session,
+                                         filename, passphrase);
     }
 
     return rc;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4666,14 +4666,13 @@ clean_exit:
 
 #endif /* LIBSSH2_ED25519 */
 
-static int
-_libssh2_pub_priv_openssh_keyfile(LIBSSH2_SESSION *session,
-                                  unsigned char **method,
-                                  size_t *method_len,
-                                  unsigned char **pubkeydata,
-                                  size_t *pubkeydata_len,
-                                  const char *privatekey,
-                                  const char *passphrase)
+static int pub_priv_openssh_keyfile(LIBSSH2_SESSION *session,
+                                    unsigned char **method,
+                                    size_t *method_len,
+                                    unsigned char **pubkeydata,
+                                    size_t *pubkeydata_len,
+                                    const char *privatekey,
+                                    const char *passphrase)
 {
     FILE *fp;
     unsigned char *buf = NULL;
@@ -4811,11 +4810,11 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     if(!pk) {
 
         /* Try OpenSSH format */
-        rc = _libssh2_pub_priv_openssh_keyfile(session,
-                                               method,
-                                               method_len,
-                                               pubkeydata, pubkeydata_len,
-                                               privatekey, passphrase);
+        rc = pub_priv_openssh_keyfile(session,
+                                      method,
+                                      method_len,
+                                      pubkeydata, pubkeydata_len,
+                                      privatekey, passphrase);
         if(rc) {
             return _libssh2_error(session,
                                   LIBSSH2_ERROR_FILE,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1150,8 +1150,7 @@ void _libssh2_openssl_crypto_exit(void) {}
 /* TODO: Optionally call a passphrase callback specified by the
  * calling program
  */
-static int
-passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
+static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
 {
     int passphrase_len = (int)strlen(passphrase);
 
@@ -1174,12 +1173,11 @@ typedef void * (*pem_read_bio_func)(BIO *, void **, pem_password_cb *,
                                     void *u);
 #endif
 
-static int
-read_private_key_from_memory(void **key_ctx,
-                             pem_read_bio_func read_private_key,
-                             const char *filedata,
-                             size_t filedata_len,
-                             const unsigned char *passphrase)
+static int read_private_key_from_memory(void **key_ctx,
+                                        pem_read_bio_func read_private_key,
+                                        const char *filedata,
+                                        size_t filedata_len,
+                                        const unsigned char *passphrase)
 {
     BIO *bp;
 
@@ -1199,11 +1197,10 @@ read_private_key_from_memory(void **key_ctx,
 #endif
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
-static int
-read_private_key_from_file(void **key_ctx,
-                           pem_read_bio_func read_private_key,
-                           const char *filename,
-                           const unsigned char *passphrase)
+static int read_private_key_from_file(void **key_ctx,
+                                      pem_read_bio_func read_private_key,
+                                      const char *filename,
+                                      const unsigned char *passphrase)
 {
     BIO *bp;
 
@@ -1257,9 +1254,9 @@ _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
     return rc;
 }
 
-static unsigned char *
-gen_publickey_from_rsa(LIBSSH2_SESSION *session, libssh2_rsa_ctx *rsa,
-                       size_t *key_len)
+static unsigned char *gen_publickey_from_rsa(LIBSSH2_SESSION *session,
+                                             libssh2_rsa_ctx *rsa,
+                                             size_t *key_len)
 {
     int            e_bytes, n_bytes;
     unsigned long  len;
@@ -1321,13 +1318,12 @@ fail:
     return key;
 }
 
-static int
-gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
-                           unsigned char **method,
-                           size_t *method_len,
-                           unsigned char **pubkeydata,
-                           size_t *pubkeydata_len,
-                           EVP_PKEY *pk)
+static int gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
+                                      unsigned char **method,
+                                      size_t *method_len,
+                                      unsigned char **pubkeydata,
+                                      size_t *pubkeydata_len,
+                                      EVP_PKEY *pk)
 {
     libssh2_rsa_ctx* rsa = NULL;
     unsigned char *key;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4073,15 +4073,14 @@ static int ecdsa_new_openssh_private(libssh2_ecdsa_ctx **ec_ctx,
     return rc;
 }
 
-static int
-_libssh2_ecdsa_new_openssh_private_sk(libssh2_ecdsa_ctx **ec_ctx,
-                                      uint8_t *flags,
-                                      const char **application,
-                                      const unsigned char **key_handle,
-                                      size_t *handle_len,
-                                      LIBSSH2_SESSION *session,
-                                      const char *filename,
-                                      const unsigned char *passphrase)
+static int ecdsa_new_openssh_private_sk(libssh2_ecdsa_ctx **ec_ctx,
+                                        uint8_t *flags,
+                                        const char **application,
+                                        const unsigned char **key_handle,
+                                        size_t *handle_len,
+                                        LIBSSH2_SESSION *session,
+                                        const char *filename,
+                                        const unsigned char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -4193,14 +4192,14 @@ _libssh2_ecdsa_new_private_sk(libssh2_ecdsa_ctx **ec_ctx,
                                     filename, passphrase);
 
     if(rc) {
-        return _libssh2_ecdsa_new_openssh_private_sk(ec_ctx,
-                                                     flags,
-                                                     application,
-                                                     key_handle,
-                                                     handle_len,
-                                                     session,
-                                                     filename,
-                                                     passphrase);
+        return ecdsa_new_openssh_private_sk(ec_ctx,
+                                            flags,
+                                            application,
+                                            key_handle,
+                                            handle_len,
+                                            session,
+                                            filename,
+                                            passphrase);
     }
 
     return rc;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -242,8 +242,7 @@ write_bn(unsigned char *buf, const BIGNUM *bn, int bn_bytes)
 #endif
 
 #ifdef USE_OPENSSL_3
-static inline void
-_libssh2_swap_bytes(unsigned char *buf, unsigned long len)
+static inline void swap_bytes(unsigned char *buf, unsigned long len)
 {
 #if !defined(WORDS_BIGENDIAN) || !WORDS_BIGENDIAN
     unsigned long i, j;
@@ -311,7 +310,7 @@ _libssh2_rsa_new(libssh2_rsa_ctx **rsa,
 
         if(nbuf) {
             memcpy(nbuf, ndata, nlen);
-            _libssh2_swap_bytes(nbuf, nlen);
+            swap_bytes(nbuf, nlen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_N, nbuf, nlen);
         }
@@ -321,7 +320,7 @@ _libssh2_rsa_new(libssh2_rsa_ctx **rsa,
         ebuf = OPENSSL_malloc(elen);
         if(ebuf) {
             memcpy(ebuf, edata, elen);
-            _libssh2_swap_bytes(ebuf, elen);
+            swap_bytes(ebuf, elen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_E, ebuf, elen);
         }
@@ -331,7 +330,7 @@ _libssh2_rsa_new(libssh2_rsa_ctx **rsa,
         dbuf = OPENSSL_malloc(dlen);
         if(dbuf) {
             memcpy(dbuf, ddata, dlen);
-            _libssh2_swap_bytes(dbuf, dlen);
+            swap_bytes(dbuf, dlen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_D, dbuf, dlen);
         }
@@ -544,7 +543,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx **dsactx,
 
         if(p_buf) {
             memcpy(p_buf, p, p_len);
-            _libssh2_swap_bytes(p_buf, p_len);
+            swap_bytes(p_buf, p_len);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_FFC_P, p_buf, p_len);
         }
@@ -555,7 +554,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx **dsactx,
 
         if(q_buf) {
             memcpy(q_buf, q, q_len);
-            _libssh2_swap_bytes(q_buf, q_len);
+            swap_bytes(q_buf, q_len);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_FFC_Q, q_buf, q_len);
         }
@@ -566,7 +565,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx **dsactx,
 
         if(g_buf) {
             memcpy(g_buf, g, g_len);
-            _libssh2_swap_bytes(g_buf, g_len);
+            swap_bytes(g_buf, g_len);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_FFC_G, g_buf, g_len);
         }
@@ -577,7 +576,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx **dsactx,
 
         if(y_buf) {
             memcpy(y_buf, y, y_len);
-            _libssh2_swap_bytes(y_buf, y_len);
+            swap_bytes(y_buf, y_len);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PUB_KEY, y_buf, y_len);
         }
@@ -588,7 +587,7 @@ _libssh2_dsa_new(libssh2_dsa_ctx **dsactx,
 
         if(x_buf) {
             memcpy(x_buf, x, x_len);
-            _libssh2_swap_bytes(x_buf, x_len);
+            swap_bytes(x_buf, x_len);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PRIV_KEY,
                                         x_buf, x_len);
@@ -3795,7 +3794,7 @@ gen_publickey_from_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
 
     /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
     memcpy(group_name, n, strlen(n));
-    _libssh2_swap_bytes(exponent, (unsigned long)exponentlen);
+    swap_bytes(exponent, (unsigned long)exponentlen);
 
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
                                                  group_name, 0);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1385,7 +1385,7 @@ __alloc_error:
 }
 
 #ifndef USE_OPENSSL_3
-static int _libssh2_rsa_new_additional_parameters(libssh2_rsa_ctx *rsa)
+static int rsa_new_additional_parameters(libssh2_rsa_ctx *rsa)
 {
     BN_CTX *ctx = NULL;
     BIGNUM *aux = NULL;
@@ -1537,7 +1537,7 @@ gen_publickey_from_rsa_openssh_priv_data(LIBSSH2_SESSION *session,
 
 #ifndef USE_OPENSSL_3
     if(rsa)
-        rc = _libssh2_rsa_new_additional_parameters(rsa);
+        rc = rsa_new_additional_parameters(rsa);
 #endif
 
     if(rsa && pubkeydata && method) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -205,22 +205,21 @@ static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
                                           size_t privatekeydata_len,
                                           const unsigned char *passphrase);
 
-static int
-_libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
-                                      void **key_ctx,
-                                      const char *key_type,
-                                      unsigned char **method,
-                                      size_t *method_len,
-                                      unsigned char **pubkeydata,
-                                      size_t *pubkeydata_len,
-                                      int *algorithm,
-                                      unsigned char *flags,
-                                      const char **application,
-                                      const unsigned char **key_handle,
-                                      size_t *handle_len,
-                                      const char *privatekeydata,
-                                      size_t privatekeydata_len,
-                                      const unsigned char *passphrase);
+static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
+                                        void **key_ctx,
+                                        const char *key_type,
+                                        unsigned char **method,
+                                        size_t *method_len,
+                                        unsigned char **pubkeydata,
+                                        size_t *pubkeydata_len,
+                                        int *algorithm,
+                                        unsigned char *flags,
+                                        const char **application,
+                                        const unsigned char **key_handle,
+                                        size_t *handle_len,
+                                        const char *privatekeydata,
+                                        size_t privatekeydata_len,
+                                        const unsigned char *passphrase);
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
 static unsigned char *
@@ -2069,21 +2068,21 @@ int _libssh2_ecdsa_new_private_frommemory_sk(libssh2_ecdsa_ctx **ec_ctx,
                                              const unsigned char *passphrase)
 {
     int algorithm;
-    return _libssh2_sk_pub_openssh_keyfilememory(session,
-                                                 (void **)ec_ctx,
-                                          "sk-ecdsa-sha2-nistp256@openssh.com",
-                                                 NULL,
-                                                 NULL,
-                                                 NULL,
-                                                 NULL,
-                                                 &algorithm,
-                                                 flags,
-                                                 application,
-                                                 key_handle,
-                                                 handle_len,
-                                                 filedata,
-                                                 filedata_len,
-                                                 passphrase);
+    return sk_pub_openssh_keyfilememory(session,
+                                        (void **)ec_ctx,
+                                        "sk-ecdsa-sha2-nistp256@openssh.com",
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        &algorithm,
+                                        flags,
+                                        application,
+                                        key_handle,
+                                        handle_len,
+                                        filedata,
+                                        filedata_len,
+                                        passphrase);
 }
 
 #endif /* LIBSSH2_ECDSA */
@@ -2707,21 +2706,21 @@ _libssh2_ed25519_new_private_frommemory_sk(libssh2_ed25519_ctx **ed_ctx,
                                            const unsigned char *passphrase)
 {
     int algorithm;
-    return _libssh2_sk_pub_openssh_keyfilememory(session,
-                                                 (void **)ed_ctx,
-                                                 "sk-ssh-ed25519@openssh.com",
-                                                 NULL,
-                                                 NULL,
-                                                 NULL,
-                                                 NULL,
-                                                 &algorithm,
-                                                 flags,
-                                                 application,
-                                                 key_handle,
-                                                 handle_len,
-                                                 filedata,
-                                                 filedata_len,
-                                                 passphrase);
+    return sk_pub_openssh_keyfilememory(session,
+                                        (void **)ed_ctx,
+                                        "sk-ssh-ed25519@openssh.com",
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        &algorithm,
+                                        flags,
+                                        application,
+                                        key_handle,
+                                        handle_len,
+                                        filedata,
+                                        filedata_len,
+                                        passphrase);
 }
 
 int
@@ -5024,22 +5023,21 @@ static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
     return rc;
 }
 
-static int
-_libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
-                                      void **key_ctx,
-                                      const char *key_type,
-                                      unsigned char **method,
-                                      size_t *method_len,
-                                      unsigned char **pubkeydata,
-                                      size_t *pubkeydata_len,
-                                      int *algorithm,
-                                      unsigned char *flags,
-                                      const char **application,
-                                      const unsigned char **key_handle,
-                                      size_t *handle_len,
-                                      const char *privatekeydata,
-                                      size_t privatekeydata_len,
-                                      const unsigned char *passphrase)
+static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
+                                        void **key_ctx,
+                                        const char *key_type,
+                                        unsigned char **method,
+                                        size_t *method_len,
+                                        unsigned char **pubkeydata,
+                                        size_t *pubkeydata_len,
+                                        int *algorithm,
+                                        unsigned char *flags,
+                                        const char **application,
+                                        const unsigned char **key_handle,
+                                        size_t *handle_len,
+                                        const char *privatekeydata,
+                                        size_t privatekeydata_len,
+                                        const unsigned char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;
@@ -5277,19 +5275,19 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 
     if(!pk) {
         /* Try OpenSSH format */
-        st = _libssh2_sk_pub_openssh_keyfilememory(session, NULL, NULL,
-                                                   method,
-                                                   method_len,
-                                                   pubkeydata,
-                                                   pubkeydata_len,
-                                                   algorithm,
-                                                   flags,
-                                                   application,
-                                                   key_handle,
-                                                   handle_len,
-                                                   privatekeydata,
-                                                   privatekeydata_len,
-                                            (const unsigned char *)passphrase);
+        st = sk_pub_openssh_keyfilememory(session, NULL, NULL,
+                                          method,
+                                          method_len,
+                                          pubkeydata,
+                                          pubkeydata_len,
+                                          algorithm,
+                                          flags,
+                                          application,
+                                          key_handle,
+                                          handle_len,
+                                          privatekeydata,
+                                          privatekeydata_len,
+                                          (const unsigned char *)passphrase);
     }
 
     return st;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -194,17 +194,16 @@ void _libssh2_hmac_cleanup(libssh2_hmac_ctx *ctx)
 #endif
 }
 
-static int
-_libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
-                                        void **key_ctx,
-                                        const char *key_type,
-                                        unsigned char **method,
-                                        size_t *method_len,
-                                        unsigned char **pubkeydata,
-                                        size_t *pubkeydata_len,
-                                        const char *privatekeydata,
-                                        size_t privatekeydata_len,
-                                        const unsigned char *passphrase);
+static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
+                                          void **key_ctx,
+                                          const char *key_type,
+                                          unsigned char **method,
+                                          size_t *method_len,
+                                          unsigned char **pubkeydata,
+                                          size_t *pubkeydata_len,
+                                          const char *privatekeydata,
+                                          size_t privatekeydata_len,
+                                          const unsigned char *passphrase);
 
 static int
 _libssh2_sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
@@ -1250,11 +1249,11 @@ _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
                                       passphrase);
 
     if(rc) {
-        rc = _libssh2_pub_priv_openssh_keyfilememory(session, (void **)rsa,
-                                                     "ssh-rsa",
-                                                     NULL, NULL, NULL, NULL,
-                                                     filedata, filedata_len,
-                                                     passphrase);
+        rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
+                                            "ssh-rsa",
+                                            NULL, NULL, NULL, NULL,
+                                            filedata, filedata_len,
+                                            passphrase);
     }
 
     return rc;
@@ -1692,11 +1691,11 @@ _libssh2_dsa_new_private_frommemory(libssh2_dsa_ctx **dsa,
                                       passphrase);
 
     if(rc) {
-        rc = _libssh2_pub_priv_openssh_keyfilememory(session, (void **)dsa,
-                                                     "ssh-dsa",
-                                                     NULL, NULL, NULL, NULL,
-                                                     filedata, filedata_len,
-                                                     passphrase);
+        rc = pub_priv_openssh_keyfilememory(session, (void **)dsa,
+                                            "ssh-dsa",
+                                            NULL, NULL, NULL, NULL,
+                                            filedata, filedata_len,
+                                            passphrase);
     }
 
     return rc;
@@ -2049,11 +2048,11 @@ _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ec_ctx,
                                       passphrase);
 
     if(rc) {
-        rc = _libssh2_pub_priv_openssh_keyfilememory(session, (void **)ec_ctx,
-                                                     "ssh-ecdsa",
-                                                     NULL, NULL, NULL, NULL,
-                                                     filedata, filedata_len,
-                                                     passphrase);
+        rc = pub_priv_openssh_keyfilememory(session, (void **)ec_ctx,
+                                            "ssh-ecdsa",
+                                            NULL, NULL, NULL, NULL,
+                                            filedata, filedata_len,
+                                            passphrase);
     }
 
     return rc;
@@ -2689,11 +2688,11 @@ _libssh2_ed25519_new_private_frommemory(libssh2_ed25519_ctx **ed_ctx,
         return 0;
     }
 
-    return _libssh2_pub_priv_openssh_keyfilememory(session, (void **)ed_ctx,
-                                                   "ssh-ed25519",
-                                                   NULL, NULL, NULL, NULL,
-                                                   filedata, filedata_len,
-                                                   passphrase);
+    return pub_priv_openssh_keyfilememory(session, (void **)ed_ctx,
+                                          "ssh-ed25519",
+                                          NULL, NULL, NULL, NULL,
+                                          filedata, filedata_len,
+                                          passphrase);
 }
 
 int
@@ -4886,17 +4885,16 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     return st;
 }
 
-static int
-_libssh2_pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
-                                        void **key_ctx,
-                                        const char *key_type,
-                                        unsigned char **method,
-                                        size_t *method_len,
-                                        unsigned char **pubkeydata,
-                                        size_t *pubkeydata_len,
-                                        const char *privatekeydata,
-                                        size_t privatekeydata_len,
-                                        const unsigned char *passphrase)
+static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
+                                          void **key_ctx,
+                                          const char *key_type,
+                                          unsigned char **method,
+                                          size_t *method_len,
+                                          unsigned char **pubkeydata,
+                                          size_t *pubkeydata_len,
+                                          const char *privatekeydata,
+                                          size_t privatekeydata_len,
+                                          const unsigned char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;
@@ -5174,7 +5172,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 
     if(!pk) {
         /* Try OpenSSH format */
-        st = _libssh2_pub_priv_openssh_keyfilememory(session, NULL, NULL,
+        st = pub_priv_openssh_keyfilememory(session, NULL, NULL,
                                                      method,
                                                      method_len,
                                                      pubkeydata,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -65,9 +65,9 @@ int _libssh2_hmac_ctx_init(libssh2_hmac_ctx *ctx)
 }
 
 #ifdef USE_OPENSSL_3
-static int _libssh2_hmac_init(libssh2_hmac_ctx *ctx,
-                              void *key, size_t keylen,
-                              const char *digest_name)
+static int hmac_init(libssh2_hmac_ctx *ctx,
+                     void *key, size_t keylen,
+                     const char *digest_name)
 {
     EVP_MAC* mac;
     OSSL_PARAM params[3];
@@ -96,7 +96,7 @@ int _libssh2_hmac_md5_init(libssh2_hmac_ctx *ctx,
                            void *key, size_t keylen)
 {
 #ifdef USE_OPENSSL_3
-    return _libssh2_hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_MD5);
+    return hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_MD5);
 #elif defined(HAVE_OPAQUE_STRUCTS)
     return HMAC_Init_ex(*ctx, key, (int)keylen, EVP_md5(), NULL);
 #else
@@ -110,7 +110,7 @@ int _libssh2_hmac_ripemd160_init(libssh2_hmac_ctx *ctx,
                                  void *key, size_t keylen)
 {
 #ifdef USE_OPENSSL_3
-    return _libssh2_hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_RIPEMD160);
+    return hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_RIPEMD160);
 #elif defined(HAVE_OPAQUE_STRUCTS)
     return HMAC_Init_ex(*ctx, key, (int)keylen, EVP_ripemd160(), NULL);
 #else
@@ -123,7 +123,7 @@ int _libssh2_hmac_sha1_init(libssh2_hmac_ctx *ctx,
                             void *key, size_t keylen)
 {
 #ifdef USE_OPENSSL_3
-    return _libssh2_hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_SHA1);
+    return hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_SHA1);
 #elif defined(HAVE_OPAQUE_STRUCTS)
     return HMAC_Init_ex(*ctx, key, (int)keylen, EVP_sha1(), NULL);
 #else
@@ -135,7 +135,7 @@ int _libssh2_hmac_sha256_init(libssh2_hmac_ctx *ctx,
                               void *key, size_t keylen)
 {
 #ifdef USE_OPENSSL_3
-    return _libssh2_hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_SHA2_256);
+    return hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_SHA2_256);
 #elif defined(HAVE_OPAQUE_STRUCTS)
     return HMAC_Init_ex(*ctx, key, (int)keylen, EVP_sha256(), NULL);
 #else
@@ -147,7 +147,7 @@ int _libssh2_hmac_sha512_init(libssh2_hmac_ctx *ctx,
                               void *key, size_t keylen)
 {
 #ifdef USE_OPENSSL_3
-    return _libssh2_hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_SHA2_512);
+    return hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_SHA2_512);
 #elif defined(HAVE_OPAQUE_STRUCTS)
     return HMAC_Init_ex(*ctx, key, (int)keylen, EVP_sha512(), NULL);
 #else

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -912,13 +912,13 @@ void _libssh2_hmac_cleanup(libssh2_hmac_ctx *ctx)
  * Windows CNG backend: Key functions
  */
 
-static int _libssh2_wincng_key_sha_verify(struct wincng_key_ctx *ctx,
-                                          ULONG hashlen,
-                                          const unsigned char *sig,
-                                          ULONG sig_len,
-                                          const unsigned char *m,
-                                          ULONG m_len,
-                                          ULONG flags)
+static int wincng_key_sha_verify(struct wincng_key_ctx *ctx,
+                                 ULONG hashlen,
+                                 const unsigned char *sig,
+                                 ULONG sig_len,
+                                 const unsigned char *m,
+                                 ULONG m_len,
+                                 ULONG flags)
 {
     BCRYPT_PKCS1_PADDING_INFO paddingInfoPKCS1;
     BCRYPT_ALG_HANDLE hAlgHash;
@@ -1541,10 +1541,10 @@ _libssh2_wincng_rsa_sha1_verify(libssh2_rsa_ctx *rsactx,
                                 const unsigned char *m,
                                 size_t m_len)
 {
-    return _libssh2_wincng_key_sha_verify(rsactx, SHA_DIGEST_LENGTH,
-                                          sig, (ULONG)sig_len,
-                                          m, (ULONG)m_len,
-                                          BCRYPT_PAD_PKCS1);
+    return wincng_key_sha_verify(rsactx, SHA_DIGEST_LENGTH,
+                                 sig, (ULONG)sig_len,
+                                 m, (ULONG)m_len,
+                                 BCRYPT_PAD_PKCS1);
 }
 #endif
 
@@ -1557,10 +1557,10 @@ _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx *rsactx,
                                 const unsigned char *m,
                                 size_t m_len)
 {
-    return _libssh2_wincng_key_sha_verify(rsactx, (ULONG)hash_len,
-                                          sig, (ULONG)sig_len,
-                                          m, (ULONG)m_len,
-                                          BCRYPT_PAD_PKCS1);
+    return wincng_key_sha_verify(rsactx, (ULONG)hash_len,
+                                 sig, (ULONG)sig_len,
+                                 m, (ULONG)m_len,
+                                 BCRYPT_PAD_PKCS1);
 }
 #endif
 
@@ -1892,8 +1892,8 @@ _libssh2_wincng_dsa_sha1_verify(libssh2_dsa_ctx *dsa,
                                 const unsigned char *m,
                                 size_t m_len)
 {
-    return _libssh2_wincng_key_sha_verify(dsa, SHA_DIGEST_LENGTH, sig_fixed,
-                                          40, m, (ULONG)m_len, 0);
+    return wincng_key_sha_verify(dsa, SHA_DIGEST_LENGTH, sig_fixed,
+                                 40, m, (ULONG)m_len, 0);
 }
 
 int

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1162,11 +1162,10 @@ static int wincng_bn_ltob(unsigned char *pbInput,
     return 0;
 }
 
-static int
-_libssh2_wincng_asn_decode_bn(unsigned char *pbEncoded,
-                              DWORD cbEncoded,
-                              unsigned char **ppbDecoded,
-                              DWORD *pcbDecoded)
+static int wincng_asn_decode_bn(unsigned char *pbEncoded,
+                                DWORD cbEncoded,
+                                unsigned char **ppbDecoded,
+                                DWORD *pcbDecoded)
 {
     unsigned char *pbDecoded = NULL;
     PCRYPT_DATA_BLOB pbInteger;
@@ -1215,10 +1214,10 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
             if(rcbDecoded) {
                 for(index = 0; index < length; index++) {
                     pBlob = &pbDecoded->rgValue[index];
-                    ret = _libssh2_wincng_asn_decode_bn(pBlob->pbData,
-                                                        pBlob->cbData,
-                                                        &rpbDecoded[index],
-                                                        &rcbDecoded[index]);
+                    ret = wincng_asn_decode_bn(pBlob->pbData,
+                                               pBlob->cbData,
+                                               &rpbDecoded[index],
+                                               &rcbDecoded[index]);
                     if(ret)
                         break;
                 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1771,11 +1771,10 @@ _libssh2_wincng_dsa_new(libssh2_dsa_ctx **dsa,
 }
 
 #ifdef HAVE_LIBCRYPT32
-static int
-_libssh2_wincng_dsa_new_private_parse(libssh2_dsa_ctx **dsa,
-                                      LIBSSH2_SESSION *session,
-                                      unsigned char *pbEncoded,
-                                      size_t cbEncoded)
+static int wincng_dsa_new_private_parse(libssh2_dsa_ctx **dsa,
+                                        LIBSSH2_SESSION *session,
+                                        unsigned char *pbEncoded,
+                                        size_t cbEncoded)
 {
     unsigned char **rpbDecoded;
     DWORD *rcbDecoded, index, length;
@@ -1834,8 +1833,8 @@ _libssh2_wincng_dsa_new_private(libssh2_dsa_ctx **dsa,
         return -1;
     }
 
-    return _libssh2_wincng_dsa_new_private_parse(dsa, session,
-                                                 pbEncoded, cbEncoded);
+    return wincng_dsa_new_private_parse(dsa, session,
+                                        pbEncoded, cbEncoded);
 #else
     (void)dsa;
     (void)filename;
@@ -1866,8 +1865,8 @@ _libssh2_wincng_dsa_new_private_frommemory(libssh2_dsa_ctx **dsa,
         return -1;
     }
 
-    return _libssh2_wincng_dsa_new_private_parse(dsa, session,
-                                                 pbEncoded, cbEncoded);
+    return wincng_dsa_new_private_parse(dsa, session,
+                                        pbEncoded, cbEncoded);
 #else
     (void)dsa;
     (void)filedata;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2300,9 +2300,8 @@ cleanup:
     return result;
 }
 
-static void
-_libssh_wincng_reverse_bytes(IN PUCHAR buffer,
-                             IN size_t buffer_len)
+static void wincng_reverse_bytes(IN PUCHAR buffer,
+                                 IN size_t buffer_len)
 {
     PUCHAR start = buffer;
     PUCHAR end = buffer + buffer_len - 1;
@@ -2584,7 +2583,7 @@ _libssh2_wincng_ecdh_gen_k(OUT libssh2_bn **secret,
      * raw secret, so we need to swap it to big endian order.
      */
 
-    _libssh_wincng_reverse_bytes((*secret)->bignum, secret_len);
+    wincng_reverse_bytes((*secret)->bignum, secret_len);
 
     result = LIBSSH2_ERROR_NONE;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -118,7 +118,7 @@
 #define PKCS_RSA_PRIVATE_KEY ((LPCSTR)(size_t)43)
 #endif
 
-static void _libssh2_wincng_safe_free(void *buf, size_t len)
+static void wincng_safe_free(void *buf, size_t len)
 {
     if(!buf)
         return;
@@ -281,7 +281,7 @@ _libssh2_wincng_bignum_mod_exp(libssh2_bn *r,
                                         r->bignum, r->length, &offset,
                                         BCRYPT_PAD_NONE);
 
-                    _libssh2_wincng_safe_free(bignum, length);
+                    wincng_safe_free(bignum, length);
 
                     if(BCRYPT_SUCCESS(ret)) {
                         _libssh2_wincng_bignum_resize(r, offset);
@@ -297,7 +297,7 @@ _libssh2_wincng_bignum_mod_exp(libssh2_bn *r,
         BCryptDestroyKey(hKey);
     }
 
-    _libssh2_wincng_safe_free(rsakey, keylen);
+    wincng_safe_free(rsakey, keylen);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
@@ -402,11 +402,11 @@ _libssh2_wincng_bignum_free(libssh2_bn *bn)
 {
     if(bn) {
         if(bn->bignum) {
-            _libssh2_wincng_safe_free(bn->bignum, bn->length);
+            wincng_safe_free(bn->bignum, bn->length);
             bn->bignum = NULL;
         }
         bn->length = 0;
-        _libssh2_wincng_safe_free(bn, sizeof(libssh2_bn));
+        wincng_safe_free(bn, sizeof(libssh2_bn));
     }
 }
 
@@ -788,7 +788,7 @@ int _libssh2_wincng_hash_init(struct wincng_hash_ctx *ctx,
                            pbHashObject, dwHashObject,
                            key, keylen, 0);
     if(!BCRYPT_SUCCESS(ret)) {
-        _libssh2_wincng_safe_free(pbHashObject, dwHashObject);
+        wincng_safe_free(pbHashObject, dwHashObject);
         return -1;
     }
 
@@ -822,7 +822,7 @@ int _libssh2_wincng_hash_final(struct wincng_hash_ctx *ctx,
     BCryptDestroyHash(ctx->hHash);
     ctx->hHash = NULL;
 
-    _libssh2_wincng_safe_free(ctx->pbHashObject, ctx->dwHashObject);
+    wincng_safe_free(ctx->pbHashObject, ctx->dwHashObject);
     ctx->pbHashObject = NULL;
     ctx->dwHashObject = 0;
 
@@ -918,7 +918,7 @@ void _libssh2_hmac_cleanup(libssh2_hmac_ctx *ctx)
     BCryptDestroyHash(ctx->hHash);
     ctx->hHash = NULL;
 
-    _libssh2_wincng_safe_free(ctx->pbHashObject, ctx->dwHashObject);
+    wincng_safe_free(ctx->pbHashObject, ctx->dwHashObject);
     ctx->pbHashObject = NULL;
     ctx->dwHashObject = 0;
 }
@@ -979,17 +979,17 @@ static int _libssh2_wincng_key_sha_verify(struct wincng_key_ctx *ctx,
     ret = _libssh2_wincng_hash(data, datalen,
                                hAlgHash,
                                hash, hashlen);
-    _libssh2_wincng_safe_free(data, datalen);
+    wincng_safe_free(data, datalen);
 
     if(ret) {
-        _libssh2_wincng_safe_free(hash, hashlen);
+        wincng_safe_free(hash, hashlen);
         return -1;
     }
 
     datalen = sig_len;
     data = malloc(datalen);
     if(!data) {
-        _libssh2_wincng_safe_free(hash, hashlen);
+        wincng_safe_free(hash, hashlen);
         return -1;
     }
 
@@ -1004,8 +1004,8 @@ static int _libssh2_wincng_key_sha_verify(struct wincng_key_ctx *ctx,
     ret = BCryptVerifySignature(ctx->hKey, pPaddingInfo,
                                 hash, hashlen, data, datalen, flags);
 
-    _libssh2_wincng_safe_free(hash, hashlen);
-    _libssh2_wincng_safe_free(data, datalen);
+    wincng_safe_free(hash, hashlen);
+    wincng_safe_free(data, datalen);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
@@ -1131,7 +1131,7 @@ static int _libssh2_wincng_asn_decode(unsigned char *pbEncoded,
                               pbEncoded, cbEncoded, 0, NULL,
                               pbDecoded, &cbDecoded);
     if(!ret) {
-        _libssh2_wincng_safe_free(pbDecoded, cbDecoded);
+        wincng_safe_free(pbDecoded, cbDecoded);
         return -1;
     }
 
@@ -1201,7 +1201,7 @@ _libssh2_wincng_asn_decode_bn(unsigned char *pbEncoded,
             *ppbDecoded = pbDecoded;
             *pcbDecoded = cbDecoded;
         }
-        _libssh2_wincng_safe_free(pbInteger, cbInteger);
+        wincng_safe_free(pbInteger, cbInteger);
     }
 
     return ret;
@@ -1247,8 +1247,8 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
                 }
                 else {
                     for(length = 0; length < index; length++) {
-                        _libssh2_wincng_safe_free(rpbDecoded[length],
-                                                  rcbDecoded[length]);
+                        wincng_safe_free(rpbDecoded[length],
+                                         rcbDecoded[length]);
                         rpbDecoded[length] = NULL;
                         rcbDecoded[length] = 0;
                     }
@@ -1265,7 +1265,7 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
             ret = -1;
         }
 
-        _libssh2_wincng_safe_free(pbDecoded, cbDecoded);
+        wincng_safe_free(pbDecoded, cbDecoded);
     }
 
     return ret;
@@ -1421,14 +1421,14 @@ _libssh2_wincng_rsa_new(libssh2_rsa_ctx **rsa,
     ret = BCryptImportKeyPair(wincng_ctx.hAlgRSA, NULL, lpszBlobType,
                               &hKey, (PUCHAR)rsakey, keylen, 0);
     if(!BCRYPT_SUCCESS(ret)) {
-        _libssh2_wincng_safe_free(rsakey, keylen);
+        wincng_safe_free(rsakey, keylen);
         return -1;
     }
 
     *rsa = malloc(sizeof(libssh2_rsa_ctx));
     if(!(*rsa)) {
         BCryptDestroyKey(hKey);
-        _libssh2_wincng_safe_free(rsakey, keylen);
+        wincng_safe_free(rsakey, keylen);
         return -1;
     }
 
@@ -1457,7 +1457,7 @@ _libssh2_wincng_rsa_new_private_parse(libssh2_rsa_ctx **rsa,
                                      PKCS_RSA_PRIVATE_KEY,
                                      &pbStructInfo, &cbStructInfo);
 
-    _libssh2_wincng_safe_free(pbEncoded, cbEncoded);
+    wincng_safe_free(pbEncoded, cbEncoded);
 
     if(ret) {
         return -1;
@@ -1467,14 +1467,14 @@ _libssh2_wincng_rsa_new_private_parse(libssh2_rsa_ctx **rsa,
                               LEGACY_RSAPRIVATE_BLOB, &hKey,
                               pbStructInfo, cbStructInfo, 0);
     if(!BCRYPT_SUCCESS(ret)) {
-        _libssh2_wincng_safe_free(pbStructInfo, cbStructInfo);
+        wincng_safe_free(pbStructInfo, cbStructInfo);
         return -1;
     }
 
     *rsa = malloc(sizeof(libssh2_rsa_ctx));
     if(!(*rsa)) {
         BCryptDestroyKey(hKey);
-        _libssh2_wincng_safe_free(pbStructInfo, cbStructInfo);
+        wincng_safe_free(pbStructInfo, cbStructInfo);
         return -1;
     }
 
@@ -1636,7 +1636,7 @@ _libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
             ret = (NTSTATUS)STATUS_NO_MEMORY;
     }
 
-    _libssh2_wincng_safe_free(data, datalen);
+    wincng_safe_free(data, datalen);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
@@ -1676,8 +1676,8 @@ _libssh2_wincng_rsa_free(libssh2_rsa_ctx *rsa)
     BCryptDestroyKey(rsa->hKey);
     rsa->hKey = NULL;
 
-    _libssh2_wincng_safe_free(rsa->pbKeyObject, rsa->cbKeyObject);
-    _libssh2_wincng_safe_free(rsa, sizeof(libssh2_rsa_ctx));
+    wincng_safe_free(rsa->pbKeyObject, rsa->cbKeyObject);
+    wincng_safe_free(rsa, sizeof(libssh2_rsa_ctx));
 }
 #endif
 
@@ -1774,14 +1774,14 @@ _libssh2_wincng_dsa_new(libssh2_dsa_ctx **dsa,
     ret = BCryptImportKeyPair(wincng_ctx.hAlgDSA, NULL, lpszBlobType,
                               &hKey, (PUCHAR)dsakey, keylen, 0);
     if(!BCRYPT_SUCCESS(ret)) {
-        _libssh2_wincng_safe_free(dsakey, keylen);
+        wincng_safe_free(dsakey, keylen);
         return -1;
     }
 
     *dsa = malloc(sizeof(libssh2_dsa_ctx));
     if(!(*dsa)) {
         BCryptDestroyKey(hKey);
-        _libssh2_wincng_safe_free(dsakey, keylen);
+        wincng_safe_free(dsakey, keylen);
         return -1;
     }
 
@@ -1808,7 +1808,7 @@ _libssh2_wincng_dsa_new_private_parse(libssh2_dsa_ctx **dsa,
     ret = _libssh2_wincng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
                                          &rpbDecoded, &rcbDecoded, &length);
 
-    _libssh2_wincng_safe_free(pbEncoded, cbEncoded);
+    wincng_safe_free(pbEncoded, cbEncoded);
 
     if(ret) {
         return -1;
@@ -1827,7 +1827,7 @@ _libssh2_wincng_dsa_new_private_parse(libssh2_dsa_ctx **dsa,
     }
 
     for(index = 0; index < length; index++) {
-        _libssh2_wincng_safe_free(rpbDecoded[index], rcbDecoded[index]);
+        wincng_safe_free(rpbDecoded[index], rcbDecoded[index]);
         rpbDecoded[index] = NULL;
         rcbDecoded[index] = 0;
     }
@@ -1943,7 +1943,7 @@ _libssh2_wincng_dsa_sha1_sign(libssh2_dsa_ctx *dsa,
                     memcpy(sig_fixed, sig, siglen);
                 }
 
-                _libssh2_wincng_safe_free(sig, siglen);
+                wincng_safe_free(sig, siglen);
             }
             else
                 ret = (NTSTATUS)STATUS_NO_MEMORY;
@@ -1952,7 +1952,7 @@ _libssh2_wincng_dsa_sha1_sign(libssh2_dsa_ctx *dsa,
             ret = (NTSTATUS)STATUS_NO_MEMORY;
     }
 
-    _libssh2_wincng_safe_free(data, datalen);
+    wincng_safe_free(data, datalen);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
@@ -1966,8 +1966,8 @@ _libssh2_wincng_dsa_free(libssh2_dsa_ctx *dsa)
     BCryptDestroyKey(dsa->hKey);
     dsa->hKey = NULL;
 
-    _libssh2_wincng_safe_free(dsa->pbKeyObject, dsa->cbKeyObject);
-    _libssh2_wincng_safe_free(dsa, sizeof(libssh2_dsa_ctx));
+    wincng_safe_free(dsa->pbKeyObject, dsa->cbKeyObject);
+    wincng_safe_free(dsa, sizeof(libssh2_dsa_ctx));
 }
 #endif
 
@@ -3216,7 +3216,7 @@ _libssh2_wincng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
     ret = _libssh2_wincng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
                                          &rpbDecoded, &rcbDecoded, &length);
 
-    _libssh2_wincng_safe_free(pbEncoded, cbEncoded);
+    wincng_safe_free(pbEncoded, cbEncoded);
 
     if(ret) {
         return -1;
@@ -3290,7 +3290,7 @@ _libssh2_wincng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
     }
 
     for(index = 0; index < length; index++) {
-        _libssh2_wincng_safe_free(rpbDecoded[index], rcbDecoded[index]);
+        wincng_safe_free(rpbDecoded[index], rcbDecoded[index]);
         rpbDecoded[index] = NULL;
         rcbDecoded[index] = 0;
     }
@@ -3487,10 +3487,10 @@ _libssh2_wincng_cipher_init(libssh2_cipher_ctx *h,
                           pbKeyObject, dwKeyObject,
                           (PUCHAR)header, keylen, 0);
 
-    _libssh2_wincng_safe_free(header, keylen);
+    wincng_safe_free(header, keylen);
 
     if(!BCRYPT_SUCCESS(ret)) {
-        _libssh2_wincng_safe_free(pbKeyObject, dwKeyObject);
+        wincng_safe_free(pbKeyObject, dwKeyObject);
         return -1;
     }
 
@@ -3503,7 +3503,7 @@ _libssh2_wincng_cipher_init(libssh2_cipher_ctx *h,
         pbIVCopy = malloc(dwBlockLength);
         if(!pbIVCopy) {
             BCryptDestroyKey(hKey);
-            _libssh2_wincng_safe_free(pbKeyObject, dwKeyObject);
+            wincng_safe_free(pbKeyObject, dwKeyObject);
             return -1;
         }
         memcpy(pbIVCopy, iv, dwBlockLength);
@@ -3603,7 +3603,7 @@ _libssh2_wincng_cipher_crypt(libssh2_cipher_ctx *ctx,
                 }
             }
 
-            _libssh2_wincng_safe_free(pbOutput, cbOutput);
+            wincng_safe_free(pbOutput, cbOutput);
         }
         else
             ret = (NTSTATUS)STATUS_NO_MEMORY;
@@ -3618,15 +3618,15 @@ _libssh2_wincng_cipher_dtor(libssh2_cipher_ctx *ctx)
     BCryptDestroyKey(ctx->hKey);
     ctx->hKey = NULL;
 
-    _libssh2_wincng_safe_free(ctx->pbKeyObject, ctx->dwKeyObject);
+    wincng_safe_free(ctx->pbKeyObject, ctx->dwKeyObject);
     ctx->pbKeyObject = NULL;
     ctx->dwKeyObject = 0;
 
-    _libssh2_wincng_safe_free(ctx->pbIV, ctx->dwBlockLength);
+    wincng_safe_free(ctx->pbIV, ctx->dwBlockLength);
     ctx->pbIV = NULL;
     ctx->dwBlockLength = 0;
 
-    _libssh2_wincng_safe_free(ctx->pbCtr, ctx->dwCtrLength);
+    wincng_safe_free(ctx->pbCtr, ctx->dwCtrLength);
     ctx->pbCtr = NULL;
     ctx->dwCtrLength = 0;
 }
@@ -3782,7 +3782,7 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
                 free(dh_key_blob);
             }
             else { /* we may have potentially private data, use secure free */
-                _libssh2_wincng_safe_free(dh_key_blob, key_length_bytes);
+                wincng_safe_free(dh_key_blob, key_length_bytes);
             }
             return -1;
         }
@@ -3802,7 +3802,7 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
                 free(dh_key_blob);
             }
             else { /* we may have potentially private data, use secure free */
-                _libssh2_wincng_safe_free(dh_key_blob, key_length_bytes);
+                wincng_safe_free(dh_key_blob, key_length_bytes);
             }
             return -1;
         }
@@ -3817,12 +3817,12 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
             /* BCRYPT_DH_PRIVATE_BLOB additionally contains the Private data */
             dhctx->dh_privbn = _libssh2_wincng_bignum_init();
             if(!dhctx->dh_privbn) {
-                _libssh2_wincng_safe_free(dh_key_blob, key_length_bytes);
+                wincng_safe_free(dh_key_blob, key_length_bytes);
                 return -1;
             }
             if(_libssh2_wincng_bignum_resize(dhctx->dh_privbn,
                                              dh_key_blob->cbKey)) {
-                _libssh2_wincng_safe_free(dh_key_blob, key_length_bytes);
+                wincng_safe_free(dh_key_blob, key_length_bytes);
                 return -1;
             }
 
@@ -3836,7 +3836,7 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
              * odd primes can be used with the RSA-based fallback while
              * DH itself does not seem to care about it being odd or not. */
             if(!(dhctx->dh_privbn->bignum[dhctx->dh_privbn->length-1] % 2)) {
-                _libssh2_wincng_safe_free(dh_key_blob, key_length_bytes);
+                wincng_safe_free(dh_key_blob, key_length_bytes);
                 /* discard everything first, then try again */
                 _libssh2_dh_dtor(dhctx);
                 _libssh2_dh_init(dhctx);
@@ -3844,7 +3844,7 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
             }
         }
 
-        _libssh2_wincng_safe_free(dh_key_blob, key_length_bytes);
+        wincng_safe_free(dh_key_blob, key_length_bytes);
 
         return 0;
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -245,7 +245,7 @@ static int wincng_bignum_mod_exp(libssh2_bn *r,
     if(!rsakey)
         return -1;
 
-    /* https://msdn.microsoft.com/library/windows/desktop/aa375531.aspx */
+    /* https://learn.microsoft.com/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_rsakey_blob */
     rsakey->Magic = BCRYPT_RSAPUBLIC_MAGIC;
     rsakey->BitLength = m->length * 8;
     rsakey->cbPublicExp = p->length;
@@ -1323,7 +1323,7 @@ _libssh2_wincng_rsa_new(libssh2_rsa_ctx **rsa,
 
     memset(rsakey, 0, keylen);
 
-    /* https://msdn.microsoft.com/library/windows/desktop/aa375531.aspx */
+    /* https://learn.microsoft.com/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_rsakey_blob */
     rsakey->BitLength = mlen * 8;
     rsakey->cbPublicExp = elen;
     rsakey->cbModulus = mlen;
@@ -1699,7 +1699,7 @@ _libssh2_wincng_dsa_new(libssh2_dsa_ctx **dsa,
 
     memset(dsakey, 0, keylen);
 
-    /* https://msdn.microsoft.com/library/windows/desktop/aa833126.aspx */
+    /* https://learn.microsoft.com/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_dsa_key_blob */
     dsakey->cbKey = length;
 
     memset(dsakey->Count, -1, sizeof(dsakey->Count));
@@ -3335,8 +3335,7 @@ _libssh2_wincng_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 
     ret = wincng_load_private_memory(session, privatekeydata,
                                      privatekeydata_len,
-                                     (const unsigned char *)
-                                         passphrase,
+                                     (const unsigned char *)passphrase,
                                      &pbEncoded, &cbEncoded, 1, 1);
     if(ret) {
         return -1;
@@ -3355,8 +3354,8 @@ _libssh2_wincng_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     (void)passphrase;
 
     return _libssh2_error(session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
-                    "Unable to extract public key from private key in memory: "
-                    "Method unsupported in Windows CNG backend");
+                          "Unable to extract public key from private key in "
+                          "memory: Method unsupported in Windows CNG backend");
 #endif /* HAVE_LIBCRYPT32 */
 }
 
@@ -3389,8 +3388,8 @@ _libssh2_wincng_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
     (void)passphrase;
 
     return _libssh2_error(session, LIBSSH2_ERROR_FILE,
-                    "Unable to extract public SK key from private key file: "
-                    "Method unimplemented in Windows CNG backend");
+                          "Unable to extract public SK key from private key "
+                          "file: Method unimplemented in Windows CNG backend");
 }
 
 /*******************************************************************/

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1559,13 +1559,12 @@ _libssh2_wincng_rsa_sha2_verify(libssh2_rsa_ctx *rsactx,
 }
 #endif
 
-static int
-_libssh2_wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
-                             libssh2_rsa_ctx *rsa,
-                             const unsigned char *hash,
-                             size_t hash_len,
-                             unsigned char **signature,
-                             size_t *signature_len)
+static int wincng_rsa_sha_sign(LIBSSH2_SESSION *session,
+                               libssh2_rsa_ctx *rsa,
+                               const unsigned char *hash,
+                               size_t hash_len,
+                               unsigned char **signature,
+                               size_t *signature_len)
 {
     BCRYPT_PKCS1_PADDING_INFO paddingInfo;
     unsigned char *data, *sig;
@@ -1628,9 +1627,9 @@ _libssh2_wincng_rsa_sha1_sign(LIBSSH2_SESSION *session,
                               unsigned char **signature,
                               size_t *signature_len)
 {
-    return _libssh2_wincng_rsa_sha_sign(session, rsactx,
-                                        hash, hash_len,
-                                        signature, signature_len);
+    return wincng_rsa_sha_sign(session, rsactx,
+                               hash, hash_len,
+                               signature, signature_len);
 }
 
 int
@@ -1641,9 +1640,9 @@ _libssh2_wincng_rsa_sha2_sign(LIBSSH2_SESSION *session,
                               unsigned char **signature,
                               size_t *signature_len)
 {
-    return _libssh2_wincng_rsa_sha_sign(session, rsactx,
-                                        hash, hash_len,
-                                        signature, signature_len);
+    return wincng_rsa_sha_sign(session, rsactx,
+                               hash, hash_len,
+                               signature, signature_len);
 }
 
 void

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1189,12 +1189,11 @@ static int wincng_asn_decode_bn(unsigned char *pbEncoded,
     return ret;
 }
 
-static int
-_libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
-                               DWORD cbEncoded,
-                               unsigned char ***prpbDecoded,
-                               DWORD **prcbDecoded,
-                               DWORD *pcbCount)
+static int wincng_asn_decode_bns(unsigned char *pbEncoded,
+                                 DWORD cbEncoded,
+                                 unsigned char ***prpbDecoded,
+                                 DWORD **prcbDecoded,
+                                 DWORD *pcbCount)
 {
     PCRYPT_DER_BLOB pBlob;
     unsigned char **rpbDecoded;
@@ -1787,8 +1786,8 @@ _libssh2_wincng_dsa_new_private_parse(libssh2_dsa_ctx **dsa,
 
     (void)session;
 
-    ret = _libssh2_wincng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
-                                         &rpbDecoded, &rcbDecoded, &length);
+    ret = wincng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
+                                &rpbDecoded, &rcbDecoded, &length);
 
     wincng_safe_free(pbEncoded, cbEncoded);
 
@@ -3194,8 +3193,8 @@ _libssh2_wincng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
     DWORD index, offset, length = 0;
     int ret;
 
-    ret = _libssh2_wincng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
-                                         &rpbDecoded, &rcbDecoded, &length);
+    ret = wincng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
+                                &rpbDecoded, &rcbDecoded, &length);
 
     wincng_safe_free(pbEncoded, cbEncoded);
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2063,10 +2063,9 @@ static int wincng_p1363signature_from_point(IN const unsigned char *r,
 /*
  * Create a CNG public key from an ECC point.
  */
-static int
-_libssh2_wincng_publickey_from_point(IN wincng_ecc_keytype keytype,
-                                     IN struct ecdsa_point *point,
-                                     OUT BCRYPT_KEY_HANDLE *key)
+static int wincng_publickey_from_point(IN wincng_ecc_keytype keytype,
+                                       IN struct ecdsa_point *point,
+                                       OUT BCRYPT_KEY_HANDLE *key)
 {
     int result = LIBSSH2_ERROR_NONE;
     NTSTATUS status;
@@ -2454,7 +2453,7 @@ _libssh2_wincng_ecdsa_curve_name_with_octal_new(
         goto cleanup;
     }
 
-    result = _libssh2_wincng_publickey_from_point(
+    result = wincng_publickey_from_point(
         WINCNG_ECC_KEYTYPE_ECDSA,
         &publickey,
         &publickey_handle);
@@ -2512,7 +2511,7 @@ _libssh2_wincng_ecdh_gen_k(OUT libssh2_bn **secret,
         return result;
     }
 
-    result = _libssh2_wincng_publickey_from_point(
+    result = wincng_publickey_from_point(
         WINCNG_ECC_KEYTYPE_ECDH,
         &server_publickey,
         &publickey_handle);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1420,11 +1420,10 @@ _libssh2_wincng_rsa_new(libssh2_rsa_ctx **rsa,
 }
 
 #ifdef HAVE_LIBCRYPT32
-static int
-_libssh2_wincng_rsa_new_private_parse(libssh2_rsa_ctx **rsa,
-                                      LIBSSH2_SESSION *session,
-                                      unsigned char *pbEncoded,
-                                      size_t cbEncoded)
+static int wincng_rsa_new_private_parse(libssh2_rsa_ctx **rsa,
+                                        LIBSSH2_SESSION *session,
+                                        unsigned char *pbEncoded,
+                                        size_t cbEncoded)
 {
     BCRYPT_KEY_HANDLE hKey;
     unsigned char *pbStructInfo;
@@ -1483,8 +1482,8 @@ _libssh2_wincng_rsa_new_private(libssh2_rsa_ctx **rsa,
         return -1;
     }
 
-    return _libssh2_wincng_rsa_new_private_parse(rsa, session,
-                                                 pbEncoded, cbEncoded);
+    return wincng_rsa_new_private_parse(rsa, session,
+                                        pbEncoded, cbEncoded);
 #else
     (void)rsa;
     (void)filename;
@@ -1515,8 +1514,8 @@ _libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
         return -1;
     }
 
-    return _libssh2_wincng_rsa_new_private_parse(rsa, session,
-                                                 pbEncoded, cbEncoded);
+    return wincng_rsa_new_private_parse(rsa, session,
+                                        pbEncoded, cbEncoded);
 #else
     (void)rsa;
     (void)filedata;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -785,9 +785,8 @@ int _libssh2_wincng_hash_init(struct wincng_hash_ctx *ctx,
     return 0;
 }
 
-int
-_libssh2_wincng_hash_update(struct wincng_hash_ctx *ctx,
-                            const void *data, ULONG datalen)
+int _libssh2_wincng_hash_update(struct wincng_hash_ctx *ctx,
+                                const void *data, ULONG datalen)
 {
     int ret;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -995,13 +995,13 @@ static int wincng_key_sha_verify(struct wincng_key_ctx *ctx,
 }
 
 #ifdef HAVE_LIBCRYPT32
-static int _libssh2_wincng_load_pem(LIBSSH2_SESSION *session,
-                                    const char *filename,
-                                    const unsigned char *passphrase,
-                                    const char *headerbegin,
-                                    const char *headerend,
-                                    unsigned char **data,
-                                    size_t *datalen)
+static int wincng_load_pem(LIBSSH2_SESSION *session,
+                           const char *filename,
+                           const unsigned char *passphrase,
+                           const char *headerbegin,
+                           const char *headerend,
+                           unsigned char **data,
+                           size_t *datalen)
 {
     FILE *fp;
     int ret;
@@ -1032,15 +1032,15 @@ static int _libssh2_wincng_load_private(LIBSSH2_SESSION *session,
     int ret = -1;
 
     if(ret && tryLoadRSA) {
-        ret = _libssh2_wincng_load_pem(session, filename, passphrase,
-                                       PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                                       &data, &datalen);
+        ret = wincng_load_pem(session, filename, passphrase,
+                              PEM_RSA_HEADER, PEM_RSA_FOOTER,
+                              &data, &datalen);
     }
 
     if(ret && tryLoadDSA) {
-        ret = _libssh2_wincng_load_pem(session, filename, passphrase,
-                                       PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                                       &data, &datalen);
+        ret = wincng_load_pem(session, filename, passphrase,
+                              PEM_DSA_HEADER, PEM_DSA_FOOTER,
+                              &data, &datalen);
     }
 
     if(!ret) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1958,8 +1958,7 @@ _libssh2_wincng_dsa_free(libssh2_dsa_ctx *dsa)
 /*
  * Decode an uncompressed point.
  */
-static int
-_libssh2_wincng_ecdsa_decode_uncompressed_point(
+static int wincng_ecdsa_decode_uncompressed_point(
     IN const unsigned char *encoded_point,
     IN size_t encoded_point_len,
     OUT struct ecdsa_point *point)
@@ -2451,7 +2450,7 @@ _libssh2_wincng_ecdsa_curve_name_with_octal_new(
 
     *key = NULL;
 
-    result = _libssh2_wincng_ecdsa_decode_uncompressed_point(
+    result = wincng_ecdsa_decode_uncompressed_point(
         publickey_encoded,
         publickey_encoded_len,
         &publickey);
@@ -2509,7 +2508,7 @@ _libssh2_wincng_ecdh_gen_k(OUT libssh2_bn **secret,
     *secret = NULL;
 
     /* Decode the public key */
-    result = _libssh2_wincng_ecdsa_decode_uncompressed_point(
+    result = wincng_ecdsa_decode_uncompressed_point(
         server_publickey_encoded,
         server_publickey_encoded_len,
         &server_publickey);
@@ -2877,7 +2876,7 @@ _libssh2_wincng_parse_ecdsa_privatekey(OUT struct wincng_ecdsa_ctx **key,
         goto cleanup;
     }
 
-    result = _libssh2_wincng_ecdsa_decode_uncompressed_point(
+    result = wincng_ecdsa_decode_uncompressed_point(
         publickey,
         publickey_len,
         &q);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2131,12 +2131,11 @@ cleanup:
 /*
  * Create a CNG private key from an ECC point.
  */
-static int
-_libssh2_wincng_privatekey_from_point(IN wincng_ecc_keytype keytype,
-                                      IN struct ecdsa_point *q,
-                                      IN unsigned char *d,
-                                      IN size_t d_len,
-                                      OUT BCRYPT_KEY_HANDLE *key)
+static int wincng_privatekey_from_point(IN wincng_ecc_keytype keytype,
+                                        IN struct ecdsa_point *q,
+                                        IN unsigned char *d,
+                                        IN size_t d_len,
+                                        OUT BCRYPT_KEY_HANDLE *key)
 {
     int result = LIBSSH2_ERROR_NONE;
     NTSTATUS status;
@@ -2888,7 +2887,7 @@ static int wincng_parse_ecdsa_privatekey(OUT struct wincng_ecdsa_ctx **key,
     /* Ignore the rest (comment, etc) */
 
     /* Use Q and d to create a key handle */
-    result = _libssh2_wincng_privatekey_from_point(
+    result = wincng_privatekey_from_point(
         WINCNG_ECC_KEYTYPE_ECDSA,
         &q,
         d,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3166,11 +3166,10 @@ _libssh2_wincng_ecdsa_get_curve_type(IN struct wincng_ecdsa_ctx *key)
  */
 
 #ifdef HAVE_LIBCRYPT32
-static DWORD
-_libssh2_wincng_pub_priv_write(unsigned char *key,
-                               DWORD offset,
-                               const unsigned char *bignum,
-                               const DWORD length)
+static DWORD wincng_pub_priv_write(unsigned char *key,
+                                   DWORD offset,
+                                   const unsigned char *bignum,
+                                   const DWORD length)
 {
     _libssh2_htonu32(key + offset, length);
     offset += 4;
@@ -3219,15 +3218,15 @@ _libssh2_wincng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
         keylen = 4 + mthlen + 4 + rcbDecoded[2] + 4 + rcbDecoded[1];
         key = LIBSSH2_ALLOC(session, keylen);
         if(key) {
-            offset = _libssh2_wincng_pub_priv_write(key, 0, mth, mthlen);
+            offset = wincng_pub_priv_write(key, 0, mth, mthlen);
 
-            offset = _libssh2_wincng_pub_priv_write(key, offset,
-                                                    rpbDecoded[2],
-                                                    rcbDecoded[2]);
+            offset = wincng_pub_priv_write(key, offset,
+                                           rpbDecoded[2],
+                                           rcbDecoded[2]);
 
-            _libssh2_wincng_pub_priv_write(key, offset,
-                                           rpbDecoded[1],
-                                           rcbDecoded[1]);
+            wincng_pub_priv_write(key, offset,
+                                  rpbDecoded[1],
+                                  rcbDecoded[1]);
         }
         else {
             ret = -1;
@@ -3247,23 +3246,23 @@ _libssh2_wincng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
                             + 4 + rcbDecoded[3] + 4 + rcbDecoded[4];
         key = LIBSSH2_ALLOC(session, keylen);
         if(key) {
-            offset = _libssh2_wincng_pub_priv_write(key, 0, mth, mthlen);
+            offset = wincng_pub_priv_write(key, 0, mth, mthlen);
 
-            offset = _libssh2_wincng_pub_priv_write(key, offset,
-                                                    rpbDecoded[1],
-                                                    rcbDecoded[1]);
+            offset = wincng_pub_priv_write(key, offset,
+                                           rpbDecoded[1],
+                                           rcbDecoded[1]);
 
-            offset = _libssh2_wincng_pub_priv_write(key, offset,
-                                                    rpbDecoded[2],
-                                                    rcbDecoded[2]);
+            offset = wincng_pub_priv_write(key, offset,
+                                           rpbDecoded[2],
+                                           rcbDecoded[2]);
 
-            offset = _libssh2_wincng_pub_priv_write(key, offset,
-                                                    rpbDecoded[3],
-                                                    rcbDecoded[3]);
+            offset = wincng_pub_priv_write(key, offset,
+                                           rpbDecoded[3],
+                                           rcbDecoded[3]);
 
-            _libssh2_wincng_pub_priv_write(key, offset,
-                                           rpbDecoded[4],
-                                           rcbDecoded[4]);
+            wincng_pub_priv_write(key, offset,
+                                  rpbDecoded[4],
+                                  rcbDecoded[4]);
         }
         else {
             ret = -1;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2801,10 +2801,9 @@ cleanup:
     return result;
 }
 
-static int
-_libssh2_wincng_parse_ecdsa_privatekey(OUT struct wincng_ecdsa_ctx **key,
-                                       IN unsigned char *privatekey,
-                                       IN size_t privatekey_len)
+static int wincng_parse_ecdsa_privatekey(OUT struct wincng_ecdsa_ctx **key,
+                                         IN unsigned char *privatekey,
+                                         IN size_t privatekey_len)
 {
     char *keytype = NULL;
     size_t keytype_len;
@@ -3016,9 +3015,7 @@ _libssh2_wincng_ecdsa_new_private_frommemory(
         goto cleanup;
     }
 
-    result = _libssh2_wincng_parse_ecdsa_privatekey(key,
-                                                    privatekey,
-                                                    privatekey_len);
+    result = wincng_parse_ecdsa_privatekey(key, privatekey, privatekey_len);
 
 cleanup:
     if(result != LIBSSH2_ERROR_NONE) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3177,14 +3177,13 @@ static DWORD wincng_pub_priv_write(unsigned char *key,
     return offset;
 }
 
-static int
-_libssh2_wincng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
-                                       unsigned char **method,
-                                       size_t *method_len,
-                                       unsigned char **pubkeydata,
-                                       size_t *pubkeydata_len,
-                                       unsigned char *pbEncoded,
-                                       size_t cbEncoded)
+static int wincng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
+                                         unsigned char **method,
+                                         size_t *method_len,
+                                         unsigned char **pubkeydata,
+                                         size_t *pubkeydata_len,
+                                         unsigned char *pbEncoded,
+                                         size_t cbEncoded)
 {
     unsigned char **rpbDecoded = NULL;
     DWORD *rcbDecoded = NULL;
@@ -3316,9 +3315,9 @@ _libssh2_wincng_pub_priv_keyfile(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    return _libssh2_wincng_pub_priv_keyfile_parse(session, method, method_len,
-                                                  pubkeydata, pubkeydata_len,
-                                                  pbEncoded, cbEncoded);
+    return wincng_pub_priv_keyfile_parse(session, method, method_len,
+                                         pubkeydata, pubkeydata_len,
+                                         pbEncoded, cbEncoded);
 #else
     (void)method;
     (void)method_len;
@@ -3357,9 +3356,9 @@ _libssh2_wincng_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    return _libssh2_wincng_pub_priv_keyfile_parse(session, method, method_len,
-                                                  pubkeydata, pubkeydata_len,
-                                                  pbEncoded, cbEncoded);
+    return wincng_pub_priv_keyfile_parse(session, method, method_len,
+                                         pubkeydata, pubkeydata_len,
+                                         pbEncoded, cbEncoded);
 #else
     (void)method;
     (void)method_len;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -183,8 +183,7 @@ static int wincng_bignum_resize(libssh2_bn *bn, ULONG length)
     return 0;
 }
 
-static int
-_libssh2_wincng_bignum_rand(libssh2_bn *rnd, int bits, int top, int bottom)
+static int wincng_bignum_rand(libssh2_bn *rnd, int bits, int top, int bottom)
 {
     unsigned char *bignum;
     ULONG length;
@@ -3851,7 +3850,7 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
     dhctx->dh_privbn = _libssh2_wincng_bignum_init();
     if(!dhctx->dh_privbn)
         return -1;
-    if(_libssh2_wincng_bignum_rand(dhctx->dh_privbn, (group_order*8)-1, 0, -1))
+    if(wincng_bignum_rand(dhctx->dh_privbn, (group_order*8)-1, 0, -1))
         return -1;
     if(_libssh2_wincng_bignum_mod_exp(public, g, dhctx->dh_privbn, p))
         return -1;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2206,8 +2206,7 @@ cleanup:
 /*
  * Get the uncompressed point encoding for a CNG key.
  */
-static int
-_libssh2_wincng_uncompressed_point_from_publickey(
+static int wincng_uncompressed_point_from_publickey(
     IN LIBSSH2_SESSION *session,
     IN libssh2_curve_type curve,
     IN BCRYPT_KEY_HANDLE key,
@@ -2386,7 +2385,7 @@ _libssh2_wincng_ecdh_create_key(IN LIBSSH2_SESSION *session,
         goto cleanup;
     }
 
-    result = _libssh2_wincng_uncompressed_point_from_publickey(
+    result = wincng_uncompressed_point_from_publickey(
         session,
         curve,
         key_handle,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -146,8 +146,7 @@ static void memcpy_with_be_padding(unsigned char *dest, ULONG dest_len,
  * Windows CNG backend: BigNumber functions
  */
 
-libssh2_bn *
-_libssh2_wincng_bignum_init(void)
+libssh2_bn *_libssh2_wincng_bignum_init(void)
 {
     libssh2_bn *bignum;
 
@@ -160,8 +159,7 @@ _libssh2_wincng_bignum_init(void)
     return bignum;
 }
 
-static int
-_libssh2_wincng_bignum_resize(libssh2_bn *bn, ULONG length)
+static int wincng_bignum_resize(libssh2_bn *bn, ULONG length)
 {
     unsigned char *bignum;
 
@@ -195,7 +193,7 @@ _libssh2_wincng_bignum_rand(libssh2_bn *rnd, int bits, int top, int bottom)
         return -1;
 
     length = (ULONG)(ceil(((double)bits) / 8.0) * sizeof(unsigned char));
-    if(_libssh2_wincng_bignum_resize(rnd, length))
+    if(wincng_bignum_resize(rnd, length))
         return -1;
 
     bignum = rnd->bignum;
@@ -270,7 +268,7 @@ _libssh2_wincng_bignum_mod_exp(libssh2_bn *r,
         ret = BCryptEncrypt(hKey, a->bignum, a->length, NULL, NULL, 0,
                             NULL, 0, &length, BCRYPT_PAD_NONE);
         if(BCRYPT_SUCCESS(ret)) {
-            if(!_libssh2_wincng_bignum_resize(r, length)) {
+            if(!wincng_bignum_resize(r, length)) {
                 length = max(a->length, length);
                 bignum = malloc(length);
                 if(bignum) {
@@ -284,7 +282,7 @@ _libssh2_wincng_bignum_mod_exp(libssh2_bn *r,
                     wincng_safe_free(bignum, length);
 
                     if(BCRYPT_SUCCESS(ret)) {
-                        _libssh2_wincng_bignum_resize(r, offset);
+                        wincng_bignum_resize(r, offset);
                     }
                 }
                 else
@@ -317,7 +315,7 @@ _libssh2_wincng_bignum_set_word(libssh2_bn *bn, ULONG word)
     bits++;
 
     length = (ULONG)(ceil(((double)bits) / 8.0) * sizeof(unsigned char));
-    if(_libssh2_wincng_bignum_resize(bn, length))
+    if(wincng_bignum_resize(bn, length))
         return -1;
 
     for(offset = 0; offset < length; offset++)
@@ -359,7 +357,7 @@ _libssh2_wincng_bignum_from_bin(libssh2_bn *bn, ULONG len,
     if(!bn || !bin || !len)
         return -1;
 
-    if(_libssh2_wincng_bignum_resize(bn, len))
+    if(wincng_bignum_resize(bn, len))
         return -1;
 
     memcpy(bn->bignum, bin, len);
@@ -2585,7 +2583,7 @@ _libssh2_wincng_ecdh_gen_k(OUT libssh2_bn **secret,
         goto cleanup;
     }
 
-    if(_libssh2_wincng_bignum_resize(*secret, secret_len)) {
+    if(wincng_bignum_resize(*secret, secret_len)) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
     }
@@ -3796,7 +3794,7 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
         /* BCRYPT_DH_PUBLIC_BLOB corresponds to a BCRYPT_DH_KEY_BLOB header
          * followed by the Modulus, Generator and Public data. Those components
          * each have equal size, specified by dh_key_blob->cbKey. */
-        if(_libssh2_wincng_bignum_resize(public, dh_key_blob->cbKey)) {
+        if(wincng_bignum_resize(public, dh_key_blob->cbKey)) {
             if(hasAlgDHwithKDF == 1) {
                 /* We have no private data, because raw KDF is supported */
                 free(dh_key_blob);
@@ -3820,8 +3818,8 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
                 wincng_safe_free(dh_key_blob, key_length_bytes);
                 return -1;
             }
-            if(_libssh2_wincng_bignum_resize(dhctx->dh_privbn,
-                                             dh_key_blob->cbKey)) {
+            if(wincng_bignum_resize(dhctx->dh_privbn,
+                                    dh_key_blob->cbKey)) {
                 wincng_safe_free(dh_key_blob, key_length_bytes);
                 return -1;
             }
@@ -3939,7 +3937,7 @@ _libssh2_dh_secret(struct wincng_dh_ctx *dhctx, libssh2_bn *secret,
 
         /* Expand the secret bignum to be ready to receive the derived secret
          * */
-        if(_libssh2_wincng_bignum_resize(secret, secret_len_bytes)) {
+        if(wincng_bignum_resize(secret, secret_len_bytes)) {
             status = (NTSTATUS)STATUS_NO_MEMORY;
             goto out;
         }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3511,8 +3511,7 @@ _libssh2_wincng_cipher_init(libssh2_cipher_ctx *h,
 
 /* Increments an AES CTR buffer to prepare it for use with the
    next AES block. */
-static void _libssh2_aes_ctr_increment(unsigned char *ctr,
-                                       size_t length)
+static void aes_ctr_increment(unsigned char *ctr, size_t length)
 {
     unsigned char *pc;
     unsigned int val, carry;
@@ -3575,7 +3574,7 @@ _libssh2_wincng_cipher_crypt(libssh2_cipher_ctx *ctx,
                 if(algo.ctrMode) {
                     /* NOLINTNEXTLINE(readability-suspicious-call-argument) */
                     _libssh2_xor_data(block, block, pbOutput, blocksize);
-                    _libssh2_aes_ctr_increment(ctx->pbCtr, ctx->dwCtrLength);
+                    aes_ctr_increment(ctx->pbCtr, ctx->dwCtrLength);
                 }
                 else {
                     memcpy(block, pbOutput, cbOutput);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3642,8 +3642,7 @@ _libssh2_dh_dtor(struct wincng_dh_ctx *dhctx)
     }
 }
 
-static int
-round_down(int number, int multiple)
+static int round_down(int number, int multiple)
 {
     return (number / multiple) * multiple;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1051,13 +1051,13 @@ static int wincng_load_private(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int _libssh2_wincng_load_private_memory(LIBSSH2_SESSION *session,
-                                               const char *privatekeydata,
-                                               size_t privatekeydata_len,
-                                               const unsigned char *passphrase,
-                                               unsigned char **ppbEncoded,
-                                               size_t *pcbEncoded,
-                                               int tryLoadRSA, int tryLoadDSA)
+static int wincng_load_private_memory(LIBSSH2_SESSION *session,
+                                      const char *privatekeydata,
+                                      size_t privatekeydata_len,
+                                      const unsigned char *passphrase,
+                                      unsigned char **ppbEncoded,
+                                      size_t *pcbEncoded,
+                                      int tryLoadRSA, int tryLoadDSA)
 {
     unsigned char *data = NULL;
     size_t datalen = 0;
@@ -1512,9 +1512,9 @@ _libssh2_wincng_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
     size_t cbEncoded;
     int ret;
 
-    ret = _libssh2_wincng_load_private_memory(session, filedata, filedata_len,
-                                              passphrase,
-                                              &pbEncoded, &cbEncoded, 1, 0);
+    ret = wincng_load_private_memory(session, filedata, filedata_len,
+                                     passphrase,
+                                     &pbEncoded, &cbEncoded, 1, 0);
     if(ret) {
         return -1;
     }
@@ -1865,9 +1865,9 @@ _libssh2_wincng_dsa_new_private_frommemory(libssh2_dsa_ctx **dsa,
     size_t cbEncoded;
     int ret;
 
-    ret = _libssh2_wincng_load_private_memory(session, filedata, filedata_len,
-                                              passphrase,
-                                              &pbEncoded, &cbEncoded, 0, 1);
+    ret = wincng_load_private_memory(session, filedata, filedata_len,
+                                     passphrase,
+                                     &pbEncoded, &cbEncoded, 0, 1);
     if(ret) {
         return -1;
     }
@@ -3351,11 +3351,11 @@ _libssh2_wincng_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     size_t cbEncoded;
     int ret;
 
-    ret = _libssh2_wincng_load_private_memory(session, privatekeydata,
-                                              privatekeydata_len,
-                                              (const unsigned char *)
-                                                  passphrase,
-                                              &pbEncoded, &cbEncoded, 1, 1);
+    ret = wincng_load_private_memory(session, privatekeydata,
+                                     privatekeydata_len,
+                                     (const unsigned char *)
+                                         passphrase,
+                                     &pbEncoded, &cbEncoded, 1, 1);
     if(ret) {
         return -1;
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -477,17 +477,6 @@ struct ecdsa_point {
     ULONG y_len;
 };
 
-/* Lookup libssh2_curve_type by name */
-static int
-_libssh2_wincng_ecdsa_curve_type_from_name(IN const char *name,
-                                           OUT libssh2_curve_type *out_curve);
-
-/* Parse an OpenSSL-formatted ECDSA private key */
-static int
-_libssh2_wincng_parse_ecdsa_privatekey(OUT struct wincng_ecdsa_ctx **key,
-                                       IN unsigned char *privatekey,
-                                       IN size_t privatekey_len);
-
 #endif
 
 /*******************************************************************/
@@ -2624,7 +2613,7 @@ cleanup:
  * _libssh2_ecdsa_curve_type_from_name
  *
  */
-int
+static int
 _libssh2_wincng_ecdsa_curve_type_from_name(IN const char *name,
                                            OUT libssh2_curve_type *out_curve)
 {
@@ -2821,7 +2810,7 @@ cleanup:
     return result;
 }
 
-int
+static int
 _libssh2_wincng_parse_ecdsa_privatekey(OUT struct wincng_ecdsa_ctx **key,
                                        IN unsigned char *privatekey,
                                        IN size_t privatekey_len)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1999,14 +1999,13 @@ static int wincng_ecdsa_decode_uncompressed_point(
  * The IEEE P-1363 format is defined as r || s,
  * where r and s are of the same length.
  */
-static int
-_libssh2_wincng_p1363signature_from_point(IN const unsigned char *r,
-                                          IN size_t r_len,
-                                          IN const unsigned char *s,
-                                          IN size_t s_len,
-                                          IN libssh2_curve_type curve,
-                                          OUT PUCHAR *signature,
-                                          OUT size_t *signature_length)
+static int wincng_p1363signature_from_point(IN const unsigned char *r,
+                                            IN size_t r_len,
+                                            IN const unsigned char *s,
+                                            IN size_t s_len,
+                                            IN libssh2_curve_type curve,
+                                            OUT PUCHAR *signature,
+                                            OUT size_t *signature_length)
 {
     const unsigned char *r_trimmed;
     const unsigned char *s_trimmed;
@@ -2648,7 +2647,7 @@ _libssh2_wincng_ecdsa_verify(IN struct wincng_ecdsa_ctx *key,
     BCRYPT_ALG_HANDLE hash_alg;
 
     /* CNG expects signatures in IEEE P-1363 format. */
-    result = _libssh2_wincng_p1363signature_from_point(
+    result = wincng_p1363signature_from_point(
         r,
         r_len,
         s,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -224,11 +224,10 @@ static int wincng_bignum_rand(libssh2_bn *rnd, int bits, int top, int bottom)
     return 0;
 }
 
-static int
-_libssh2_wincng_bignum_mod_exp(libssh2_bn *r,
-                               libssh2_bn *a,
-                               libssh2_bn *p,
-                               libssh2_bn *m)
+static int wincng_bignum_mod_exp(libssh2_bn *r,
+                                 libssh2_bn *a,
+                                 libssh2_bn *p,
+                                 libssh2_bn *m)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_RSAKEY_BLOB *rsakey;
@@ -3852,7 +3851,7 @@ _libssh2_dh_key_pair(struct wincng_dh_ctx *dhctx, libssh2_bn *public,
         return -1;
     if(wincng_bignum_rand(dhctx->dh_privbn, (group_order*8)-1, 0, -1))
         return -1;
-    if(_libssh2_wincng_bignum_mod_exp(public, g, dhctx->dh_privbn, p))
+    if(wincng_bignum_mod_exp(public, g, dhctx->dh_privbn, p))
         return -1;
 
     return 0;
@@ -3987,7 +3986,7 @@ out:
 
 fb:
     /* Compute the shared secret */
-    return _libssh2_wincng_bignum_mod_exp(secret, f, dhctx->dh_privbn, p);
+    return wincng_bignum_mod_exp(secret, f, dhctx->dh_privbn, p);
 }
 
 /* _libssh2_supported_key_sign_algorithms

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2604,9 +2604,8 @@ cleanup:
  * _libssh2_ecdsa_curve_type_from_name
  *
  */
-static int
-_libssh2_wincng_ecdsa_curve_type_from_name(IN const char *name,
-                                           OUT libssh2_curve_type *out_curve)
+static int wincng_ecdsa_curve_type_from_name(IN const char *name,
+                                             OUT libssh2_curve_type *out_curve)
 {
     unsigned int curve;
 
@@ -2858,7 +2857,7 @@ static int wincng_parse_ecdsa_privatekey(OUT struct wincng_ecdsa_ctx **key,
         goto cleanup;
     }
 
-    result = _libssh2_wincng_ecdsa_curve_type_from_name(keytype, &curve_type);
+    result = wincng_ecdsa_curve_type_from_name(keytype, &curve_type);
     if(result < 0) {
         goto cleanup;
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1125,11 +1125,10 @@ static int wincng_asn_decode(unsigned char *pbEncoded,
     return 0;
 }
 
-static int
-_libssh2_wincng_bn_ltob(unsigned char *pbInput,
-                        DWORD cbInput,
-                        unsigned char **ppbOutput,
-                        DWORD *pcbOutput)
+static int wincng_bn_ltob(unsigned char *pbInput,
+                          DWORD cbInput,
+                          unsigned char **ppbOutput,
+                          DWORD *pcbOutput)
 {
     unsigned char *pbOutput;
     DWORD cbOutput, index, offset, length;
@@ -1178,9 +1177,9 @@ _libssh2_wincng_asn_decode_bn(unsigned char *pbEncoded,
                             X509_MULTI_BYTE_UINT,
                             (void *)&pbInteger, &cbInteger);
     if(!ret) {
-        ret = _libssh2_wincng_bn_ltob(pbInteger->pbData,
-                                      pbInteger->cbData,
-                                      &pbDecoded, &cbDecoded);
+        ret = wincng_bn_ltob(pbInteger->pbData,
+                             pbInteger->cbData,
+                             &pbDecoded, &cbDecoded);
         if(!ret) {
             *ppbDecoded = pbDecoded;
             *pcbDecoded = cbDecoded;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1254,8 +1254,7 @@ static int wincng_asn_decode_bns(unsigned char *pbEncoded,
 #endif /* HAVE_LIBCRYPT32 */
 
 #if LIBSSH2_RSA || LIBSSH2_DSA
-static ULONG
-_libssh2_wincng_bn_size(const unsigned char *bignum, ULONG length)
+static ULONG wincng_bn_size(const unsigned char *bignum, ULONG length)
 {
     ULONG offset;
 
@@ -1305,15 +1304,15 @@ _libssh2_wincng_rsa_new(libssh2_rsa_ctx **rsa,
     ULONG keylen, offset, mlen, p1len = 0, p2len = 0;
     int ret;
 
-    mlen = max(_libssh2_wincng_bn_size(ndata, nlen),
-               _libssh2_wincng_bn_size(ddata, dlen));
+    mlen = max(wincng_bn_size(ndata, nlen),
+               wincng_bn_size(ddata, dlen));
     offset = sizeof(BCRYPT_RSAKEY_BLOB);
     keylen = offset + elen + mlen;
     if(ddata && dlen > 0) {
-        p1len = max(_libssh2_wincng_bn_size(pdata, plen),
-                    _libssh2_wincng_bn_size(e1data, e1len));
-        p2len = max(_libssh2_wincng_bn_size(qdata, qlen),
-                    _libssh2_wincng_bn_size(e2data, e2len));
+        p1len = max(wincng_bn_size(pdata, plen),
+                    wincng_bn_size(e1data, e1len));
+        p2len = max(wincng_bn_size(qdata, qlen),
+                    wincng_bn_size(e2data, e2len));
         keylen += p1len * 3 + p2len * 2 + mlen;
     }
 
@@ -1687,9 +1686,9 @@ _libssh2_wincng_dsa_new(libssh2_dsa_ctx **dsa,
     ULONG keylen, offset, length;
     int ret;
 
-    length = max(max(_libssh2_wincng_bn_size(pdata, plen),
-                     _libssh2_wincng_bn_size(gdata, glen)),
-                 _libssh2_wincng_bn_size(ydata, ylen));
+    length = max(max(wincng_bn_size(pdata, plen),
+                     wincng_bn_size(gdata, glen)),
+                 wincng_bn_size(ydata, ylen));
     offset = sizeof(BCRYPT_DSA_KEY_BLOB);
     keylen = offset + length * 3;
     if(xdata && xlen > 0)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1087,11 +1087,11 @@ static int wincng_load_private_memory(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int _libssh2_wincng_asn_decode(unsigned char *pbEncoded,
-                                      DWORD cbEncoded,
-                                      LPCSTR lpszStructType,
-                                      unsigned char **ppbDecoded,
-                                      DWORD *pcbDecoded)
+static int wincng_asn_decode(unsigned char *pbEncoded,
+                             DWORD cbEncoded,
+                             LPCSTR lpszStructType,
+                             unsigned char **ppbDecoded,
+                             DWORD *pcbDecoded)
 {
     unsigned char *pbDecoded = NULL;
     DWORD cbDecoded = 0;
@@ -1174,9 +1174,9 @@ _libssh2_wincng_asn_decode_bn(unsigned char *pbEncoded,
     DWORD cbDecoded = 0, cbInteger;
     int ret;
 
-    ret = _libssh2_wincng_asn_decode(pbEncoded, cbEncoded,
-                                     X509_MULTI_BYTE_UINT,
-                                     (void *)&pbInteger, &cbInteger);
+    ret = wincng_asn_decode(pbEncoded, cbEncoded,
+                            X509_MULTI_BYTE_UINT,
+                            (void *)&pbInteger, &cbInteger);
     if(!ret) {
         ret = _libssh2_wincng_bn_ltob(pbInteger->pbData,
                                       pbInteger->cbData,
@@ -1204,9 +1204,9 @@ _libssh2_wincng_asn_decode_bns(unsigned char *pbEncoded,
     DWORD cbDecoded, *rcbDecoded, index, length;
     int ret;
 
-    ret = _libssh2_wincng_asn_decode(pbEncoded, cbEncoded,
-                                     X509_SEQUENCE_OF_ANY,
-                                     (void *)&pbDecoded, &cbDecoded);
+    ret = wincng_asn_decode(pbEncoded, cbEncoded,
+                            X509_SEQUENCE_OF_ANY,
+                            (void *)&pbDecoded, &cbDecoded);
     if(!ret) {
         length = pbDecoded->cValue;
 
@@ -1437,9 +1437,9 @@ _libssh2_wincng_rsa_new_private_parse(libssh2_rsa_ctx **rsa,
 
     (void)session;
 
-    ret = _libssh2_wincng_asn_decode(pbEncoded, (DWORD)cbEncoded,
-                                     PKCS_RSA_PRIVATE_KEY,
-                                     &pbStructInfo, &cbStructInfo);
+    ret = wincng_asn_decode(pbEncoded, (DWORD)cbEncoded,
+                            PKCS_RSA_PRIVATE_KEY,
+                            &pbStructInfo, &cbStructInfo);
 
     wincng_safe_free(pbEncoded, cbEncoded);
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1020,12 +1020,12 @@ static int wincng_load_pem(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int _libssh2_wincng_load_private(LIBSSH2_SESSION *session,
-                                        const char *filename,
-                                        const unsigned char *passphrase,
-                                        unsigned char **ppbEncoded,
-                                        size_t *pcbEncoded,
-                                        int tryLoadRSA, int tryLoadDSA)
+static int wincng_load_private(LIBSSH2_SESSION *session,
+                               const char *filename,
+                               const unsigned char *passphrase,
+                               unsigned char **ppbEncoded,
+                               size_t *pcbEncoded,
+                               int tryLoadRSA, int tryLoadDSA)
 {
     unsigned char *data = NULL;
     size_t datalen = 0;
@@ -1481,8 +1481,8 @@ _libssh2_wincng_rsa_new_private(libssh2_rsa_ctx **rsa,
     size_t cbEncoded;
     int ret;
 
-    ret = _libssh2_wincng_load_private(session, filename, passphrase,
-                                       &pbEncoded, &cbEncoded, 1, 0);
+    ret = wincng_load_private(session, filename, passphrase,
+                              &pbEncoded, &cbEncoded, 1, 0);
     if(ret) {
         return -1;
     }
@@ -1834,8 +1834,8 @@ _libssh2_wincng_dsa_new_private(libssh2_dsa_ctx **dsa,
     size_t cbEncoded;
     int ret;
 
-    ret = _libssh2_wincng_load_private(session, filename, passphrase,
-                                       &pbEncoded, &cbEncoded, 0, 1);
+    ret = wincng_load_private(session, filename, passphrase,
+                              &pbEncoded, &cbEncoded, 0, 1);
     if(ret) {
         return -1;
     }
@@ -3313,9 +3313,9 @@ _libssh2_wincng_pub_priv_keyfile(LIBSSH2_SESSION *session,
     size_t cbEncoded;
     int ret;
 
-    ret = _libssh2_wincng_load_private(session, privatekey,
-                                       (const unsigned char *)passphrase,
-                                       &pbEncoded, &cbEncoded, 1, 1);
+    ret = wincng_load_private(session, privatekey,
+                              (const unsigned char *)passphrase,
+                              &pbEncoded, &cbEncoded, 1, 1);
     if(ret) {
         return -1;
     }


### PR DESCRIPTION
Also:
- drop two redundant static declarations.
- add missing `static` to two definitions.
- unfold a couple of lines.
- fix indentation, URLs along the way.

Follow-up to 8c9b7771ee9ee6b55e0c340bd519fe74a4b5fd1a #1931
Follow-up to 689b20232070662daba003c7993585bd57fd92a7 #1923
