### PR TITLE
src: formatting

### DIFF
--- a/docs/AUTHORS
+++ b/docs/AUTHORS
@@ -41,6 +41,7 @@ Daiki Ueno
 Dan Casey
 Dan Fandrich
 Daniel Stenberg
+Danny Smith
 Dave Hayden
 Dave McCaldon
 David Benjamin

--- a/src/agent.c
+++ b/src/agent.c
@@ -248,8 +248,7 @@ struct _LIBSSH2_AGENT
 
 #define WIN32_OPENSSH_AGENT_SOCK "\\\\.\\pipe\\openssh-ssh-agent"
 
-static int
-agent_connect_openssh(LIBSSH2_AGENT *agent)
+static int agent_connect_openssh(LIBSSH2_AGENT *agent)
 {
     int ret = LIBSSH2_ERROR_NONE;
     const char *path;
@@ -362,16 +361,16 @@ cleanup:
     *(total) = 0;                                                      \
     return rc;
 
-static int
-win32_openssh_send_all(LIBSSH2_AGENT *agent, void *buffer, size_t length,
-                       size_t *send_recv_total)
+static int win32_openssh_send_all(LIBSSH2_AGENT *agent,
+                                  void *buffer, size_t length,
+                                  size_t *send_recv_total)
 {
     WIN32_RECV_SEND_ALL(WriteFile, agent, buffer, length, send_recv_total)
 }
 
-static int
-win32_openssh_recv_all(LIBSSH2_AGENT *agent, void *buffer, size_t length,
-                       size_t *send_recv_total)
+static int win32_openssh_recv_all(LIBSSH2_AGENT *agent,
+                                  void *buffer, size_t length,
+                                  size_t *send_recv_total)
 {
     WIN32_RECV_SEND_ALL(ReadFile, agent, buffer, length, send_recv_total)
 }
@@ -443,8 +442,7 @@ static int agent_transact_openssh(LIBSSH2_AGENT *agent,
     return LIBSSH2_ERROR_NONE;
 }
 
-static int
-agent_disconnect_openssh(LIBSSH2_AGENT *agent)
+static int agent_disconnect_openssh(LIBSSH2_AGENT *agent)
 {
     if(!CancelIo(agent->pipe))
         return _libssh2_error(agent->session, LIBSSH2_ERROR_SOCKET_DISCONNECT,
@@ -474,8 +472,7 @@ static struct agent_ops agent_ops_openssh = {
 #endif /* HAVE_WIN32_AGENTS */
 
 #ifdef PF_UNIX
-static int
-agent_connect_unix(LIBSSH2_AGENT *agent)
+static int agent_connect_unix(LIBSSH2_AGENT *agent)
 {
     const char *path;
     struct sockaddr_un s_un;
@@ -618,8 +615,7 @@ static int agent_transact_unix(LIBSSH2_AGENT *agent,
     return 0;
 }
 
-static int
-agent_disconnect_unix(LIBSSH2_AGENT *agent)
+static int agent_disconnect_unix(LIBSSH2_AGENT *agent)
 {
     int ret;
     ret = close(agent->fd);
@@ -649,8 +645,7 @@ static struct agent_ops agent_ops_unix = {
 #define PAGEANT_COPYDATA_ID 0x804e50ba   /* random goop */
 #define PAGEANT_MAX_MSGLEN  8192
 
-static int
-agent_connect_pageant(LIBSSH2_AGENT *agent)
+static int agent_connect_pageant(LIBSSH2_AGENT *agent)
 {
     HWND hwnd;
     hwnd = FindWindowA("Pageant", "Pageant");
@@ -735,8 +730,7 @@ static int agent_transact_pageant(LIBSSH2_AGENT *agent,
     return 0;
 }
 
-static int
-agent_disconnect_pageant(LIBSSH2_AGENT *agent)
+static int agent_disconnect_pageant(LIBSSH2_AGENT *agent)
 {
     agent->fd = LIBSSH2_INVALID_SOCKET;
     return 0;
@@ -763,9 +757,10 @@ static struct {
     {NULL, NULL}
 };
 
-static int
-agent_sign(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
-           const unsigned char *data, size_t data_len, void **abstract)
+static int agent_sign(LIBSSH2_SESSION *session,
+                      unsigned char **sig, size_t *sig_len,
+                      const unsigned char *data, size_t data_len,
+                      void **abstract)
 {
     LIBSSH2_AGENT *agent = (LIBSSH2_AGENT *)(*abstract);
     struct agent_transaction_ctx *transctx = &agent->transctx;
@@ -925,8 +920,7 @@ error:
     return _libssh2_error(session, rc, "agent sign failure");
 }
 
-static int
-agent_list_identities(LIBSSH2_AGENT *agent)
+static int agent_list_identities(LIBSSH2_AGENT *agent)
 {
     struct agent_transaction_ctx *transctx = &agent->transctx;
     ssize_t len, num_identities;
@@ -1060,8 +1054,7 @@ error:
                           "agent list id failed");
 }
 
-static void
-agent_free_identities(LIBSSH2_AGENT *agent)
+static void agent_free_identities(LIBSSH2_AGENT *agent)
 {
     struct agent_publickey *node;
     struct agent_publickey *next;
@@ -1082,8 +1075,8 @@ agent_free_identities(LIBSSH2_AGENT *agent)
  * Copies data from the internal to the external representation struct.
  *
  */
-static struct libssh2_agent_publickey *
-agent_publickey_to_external(struct agent_publickey *node)
+static struct libssh2_agent_publickey *agent_publickey_to_external(
+    struct agent_publickey *node)
 {
     struct libssh2_agent_publickey *ext = &node->external;
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -1099,8 +1099,8 @@ agent_publickey_to_external(struct agent_publickey *node)
  * Init an ssh-agent handle. Returns the pointer to the handle.
  *
  */
-LIBSSH2_API LIBSSH2_AGENT *
-libssh2_agent_init(LIBSSH2_SESSION *session)
+LIBSSH2_API
+LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_AGENT *agent;
 
@@ -1131,8 +1131,8 @@ libssh2_agent_init(LIBSSH2_SESSION *session)
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API int
-libssh2_agent_connect(LIBSSH2_AGENT *agent)
+LIBSSH2_API
+int libssh2_agent_connect(LIBSSH2_AGENT *agent)
 {
     int i, rc = -1;
     for(i = 0; supported_backends[i].name; i++) {
@@ -1151,8 +1151,8 @@ libssh2_agent_connect(LIBSSH2_AGENT *agent)
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API int
-libssh2_agent_list_identities(LIBSSH2_AGENT *agent)
+LIBSSH2_API
+int libssh2_agent_list_identities(LIBSSH2_AGENT *agent)
 {
     memset(&agent->transctx, 0, sizeof(agent->transctx));
     /* Abandon the last fetched identities */
@@ -1172,10 +1172,10 @@ libssh2_agent_list_identities(LIBSSH2_AGENT *agent)
  * 1 if end of public keys
  * [negative] on errors
  */
-LIBSSH2_API int
-libssh2_agent_get_identity(LIBSSH2_AGENT *agent,
-                           struct libssh2_agent_publickey **store,
-                           struct libssh2_agent_publickey *prev)
+LIBSSH2_API
+int libssh2_agent_get_identity(LIBSSH2_AGENT *agent,
+                               struct libssh2_agent_publickey **store,
+                               struct libssh2_agent_publickey *prev)
 {
     struct agent_publickey *node;
     if(prev && prev->node) {
@@ -1204,10 +1204,10 @@ libssh2_agent_get_identity(LIBSSH2_AGENT *agent,
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API int
-libssh2_agent_userauth(LIBSSH2_AGENT *agent,
-                       const char *username,
-                       struct libssh2_agent_publickey *identity)
+LIBSSH2_API
+int libssh2_agent_userauth(LIBSSH2_AGENT *agent,
+                           const char *username,
+                           struct libssh2_agent_publickey *identity)
 {
     void *abstract = agent;
     int rc;
@@ -1234,15 +1234,15 @@ libssh2_agent_userauth(LIBSSH2_AGENT *agent,
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API int
-libssh2_agent_sign(LIBSSH2_AGENT *agent,
-                   struct libssh2_agent_publickey *identity,
-                   unsigned char **sig,
-                   size_t *s_len,
-                   const unsigned char *data,
-                   size_t d_len,
-                   const char *method,
-                   unsigned int method_len)
+LIBSSH2_API
+int libssh2_agent_sign(LIBSSH2_AGENT *agent,
+                       struct libssh2_agent_publickey *identity,
+                       unsigned char **sig,
+                       size_t *s_len,
+                       const unsigned char *data,
+                       size_t d_len,
+                       const char *method,
+                       unsigned int method_len)
 {
     void *abstract = agent;
     int rc;
@@ -1285,8 +1285,8 @@ libssh2_agent_sign(LIBSSH2_AGENT *agent,
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API int
-libssh2_agent_disconnect(LIBSSH2_AGENT *agent)
+LIBSSH2_API
+int libssh2_agent_disconnect(LIBSSH2_AGENT *agent)
 {
     if(agent->ops && agent->fd != LIBSSH2_INVALID_SOCKET)
         return agent->ops->disconnect(agent);
@@ -1299,8 +1299,8 @@ libssh2_agent_disconnect(LIBSSH2_AGENT *agent)
  * Free an ssh-agent handle.  This function also frees the internal
  * collection of public keys.
  */
-LIBSSH2_API void
-libssh2_agent_free(LIBSSH2_AGENT *agent)
+LIBSSH2_API
+void libssh2_agent_free(LIBSSH2_AGENT *agent)
 {
     /* Allow connection freeing when the socket has lost its connection */
     if(agent->fd != LIBSSH2_INVALID_SOCKET) {
@@ -1320,8 +1320,8 @@ libssh2_agent_free(LIBSSH2_AGENT *agent)
  * Allows a custom agent socket path beyond SSH_AUTH_SOCK env
  *
  */
-LIBSSH2_API void
-libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
+LIBSSH2_API
+void libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
 {
     if(agent->identity_agent_path) {
         LIBSSH2_FREE(agent->session, agent->identity_agent_path);
@@ -1345,7 +1345,8 @@ libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
  * Returns the custom agent socket path if set
  *
  */
-LIBSSH2_API const char *libssh2_agent_get_identity_path(LIBSSH2_AGENT *agent)
+LIBSSH2_API
+const char *libssh2_agent_get_identity_path(LIBSSH2_AGENT *agent)
 {
     return agent->identity_agent_path;
 }

--- a/src/agent.c
+++ b/src/agent.c
@@ -1070,10 +1070,7 @@ static void agent_free_identities(LIBSSH2_AGENT *agent)
 
 #define AGENT_PUBLICKEY_MAGIC 0x3bdefed2
 /*
- * agent_publickey_to_external
- *
  * Copies data from the internal to the external representation struct.
- *
  */
 static struct libssh2_agent_publickey *agent_publickey_to_external(
     struct agent_publickey *node)
@@ -1087,10 +1084,7 @@ static struct libssh2_agent_publickey *agent_publickey_to_external(
 }
 
 /*
- * libssh2_agent_init
- *
  * Init an ssh-agent handle. Returns the pointer to the handle.
- *
  */
 LIBSSH2_API
 LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
@@ -1118,8 +1112,6 @@ LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
 }
 
 /*
- * libssh2_agent_connect
- *
  * Connect to an ssh-agent.
  *
  * Returns 0 if succeeded, or a negative value for error.
@@ -1138,8 +1130,6 @@ int libssh2_agent_connect(LIBSSH2_AGENT *agent)
 }
 
 /*
- * libssh2_agent_list_identities
- *
  * Request ssh-agent to list identities.
  *
  * Returns 0 if succeeded, or a negative value for error.
@@ -1154,8 +1144,6 @@ int libssh2_agent_list_identities(LIBSSH2_AGENT *agent)
 }
 
 /*
- * libssh2_agent_get_identity
- *
  * Traverse the internal list of public keys. Pass NULL to 'prev' to get
  * the first one. Or pass a pointer to the previously returned one to get the
  * next.
@@ -1191,8 +1179,6 @@ int libssh2_agent_get_identity(LIBSSH2_AGENT *agent,
 }
 
 /*
- * libssh2_agent_userauth
- *
  * Do publickey user authentication with the help of ssh-agent.
  *
  * Returns 0 if succeeded, or a negative value for error.
@@ -1221,8 +1207,6 @@ int libssh2_agent_userauth(LIBSSH2_AGENT *agent,
 }
 
 /*
- * libssh2_agent_sign
- *
  * Sign a payload using a system-installed ssh-agent.
  *
  * Returns 0 if succeeded, or a negative value for error.
@@ -1272,8 +1256,6 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
 }
 
 /*
- * libssh2_agent_disconnect
- *
  * Close a connection to an ssh-agent.
  *
  * Returns 0 if succeeded, or a negative value for error.
@@ -1287,8 +1269,6 @@ int libssh2_agent_disconnect(LIBSSH2_AGENT *agent)
 }
 
 /*
- * libssh2_agent_free
- *
  * Free an ssh-agent handle.  This function also frees the internal
  * collection of public keys.
  */
@@ -1308,10 +1288,7 @@ void libssh2_agent_free(LIBSSH2_AGENT *agent)
 }
 
 /*
- * libssh2_agent_set_identity_path
- *
  * Allows a custom agent socket path beyond SSH_AUTH_SOCK env
- *
  */
 LIBSSH2_API
 void libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
@@ -1333,10 +1310,7 @@ void libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
 }
 
 /*
- * libssh2_agent_get_identity_path
- *
  * Returns the custom agent socket path if set
- *
  */
 LIBSSH2_API
 const char *libssh2_agent_get_identity_path(LIBSSH2_AGENT *agent)

--- a/src/channel.c
+++ b/src/channel.c
@@ -353,11 +353,14 @@ channel_error:
  *
  * Establish a generic session channel
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *channel_type,
-                        unsigned int channel_type_len,
-                        unsigned int window_size, unsigned int packet_size,
-                        const char *message, unsigned int message_len)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_channel_open_ex(LIBSSH2_SESSION *session,
+                                         const char *channel_type,
+                                         unsigned int channel_type_len,
+                                         unsigned int window_size,
+                                         unsigned int packet_size,
+                                         const char *message,
+                                         unsigned int message_len)
 {
     LIBSSH2_CHANNEL *ptr;
 
@@ -439,9 +442,10 @@ channel_direct_tcpip(LIBSSH2_SESSION *session, const char *host,
  *
  * Tunnel TCP/IP connect through the SSH session to direct host/port
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
-                                int port, const char *shost, int sport)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session,
+                                                 const char *host, int port,
+                                                 const char *shost, int sport)
 {
     LIBSSH2_CHANNEL *ptr;
 
@@ -517,10 +521,10 @@ channel_direct_streamlocal(LIBSSH2_SESSION *session, const char *socket_path,
  *
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_direct_streamlocal_ex(LIBSSH2_SESSION *session,
-                                      const char *socket_path,
-                                      const char *shost, int sport)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_channel_direct_streamlocal_ex(
+    LIBSSH2_SESSION *session,
+    const char *socket_path, const char *shost, int sport)
 {
     LIBSSH2_CHANNEL *ptr;
 
@@ -692,9 +696,11 @@ channel_forward_listen(LIBSSH2_SESSION *session, const char *host,
  *
  * Bind a port on the remote host and listen for connections
  */
-LIBSSH2_API LIBSSH2_LISTENER *
-libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session, const char *host,
-                                  int port, int *bound_port, int queue_maxsize)
+LIBSSH2_API
+LIBSSH2_LISTENER *libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session,
+                                                    const char *host,
+                                                    int port, int *bound_port,
+                                                    int queue_maxsize)
 {
     LIBSSH2_LISTENER *ptr;
 
@@ -805,8 +811,8 @@ int _libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
  *
  * Return 0 on success, LIBSSH2_ERROR_EAGAIN if would block, -1 on error
  */
-LIBSSH2_API int
-libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
+LIBSSH2_API
+int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
 {
     int rc;
 
@@ -861,8 +867,8 @@ channel_forward_accept(LIBSSH2_LISTENER *listener)
  *
  * Accept a connection
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_forward_accept(LIBSSH2_LISTENER *listener)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_channel_forward_accept(LIBSSH2_LISTENER *listener)
 {
     LIBSSH2_CHANNEL *ptr;
 
@@ -987,10 +993,10 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
  *
  * Set an environment variable prior to requesting a shell/program/subsystem
  */
-LIBSSH2_API int
-libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
-                          const char *varname, unsigned int varname_len,
-                          const char *value, unsigned int value_len)
+LIBSSH2_API
+int libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
+                              const char *varname, unsigned int varname_len,
+                              const char *value, unsigned int value_len)
 {
     int rc;
 
@@ -1217,8 +1223,8 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
  * listener on the remote side. Once the channel is closed, the agent
  * listener continues to exist.
  */
-LIBSSH2_API int
-libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel)
+LIBSSH2_API
+int libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel)
 {
     int rc;
 
@@ -1267,11 +1273,12 @@ libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel)
  * libssh2_channel_request_pty_ex
  * Duh... Request a PTY
  */
-LIBSSH2_API int
-libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel, const char *term,
-                               unsigned int term_len, const char *modes,
-                               unsigned int modes_len, int width, int height,
-                               int width_px, int height_px)
+LIBSSH2_API
+int libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel, const char *term,
+                                   unsigned int term_len, const char *modes,
+                                   unsigned int modes_len,
+                                   int width, int height,
+                                   int width_px, int height_px)
 {
     int rc;
 
@@ -1343,9 +1350,10 @@ channel_request_pty_size(LIBSSH2_CHANNEL *channel, int width,
     return retcode;
 }
 
-LIBSSH2_API int
-libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel, int width,
-                                    int height, int width_px, int height_px)
+LIBSSH2_API
+int libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel,
+                                        int width, int height,
+                                        int width_px, int height_px)
 {
     int rc;
 
@@ -1500,10 +1508,10 @@ channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
  * libssh2_channel_x11_req_ex
  * Request X11 forwarding
  */
-LIBSSH2_API int
-libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel, int single_connection,
-                           const char *auth_proto, const char *auth_cookie,
-                           int screen_number)
+LIBSSH2_API
+int libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel, int single_connection,
+                               const char *auth_proto, const char *auth_cookie,
+                               int screen_number)
 {
     int rc;
 
@@ -1630,10 +1638,12 @@ _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
  *
  * Primitive for libssh2_channel_(shell|exec|subsystem)
  */
-LIBSSH2_API int
-libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
-                                const char *request, unsigned int request_len,
-                                const char *message, unsigned int message_len)
+LIBSSH2_API
+int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
+                                    const char *request,
+                                    unsigned int request_len,
+                                    const char *message,
+                                    unsigned int message_len)
 {
     int rc;
 
@@ -1653,8 +1663,8 @@ libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
  * Set a channel's BEHAVIOR blocking on or off. The socket will remain non-
  * blocking.
  */
-LIBSSH2_API void
-libssh2_channel_set_blocking(LIBSSH2_CHANNEL *channel, int blocking)
+LIBSSH2_API
+void libssh2_channel_set_blocking(LIBSSH2_CHANNEL *channel, int blocking)
 {
     if(channel)
         (void)_libssh2_session_set_blocking(channel->session, blocking);
@@ -1763,8 +1773,8 @@ _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
  * Flush data from one (or all) stream
  * Returns number of bytes flushed, or negative on failure
  */
-LIBSSH2_API int
-libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel, int streamid)
+LIBSSH2_API
+int libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel, int streamid)
 {
     int rc;
 
@@ -1784,8 +1794,8 @@ libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel, int streamid)
  * return error values in case of errors so we return a zero if channel is
  * NULL.
  */
-LIBSSH2_API int
-libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel)
+LIBSSH2_API
+int libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel)
 {
     if(!channel)
         return 0;
@@ -1803,14 +1813,14 @@ libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel)
  * corresponding string parameter is NULL.  Returns LIBSSH2_ERROR_NONE
  * on success, or an API error code.
  */
-LIBSSH2_API int
-libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
-                                char **exitsignal,
-                                size_t *exitsignal_len,
-                                char **errmsg,
-                                size_t *errmsg_len,
-                                char **langtag,
-                                size_t *langtag_len)
+LIBSSH2_API
+int libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
+                                    char **exitsignal,
+                                    size_t *exitsignal_len,
+                                    char **errmsg,
+                                    size_t *errmsg_len,
+                                    char **langtag,
+                                    size_t *langtag_len)
 {
     size_t namelen = 0;
 
@@ -1946,10 +1956,10 @@ _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
  * Note that it might return EAGAIN too which is highly stupid.
  *
  */
-LIBSSH2_API unsigned long
-libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
-                                      unsigned long adjustment,
-                                      unsigned char force)
+LIBSSH2_API
+unsigned long libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
+                                                    unsigned long adjustment,
+                                                    unsigned char force)
 {
     unsigned int window;
     int rc;
@@ -1979,11 +1989,11 @@ libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
  *
  * Returns the "normal" error code: 0 for success, negative for failure.
  */
-LIBSSH2_API int
-libssh2_channel_receive_window_adjust2(LIBSSH2_CHANNEL *channel,
-                                       unsigned long adjustment,
-                                       unsigned char force,
-                                       unsigned int *storewindow)
+LIBSSH2_API
+int libssh2_channel_receive_window_adjust2(LIBSSH2_CHANNEL *channel,
+                                           unsigned long adjustment,
+                                           unsigned char force,
+                                           unsigned int *storewindow)
 {
     int rc;
 
@@ -2028,9 +2038,9 @@ _libssh2_channel_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode)
  * libssh2_channel_handle_extended_data2
  *
  */
-LIBSSH2_API int
-libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
-                                      int ignore_mode)
+LIBSSH2_API
+int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
+                                          int ignore_mode)
 {
     int rc;
 
@@ -2051,9 +2061,9 @@ libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
  * standard data? [everything via _read()]? (MERGE) Ignore it entirely [toss
  * out packets as they come in]? (IGNORE)
  */
-LIBSSH2_API void
-libssh2_channel_handle_extended_data(LIBSSH2_CHANNEL *channel,
-                                     int ignore_mode)
+LIBSSH2_API
+void libssh2_channel_handle_extended_data(LIBSSH2_CHANNEL *channel,
+                                          int ignore_mode)
 {
     (void)libssh2_channel_handle_extended_data2(channel, ignore_mode);
 }
@@ -2241,9 +2251,9 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
  * receive a full buffer's wort of contents. An application may choose to
  * adjust the receive window more to increase transfer performance.
  */
-LIBSSH2_API ssize_t
-libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id, char *buf,
-                        size_t buflen)
+LIBSSH2_API
+ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id,
+                                char *buf, size_t buflen)
 {
     ssize_t rc;
     unsigned long recv_window;
@@ -2473,9 +2483,9 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
  *
  * Send data to a channel
  */
-LIBSSH2_API ssize_t
-libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
-                         const char *buf, size_t buflen)
+LIBSSH2_API
+ssize_t libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
+                                 const char *buf, size_t buflen)
 {
     ssize_t rc;
 
@@ -2524,8 +2534,8 @@ static int channel_send_eof(LIBSSH2_CHANNEL *channel)
  *
  * Send EOF on channel
  */
-LIBSSH2_API int
-libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel)
+LIBSSH2_API
+int libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel)
 {
     int rc;
 
@@ -2541,8 +2551,8 @@ libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel)
  *
  * Read channel's eof status
  */
-LIBSSH2_API int
-libssh2_channel_eof(LIBSSH2_CHANNEL *channel)
+LIBSSH2_API
+int libssh2_channel_eof(LIBSSH2_CHANNEL *channel)
 {
     LIBSSH2_SESSION *session;
     struct packet *packet;
@@ -2632,8 +2642,8 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
  *
  * Awaiting channel EOF
  */
-LIBSSH2_API int
-libssh2_channel_wait_eof(LIBSSH2_CHANNEL *channel)
+LIBSSH2_API
+int libssh2_channel_wait_eof(LIBSSH2_CHANNEL *channel)
 {
     int rc;
 
@@ -2730,8 +2740,8 @@ int _libssh2_channel_close(LIBSSH2_CHANNEL *channel)
  *
  * Close a channel
  */
-LIBSSH2_API int
-libssh2_channel_close(LIBSSH2_CHANNEL *channel)
+LIBSSH2_API
+int libssh2_channel_close(LIBSSH2_CHANNEL *channel)
 {
     int rc;
 
@@ -2791,8 +2801,8 @@ static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
  *
  * Awaiting channel close after EOF
  */
-LIBSSH2_API int
-libssh2_channel_wait_closed(LIBSSH2_CHANNEL *channel)
+LIBSSH2_API
+int libssh2_channel_wait_closed(LIBSSH2_CHANNEL *channel)
 {
     int rc;
 
@@ -2938,8 +2948,8 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
  *
  * Returns 0 on success, negative on failure
  */
-LIBSSH2_API int
-libssh2_channel_free(LIBSSH2_CHANNEL *channel)
+LIBSSH2_API
+int libssh2_channel_free(LIBSSH2_CHANNEL *channel)
 {
     int rc;
 
@@ -2958,10 +2968,11 @@ libssh2_channel_free(LIBSSH2_CHANNEL *channel)
  * read window_size_initial (if passed) will be populated with the
  * window_size_initial as defined by the channel_open request
  */
-LIBSSH2_API unsigned long
-libssh2_channel_window_read_ex(LIBSSH2_CHANNEL *channel,
-        /* FIXME: -> size_t */ unsigned long *read_avail,
-                               unsigned long *window_size_initial)
+LIBSSH2_API
+unsigned long libssh2_channel_window_read_ex(
+    LIBSSH2_CHANNEL *channel,
+    unsigned long *read_avail, /* FIXME: -> size_t */
+    unsigned long *window_size_initial)
 {
     if(!channel)
         return 0; /* no channel, no window! */
@@ -3013,9 +3024,10 @@ libssh2_channel_window_read_ex(LIBSSH2_CHANNEL *channel,
  * passed) will be populated with the size of the initial window as defined by
  * the channel_open request
  */
-LIBSSH2_API unsigned long
-libssh2_channel_window_write_ex(LIBSSH2_CHANNEL *channel,
-                                unsigned long *window_size_initial)
+LIBSSH2_API
+unsigned long libssh2_channel_window_write_ex(
+    LIBSSH2_CHANNEL *channel,
+    unsigned long *window_size_initial)
 {
     if(!channel)
         return 0; /* no channel, no window! */
@@ -3098,10 +3110,9 @@ static int channel_signal(LIBSSH2_CHANNEL *channel,
     return retcode;
 }
 
-LIBSSH2_API int
-libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
-                          const char *signame,
-                          size_t signame_len)
+LIBSSH2_API
+int libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
+                              const char *signame, size_t signame_len)
 {
     int rc;
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -381,9 +381,9 @@ LIBSSH2_CHANNEL *libssh2_channel_open_ex(LIBSSH2_SESSION *session,
  *
  * Tunnel TCP/IP connect through the SSH session to direct host/port
  */
-static LIBSSH2_CHANNEL *
-channel_direct_tcpip(LIBSSH2_SESSION *session, const char *host,
-                     int port, const char *shost, int sport)
+static LIBSSH2_CHANNEL *channel_direct_tcpip(LIBSSH2_SESSION *session,
+                                             const char *host, int port,
+                                             const char *shost, int sport)
 {
     LIBSSH2_CHANNEL *channel;
     unsigned char *s;
@@ -463,9 +463,10 @@ LIBSSH2_CHANNEL *libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session,
  *
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
-static LIBSSH2_CHANNEL *
-channel_direct_streamlocal(LIBSSH2_SESSION *session, const char *socket_path,
-                           const char *shost, int sport)
+static LIBSSH2_CHANNEL *channel_direct_streamlocal(
+    LIBSSH2_SESSION *session,
+    const char *socket_path,
+    const char *shost, int sport)
 {
     LIBSSH2_CHANNEL *channel;
     unsigned char *s;
@@ -542,9 +543,10 @@ LIBSSH2_CHANNEL *libssh2_channel_direct_streamlocal_ex(
  *
  * Bind a port on the remote host and listen for connections
  */
-static LIBSSH2_LISTENER *
-channel_forward_listen(LIBSSH2_SESSION *session, const char *host,
-                       int port, int *bound_port, int queue_maxsize)
+static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
+                                                const char *host, int port,
+                                                int *bound_port,
+                                                int queue_maxsize)
 {
     unsigned char *s;
     static const unsigned char reply_codes[3] =
@@ -829,8 +831,7 @@ int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
  *
  * Accept a connection
  */
-static LIBSSH2_CHANNEL *
-channel_forward_accept(LIBSSH2_LISTENER *listener)
+static LIBSSH2_CHANNEL *channel_forward_accept(LIBSSH2_LISTENER *listener)
 {
     int rc;
 
@@ -1292,9 +1293,8 @@ int libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel, const char *term,
     return rc;
 }
 
-static int
-channel_request_pty_size(LIBSSH2_CHANNEL *channel, int width,
-                         int height, int width_px, int height_px)
+static int channel_request_pty_size(LIBSSH2_CHANNEL *channel, int width,
+                                    int height, int width_px, int height_px)
 {
     LIBSSH2_SESSION *session = channel->session;
     unsigned char *s;
@@ -1373,10 +1373,9 @@ int libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel,
  * channel_x11_req
  * Request X11 forwarding
  */
-static int
-channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
-                const char *auth_proto, const char *auth_cookie,
-                int screen_number)
+static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
+                           const char *auth_proto, const char *auth_cookie,
+                           int screen_number)
 {
     LIBSSH2_SESSION *session = channel->session;
     unsigned char *s;

--- a/src/channel.c
+++ b/src/channel.c
@@ -56,8 +56,6 @@
 #include "session.h"
 
 /*
- *  _libssh2_channel_nextid
- *
  * Determine the next channel ID we can use at our end
  */
 uint32_t
@@ -89,8 +87,6 @@ _libssh2_channel_nextid(LIBSSH2_SESSION *session)
 }
 
 /*
- * _libssh2_channel_locate
- *
  * Locate a channel pointer by number
  */
 LIBSSH2_CHANNEL *
@@ -123,8 +119,6 @@ _libssh2_channel_locate(LIBSSH2_SESSION *session, uint32_t channel_id)
 }
 
 /*
- * _libssh2_channel_open
- *
  * Establish a generic session channel
  */
 LIBSSH2_CHANNEL *
@@ -349,8 +343,6 @@ channel_error:
 }
 
 /*
- * libssh2_channel_open_ex
- *
  * Establish a generic session channel
  */
 LIBSSH2_API
@@ -377,8 +369,6 @@ LIBSSH2_CHANNEL *libssh2_channel_open_ex(LIBSSH2_SESSION *session,
 }
 
 /*
- * libssh2_channel_direct_tcpip_ex
- *
  * Tunnel TCP/IP connect through the SSH session to direct host/port
  */
 static LIBSSH2_CHANNEL *channel_direct_tcpip(LIBSSH2_SESSION *session,
@@ -438,8 +428,6 @@ static LIBSSH2_CHANNEL *channel_direct_tcpip(LIBSSH2_SESSION *session,
 }
 
 /*
- * libssh2_channel_direct_tcpip_ex
- *
  * Tunnel TCP/IP connect through the SSH session to direct host/port
  */
 LIBSSH2_API
@@ -459,8 +447,6 @@ LIBSSH2_CHANNEL *libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session,
 }
 
 /*
- * libssh2_channel_direct_streamlocal_ex
- *
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
 static LIBSSH2_CHANNEL *channel_direct_streamlocal(
@@ -518,8 +504,6 @@ static LIBSSH2_CHANNEL *channel_direct_streamlocal(
 }
 
 /*
- * libssh2_channel_direct_streamlocal_ex
- *
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
 LIBSSH2_API
@@ -539,8 +523,6 @@ LIBSSH2_CHANNEL *libssh2_channel_direct_streamlocal_ex(
 }
 
 /*
- * channel_forward_listen
- *
  * Bind a port on the remote host and listen for connections
  */
 static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
@@ -694,8 +676,6 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
 }
 
 /*
- * libssh2_channel_forward_listen_ex
- *
  * Bind a port on the remote host and listen for connections
  */
 LIBSSH2_API
@@ -716,8 +696,6 @@ LIBSSH2_LISTENER *libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session,
 }
 
 /*
- * _libssh2_channel_forward_cancel
- *
  * Stop listening on a remote port and free the listener
  * Toss out any pending (un-accept()ed) connections
  *
@@ -806,8 +784,6 @@ int _libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
 }
 
 /*
- * libssh2_channel_forward_cancel
- *
  * Stop listening on a remote port and free the listener
  * Toss out any pending (un-accept()ed) connections
  *
@@ -827,8 +803,6 @@ int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
 }
 
 /*
- * channel_forward_accept
- *
  * Accept a connection
  */
 static LIBSSH2_CHANNEL *channel_forward_accept(LIBSSH2_LISTENER *listener)
@@ -864,8 +838,6 @@ static LIBSSH2_CHANNEL *channel_forward_accept(LIBSSH2_LISTENER *listener)
 }
 
 /*
- * libssh2_channel_forward_accept
- *
  * Accept a connection
  */
 LIBSSH2_API
@@ -882,8 +854,6 @@ LIBSSH2_CHANNEL *libssh2_channel_forward_accept(LIBSSH2_LISTENER *listener)
 }
 
 /*
- * channel_setenv
- *
  * Set an environment variable prior to requesting a shell/program/subsystem
  */
 static int channel_setenv(LIBSSH2_CHANNEL *channel,
@@ -990,8 +960,6 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
 }
 
 /*
- * libssh2_channel_setenv_ex
- *
  * Set an environment variable prior to requesting a shell/program/subsystem
  */
 LIBSSH2_API
@@ -1011,7 +979,6 @@ int libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
 }
 
 /*
- * channel_request_pty
  * Duh... Request a PTY
  */
 static int channel_request_pty(LIBSSH2_CHANNEL *channel,
@@ -1112,10 +1079,9 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
                           "channel request-pty");
 }
 
-/**
- * channel_request_auth_agent
+/*
  * The actual re-entrant method which requests an auth agent.
- * */
+ */
 static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
                                       const char *request_str,
                                       int request_str_len)
@@ -1217,8 +1183,6 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
 }
 
 /*
- * libssh2_channel_request_auth_agent
- *
  * Requests that agent forwarding be enabled for the session. The
  * request must be sent over a specific channel, which starts the agent
  * listener on the remote side. Once the channel is closed, the agent
@@ -1271,7 +1235,6 @@ int libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * libssh2_channel_request_pty_ex
  * Duh... Request a PTY
  */
 LIBSSH2_API
@@ -1370,7 +1333,6 @@ int libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel,
 #define LIBSSH2_X11_RANDOM_COOKIE_LEN       32
 
 /*
- * channel_x11_req
  * Request X11 forwarding
  */
 static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
@@ -1504,7 +1466,6 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
 }
 
 /*
- * libssh2_channel_x11_req_ex
  * Request X11 forwarding
  */
 LIBSSH2_API
@@ -1524,8 +1485,6 @@ int libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel, int single_connection,
 }
 
 /*
- * _libssh2_channel_process_startup
- *
  * Primitive for libssh2_channel_(shell|exec|subsystem)
  */
 int
@@ -1633,8 +1592,6 @@ _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
 }
 
 /*
- * libssh2_channel_process_startup
- *
  * Primitive for libssh2_channel_(shell|exec|subsystem)
  */
 LIBSSH2_API
@@ -1657,8 +1614,6 @@ int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
 }
 
 /*
- * libssh2_channel_set_blocking
- *
  * Set a channel's BEHAVIOR blocking on or off. The socket will remain non-
  * blocking.
  */
@@ -1670,8 +1625,6 @@ void libssh2_channel_set_blocking(LIBSSH2_CHANNEL *channel, int blocking)
 }
 
 /*
- * _libssh2_channel_flush
- *
  * Flush data from one (or all) stream
  * Returns number of bytes flushed, or negative on failure
  */
@@ -1767,8 +1720,6 @@ _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
 }
 
 /*
- * libssh2_channel_flush_ex
- *
  * Flush data from one (or all) stream
  * Returns number of bytes flushed, or negative on failure
  */
@@ -1786,8 +1737,6 @@ int libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel, int streamid)
 }
 
 /*
- * libssh2_channel_get_exit_status
- *
  * Return the channel's program exit status. Note that the actual protocol
  * provides the full 32bit this function returns.  We cannot abuse it to
  * return error values in case of errors so we return a zero if channel is
@@ -1803,8 +1752,6 @@ int libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * libssh2_channel_get_exit_signal
- *
  * Get exit signal (without leading "SIG"), error message, and language
  * tag into newly allocated buffers of indicated length.  Caller can
  * use NULL pointers to indicate that the value should not be set.  The
@@ -1866,8 +1813,6 @@ int libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
 }
 
 /*
- * _libssh2_channel_receive_window_adjust
- *
  * Adjust the receive window for a channel by adjustment bytes. If the amount
  * to be adjusted is less than LIBSSH2_CHANNEL_MINADJUST and force is 0 the
  * adjustment amount will be queued for a later packet.
@@ -1945,7 +1890,7 @@ _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
 
 #ifndef LIBSSH2_NO_DEPRECATED
 /*
- * libssh2_channel_receive_window_adjust (DEPRECATED, DO NOT USE!)
+ * DEPRECATED, DO NOT USE!
  *
  * Adjust the receive window for a channel by adjustment bytes. If the amount
  * to be adjusted is less than LIBSSH2_CHANNEL_MINADJUST and force is 0 the
@@ -1978,8 +1923,6 @@ unsigned long libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
 #endif
 
 /*
- * libssh2_channel_receive_window_adjust2
- *
  * Adjust the receive window for a channel by adjustment bytes. If the amount
  * to be adjusted is less than LIBSSH2_CHANNEL_MINADJUST and force is 0 the
  * adjustment amount will be queued for a later packet.
@@ -2033,10 +1976,6 @@ _libssh2_channel_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode)
     return 0;
 }
 
-/*
- * libssh2_channel_handle_extended_data2
- *
- */
 LIBSSH2_API
 int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
                                           int ignore_mode)
@@ -2053,7 +1992,7 @@ int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
 
 #ifndef LIBSSH2_NO_DEPRECATED
 /*
- * libssh2_channel_handle_extended_data (DEPRECATED, DO NOT USE!)
+ * DEPRECATED, DO NOT USE!
  *
  * How should extended data look to the calling app?  Keep it in separate
  * channels[_read() _read_stdder()]? (NORMAL) Merge the extended data to the
@@ -2069,8 +2008,6 @@ void libssh2_channel_handle_extended_data(LIBSSH2_CHANNEL *channel,
 #endif
 
 /*
- * _libssh2_channel_read
- *
  * Read data from a channel
  *
  * It is important to not return 0 until the currently read channel is
@@ -2237,8 +2174,6 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
 }
 
 /*
- * libssh2_channel_read_ex
- *
  * Read data from a channel (blocking or non-blocking depending on set state)
  *
  * When this is done non-blocking, it is important to not return 0 until the
@@ -2274,8 +2209,6 @@ ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id,
 }
 
 /*
- * _libssh2_channel_packet_data_len
- *
  * Return the size of the data block of the current packet, or 0 if there
  * isn't a packet.
  */
@@ -2334,8 +2267,6 @@ _libssh2_channel_packet_data_len(LIBSSH2_CHANNEL *channel, int stream_id)
 }
 
 /*
- * _libssh2_channel_write
- *
  * Send data to a channel. Note that if this returns EAGAIN, the caller must
  * call this function again with the SAME input arguments.
  *
@@ -2478,8 +2409,6 @@ _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
 }
 
 /*
- * libssh2_channel_write_ex
- *
  * Send data to a channel
  */
 LIBSSH2_API
@@ -2498,8 +2427,6 @@ ssize_t libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
 }
 
 /*
- * channel_send_eof
- *
  * Send EOF on channel
  */
 static int channel_send_eof(LIBSSH2_CHANNEL *channel)
@@ -2529,8 +2456,6 @@ static int channel_send_eof(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * libssh2_channel_send_eof
- *
  * Send EOF on channel
  */
 LIBSSH2_API
@@ -2546,8 +2471,6 @@ int libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * libssh2_channel_eof
- *
  * Read channel's eof status
  */
 LIBSSH2_API
@@ -2588,8 +2511,6 @@ int libssh2_channel_eof(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * channel_wait_eof
- *
  * Awaiting channel EOF
  */
 static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
@@ -2637,8 +2558,6 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * libssh2_channel_wait_eof
- *
  * Awaiting channel EOF
  */
 LIBSSH2_API
@@ -2735,8 +2654,6 @@ int _libssh2_channel_close(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * libssh2_channel_close
- *
  * Close a channel
  */
 LIBSSH2_API
@@ -2752,8 +2669,6 @@ int libssh2_channel_close(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * channel_wait_closed
- *
  * Awaiting channel close after EOF
  */
 static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
@@ -2796,8 +2711,6 @@ static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * libssh2_channel_wait_closed
- *
  * Awaiting channel close after EOF
  */
 LIBSSH2_API
@@ -2813,8 +2726,6 @@ int libssh2_channel_wait_closed(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * _libssh2_channel_free
- *
  * Make sure a channel is closed, then remove the channel from the session
  * and free its resource(s)
  *
@@ -2940,8 +2851,6 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
 }
 
 /*
- * libssh2_channel_free
- *
  * Make sure a channel is closed, then remove the channel from the session
  * and free its resource(s)
  *
@@ -2958,9 +2867,8 @@ int libssh2_channel_free(LIBSSH2_CHANNEL *channel)
     BLOCK_ADJUST(rc, channel->session, _libssh2_channel_free(channel));
     return rc;
 }
+
 /*
- * libssh2_channel_window_read_ex
- *
  * Check the status of the read window. Returns the number of bytes which the
  * remote end may send without overflowing the window limit read_avail (if
  * passed) will be populated with the number of bytes actually available to be
@@ -3016,8 +2924,6 @@ unsigned long libssh2_channel_window_read_ex(
 }
 
 /*
- * libssh2_channel_window_write_ex
- *
  * Check the status of the write window Returns the number of bytes which may
  * be safely written on the channel without blocking window_size_initial (if
  * passed) will be populated with the size of the initial window as defined by

--- a/src/cipher-chachapoly.c
+++ b/src/cipher-chachapoly.c
@@ -24,12 +24,10 @@
 #include "misc.h"
 #include "cipher-chachapoly.h"
 
-int
-chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n);
+int chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n);
 
-int
-chachapoly_init(struct chachapoly_ctx *ctx, const unsigned char *key,
-                size_t keylen)
+int chachapoly_init(struct chachapoly_ctx *ctx, const unsigned char *key,
+                    size_t keylen)
 {
     if(keylen != (32 + 32)) /* 2 x 256 bit keys */
         return LIBSSH2_ERROR_INVAL;
@@ -47,10 +45,9 @@ chachapoly_init(struct chachapoly_ctx *ctx, const unsigned char *key,
  * POLY1305_TAGLEN bytes at offset 'len'+'aadlen' as the authentication
  * tag. This tag is written on encryption and verified on decryption.
  */
-int
-chachapoly_crypt(struct chachapoly_ctx *ctx, libssh2_uint64_t seqnr,
-                 unsigned char *dest, const unsigned char *src, size_t len,
-                 size_t aadlen, int do_encrypt)
+int chachapoly_crypt(struct chachapoly_ctx *ctx, libssh2_uint64_t seqnr,
+                     unsigned char *dest, const unsigned char *src, size_t len,
+                     size_t aadlen, int do_encrypt)
 {
     unsigned char seqbuf[8];
     const unsigned char one[8] = {
@@ -108,10 +105,9 @@ out:
 }
 
 /* Decrypt and extract the encrypted packet length */
-int
-chachapoly_get_length(struct chachapoly_ctx *ctx, unsigned int *plenp,
-                      libssh2_uint64_t seqnr, const unsigned char *cp,
-                      size_t len)
+int chachapoly_get_length(struct chachapoly_ctx *ctx, unsigned int *plenp,
+                          libssh2_uint64_t seqnr, const unsigned char *cp,
+                          size_t len)
 {
     unsigned char buf[4], seqbuf[8];
     unsigned char *ptr = NULL;
@@ -126,8 +122,7 @@ chachapoly_get_length(struct chachapoly_ctx *ctx, unsigned int *plenp,
     return 0;
 }
 
-int
-chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n)
+int chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n)
 {
     const unsigned char *p1 = b1, *p2 = b2;
     int ret = 0;

--- a/src/comp.c
+++ b/src/comp.c
@@ -56,13 +56,12 @@
  *
  * Minimalist compression: Absolutely none
  */
-static int
-comp_method_none_comp(LIBSSH2_SESSION *session,
-                      unsigned char *dest,
-                      size_t *dest_len,
-                      const unsigned char *src,
-                      size_t src_len,
-                      void **abstract)
+static int comp_method_none_comp(LIBSSH2_SESSION *session,
+                                 unsigned char *dest,
+                                 size_t *dest_len,
+                                 const unsigned char *src,
+                                 size_t src_len,
+                                 void **abstract)
 {
     (void)session;
     (void)abstract;
@@ -79,13 +78,12 @@ comp_method_none_comp(LIBSSH2_SESSION *session,
  *
  * Minimalist decompression: Absolutely none
  */
-static int
-comp_method_none_decomp(LIBSSH2_SESSION *session,
-                        unsigned char **dest,
-                        size_t *dest_len,
-                        size_t payload_limit,
-                        const unsigned char *src,
-                        size_t src_len, void **abstract)
+static int comp_method_none_decomp(LIBSSH2_SESSION *session,
+                                   unsigned char **dest,
+                                   size_t *dest_len,
+                                   size_t payload_limit,
+                                   const unsigned char *src,
+                                   size_t src_len, void **abstract)
 {
     (void)session;
     (void)dest;
@@ -118,8 +116,7 @@ static const struct comp_method comp_method_none = {
  * Deal...
  */
 
-static voidpf
-comp_method_zlib_alloc(voidpf opaque, uInt items, uInt size)
+static voidpf comp_method_zlib_alloc(voidpf opaque, uInt items, uInt size)
 {
     LIBSSH2_SESSION *session = (LIBSSH2_SESSION *)opaque;
 
@@ -130,8 +127,7 @@ comp_method_zlib_alloc(voidpf opaque, uInt items, uInt size)
     return (voidpf)LIBSSH2_ALLOC(session, items * (size_t)size);
 }
 
-static void
-comp_method_zlib_free(voidpf opaque, voidpf address)
+static void comp_method_zlib_free(voidpf opaque, voidpf address)
 {
     LIBSSH2_SESSION *session = (LIBSSH2_SESSION *)opaque;
 
@@ -141,9 +137,8 @@ comp_method_zlib_free(voidpf opaque, voidpf address)
 /* libssh2_comp_method_zlib_init
  * All your bandwidth are belong to us (so save some)
  */
-static int
-comp_method_zlib_init(LIBSSH2_SESSION *session, int compr,
-                      void **abstract)
+static int comp_method_zlib_init(LIBSSH2_SESSION *session, int compr,
+                                 void **abstract)
 {
     z_stream *strm;
     int status;
@@ -183,16 +178,15 @@ comp_method_zlib_init(LIBSSH2_SESSION *session, int compr,
  *
  * Compresses source to destination. Without allocation.
  */
-static int
-comp_method_zlib_comp(LIBSSH2_SESSION *session,
-                      unsigned char *dest,
-
-                      /* dest_len is a pointer to allow this function to
-                         update it with the final actual size used */
-                      size_t *dest_len,
-                      const unsigned char *src,
-                      size_t src_len,
-                      void **abstract)
+static int comp_method_zlib_comp(LIBSSH2_SESSION *session,
+                                 unsigned char *dest,
+                                 /* dest_len is a pointer to allow this
+                                    function to update it with the final
+                                    actual size used */
+                                 size_t *dest_len,
+                                 const unsigned char *src,
+                                 size_t src_len,
+                                 void **abstract)
 {
     z_stream *strm = *abstract;
     uInt out_maxlen = (uInt)*dest_len;
@@ -221,13 +215,12 @@ comp_method_zlib_comp(LIBSSH2_SESSION *session,
  *
  * Decompresses source to destination. Allocates the output memory.
  */
-static int
-comp_method_zlib_decomp(LIBSSH2_SESSION *session,
-                        unsigned char **dest,
-                        size_t *dest_len,
-                        size_t payload_limit,
-                        const unsigned char *src,
-                        size_t src_len, void **abstract)
+static int comp_method_zlib_decomp(LIBSSH2_SESSION *session,
+                                   unsigned char **dest,
+                                   size_t *dest_len,
+                                   size_t payload_limit,
+                                   const unsigned char *src,
+                                   size_t src_len, void **abstract)
 {
     z_stream *strm = *abstract;
     /* A short-term alloc of a full data chunk is better than a series of
@@ -327,8 +320,8 @@ comp_method_zlib_decomp(LIBSSH2_SESSION *session,
 /* libssh2_comp_method_zlib_dtor
  * All done, no more compression for you
  */
-static int
-comp_method_zlib_dtor(LIBSSH2_SESSION *session, int compr, void **abstract)
+static int comp_method_zlib_dtor(LIBSSH2_SESSION *session, int compr,
+                                 void **abstract)
 {
     z_stream *strm = *abstract;
 

--- a/src/comp.c
+++ b/src/comp.c
@@ -47,13 +47,11 @@
 
 #include "comp.h"
 
-/* ********
+/* ******
  * none *
- ******** */
+ ****** */
 
 /*
- * comp_method_none_comp
- *
  * Minimalist compression: Absolutely none
  */
 static int comp_method_none_comp(LIBSSH2_SESSION *session,
@@ -74,8 +72,6 @@ static int comp_method_none_comp(LIBSSH2_SESSION *session,
 }
 
 /*
- * comp_method_none_decomp
- *
  * Minimalist decompression: Absolutely none
  */
 static int comp_method_none_decomp(LIBSSH2_SESSION *session,
@@ -107,9 +103,9 @@ static const struct comp_method comp_method_none = {
 };
 
 #ifdef LIBSSH2_HAVE_ZLIB
-/* ********
+/* ******
  * zlib *
- ******** */
+ ****** */
 
 /* Memory management wrappers
  * Yes, I realize we're doing a callback to a callback,
@@ -134,7 +130,7 @@ static void comp_method_zlib_free(voidpf opaque, voidpf address)
     LIBSSH2_FREE(session, address);
 }
 
-/* libssh2_comp_method_zlib_init
+/*
  * All your bandwidth are belong to us (so save some)
  */
 static int comp_method_zlib_init(LIBSSH2_SESSION *session, int compr,
@@ -174,8 +170,6 @@ static int comp_method_zlib_init(LIBSSH2_SESSION *session, int compr,
 }
 
 /*
- * libssh2_comp_method_zlib_comp
- *
  * Compresses source to destination. Without allocation.
  */
 static int comp_method_zlib_comp(LIBSSH2_SESSION *session,
@@ -211,8 +205,6 @@ static int comp_method_zlib_comp(LIBSSH2_SESSION *session,
 }
 
 /*
- * libssh2_comp_method_zlib_decomp
- *
  * Decompresses source to destination. Allocates the output memory.
  */
 static int comp_method_zlib_decomp(LIBSSH2_SESSION *session,
@@ -317,7 +309,7 @@ static int comp_method_zlib_decomp(LIBSSH2_SESSION *session,
     return 0;
 }
 
-/* libssh2_comp_method_zlib_dtor
+/*
  * All done, no more compression for you
  */
 static int comp_method_zlib_dtor(LIBSSH2_SESSION *session, int compr,

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -57,13 +57,12 @@
  * end and that no more-preferable methods are available.
  *
  */
-static int
-crypt_none_crypt(LIBSSH2_SESSION *session,
-                 unsigned int seqno,
-                 unsigned char *buf,
-                 size_t buf_len,
-                 void **abstract,
-                 int firstlast)
+static int crypt_none_crypt(LIBSSH2_SESSION *session,
+                            unsigned int seqno,
+                            unsigned char *buf,
+                            size_t buf_len,
+                            void **abstract,
+                            int firstlast)
 {
     /* Do nothing to the data! */
     return 0;
@@ -90,12 +89,11 @@ struct crypt_ctx
     struct chachapoly_ctx chachapoly_ctx;
 };
 
-static int
-crypt_init(LIBSSH2_SESSION *session,
-           const struct crypt_method *method,
-           unsigned char *iv, int *free_iv,
-           unsigned char *secret, int *free_secret,
-           int encrypt, void **abstract)
+static int crypt_init(LIBSSH2_SESSION *session,
+                      const struct crypt_method *method,
+                      unsigned char *iv, int *free_iv,
+                      unsigned char *secret, int *free_secret,
+                      int encrypt, void **abstract)
 {
     struct crypt_ctx *ctx = LIBSSH2_ALLOC(session,
                                           sizeof(struct crypt_ctx));
@@ -114,13 +112,12 @@ crypt_init(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static int
-crypt_encrypt(LIBSSH2_SESSION *session,
-              unsigned int seqno,
-              unsigned char *buf,
-              size_t buf_len,
-              void **abstract,
-              int firstlast)
+static int crypt_encrypt(LIBSSH2_SESSION *session,
+                         unsigned int seqno,
+                         unsigned char *buf,
+                         size_t buf_len,
+                         void **abstract,
+                         int firstlast)
 {
     struct crypt_ctx *cctx = *(struct crypt_ctx **)abstract;
     (void)session;
@@ -129,8 +126,7 @@ crypt_encrypt(LIBSSH2_SESSION *session,
                                  buf_len, firstlast);
 }
 
-static int
-crypt_dtor(LIBSSH2_SESSION *session, void **abstract)
+static int crypt_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     struct crypt_ctx **cctx = (struct crypt_ctx **)abstract;
     if(cctx && *cctx) {
@@ -317,12 +313,11 @@ static const struct crypt_method crypt_method_arcfour = {
     libssh2_cipher_arcfour
 };
 
-static int
-crypt_init_arcfour128(LIBSSH2_SESSION *session,
-                      const struct crypt_method *method,
-                      unsigned char *iv, int *free_iv,
-                      unsigned char *secret, int *free_secret,
-                      int encrypt, void **abstract)
+static int crypt_init_arcfour128(LIBSSH2_SESSION *session,
+                                 const struct crypt_method *method,
+                                 unsigned char *iv, int *free_iv,
+                                 unsigned char *secret, int *free_secret,
+                                 int encrypt, void **abstract)
 {
     int rc;
 
@@ -391,12 +386,11 @@ static const struct crypt_method crypt_method_3des_cbc = {
 };
 #endif
 
-static int
-crypt_init_chacha20_poly(LIBSSH2_SESSION *session,
-           const struct crypt_method *method,
-           unsigned char *iv, int *free_iv,
-           unsigned char *secret, int *free_secret,
-           int encrypt, void **abstract)
+static int crypt_init_chacha20_poly(LIBSSH2_SESSION *session,
+                                    const struct crypt_method *method,
+                                    unsigned char *iv, int *free_iv,
+                                    unsigned char *secret, int *free_secret,
+                                    int encrypt, void **abstract)
 {
     struct crypt_ctx *ctx = LIBSSH2_ALLOC(session,
                                           sizeof(struct crypt_ctx));
@@ -420,13 +414,12 @@ crypt_init_chacha20_poly(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static int
-crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
-                                   unsigned int seqno,
-                                   unsigned char *buf,
-                                   size_t buf_len,
-                                   void **abstract,
-                                   int firstlast)
+static int crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
+                                              unsigned int seqno,
+                                              unsigned char *buf,
+                                              size_t buf_len,
+                                              void **abstract,
+                                              int firstlast)
 {
     int ret = 1;
     struct crypt_ctx *ctx = *(struct crypt_ctx **)abstract;
@@ -462,10 +455,11 @@ crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
     return (ret == 0) ? 0 : 1;
 }
 
-static int
-crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session, unsigned int seqno,
-                               unsigned char *data, size_t data_size,
-                               unsigned int *len, void **abstract)
+static int crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session,
+                                          unsigned int seqno,
+                                          unsigned char *data,
+                                          size_t data_size,
+                                          unsigned int *len, void **abstract)
 {
     struct crypt_ctx *ctx = *(struct crypt_ctx **)abstract;
 
@@ -475,8 +469,7 @@ crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session, unsigned int seqno,
                                  data_size);
 }
 
-static int
-crypt_dtor_chacha20_poly(LIBSSH2_SESSION *session, void **abstract)
+static int crypt_dtor_chacha20_poly(LIBSSH2_SESSION *session, void **abstract)
 {
     struct crypt_ctx **cctx = (struct crypt_ctx **)abstract;
     if(cctx && *cctx) {

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -44,7 +44,7 @@
 #include <assert.h>
 
 #if defined(LIBSSH2DEBUG) && defined(LIBSSH2_CRYPT_NONE_INSECURE)
-/* crypt_none_crypt
+/*
  * Minimalist cipher: no encryption. DO NOT USE.
  *
  * The SSH2 Transport allows for unencrypted data transmission using

--- a/src/global.c
+++ b/src/global.c
@@ -43,7 +43,8 @@
 static int s_initialized = 0;
 static int s_init_flags = 0;
 
-LIBSSH2_API int libssh2_init(int flags)
+LIBSSH2_API
+int libssh2_init(int flags)
 {
     if(s_initialized == 0 && !(flags & LIBSSH2_INIT_NO_CRYPTO)) {
         libssh2_crypto_init();
@@ -55,7 +56,8 @@ LIBSSH2_API int libssh2_init(int flags)
     return 0;
 }
 
-LIBSSH2_API void libssh2_exit(void)
+LIBSSH2_API
+void libssh2_exit(void)
 {
     if(s_initialized == 0)
         return;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -1393,8 +1393,8 @@ const struct hostkey_method **libssh2_hostkey_methods(void)
  * Length of buffer is determined by hash type
  * i.e. MD5 == 16, SHA1 == 20, SHA256 == 32
  */
-LIBSSH2_API const char *
-libssh2_hostkey_hash(LIBSSH2_SESSION *session, int hash_type)
+LIBSSH2_API
+const char *libssh2_hostkey_hash(LIBSSH2_SESSION *session, int hash_type)
 {
     switch(hash_type) {
 #if LIBSSH2_MD5
@@ -1480,8 +1480,9 @@ static int hostkey_type(const unsigned char *hostkey, size_t len)
  * Returns the server key and length.
  *
  */
-LIBSSH2_API const char *
-libssh2_session_hostkey(LIBSSH2_SESSION *session, size_t *len, int *type)
+LIBSSH2_API
+const char *libssh2_session_hostkey(LIBSSH2_SESSION *session, size_t *len,
+                                    int *type)
 {
     if(session->server_hostkey_len) {
         if(len)

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -46,16 +46,14 @@
 #endif
 
 #if LIBSSH2_RSA
-/* ***********
+/* *********
  * ssh-rsa *
- *********** */
+ ********* */
 
 static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
                                        void **abstract);
 
 /*
- * hostkey_method_ssh_rsa_init
- *
  * Initialize the server hostkey working area with e/n pair
  */
 static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
@@ -132,8 +130,6 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_rsa_initPEM
- *
  * Load a Private Key from a PEM file
  */
 static int hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION *session,
@@ -160,8 +156,6 @@ static int hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_rsa_initPEMFromMemory
- *
  * Load a Private Key from a memory
  */
 static int hostkey_method_ssh_rsa_initPEMFromMemory(
@@ -193,8 +187,6 @@ static int hostkey_method_ssh_rsa_initPEMFromMemory(
 
 #if LIBSSH2_RSA_SHA1
 /*
- * hostkey_method_ssh_rsa_sign
- *
  * Verify signature created by remote
  */
 static int hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION *session,
@@ -216,8 +208,6 @@ static int hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_rsa_signv
- *
  * Construct a signature from an array of vectors
  */
 static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
@@ -263,8 +253,6 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
 #endif
 
 /*
- * hostkey_method_ssh_rsa_sha2_256_sig_verify
- *
  * Verify signature created by remote
  */
 #if LIBSSH2_RSA_SHA2
@@ -291,11 +279,8 @@ static int hostkey_method_ssh_rsa_sha2_256_sig_verify(
 }
 
 /*
- * hostkey_method_ssh_rsa_sha2_256_signv
- *
  * Construct a signature from an array of vectors
  */
-
 static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
                                                  unsigned char **signature,
                                                  size_t *signature_len,
@@ -338,8 +323,6 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_rsa_sha2_512_sig_verify
- *
  * Verify signature created by remote
  */
 static int hostkey_method_ssh_rsa_sha2_512_sig_verify(
@@ -364,8 +347,6 @@ static int hostkey_method_ssh_rsa_sha2_512_sig_verify(
 }
 
 /*
- * hostkey_method_ssh_rsa_sha2_512_signv
- *
  * Construct a signature from an array of vectors
  */
 static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
@@ -412,8 +393,6 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
 #endif /* LIBSSH2_RSA_SHA2 */
 
 /*
- * hostkey_method_ssh_rsa_dtor
- *
  * Shutdown the hostkey
  */
 static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
@@ -520,16 +499,14 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512_cert = {
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
-/* ***********
+/* *********
  * ssh-dss *
- *********** */
+ ********* */
 
 static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
                                        void **abstract);
 
 /*
- * hostkey_method_ssh_dss_init
- *
  * Initialize the server hostkey working area with p/q/g/y set
  */
 static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
@@ -590,8 +567,6 @@ static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_dss_initPEM
- *
  * Load a Private Key from a PEM file
  */
 static int hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION *session,
@@ -618,8 +593,6 @@ static int hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_dss_initPEMFromMemory
- *
  * Load a Private Key from memory
  */
 static int hostkey_method_ssh_dss_initPEMFromMemory(
@@ -650,8 +623,6 @@ static int hostkey_method_ssh_dss_initPEMFromMemory(
 }
 
 /*
- * libssh2_hostkey_method_ssh_dss_sign
- *
  * Verify signature created by remote
  */
 static int hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION *session,
@@ -675,8 +646,6 @@ static int hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_dss_signv
- *
  * Construct a signature from an array of vectors
  */
 static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
@@ -723,8 +692,6 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
 }
 
 /*
- * libssh2_hostkey_method_ssh_dss_dtor
- *
  * Shutdown the hostkey method
  */
 static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
@@ -755,16 +722,14 @@ static const struct hostkey_method hostkey_method_ssh_dss = {
 
 #if LIBSSH2_ECDSA
 
-/* ***********
+/* *****************************
  * ecdsa-sha2-nistp256/384/521 *
- *********** */
+ ***************************** */
 
 static int hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
                                          void **abstract);
 
 /*
- * hostkey_method_ssh_ecdsa_init
- *
  * Initialize the server hostkey working area with e/n pair
  */
 static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
@@ -843,8 +808,6 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_ecdsa_initPEM
- *
  * Load a Private Key from a PEM file
  */
 static int hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION *session,
@@ -870,8 +833,6 @@ static int hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_ecdsa_initPEMFromMemory
- *
  * Load a Private Key from memory
  */
 static int hostkey_method_ssh_ecdsa_initPEMFromMemory(
@@ -904,8 +865,6 @@ static int hostkey_method_ssh_ecdsa_initPEMFromMemory(
 }
 
 /*
- * hostkey_method_ecdsa_sig_verify
- *
  * Verify signature created by remote
  */
 static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
@@ -976,8 +935,6 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
     } while(0)
 
 /*
- * hostkey_method_ecdsa_signv
- *
  * Construct a signature from an array of vectors
  */
 static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
@@ -1008,8 +965,6 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_ecdsa_dtor
- *
  * Shutdown the hostkey by freeing EC_KEY context
  */
 static int hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
@@ -1102,16 +1057,14 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521_cert = {
 
 #if LIBSSH2_ED25519
 
-/* ***********
+/* *********
  * ed25519 *
- *********** */
+ ********* */
 
 static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
                                            void **abstract);
 
 /*
- * hostkey_method_ssh_ed25519_init
- *
  * Initialize the server hostkey working area with e/n pair
  */
 static int hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
@@ -1159,8 +1112,6 @@ static int hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_ed25519_initPEM
- *
  * Load a Private Key from a PEM file
  */
 static int hostkey_method_ssh_ed25519_initPEM(
@@ -1189,8 +1140,6 @@ static int hostkey_method_ssh_ed25519_initPEM(
 }
 
 /*
- * hostkey_method_ssh_ed25519_initPEMFromMemory
- *
  * Load a Private Key from memory
  */
 static int hostkey_method_ssh_ed25519_initPEMFromMemory(
@@ -1223,8 +1172,6 @@ static int hostkey_method_ssh_ed25519_initPEMFromMemory(
 }
 
 /*
- * hostkey_method_ssh_ed25519_sig_verify
- *
  * Verify signature created by remote
  */
 static int hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION *session,
@@ -1251,8 +1198,6 @@ static int hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_ed25519_signv
- *
  * Construct a signature from an array of vectors
  */
 static int hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
@@ -1274,8 +1219,6 @@ static int hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
 }
 
 /*
- * hostkey_method_ssh_ed25519_dtor
- *
  * Shutdown the hostkey by freeing key context
  */
 static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
@@ -1319,8 +1262,6 @@ static const struct hostkey_method hostkey_method_ssh_ed25519_cert = {
 #endif /* LIBSSH2_ED25519 */
 
 /*
- * hostkey_methods
- *
  * Host Key order matches OpenSSH for compatibility
  */
 static const struct hostkey_method *hostkey_methods[] = {
@@ -1368,8 +1309,6 @@ const struct hostkey_method **libssh2_hostkey_methods(void)
 }
 
 /*
- * libssh2_hostkey_hash
- *
  * Returns hash signature
  * Returned buffer should NOT be freed
  * Length of buffer is determined by hash type
@@ -1457,10 +1396,7 @@ static int hostkey_type(const unsigned char *hostkey, size_t len)
 }
 
 /*
- * libssh2_session_hostkey
- *
  * Returns the server key and length.
- *
  */
 LIBSSH2_API
 const char *libssh2_session_hostkey(LIBSSH2_SESSION *session, size_t *len,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -58,11 +58,10 @@ static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
  *
  * Initialize the server hostkey working area with e/n pair
  */
-static int
-hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
-                            const unsigned char *hostkey_data,
-                            size_t hostkey_data_len,
-                            void **abstract)
+static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
+                                       const unsigned char *hostkey_data,
+                                       size_t hostkey_data_len,
+                                       void **abstract)
 {
     libssh2_rsa_ctx *rsactx;
     unsigned char *e, *n, *type;
@@ -137,11 +136,10 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
  *
  * Load a Private Key from a PEM file
  */
-static int
-hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION *session,
-                               const char *privkeyfile,
-                               const unsigned char *passphrase,
-                               void **abstract)
+static int hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION *session,
+                                          const char *privkeyfile,
+                                          const unsigned char *passphrase,
+                                          void **abstract)
 {
     libssh2_rsa_ctx *rsactx;
     int ret;
@@ -166,12 +164,12 @@ hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION *session,
  *
  * Load a Private Key from a memory
  */
-static int
-hostkey_method_ssh_rsa_initPEMFromMemory(LIBSSH2_SESSION *session,
-                                         const char *privkeyfiledata,
-                                         size_t privkeyfiledata_len,
-                                         const unsigned char *passphrase,
-                                         void **abstract)
+static int hostkey_method_ssh_rsa_initPEMFromMemory(
+    LIBSSH2_SESSION *session,
+    const char *privkeyfiledata,
+    size_t privkeyfiledata_len,
+    const unsigned char *passphrase,
+    void **abstract)
 {
     libssh2_rsa_ctx *rsactx;
     int ret;
@@ -199,12 +197,11 @@ hostkey_method_ssh_rsa_initPEMFromMemory(LIBSSH2_SESSION *session,
  *
  * Verify signature created by remote
  */
-static int
-hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION *session,
-                                  const unsigned char *sig,
-                                  size_t sig_len,
-                                  const unsigned char *m,
-                                  size_t m_len, void **abstract)
+static int hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION *session,
+                                             const unsigned char *sig,
+                                             size_t sig_len,
+                                             const unsigned char *m,
+                                             size_t m_len, void **abstract)
 {
     libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
@@ -223,13 +220,12 @@ hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION *session,
  *
  * Construct a signature from an array of vectors
  */
-static int
-hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
-                             unsigned char **signature,
-                             size_t *signature_len,
-                             int veccount,
-                             const struct iovec datavec[],
-                             void **abstract)
+static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
+                                        unsigned char **signature,
+                                        size_t *signature_len,
+                                        int veccount,
+                                        const struct iovec datavec[],
+                                        void **abstract)
 {
     libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
 
@@ -273,12 +269,12 @@ hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
  */
 #if LIBSSH2_RSA_SHA2
 
-static int
-hostkey_method_ssh_rsa_sha2_256_sig_verify(LIBSSH2_SESSION *session,
-                                           const unsigned char *sig,
-                                           size_t sig_len,
-                                           const unsigned char *m,
-                                           size_t m_len, void **abstract)
+static int hostkey_method_ssh_rsa_sha2_256_sig_verify(
+    LIBSSH2_SESSION *session,
+    const unsigned char *sig,
+    size_t sig_len,
+    const unsigned char *m,
+    size_t m_len, void **abstract)
 {
     libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
@@ -300,13 +296,12 @@ hostkey_method_ssh_rsa_sha2_256_sig_verify(LIBSSH2_SESSION *session,
  * Construct a signature from an array of vectors
  */
 
-static int
-hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
-                                      unsigned char **signature,
-                                      size_t *signature_len,
-                                      int veccount,
-                                      const struct iovec datavec[],
-                                      void **abstract)
+static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
+                                                 unsigned char **signature,
+                                                 size_t *signature_len,
+                                                 int veccount,
+                                                 const struct iovec datavec[],
+                                                 void **abstract)
 {
     libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
 
@@ -347,12 +342,12 @@ hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
  *
  * Verify signature created by remote
  */
-static int
-hostkey_method_ssh_rsa_sha2_512_sig_verify(LIBSSH2_SESSION *session,
-                                           const unsigned char *sig,
-                                           size_t sig_len,
-                                           const unsigned char *m,
-                                           size_t m_len, void **abstract)
+static int hostkey_method_ssh_rsa_sha2_512_sig_verify(
+    LIBSSH2_SESSION *session,
+    const unsigned char *sig,
+    size_t sig_len,
+    const unsigned char *m,
+    size_t m_len, void **abstract)
 {
     libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
@@ -373,13 +368,12 @@ hostkey_method_ssh_rsa_sha2_512_sig_verify(LIBSSH2_SESSION *session,
  *
  * Construct a signature from an array of vectors
  */
-static int
-hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
-                                      unsigned char **signature,
-                                      size_t *signature_len,
-                                      int veccount,
-                                      const struct iovec datavec[],
-                                      void **abstract)
+static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
+                                                 unsigned char **signature,
+                                                 size_t *signature_len,
+                                                 int veccount,
+                                                 const struct iovec datavec[],
+                                                 void **abstract)
 {
     libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
 
@@ -422,8 +416,8 @@ hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
  *
  * Shutdown the hostkey
  */
-static int
-hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session, void **abstract)
+static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
+                                       void **abstract)
 {
     libssh2_rsa_ctx *rsactx = (libssh2_rsa_ctx *)(*abstract);
     (void)session;
@@ -538,11 +532,10 @@ static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
  *
  * Initialize the server hostkey working area with p/q/g/y set
  */
-static int
-hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
-                            const unsigned char *hostkey_data,
-                            size_t hostkey_data_len,
-                            void **abstract)
+static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
+                                       const unsigned char *hostkey_data,
+                                       size_t hostkey_data_len,
+                                       void **abstract)
 {
     libssh2_dsa_ctx *dsactx;
     unsigned char *p, *q, *g, *y;
@@ -601,11 +594,10 @@ hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
  *
  * Load a Private Key from a PEM file
  */
-static int
-hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION *session,
-                               const char *privkeyfile,
-                               const unsigned char *passphrase,
-                               void **abstract)
+static int hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION *session,
+                                          const char *privkeyfile,
+                                          const unsigned char *passphrase,
+                                          void **abstract)
 {
     libssh2_dsa_ctx *dsactx;
     int ret;
@@ -630,12 +622,12 @@ hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION *session,
  *
  * Load a Private Key from memory
  */
-static int
-hostkey_method_ssh_dss_initPEMFromMemory(LIBSSH2_SESSION *session,
-                                         const char *privkeyfiledata,
-                                         size_t privkeyfiledata_len,
-                                         const unsigned char *passphrase,
-                                         void **abstract)
+static int hostkey_method_ssh_dss_initPEMFromMemory(
+    LIBSSH2_SESSION *session,
+    const char *privkeyfiledata,
+    size_t privkeyfiledata_len,
+    const unsigned char *passphrase,
+    void **abstract)
 {
     libssh2_dsa_ctx *dsactx;
     int ret;
@@ -662,12 +654,11 @@ hostkey_method_ssh_dss_initPEMFromMemory(LIBSSH2_SESSION *session,
  *
  * Verify signature created by remote
  */
-static int
-hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION *session,
-                                  const unsigned char *sig,
-                                  size_t sig_len,
-                                  const unsigned char *m,
-                                  size_t m_len, void **abstract)
+static int hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION *session,
+                                             const unsigned char *sig,
+                                             size_t sig_len,
+                                             const unsigned char *m,
+                                             size_t m_len, void **abstract)
 {
     libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *)(*abstract);
 
@@ -688,13 +679,12 @@ hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION *session,
  *
  * Construct a signature from an array of vectors
  */
-static int
-hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
-                             unsigned char **signature,
-                             size_t *signature_len,
-                             int veccount,
-                             const struct iovec datavec[],
-                             void **abstract)
+static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
+                                        unsigned char **signature,
+                                        size_t *signature_len,
+                                        int veccount,
+                                        const struct iovec datavec[],
+                                        void **abstract)
 {
     libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *)(*abstract);
     unsigned char hash[SHA_DIGEST_LENGTH];
@@ -737,8 +727,8 @@ hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
  *
  * Shutdown the hostkey method
  */
-static int
-hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session, void **abstract)
+static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
+                                       void **abstract)
 {
     libssh2_dsa_ctx *dsactx = (libssh2_dsa_ctx *)(*abstract);
     (void)session;
@@ -769,20 +759,18 @@ static const struct hostkey_method hostkey_method_ssh_dss = {
  * ecdsa-sha2-nistp256/384/521 *
  *********** */
 
-static int
-hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
-                              void **abstract);
+static int hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
+                                         void **abstract);
 
 /*
  * hostkey_method_ssh_ecdsa_init
  *
  * Initialize the server hostkey working area with e/n pair
  */
-static int
-hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
-                              const unsigned char *hostkey_data,
-                              size_t hostkey_data_len,
-                              void **abstract)
+static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
+                                         const unsigned char *hostkey_data,
+                                         size_t hostkey_data_len,
+                                         void **abstract)
 {
     libssh2_ecdsa_ctx *ec_ctx = NULL;
     unsigned char *type_str, *domain, *public_key;
@@ -859,11 +847,10 @@ hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
  *
  * Load a Private Key from a PEM file
  */
-static int
-hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION *session,
-                                 const char *privkeyfile,
-                                 const unsigned char *passphrase,
-                                 void **abstract)
+static int hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION *session,
+                                            const char *privkeyfile,
+                                            const unsigned char *passphrase,
+                                            void **abstract)
 {
     libssh2_ecdsa_ctx *ec_ctx = NULL;
     int ret;
@@ -887,12 +874,12 @@ hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION *session,
  *
  * Load a Private Key from memory
  */
-static int
-hostkey_method_ssh_ecdsa_initPEMFromMemory(LIBSSH2_SESSION *session,
-                                           const char *privkeyfiledata,
-                                           size_t privkeyfiledata_len,
-                                           const unsigned char *passphrase,
-                                           void **abstract)
+static int hostkey_method_ssh_ecdsa_initPEMFromMemory(
+    LIBSSH2_SESSION *session,
+    const char *privkeyfiledata,
+    size_t privkeyfiledata_len,
+    const unsigned char *passphrase,
+    void **abstract)
 {
     libssh2_ecdsa_ctx *ec_ctx = NULL;
     int ret;
@@ -921,12 +908,11 @@ hostkey_method_ssh_ecdsa_initPEMFromMemory(LIBSSH2_SESSION *session,
  *
  * Verify signature created by remote
  */
-static int
-hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
-                                    const unsigned char *sig,
-                                    size_t sig_len,
-                                    const unsigned char *m,
-                                    size_t m_len, void **abstract)
+static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
+                                               const unsigned char *sig,
+                                               size_t sig_len,
+                                               const unsigned char *m,
+                                               size_t m_len, void **abstract)
 {
     unsigned char *r, *s, *name;
     size_t r_len, s_len, name_len;
@@ -994,13 +980,12 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
  *
  * Construct a signature from an array of vectors
  */
-static int
-hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
-                               unsigned char **signature,
-                               size_t *signature_len,
-                               int veccount,
-                               const struct iovec datavec[],
-                               void **abstract)
+static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
+                                          unsigned char **signature,
+                                          size_t *signature_len,
+                                          int veccount,
+                                          const struct iovec datavec[],
+                                          void **abstract)
 {
     libssh2_ecdsa_ctx *ec_ctx = (libssh2_ecdsa_ctx *)(*abstract);
     libssh2_curve_type type = _libssh2_ecdsa_get_curve_type(ec_ctx);
@@ -1027,8 +1012,8 @@ hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
  *
  * Shutdown the hostkey by freeing EC_KEY context
  */
-static int
-hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session, void **abstract)
+static int hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
+                                         void **abstract)
 {
     libssh2_ecdsa_ctx *keyctx = (libssh2_ecdsa_ctx *)(*abstract);
     (void)session;
@@ -1129,11 +1114,10 @@ static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
  *
  * Initialize the server hostkey working area with e/n pair
  */
-static int
-hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
-                                const unsigned char *hostkey_data,
-                                size_t hostkey_data_len,
-                                void **abstract)
+static int hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
+                                           const unsigned char *hostkey_data,
+                                           size_t hostkey_data_len,
+                                           void **abstract)
 {
     size_t key_len;
     unsigned char *key;
@@ -1179,11 +1163,11 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
  *
  * Load a Private Key from a PEM file
  */
-static int
-hostkey_method_ssh_ed25519_initPEM(LIBSSH2_SESSION *session,
-                                   const char *privkeyfile,
-                                   const unsigned char *passphrase,
-                                   void **abstract)
+static int hostkey_method_ssh_ed25519_initPEM(
+    LIBSSH2_SESSION *session,
+    const char *privkeyfile,
+    const unsigned char *passphrase,
+    void **abstract)
 {
     libssh2_ed25519_ctx *ec_ctx = NULL;
     int ret;
@@ -1209,12 +1193,12 @@ hostkey_method_ssh_ed25519_initPEM(LIBSSH2_SESSION *session,
  *
  * Load a Private Key from memory
  */
-static int
-hostkey_method_ssh_ed25519_initPEMFromMemory(LIBSSH2_SESSION *session,
-                                             const char *privkeyfiledata,
-                                             size_t privkeyfiledata_len,
-                                             const unsigned char *passphrase,
-                                             void **abstract)
+static int hostkey_method_ssh_ed25519_initPEMFromMemory(
+    LIBSSH2_SESSION *session,
+    const char *privkeyfiledata,
+    size_t privkeyfiledata_len,
+    const unsigned char *passphrase,
+    void **abstract)
 {
     libssh2_ed25519_ctx *ed_ctx = NULL;
     int ret;
@@ -1243,12 +1227,11 @@ hostkey_method_ssh_ed25519_initPEMFromMemory(LIBSSH2_SESSION *session,
  *
  * Verify signature created by remote
  */
-static int
-hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION *session,
-                                      const unsigned char *sig,
-                                      size_t sig_len,
-                                      const unsigned char *m,
-                                      size_t m_len, void **abstract)
+static int hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION *session,
+                                                 const unsigned char *sig,
+                                                 size_t sig_len,
+                                                 const unsigned char *m,
+                                                 size_t m_len, void **abstract)
 {
     libssh2_ed25519_ctx *ctx = (libssh2_ed25519_ctx *)(*abstract);
     (void)session;
@@ -1272,13 +1255,12 @@ hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION *session,
  *
  * Construct a signature from an array of vectors
  */
-static int
-hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
-                                 unsigned char **signature,
-                                 size_t *signature_len,
-                                 int veccount,
-                                 const struct iovec datavec[],
-                                 void **abstract)
+static int hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
+                                            unsigned char **signature,
+                                            size_t *signature_len,
+                                            int veccount,
+                                            const struct iovec datavec[],
+                                            void **abstract)
 {
     libssh2_ed25519_ctx *ctx = (libssh2_ed25519_ctx *)(*abstract);
 
@@ -1296,8 +1278,8 @@ hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
  *
  * Shutdown the hostkey by freeing key context
  */
-static int
-hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session, void **abstract)
+static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
+                                           void **abstract)
 {
     libssh2_ed25519_ctx *keyctx = (libssh2_ed25519_ctx*)(*abstract);
     (void)session;

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -42,10 +42,10 @@
 
 /* Keep-alive stuff. */
 
-LIBSSH2_API void
-libssh2_keepalive_config(LIBSSH2_SESSION *session,
-                         int want_reply,
-                         unsigned int interval)
+LIBSSH2_API
+void libssh2_keepalive_config(LIBSSH2_SESSION *session,
+                              int want_reply,
+                              unsigned int interval)
 {
     if(interval == 1)
         session->keepalive_interval = 2;
@@ -54,9 +54,9 @@ libssh2_keepalive_config(LIBSSH2_SESSION *session,
     session->keepalive_want_reply = want_reply ? 1 : 0;
 }
 
-LIBSSH2_API int
-libssh2_keepalive_send(LIBSSH2_SESSION *session,
-                       int *seconds_to_next)
+LIBSSH2_API
+int libssh2_keepalive_send(LIBSSH2_SESSION *session,
+                           int *seconds_to_next)
 {
     time_t now;
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -4431,9 +4431,9 @@ _libssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
 /* libssh2_session_method_pref
  * Set preferred method
  */
-LIBSSH2_API int
-libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
-                            const char *prefs)
+LIBSSH2_API
+int libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
+                                const char *prefs)
 {
     char **prefvar, *s, *newprefs;
     char *tmpprefs = NULL;
@@ -4580,9 +4580,10 @@ libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
  * a negative number on failure
  */
 
-LIBSSH2_API int libssh2_session_supported_algs(LIBSSH2_SESSION* session,
-                                               int method_type,
-                                               const char ***algs)
+LIBSSH2_API
+int libssh2_session_supported_algs(LIBSSH2_SESSION* session,
+                                   int method_type,
+                                   const char ***algs)
 {
     unsigned int i;
     unsigned int j;

--- a/src/kex.c
+++ b/src/kex.c
@@ -104,7 +104,7 @@ do {                                                                          \
         }                                                                     \
 } while(0)
 
-/*!
+/*
  * @note The following are wrapper functions used by diffie_hellman_sha_algo().
  * TODO: Switch backend SHA macros to functions to allow function pointers
  * @discussion Ideally these would be function pointers but the backend macros
@@ -632,8 +632,7 @@ static void kex_diffie_hellman_cleanup(
     }
 }
 
-/*!
- * @function diffie_hellman_sha_algo
+/*
  * @abstract Diffie Hellman Key Exchange, Group Agnostic,
  * SHA Algorithm Agnostic
  * @result 0 on success, error code on failure
@@ -1018,7 +1017,7 @@ clean_exit:
     return ret;
 }
 
-/* kex_method_diffie_hellman_group1_sha1_key_exchange
+/*
  * Diffie-Hellman Group1 (Actually Group2) Key Exchange using SHA1
  */
 static int kex_method_diffie_hellman_group1_sha1_key_exchange(
@@ -1084,7 +1083,7 @@ clean_exit:
     return ret;
 }
 
-/* kex_method_diffie_hellman_group14_key_exchange
+/*
  * Diffie-Hellman Group14 Key Exchange with hash function callback
  */
 typedef int (*diffie_hellman_hash_func_t)(
@@ -1179,7 +1178,7 @@ clean_exit:
     return ret;
 }
 
-/* kex_method_diffie_hellman_group14_sha1_key_exchange
+/*
  * Diffie-Hellman Group14 Key Exchange using SHA1
  */
 static int kex_method_diffie_hellman_group14_sha1_key_exchange(
@@ -1192,7 +1191,7 @@ static int kex_method_diffie_hellman_group14_sha1_key_exchange(
                                                       diffie_hellman_sha_algo);
 }
 
-/* kex_method_diffie_hellman_group14_sha256_key_exchange
+/*
  * Diffie-Hellman Group14 Key Exchange using SHA256
  */
 static int kex_method_diffie_hellman_group14_sha256_key_exchange(
@@ -1205,7 +1204,7 @@ static int kex_method_diffie_hellman_group14_sha256_key_exchange(
                                                       diffie_hellman_sha_algo);
 }
 
-/* kex_method_diffie_hellman_group16_sha512_key_exchange
+/*
  * Diffie-Hellman Group16 Key Exchange using SHA512
  */
 static int kex_method_diffie_hellman_group16_sha512_key_exchange(
@@ -1297,7 +1296,7 @@ clean_exit:
     return ret;
 }
 
-/* kex_method_diffie_hellman_group18_sha512_key_exchange
+/*
  * Diffie-Hellman Group18 Key Exchange using SHA512
  */
 static int kex_method_diffie_hellman_group18_sha512_key_exchange(
@@ -1433,7 +1432,7 @@ clean_exit:
     return ret;
 }
 
-/* kex_method_diffie_hellman_group_exchange_sha1_key_exchange
+/*
  * Diffie-Hellman Group Exchange Key Exchange using SHA1
  * Negotiates random(ish) group for secret derivation
  */
@@ -1559,7 +1558,7 @@ dh_gex_clean_exit:
     return ret;
 }
 
-/* kex_method_diffie_hellman_group_exchange_sha256_key_exchange
+/*
  * Diffie-Hellman Group Exchange Key Exchange using SHA256
  * Negotiates random(ish) group for secret derivation
  */
@@ -1688,10 +1687,9 @@ dh_gex_clean_exit:
 
 #if (LIBSSH2_ECDSA || LIBSSH2_ED25519) && LIBSSH2_MLKEM
 
-/* kex_session_hybrid_curve_type
+/*
  * returns the EC curve type by name used in hybrid key exchange
  */
-
 static int kex_session_hybrid_curve_type(const char *name,
                                          libssh2_curve_type *out_type)
 {
@@ -1719,8 +1717,7 @@ static int kex_session_hybrid_curve_type(const char *name,
 
 #if LIBSSH2_ECDSA
 
-/* LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY
- *
+/*
  * Macro that create and verifies EC SHA hash with a given digest bytes
  *
  * Payload format:
@@ -1733,7 +1730,6 @@ static int kex_session_hybrid_curve_type(const char *name,
  * string   Q_C, client's ephemeral public key octet string
  * string   Q_S, server's ephemeral public key octet string
  * mpint    K,   shared secret
- *
  */
 #define LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(digest_type)            \
 do {                                                                         \
@@ -1834,8 +1830,7 @@ do {                                                                         \
 
 #if LIBSSH2_MLKEM
 
-/* LIBSSH2_KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY
- *
+/*
  * Macro that create and verifies HYBRID (EC+PQ) SHA hash with a given
  * digest bytes
  *
@@ -1849,7 +1844,6 @@ do {                                                                         \
  * string   Q_C, client's ephemeral public key octet string
  * string   Q_S, server's ephemeral public key octet string
  * mpint    K,   shared secret
- *
  */
 #define LIBSSH2_KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY(digest_type)        \
 do {                                                                         \
@@ -1953,10 +1947,9 @@ do {                                                                         \
 
 #endif
 
-/* kex_session_ecdh_curve_type
+/*
  * returns the EC curve type by name used in key exchange
  */
-
 static int kex_session_ecdh_curve_type(const char *name,
                                        libssh2_curve_type *out_type)
 {
@@ -2021,7 +2014,7 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
     }
 }
 
-/* ecdh_sha2_nistp
+/*
  * Elliptic Curve Diffie Hellman Key Exchange
  */
 static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, libssh2_curve_type type,
@@ -2189,11 +2182,9 @@ clean_exit:
     return ret;
 }
 
-/* kex_method_ecdh_key_exchange
- *
+/*
  * Elliptic Curve Diffie Hellman Key Exchange
  * supports SHA256/384/512 hashes based on negotiated ecdh method
- *
  */
 static int kex_method_ecdh_key_exchange(
     LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
@@ -2764,7 +2755,7 @@ static void kex_method_curve25519_cleanup(
     }
 }
 
-/* curve25519_sha256
+/*
  * Elliptic Curve Key Exchange
  */
 static int curve25519_sha256(
@@ -2908,10 +2899,8 @@ clean_exit:
     return ret;
 }
 
-/* kex_method_curve25519_key_exchange
- *
+/*
  * Elliptic Curve X25519 Key Exchange with SHA256 hash
- *
  */
 static int kex_method_curve25519_key_exchange(
     LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
@@ -3461,7 +3450,7 @@ kex_method_ssh_mlkem768_x25519_sha256 = {
 
 /* this kex method signals that client can receive extensions
  * as described in https://datatracker.ietf.org/doc/html/rfc8308
-*/
+ */
 
 static const struct kex_method
 kex_method_extension_negotiation = {
@@ -3514,8 +3503,7 @@ struct common_method {
     const char *name;
 };
 
-/* kex_method_strlen
- *
+/*
  * Calculate the length of a particular method list's resulting string
  * Includes SUM(strlen() of each individual method plus 1 (for coma)) - 1
  * (because the last coma isn't used)
@@ -3537,7 +3525,7 @@ static size_t kex_method_strlen(const struct common_method **method)
     return len - 1;
 }
 
-/* kex_method_list
+/*
  * Generate formatted preference list in buf
  */
 static uint32_t kex_method_list(unsigned char *buf, uint32_t list_strlen,
@@ -3579,7 +3567,7 @@ static uint32_t kex_method_list(unsigned char *buf, uint32_t list_strlen,
         }                                                                    \
     } while(0)
 
-/* kexinit
+/*
  * Send SSH_MSG_KEXINIT packet
  */
 static int kexinit(LIBSSH2_SESSION *session)
@@ -3753,7 +3741,7 @@ static int kexinit(LIBSSH2_SESSION *session)
     return 0;
 }
 
-/* _libssh2_kex_agree_instr
+/*
  * Kex specific variant of strstr()
  * Needle must be preceded by BOL or ',', and followed by ',' or EOL
  */
@@ -3809,7 +3797,6 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
     return NULL;
 }
 
-/* kex_get_method_by_name */
 static const struct common_method *kex_get_method_by_name(
     const char *name, size_t name_len,
     const struct common_method **methodlist)
@@ -3824,7 +3811,7 @@ static const struct common_method *kex_get_method_by_name(
     return NULL;
 }
 
-/* kex_agree_hostkey
+/*
  * Agree on a Hostkey which works with this kex
  */
 static int kex_agree_hostkey(LIBSSH2_SESSION *session,
@@ -3899,7 +3886,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session,
     return -1;
 }
 
-/* kex_agree_kex_hostkey
+/*
  * Agree on a Key Exchange method and a hostkey encoding type
  */
 static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
@@ -3979,7 +3966,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
     return -1;
 }
 
-/* kex_agree_crypt
+/*
  * Agree on a cipher algo
  */
 static int kex_agree_crypt(LIBSSH2_SESSION *session,
@@ -4034,7 +4021,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
     return -1;
 }
 
-/* kex_agree_mac
+/*
  * Agree on a message authentication hash
  */
 static int kex_agree_mac(LIBSSH2_SESSION *session,
@@ -4095,7 +4082,7 @@ static int kex_agree_mac(LIBSSH2_SESSION *session,
     return -1;
 }
 
-/* kex_agree_comp
+/*
  * Agree on a compression scheme
  */
 static int kex_agree_comp(LIBSSH2_SESSION *session,
@@ -4152,7 +4139,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
  * The Client gets to make the final call on "agreed methods"
  */
 
-/* kex_agree_methods
+/*
  * Decide which specific method to use of the methods offered by each party
  */
 static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,

--- a/src/kex.c
+++ b/src/kex.c
@@ -581,8 +581,7 @@ static int finish_kex(LIBSSH2_SESSION *session,
 }
 
 static void diffie_hellman_state_cleanup(
-    LIBSSH2_SESSION *session,
-    struct kmdhgGPshakex_state *exchange_state)
+    LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     libssh2_dh_dtor(&exchange_state->x);
     _libssh2_bn_free(exchange_state->e);
@@ -613,8 +612,7 @@ static void diffie_hellman_state_cleanup(
 }
 
 static void kex_diffie_hellman_cleanup(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     if(key_state->state != libssh2_NB_state_idle) {
         _libssh2_bn_free(key_state->p);
@@ -1024,8 +1022,7 @@ clean_exit:
  * Diffie-Hellman Group1 (Actually Group2) Key Exchange using SHA1
  */
 static int kex_method_diffie_hellman_group1_sha1_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     static const unsigned char p_value[128] = {
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -1104,8 +1101,7 @@ typedef int (*diffie_hellman_hash_func_t)(
     struct kmdhgGPshakex_state *exchange_state);
 
 static int kex_method_diffie_hellman_group14_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state,
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state,
     int sha_algo_value,
     void *exchange_hash_ctx,
     diffie_hellman_hash_func_t hashfunc)
@@ -1187,8 +1183,7 @@ clean_exit:
  * Diffie-Hellman Group14 Key Exchange using SHA1
  */
 static int kex_method_diffie_hellman_group14_sha1_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     libssh2_sha1_ctx ctx;
     return kex_method_diffie_hellman_group14_key_exchange(session,
@@ -1201,8 +1196,7 @@ static int kex_method_diffie_hellman_group14_sha1_key_exchange(
  * Diffie-Hellman Group14 Key Exchange using SHA256
  */
 static int kex_method_diffie_hellman_group14_sha256_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     libssh2_sha256_ctx ctx;
     return kex_method_diffie_hellman_group14_key_exchange(session,
@@ -1215,8 +1209,7 @@ static int kex_method_diffie_hellman_group14_sha256_key_exchange(
  * Diffie-Hellman Group16 Key Exchange using SHA512
  */
 static int kex_method_diffie_hellman_group16_sha512_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     static const unsigned char p_value[512] = {
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC9, 0x0F, 0xDA, 0xA2,
@@ -1308,8 +1301,7 @@ clean_exit:
  * Diffie-Hellman Group18 Key Exchange using SHA512
  */
 static int kex_method_diffie_hellman_group18_sha512_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     static const unsigned char p_value[1024] = {
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC9, 0x0F, 0xDA, 0xA2,
@@ -1446,8 +1438,7 @@ clean_exit:
  * Negotiates random(ish) group for secret derivation
  */
 static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc;
@@ -1573,8 +1564,7 @@ dh_gex_clean_exit:
  * Negotiates random(ish) group for secret derivation
  */
 static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc;
@@ -1993,8 +1983,7 @@ static int kex_session_ecdh_curve_type(const char *name,
 }
 
 static void ecdh_exchange_state_cleanup(
-    LIBSSH2_SESSION *session,
-    struct kmdhgGPshakex_state *exchange_state)
+    LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
@@ -2207,8 +2196,7 @@ clean_exit:
  *
  */
 static int kex_method_ecdh_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -2315,8 +2303,7 @@ ecdh_clean_exit:
 #if LIBSSH2_MLKEM
 
 static void mlkem_nistp_exchange_state_cleanup(
-    LIBSSH2_SESSION *session,
-    struct kmdhgGPshakex_state *exchange_state)
+    LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
@@ -2330,8 +2317,7 @@ static void mlkem_nistp_exchange_state_cleanup(
 }
 
 static void kex_method_mlkem_nistp_cleanup(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     if(key_state->public_key_oct) {
         LIBSSH2_FREE(session, key_state->public_key_oct);
@@ -2605,8 +2591,7 @@ clean_exit:
 }
 
 static int kex_method_mlkem_nistp_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -2737,8 +2722,7 @@ clean_exit:
 #if LIBSSH2_ED25519
 
 static void curve25519_exchange_state_cleanup(
-    LIBSSH2_SESSION *session,
-    struct kmdhgGPshakex_state *exchange_state)
+    LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
@@ -2752,8 +2736,7 @@ static void curve25519_exchange_state_cleanup(
 }
 
 static void kex_method_curve25519_cleanup(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     if(key_state->curve25519_public_key) {
         _libssh2_explicit_zero(key_state->curve25519_public_key,
@@ -2931,8 +2914,7 @@ clean_exit:
  *
  */
 static int kex_method_curve25519_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -3031,8 +3013,7 @@ clean_exit:
 #if LIBSSH2_MLKEM
 
 static void mlkem768x25519_exchange_state_cleanup(
-    LIBSSH2_SESSION *session,
-    struct kmdhgGPshakex_state *exchange_state)
+    LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     _libssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
@@ -3046,8 +3027,7 @@ static void mlkem768x25519_exchange_state_cleanup(
 }
 
 static void kex_method_mlkem768x25519_cleanup(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     if(key_state->curve25519_public_key) {
         _libssh2_explicit_zero(key_state->curve25519_public_key,
@@ -3250,8 +3230,7 @@ clean_exit:
 }
 
 static int kex_method_mlkem768x25519_key_exchange(
-    LIBSSH2_SESSION *session,
-    struct key_exchange_state_low *key_state)
+    LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     int ret = 0;
     int rc = 0;
@@ -3542,8 +3521,7 @@ struct common_method {
  * (because the last coma isn't used)
  * Another sign of bad coding practices gone mad.  Pretend you don't see this.
  */
-static size_t
-kex_method_strlen(const struct common_method **method)
+static size_t kex_method_strlen(const struct common_method **method)
 {
     size_t len = 0;
 
@@ -3562,9 +3540,8 @@ kex_method_strlen(const struct common_method **method)
 /* kex_method_list
  * Generate formatted preference list in buf
  */
-static uint32_t
-kex_method_list(unsigned char *buf, uint32_t list_strlen,
-                const struct common_method **method)
+static uint32_t kex_method_list(unsigned char *buf, uint32_t list_strlen,
+                                const struct common_method **method)
 {
     _libssh2_htonu32(buf, list_strlen);
     buf += 4;
@@ -3833,9 +3810,9 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
 }
 
 /* kex_get_method_by_name */
-static const struct common_method *
-kex_get_method_by_name(const char *name, size_t name_len,
-                       const struct common_method **methodlist)
+static const struct common_method *kex_get_method_by_name(
+    const char *name, size_t name_len,
+    const struct common_method **methodlist)
 {
     while(*methodlist) {
         if((strlen((*methodlist)->name) == name_len) &&

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -90,8 +90,8 @@ static void free_host(LIBSSH2_SESSION *session, struct known_host *entry)
  * Init a collection of known hosts. Returns the pointer to a collection.
  *
  */
-LIBSSH2_API LIBSSH2_KNOWNHOSTS *
-libssh2_knownhost_init(LIBSSH2_SESSION *session)
+LIBSSH2_API
+LIBSSH2_KNOWNHOSTS *libssh2_knownhost_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_KNOWNHOSTS *knh =
         LIBSSH2_ALLOC(session, sizeof(struct _LIBSSH2_KNOWNHOSTS));
@@ -301,11 +301,11 @@ error:
  * The keylen parameter may be omitted (zero) if the key is provided as a
  * NULL-terminated base64-encoded string.
  */
-LIBSSH2_API int
-libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
-                      const char *host, const char *salt,
-                      const char *key, size_t keylen,
-                      int typemask, struct libssh2_knownhost **store)
+LIBSSH2_API
+int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
+                          const char *host, const char *salt,
+                          const char *key, size_t keylen,
+                          int typemask, struct libssh2_knownhost **store)
 {
     return knownhost_add(hosts, host, salt, NULL, 0, key, keylen, NULL,
                          0, typemask, store);
@@ -337,12 +337,12 @@ libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
  * The keylen parameter may be omitted (zero) if the key is provided as a
  * NULL-terminated base64-encoded string.
  */
-LIBSSH2_API int
-libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
-                       const char *host, const char *salt,
-                       const char *key, size_t keylen,
-                       const char *comment, size_t commentlen,
-                       int typemask, struct libssh2_knownhost **store)
+LIBSSH2_API
+int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
+                           const char *host, const char *salt,
+                           const char *key, size_t keylen,
+                           const char *comment, size_t commentlen,
+                           int typemask, struct libssh2_knownhost **store)
 {
     return knownhost_add(hosts, host, salt, NULL, 0, key, keylen,
                          comment, commentlen, typemask, store);
@@ -533,11 +533,11 @@ knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
  * LIBSSH2_KNOWNHOST_CHECK_MATCH
  * LIBSSH2_KNOWNHOST_CHECK_MISMATCH
  */
-LIBSSH2_API int
-libssh2_knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
-                        const char *host, const char *key, size_t keylen,
-                        int typemask,
-                        struct libssh2_knownhost **store)
+LIBSSH2_API
+int libssh2_knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
+                            const char *host, const char *key, size_t keylen,
+                            int typemask,
+                            struct libssh2_knownhost **store)
 {
     return knownhost_check(hosts, host, -1, key, keylen,
                            typemask, store);
@@ -566,12 +566,12 @@ libssh2_knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
  * LIBSSH2_KNOWNHOST_CHECK_MATCH
  * LIBSSH2_KNOWNHOST_CHECK_MISMATCH
  */
-LIBSSH2_API int
-libssh2_knownhost_checkp(LIBSSH2_KNOWNHOSTS *hosts,
-                         const char *host, int port,
-                         const char *key, size_t keylen,
-                         int typemask,
-                         struct libssh2_knownhost **store)
+LIBSSH2_API
+int libssh2_knownhost_checkp(LIBSSH2_KNOWNHOSTS *hosts,
+                             const char *host, int port,
+                             const char *key, size_t keylen,
+                             int typemask,
+                             struct libssh2_knownhost **store)
 {
     return knownhost_check(hosts, host, port, key, keylen,
                            typemask, store);
@@ -583,9 +583,9 @@ libssh2_knownhost_checkp(LIBSSH2_KNOWNHOSTS *hosts,
  * Remove a host from the collection of known hosts.
  *
  */
-LIBSSH2_API int
-libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
-                      struct libssh2_knownhost *entry)
+LIBSSH2_API
+int libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
+                          struct libssh2_knownhost *entry)
 {
     struct known_host *node;
 
@@ -616,8 +616,8 @@ libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
  * Free an entire collection of known hosts.
  *
  */
-LIBSSH2_API void
-libssh2_knownhost_free(LIBSSH2_KNOWNHOSTS *hosts)
+LIBSSH2_API
+void libssh2_knownhost_free(LIBSSH2_KNOWNHOSTS *hosts)
 {
     struct known_host *node;
     struct known_host *next;
@@ -892,9 +892,9 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
  * 'ssh-rsa' [base64-encoded-key]
  *
  */
-LIBSSH2_API int
-libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
-                           const char *line, size_t len, int type)
+LIBSSH2_API
+int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
+                               const char *line, size_t len, int type)
 {
     const char *cp;
     const char *hostp;
@@ -972,9 +972,9 @@ libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
  * Returns a negative value for error or number of successfully added hosts.
  *
  */
-LIBSSH2_API int
-libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
-                           const char *filename, int type)
+LIBSSH2_API
+int libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
+                               const char *filename, int type)
 {
     FILE *file;
     int num = 0;
@@ -1189,12 +1189,12 @@ knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
  * Note that this function returns LIBSSH2_ERROR_BUFFER_TOO_SMALL if the given
  * output buffer is too small to hold the desired output.
  */
-LIBSSH2_API int
-libssh2_knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
-                            struct libssh2_knownhost *known,
-                            char *buffer, size_t buflen,
-                            size_t *outlen, /* the amount of written data */
-                            int type)
+LIBSSH2_API
+int libssh2_knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
+                                struct libssh2_knownhost *known,
+                                char *buffer, size_t buflen,
+                                size_t *outlen, /* amount of written data */
+                                int type)
 {
     struct known_host *node;
 
@@ -1212,9 +1212,9 @@ libssh2_knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
  *
  * Write hosts+key pairs to the given file.
  */
-LIBSSH2_API int
-libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
-                            const char *filename, int type)
+LIBSSH2_API
+int libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
+                                const char *filename, int type)
 {
     struct known_host *node;
     FILE *file;
@@ -1268,10 +1268,10 @@ libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
  * 1 if end of hosts
  * [negative] on errors
  */
-LIBSSH2_API int
-libssh2_knownhost_get(LIBSSH2_KNOWNHOSTS *hosts,
-                      struct libssh2_knownhost **store,
-                      struct libssh2_knownhost *prev)
+LIBSSH2_API
+int libssh2_knownhost_get(LIBSSH2_KNOWNHOSTS *hosts,
+                          struct libssh2_knownhost **store,
+                          struct libssh2_knownhost *prev)
 {
     struct known_host *node;
     if(prev && prev->node) {

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -85,10 +85,7 @@ static void free_host(LIBSSH2_SESSION *session, struct known_host *entry)
 }
 
 /*
- * libssh2_knownhost_init
- *
  * Init a collection of known hosts. Returns the pointer to a collection.
- *
  */
 LIBSSH2_API
 LIBSSH2_KNOWNHOSTS *libssh2_knownhost_init(LIBSSH2_SESSION *session)
@@ -112,10 +109,7 @@ LIBSSH2_KNOWNHOSTS *libssh2_knownhost_init(LIBSSH2_SESSION *session)
 
 #define KNOWNHOST_MAGIC 0xdeadcafe
 /*
- * knownhost_to_external
- *
  * Copies data from the internal to the external representation struct.
- *
  */
 static struct libssh2_knownhost *knownhost_to_external(struct known_host *node)
 {
@@ -131,13 +125,12 @@ static struct libssh2_knownhost *knownhost_to_external(struct known_host *node)
     return ext;
 }
 
-static int
-knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
-              const char *host, const char *salt,
-              const char *key_type_name, size_t key_type_len,
-              const char *key, size_t keylen,
-              const char *comment, size_t commentlen,
-              int typemask, struct libssh2_knownhost **store)
+static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
+                         const char *host, const char *salt,
+                         const char *key_type_name, size_t key_type_len,
+                         const char *key, size_t keylen,
+                         const char *comment, size_t commentlen,
+                         int typemask, struct libssh2_knownhost **store)
 {
     struct known_host *entry;
     size_t hostlen = strlen(host);
@@ -349,8 +342,6 @@ int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * knownhost_check
- *
  * Check a host and its associated key against the collection of known hosts.
  *
  * The typemask is the type/format of the given host name and key
@@ -366,12 +357,11 @@ int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
  * LIBSSH2_KNOWNHOST_CHECK_MATCH
  * LIBSSH2_KNOWNHOST_CHECK_MISMATCH
  */
-static int
-knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
-                const char *hostp, int port,
-                const char *key, size_t keylen,
-                int typemask,
-                struct libssh2_knownhost **store)
+static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
+                           const char *hostp, int port,
+                           const char *key, size_t keylen,
+                           int typemask,
+                           struct libssh2_knownhost **store)
 {
     struct known_host *node;
     struct known_host *badkey = NULL;
@@ -516,8 +506,6 @@ knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_check
- *
  * Check a host and its associated key against the collection of known hosts.
  *
  * The typemask is the type/format of the given host name and key
@@ -544,8 +532,6 @@ int libssh2_knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_checkp
- *
  * Check a host+port and its associated key against the collection of known
  * hosts.
  *
@@ -578,10 +564,7 @@ int libssh2_knownhost_checkp(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_del
- *
  * Remove a host from the collection of known hosts.
- *
  */
 LIBSSH2_API
 int libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
@@ -611,10 +594,7 @@ int libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_free
- *
  * Free an entire collection of known hosts.
- *
  */
 LIBSSH2_API
 void libssh2_knownhost_free(LIBSSH2_KNOWNHOSTS *hosts)
@@ -630,10 +610,10 @@ void libssh2_knownhost_free(LIBSSH2_KNOWNHOSTS *hosts)
 }
 
 /* old style plain text: [name]([,][name])*
-
-   for the sake of simplicity, we add them as separate hosts with the same
-   key
-*/
+ *
+ * for the sake of simplicity, we add them as separate hosts with the same
+ * key
+ */
 static int oldstyle_hostline(LIBSSH2_KNOWNHOSTS *hosts,
                              const char *host, size_t hostlen,
                              const char *key_type_name, size_t key_type_len,
@@ -749,8 +729,6 @@ static int hashed_hostline(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * hostline
- *
  * Parse a single known_host line pre-split into host and key.
  *
  * The key part may include an optional comment which will be parsed here
@@ -865,8 +843,6 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_readline
- *
  * Pass in a line of a file of 'type'.
  *
  * LIBSSH2_KNOWNHOST_FILE_OPENSSH is the only supported type.
@@ -965,12 +941,9 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_readfile
- *
  * Read hosts+key pairs from a given file.
  *
  * Returns a negative value for error or number of successfully added hosts.
- *
  */
 LIBSSH2_API
 int libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
@@ -1006,21 +979,17 @@ int libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * knownhost_writeline
- *
  * Ask libssh2 to convert a known host to an output line for storage.
  *
  * Note that this function returns LIBSSH2_ERROR_BUFFER_TOO_SMALL if the given
  * output buffer is too small to hold the desired output. The 'outlen' field
  * will then contain the size libssh2 wanted to store, which then is the
  * smallest sufficient buffer it would require.
- *
  */
-static int
-knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
-                    struct known_host *node,
-                    char *buf, size_t buflen,
-                    size_t *outlen, int type)
+static int knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
+                               struct known_host *node,
+                               char *buf, size_t buflen,
+                               size_t *outlen, int type)
 {
     size_t required_size;
 
@@ -1182,8 +1151,6 @@ knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_writeline
- *
  * Ask libssh2 to convert a known host to an output line for storage.
  *
  * Note that this function returns LIBSSH2_ERROR_BUFFER_TOO_SMALL if the given
@@ -1208,8 +1175,6 @@ int libssh2_knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_writefile
- *
  * Write hosts+key pairs to the given file.
  */
 LIBSSH2_API
@@ -1258,8 +1223,6 @@ int libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
 }
 
 /*
- * libssh2_knownhost_get
- *
  * Traverse the internal list of known hosts. Pass NULL to 'prev' to get
  * the first one.
  *

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -905,12 +905,9 @@ _libssh2_dh_dtor(libssh2_dh_ctx *dhctx)
     *dhctx = NULL;
 }
 
-/* _libssh2_supported_key_sign_algorithms
- *
+/*
  * Return supported key hash algo upgrades, see crypto.h
- *
  */
-
 const char *
 _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
                                        unsigned char *key_method,

--- a/src/mac.c
+++ b/src/mac.c
@@ -41,8 +41,7 @@
 #include "mac.h"
 
 #if defined(LIBSSH2DEBUG) && defined(LIBSSH2_MAC_NONE_INSECURE)
-/* mac_none_MAC
- *
+/*
  * Minimalist MAC: No MAC. DO NOT USE.
  *
  * The SSH2 Transport allows implementations to forego a message
@@ -53,7 +52,6 @@
  * Enabling this option will allow for "none" as a negotiable method,
  * however it still requires that the method be advertised by the remote
  * end and that no more-preferable methods are available.
- *
  */
 static int mac_none_MAC(LIBSSH2_SESSION *session,
                         unsigned char *buf, uint32_t seqno,
@@ -76,7 +74,7 @@ static const struct mac_method mac_method_none = {
 };
 #endif /* defined(LIBSSH2DEBUG) && defined(LIBSSH2_MAC_NONE_INSECURE) */
 
-/* mac_method_common_init
+/*
  * Initialize simple mac methods
  */
 static int mac_method_common_init(LIBSSH2_SESSION *session, unsigned char *key,
@@ -89,7 +87,7 @@ static int mac_method_common_init(LIBSSH2_SESSION *session, unsigned char *key,
     return 0;
 }
 
-/* mac_method_common_dtor
+/*
  * Cleanup simple mac methods
  */
 static int mac_method_common_dtor(LIBSSH2_SESSION *session, void **abstract)
@@ -103,7 +101,7 @@ static int mac_method_common_dtor(LIBSSH2_SESSION *session, void **abstract)
 }
 
 #if LIBSSH2_HMAC_SHA512
-/* mac_method_hmac_sha512_hash
+/*
  * Calculate hash using full sha512 value
  */
 static int mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION *session,
@@ -157,7 +155,7 @@ static const struct mac_method mac_method_hmac_sha2_512_etm = {
 #endif
 
 #if LIBSSH2_HMAC_SHA256
-/* mac_method_hmac_sha256_hash
+/*
  * Calculate hash using full sha256 value
  */
 static int mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION *session,
@@ -210,7 +208,7 @@ static const struct mac_method mac_method_hmac_sha2_256_etm = {
 
 #endif
 
-/* mac_method_hmac_sha1_hash
+/*
  * Calculate hash using full sha1 value
  */
 static int mac_method_hmac_sha1_hash(LIBSSH2_SESSION *session,
@@ -261,7 +259,7 @@ static const struct mac_method mac_method_hmac_sha1_etm = {
     1
 };
 
-/* mac_method_hmac_sha1_96_hash
+/*
  * Calculate hash using first 96 bits of sha1 value
  */
 static int mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
@@ -292,7 +290,7 @@ static const struct mac_method mac_method_hmac_sha1_96 = {
 };
 
 #if LIBSSH2_MD5
-/* mac_method_hmac_md5_hash
+/*
  * Calculate hash using full md5 value
  */
 static int mac_method_hmac_md5_hash(LIBSSH2_SESSION *session,
@@ -333,7 +331,7 @@ static const struct mac_method mac_method_hmac_md5 = {
     0
 };
 
-/* mac_method_hmac_md5_96_hash
+/*
  * Calculate hash using first 96 bits of md5 value
  */
 static int mac_method_hmac_md5_96_hash(LIBSSH2_SESSION *session,
@@ -365,7 +363,7 @@ static const struct mac_method mac_method_hmac_md5_96 = {
 #endif /* LIBSSH2_MD5 */
 
 #if LIBSSH2_HMAC_RIPEMD
-/* mac_method_hmac_ripemd160_hash
+/*
  * Calculate hash using ripemd160 value
  */
 static int mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION *session,

--- a/src/mac.c
+++ b/src/mac.c
@@ -55,11 +55,12 @@
  * end and that no more-preferable methods are available.
  *
  */
-static int
-mac_none_MAC(LIBSSH2_SESSION *session, unsigned char *buf,
-             uint32_t seqno, const unsigned char *packet,
-             size_t packet_len, const unsigned char *addtl,
-             size_t addtl_len, void **abstract)
+static int mac_none_MAC(LIBSSH2_SESSION *session,
+                        unsigned char *buf, uint32_t seqno,
+                        const unsigned char *packet,
+                        size_t packet_len,
+                        const unsigned char *addtl,
+                        size_t addtl_len, void **abstract)
 {
     return 0;
 }
@@ -78,9 +79,8 @@ static const struct mac_method mac_method_none = {
 /* mac_method_common_init
  * Initialize simple mac methods
  */
-static int
-mac_method_common_init(LIBSSH2_SESSION *session, unsigned char *key,
-                       int *free_key, void **abstract)
+static int mac_method_common_init(LIBSSH2_SESSION *session, unsigned char *key,
+                                  int *free_key, void **abstract)
 {
     *abstract = key;
     *free_key = 0;
@@ -92,8 +92,7 @@ mac_method_common_init(LIBSSH2_SESSION *session, unsigned char *key,
 /* mac_method_common_dtor
  * Cleanup simple mac methods
  */
-static int
-mac_method_common_dtor(LIBSSH2_SESSION *session, void **abstract)
+static int mac_method_common_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     if(*abstract) {
         LIBSSH2_FREE(session, *abstract);
@@ -107,13 +106,12 @@ mac_method_common_dtor(LIBSSH2_SESSION *session, void **abstract)
 /* mac_method_hmac_sha512_hash
  * Calculate hash using full sha512 value
  */
-static int
-mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION *session,
-                              unsigned char *buf, uint32_t seqno,
-                              const unsigned char *packet,
-                              size_t packet_len,
-                              const unsigned char *addtl,
-                              size_t addtl_len, void **abstract)
+static int mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION *session,
+                                         unsigned char *buf, uint32_t seqno,
+                                         const unsigned char *packet,
+                                         size_t packet_len,
+                                         const unsigned char *addtl,
+                                         size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -162,13 +160,12 @@ static const struct mac_method mac_method_hmac_sha2_512_etm = {
 /* mac_method_hmac_sha256_hash
  * Calculate hash using full sha256 value
  */
-static int
-mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION *session,
-                              unsigned char *buf, uint32_t seqno,
-                              const unsigned char *packet,
-                              size_t packet_len,
-                              const unsigned char *addtl,
-                              size_t addtl_len, void **abstract)
+static int mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION *session,
+                                         unsigned char *buf, uint32_t seqno,
+                                         const unsigned char *packet,
+                                         size_t packet_len,
+                                         const unsigned char *addtl,
+                                         size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -216,13 +213,12 @@ static const struct mac_method mac_method_hmac_sha2_256_etm = {
 /* mac_method_hmac_sha1_hash
  * Calculate hash using full sha1 value
  */
-static int
-mac_method_hmac_sha1_hash(LIBSSH2_SESSION *session,
-                          unsigned char *buf, uint32_t seqno,
-                          const unsigned char *packet,
-                          size_t packet_len,
-                          const unsigned char *addtl,
-                          size_t addtl_len, void **abstract)
+static int mac_method_hmac_sha1_hash(LIBSSH2_SESSION *session,
+                                     unsigned char *buf, uint32_t seqno,
+                                     const unsigned char *packet,
+                                     size_t packet_len,
+                                     const unsigned char *addtl,
+                                     size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -268,13 +264,12 @@ static const struct mac_method mac_method_hmac_sha1_etm = {
 /* mac_method_hmac_sha1_96_hash
  * Calculate hash using first 96 bits of sha1 value
  */
-static int
-mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
-                             unsigned char *buf, uint32_t seqno,
-                             const unsigned char *packet,
-                             size_t packet_len,
-                             const unsigned char *addtl,
-                             size_t addtl_len, void **abstract)
+static int mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
+                                        unsigned char *buf, uint32_t seqno,
+                                        const unsigned char *packet,
+                                        size_t packet_len,
+                                        const unsigned char *addtl,
+                                        size_t addtl_len, void **abstract)
 {
     unsigned char temp[SHA_DIGEST_LENGTH];
 
@@ -300,13 +295,12 @@ static const struct mac_method mac_method_hmac_sha1_96 = {
 /* mac_method_hmac_md5_hash
  * Calculate hash using full md5 value
  */
-static int
-mac_method_hmac_md5_hash(LIBSSH2_SESSION *session, unsigned char *buf,
-                         uint32_t seqno,
-                         const unsigned char *packet,
-                         size_t packet_len,
-                         const unsigned char *addtl,
-                         size_t addtl_len, void **abstract)
+static int mac_method_hmac_md5_hash(LIBSSH2_SESSION *session,
+                                    unsigned char *buf, uint32_t seqno,
+                                    const unsigned char *packet,
+                                    size_t packet_len,
+                                    const unsigned char *addtl,
+                                    size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -342,13 +336,12 @@ static const struct mac_method mac_method_hmac_md5 = {
 /* mac_method_hmac_md5_96_hash
  * Calculate hash using first 96 bits of md5 value
  */
-static int
-mac_method_hmac_md5_96_hash(LIBSSH2_SESSION *session,
-                            unsigned char *buf, uint32_t seqno,
-                            const unsigned char *packet,
-                            size_t packet_len,
-                            const unsigned char *addtl,
-                            size_t addtl_len, void **abstract)
+static int mac_method_hmac_md5_96_hash(LIBSSH2_SESSION *session,
+                                       unsigned char *buf, uint32_t seqno,
+                                       const unsigned char *packet,
+                                       size_t packet_len,
+                                       const unsigned char *addtl,
+                                       size_t addtl_len, void **abstract)
 {
     unsigned char temp[MD5_DIGEST_LENGTH];
 
@@ -375,14 +368,12 @@ static const struct mac_method mac_method_hmac_md5_96 = {
 /* mac_method_hmac_ripemd160_hash
  * Calculate hash using ripemd160 value
  */
-static int
-mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION *session,
-                               unsigned char *buf, uint32_t seqno,
-                               const unsigned char *packet,
-                               size_t packet_len,
-                               const unsigned char *addtl,
-                               size_t addtl_len,
-                               void **abstract)
+static int mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION *session,
+                                          unsigned char *buf, uint32_t seqno,
+                                          const unsigned char *packet,
+                                          size_t packet_len,
+                                          const unsigned char *addtl,
+                                          size_t addtl_len, void **abstract)
 {
     libssh2_hmac_ctx ctx;
     unsigned char seqno_buf[4];
@@ -459,9 +450,8 @@ _libssh2_mac_methods(void)
 }
 
 #if LIBSSH2_AES_GCM
-static int
-mac_method_none_init(LIBSSH2_SESSION *session, unsigned char *key,
-                     int *free_key, void **abstract)
+static int mac_method_none_init(LIBSSH2_SESSION *session, unsigned char *key,
+                                int *free_key, void **abstract)
 {
     (void)session;
     (void)key;
@@ -470,13 +460,12 @@ mac_method_none_init(LIBSSH2_SESSION *session, unsigned char *key,
     return 0;
 }
 
-static int
-mac_method_hmac_none_hash(LIBSSH2_SESSION *session,
-                          unsigned char *buf, uint32_t seqno,
-                          const unsigned char *packet,
-                          size_t packet_len,
-                          const unsigned char *addtl,
-                          size_t addtl_len, void **abstract)
+static int mac_method_hmac_none_hash(LIBSSH2_SESSION *session,
+                                     unsigned char *buf, uint32_t seqno,
+                                     const unsigned char *packet,
+                                     size_t packet_len,
+                                     const unsigned char *addtl,
+                                     size_t addtl_len, void **abstract)
 {
     (void)session;
     (void)buf;
@@ -489,8 +478,7 @@ mac_method_hmac_none_hash(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static int
-mac_method_none_dtor(LIBSSH2_SESSION *session, void **abstract)
+static int mac_method_none_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
     (void)session;
     (void)abstract;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -941,11 +941,8 @@ _libssh2_dh_dtor(libssh2_dh_ctx *dhctx)
  */
 
 /*
- * _libssh2_ecdsa_create_key
- *
  * Creates a local private key based on input curve
  * and returns octal value and octal length
- *
  */
 int
 _libssh2_mbedtls_ecdsa_create_key(LIBSSH2_SESSION *session,
@@ -991,10 +988,8 @@ failed:
     return -1;
 }
 
-/* _libssh2_ecdsa_curve_name_with_octal_new
- *
+/*
  * Creates a new public key given an octal string, length and type
- *
  */
 int
 _libssh2_mbedtls_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx **ec_ctx,
@@ -1030,8 +1025,7 @@ failed:
     return -1;
 }
 
-/* _libssh2_ecdh_gen_k
- *
+/*
  * Computes the shared secret K given a local private key,
  * remote public key and length
  */
@@ -1087,10 +1081,8 @@ cleanup:
         }                                                                     \
     } while(0)
 
-/* _libssh2_ecdsa_verify
- *
+/*
  * Verifies the ECDSA signature of a hashed message
- *
  */
 int
 _libssh2_mbedtls_ecdsa_verify(libssh2_ecdsa_ctx *ec_ctx,
@@ -1244,10 +1236,8 @@ cleanup:
     return *ctx ? 0 : -1;
 }
 
-/* _libssh2_ecdsa_new_private
- *
+/*
  * Creates a new private key given a file path and password
- *
  */
 int
 _libssh2_mbedtls_ecdsa_new_private(libssh2_ecdsa_ctx **ec_ctx,
@@ -1303,10 +1293,8 @@ cleanup:
     return *ec_ctx ? 0 : -1;
 }
 
-/* _libssh2_ecdsa_new_private
- *
+/*
  * Creates a new private key given a file data and password
- *
  */
 int
 _libssh2_mbedtls_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ec_ctx,
@@ -1372,10 +1360,8 @@ done:
     return p + size;
 }
 
-/* _libssh2_ecdsa_sign
- *
+/*
  * Computes the ECDSA signature of a previously-hashed message
- *
  */
 int
 _libssh2_mbedtls_ecdsa_sign(LIBSSH2_SESSION *session,
@@ -1431,10 +1417,8 @@ cleanup:
     return *signature ? 0 : -1;
 }
 
-/* _libssh2_ecdsa_get_curve_type
- *
+/*
  * returns key curve type that maps to libssh2_curve_type
- *
  */
 libssh2_curve_type
 _libssh2_mbedtls_ecdsa_get_curve_type(libssh2_ecdsa_ctx *ec_ctx)
@@ -1442,10 +1426,8 @@ _libssh2_mbedtls_ecdsa_get_curve_type(libssh2_ecdsa_ctx *ec_ctx)
     return (libssh2_curve_type)ec_ctx->MBEDTLS_PRIVATE(grp).id;
 }
 
-/* _libssh2_ecdsa_curve_type_from_name
- *
+/*
  * returns 0 for success, key curve type that maps to libssh2_curve_type
- *
  */
 int
 _libssh2_mbedtls_ecdsa_curve_type_from_name(const char *name,
@@ -1482,10 +1464,8 @@ _libssh2_mbedtls_ecdsa_free(libssh2_ecdsa_ctx *ctx)
 }
 #endif /* LIBSSH2_ECDSA */
 
-/* _libssh2_supported_key_sign_algorithms
- *
+/*
  * Return supported key hash algo upgrades, see crypto.h
- *
  */
 const char *
 _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,

--- a/src/misc.c
+++ b/src/misc.c
@@ -379,10 +379,10 @@ static const short base64_reverse_table[256] = {
  *
  * Legacy public function.
  */
-LIBSSH2_API int
-libssh2_base64_decode(LIBSSH2_SESSION *session, char **dest,
-                      unsigned int *dest_len, const char *src,
-                      unsigned int src_len)
+LIBSSH2_API
+int libssh2_base64_decode(LIBSSH2_SESSION *session,
+                          char **dest, unsigned int *dest_len,
+                          const char *src, unsigned int src_len)
 {
     int rc;
     size_t dlen;
@@ -532,8 +532,8 @@ size_t _libssh2_base64_encode(LIBSSH2_SESSION *session,
 }
 /* ---- End of Base64 Encoding ---- */
 
-LIBSSH2_API void
-libssh2_free(LIBSSH2_SESSION *session, void *ptr)
+LIBSSH2_API
+void libssh2_free(LIBSSH2_SESSION *session, void *ptr)
 {
     LIBSSH2_FREE(session, ptr);
 }
@@ -541,16 +541,16 @@ libssh2_free(LIBSSH2_SESSION *session, void *ptr)
 #ifdef LIBSSH2DEBUG
 #include <stdarg.h>
 
-LIBSSH2_API int
-libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
+LIBSSH2_API
+int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     session->showmask = bitmask;
     return 0;
 }
 
-LIBSSH2_API int
-libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
-                         libssh2_trace_handler_func callback)
+LIBSSH2_API
+int libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
+                             libssh2_trace_handler_func callback)
 {
     session->tracehandler = callback;
     session->tracehandler_context = context;
@@ -630,17 +630,17 @@ _libssh2_debug_low(LIBSSH2_SESSION *session, int context, const char *format,
 }
 
 #else
-LIBSSH2_API int
-libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
+LIBSSH2_API
+int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     (void)session;
     (void)bitmask;
     return 0;
 }
 
-LIBSSH2_API int
-libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
-                         libssh2_trace_handler_func callback)
+LIBSSH2_API
+int libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
+                             libssh2_trace_handler_func callback)
 {
     (void)session;
     (void)context;

--- a/src/misc.c
+++ b/src/misc.c
@@ -150,13 +150,11 @@ int _libssh2_wsa2errno(void)
 }
 #endif
 
-/* _libssh2_recv
- *
+/*
  * Replacement for the standard recv, return -errno on failure.
  */
-ssize_t
-_libssh2_recv(libssh2_socket_t socket, void *buffer, size_t length,
-              int flags, void **abstract)
+ssize_t _libssh2_recv(libssh2_socket_t socket, void *buffer, size_t length,
+                      int flags, void **abstract)
 {
     ssize_t rc;
 
@@ -189,13 +187,12 @@ _libssh2_recv(libssh2_socket_t socket, void *buffer, size_t length,
     return rc;
 }
 
-/* _libssh2_send
- *
+/*
  * Replacement for the standard send, return -errno on failure.
  */
-ssize_t
-_libssh2_send(libssh2_socket_t socket, const void *buffer, size_t length,
-              int flags, void **abstract)
+ssize_t _libssh2_send(libssh2_socket_t socket,
+                      const void *buffer, size_t length,
+                      int flags, void **abstract)
 {
     ssize_t rc;
 
@@ -223,9 +220,7 @@ _libssh2_send(libssh2_socket_t socket, const void *buffer, size_t length,
     return rc;
 }
 
-/* libssh2_ntohu32 */
-uint32_t
-_libssh2_ntohu32(const unsigned char *buf)
+uint32_t _libssh2_ntohu32(const unsigned char *buf)
 {
     return ((uint32_t)buf[0] << 24)
          | ((uint32_t)buf[1] << 16)
@@ -233,9 +228,7 @@ _libssh2_ntohu32(const unsigned char *buf)
          | ((uint32_t)buf[3]);
 }
 
-/* _libssh2_ntohu64 */
-libssh2_uint64_t
-_libssh2_ntohu64(const unsigned char *buf)
+libssh2_uint64_t _libssh2_ntohu64(const unsigned char *buf)
 {
     return ((libssh2_uint64_t)buf[0] << 56)
          | ((libssh2_uint64_t)buf[1] << 48)
@@ -247,9 +240,7 @@ _libssh2_ntohu64(const unsigned char *buf)
          | ((libssh2_uint64_t)buf[7]);
 }
 
-/* _libssh2_htonu32 */
-void
-_libssh2_htonu32(unsigned char *buf, uint32_t value)
+void _libssh2_htonu32(unsigned char *buf, uint32_t value)
 {
     buf[0] = (unsigned char)((value >> 24) & 0xFF);
     buf[1] = (value >> 16) & 0xFF;
@@ -257,14 +248,12 @@ _libssh2_htonu32(unsigned char *buf, uint32_t value)
     buf[3] = value & 0xFF;
 }
 
-/* _libssh2_store_u32 */
 void _libssh2_store_u32(unsigned char **buf, uint32_t value)
 {
     _libssh2_htonu32(*buf, value);
     *buf += sizeof(uint32_t);
 }
 
-/* _libssh2_store_u64 */
 void _libssh2_store_u64(unsigned char **buf, libssh2_uint64_t value)
 {
     unsigned char *ptr = *buf;
@@ -281,7 +270,6 @@ void _libssh2_store_u64(unsigned char **buf, libssh2_uint64_t value)
     *buf += sizeof(libssh2_uint64_t);
 }
 
-/* _libssh2_store_str */
 int _libssh2_store_str(unsigned char **buf, const char *str, size_t len)
 {
     uint32_t len_stored = (uint32_t)len;
@@ -296,9 +284,8 @@ int _libssh2_store_str(unsigned char **buf, const char *str, size_t len)
     return len_stored == len;
 }
 
-/* _libssh2_store_str */
 int _libssh2_store_hybrid_str(unsigned char **buf, const char *str_1,
-                        size_t len_1, const char *str_2, size_t len_2)
+                              size_t len_1, const char *str_2, size_t len_2)
 {
     uint32_t len_stored;
 
@@ -322,7 +309,6 @@ int _libssh2_store_hybrid_str(unsigned char **buf, const char *str_1,
     return len_stored == len_1 + len_2;
 }
 
-/* _libssh2_store_bignum2_bytes */
 int _libssh2_store_bignum2_bytes(unsigned char **buf,
                                  const unsigned char *bytes,
                                  size_t len)
@@ -375,9 +361,8 @@ static const short base64_reverse_table[256] = {
 };
 
 #ifndef LIBSSH2_NO_DEPRECATED
-/* libssh2_base64_decode (DEPRECATED, DO NOT USE!)
- *
- * Legacy public function.
+/*
+ * Legacy public function. (DEPRECATED, DO NOT USE!)
  */
 LIBSSH2_API
 int libssh2_base64_decode(LIBSSH2_SESSION *session,
@@ -396,8 +381,7 @@ int libssh2_base64_decode(LIBSSH2_SESSION *session,
 }
 #endif
 
-/* _libssh2_base64_decode
- *
+/*
  * Decode a base64 chunk and store it into a newly alloc'd buffer
  */
 int _libssh2_base64_decode(LIBSSH2_SESSION *session,
@@ -743,28 +727,22 @@ void _libssh2_list_insert(struct list_node *after, /* insert before this */
 
 /* Defined in libssh2_priv.h for the correct platforms */
 #ifdef LIBSSH2_GETTIMEOFDAY
+
 /*
- * _libssh2_gettimeofday
  * Implementation according to:
  * The Open Group Base Specifications Issue 6
  * IEEE Std 1003.1, 2004 Edition
+ *
+ * THIS SOFTWARE IS NOT COPYRIGHTED
+ *
+ * This source code is offered for use in the public domain. You may
+ * use, modify or distribute it freely.
+ *
+ * This code is distributed in the hope that it will be useful but
+ * WITHOUT ANY WARRANTY. ALL WARRANTIES, EXPRESS OR IMPLIED ARE HEREBY
+ * DISCLAIMED. This includes but is not limited to warranties of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
-
-/*
- *  THIS SOFTWARE IS NOT COPYRIGHTED
- *
- *  This source code is offered for use in the public domain. You may
- *  use, modify or distribute it freely.
- *
- *  This code is distributed in the hope that it will be useful but
- *  WITHOUT ANY WARRANTY. ALL WARRANTIES, EXPRESS OR IMPLIED ARE HEREBY
- *  DISCLAIMED. This includes but is not limited to warranties of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
- *  Contributed by:
- *  Danny Smith <dannysmith@users.sourceforge.net>
- */
-
 int _libssh2_gettimeofday(struct timeval *tp, void *tzp)
 {
     (void)tzp;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -222,8 +222,8 @@ static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
                                         const unsigned char *passphrase);
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
-static unsigned char *
-write_bn(unsigned char *buf, const BIGNUM *bn, int bn_bytes)
+static unsigned char *write_bn(unsigned char *buf, const BIGNUM *bn,
+                               int bn_bytes)
 {
     unsigned char *p = buf;
 
@@ -1458,14 +1458,14 @@ out:
 }
 #endif /* ndef USE_OPENSSL_3 */
 
-static int
-gen_publickey_from_rsa_openssh_priv_data(LIBSSH2_SESSION *session,
-                                         struct string_buf *decrypted,
-                                         unsigned char **method,
-                                         size_t *method_len,
-                                         unsigned char **pubkeydata,
-                                         size_t *pubkeydata_len,
-                                         libssh2_rsa_ctx **rsa_ctx)
+static int gen_publickey_from_rsa_openssh_priv_data(
+    LIBSSH2_SESSION *session,
+    struct string_buf *decrypted,
+    unsigned char **method,
+    size_t *method_len,
+    unsigned char **pubkeydata,
+    size_t *pubkeydata_len,
+    libssh2_rsa_ctx **rsa_ctx)
 {
     int rc = 0;
     size_t nlen, elen, dlen, plen, qlen, coefflen, commentlen;
@@ -1834,14 +1834,14 @@ __alloc_error:
                           "Unable to allocate memory for private key data");
 }
 
-static int
-gen_publickey_from_dsa_openssh_priv_data(LIBSSH2_SESSION *session,
-                                         struct string_buf *decrypted,
-                                         unsigned char **method,
-                                         size_t *method_len,
-                                         unsigned char **pubkeydata,
-                                         size_t *pubkeydata_len,
-                                         libssh2_dsa_ctx **dsa_ctx)
+static int gen_publickey_from_dsa_openssh_priv_data(
+    LIBSSH2_SESSION *session,
+    struct string_buf *decrypted,
+    unsigned char **method,
+    size_t *method_len,
+    unsigned char **pubkeydata,
+    size_t *pubkeydata_len,
+    libssh2_dsa_ctx **dsa_ctx)
 {
     int rc = 0;
     size_t plen, qlen, glen, pub_len, priv_len;
@@ -2215,14 +2215,14 @@ fail:
     return -1;
 }
 
-static int
-gen_publickey_from_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
-                                             struct string_buf *decrypted,
-                                             unsigned char **method,
-                                             size_t *method_len,
-                                             unsigned char **pubkeydata,
-                                             size_t *pubkeydata_len,
-                                             libssh2_ed25519_ctx **out_ctx)
+static int gen_publickey_from_ed25519_openssh_priv_data(
+    LIBSSH2_SESSION *session,
+    struct string_buf *decrypted,
+    unsigned char **method,
+    size_t *method_len,
+    unsigned char **pubkeydata,
+    size_t *pubkeydata_len,
+    libssh2_ed25519_ctx **out_ctx)
 {
     libssh2_ed25519_ctx *ctx = NULL;
     unsigned char *method_buf = NULL;
@@ -2358,18 +2358,18 @@ clean_exit:
     return -1;
 }
 
-static int
-gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
-                                                struct string_buf *decrypted,
-                                                unsigned char **method,
-                                                size_t *method_len,
-                                                unsigned char **pubkeydata,
-                                                size_t *pubkeydata_len,
-                                                unsigned char *flags,
-                                                const char **application,
-                                              const unsigned char **key_handle,
-                                                size_t *handle_len,
-                                                libssh2_ed25519_ctx **out_ctx)
+static int gen_publickey_from_sk_ed25519_openssh_priv_data(
+    LIBSSH2_SESSION *session,
+    struct string_buf *decrypted,
+    unsigned char **method,
+    size_t *method_len,
+    unsigned char **pubkeydata,
+    size_t *pubkeydata_len,
+    unsigned char *flags,
+    const char **application,
+    const unsigned char **key_handle,
+    size_t *handle_len,
+    libssh2_ed25519_ctx **out_ctx)
 {
     const char *key_type = "sk-ssh-ed25519@openssh.com";
 
@@ -3722,15 +3722,15 @@ clean_exit:
     return -1;
 }
 
-static int
-gen_publickey_from_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
-                                           libssh2_curve_type curve_type,
-                                           struct string_buf *decrypted,
-                                           unsigned char **method,
-                                           size_t *method_len,
-                                           unsigned char **pubkeydata,
-                                           size_t *pubkeydata_len,
-                                           libssh2_ecdsa_ctx **ec_ctx)
+static int gen_publickey_from_ecdsa_openssh_priv_data(
+    LIBSSH2_SESSION *session,
+    libssh2_curve_type curve_type,
+    struct string_buf *decrypted,
+    unsigned char **method,
+    size_t *method_len,
+    unsigned char **pubkeydata,
+    size_t *pubkeydata_len,
+    libssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
     size_t curvelen, exponentlen, pointlen;
@@ -3871,18 +3871,18 @@ fail:
     return rc;
 }
 
-static int
-gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
-                                              struct string_buf *decrypted,
-                                              unsigned char **method,
-                                              size_t *method_len,
-                                              unsigned char **pubkeydata,
-                                              size_t *pubkeydata_len,
-                                              uint8_t *flags,
-                                              const char **application,
-                                              const unsigned char **key_handle,
-                                              size_t *handle_len,
-                                              libssh2_ecdsa_ctx **ec_ctx)
+static int gen_publickey_from_sk_ecdsa_openssh_priv_data(
+    LIBSSH2_SESSION *session,
+    struct string_buf *decrypted,
+    unsigned char **method,
+    size_t *method_len,
+    unsigned char **pubkeydata,
+    size_t *pubkeydata_len,
+    uint8_t *flags,
+    const char **application,
+    const unsigned char **key_handle,
+    size_t *handle_len,
+    libssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
     size_t curvelen, pointlen, key_len, app_len;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -724,13 +724,10 @@ _libssh2_dsa_sha1_verify(libssh2_dsa_ctx *dsactx,
 
 #if LIBSSH2_ECDSA
 
-/* _libssh2_ecdsa_get_curve_type
- *
+/*
  * returns key curve type that maps to libssh2_curve_type
- *
  */
-libssh2_curve_type
-_libssh2_ecdsa_get_curve_type(libssh2_ecdsa_ctx *ec_ctx)
+libssh2_curve_type _libssh2_ecdsa_get_curve_type(libssh2_ecdsa_ctx *ec_ctx)
 {
 #ifdef USE_OPENSSL_3
     int bits = 0;
@@ -753,10 +750,8 @@ _libssh2_ecdsa_get_curve_type(libssh2_ecdsa_ctx *ec_ctx)
 #endif
 }
 
-/* _libssh2_ecdsa_curve_type_from_name
- *
+/*
  * returns 0 for success, key curve type that maps to libssh2_curve_type
- *
  */
 int
 _libssh2_ecdsa_curve_type_from_name(const char *name,
@@ -784,15 +779,13 @@ _libssh2_ecdsa_curve_type_from_name(const char *name,
     return 0;
 }
 
-/* _libssh2_ecdsa_curve_name_with_octal_new
- *
+/*
  * Creates a new public key given an octal string, length and type
- *
  */
-int
-_libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx **ec_ctx,
-     const unsigned char *k,
-     size_t k_len, libssh2_curve_type curve)
+int _libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx **ec_ctx,
+                                             const unsigned char *k,
+                                             size_t k_len,
+                                             libssh2_curve_type curve)
 {
     int ret = 0;
 
@@ -4206,13 +4199,9 @@ _libssh2_ecdsa_new_private_sk(libssh2_ecdsa_ctx **ec_ctx,
 }
 
 /*
- * _libssh2_ecdsa_create_key
- *
  * Creates a local private key based on input curve
  * and returns octal value and octal length
- *
  */
-
 int
 _libssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
                           libssh2_ec_key **out_private_key,
@@ -4326,12 +4315,10 @@ clean_exit:
     return (ret == 1) ? 0 : -1;
 }
 
-/* _libssh2_ecdh_gen_k
- *
+/*
  * Computes the shared secret K given a local private key,
  * remote public key and length
  */
-
 int
 _libssh2_ecdh_gen_k(libssh2_bn **k, libssh2_ec_key *private_key,
                     const unsigned char *server_public_key,
@@ -5324,10 +5311,8 @@ _libssh2_bn_from_bin(libssh2_bn *bn, size_t len, const unsigned char *val)
     return 0;
 }
 
-/* _libssh2_supported_key_sign_algorithms
- *
+/*
  * Return supported key hash algo upgrades, see crypto.h
- *
  */
 const char *
 _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -353,8 +353,7 @@ static struct asn1Element lastbytebitcount = {
  *
  *******************************************************************/
 
-int
-_libssh2_random(unsigned char *buf, size_t len)
+int _libssh2_random(unsigned char *buf, size_t len)
 {
     Qus_EC_t errcode;
 
@@ -364,8 +363,7 @@ _libssh2_random(unsigned char *buf, size_t len)
     return errcode.Bytes_Available ? -1 : 0;
 }
 
-libssh2_bn *
-_libssh2_bn_init(void)
+libssh2_bn *_libssh2_bn_init(void)
 {
     libssh2_bn *bignum;
 
@@ -378,8 +376,7 @@ _libssh2_bn_init(void)
     return bignum;
 }
 
-void
-_libssh2_bn_free(libssh2_bn *bn)
+void _libssh2_bn_free(libssh2_bn *bn)
 {
     if(bn) {
         if(bn->bignum) {
@@ -393,8 +390,7 @@ _libssh2_bn_free(libssh2_bn *bn)
     }
 }
 
-static int
-_libssh2_bn_resize(libssh2_bn *bn, size_t newlen)
+static int _libssh2_bn_resize(libssh2_bn *bn, size_t newlen)
 {
     unsigned char *bignum;
 
@@ -429,8 +425,7 @@ _libssh2_bn_resize(libssh2_bn *bn, size_t newlen)
     return 0;
 }
 
-unsigned long
-_libssh2_bn_bits(libssh2_bn *bn)
+unsigned long _libssh2_bn_bits(libssh2_bn *bn)
 {
     unsigned int i;
     unsigned char b;
@@ -451,8 +446,7 @@ _libssh2_bn_bits(libssh2_bn *bn)
     return 0;
 }
 
-int
-_libssh2_bn_from_bin(libssh2_bn *bn, size_t len, const unsigned char *val)
+int _libssh2_bn_from_bin(libssh2_bn *bn, size_t len, const unsigned char *val)
 {
     size_t i;
 
@@ -471,15 +465,13 @@ _libssh2_bn_from_bin(libssh2_bn *bn, size_t len, const unsigned char *val)
     return 0;
 }
 
-int
-_libssh2_bn_set_word(libssh2_bn *bn, unsigned long val)
+int _libssh2_bn_set_word(libssh2_bn *bn, unsigned long val)
 {
     val = htonl(val);
     return _libssh2_bn_from_bin(bn, sizeof(val), (unsigned char *) &val);
 }
 
-int
-_libssh2_bn_to_bin(libssh2_bn *bn, unsigned char *val)
+int _libssh2_bn_to_bin(libssh2_bn *bn, unsigned char *val)
 {
     int i;
 
@@ -492,8 +484,7 @@ _libssh2_bn_to_bin(libssh2_bn *bn, unsigned char *val)
     return 0;
 }
 
-static int
-_libssh2_bn_from_bn(libssh2_bn *to, libssh2_bn *from)
+static int _libssh2_bn_from_bn(libssh2_bn *to, libssh2_bn *from)
 {
     int i;
 
@@ -515,8 +506,7 @@ _libssh2_bn_from_bn(libssh2_bn *to, libssh2_bn *from)
  *
  *******************************************************************/
 
-static char *
-getASN1Element(struct asn1Element *elem, char *beg, char *end)
+static char *getASN1Element(struct asn1Element *elem, char *beg, char *end)
 {
     unsigned char b;
     unsigned long len;
@@ -583,8 +573,7 @@ getASN1Element(struct asn1Element *elem, char *beg, char *end)
     return elem->end;
 }
 
-static struct asn1Element *
-asn1_new(unsigned int type, unsigned int length)
+static struct asn1Element *asn1_new(unsigned int type, unsigned int length)
 {
     struct asn1Element *e;
     unsigned int hdrl = 2;
@@ -628,8 +617,8 @@ asn1_new(unsigned int type, unsigned int length)
     return e;
 }
 
-static struct asn1Element *
-asn1_new_from_bytes(const unsigned char *data, unsigned int length)
+static struct asn1Element *asn1_new_from_bytes(const unsigned char *data,
+                                               unsigned int length)
 {
     struct asn1Element *e;
     struct asn1Element et;
@@ -644,8 +633,7 @@ asn1_new_from_bytes(const unsigned char *data, unsigned int length)
     return e;
 }
 
-static void
-asn1delete(struct asn1Element *e)
+static void asn1delete(struct asn1Element *e)
 {
     if(e) {
         if(e->header)
@@ -654,8 +642,7 @@ asn1delete(struct asn1Element *e)
     }
 }
 
-static struct asn1Element *
-asn1uint(libssh2_bn *bn)
+static struct asn1Element *asn1uint(libssh2_bn *bn)
 {
     struct asn1Element *e;
     int bits;
@@ -679,8 +666,8 @@ asn1uint(libssh2_bn *bn)
     return e;
 }
 
-static struct asn1Element *
-asn1containerv(unsigned int type, struct valiststr args)
+static struct asn1Element *asn1containerv(unsigned int type,
+                                          struct valiststr args)
 {
     struct valiststr va;
     struct asn1Element *e;
@@ -704,8 +691,7 @@ asn1containerv(unsigned int type, struct valiststr args)
 }
 
 /* VARARGS1 */
-static struct asn1Element *
-asn1container(unsigned int type, ...)
+static struct asn1Element *asn1container(unsigned int type, ...)
 {
     struct valiststr va;
     struct asn1Element *e;
@@ -716,8 +702,9 @@ asn1container(unsigned int type, ...)
     return e;
 }
 
-static struct asn1Element *
-asn1bytes(unsigned int type, const unsigned char *bytes, unsigned int length)
+static struct asn1Element *asn1bytes(unsigned int type,
+                                     const unsigned char *bytes,
+                                     unsigned int length)
 {
     struct asn1Element *e;
 
@@ -727,8 +714,7 @@ asn1bytes(unsigned int type, const unsigned char *bytes, unsigned int length)
     return e;
 }
 
-static struct asn1Element *
-rsapublickey(libssh2_bn *e, libssh2_bn *m)
+static struct asn1Element *rsapublickey(libssh2_bn *e, libssh2_bn *m)
 {
     struct asn1Element *publicexponent;
     struct asn1Element *modulus;
@@ -751,10 +737,14 @@ rsapublickey(libssh2_bn *e, libssh2_bn *m)
     return rsapubkey;
 }
 
-static struct asn1Element *
-rsaprivatekey(libssh2_bn *e, libssh2_bn *m, libssh2_bn *d,
-              libssh2_bn *p, libssh2_bn *q,
-              libssh2_bn *exp1, libssh2_bn *exp2, libssh2_bn *coeff)
+static struct asn1Element *rsaprivatekey(libssh2_bn *e,
+                                         libssh2_bn *m,
+                                         libssh2_bn *d,
+                                         libssh2_bn *p,
+                                         libssh2_bn *q,
+                                         libssh2_bn *exp1,
+                                         libssh2_bn *exp2,
+                                         libssh2_bn *coeff)
 {
     struct asn1Element *version;
     struct asn1Element *modulus;
@@ -799,9 +789,9 @@ rsaprivatekey(libssh2_bn *e, libssh2_bn *m, libssh2_bn *d,
     return rsaprivkey;
 }
 
-static struct asn1Element *
-subjectpublickeyinfo(struct asn1Element *pubkey, const unsigned char *algo,
-                     struct asn1Element *parameters)
+static struct asn1Element *subjectpublickeyinfo(struct asn1Element *pubkey,
+                                                const unsigned char *algo,
+                                                struct asn1Element *parameters)
 {
     struct asn1Element *subjpubkey;
     struct asn1Element *algorithm;
@@ -826,8 +816,7 @@ subjectpublickeyinfo(struct asn1Element *pubkey, const unsigned char *algo,
     return subjpubkeyinfo;
 }
 
-static struct asn1Element *
-rsasubjectpublickeyinfo(struct asn1Element *pubkey)
+static struct asn1Element *rsasubjectpublickeyinfo(struct asn1Element *pubkey)
 {
     struct asn1Element *parameters;
     struct asn1Element *subjpubkeyinfo;
@@ -843,9 +832,9 @@ rsasubjectpublickeyinfo(struct asn1Element *pubkey)
     return subjpubkeyinfo;
 }
 
-static struct asn1Element *
-privatekeyinfo(struct asn1Element *privkey, const unsigned char *algo,
-               struct asn1Element *parameters)
+static struct asn1Element *privatekeyinfo(struct asn1Element *privkey,
+                                          const unsigned char *algo,
+                                          struct asn1Element *parameters)
 {
     struct asn1Element *version;
     struct asn1Element *privatekey;
@@ -872,8 +861,7 @@ privatekeyinfo(struct asn1Element *privkey, const unsigned char *algo,
     return privkeyinfo;
 }
 
-static struct asn1Element *
-rsaprivatekeyinfo(struct asn1Element *privkey)
+static struct asn1Element *rsaprivatekeyinfo(struct asn1Element *privkey)
 {
     struct asn1Element *parameters;
     struct asn1Element *privkeyinfo;
@@ -894,8 +882,8 @@ rsaprivatekeyinfo(struct asn1Element *privkey)
  *
  *******************************************************************/
 
-static struct os400qc3_crypto_ctx *
-libssh2_init_crypto_ctx(struct os400qc3_crypto_ctx *ctx)
+static struct os400qc3_crypto_ctx *init_crypto_ctx(
+    struct os400qc3_crypto_ctx *ctx)
 {
     if(!ctx)
         ctx = (struct os400qc3_crypto_ctx *) malloc(sizeof(*ctx));
@@ -908,8 +896,7 @@ libssh2_init_crypto_ctx(struct os400qc3_crypto_ctx *ctx)
     return ctx;
 }
 
-static int
-null_token(const char *token)
+static int null_token(const char *token)
 {
     return !memcmp(token, nulltoken.Key_Context_Token,
                    sizeof(nulltoken.Key_Context_Token));
@@ -1005,9 +992,9 @@ _libssh2_os400qc3_hash(const unsigned char *message, unsigned long len,
     return 0;
 }
 
-static int
-libssh2_os400qc3_hmac_init(struct os400qc3_crypto_ctx *ctx,
-                           int algo, size_t minkeylen, void *key, int keylen)
+static int os400qc3_hmac_init(struct os400qc3_crypto_ctx *ctx,
+                              int algo, size_t minkeylen,
+                              void *key, int keylen)
 {
     Qus_EC_t errcode;
 
@@ -1041,34 +1028,34 @@ int _libssh2_hmac_ctx_init(libssh2_hmac_ctx *ctx)
 int _libssh2_hmac_md5_init(libssh2_hmac_ctx *ctx,
                            void *key, size_t keylen)
 {
-    return libssh2_os400qc3_hmac_init(ctx, Qc3_MD5,                     \
-                                      MD5_DIGEST_LENGTH,                \
-                                      key, keylen);
+    return os400qc3_hmac_init(ctx, Qc3_MD5,                     \
+                              MD5_DIGEST_LENGTH,                \
+                              key, keylen);
 }
 #endif
 
 int _libssh2_hmac_sha1_init(libssh2_hmac_ctx *ctx,
                             void *key, size_t keylen)
 {
-    return libssh2_os400qc3_hmac_init(ctx, Qc3_SHA1,                    \
-                                      SHA_DIGEST_LENGTH,                \
-                                      key, keylen);
+    return os400qc3_hmac_init(ctx, Qc3_SHA1,                    \
+                              SHA_DIGEST_LENGTH,                \
+                              key, keylen);
 }
 
 int _libssh2_hmac_sha256_init(libssh2_hmac_ctx *ctx,
                               void *key, size_t keylen)
 {
-    return libssh2_os400qc3_hmac_init(ctx, Qc3_SHA256,                  \
-                                      SHA256_DIGEST_LENGTH,             \
-                                      key, keylen);
+    return os400qc3_hmac_init(ctx, Qc3_SHA256,                  \
+                              SHA256_DIGEST_LENGTH,             \
+                              key, keylen);
 }
 
 int _libssh2_hmac_sha512_init(libssh2_hmac_ctx *ctx,
                               void *key, size_t keylen)
 {
-    return libssh2_os400qc3_hmac_init(ctx, Qc3_SHA512,                  \
-                                      SHA512_DIGEST_LENGTH,             \
-                                      key, keylen);
+    return os400qc3_hmac_init(ctx, Qc3_SHA512,                  \
+                              SHA512_DIGEST_LENGTH,             \
+                              key, keylen);
 }
 
 int _libssh2_hmac_update(libssh2_hmac_ctx *ctx,
@@ -1122,7 +1109,7 @@ _libssh2_cipher_init(libssh2_cipher_ctx *h, LIBSSH2_CIPHER_T(algo),
     if(!h)
         return -1;
 
-    libssh2_init_crypto_ctx(h);
+    init_crypto_ctx(h);
     algd.Block_Cipher_Alg = algo.algo;
     algd.Block_Length = algo.size;
     algd.Mode = algo.mode;
@@ -1209,7 +1196,7 @@ _libssh2_rsa_new(libssh2_rsa_ctx **rsa,
     int ret = 0;
     int i;
 
-    ctx = libssh2_init_crypto_ctx(NULL);
+    ctx = init_crypto_ctx(NULL);
     if(!ctx)
         ret = -1;
     if(!ret) {
@@ -1382,8 +1369,7 @@ _libssh2_os400qc3_dh_dtor(_libssh2_dh_ctx *dhctx)
  *
  *******************************************************************/
 
-static int
-oidcmp(const struct asn1Element *e, const unsigned char *oid)
+static int oidcmp(const struct asn1Element *e, const unsigned char *oid)
 {
     int i = e->end - e->beg - *oid++;
 
@@ -1394,8 +1380,7 @@ oidcmp(const struct asn1Element *e, const unsigned char *oid)
     return i;
 }
 
-static int
-asn1getword(struct asn1Element *e, unsigned long *v)
+static int asn1getword(struct asn1Element *e, unsigned long *v)
 {
     unsigned long a;
     const unsigned char *cp;
@@ -1412,9 +1397,9 @@ asn1getword(struct asn1Element *e, unsigned long *v)
     return 0;
 }
 
-static int
-pbkdf1(LIBSSH2_SESSION *session, char **dk, const unsigned char *passphrase,
-       struct pkcs5params *pkcs5)
+static int pbkdf1(LIBSSH2_SESSION *session, char **dk,
+                  const unsigned char *passphrase,
+                  struct pkcs5params *pkcs5)
 {
     int i;
     Qc3_Format_ALGD0100_T hctx;
@@ -1469,9 +1454,9 @@ pbkdf1(LIBSSH2_SESSION *session, char **dk, const unsigned char *passphrase,
     return 0;
 }
 
-static int
-pbkdf2(LIBSSH2_SESSION *session, char **dk, const unsigned char *passphrase,
-       struct pkcs5params *pkcs5)
+static int pbkdf2(LIBSSH2_SESSION *session, char **dk,
+                  const unsigned char *passphrase,
+                  struct pkcs5params *pkcs5)
 {
     size_t i;
     size_t k;
@@ -1493,8 +1478,8 @@ pbkdf2(LIBSSH2_SESSION *session, char **dk, const unsigned char *passphrase,
         return -1;
 
     /* Create an HMAC context for our computations. */
-    if(!libssh2_os400qc3_hmac_init(&hctx, pkcs5->hash, pkcs5->hashlen,
-                                   (void *) passphrase, strlen(passphrase)))
+    if(!os400qc3_hmac_init(&hctx, pkcs5->hash, pkcs5->hashlen,
+                           (void *) passphrase, strlen(passphrase)))
         return -1;
 
     /* Allocate the derived key buffer. */
@@ -1535,9 +1520,10 @@ pbkdf2(LIBSSH2_SESSION *session, char **dk, const unsigned char *passphrase,
     return 0;
 }
 
-static int
-parse_pkcs5_algorithm(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
-                      struct asn1Element *algid, struct pkcs5algo **algotable)
+static int parse_pkcs5_algorithm(LIBSSH2_SESSION *session,
+                                 struct pkcs5params *pkcs5,
+                                 struct asn1Element *algid,
+                                 struct pkcs5algo **algotable)
 {
     struct asn1Element oid;
     struct asn1Element param;
@@ -1558,9 +1544,8 @@ parse_pkcs5_algorithm(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
     return -1;
 }
 
-static int
-parse_pbes2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
-            struct pkcs5algo *algo, struct asn1Element *param)
+static int parse_pbes2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
+                       struct pkcs5algo *algo, struct asn1Element *param)
 {
     struct asn1Element keyDerivationFunc;
     struct asn1Element encryptionScheme;
@@ -1581,9 +1566,8 @@ parse_pbes2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
     return 0;
 }
 
-static int
-parse_pbkdf2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
-             struct pkcs5algo *algo, struct asn1Element *param)
+static int parse_pbkdf2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
+                        struct pkcs5algo *algo, struct asn1Element *param)
 {
     struct asn1Element salt;
     struct asn1Element iterationCount;
@@ -1633,9 +1617,10 @@ parse_pbkdf2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
     return 0;
 }
 
-static int
-parse_hmacWithSHA1(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
-                   struct pkcs5algo *algo, struct asn1Element *param)
+static int parse_hmacWithSHA1(LIBSSH2_SESSION *session,
+                              struct pkcs5params *pkcs5,
+                              struct pkcs5algo *algo,
+                              struct asn1Element *param)
 {
     if(!param || *param->header != ASN1_NULL)
         return -1;
@@ -1644,9 +1629,8 @@ parse_hmacWithSHA1(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
     return 0;
 }
 
-static int
-parse_iv(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
-         struct pkcs5algo *algo, struct asn1Element *param)
+static int parse_iv(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
+                    struct pkcs5algo *algo, struct asn1Element *param)
 {
     if(!param || *param->header != ASN1_OCTET_STRING ||
         param->end - param->beg != algo->ivlen)
@@ -1662,9 +1646,8 @@ parse_iv(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
     return 0;
 }
 
-static int
-parse_rc2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
-          struct pkcs5algo *algo, struct asn1Element *param)
+static int parse_rc2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
+                     struct pkcs5algo *algo, struct asn1Element *param)
 {
     struct asn1Element iv;
     unsigned long effkeysize;
@@ -1711,9 +1694,8 @@ parse_rc2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
     return 0;
 }
 
-static int
-parse_pbes1(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
-            struct pkcs5algo *algo, struct asn1Element *param)
+static int parse_pbes1(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
+                       struct pkcs5algo *algo, struct asn1Element *param)
 {
     struct asn1Element salt;
     struct asn1Element iterationCount;
@@ -1749,10 +1731,10 @@ parse_pbes1(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
     return 0;
 }
 
-static int
-pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
-         const unsigned char *data, unsigned int datalen,
-         const unsigned char *passphrase, struct asn1Element *privkeyinfo)
+static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
+                    const unsigned char *data, unsigned int datalen,
+                    const unsigned char *passphrase,
+                    struct asn1Element *privkeyinfo)
 {
     struct asn1Element encprivkeyinfo;
     struct asn1Element pkcs5alg;
@@ -1822,12 +1804,12 @@ pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
     memcpy(algd.Init_Vector, pkcs5.iv, pkcs5.ivlen);
 
     /* Create the key and algorithm context tokens. */
-    *ctx = libssh2_init_crypto_ctx(NULL);
+    *ctx = init_crypto_ctx(NULL);
     if(!*ctx) {
         LIBSSH2_FREE(session, dk);
         return -1;
     }
-    libssh2_init_crypto_ctx(*ctx);
+    init_crypto_ctx(*ctx);
     set_EC_length(errcode, sizeof(errcode));
     Qc3CreateKeyContext(dk, &pkcs5.dklen, binstring, &algd.Block_Cipher_Alg,
                         qc3clear, NULL, NULL, (*ctx)->key.Key_Context_Token,
@@ -1850,10 +1832,9 @@ pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
     return 1;       /* Tell it's encrypted. */
 }
 
-static int
-rsapkcs8privkey(LIBSSH2_SESSION *session,
-                const unsigned char *data, unsigned int datalen,
-                const unsigned char *passphrase, void *loadkeydata)
+static int rsapkcs8privkey(LIBSSH2_SESSION *session,
+                           const unsigned char *data, unsigned int datalen,
+                           const unsigned char *passphrase, void *loadkeydata)
 {
     libssh2_rsa_ctx *ctx = (libssh2_rsa_ctx *) loadkeydata;
     char keyform = Qc3_Clear;
@@ -1889,8 +1870,7 @@ rsapkcs8privkey(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static char *
-storewithlength(char *p, const char *data, int length)
+static char *storewithlength(char *p, const char *data, int length)
 {
     _libssh2_htonu32(p, length);
     if(length)
@@ -1898,10 +1878,9 @@ storewithlength(char *p, const char *data, int length)
     return p + 4 + length;
 }
 
-static int
-sshrsapubkey(LIBSSH2_SESSION *session, char **sshpubkey,
-             struct asn1Element *params, struct asn1Element *key,
-             const char *method)
+static int sshrsapubkey(LIBSSH2_SESSION *session, char **sshpubkey,
+                        struct asn1Element *params, struct asn1Element *key,
+                        const char *method)
 {
     int methlen = strlen(method);
     struct asn1Element keyseq;
@@ -1930,10 +1909,9 @@ sshrsapubkey(LIBSSH2_SESSION *session, char **sshpubkey,
     return len;
 }
 
-static int
-rsapkcs8pubkey(LIBSSH2_SESSION *session,
-               const unsigned char *data, unsigned int datalen,
-               const unsigned char *passphrase, void *loadkeydata)
+static int rsapkcs8pubkey(LIBSSH2_SESSION *session,
+                          const unsigned char *data, unsigned int datalen,
+                          const unsigned char *passphrase, void *loadkeydata)
 {
     struct loadpubkeydata *p = (struct loadpubkeydata *) loadkeydata;
     char *buf;
@@ -2002,10 +1980,9 @@ rsapkcs8pubkey(LIBSSH2_SESSION *session,
     return -1;                              /* Algorithm not supported. */
 }
 
-static int
-pkcs1topkcs8(LIBSSH2_SESSION *session,
-             const unsigned char **data8, unsigned int *datalen8,
-             const unsigned char *data1, unsigned int datalen1)
+static int pkcs1topkcs8(LIBSSH2_SESSION *session,
+                        const unsigned char **data8, unsigned int *datalen8,
+                        const unsigned char *data1, unsigned int datalen1)
 {
     struct asn1Element *prvk;
     struct asn1Element *pkcs8;
@@ -2039,10 +2016,9 @@ pkcs1topkcs8(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static int
-rsapkcs1privkey(LIBSSH2_SESSION *session,
-                const unsigned char *data, unsigned int datalen,
-                const unsigned char *passphrase, void *loadkeydata)
+static int rsapkcs1privkey(LIBSSH2_SESSION *session,
+                           const unsigned char *data, unsigned int datalen,
+                           const unsigned char *passphrase, void *loadkeydata)
 {
     const unsigned char *data8;
     unsigned int datalen8;
@@ -2055,10 +2031,9 @@ rsapkcs1privkey(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int
-rsapkcs1pubkey(LIBSSH2_SESSION *session,
-               const unsigned char *data, unsigned int datalen,
-               const unsigned char *passphrase, void *loadkeydata)
+static int rsapkcs1pubkey(LIBSSH2_SESSION *session,
+                          const unsigned char *data, unsigned int datalen,
+                          const unsigned char *passphrase, void *loadkeydata)
 {
     const unsigned char *data8;
     unsigned int datalen8;
@@ -2071,11 +2046,10 @@ rsapkcs1pubkey(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int
-try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
-             const unsigned char *passphrase,
-             const char *header, const char *trailer,
-             loadkeyproc proc, void *loadkeydata)
+static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
+                        const unsigned char *passphrase,
+                        const char *header, const char *trailer,
+                        loadkeyproc proc, void *loadkeydata)
 {
     unsigned char *data = NULL;
     size_t datalen = 0;
@@ -2109,10 +2083,11 @@ try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
     return -1;
 }
 
-static int
-load_rsa_private_file(LIBSSH2_SESSION *session, const char *filename,
-                      unsigned const char *passphrase,
-                      loadkeyproc proc1, loadkeyproc proc8, void *loadkeydata)
+static int load_rsa_private_file(LIBSSH2_SESSION *session,
+                                 const char *filename,
+                                 unsigned const char *passphrase,
+                                 loadkeyproc proc1, loadkeyproc proc8,
+                                 void *loadkeydata)
 {
     FILE *fp = fopen(filename, fopenrbmode);
     unsigned char *data = NULL;
@@ -2176,7 +2151,7 @@ int
 _libssh2_rsa_new_private(libssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                          const char *filename, unsigned const char *passphrase)
 {
-    libssh2_rsa_ctx *ctx = libssh2_init_crypto_ctx(NULL);
+    libssh2_rsa_ctx *ctx = init_crypto_ctx(NULL);
     int ret;
 
     if(!ctx)
@@ -2240,7 +2215,7 @@ _libssh2_rsa_new_private_frommemory(libssh2_rsa_ctx **rsa,
                                     size_t filedata_len,
                                     unsigned const char *passphrase)
 {
-    libssh2_rsa_ctx *ctx = libssh2_init_crypto_ctx(NULL);
+    libssh2_rsa_ctx *ctx = init_crypto_ctx(NULL);
     unsigned char *data = NULL;
     size_t datalen = 0;
     int ret;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2478,10 +2478,8 @@ _libssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session,
     return 0;
 }
 
-/* _libssh2_supported_key_sign_algorithms
- *
+/*
  * Return supported key hash algo upgrades, see crypto.h
- *
  */
 const char *
 _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,

--- a/src/packet.c
+++ b/src/packet.c
@@ -62,10 +62,10 @@
  *
  * Queue a connection request for a listener
  */
-static inline int
-packet_queue_listener(LIBSSH2_SESSION *session, unsigned char *data,
-                      size_t datalen,
-                      struct packet_queue_listener_state *listen_state)
+static inline int packet_queue_listener(
+    LIBSSH2_SESSION *session,
+    unsigned char *data, size_t datalen,
+    struct packet_queue_listener_state *listen_state)
 {
     /*
      * Look for a matching listener
@@ -276,10 +276,10 @@ packet_queue_listener(LIBSSH2_SESSION *session, unsigned char *data,
  *
  * Accept a forwarded X11 connection
  */
-static inline int
-packet_x11_open(LIBSSH2_SESSION *session, unsigned char *data,
-                size_t datalen,
-                struct packet_x11_open_state *x11open_state)
+static inline int packet_x11_open(
+    LIBSSH2_SESSION *session,
+    unsigned char *data, size_t datalen,
+    struct packet_x11_open_state *x11open_state)
 {
     uint32_t failure_code = SSH_OPEN_CONNECT_FAILED;
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */
@@ -477,10 +477,10 @@ x11_exit:
  *
  * Open a connection to authentication agent
  */
-static inline int
-packet_authagent_open(LIBSSH2_SESSION *session,
-                      unsigned char *data, size_t datalen,
-                      struct packet_authagent_state *authagent_state)
+static inline int packet_authagent_open(
+    LIBSSH2_SESSION *session,
+    unsigned char *data, size_t datalen,
+    struct packet_authagent_state *authagent_state)
 {
     uint32_t failure_code = SSH_OPEN_CONNECT_FAILED;
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */

--- a/src/packet.c
+++ b/src/packet.c
@@ -58,8 +58,6 @@
 #include "packet.h"
 
 /*
- * libssh2_packet_queue_listener
- *
  * Queue a connection request for a listener
  */
 static inline int packet_queue_listener(
@@ -272,8 +270,6 @@ static inline int packet_queue_listener(
 }
 
 /*
- * packet_x11_open
- *
  * Accept a forwarded X11 connection
  */
 static inline int packet_x11_open(
@@ -473,8 +469,6 @@ x11_exit:
 }
 
 /*
- * packet_authagent_open
- *
  * Open a connection to authentication agent
  */
 static inline int packet_authagent_open(
@@ -637,8 +631,6 @@ authagent_exit:
 }
 
 /*
- * _libssh2_packet_add
- *
  * Create a new packet and attach it to the brigade. Called from the transport
  * layer when it has received a packet.
  *
@@ -1461,8 +1453,6 @@ libssh2_packet_add_jump_authagent:
 }
 
 /*
- * _libssh2_packet_ask
- *
  * Scan the brigade for a matching packet type, optionally poll the socket for
  * a packet first
  */
@@ -1508,8 +1498,6 @@ _libssh2_packet_ask(LIBSSH2_SESSION *session, unsigned char packet_type,
 }
 
 /*
- * libssh2_packet_askv
- *
  * Scan for any of a list of packet types in the brigade, optionally poll the
  * socket for a packet first
  */
@@ -1535,8 +1523,6 @@ _libssh2_packet_askv(LIBSSH2_SESSION *session,
 }
 
 /*
- * _libssh2_packet_require
- *
  * Loops _libssh2_transport_read() until the packet requested is available
  * SSH_DISCONNECT or a SOCKET_DISCONNECTED will cause a bailout
  *
@@ -1599,8 +1585,6 @@ _libssh2_packet_require(LIBSSH2_SESSION *session, unsigned char packet_type,
 }
 
 /*
- * _libssh2_packet_burn
- *
  * Loops _libssh2_transport_read() until any packet is available and promptly
  * discards it.
  * Used during KEX exchange to discard badly guessed KEX_INIT packets
@@ -1663,8 +1647,6 @@ _libssh2_packet_burn(LIBSSH2_SESSION *session,
 }
 
 /*
- * _libssh2_packet_requirev
- *
  * Loops _libssh2_transport_read() until one of a list of packet types
  * requested is available. SSH_DISCONNECT or a SOCKET_DISCONNECTED will cause
  * a bailout. packet_types is a null terminated list of packet_type numbers

--- a/src/pem.c
+++ b/src/pem.c
@@ -40,8 +40,7 @@
 
 #include "libssh2_priv.h"
 
-static int
-readline(char *line, int line_size, FILE *fp)
+static int readline(char *line, int line_size, FILE *fp)
 {
     size_t len;
 
@@ -69,10 +68,9 @@ readline(char *line, int line_size, FILE *fp)
     return 0;
 }
 
-static int
-readline_memory(char *line, size_t line_size,
-                const char *filedata, size_t filedata_len,
-                size_t *filedata_offset)
+static int readline_memory(char *line, size_t line_size,
+                           const char *filedata, size_t filedata_len,
+                           size_t *filedata_offset)
 {
     size_t off, len;
 
@@ -414,11 +412,11 @@ out:
 #define OPENSSH_HEADER_BEGIN "-----BEGIN OPENSSH PRIVATE KEY-----"
 #define OPENSSH_HEADER_END "-----END OPENSSH PRIVATE KEY-----"
 
-static int
-_libssh2_openssh_pem_parse_data(LIBSSH2_SESSION *session,
-                                const unsigned char *passphrase,
-                                const char *b64data, size_t b64datalen,
-                                struct string_buf **decrypted_buf)
+static int _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION *session,
+                                           const unsigned char *passphrase,
+                                           const char *b64data,
+                                           size_t b64datalen,
+                                           struct string_buf **decrypted_buf)
 {
     const struct crypt_method *method = NULL;
     struct string_buf decoded, decrypted, kdf_buf;
@@ -898,9 +896,8 @@ out:
     return ret;
 }
 
-static int
-read_asn1_length(const unsigned char *data,
-                 size_t datalen, size_t *len)
+static int read_asn1_length(const unsigned char *data,
+                            size_t datalen, size_t *len)
 {
     unsigned int lenlen;
     int nextpos;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -564,8 +564,8 @@ err_exit:
  *
  * Startup the publickey subsystem
  */
-LIBSSH2_API LIBSSH2_PUBLICKEY *
-libssh2_publickey_init(LIBSSH2_SESSION *session)
+LIBSSH2_API
+LIBSSH2_PUBLICKEY *libssh2_publickey_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_PUBLICKEY *ptr;
 
@@ -579,12 +579,13 @@ libssh2_publickey_init(LIBSSH2_SESSION *session)
  *
  * Add a new public key entry
  */
-LIBSSH2_API int
-libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
-                         unsigned long name_len, const unsigned char *blob,
-                         unsigned long blob_len, char overwrite,
-                         unsigned long num_attrs,
-                         const libssh2_publickey_attribute attrs[])
+LIBSSH2_API
+int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
+                             const unsigned char *name, unsigned long name_len,
+                             const unsigned char *blob, unsigned long blob_len,
+                             char overwrite,
+                             unsigned long num_attrs,
+                             const libssh2_publickey_attribute attrs[])
 {
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_SESSION *session;
@@ -727,10 +728,12 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
  * Remove an existing publickey so that authentication can no longer be
  * performed using it
  */
-LIBSSH2_API int
-libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
-                            const unsigned char *name, unsigned long name_len,
-                            const unsigned char *blob, unsigned long blob_len)
+LIBSSH2_API
+int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
+                                const unsigned char *name,
+                                unsigned long name_len,
+                                const unsigned char *blob,
+                                unsigned long blob_len)
 {
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_SESSION *session;
@@ -812,9 +815,10 @@ libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
 /* libssh2_publickey_list_fetch
  * Fetch a list of supported public key from a server
  */
-LIBSSH2_API int
-libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey, unsigned long *num_keys,
-                             libssh2_publickey_list **pkey_list)
+LIBSSH2_API
+int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
+                                 unsigned long *num_keys,
+                                 libssh2_publickey_list **pkey_list)
 {
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_SESSION *session;
@@ -1212,9 +1216,9 @@ err_exit:
 /* libssh2_publickey_list_free
  * Free a previously fetched list of public keys
  */
-LIBSSH2_API void
-libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
-                            libssh2_publickey_list *pkey_list)
+LIBSSH2_API
+void libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
+                                 libssh2_publickey_list *pkey_list)
 {
     LIBSSH2_SESSION *session;
     libssh2_publickey_list *p = pkey_list;
@@ -1238,8 +1242,8 @@ libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
 /* libssh2_publickey_shutdown
  * Shutdown the publickey subsystem
  */
-LIBSSH2_API int
-libssh2_publickey_shutdown(LIBSSH2_PUBLICKEY *pkey)
+LIBSSH2_API
+int libssh2_publickey_shutdown(LIBSSH2_PUBLICKEY *pkey)
 {
     LIBSSH2_SESSION *session;
     int rc;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -95,8 +95,6 @@ static const struct publickey_code_list publickey_status_codes[] = {
 #undef STRLEN
 
 /*
- * publickey_status_error
- *
  * Format an error message from a status code
  */
 static void publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
@@ -121,8 +119,6 @@ static void publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
 }
 
 /*
- * publickey_packet_receive
- *
  * Read a packet from the subsystem
  */
 static int publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
@@ -183,8 +179,7 @@ static int publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
     return 0;
 }
 
-/* publickey_response_id
- *
+/*
  * Translate a string response name to a numeric code
  * Data will be incremented by 4 + response_len on success only
  */
@@ -218,8 +213,7 @@ static int publickey_response_id(unsigned char **pdata, size_t data_len)
     return -1;
 }
 
-/* publickey_response_success
- *
+/*
  * Generic helper routine to wait for success response and nothing else
  */
 static int publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
@@ -286,13 +280,11 @@ err_exit:
     return -1;
 }
 
-/* *****************
+/* ***************
  * Publickey API *
- ***************** */
+ *************** */
 
 /*
- * publickey_init
- *
  * Startup the publickey subsystem
  */
 static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
@@ -557,8 +549,6 @@ err_exit:
 }
 
 /*
- * libssh2_publickey_init
- *
  * Startup the publickey subsystem
  */
 LIBSSH2_API
@@ -572,8 +562,6 @@ LIBSSH2_PUBLICKEY *libssh2_publickey_init(LIBSSH2_SESSION *session)
 }
 
 /*
- * libssh2_publickey_add_ex
- *
  * Add a new public key entry
  */
 LIBSSH2_API
@@ -721,7 +709,7 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
     return rc;
 }
 
-/* libssh2_publickey_remove_ex
+/*
  * Remove an existing publickey so that authentication can no longer be
  * performed using it
  */
@@ -809,7 +797,7 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
     return rc;
 }
 
-/* libssh2_publickey_list_fetch
+/*
  * Fetch a list of supported public key from a server
  */
 LIBSSH2_API
@@ -1210,7 +1198,7 @@ err_exit:
     return -1;
 }
 
-/* libssh2_publickey_list_free
+/*
  * Free a previously fetched list of public keys
  */
 LIBSSH2_API
@@ -1236,7 +1224,7 @@ void libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
     LIBSSH2_FREE(session, pkey_list);
 }
 
-/* libssh2_publickey_shutdown
+/*
  * Shutdown the publickey subsystem
  */
 LIBSSH2_API

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -99,9 +99,9 @@ static const struct publickey_code_list publickey_status_codes[] = {
  *
  * Format an error message from a status code
  */
-static void
-publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
-                       LIBSSH2_SESSION *session, unsigned long status)
+static void publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
+                                   LIBSSH2_SESSION *session,
+                                   unsigned long status)
 {
     const char *msg;
 
@@ -125,9 +125,8 @@ publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
  *
  * Read a packet from the subsystem
  */
-static int
-publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
-                         unsigned char **data, size_t *data_len)
+static int publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
+                                    unsigned char **data, size_t *data_len)
 {
     LIBSSH2_CHANNEL *channel = pkey->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -189,8 +188,7 @@ publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
  * Translate a string response name to a numeric code
  * Data will be incremented by 4 + response_len on success only
  */
-static int
-publickey_response_id(unsigned char **pdata, size_t data_len)
+static int publickey_response_id(unsigned char **pdata, size_t data_len)
 {
     size_t response_len;
     unsigned char *data = *pdata;
@@ -224,8 +222,7 @@ publickey_response_id(unsigned char **pdata, size_t data_len)
  *
  * Generic helper routine to wait for success response and nothing else
  */
-static int
-publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
+static int publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
 {
     LIBSSH2_SESSION *session = pkey->channel->session;
     unsigned char *data, *s;

--- a/src/scp.c
+++ b/src/scp.c
@@ -131,9 +131,8 @@
   until then it is kept static and in this source file.
 */
 
-static size_t
-shell_quotearg(const char *path, unsigned char *buf,
-               size_t bufsize)
+static size_t shell_quotearg(const char *path,
+                             unsigned char *buf, size_t bufsize)
 {
     const char *src;
     unsigned char *dst, *endp;
@@ -276,8 +275,8 @@ shell_quotearg(const char *path, unsigned char *buf,
  * Open a channel and request a remote file via SCP
  *
  */
-static LIBSSH2_CHANNEL *
-scp_recv(LIBSSH2_SESSION *session, const char *path, libssh2_struct_stat *sb)
+static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
+                                 const char *path, libssh2_struct_stat *sb)
 {
     size_t cmd_len;
     int rc;
@@ -857,9 +856,10 @@ LIBSSH2_CHANNEL *libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
  * Send a file using SCP
  *
  */
-static LIBSSH2_CHANNEL *
-scp_send(LIBSSH2_SESSION *session, const char *path, int mode,
-         libssh2_int64_t size, time_t mtime, time_t atime)
+static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
+                                 const char *path, int mode,
+                                 libssh2_int64_t size,
+                                 time_t mtime, time_t atime)
 {
     size_t cmd_len;
     int rc;

--- a/src/scp.c
+++ b/src/scp.c
@@ -806,8 +806,9 @@ scp_recv_error:
  * where the st_size member of struct stat is limited to 2 GB (e.g. windows).
  *
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path, struct stat *sb)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path,
+                                  struct stat *sb)
 {
     LIBSSH2_CHANNEL *ptr;
 
@@ -841,9 +842,9 @@ libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path, struct stat *sb)
  * on platforms that support it.
  *
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
-                  libssh2_struct_stat *sb)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
+                                   libssh2_struct_stat *sb)
 {
     LIBSSH2_CHANNEL *ptr;
     BLOCK_ADJUST_ERRNO(ptr, session, scp_recv(session, path, sb));
@@ -1167,9 +1168,11 @@ scp_send_error:
  *
  * Send a file using SCP. Old API.
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_scp_send_ex(LIBSSH2_SESSION *session, const char *path, int mode,
-                    size_t size, long mtime, long atime)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_scp_send_ex(LIBSSH2_SESSION *session,
+                                     const char *path, int mode,
+                                     size_t size,
+                                     long mtime, long atime)
 {
     LIBSSH2_CHANNEL *ptr;
     BLOCK_ADJUST_ERRNO(ptr, session,
@@ -1184,9 +1187,11 @@ libssh2_scp_send_ex(LIBSSH2_SESSION *session, const char *path, int mode,
  *
  * Send a file using SCP
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_scp_send64(LIBSSH2_SESSION *session, const char *path, int mode,
-                   libssh2_int64_t size, time_t mtime, time_t atime)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_scp_send64(LIBSSH2_SESSION *session,
+                                    const char *path, int mode,
+                                    libssh2_int64_t size,
+                                    time_t mtime, time_t atime)
 {
     LIBSSH2_CHANNEL *ptr;
     BLOCK_ADJUST_ERRNO(ptr, session,

--- a/src/scp.c
+++ b/src/scp.c
@@ -130,7 +130,6 @@
   Note: this function could possible be used elsewhere within libssh2, but
   until then it is kept static and in this source file.
 */
-
 static size_t shell_quotearg(const char *path,
                              unsigned char *buf, size_t bufsize)
 {
@@ -270,10 +269,7 @@ static size_t shell_quotearg(const char *path,
 }
 
 /*
- * scp_recv
- *
  * Open a channel and request a remote file via SCP
- *
  */
 static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                                  const char *path, libssh2_struct_stat *sb)
@@ -798,12 +794,11 @@ scp_recv_error:
 
 #ifndef LIBSSH2_NO_DEPRECATED
 /*
- * libssh2_scp_recv (DEPRECATED, DO NOT USE!)
+ * DEPRECATED, DO NOT USE!
  *
  * Open a channel and request a remote file via SCP.  This receives files
  * larger than 2 GB, but is unable to report the proper size on platforms
  * where the st_size member of struct stat is limited to 2 GB (e.g. windows).
- *
  */
 LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path,
@@ -835,11 +830,8 @@ LIBSSH2_CHANNEL *libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path,
 #endif
 
 /*
- * libssh2_scp_recv2
- *
  * Open a channel and request a remote file via SCP.  This supports files > 2GB
  * on platforms that support it.
- *
  */
 LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
@@ -851,10 +843,7 @@ LIBSSH2_CHANNEL *libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
 }
 
 /*
- * scp_send
- *
  * Send a file using SCP
- *
  */
 static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
                                  const char *path, int mode,
@@ -1164,7 +1153,7 @@ scp_send_error:
 
 #ifndef LIBSSH2_NO_DEPRECATED
 /*
- * libssh2_scp_send_ex (DEPRECATED, DO NOT USE!)
+ * DEPRECATED, DO NOT USE!
  *
  * Send a file using SCP. Old API.
  */
@@ -1183,8 +1172,6 @@ LIBSSH2_CHANNEL *libssh2_scp_send_ex(LIBSSH2_SESSION *session,
 #endif
 
 /*
- * libssh2_scp_send64
- *
  * Send a file using SCP
  */
 LIBSSH2_API

--- a/src/session.c
+++ b/src/session.c
@@ -387,8 +387,8 @@ get_socket_nonblocking(libssh2_socket_t sockfd)
 /* libssh2_session_banner_set
  * Set the local banner to use in the server handshake.
  */
-LIBSSH2_API int
-libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
+LIBSSH2_API
+int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
 {
     size_t banner_len = banner ? strlen(banner) : 0;
 
@@ -423,8 +423,8 @@ libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
 /* libssh2_banner_set
  * Set the local banner. DEPRECATED VERSION
  */
-LIBSSH2_API int
-libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner)
+LIBSSH2_API
+int libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner)
 {
     return libssh2_session_banner_set(session, banner);
 }
@@ -439,10 +439,11 @@ libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner)
  * callbacks An additional pointer value may be optionally passed to be sent
  * to the callbacks (so they know who's asking)
  */
-LIBSSH2_API LIBSSH2_SESSION *
-libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
-                        LIBSSH2_FREE_FUNC(*my_free),
-                        LIBSSH2_REALLOC_FUNC(*my_realloc), void *abstract)
+LIBSSH2_API
+LIBSSH2_SESSION *libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
+                                         LIBSSH2_FREE_FUNC(*my_free),
+                                         LIBSSH2_REALLOC_FUNC(*my_realloc),
+                                         void *abstract)
 {
     LIBSSH2_ALLOC_FUNC(*local_alloc) = libssh2_default_alloc;
     LIBSSH2_FREE_FUNC(*local_free) = libssh2_default_free;
@@ -493,9 +494,10 @@ libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type"
 #endif
-LIBSSH2_API libssh2_cb_generic *
-libssh2_session_callback_set2(LIBSSH2_SESSION *session, int cbtype,
-                              libssh2_cb_generic *callback)
+LIBSSH2_API
+libssh2_cb_generic *libssh2_session_callback_set2(LIBSSH2_SESSION *session,
+                                                  int cbtype,
+                                                  libssh2_cb_generic *callback)
 {
     libssh2_cb_generic *oldcb;
 
@@ -578,9 +580,9 @@ libssh2_session_callback_set2(LIBSSH2_SESSION *session, int cbtype,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
-LIBSSH2_API void *
-libssh2_session_callback_set(LIBSSH2_SESSION *session,
-                             int cbtype, void *callback)
+LIBSSH2_API
+void *libssh2_session_callback_set(LIBSSH2_SESSION *session,
+                                   int cbtype, void *callback)
 {
     return (void *)libssh2_session_callback_set2(session, cbtype,
                                                (libssh2_cb_generic *)callback);
@@ -881,8 +883,8 @@ session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
  *
  * Returns: 0 on success, or non-zero on failure
  */
-LIBSSH2_API int
-libssh2_session_handshake(LIBSSH2_SESSION *session, libssh2_socket_t sock)
+LIBSSH2_API
+int libssh2_session_handshake(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 {
     int rc;
 
@@ -903,8 +905,8 @@ libssh2_session_handshake(LIBSSH2_SESSION *session, libssh2_socket_t sock)
  *
  * Returns: 0 on success, or non-zero on failure
  */
-LIBSSH2_API int
-libssh2_session_startup(LIBSSH2_SESSION *session, int sock)
+LIBSSH2_API
+int libssh2_session_startup(LIBSSH2_SESSION *session, int sock)
 {
     return libssh2_session_handshake(session, (libssh2_socket_t)sock);
 }
@@ -1183,8 +1185,8 @@ session_free(LIBSSH2_SESSION *session)
  * Frees the memory allocated to the session
  * Also closes and frees any channels attached to this session
  */
-LIBSSH2_API int
-libssh2_session_free(LIBSSH2_SESSION *session)
+LIBSSH2_API
+int libssh2_session_free(LIBSSH2_SESSION *session)
 {
     int rc;
 
@@ -1251,9 +1253,9 @@ session_disconnect(LIBSSH2_SESSION *session, int reason,
 /*
  * libssh2_session_disconnect_ex
  */
-LIBSSH2_API int
-libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
-                              const char *description, const char *lang)
+LIBSSH2_API
+int libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
+                                  const char *description, const char *lang)
 {
     int rc;
     session->state &= ~LIBSSH2_STATE_INITIAL_KEX;
@@ -1271,8 +1273,8 @@ libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
  * NOTE: Currently lang_cs and lang_sc are ALWAYS set to empty string
  * regardless of actual negotiation Strings should NOT be freed
  */
-LIBSSH2_API const char *
-libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
+LIBSSH2_API
+const char *libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
 {
     /* All methods have char *name as their first element */
     const struct kex_method *method = NULL;
@@ -1334,8 +1336,8 @@ libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
 /* libssh2_session_abstract
  * Retrieve a pointer to the abstract property
  */
-LIBSSH2_API void **
-libssh2_session_abstract(LIBSSH2_SESSION *session)
+LIBSSH2_API
+void **libssh2_session_abstract(LIBSSH2_SESSION *session)
 {
     return &session->abstract;
 }
@@ -1346,9 +1348,9 @@ libssh2_session_abstract(LIBSSH2_SESSION *session)
  * non-zero then the string placed into errmsg must be freed by the calling
  * program. Otherwise it is assumed to be owned by libssh2
  */
-LIBSSH2_API int
-libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
-                           int *errmsg_len, int want_buf)
+LIBSSH2_API
+int libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
+                               int *errmsg_len, int want_buf)
 {
     size_t msglen = 0;
 
@@ -1399,8 +1401,8 @@ libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
  *
  * Returns error code
  */
-LIBSSH2_API int
-libssh2_session_last_errno(LIBSSH2_SESSION *session)
+LIBSSH2_API
+int libssh2_session_last_errno(LIBSSH2_SESSION *session)
 {
     return session->err_code;
 }
@@ -1413,10 +1415,10 @@ libssh2_session_last_errno(LIBSSH2_SESSION *session)
  * language wrappers (i.e. Python or Perl) that may extend the library
  * features while still relying on its error reporting mechanism.
  */
-LIBSSH2_API int
-libssh2_session_set_last_error(LIBSSH2_SESSION* session,
-                               int errcode,
-                               const char *errmsg)
+LIBSSH2_API
+int libssh2_session_set_last_error(LIBSSH2_SESSION* session,
+                                   int errcode,
+                                   const char *errmsg)
 {
     return _libssh2_error_flags(session, errcode, errmsg,
                                 LIBSSH2_ERR_FLAG_DUP);
@@ -1428,8 +1430,8 @@ libssh2_session_set_last_error(LIBSSH2_SESSION* session,
  *
  * Return error code.
  */
-LIBSSH2_API int
-libssh2_session_flag(LIBSSH2_SESSION *session, int flag, int value)
+LIBSSH2_API
+int libssh2_session_flag(LIBSSH2_SESSION *session, int flag, int value)
 {
     switch(flag) {
     case LIBSSH2_FLAG_SIGPIPE:
@@ -1471,8 +1473,8 @@ _libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
  * Set a channel's blocking mode on or off, similar to a socket's
  * fcntl(fd, F_SETFL, O_NONBLOCK); type command
  */
-LIBSSH2_API void
-libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
+LIBSSH2_API
+void libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
 {
     (void)_libssh2_session_set_blocking(session, blocking);
 }
@@ -1481,8 +1483,8 @@ libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
  *
  * Returns a session's blocking mode on or off
  */
-LIBSSH2_API int
-libssh2_session_get_blocking(LIBSSH2_SESSION *session)
+LIBSSH2_API
+int libssh2_session_get_blocking(LIBSSH2_SESSION *session)
 {
     return session->api_block_mode;
 }
@@ -1492,8 +1494,8 @@ libssh2_session_get_blocking(LIBSSH2_SESSION *session)
  * Set a session's timeout (in msec) for blocking mode,
  * or 0 to disable timeouts.
  */
-LIBSSH2_API void
-libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
+LIBSSH2_API
+void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
 {
     session->api_timeout = timeout;
 }
@@ -1502,8 +1504,8 @@ libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
  *
  * Returns a session's timeout, or 0 if disabled
  */
-LIBSSH2_API long
-libssh2_session_get_timeout(LIBSSH2_SESSION *session)
+LIBSSH2_API
+long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
 {
     return session->api_timeout;
 }
@@ -1513,8 +1515,8 @@ libssh2_session_get_timeout(LIBSSH2_SESSION *session)
  * Set a session's timeout (in sec) when reading packets,
  * or 0 to use default of 60 seconds.
  */
-LIBSSH2_API void
-libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
+LIBSSH2_API
+void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
 {
     if(timeout <= 0) {
         timeout = LIBSSH2_DEFAULT_READ_TIMEOUT;
@@ -1526,8 +1528,8 @@ libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
  *
  * Returns a session's timeout. Default is 60 seconds.
  */
-LIBSSH2_API long
-libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
+LIBSSH2_API
+long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
 {
     return session->packet_read_timeout;
 }
@@ -1538,8 +1540,8 @@ libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
  * Returns 0 if no data is waiting on channel,
  * non-0 if data is available
  */
-LIBSSH2_API int
-libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
+LIBSSH2_API
+int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
 {
     LIBSSH2_SESSION *session;
     struct packet *packet;
@@ -1603,8 +1605,8 @@ poll_listener_queued(LIBSSH2_LISTENER *listener)
  *
  * Poll sockets, channels, and listeners for activity
  */
-LIBSSH2_API int
-libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
+LIBSSH2_API
+int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 {
     long timeout_remaining;
     unsigned int i, active_fds;
@@ -1942,8 +1944,8 @@ libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
  * Returns LIBSSH2_SOCKET_BLOCK_INBOUND if recv() blocked
  * or LIBSSH2_SOCKET_BLOCK_OUTBOUND if send() blocked
  */
-LIBSSH2_API int
-libssh2_session_block_directions(LIBSSH2_SESSION *session)
+LIBSSH2_API
+int libssh2_session_block_directions(LIBSSH2_SESSION *session)
 {
     return session->socket_block_directions;
 }
@@ -1952,8 +1954,8 @@ libssh2_session_block_directions(LIBSSH2_SESSION *session)
  * Get the remote banner (server ID string)
  */
 
-LIBSSH2_API const char *
-libssh2_session_banner_get(LIBSSH2_SESSION *session)
+LIBSSH2_API
+const char *libssh2_session_banner_get(LIBSSH2_SESSION *session)
 {
     /* to avoid a coredump when session is NULL */
     if(!session)

--- a/src/session.c
+++ b/src/session.c
@@ -70,8 +70,7 @@
 
 /* libssh2_default_alloc
  */
-static
-LIBSSH2_ALLOC_FUNC(libssh2_default_alloc)
+static LIBSSH2_ALLOC_FUNC(libssh2_default_alloc)
 {
     (void)abstract;
     return malloc(count);
@@ -79,8 +78,7 @@ LIBSSH2_ALLOC_FUNC(libssh2_default_alloc)
 
 /* libssh2_default_free
  */
-static
-LIBSSH2_FREE_FUNC(libssh2_default_free)
+static LIBSSH2_FREE_FUNC(libssh2_default_free)
 {
     (void)abstract;
     free(ptr);
@@ -88,8 +86,7 @@ LIBSSH2_FREE_FUNC(libssh2_default_free)
 
 /* libssh2_default_realloc
  */
-static
-LIBSSH2_REALLOC_FUNC(libssh2_default_realloc)
+static LIBSSH2_REALLOC_FUNC(libssh2_default_realloc)
 {
     (void)abstract;
     return realloc(ptr, count);
@@ -103,8 +100,7 @@ LIBSSH2_REALLOC_FUNC(libssh2_default_realloc)
  * Returns: 0 on success, LIBSSH2_ERROR_EAGAIN if read would block, negative
  * on failure
  */
-static int
-banner_receive(LIBSSH2_SESSION *session)
+static int banner_receive(LIBSSH2_SESSION *session)
 {
     ssize_t ret;
     size_t banner_len;
@@ -209,8 +205,7 @@ banner_receive(LIBSSH2_SESSION *session)
  * be sent, and this function should then be called with the same argument set
  * (same data pointer and same data_len) until zero or failure is returned.
  */
-static int
-banner_send(LIBSSH2_SESSION *session)
+static int banner_send(LIBSSH2_SESSION *session)
 {
     const char *banner = LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
     size_t banner_len = sizeof(LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF) - 1;
@@ -289,9 +284,8 @@ banner_send(LIBSSH2_SESSION *session)
  * non-blocking mode based on the 'nonblock' boolean argument. This function
  * is copied from the libcurl sources with permission.
  */
-static int
-session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
-                 int nonblock /* TRUE or FALSE */ )
+static int session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
+                            int nonblock /* TRUE or FALSE */ )
 {
 #ifdef HAVE_O_NONBLOCK
     /* most recent unix versions */
@@ -332,9 +326,8 @@ session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
  *
  * gets the given blocking or non-blocking state of the socket.
  */
-static int
-get_socket_nonblocking(libssh2_socket_t sockfd)
-{                               /* operate on this */
+static int get_socket_nonblocking(libssh2_socket_t sockfd)
+{                                 /* operate on this */
 #ifdef HAVE_O_NONBLOCK
     /* most recent unix versions */
     int flags = fcntl(sockfd, F_GETFL, 0);
@@ -735,8 +728,7 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
     return 0; /* ready to try again */
 }
 
-static int
-session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
+static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 {
     int rc;
 
@@ -918,8 +910,7 @@ int libssh2_session_startup(LIBSSH2_SESSION *session, int sock)
  * Frees the memory allocated to the session
  * Also closes and frees any channels attached to this session
  */
-static int
-session_free(LIBSSH2_SESSION *session)
+static int session_free(LIBSSH2_SESSION *session)
 {
     int rc;
     struct packet *pkg;
@@ -1198,10 +1189,9 @@ int libssh2_session_free(LIBSSH2_SESSION *session)
 /*
  * session_disconnect
  */
-static int
-session_disconnect(LIBSSH2_SESSION *session, int reason,
-                   const char *description,
-                   const char *lang)
+static int session_disconnect(LIBSSH2_SESSION *session, int reason,
+                              const char *description,
+                              const char *lang)
 {
     unsigned char *s;
     size_t descr_len = 0, lang_len = 0;
@@ -1582,8 +1572,7 @@ int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
  * Returns 0 if writing to channel would block,
  * non-0 if data can be written without blocking
  */
-static inline int
-poll_channel_write(LIBSSH2_CHANNEL *channel)
+static inline int poll_channel_write(LIBSSH2_CHANNEL *channel)
 {
     return channel->local.window_size ? 1 : 0;
 }
@@ -1593,8 +1582,7 @@ poll_channel_write(LIBSSH2_CHANNEL *channel)
  * Returns 0 if no connections are waiting to be accepted
  * non-0 if one or more connections are available
  */
-static inline int
-poll_listener_queued(LIBSSH2_LISTENER *listener)
+static inline int poll_listener_queued(LIBSSH2_LISTENER *listener)
 {
     return _libssh2_list_first(&listener->queue) ? 1 : 0;
 }

--- a/src/session.c
+++ b/src/session.c
@@ -68,24 +68,21 @@
 #undef libssh2_usec_t
 #endif
 
-/* libssh2_default_alloc
- */
+/* libssh2_default_alloc */
 static LIBSSH2_ALLOC_FUNC(libssh2_default_alloc)
 {
     (void)abstract;
     return malloc(count);
 }
 
-/* libssh2_default_free
- */
+/* libssh2_default_free */
 static LIBSSH2_FREE_FUNC(libssh2_default_free)
 {
     (void)abstract;
     free(ptr);
 }
 
-/* libssh2_default_realloc
- */
+/* libssh2_default_realloc */
 static LIBSSH2_REALLOC_FUNC(libssh2_default_realloc)
 {
     (void)abstract;
@@ -93,8 +90,6 @@ static LIBSSH2_REALLOC_FUNC(libssh2_default_realloc)
 }
 
 /*
- * banner_receive
- *
  * Wait for a hello from the remote host
  * Allocate a buffer and store the banner in session->remote.banner
  * Returns: 0 on success, LIBSSH2_ERROR_EAGAIN if read would block, negative
@@ -196,8 +191,6 @@ static int banner_receive(LIBSSH2_SESSION *session)
 }
 
 /*
- * banner_send
- *
  * Send the default banner, or the one set via libssh2_setopt_string
  *
  * Returns LIBSSH2_ERROR_EAGAIN if it would block - and if it does so, you
@@ -322,8 +315,6 @@ static int session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
 }
 
 /*
- * get_socket_nonblocking
- *
  * gets the given blocking or non-blocking state of the socket.
  */
 static int get_socket_nonblocking(libssh2_socket_t sockfd)
@@ -377,7 +368,7 @@ static int get_socket_nonblocking(libssh2_socket_t sockfd)
 #endif
 }
 
-/* libssh2_session_banner_set
+/*
  * Set the local banner to use in the server handshake.
  */
 LIBSSH2_API
@@ -413,7 +404,7 @@ int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
 }
 
 #ifndef LIBSSH2_NO_DEPRECATED
-/* libssh2_banner_set
+/*
  * Set the local banner. DEPRECATED VERSION
  */
 LIBSSH2_API
@@ -424,8 +415,6 @@ int libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner)
 #endif
 
 /*
- * libssh2_session_init_ex
- *
  * Allocate and initialize a libssh2 session structure. Allows for malloc
  * callbacks in case the calling program has its own memory manager It's
  * allowable (but unadvisable) to define some but not all of the malloc
@@ -478,8 +467,6 @@ LIBSSH2_SESSION *libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
 }
 
 /*
- * libssh2_session_callback_set2
- *
  * Set (or reset) a callback function
  * Returns the prior address
  */
@@ -555,7 +542,7 @@ libssh2_cb_generic *libssh2_session_callback_set2(LIBSSH2_SESSION *session,
 #endif
 
 /*
- * libssh2_session_callback_set (DEPRECATED, DO NOT USE!)
+ * DEPRECATED, DO NOT USE!
  *
  * Set (or reset) a callback function
  * Returns the prior address
@@ -587,8 +574,6 @@ void *libssh2_session_callback_set(LIBSSH2_SESSION *session,
 #endif
 
 /*
- * _libssh2_wait_socket
- *
  * Utility function that waits for action on the socket. Returns 0 when ready
  * to run again or error on timeout.
  */
@@ -868,8 +853,6 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 }
 
 /*
- * libssh2_session_handshake
- *
  * session: LIBSSH2_SESSION struct allocated and owned by the calling program
  * sock:    *must* be populated with an opened and connected socket.
  *
@@ -887,8 +870,6 @@ int libssh2_session_handshake(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 
 #ifndef LIBSSH2_NO_DEPRECATED
 /*
- * libssh2_session_startup
- *
  * DEPRECATED. Use libssh2_session_handshake() instead! This function is not
  * portable enough.
  *
@@ -905,8 +886,6 @@ int libssh2_session_startup(LIBSSH2_SESSION *session, int sock)
 #endif
 
 /*
- * session_free
- *
  * Frees the memory allocated to the session
  * Also closes and frees any channels attached to this session
  */
@@ -1171,8 +1150,6 @@ static int session_free(LIBSSH2_SESSION *session)
 }
 
 /*
- * libssh2_session_free
- *
  * Frees the memory allocated to the session
  * Also closes and frees any channels attached to this session
  */
@@ -1186,9 +1163,6 @@ int libssh2_session_free(LIBSSH2_SESSION *session)
     return rc;
 }
 
-/*
- * session_disconnect
- */
 static int session_disconnect(LIBSSH2_SESSION *session, int reason,
                               const char *description,
                               const char *lang)
@@ -1240,9 +1214,6 @@ static int session_disconnect(LIBSSH2_SESSION *session, int reason,
     return 0;
 }
 
-/*
- * libssh2_session_disconnect_ex
- */
 LIBSSH2_API
 int libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
                                   const char *description, const char *lang)
@@ -1256,8 +1227,7 @@ int libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
     return rc;
 }
 
-/* libssh2_session_methods
- *
+/*
  * Return the currently active methods for method_type
  *
  * NOTE: Currently lang_cs and lang_sc are ALWAYS set to empty string
@@ -1323,7 +1293,7 @@ const char *libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
     return method->name;
 }
 
-/* libssh2_session_abstract
+/*
  * Retrieve a pointer to the abstract property
  */
 LIBSSH2_API
@@ -1332,8 +1302,7 @@ void **libssh2_session_abstract(LIBSSH2_SESSION *session)
     return &session->abstract;
 }
 
-/* libssh2_session_last_error
- *
+/*
  * Returns error code and populates an error string into errmsg If want_buf is
  * non-zero then the string placed into errmsg must be freed by the calling
  * program. Otherwise it is assumed to be owned by libssh2
@@ -1387,8 +1356,7 @@ int libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
     return session->err_code;
 }
 
-/* libssh2_session_last_errno
- *
+/*
  * Returns error code
  */
 LIBSSH2_API
@@ -1397,8 +1365,7 @@ int libssh2_session_last_errno(LIBSSH2_SESSION *session)
     return session->err_code;
 }
 
-/* libssh2_session_set_last_error
- *
+/*
  * Sets the internal error code for the session.
  *
  * This function is available specifically to be used by high level
@@ -1414,8 +1381,7 @@ int libssh2_session_set_last_error(LIBSSH2_SESSION* session,
                                 LIBSSH2_ERR_FLAG_DUP);
 }
 
-/* libssh2_session_flag
- *
+/*
  * Set/Get session flags
  *
  * Return error code.
@@ -1441,8 +1407,7 @@ int libssh2_session_flag(LIBSSH2_SESSION *session, int flag, int value)
     return LIBSSH2_ERROR_NONE;
 }
 
-/* _libssh2_session_set_blocking
- *
+/*
  * Set a session's blocking mode on or off, return the previous status when
  * this function is called. Note this function does not alter the state of the
  * actual socket involved.
@@ -1458,8 +1423,7 @@ _libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
     return bl;
 }
 
-/* libssh2_session_set_blocking
- *
+/*
  * Set a channel's blocking mode on or off, similar to a socket's
  * fcntl(fd, F_SETFL, O_NONBLOCK); type command
  */
@@ -1469,8 +1433,7 @@ void libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
     (void)_libssh2_session_set_blocking(session, blocking);
 }
 
-/* libssh2_session_get_blocking
- *
+/*
  * Returns a session's blocking mode on or off
  */
 LIBSSH2_API
@@ -1479,8 +1442,7 @@ int libssh2_session_get_blocking(LIBSSH2_SESSION *session)
     return session->api_block_mode;
 }
 
-/* libssh2_session_set_timeout
- *
+/*
  * Set a session's timeout (in msec) for blocking mode,
  * or 0 to disable timeouts.
  */
@@ -1490,8 +1452,7 @@ void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
     session->api_timeout = timeout;
 }
 
-/* libssh2_session_get_timeout
- *
+/*
  * Returns a session's timeout, or 0 if disabled
  */
 LIBSSH2_API
@@ -1500,8 +1461,7 @@ long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
     return session->api_timeout;
 }
 
-/* libssh2_session_set_read_timeout
- *
+/*
  * Set a session's timeout (in sec) when reading packets,
  * or 0 to use default of 60 seconds.
  */
@@ -1514,8 +1474,7 @@ void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
     session->packet_read_timeout = timeout;
 }
 
-/* libssh2_session_get_read_timeout
- *
+/*
  * Returns a session's timeout. Default is 60 seconds.
  */
 LIBSSH2_API
@@ -1525,8 +1484,6 @@ long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
 }
 
 /*
- * libssh2_poll_channel_read
- *
  * Returns 0 if no data is waiting on channel,
  * non-0 if data is available
  */
@@ -1567,8 +1524,6 @@ int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
 }
 
 /*
- * poll_channel_write
- *
  * Returns 0 if writing to channel would block,
  * non-0 if data can be written without blocking
  */
@@ -1577,8 +1532,7 @@ static inline int poll_channel_write(LIBSSH2_CHANNEL *channel)
     return channel->local.window_size ? 1 : 0;
 }
 
-/* poll_listener_queued
- *
+/*
  * Returns 0 if no connections are waiting to be accepted
  * non-0 if one or more connections are available
  */
@@ -1589,8 +1543,6 @@ static inline int poll_listener_queued(LIBSSH2_LISTENER *listener)
 
 #ifndef LIBSSH2_NO_DEPRECATED
 /*
- * libssh2_poll
- *
  * Poll sockets, channels, and listeners for activity
  */
 LIBSSH2_API
@@ -1926,8 +1878,6 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 #endif /* LIBSSH2_NO_DEPRECATED */
 
 /*
- * libssh2_session_block_directions
- *
  * Get blocked direction when a function returns LIBSSH2_ERROR_EAGAIN
  * Returns LIBSSH2_SOCKET_BLOCK_INBOUND if recv() blocked
  * or LIBSSH2_SOCKET_BLOCK_OUTBOUND if send() blocked
@@ -1938,10 +1888,9 @@ int libssh2_session_block_directions(LIBSSH2_SESSION *session)
     return session->socket_block_directions;
 }
 
-/* libssh2_session_banner_get
+/*
  * Get the remote banner (server ID string)
  */
-
 LIBSSH2_API
 const char *libssh2_session_banner_get(LIBSSH2_SESSION *session)
 {

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -162,7 +162,7 @@ static int add_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
     }
 }
 
-/* sftp_packet_add
+/*
  * Add a packet to the SFTP packet brigade
  */
 static int sftp_packet_add(LIBSSH2_SFTP *sftp,
@@ -255,7 +255,7 @@ static int sftp_packet_add(LIBSSH2_SFTP *sftp,
     return LIBSSH2_ERROR_NONE;
 }
 
-/* sftp_packet_read
+/*
  * Frame an SFTP packet off the channel
  */
 static int sftp_packet_read(LIBSSH2_SFTP *sftp)
@@ -409,8 +409,7 @@ window_adjust:
     /* WON'T REACH */
 }
 
-/* sftp_packetlist_flush
- *
+/*
  * Remove all pending packets in the packet_list and the corresponding one(s)
  * in the SFTP packet brigade.
  */
@@ -449,8 +448,6 @@ static void sftp_packetlist_flush(LIBSSH2_SFTP_HANDLE *handle)
 }
 
 /*
- * sftp_packet_ask
- *
  * Checks if there's a matching SFTP packet available.
  */
 static int sftp_packet_ask(LIBSSH2_SFTP *sftp, unsigned char packet_type,
@@ -486,7 +483,7 @@ static int sftp_packet_ask(LIBSSH2_SFTP *sftp, unsigned char packet_type,
     return -1;
 }
 
-/* sftp_packet_require
+/*
  * A la libssh2_packet_require
  */
 static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
@@ -539,7 +536,7 @@ static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
     return LIBSSH2_ERROR_SOCKET_DISCONNECT;
 }
 
-/* sftp_packet_requirev
+/*
  * Require one of N possible responses
  */
 static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
@@ -604,7 +601,7 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
     return LIBSSH2_ERROR_SOCKET_DISCONNECT;
 }
 
-/* sftp_attrsize
+/*
  * Size that attr with this flagset will occupy when turned into a bin struct
  */
 static int sftp_attrsize(unsigned long flags)
@@ -617,7 +614,7 @@ static int sftp_attrsize(unsigned long flags)
     /* atime + mtime as u32 */
 }
 
-/* sftp_attr2bin
+/*
  * Populate attributes into an SFTP block
  */
 static ssize_t sftp_attr2bin(unsigned char *p,
@@ -661,8 +658,6 @@ static ssize_t sftp_attr2bin(unsigned char *p,
     return s - p;
 }
 
-/* sftp_bin2attr
- */
 static ssize_t sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs,
                              const unsigned char *p, size_t data_len)
 {
@@ -737,13 +732,13 @@ static ssize_t sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs,
     return buf.dataptr - buf.data;
 }
 
-/* ************
+/* **********
  * SFTP API *
- ************ */
+ ********** */
 
 LIBSSH2_CHANNEL_CLOSE_FUNC(libssh2_sftp_dtor);
 
-/* libssh2_sftp_dtor
+/*
  * Shutdown an SFTP stream when the channel closes
  */
 LIBSSH2_CHANNEL_CLOSE_FUNC(libssh2_sftp_dtor)
@@ -766,7 +761,7 @@ LIBSSH2_CHANNEL_CLOSE_FUNC(libssh2_sftp_dtor)
     LIBSSH2_FREE(session, sftp);
 }
 
-/* sftp_init
+/*
  * Startup an SFTP session
  */
 static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
@@ -1021,7 +1016,7 @@ sftp_init_error:
     return NULL;
 }
 
-/* libssh2_sftp_init
+/*
  * Startup an SFTP session
  */
 LIBSSH2_API
@@ -1042,7 +1037,7 @@ LIBSSH2_SFTP *libssh2_sftp_init(LIBSSH2_SESSION *session)
     return ptr;
 }
 
-/* sftp_shutdown
+/*
  * Shuts down the SFTP subsystem
  */
 static int sftp_shutdown(LIBSSH2_SFTP *sftp)
@@ -1115,8 +1110,8 @@ static int sftp_shutdown(LIBSSH2_SFTP *sftp)
     return rc;
 }
 
-/* libssh2_sftp_shutdown
- * Shutsdown the SFTP subsystem
+/*
+ * Shuts down the SFTP subsystem
  */
 LIBSSH2_API
 int libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp)
@@ -1132,8 +1127,6 @@ int libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp)
  * SFTP File and Directory Ops *
  *******************************/
 
-/* sftp_open
- */
 static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
                                       const char *filename,
                                       size_t filename_len,
@@ -1366,8 +1359,6 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
     return NULL;
 }
 
-/* libssh2_sftp_open_ex
- */
 LIBSSH2_API
 LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
                                           const char *filename,
@@ -1386,8 +1377,6 @@ LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
     return hnd;
 }
 
-/* libssh2_sftp_open_ex_r
- */
 LIBSSH2_API
 LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
                                             const char *filename,
@@ -1407,7 +1396,7 @@ LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
     return hnd;
 }
 
-/* sftp_read
+/*
  * Read from an SFTP file handle
  */
 static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
@@ -1802,7 +1791,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                           "sftp_read() internal error");
 }
 
-/* libssh2_sftp_read
+/*
  * Read from an SFTP file handle
  */
 LIBSSH2_API
@@ -1817,7 +1806,7 @@ ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
     return rc;
 }
 
-/* sftp_readdir
+/*
  * Read from an SFTP directory handle
  */
 static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
@@ -2035,7 +2024,7 @@ end:
                         longentry_maxlen, attrs);
 }
 
-/* libssh2_sftp_readdir_ex
+/*
  * Read from an SFTP directory handle
  */
 LIBSSH2_API
@@ -2053,8 +2042,7 @@ int libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle,
     return (int)rc;  /* FIXME: -> ssize_t */
 }
 
-/* sftp_write
- *
+/*
  * Write data to an SFTP handle. Returns the number of bytes written, or
  * a negative error code.
  *
@@ -2303,7 +2291,7 @@ static ssize_t sftp_write(LIBSSH2_SFTP_HANDLE *handle, const char *buffer,
         return 0; /* nothing was acked, and no EAGAIN was received! */
 }
 
-/* libssh2_sftp_write
+/*
  * Write data to a file handle
  */
 LIBSSH2_API
@@ -2407,7 +2395,7 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
     return 0;
 }
 
-/* libssh2_sftp_fsync
+/*
  * Commit data on the handle to disk.
  */
 LIBSSH2_API
@@ -2421,7 +2409,7 @@ int libssh2_sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
     return rc;
 }
 
-/* sftp_fstat
+/*
  * Get or Set stat on a file
  */
 static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
@@ -2530,7 +2518,7 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
     return 0;
 }
 
-/* libssh2_sftp_fstat_ex
+/*
  * Get or Set stat on a file
  */
 LIBSSH2_API
@@ -2545,7 +2533,7 @@ int libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
     return rc;
 }
 
-/* libssh2_sftp_seek64
+/*
  * Set the read/write pointer to an arbitrary position within the file
  */
 LIBSSH2_API
@@ -2571,7 +2559,7 @@ void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle, libssh2_uint64_t offset)
     handle->u.file.eof = FALSE;
 }
 
-/* libssh2_sftp_seek
+/*
  * Set the read/write pointer to an arbitrary position within the file
  */
 LIBSSH2_API
@@ -2580,7 +2568,7 @@ void libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset)
     libssh2_sftp_seek64(handle, (libssh2_uint64_t)offset);
 }
 
-/* libssh2_sftp_tell
+/*
  * Return the current read/write pointer's offset
  */
 LIBSSH2_API
@@ -2595,7 +2583,7 @@ size_t libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle)
     return (size_t)(handle->u.file.offset);
 }
 
-/* libssh2_sftp_tell64
+/*
  * Return the current read/write pointer's offset
  */
 LIBSSH2_API
@@ -2641,8 +2629,7 @@ static void sftp_packet_flush(LIBSSH2_SFTP *sftp)
     }
 }
 
-/* sftp_close_handle
- *
+/*
  * Close a file or directory handle.
  * Also frees handle resource and unlinks it from the SFTP structure.
  * The handle is no longer usable after return of this function, unless
@@ -2764,8 +2751,7 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
     return rc;
 }
 
-/* libssh2_sftp_close_handle
- *
+/*
  * Close a file or directory handle
  * Also frees handle resource and unlinks it from the SFTP structure
  */
@@ -2780,7 +2766,7 @@ int libssh2_sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
     return rc;
 }
 
-/* sftp_unlink
+/*
  * Delete a file from the remote server
  */
 static int sftp_unlink(LIBSSH2_SFTP *sftp,
@@ -2878,7 +2864,7 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
     }
 }
 
-/* libssh2_sftp_unlink_ex
+/*
  * Delete a file from the remote server
  */
 LIBSSH2_API
@@ -2893,7 +2879,7 @@ int libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp,
     return rc;
 }
 
-/* sftp_rename
+/*
  * Rename a file on the remote server
  */
 static int sftp_rename(LIBSSH2_SFTP *sftp,
@@ -3032,7 +3018,7 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
     return retcode;
 }
 
-/* libssh2_sftp_rename_ex
+/*
  * Rename a file on the remote server
  */
 LIBSSH2_API
@@ -3168,7 +3154,7 @@ sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
     return 0;
 }
 
-/* libssh2_sftp_posix_rename_ex
+/*
  * Rename a file on the remote server using the posix-rename@openssh.com
  * extension.
  */
@@ -3188,7 +3174,7 @@ int libssh2_sftp_posix_rename_ex(LIBSSH2_SFTP *sftp,
     return rc;
 }
 
-/* sftp_fstatvfs
+/*
  * Get file system statistics
  */
 static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
@@ -3318,7 +3304,7 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
     return 0;
 }
 
-/* libssh2_sftp_fstatvfs
+/*
  * Get filesystem space and inode utilization (requires fstatvfs@openssh.com
  * support on the server)
  */
@@ -3334,7 +3320,7 @@ int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
     return rc;
 }
 
-/* sftp_statvfs
+/*
  * Get file system statistics
  */
 static int sftp_statvfs(LIBSSH2_SFTP *sftp,
@@ -3464,7 +3450,7 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
     return 0;
 }
 
-/* libssh2_sftp_statvfs_ex
+/*
  * Get filesystem space and inode utilization (requires statvfs@openssh.com
  * support on the server)
  */
@@ -3481,7 +3467,7 @@ int libssh2_sftp_statvfs(LIBSSH2_SFTP *sftp,
     return rc;
 }
 
-/* sftp_mkdir
+/*
  * Create an SFTP directory
  */
 static int sftp_mkdir(LIBSSH2_SFTP *sftp,
@@ -3592,7 +3578,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
     }
 }
 
-/* libssh2_sftp_mkdir_ex
+/*
  * Create an SFTP directory
  */
 LIBSSH2_API
@@ -3607,7 +3593,7 @@ int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
     return rc;
 }
 
-/* sftp_rmdir
+/*
  * Remove a directory
  */
 static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
@@ -3703,7 +3689,7 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
     }
 }
 
-/* libssh2_sftp_rmdir_ex
+/*
  * Remove a directory
  */
 LIBSSH2_API
@@ -3718,7 +3704,7 @@ int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
     return rc;
 }
 
-/* sftp_stat
+/*
  * Stat a file or symbolic link
  */
 static int sftp_stat(LIBSSH2_SFTP *sftp,
@@ -3850,7 +3836,7 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
     return 0;
 }
 
-/* libssh2_sftp_stat_ex
+/*
  * Stat a file or symbolic link
  */
 LIBSSH2_API
@@ -3866,7 +3852,7 @@ int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
     return rc;
 }
 
-/* sftp_symlink
+/*
  * Read or set a symlink
  */
 static int sftp_symlink(LIBSSH2_SFTP *sftp,
@@ -4061,7 +4047,7 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
     return retcode;
 }
 
-/* libssh2_sftp_symlink_ex
+/*
  * Read or set a symlink
  */
 LIBSSH2_API
@@ -4079,7 +4065,7 @@ int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
     return rc;
 }
 
-/* libssh2_sftp_last_error
+/*
  * Returns the last error code reported by SFTP
  */
 LIBSSH2_API
@@ -4091,7 +4077,7 @@ unsigned long libssh2_sftp_last_error(LIBSSH2_SFTP *sftp)
     return sftp->last_errno;
 }
 
-/* libssh2_sftp_get_channel
+/*
  * Return the channel of sftp, then caller can control the channel's behavior.
  */
 LIBSSH2_API

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -108,8 +108,8 @@ static void sftp_packet_flush(LIBSSH2_SFTP *sftp);
  *
  * Returns NULL if ID not in list.
  */
-static struct sftp_zombie_requests *
-find_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
+static struct sftp_zombie_requests *find_zombie_request(LIBSSH2_SFTP *sftp,
+                                                        uint32_t request_id)
 {
     struct sftp_zombie_requests *zombie =
         _libssh2_list_first(&sftp->zombie_requests);
@@ -124,8 +124,7 @@ find_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
     return zombie;
 }
 
-static void
-remove_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
+static void remove_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
 {
     LIBSSH2_SESSION *session = sftp->channel->session;
 
@@ -142,8 +141,7 @@ remove_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
     }
 }
 
-static int
-add_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
+static int add_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
 {
     LIBSSH2_SESSION *session = sftp->channel->session;
 
@@ -167,9 +165,8 @@ add_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
 /* sftp_packet_add
  * Add a packet to the SFTP packet brigade
  */
-static int
-sftp_packet_add(LIBSSH2_SFTP *sftp, unsigned char *data,
-                size_t data_len)
+static int sftp_packet_add(LIBSSH2_SFTP *sftp,
+                           unsigned char *data, size_t data_len)
 {
     LIBSSH2_SESSION *session = sftp->channel->session;
     struct sftp_packet *packet;
@@ -261,8 +258,7 @@ sftp_packet_add(LIBSSH2_SFTP *sftp, unsigned char *data,
 /* sftp_packet_read
  * Frame an SFTP packet off the channel
  */
-static int
-sftp_packet_read(LIBSSH2_SFTP *sftp)
+static int sftp_packet_read(LIBSSH2_SFTP *sftp)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -457,10 +453,9 @@ static void sftp_packetlist_flush(LIBSSH2_SFTP_HANDLE *handle)
  *
  * Checks if there's a matching SFTP packet available.
  */
-static int
-sftp_packet_ask(LIBSSH2_SFTP *sftp, unsigned char packet_type,
-                uint32_t request_id, unsigned char **data,
-                size_t *data_len)
+static int sftp_packet_ask(LIBSSH2_SFTP *sftp, unsigned char packet_type,
+                           uint32_t request_id,
+                           unsigned char **data, size_t *data_len)
 {
     LIBSSH2_SESSION *session = sftp->channel->session;
     struct sftp_packet *packet = _libssh2_list_first(&sftp->packets);
@@ -494,10 +489,10 @@ sftp_packet_ask(LIBSSH2_SFTP *sftp, unsigned char packet_type,
 /* sftp_packet_require
  * A la libssh2_packet_require
  */
-static int
-sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
-                    uint32_t request_id, unsigned char **data,
-                    size_t *data_len, size_t required_size)
+static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
+                               uint32_t request_id,
+                               unsigned char **data, size_t *data_len,
+                               size_t required_size)
 {
     LIBSSH2_SESSION *session = sftp->channel->session;
     int rc;
@@ -547,11 +542,11 @@ sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
 /* sftp_packet_requirev
  * Require one of N possible responses
  */
-static int
-sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
-                     const unsigned char *valid_responses,
-                     uint32_t request_id, unsigned char **data,
-                     size_t *data_len, size_t required_size)
+static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
+                                const unsigned char *valid_responses,
+                                uint32_t request_id,
+                                unsigned char **data, size_t *data_len,
+                                size_t required_size)
 {
     int i;
     int rc;
@@ -625,8 +620,8 @@ static int sftp_attrsize(unsigned long flags)
 /* sftp_attr2bin
  * Populate attributes into an SFTP block
  */
-static ssize_t
-sftp_attr2bin(unsigned char *p, const LIBSSH2_SFTP_ATTRIBUTES *attrs)
+static ssize_t sftp_attr2bin(unsigned char *p,
+                             const LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
     unsigned char *s = p;
     uint32_t flag_mask =
@@ -668,9 +663,8 @@ sftp_attr2bin(unsigned char *p, const LIBSSH2_SFTP_ATTRIBUTES *attrs)
 
 /* sftp_bin2attr
  */
-static ssize_t
-sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs, const unsigned char *p,
-              size_t data_len)
+static ssize_t sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs,
+                             const unsigned char *p, size_t data_len)
 {
     struct string_buf buf;
     uint32_t flags = 0;
@@ -1051,8 +1045,7 @@ LIBSSH2_SFTP *libssh2_sftp_init(LIBSSH2_SESSION *session)
 /* sftp_shutdown
  * Shuts down the SFTP subsystem
  */
-static int
-sftp_shutdown(LIBSSH2_SFTP *sftp)
+static int sftp_shutdown(LIBSSH2_SFTP *sftp)
 {
     int rc;
     LIBSSH2_SESSION *session = sftp->channel->session;
@@ -2656,8 +2649,7 @@ static void sftp_packet_flush(LIBSSH2_SFTP *sftp)
  * the return value is LIBSSH2_ERROR_EAGAIN in which case this function
  * should be called again.
  */
-static int
-sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
+static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
 {
     LIBSSH2_SFTP *sftp = handle->sftp;
     LIBSSH2_CHANNEL *channel = sftp->channel;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1030,7 +1030,8 @@ sftp_init_error:
 /* libssh2_sftp_init
  * Startup an SFTP session
  */
-LIBSSH2_API LIBSSH2_SFTP *libssh2_sftp_init(LIBSSH2_SESSION *session)
+LIBSSH2_API
+LIBSSH2_SFTP *libssh2_sftp_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_SFTP *ptr;
 
@@ -1124,8 +1125,8 @@ sftp_shutdown(LIBSSH2_SFTP *sftp)
 /* libssh2_sftp_shutdown
  * Shutsdown the SFTP subsystem
  */
-LIBSSH2_API int
-libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp)
+LIBSSH2_API
+int libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp)
 {
     int rc;
     if(!sftp)
@@ -1140,10 +1141,12 @@ libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp)
 
 /* sftp_open
  */
-static LIBSSH2_SFTP_HANDLE *
-sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
-          size_t filename_len, uint32_t flags, long mode,
-          int open_type, LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
+static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
+                                      const char *filename,
+                                      size_t filename_len,
+                                      uint32_t flags, long mode,
+                                      int open_type,
+                                      LIBSSH2_SFTP_ATTRIBUTES *attrs_in)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -1372,10 +1375,12 @@ sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
 
 /* libssh2_sftp_open_ex
  */
-LIBSSH2_API LIBSSH2_SFTP_HANDLE *
-libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
-                     unsigned int filename_len, unsigned long flags, long mode,
-                     int open_type)
+LIBSSH2_API
+LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
+                                          const char *filename,
+                                          unsigned int filename_len,
+                                          unsigned long flags, long mode,
+                                          int open_type)
 {
     LIBSSH2_SFTP_HANDLE *hnd;
 
@@ -1390,10 +1395,13 @@ libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp, const char *filename,
 
 /* libssh2_sftp_open_ex_r
  */
-LIBSSH2_API LIBSSH2_SFTP_HANDLE *
-libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
-                       size_t filename_len, unsigned long flags, long mode,
-                       int open_type, LIBSSH2_SFTP_ATTRIBUTES *attrs)
+LIBSSH2_API
+LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
+                                            const char *filename,
+                                            size_t filename_len,
+                                            unsigned long flags, long mode,
+                                            int open_type,
+                                            LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
     LIBSSH2_SFTP_HANDLE *hnd;
 
@@ -1409,8 +1417,8 @@ libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp, const char *filename,
 /* sftp_read
  * Read from an SFTP file handle
  */
-static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
-                         size_t buffer_size)
+static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
+                         char *buffer, size_t buffer_size)
 {
     LIBSSH2_SFTP *sftp = handle->sftp;
     LIBSSH2_CHANNEL *channel = sftp->channel;
@@ -1804,9 +1812,9 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
 /* libssh2_sftp_read
  * Read from an SFTP file handle
  */
-LIBSSH2_API ssize_t
-libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
-                  size_t buffer_maxlen)
+LIBSSH2_API
+ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
+                          char *buffer, size_t buffer_maxlen)
 {
     ssize_t rc;
     if(!handle)
@@ -2037,11 +2045,11 @@ end:
 /* libssh2_sftp_readdir_ex
  * Read from an SFTP directory handle
  */
-LIBSSH2_API int
-libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
-                        size_t buffer_maxlen, char *longentry,
-                        size_t longentry_maxlen,
-                        LIBSSH2_SFTP_ATTRIBUTES *attrs)
+LIBSSH2_API
+int libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle,
+                            char *buffer, size_t buffer_maxlen,
+                            char *longentry, size_t longentry_maxlen,
+                            LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
     ssize_t rc;
     if(!handle)
@@ -2305,9 +2313,9 @@ static ssize_t sftp_write(LIBSSH2_SFTP_HANDLE *handle, const char *buffer,
 /* libssh2_sftp_write
  * Write data to a file handle
  */
-LIBSSH2_API ssize_t
-libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle, const char *buffer,
-                   size_t count)
+LIBSSH2_API
+ssize_t libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle,
+                           const char *buffer, size_t count)
 {
     ssize_t rc;
     if(!handle)
@@ -2409,8 +2417,8 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
 /* libssh2_sftp_fsync
  * Commit data on the handle to disk.
  */
-LIBSSH2_API int
-libssh2_sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
+LIBSSH2_API
+int libssh2_sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
 {
     int rc;
     if(!handle)
@@ -2532,9 +2540,9 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
 /* libssh2_sftp_fstat_ex
  * Get or Set stat on a file
  */
-LIBSSH2_API int
-libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
-                      LIBSSH2_SFTP_ATTRIBUTES *attrs, int setstat)
+LIBSSH2_API
+int libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
+                          LIBSSH2_SFTP_ATTRIBUTES *attrs, int setstat)
 {
     int rc;
     if(!handle || !attrs)
@@ -2547,8 +2555,8 @@ libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
 /* libssh2_sftp_seek64
  * Set the read/write pointer to an arbitrary position within the file
  */
-LIBSSH2_API void
-libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle, libssh2_uint64_t offset)
+LIBSSH2_API
+void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle, libssh2_uint64_t offset)
 {
     if(!handle)
         return;
@@ -2573,8 +2581,8 @@ libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle, libssh2_uint64_t offset)
 /* libssh2_sftp_seek
  * Set the read/write pointer to an arbitrary position within the file
  */
-LIBSSH2_API void
-libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset)
+LIBSSH2_API
+void libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset)
 {
     libssh2_sftp_seek64(handle, (libssh2_uint64_t)offset);
 }
@@ -2582,8 +2590,8 @@ libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset)
 /* libssh2_sftp_tell
  * Return the current read/write pointer's offset
  */
-LIBSSH2_API size_t
-libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle)
+LIBSSH2_API
+size_t libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle)
 {
     if(!handle)
         return 0; /* no handle, no size */
@@ -2597,8 +2605,8 @@ libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle)
 /* libssh2_sftp_tell64
  * Return the current read/write pointer's offset
  */
-LIBSSH2_API libssh2_uint64_t
-libssh2_sftp_tell64(LIBSSH2_SFTP_HANDLE *handle)
+LIBSSH2_API
+libssh2_uint64_t libssh2_sftp_tell64(LIBSSH2_SFTP_HANDLE *handle)
 {
     if(!handle)
         return 0; /* no handle, no size */
@@ -2769,8 +2777,8 @@ sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
  * Close a file or directory handle
  * Also frees handle resource and unlinks it from the SFTP structure
  */
-LIBSSH2_API int
-libssh2_sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
+LIBSSH2_API
+int libssh2_sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
 {
     int rc;
     if(!handle)
@@ -2783,8 +2791,8 @@ libssh2_sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
 /* sftp_unlink
  * Delete a file from the remote server
  */
-static int sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename,
-                       size_t filename_len)
+static int sftp_unlink(LIBSSH2_SFTP *sftp,
+                       const char *filename, size_t filename_len)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -2881,9 +2889,9 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename,
 /* libssh2_sftp_unlink_ex
  * Delete a file from the remote server
  */
-LIBSSH2_API int
-libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp, const char *filename,
-                       unsigned int filename_len)
+LIBSSH2_API
+int libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp,
+                           const char *filename, unsigned int filename_len)
 {
     int rc;
     if(!sftp)
@@ -2896,7 +2904,8 @@ libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp, const char *filename,
 /* sftp_rename
  * Rename a file on the remote server
  */
-static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
+static int sftp_rename(LIBSSH2_SFTP *sftp,
+                       const char *source_filename,
                        unsigned int source_filename_len,
                        const char *dest_filename,
                        unsigned int dest_filename_len, long flags)
@@ -3034,11 +3043,12 @@ static int sftp_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
 /* libssh2_sftp_rename_ex
  * Rename a file on the remote server
  */
-LIBSSH2_API int
-libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp, const char *source_filename,
-                       unsigned int source_filename_len,
-                       const char *dest_filename,
-                       unsigned int dest_filename_len, long flags)
+LIBSSH2_API
+int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
+                           const char *source_filename,
+                           unsigned int source_filename_len,
+                           const char *dest_filename,
+                           unsigned int dest_filename_len, long flags)
 {
     int rc;
     if(!sftp)
@@ -3170,11 +3180,12 @@ sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
  * Rename a file on the remote server using the posix-rename@openssh.com
  * extension.
  */
-LIBSSH2_API int
-libssh2_sftp_posix_rename_ex(LIBSSH2_SFTP *sftp, const char *source_filename,
-                             size_t source_filename_len,
-                             const char *dest_filename,
-                             size_t dest_filename_len)
+LIBSSH2_API
+int libssh2_sftp_posix_rename_ex(LIBSSH2_SFTP *sftp,
+                                 const char *source_filename,
+                                 size_t source_filename_len,
+                                 const char *dest_filename,
+                                 size_t dest_filename_len)
 {
     int rc;
     if(!sftp)
@@ -3319,8 +3330,9 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
  * Get filesystem space and inode utilization (requires fstatvfs@openssh.com
  * support on the server)
  */
-LIBSSH2_API int
-libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
+LIBSSH2_API
+int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
+                          LIBSSH2_SFTP_STATVFS *st)
 {
     int rc;
     if(!handle || !st)
@@ -3333,8 +3345,9 @@ libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
 /* sftp_statvfs
  * Get file system statistics
  */
-static int sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
-                        unsigned int path_len, LIBSSH2_SFTP_STATVFS *st)
+static int sftp_statvfs(LIBSSH2_SFTP *sftp,
+                        const char *path, unsigned int path_len,
+                        LIBSSH2_SFTP_STATVFS *st)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -3463,9 +3476,10 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
  * Get filesystem space and inode utilization (requires statvfs@openssh.com
  * support on the server)
  */
-LIBSSH2_API int
-libssh2_sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
-                     size_t path_len, LIBSSH2_SFTP_STATVFS *st)
+LIBSSH2_API
+int libssh2_sftp_statvfs(LIBSSH2_SFTP *sftp,
+                         const char *path, size_t path_len,
+                         LIBSSH2_SFTP_STATVFS *st)
 {
     int rc;
     if(!sftp || !st)
@@ -3478,8 +3492,8 @@ libssh2_sftp_statvfs(LIBSSH2_SFTP *sftp, const char *path,
 /* sftp_mkdir
  * Create an SFTP directory
  */
-static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
-                      unsigned int path_len, long mode)
+static int sftp_mkdir(LIBSSH2_SFTP *sftp,
+                      const char *path, unsigned int path_len, long mode)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -3589,9 +3603,9 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
 /* libssh2_sftp_mkdir_ex
  * Create an SFTP directory
  */
-LIBSSH2_API int
-libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp, const char *path,
-                      unsigned int path_len, long mode)
+LIBSSH2_API
+int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
+                          const char *path, unsigned int path_len, long mode)
 {
     int rc;
     if(!sftp)
@@ -3700,9 +3714,9 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
 /* libssh2_sftp_rmdir_ex
  * Remove a directory
  */
-LIBSSH2_API int
-libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp, const char *path,
-                      unsigned int path_len)
+LIBSSH2_API
+int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
+                          const char *path, unsigned int path_len)
 {
     int rc;
     if(!sftp)
@@ -3715,9 +3729,9 @@ libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp, const char *path,
 /* sftp_stat
  * Stat a file or symbolic link
  */
-static int sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
-                     unsigned int path_len, int stat_type,
-                     LIBSSH2_SFTP_ATTRIBUTES *attrs)
+static int sftp_stat(LIBSSH2_SFTP *sftp,
+                     const char *path, unsigned int path_len,
+                     int stat_type, LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -3847,10 +3861,10 @@ static int sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
 /* libssh2_sftp_stat_ex
  * Stat a file or symbolic link
  */
-LIBSSH2_API int
-libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp, const char *path,
-                     unsigned int path_len, int stat_type,
-                     LIBSSH2_SFTP_ATTRIBUTES *attrs)
+LIBSSH2_API
+int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
+                         const char *path, unsigned int path_len,
+                         int stat_type, LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
     int rc;
     if(!sftp)
@@ -3863,9 +3877,10 @@ libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp, const char *path,
 /* sftp_symlink
  * Read or set a symlink
  */
-static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
-                        unsigned int path_len, char *target,
-                        unsigned int target_len, int link_type)
+static int sftp_symlink(LIBSSH2_SFTP *sftp,
+                        const char *path, unsigned int path_len,
+                        char *target, unsigned int target_len,
+                        int link_type)
 {
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -4057,10 +4072,11 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
 /* libssh2_sftp_symlink_ex
  * Read or set a symlink
  */
-LIBSSH2_API int
-libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp, const char *path,
-                        unsigned int path_len, char *target,
-                        unsigned int target_len, int link_type)
+LIBSSH2_API
+int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
+                            const char *path, unsigned int path_len,
+                            char *target, unsigned int target_len,
+                            int link_type)
 {
     int rc;
     if(!sftp)
@@ -4074,8 +4090,8 @@ libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp, const char *path,
 /* libssh2_sftp_last_error
  * Returns the last error code reported by SFTP
  */
-LIBSSH2_API unsigned long
-libssh2_sftp_last_error(LIBSSH2_SFTP *sftp)
+LIBSSH2_API
+unsigned long libssh2_sftp_last_error(LIBSSH2_SFTP *sftp)
 {
     if(!sftp)
         return 0;
@@ -4086,8 +4102,8 @@ libssh2_sftp_last_error(LIBSSH2_SFTP *sftp)
 /* libssh2_sftp_get_channel
  * Return the channel of sftp, then caller can control the channel's behavior.
  */
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_sftp_get_channel(LIBSSH2_SFTP *sftp)
+LIBSSH2_API
+LIBSSH2_CHANNEL *libssh2_sftp_get_channel(LIBSSH2_SFTP *sftp)
 {
     if(!sftp)
         return NULL;

--- a/src/transport.c
+++ b/src/transport.c
@@ -53,9 +53,8 @@
 
 #ifdef LIBSSH2DEBUG
 #define UNPRINTABLE_CHAR '.'
-static void
-debugdump(LIBSSH2_SESSION *session,
-          const char *desc, const unsigned char *ptr, size_t size)
+static void debugdump(LIBSSH2_SESSION *session,
+                      const char *desc, const unsigned char *ptr, size_t size)
 {
     size_t i;
     size_t c;
@@ -122,9 +121,8 @@ debugdump(LIBSSH2_SESSION *session,
  *
  * returns 0 on success and negative on failure
  */
-static int
-decrypt(LIBSSH2_SESSION *session, unsigned char *source,
-        unsigned char *dest, ssize_t len, int firstlast)
+static int decrypt(LIBSSH2_SESSION *session, unsigned char *source,
+                   unsigned char *dest, ssize_t len, int firstlast)
 {
     struct transportpacket *p = &session->packet;
     int blocksize = session->remote.crypt->blocksize;
@@ -177,8 +175,7 @@ decrypt(LIBSSH2_SESSION *session, unsigned char *source,
  * fullpacket() gets called when a full packet has been received and properly
  * collected.
  */
-static int
-fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */ )
+static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
 {
     unsigned char macbuf[MAX_MACSIZE];
     struct transportpacket *p = &session->packet;
@@ -915,9 +912,8 @@ libssh2_transport_read_point1:
     return LIBSSH2_ERROR_SOCKET_RECV; /* we never reach this point */
 }
 
-static int
-send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
-              size_t data_len, ssize_t *ret)
+static int send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
+                         size_t data_len, ssize_t *ret)
 {
     ssize_t rc;
     ssize_t length;

--- a/src/transport.c
+++ b/src/transport.c
@@ -355,15 +355,11 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
 }
 
 /*
- * _libssh2_transport_read
- *
  * Collect a packet into the input queue.
  *
  * Returns packet type added to input queue (0 if nothing added), or a
  * negative error number.
- */
-
-/*
+ *
  * This function reads the binary stream as specified in chapter 6 of RFC4253
  * "The Secure Shell (SSH) Transport Layer Protocol"
  *
@@ -980,8 +976,6 @@ static int send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
 }
 
 /*
- * libssh2_transport_send
- *
  * Send a packet, encrypting it and adding a MAC code if necessary
  * Returns 0 on success, non-zero on failure.
  *

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1403,9 +1403,9 @@ static int is_version_less_than_78(const char *version)
  * @param key_method_len length of the key method buffer
  * @result error code or zero on success
  */
-static int _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
-                                       unsigned char **key_method,
-                                       size_t *key_method_len)
+static int key_sign_algorithm(LIBSSH2_SESSION *session,
+                              unsigned char **key_method,
+                              size_t *key_method_len)
 {
     const char *s = NULL;
     const char *a = NULL;
@@ -1637,9 +1637,9 @@ retry_auth:
          * it is our first auth attempt, otherwise fallback to
          * the key default algo */
         if(auth_attempts == 1) {
-            rc = _libssh2_key_sign_algorithm(session,
-                                           &session->userauth_pblc_method,
-                                           &session->userauth_pblc_method_len);
+            rc = key_sign_algorithm(session,
+                                    &session->userauth_pblc_method,
+                                    &session->userauth_pblc_method_len);
 
             if(rc)
                 return rc;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -56,16 +56,15 @@
 #include <stdlib.h>  /* strtol() */
 
 /*
- *  Cap each userauth input field below the per-call transport
- *  limit. Bounds packet-size arithmetic to prevent size_t wrap
- *  and undersized allocations on 32-bit (or any) platforms.
- *  Packets with multiple near-cap fields may still exceed the
- *  transport limit and be rejected later with LIBSSH2_ERROR_INVAL.
+ * Cap each userauth input field below the per-call transport
+ * limit. Bounds packet-size arithmetic to prevent size_t wrap
+ * and undersized allocations on 32-bit (or any) platforms.
+ * Packets with multiple near-cap fields may still exceed the
+ * transport limit and be rejected later with LIBSSH2_ERROR_INVAL.
  */
 #define MAX_INPUT_LEN (MAX_SSH_PACKET_LEN - 0x100)
 
-/* userauth_list
- *
+/*
  * List authentication methods
  * Will yield successful login if "none" happens to be allowable for this user
  * Not a common configuration for any SSH server though
@@ -251,8 +250,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
     return (char *)session->userauth_list_data;
 }
 
-/* libssh2_userauth_list
- *
+/*
  * List authentication methods
  * Will yield successful login if "none" happens to be allowable for this user
  * Not a common configuration for any SSH server though
@@ -268,8 +266,7 @@ char *libssh2_userauth_list(LIBSSH2_SESSION *session,
     return ptr;
 }
 
-/* libssh2_userauth_banner
- *
+/*
  * Retrieve banner message from server, if available.
  * When no such message is sent by server or if no authentication attempt has
  * been made, this function returns LIBSSH2_ERROR_MISSING_USERAUTH_BANNER.
@@ -293,8 +290,6 @@ int libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
 }
 
 /*
- * libssh2_userauth_authenticated
- *
  * Returns: 0 if not yet authenticated
  *          1 if already authenticated
  */
@@ -304,7 +299,7 @@ int libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
     return (session->state & LIBSSH2_STATE_AUTHENTICATED) ? 1 : 0;
 }
 
-/* userauth_password
+/*
  * Plain ol' login
  */
 static int userauth_password(LIBSSH2_SESSION *session,
@@ -570,11 +565,8 @@ password_response:
 }
 
 /*
- * libssh2_userauth_password_ex
- *
  * Plain ol' login
  */
-
 LIBSSH2_API
 int libssh2_userauth_password_ex(
     LIBSSH2_SESSION *session,
@@ -665,8 +657,6 @@ static int memory_read_publickey(LIBSSH2_SESSION *session,
 }
 
 /*
- * file_read_publickey
- *
  * Read a public key from an id_???.pub style file
  *
  * Returns an allocated string containing the decoded key in *pubkeydata
@@ -807,7 +797,7 @@ static int memory_read_privatekey(LIBSSH2_SESSION *session,
     return 0;
 }
 
-/* libssh2_file_read_privatekey
+/*
  * Read a PEM encoded private key from an id_??? style file
  */
 static int file_read_privatekey(LIBSSH2_SESSION *session,
@@ -1042,7 +1032,7 @@ libssh2_sign_sk(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     return rc;
 }
 
-/* userauth_hostbased_fromfile
+/*
  * Authenticate using a keypair found in the named files
  */
 static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
@@ -1288,7 +1278,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                           "username/public key combination");
 }
 
-/* libssh2_userauth_hostbased_fromfile_ex
+/*
  * Authenticate using a keypair found in the named files
  */
 LIBSSH2_API
@@ -1393,7 +1383,6 @@ static int is_version_less_than_78(const char *version)
 }
 
 /**
- * @function _libssh2_key_sign_algorithm
  * @abstract Upgrades the algorithm used for public key signing RFC 8332
  * @discussion Based on the incoming key_method value, this function
  * will upgrade the key method input based on user preferences,
@@ -1965,7 +1954,6 @@ retry_auth:
 }
 
 /*
- * userauth_publickey_frommemory
  * Authenticate using a keypair from memory
  */
 static int userauth_publickey_frommemory(LIBSSH2_SESSION *session,
@@ -2023,7 +2011,6 @@ static int userauth_publickey_frommemory(LIBSSH2_SESSION *session,
 }
 
 /*
- * userauth_publickey_fromfile
  * Authenticate using a keypair found in the named files
  */
 static int userauth_publickey_fromfile(LIBSSH2_SESSION *session,
@@ -2073,7 +2060,7 @@ static int userauth_publickey_fromfile(LIBSSH2_SESSION *session,
     return rc;
 }
 
-/* libssh2_userauth_publickey_frommemory
+/*
  * Authenticate using a keypair from memory
  */
 LIBSSH2_API
@@ -2104,7 +2091,7 @@ int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
     return rc;
 }
 
-/* libssh2_userauth_publickey_fromfile_ex
+/*
  * Authenticate using a keypair found in the named files
  */
 LIBSSH2_API
@@ -2130,7 +2117,7 @@ int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
     return rc;
 }
 
-/* libssh2_userauth_publickey_ex
+/*
  * Authenticate using an external callback function
  */
 LIBSSH2_API
@@ -2155,8 +2142,6 @@ int libssh2_userauth_publickey(
 }
 
 /*
- * userauth_keyboard_interactive
- *
  * Authenticate using a challenge-response authentication
  */
 static int userauth_keyboard_interactive(
@@ -2432,8 +2417,6 @@ cleanup:
 }
 
 /*
- * libssh2_userauth_keyboard_interactive_ex
- *
  * Authenticate using a challenge-response authentication
  */
 LIBSSH2_API
@@ -2450,8 +2433,6 @@ int libssh2_userauth_keyboard_interactive_ex(
 }
 
 /*
- * libssh2_userauth_publickey_sk
- *
  * Authenticate using an external callback function
  */
 LIBSSH2_API

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -258,9 +258,9 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
  * Not a common configuration for any SSH server though
  * username should be NULL, or a null terminated string
  */
-LIBSSH2_API char *
-libssh2_userauth_list(LIBSSH2_SESSION *session, const char *username,
-                      unsigned int username_len)
+LIBSSH2_API
+char *libssh2_userauth_list(LIBSSH2_SESSION *session,
+                            const char *username, unsigned int username_len)
 {
     char *ptr;
     BLOCK_ADJUST_ERRNO(ptr, session,
@@ -274,8 +274,8 @@ libssh2_userauth_list(LIBSSH2_SESSION *session, const char *username,
  * When no such message is sent by server or if no authentication attempt has
  * been made, this function returns LIBSSH2_ERROR_MISSING_USERAUTH_BANNER.
  */
-LIBSSH2_API int
-libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
+LIBSSH2_API
+int libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
 {
     if(!session)
         return LIBSSH2_ERROR_MISSING_USERAUTH_BANNER;
@@ -298,8 +298,8 @@ libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
  * Returns: 0 if not yet authenticated
  *          1 if already authenticated
  */
-LIBSSH2_API int
-libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
+LIBSSH2_API
+int libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
 {
     return (session->state & LIBSSH2_STATE_AUTHENTICATED) ? 1 : 0;
 }
@@ -574,11 +574,12 @@ password_response:
  * Plain ol' login
  */
 
-LIBSSH2_API int
-libssh2_userauth_password_ex(LIBSSH2_SESSION *session, const char *username,
-                             unsigned int username_len, const char *password,
-                             unsigned int password_len,
-                             LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb))
+LIBSSH2_API
+int libssh2_userauth_password_ex(
+    LIBSSH2_SESSION *session,
+    const char *username, unsigned int username_len,
+    const char *password, unsigned int password_len,
+    LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb))
 {
     int rc;
     BLOCK_ADJUST(rc, session,
@@ -1283,17 +1284,17 @@ userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
 /* libssh2_userauth_hostbased_fromfile_ex
  * Authenticate using a keypair found in the named files
  */
-LIBSSH2_API int
-libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
-                                       const char *username,
-                                       unsigned int username_len,
-                                       const char *publickey,
-                                       const char *privatekey,
-                                       const char *passphrase,
-                                       const char *hostname,
-                                       unsigned int hostname_len,
-                                       const char *local_username,
-                                       unsigned int local_username_len)
+LIBSSH2_API
+int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
+                                           const char *username,
+                                           unsigned int username_len,
+                                           const char *publickey,
+                                           const char *privatekey,
+                                           const char *passphrase,
+                                           const char *hostname,
+                                           unsigned int hostname_len,
+                                           const char *local_username,
+                                           unsigned int local_username_len)
 {
     int rc;
     BLOCK_ADJUST(rc, session,
@@ -2071,15 +2072,15 @@ userauth_publickey_fromfile(LIBSSH2_SESSION *session,
 /* libssh2_userauth_publickey_frommemory
  * Authenticate using a keypair from memory
  */
-LIBSSH2_API int
-libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
-                                      const char *username,
-                                      size_t username_len,
-                                      const char *publickeyfiledata,
-                                      size_t publickeyfiledata_len,
-                                      const char *privatekeyfiledata,
-                                      size_t privatekeyfiledata_len,
-                                      const char *passphrase)
+LIBSSH2_API
+int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
+                                          const char *username,
+                                          size_t username_len,
+                                          const char *publickeyfiledata,
+                                          size_t publickeyfiledata_len,
+                                          const char *privatekeyfiledata,
+                                          size_t privatekeyfiledata_len,
+                                          const char *passphrase)
 {
     int rc;
 
@@ -2102,13 +2103,13 @@ libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
 /* libssh2_userauth_publickey_fromfile_ex
  * Authenticate using a keypair found in the named files
  */
-LIBSSH2_API int
-libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
-                                       const char *username,
-                                       unsigned int username_len,
-                                       const char *publickey,
-                                       const char *privatekey,
-                                       const char *passphrase)
+LIBSSH2_API
+int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
+                                           const char *username,
+                                           unsigned int username_len,
+                                           const char *publickey,
+                                           const char *privatekey,
+                                           const char *passphrase)
 {
     int rc;
 
@@ -2128,13 +2129,13 @@ libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
 /* libssh2_userauth_publickey_ex
  * Authenticate using an external callback function
  */
-LIBSSH2_API int
-libssh2_userauth_publickey(LIBSSH2_SESSION *session,
-                           const char *username,
-                           const unsigned char *pubkeydata,
-                           size_t pubkeydata_len,
-                          LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(*sign_callback),
-                           void **abstract)
+LIBSSH2_API
+int libssh2_userauth_publickey(
+    LIBSSH2_SESSION *session,
+    const char *username,
+    const unsigned char *pubkeydata, size_t pubkeydata_len,
+    LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(*sign_callback),
+    void **abstract)
 {
     int rc;
 
@@ -2432,11 +2433,11 @@ cleanup:
  *
  * Authenticate using a challenge-response authentication
  */
-LIBSSH2_API int
-libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION *session,
-                                         const char *username,
-                                         unsigned int username_len,
-                     LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback))
+LIBSSH2_API
+int libssh2_userauth_keyboard_interactive_ex(
+    LIBSSH2_SESSION *session,
+    const char *username, unsigned int username_len,
+    LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback))
 {
     int rc;
     BLOCK_ADJUST(rc, session,
@@ -2450,17 +2451,15 @@ libssh2_userauth_keyboard_interactive_ex(LIBSSH2_SESSION *session,
  *
  * Authenticate using an external callback function
  */
-LIBSSH2_API int
-libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
-                              const char *username,
-                              size_t username_len,
-                              const unsigned char *publickeydata,
-                              size_t publickeydata_len,
-                              const char *privatekeydata,
-                              size_t privatekeydata_len,
-                              const char *passphrase,
-                              LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback),
-                              void **abstract)
+LIBSSH2_API
+int libssh2_userauth_publickey_sk(
+    LIBSSH2_SESSION *session,
+    const char *username, size_t username_len,
+    const unsigned char *publickeydata, size_t publickeydata_len,
+    const char *privatekeydata, size_t privatekeydata_len,
+    const char *passphrase,
+    LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback),
+    void **abstract)
 {
     int rc = LIBSSH2_ERROR_NONE;
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -307,11 +307,12 @@ int libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
 /* userauth_password
  * Plain ol' login
  */
-static int
-userauth_password(LIBSSH2_SESSION *session,
-                  const char *username, unsigned int username_len,
-                  const unsigned char *password, unsigned int password_len,
-                  LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb))
+static int userauth_password(LIBSSH2_SESSION *session,
+                            const char *username,
+                            unsigned int username_len,
+                            const unsigned char *password,
+                            unsigned int password_len,
+                            LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb))
 {
     unsigned char *s;
     static const unsigned char reply_codes[4] = {
@@ -590,13 +591,13 @@ int libssh2_userauth_password_ex(
     return rc;
 }
 
-static int
-memory_read_publickey(LIBSSH2_SESSION *session, unsigned char **method,
-                      size_t *method_len,
-                      unsigned char **pubkeydata,
-                      size_t *pubkeydata_len,
-                      const char *pubkeyfiledata,
-                      size_t pubkeyfiledata_len)
+static int memory_read_publickey(LIBSSH2_SESSION *session,
+                                 unsigned char **method,
+                                 size_t *method_len,
+                                 unsigned char **pubkeydata,
+                                 size_t *pubkeydata_len,
+                                 const char *pubkeyfiledata,
+                                 size_t pubkeyfiledata_len)
 {
     unsigned char *pubkey = NULL, *sp1, *sp2, *tmp;
     size_t pubkey_len = pubkeyfiledata_len;
@@ -673,12 +674,12 @@ memory_read_publickey(LIBSSH2_SESSION *session, unsigned char **method,
  * Returns an allocated string containing the key method (e.g. "ssh-dss")
  * in method on success.
  */
-static int
-file_read_publickey(LIBSSH2_SESSION *session, unsigned char **method,
-                    size_t *method_len,
-                    unsigned char **pubkeydata,
-                    size_t *pubkeydata_len,
-                    const char *pubkeyfile)
+static int file_read_publickey(LIBSSH2_SESSION *session,
+                               unsigned char **method,
+                               size_t *method_len,
+                               unsigned char **pubkeydata,
+                               size_t *pubkeydata_len,
+                               const char *pubkeyfile)
 {
     FILE *fd;
     char c;
@@ -767,13 +768,14 @@ file_read_publickey(LIBSSH2_SESSION *session, unsigned char **method,
     return 0;
 }
 
-static int
-memory_read_privatekey(LIBSSH2_SESSION *session,
-                       const struct hostkey_method **hostkey_method,
-                       void **hostkey_abstract,
-                       const unsigned char *method, size_t method_len,
-                       const char *privkeyfiledata, size_t privkeyfiledata_len,
-                       const char *passphrase)
+static int memory_read_privatekey(LIBSSH2_SESSION *session,
+                                  const struct hostkey_method **hostkey_method,
+                                  void **hostkey_abstract,
+                                  const unsigned char *method,
+                                  size_t method_len,
+                                  const char *privkeyfiledata,
+                                  size_t privkeyfiledata_len,
+                                  const char *passphrase)
 {
     const struct hostkey_method **hostkey_methods_avail =
         libssh2_hostkey_methods();
@@ -808,12 +810,13 @@ memory_read_privatekey(LIBSSH2_SESSION *session,
 /* libssh2_file_read_privatekey
  * Read a PEM encoded private key from an id_??? style file
  */
-static int
-file_read_privatekey(LIBSSH2_SESSION *session,
-                     const struct hostkey_method **hostkey_method,
-                     void **hostkey_abstract,
-                     const unsigned char *method, size_t method_len,
-                     const char *privkeyfile, const char *passphrase)
+static int file_read_privatekey(LIBSSH2_SESSION *session,
+                                const struct hostkey_method **hostkey_method,
+                                void **hostkey_abstract,
+                                const unsigned char *method,
+                                size_t method_len,
+                                const char *privkeyfile,
+                                const char *passphrase)
 {
     const struct hostkey_method **hostkey_methods_avail =
         libssh2_hostkey_methods();
@@ -857,9 +860,10 @@ struct privkey_mem {
     size_t data_len;
 };
 
-static int
-sign_frommemory(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
-                const unsigned char *data, size_t data_len, void **abstract)
+static int sign_frommemory(LIBSSH2_SESSION *session,
+                           unsigned char **sig, size_t *sig_len,
+                          const unsigned char *data, size_t data_len,
+                          void **abstract)
 {
     struct privkey_mem *pk_mem = (struct privkey_mem *)(*abstract);
     const struct hostkey_method *privkeyobj;
@@ -897,9 +901,10 @@ sign_frommemory(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
     return 0;
 }
 
-static int
-sign_fromfile(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
-              const unsigned char *data, size_t data_len, void **abstract)
+static int sign_fromfile(LIBSSH2_SESSION *session,
+                         unsigned char **sig, size_t *sig_len,
+                         const unsigned char *data, size_t data_len,
+                         void **abstract)
 {
     struct privkey_file *privkey_file = (struct privkey_file *)(*abstract);
     const struct hostkey_method *privkeyobj;
@@ -1040,14 +1045,16 @@ libssh2_sign_sk(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
 /* userauth_hostbased_fromfile
  * Authenticate using a keypair found in the named files
  */
-static int
-userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
-                            const char *username, size_t username_len,
-                            const char *publickey, const char *privatekey,
-                            const char *passphrase, const char *hostname,
-                            size_t hostname_len,
-                            const char *local_username,
-                            size_t local_username_len)
+static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
+                                       const char *username,
+                                       size_t username_len,
+                                       const char *publickey,
+                                       const char *privatekey,
+                                       const char *passphrase,
+                                       const char *hostname,
+                                       size_t hostname_len,
+                                       const char *local_username,
+                                       size_t local_username_len)
 {
     int rc;
 
@@ -1396,10 +1403,9 @@ static int is_version_less_than_78(const char *version)
  * @param key_method_len length of the key method buffer
  * @result error code or zero on success
  */
-static int
-_libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
-                            unsigned char **key_method,
-                            size_t *key_method_len)
+static int _libssh2_key_sign_algorithm(LIBSSH2_SESSION *session,
+                                       unsigned char **key_method,
+                                       size_t *key_method_len)
 {
     const char *s = NULL;
     const char *a = NULL;
@@ -1962,15 +1968,14 @@ retry_auth:
  * userauth_publickey_frommemory
  * Authenticate using a keypair from memory
  */
-static int
-userauth_publickey_frommemory(LIBSSH2_SESSION *session,
-                              const char *username,
-                              size_t username_len,
-                              const char *publickeydata,
-                              size_t publickeydata_len,
-                              const char *privatekeydata,
-                              size_t privatekeydata_len,
-                              const char *passphrase)
+static int userauth_publickey_frommemory(LIBSSH2_SESSION *session,
+                                         const char *username,
+                                         size_t username_len,
+                                         const char *publickeydata,
+                                         size_t publickeydata_len,
+                                         const char *privatekeydata,
+                                         size_t privatekeydata_len,
+                                         const char *passphrase)
 {
     unsigned char *pubkeydata = NULL;
     size_t pubkeydata_len = 0;
@@ -2021,13 +2026,12 @@ userauth_publickey_frommemory(LIBSSH2_SESSION *session,
  * userauth_publickey_fromfile
  * Authenticate using a keypair found in the named files
  */
-static int
-userauth_publickey_fromfile(LIBSSH2_SESSION *session,
-                            const char *username,
-                            size_t username_len,
-                            const char *publickey,
-                            const char *privatekey,
-                            const char *passphrase)
+static int userauth_publickey_fromfile(LIBSSH2_SESSION *session,
+                                       const char *username,
+                                       size_t username_len,
+                                       const char *publickey,
+                                       const char *privatekey,
+                                       const char *passphrase)
 {
     unsigned char *pubkeydata = NULL;
     size_t pubkeydata_len = 0;
@@ -2155,11 +2159,10 @@ int libssh2_userauth_publickey(
  *
  * Authenticate using a challenge-response authentication
  */
-static int
-userauth_keyboard_interactive(LIBSSH2_SESSION *session,
-                              const char *username,
-                              unsigned int username_len,
-                     LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback))
+static int userauth_keyboard_interactive(
+    LIBSSH2_SESSION *session,
+    const char *username, unsigned int username_len,
+    LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback))
 {
     unsigned char *s;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2326,8 +2326,6 @@ _libssh2_wincng_ecdsa_free(IN struct wincng_ecdsa_ctx *key)
 }
 
 /*
- * _libssh2_ecdsa_create_key
- *
  * Creates a local private ECDH key based on input curve
  * and returns the public key in uncompressed point encoding.
  */
@@ -2418,8 +2416,6 @@ cleanup:
 }
 
 /*
- * _libssh2_ecdsa_curve_name_with_octal_new
- *
  * Creates an ECDSA public key from an uncompressed point.
  */
 int
@@ -2476,8 +2472,6 @@ cleanup:
 }
 
 /*
- * _libssh2_ecdh_gen_k
- *
  * Computes the shared secret K given a local private key,
  * remote public key and length
  */
@@ -2595,10 +2589,6 @@ cleanup:
     return result;
 }
 
-/*
- * _libssh2_ecdsa_curve_type_from_name
- *
- */
 static int wincng_ecdsa_curve_type_from_name(IN const char *name,
                                              OUT libssh2_curve_type *out_curve)
 {
@@ -2620,10 +2610,7 @@ static int wincng_ecdsa_curve_type_from_name(IN const char *name,
 }
 
 /*
- * _libssh2_ecdsa_verify
- *
  * Verifies the ECDSA signature of a hashed message
- *
  */
 int
 _libssh2_wincng_ecdsa_verify(IN struct wincng_ecdsa_ctx *key,
@@ -2722,10 +2709,7 @@ cleanup:
 }
 
 /*
- *_libssh2_ecdsa_new_private
- *
  * Creates a new private key given a file path and password
- *
  */
 int
 _libssh2_wincng_ecdsa_new_private(OUT struct wincng_ecdsa_ctx **key,
@@ -2916,8 +2900,6 @@ cleanup:
 }
 
 /*
- * _libssh2_ecdsa_new_private
- *
  * Creates a new private key given a file data and password.
  * ECDSA private key files use the decoding defined in PROTOCOL.key
  * in the OpenSSL source tree.
@@ -3023,10 +3005,7 @@ cleanup:
 }
 
 /*
- * _libssh2_ecdsa_sign
- *
  * Computes the ECDSA signature of a previously-hashed message
- *
  */
 int
 _libssh2_wincng_ecdsa_sign(IN LIBSSH2_SESSION *session,
@@ -3130,10 +3109,7 @@ cleanup:
 }
 
 /*
- * _libssh2_ecdsa_get_curve_type
- *
  * returns key curve type that maps to libssh2_curve_type
- *
  */
 libssh2_curve_type
 _libssh2_wincng_ecdsa_get_curve_type(IN struct wincng_ecdsa_ctx *key)
@@ -3955,12 +3931,9 @@ fb:
     return wincng_bignum_mod_exp(secret, f, dhctx->dh_privbn, p);
 }
 
-/* _libssh2_supported_key_sign_algorithms
- *
+/*
  * Return supported key hash algo upgrades, see crypto.h
- *
  */
-
 const char *
 _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
                                        unsigned char *key_method,


### PR DESCRIPTION
- move return type inline with the declaration.
  (for statics and public APIs)
- move `LIBSSH2_API` attribute to distinct lines in definitions.
  (This attribute is redundant here and can be deleted in a future commit)
- delete copy of function name from function top comments.
- os400qc3: drop 'libssh2' prefixes for statics.
- move an author name from comment to `AUTHORS`.
- misc formatting fixes along the way.

---

https://github.com/libssh2/libssh2/pull/1935/files?w=1
