### PR TITLE
src: formatting (cont. 2)

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -873,9 +873,8 @@ static int agent_sign(LIBSSH2_SESSION *session,
     if(((size_t)method_len != session->userauth_pblc_method_len &&
         method_len != plain_len) ||
        memcmp(method_name, session->userauth_pblc_method, method_len)) {
-        _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Agent sign method %.*s",
-                       (int)method_len, method_name));
+        _libssh2_debug((session, LIBSSH2_TRACE_KEX, "Agent sign method %.*s",
+                        (int)method_len, method_name));
 
         rc = LIBSSH2_ERROR_ALGO_UNSUPPORTED;
         goto error;

--- a/src/channel.c
+++ b/src/channel.c
@@ -81,7 +81,7 @@ uint32_t _libssh2_channel_nextid(LIBSSH2_SESSION *session)
      */
     session->next_channel = id + 1;
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                   "Allocated new channel ID#%u", id));
+                    "Allocated new channel ID#%u", id));
     return id;
 }
 
@@ -150,8 +150,8 @@ LIBSSH2_CHANNEL *_libssh2_channel_open(LIBSSH2_SESSION *session,
                sizeof(session->open_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Opening Channel - win %d pack %d", window_size,
-                       packet_size));
+                        "Opening Channel - win %d pack %d", window_size,
+                        packet_size));
         session->open_channel =
             LIBSSH2_CALLOC(session, sizeof(LIBSSH2_CHANNEL));
         if(!session->open_channel) {
@@ -210,8 +210,7 @@ LIBSSH2_CHANNEL *_libssh2_channel_open(LIBSSH2_SESSION *session,
             return NULL;
         }
         else if(rc) {
-            _libssh2_error(session, rc,
-                           "Unable to send channel-open request");
+            _libssh2_error(session, rc, "Unable to send channel-open request");
             goto channel_error;
         }
 
@@ -257,14 +256,14 @@ LIBSSH2_CHANNEL *_libssh2_channel_open(LIBSSH2_SESSION *session,
             session->open_channel->local.packet_size =
                 _libssh2_ntohu32(session->open_data + 13);
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Connection Established - ID: %u/%u win: %u/%u"
-                           " pack: %u/%u",
-                           session->open_channel->local.id,
-                           session->open_channel->remote.id,
-                           session->open_channel->local.window_size,
-                           session->open_channel->remote.window_size,
-                           session->open_channel->local.packet_size,
-                           session->open_channel->remote.packet_size));
+                            "Connection Established - ID: %u/%u win: %u/%u"
+                            " pack: %u/%u",
+                            session->open_channel->local.id,
+                            session->open_channel->remote.id,
+                            session->open_channel->local.window_size,
+                            session->open_channel->remote.window_size,
+                            session->open_channel->local.packet_size,
+                            session->open_channel->remote.packet_size));
             LIBSSH2_FREE(session, session->open_packet);
             session->open_packet = NULL;
             LIBSSH2_FREE(session, session->open_data);
@@ -384,8 +383,8 @@ static LIBSSH2_CHANNEL *channel_direct_tcpip(LIBSSH2_SESSION *session,
             session->direct_host_len + session->direct_shost_len + 16;
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Requesting direct-tcpip session from %s:%d to %s:%d",
-                       shost, sport, host, port));
+                        "Requesting direct-tcpip session from %s:%d to %s:%d",
+                        shost, sport, host, port));
 
         s = session->direct_message =
             LIBSSH2_ALLOC(session, session->direct_message_len);
@@ -401,13 +400,12 @@ static LIBSSH2_CHANNEL *channel_direct_tcpip(LIBSSH2_SESSION *session,
         _libssh2_store_u32(&s, sport);
     }
 
-    channel =
-        _libssh2_channel_open(session, "direct-tcpip",
-                              sizeof("direct-tcpip") - 1,
-                              LIBSSH2_CHANNEL_WINDOW_DEFAULT,
-                              LIBSSH2_CHANNEL_PACKET_DEFAULT,
-                              session->direct_message,
-                              session->direct_message_len);
+    channel = _libssh2_channel_open(session, "direct-tcpip",
+                                    sizeof("direct-tcpip") - 1,
+                                    LIBSSH2_CHANNEL_WINDOW_DEFAULT,
+                                    LIBSSH2_CHANNEL_PACKET_DEFAULT,
+                                    session->direct_message,
+                                    session->direct_message_len);
 
     if(!channel &&
        libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
@@ -447,10 +445,10 @@ LIBSSH2_CHANNEL *libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session,
 /*
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
-static LIBSSH2_CHANNEL *channel_direct_streamlocal(
-    LIBSSH2_SESSION *session,
-    const char *socket_path,
-    const char *shost, int sport)
+static LIBSSH2_CHANNEL *channel_direct_streamlocal(LIBSSH2_SESSION *session,
+                                                   const char *socket_path,
+                                                   const char *shost,
+                                                   int sport)
 {
     LIBSSH2_CHANNEL *channel;
     unsigned char *s;
@@ -462,14 +460,15 @@ static LIBSSH2_CHANNEL *channel_direct_streamlocal(
             session->direct_host_len + session->direct_shost_len + 12;
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Requesting direct-streamlocal session to %s",
-                       socket_path));
+                        "Requesting direct-streamlocal session to %s",
+                        socket_path));
 
         s = session->direct_message =
             LIBSSH2_ALLOC(session, session->direct_message_len);
         if(!session->direct_message) {
             _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                "Unable to allocate memory for direct-streamlocal connection");
+                           "Unable to allocate memory "
+                           "for direct-streamlocal connection");
             return NULL;
         }
         _libssh2_store_str(&s, socket_path, session->direct_host_len);
@@ -549,8 +548,8 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
                sizeof(session->fwdLstn_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Requesting tcpip-forward session for %s:%d", host,
-                       port));
+                        "Requesting tcpip-forward session for %s:%d", host,
+                        port));
 
         s = session->fwdLstn_packet =
             LIBSSH2_ALLOC(session, session->fwdLstn_packet_len);
@@ -636,9 +635,8 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
                     if(data_len >= 5 && !port) {
                         listener->port = _libssh2_ntohu32(data + 1);
                         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                                       "Dynamic tcpip-forward port "
-                                       "allocated: %d",
-                                       listener->port));
+                                        "Dynamic tcpip-forward port "
+                                        "allocated: %d", listener->port));
                     }
                     else
                         listener->port = port;
@@ -713,8 +711,8 @@ int _libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
 
     if(listener->chanFwdCncl_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Cancelling tcpip-forward session for %s:%d",
-                       listener->host, listener->port));
+                        "Cancelling tcpip-forward session for %s:%d",
+                        listener->host, listener->port));
 
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
@@ -873,9 +871,9 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
                sizeof(channel->setenv_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Setting remote environment variable: %s=%s on "
-                       "channel %u/%u",
-                       varname, value, channel->local.id, channel->remote.id));
+                        "Setting remote environment variable: %s=%s on "
+                        "channel %u/%u", varname, value, channel->local.id,
+                        channel->remote.id));
 
         s = channel->setenv_packet =
             LIBSSH2_ALLOC(session, channel->setenv_packet_len);
@@ -924,8 +922,7 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
     if(channel->setenv_state == libssh2_NB_state_sent) {
         rc = _libssh2_packet_requirev(session, reply_codes, &data, &data_len,
                                       1, channel->setenv_local_channel, 4,
-                                      &channel->
-                                      setenv_packet_requirev_state);
+                                      &channel->setenv_packet_requirev_state);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             return rc;
         }
@@ -1005,8 +1002,8 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
                sizeof(channel->reqPTY_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Allocating tty on channel %u/%u", channel->local.id,
-                       channel->remote.id));
+                        "Allocating tty on channel %u/%u", channel->local.id,
+                        channel->remote.id));
 
         s = channel->reqPTY_packet;
 
@@ -1105,8 +1102,8 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
                sizeof(channel->req_auth_agent_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Requesting auth agent on channel %u/%u",
-                       channel->local.id, channel->remote.id));
+                        "Requesting auth agent on channel %u/%u",
+                        channel->local.id, channel->remote.id));
 
         /*
          *  byte      SSH_MSG_CHANNEL_REQUEST
@@ -1266,9 +1263,8 @@ static int channel_request_pty_size(LIBSSH2_CHANNEL *channel, int width,
                sizeof(channel->reqPTY_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "changing tty size on channel %u/%u",
-                       channel->local.id,
-                       channel->remote.id));
+                        "changing tty size on channel %u/%u",
+                        channel->local.id, channel->remote.id));
 
         s = channel->reqPTY_packet;
 
@@ -1353,12 +1349,13 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
                sizeof(channel->reqX11_packet_requirev_state));
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Requesting x11-req for channel %u/%u: single=%d "
-                       "proto=%s cookie=%s screen=%d",
-                       channel->local.id, channel->remote.id,
-                       single_connection,
-                       auth_proto ? auth_proto : "MIT-MAGIC-COOKIE-1",
-                       auth_cookie ? auth_cookie : "<random>", screen_number));
+                        "Requesting x11-req for channel %u/%u: single=%d "
+                        "proto=%s cookie=%s screen=%d",
+                        channel->local.id, channel->remote.id,
+                        single_connection,
+                        auth_proto ? auth_proto : "MIT-MAGIC-COOKIE-1",
+                        auth_cookie ? auth_cookie : "<random>",
+                        screen_number));
 
         s = channel->reqX11_packet =
             LIBSSH2_ALLOC(session, channel->reqX11_packet_len);
@@ -1371,7 +1368,7 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
         _libssh2_store_u32(&s, channel->remote.id);
         _libssh2_store_str(&s, "x11-req", sizeof("x11-req") - 1);
 
-        *(s++) = 0x01;          /* want_reply */
+        *(s++) = 0x01; /* want_reply */
         *(s++) = single_connection ? 0x01 : 0x00;
 
         _libssh2_store_str(&s, auth_proto ? auth_proto : "MIT-MAGIC-COOKIE-1",
@@ -1407,8 +1404,7 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
 
     if(channel->reqX11_state == libssh2_NB_state_created) {
         rc = _libssh2_transport_send(session, channel->reqX11_packet,
-                                     channel->reqX11_packet_len,
-                                     NULL, 0);
+                                     channel->reqX11_packet_len, NULL, 0);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             _libssh2_error(session, rc, "Would block sending X11-req packet");
             return rc;
@@ -1506,9 +1502,9 @@ int _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
             channel->process_packet_len += 4;
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "starting request(%s) on channel %u/%u, message=%s",
-                       request, channel->local.id, channel->remote.id,
-                       message ? message : "<null>"));
+                        "starting request(%s) on channel %u/%u, message=%s",
+                        request, channel->local.id, channel->remote.id,
+                        message ? message : "<null>"));
         s = channel->process_packet =
             LIBSSH2_ALLOC(session, channel->process_packet_len);
         if(!channel->process_packet)
@@ -1534,8 +1530,7 @@ int _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                      (const unsigned char *)message,
                                      message_len);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
-            _libssh2_error(session, rc,
-                           "Would block sending channel request");
+            _libssh2_error(session, rc, "Would block sending channel request");
             return rc;
         }
         else if(rc) {
@@ -1634,7 +1629,7 @@ int _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
             if(packet->data_len < 1) {
                 packet = next;
                 _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
-                               "Unexpected packet length"));
+                                "Unexpected packet length"));
                 continue;
             }
 
@@ -1670,10 +1665,10 @@ int _libssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
                         packet->data_head;
 
                     _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                                   "Flushing %ld bytes of data from stream "
-                                   "%d on channel %u/%u",
-                                   (long)bytes_to_flush, packet_stream_id,
-                                   channel->local.id, channel->remote.id));
+                                    "Flushing %ld bytes of data from stream "
+                                    "%d on channel %u/%u",
+                                    (long)bytes_to_flush, packet_stream_id,
+                                    channel->local.id, channel->remote.id));
 
                     /* It's one of the streams we wanted to flush */
                     channel->flush_refund_bytes += packet->data_len - 13;
@@ -1769,7 +1764,8 @@ int libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
                 *exitsignal = LIBSSH2_ALLOC(session, namelen + 1);
                 if(!*exitsignal) {
                     return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                                  "Unable to allocate memory for signal name");
+                                          "Unable to allocate memory "
+                                          "for signal name");
                 }
                 memcpy(*exitsignal, channel->exit_signal, namelen);
                 (*exitsignal)[namelen] = '\0';
@@ -1823,9 +1819,10 @@ int _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
         if(!force &&
            (adjustment + channel->adjust_queue < LIBSSH2_CHANNEL_MINADJUST)) {
             _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                           "Queueing %u bytes for receive window adjustment "
-                           "for channel %u/%u",
-                           adjustment, channel->local.id, channel->remote.id));
+                            "Queueing %u bytes for receive window adjustment "
+                            "for channel %u/%u",
+                            adjustment, channel->local.id,
+                            channel->remote.id));
             channel->adjust_queue += adjustment;
             return 0;
         }
@@ -1842,9 +1839,9 @@ int _libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
         _libssh2_htonu32(&channel->adjust_adjust[1], channel->remote.id);
         _libssh2_htonu32(&channel->adjust_adjust[5], adjustment);
         _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                       "Adjusting window %u bytes for data on "
-                       "channel %u/%u",
-                       adjustment, channel->local.id, channel->remote.id));
+                        "Adjusting window %u bytes for data on "
+                        "channel %u/%u",
+                        adjustment, channel->local.id, channel->remote.id));
 
         channel->adjust_state = libssh2_NB_state_created;
     }
@@ -1942,9 +1939,9 @@ int _libssh2_channel_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode)
 {
     if(channel->extData2_state == libssh2_NB_state_idle) {
         _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                       "Setting channel %u/%u handle_extended_data"
-                       " mode to %d",
-                       channel->local.id, channel->remote.id, ignore_mode));
+                        "Setting channel %u/%u handle_extended_data"
+                        " mode to %d",
+                        channel->local.id, channel->remote.id, ignore_mode));
         channel->remote.extended_data_ignore_mode = (char)ignore_mode;
 
         channel->extData2_state = libssh2_NB_state_created;
@@ -2017,10 +2014,10 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
     struct packet *read_next;
 
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                   "channel_read() wants %ld bytes from channel %u/%u "
-                   "stream #%d",
-                   (long)buflen, channel->local.id, channel->remote.id,
-                   stream_id));
+                    "channel_read() wants %ld bytes from channel %u/%u "
+                    "stream #%d",
+                    (long)buflen, channel->local.id, channel->remote.id,
+                    stream_id));
 
     /* expand the receiving window first if it has become too narrow */
     if((channel->read_state == libssh2_NB_state_jump1) ||
@@ -2073,7 +2070,7 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
             if(readpkt->data_len != 1 ||
                readpkt->data[0] != SSH_MSG_REQUEST_FAILURE) {
                 _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
-                               "Unexpected packet length"));
+                                "Unexpected packet length"));
             }
 
             continue;
@@ -2113,10 +2110,10 @@ ssize_t _libssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
             }
 
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "channel_read() got %ld of data from %u/%u/%d%s",
-                           (long)bytes_want, channel->local.id,
-                           channel->remote.id, stream_id,
-                           unlink_packet ? " [ul]" : ""));
+                            "channel_read() got %ld of data from %u/%u/%d%s",
+                            (long)bytes_want, channel->local.id,
+                            channel->remote.id, stream_id,
+                            unlink_packet ? " [ul]" : ""));
 
             /* copy data from this struct to the target buffer */
             memcpy(&buf[bytes_read],
@@ -2219,7 +2216,7 @@ size_t _libssh2_channel_packet_data_len(LIBSSH2_CHANNEL *channel,
         if(read_packet->data_len < 5) {
             read_packet = next_packet;
             _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
-                           "Unexpected packet length"));
+                            "Unexpected packet length"));
             continue;
         }
 
@@ -2283,9 +2280,9 @@ ssize_t _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         unsigned char *s = channel->write_packet;
 
         _libssh2_debug((channel->session, LIBSSH2_TRACE_CONN,
-                       "Writing %ld bytes on channel %u/%u, stream #%d",
-                       (long)buflen, channel->local.id, channel->remote.id,
-                       stream_id));
+                        "Writing %ld bytes on channel %u/%u, stream #%d",
+                        (long)buflen, channel->local.id, channel->remote.id,
+                        stream_id));
 
         if(channel->local.close)
             return _libssh2_error(channel->session,
@@ -2332,18 +2329,18 @@ ssize_t _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         /* REMEMBER local means local as the SOURCE of the data */
         if(channel->write_bufwrite > channel->local.window_size) {
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Splitting write block due to %u byte "
-                           "window_size on %u/%u/%d",
-                           channel->local.window_size, channel->local.id,
-                           channel->remote.id, stream_id));
+                            "Splitting write block due to %u byte "
+                            "window_size on %u/%u/%d",
+                            channel->local.window_size, channel->local.id,
+                            channel->remote.id, stream_id));
             channel->write_bufwrite = channel->local.window_size;
         }
         if(channel->write_bufwrite > channel->local.packet_size) {
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Splitting write block due to %u byte "
-                           "packet_size on %u/%u/%d",
-                           channel->local.packet_size, channel->local.id,
-                           channel->remote.id, stream_id));
+                            "Splitting write block due to %u byte "
+                            "packet_size on %u/%u/%d",
+                            channel->local.packet_size, channel->local.id,
+                            channel->remote.id, stream_id));
             channel->write_bufwrite = channel->local.packet_size;
         }
         /* store the size here only, the buffer is passed in as-is to
@@ -2352,9 +2349,9 @@ ssize_t _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         channel->write_packet_len = s - channel->write_packet;
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Sending %ld bytes on channel %u/%u, stream_id=%d",
-                       (long)channel->write_bufwrite, channel->local.id,
-                       channel->remote.id, stream_id));
+                        "Sending %ld bytes on channel %u/%u, stream_id=%d",
+                        (long)channel->write_bufwrite, channel->local.id,
+                        channel->remote.id, stream_id));
 
         channel->write_state = libssh2_NB_state_created;
     }
@@ -2364,13 +2361,11 @@ ssize_t _libssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
                                      channel->write_packet_len,
                                      buf, channel->write_bufwrite);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
-            return _libssh2_error(session, rc,
-                                  "Unable to send channel data");
+            return _libssh2_error(session, rc, "Unable to send channel data");
         }
         else if(rc) {
             channel->write_state = libssh2_NB_state_idle;
-            return _libssh2_error(session, rc,
-                                  "Unable to send channel data");
+            return _libssh2_error(session, rc, "Unable to send channel data");
         }
         /* Shrink local window size */
         channel->local.window_size -= (uint32_t)channel->write_bufwrite;
@@ -2423,8 +2418,8 @@ static int channel_send_eof(LIBSSH2_CHANNEL *channel)
     int rc;
 
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                   "Sending EOF on channel %u/%u",
-                   channel->local.id, channel->remote.id));
+                    "Sending EOF on channel %u/%u",
+                    channel->local.id, channel->remote.id));
     packet[0] = SSH_MSG_CHANNEL_EOF;
     _libssh2_htonu32(packet + 1, channel->remote.id);
     rc = _libssh2_transport_send(session, packet, 5, NULL, 0);
@@ -2479,7 +2474,7 @@ int libssh2_channel_eof(LIBSSH2_CHANNEL *channel)
         if(packet->data_len < 1) {
             packet = next_packet;
             _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
-                           "Unexpected packet length"));
+                            "Unexpected packet length"));
             continue;
         }
 
@@ -2506,8 +2501,8 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
 
     if(channel->wait_eof_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Awaiting EOF for channel %u/%u", channel->local.id,
-                       channel->remote.id));
+                        "Awaiting EOF for channel %u/%u", channel->local.id,
+                        channel->remote.id));
 
         channel->wait_eof_state = libssh2_NB_state_created;
     }
@@ -2586,7 +2581,7 @@ int _libssh2_channel_close(LIBSSH2_CHANNEL *channel)
 
     if(channel->close_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_CONN, "Closing channel %u/%u",
-                       channel->local.id, channel->remote.id));
+                        channel->local.id, channel->remote.id));
 
         channel->close_packet[0] = SSH_MSG_CHANNEL_CLOSE;
         _libssh2_htonu32(channel->close_packet + 1, channel->remote.id);
@@ -2669,8 +2664,8 @@ static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
 
     if(channel->wait_closed_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Awaiting close of channel %u/%u", channel->local.id,
-                       channel->remote.id));
+                        "Awaiting close of channel %u/%u", channel->local.id,
+                        channel->remote.id));
 
         channel->wait_closed_state = libssh2_NB_state_created;
     }
@@ -2728,8 +2723,8 @@ int _libssh2_channel_free(LIBSSH2_CHANNEL *channel)
 
     if(channel->free_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Freeing channel %u/%u resources", channel->local.id,
-                       channel->remote.id));
+                        "Freeing channel %u/%u resources", channel->local.id,
+                        channel->remote.id));
 
         channel->free_state = libssh2_NB_state_created;
     }
@@ -2886,7 +2881,7 @@ unsigned long libssh2_channel_window_read_ex(
             if(packet->data_len < 1) {
                 packet = next_packet;
                 _libssh2_debug((channel->session, LIBSSH2_TRACE_ERROR,
-                               "Unexpected packet length"));
+                                "Unexpected packet length"));
                 continue;
             }
 

--- a/src/comp.c
+++ b/src/comp.c
@@ -161,7 +161,7 @@ static int comp_method_zlib_init(LIBSSH2_SESSION *session, int compr,
     if(status != Z_OK) {
         LIBSSH2_FREE(session, strm);
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "unhandled zlib error %d", status));
+                        "unhandled zlib error %d", status));
         return LIBSSH2_ERROR_COMPRESS;
     }
     *abstract = strm;
@@ -199,8 +199,8 @@ static int comp_method_zlib_comp(LIBSSH2_SESSION *session,
     }
 
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                   "unhandled zlib compression error %d, avail_out %u",
-                   status, strm->avail_out));
+                    "unhandled zlib compression error %d, avail_out %u",
+                    status, strm->avail_out));
     return _libssh2_error(session, LIBSSH2_ERROR_ZLIB, "compression failure");
 }
 
@@ -278,7 +278,7 @@ static int comp_method_zlib_decomp(LIBSSH2_SESSION *session,
             /* error state */
             LIBSSH2_FREE(session, out);
             _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                           "unhandled zlib error %d", status));
+                            "unhandled zlib error %d", status));
             return _libssh2_error(session, LIBSSH2_ERROR_ZLIB,
                                   "decompression failure");
         }

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -73,7 +73,7 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
 
     if(hostkey_data_len < 19) {
         _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
-                       "host key length too short"));
+                        "host key length too short"));
         return -1;
     }
 
@@ -103,7 +103,7 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
 #endif
     {
         _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
-                       "unexpected rsa type: %.*s", (int)type_len, type));
+                        "unexpected rsa type: %.*s", (int)type_len, type));
         return -1;
     }
 
@@ -418,7 +418,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa = {
     hostkey_method_ssh_rsa_initPEMFromMemory,
     hostkey_method_ssh_rsa_sig_verify,
     hostkey_method_ssh_rsa_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
 
@@ -434,7 +434,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256 = {
     hostkey_method_ssh_rsa_initPEMFromMemory,
     hostkey_method_ssh_rsa_sha2_256_sig_verify,
     hostkey_method_ssh_rsa_sha2_256_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
 
@@ -446,7 +446,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512 = {
     hostkey_method_ssh_rsa_initPEMFromMemory,
     hostkey_method_ssh_rsa_sha2_512_sig_verify,
     hostkey_method_ssh_rsa_sha2_512_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
 
@@ -462,7 +462,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_cert = {
     hostkey_method_ssh_rsa_initPEMFromMemory,
     NULL,
     hostkey_method_ssh_rsa_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
 
@@ -478,7 +478,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256_cert = {
     hostkey_method_ssh_rsa_initPEMFromMemory,
     NULL,
     hostkey_method_ssh_rsa_sha2_256_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
 
@@ -490,7 +490,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512_cert = {
     hostkey_method_ssh_rsa_initPEMFromMemory,
     NULL,
     hostkey_method_ssh_rsa_sha2_512_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
 
@@ -526,7 +526,7 @@ static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
 
     if(hostkey_data_len < 27) {
         _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
-                       "host key length too short"));
+                        "host key length too short"));
         return -1;
     }
 
@@ -715,7 +715,7 @@ static const struct hostkey_method hostkey_method_ssh_dss = {
     hostkey_method_ssh_dss_initPEMFromMemory,
     hostkey_method_ssh_dss_sig_verify,
     hostkey_method_ssh_dss_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_dss_dtor,
 };
 #endif /* LIBSSH2_DSA */
@@ -750,7 +750,7 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
 
     if(hostkey_data_len < 39) {
         _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
-                       "host key length too short"));
+                        "host key length too short"));
         return -1;
     }
 
@@ -989,7 +989,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256 = {
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
     hostkey_method_ssh_ecdsa_sig_verify,
     hostkey_method_ssh_ecdsa_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_ecdsa_dtor,
 };
 
@@ -1001,7 +1001,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp384 = {
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
     hostkey_method_ssh_ecdsa_sig_verify,
     hostkey_method_ssh_ecdsa_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_ecdsa_dtor,
 };
 
@@ -1013,7 +1013,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521 = {
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
     hostkey_method_ssh_ecdsa_sig_verify,
     hostkey_method_ssh_ecdsa_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_ecdsa_dtor,
 };
 
@@ -1025,7 +1025,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256_cert = {
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
     NULL,
     hostkey_method_ssh_ecdsa_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_ecdsa_dtor,
 };
 
@@ -1037,7 +1037,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp384_cert = {
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
     NULL,
     hostkey_method_ssh_ecdsa_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_ecdsa_dtor,
 };
 
@@ -1049,7 +1049,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521_cert = {
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
     NULL,
     hostkey_method_ssh_ecdsa_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_ecdsa_dtor,
 };
 
@@ -1084,7 +1084,7 @@ static int hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
 
     if(hostkey_data_len < 19) {
         _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
-                       "host key length too short"));
+                        "host key length too short"));
         return -1;
     }
 
@@ -1224,7 +1224,7 @@ static int hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
 static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
                                            void **abstract)
 {
-    libssh2_ed25519_ctx *keyctx = (libssh2_ed25519_ctx*)(*abstract);
+    libssh2_ed25519_ctx *keyctx = (libssh2_ed25519_ctx *)(*abstract);
     (void)session;
 
     if(keyctx)
@@ -1243,7 +1243,7 @@ static const struct hostkey_method hostkey_method_ssh_ed25519 = {
     hostkey_method_ssh_ed25519_initPEMFromMemory,
     hostkey_method_ssh_ed25519_sig_verify,
     hostkey_method_ssh_ed25519_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_ed25519_dtor,
 };
 
@@ -1255,7 +1255,7 @@ static const struct hostkey_method hostkey_method_ssh_ed25519_cert = {
     hostkey_method_ssh_ed25519_initPEMFromMemory,
     hostkey_method_ssh_ed25519_sig_verify,
     hostkey_method_ssh_ed25519_signv,
-    NULL,                       /* encrypt */
+    NULL, /* encrypt */
     hostkey_method_ssh_ed25519_dtor,
 };
 

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -55,8 +55,7 @@ void libssh2_keepalive_config(LIBSSH2_SESSION *session,
 }
 
 LIBSSH2_API
-int libssh2_keepalive_send(LIBSSH2_SESSION *session,
-                           int *seconds_to_next)
+int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 {
     time_t now;
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -57,52 +57,54 @@
 
 #define LIBSSH2_KEX_METHOD_SHA_VALUE_HASH(digest_type, value,                 \
                                           reqlen, version)                    \
-do {                                                                          \
-    libssh2_sha##digest_type##_ctx hash;                                      \
-    size_t len = 0;                                                           \
-    if(!(value)) {                                                            \
-        (value) = LIBSSH2_ALLOC(session,                                      \
-                                (reqlen) + SHA##digest_type##_DIGEST_LENGTH); \
-    }                                                                         \
-    if(value)                                                                 \
-        while(len < (size_t)(reqlen)) {                                       \
-            if(!libssh2_sha##digest_type##_init(&hash) ||                     \
-               !libssh2_sha##digest_type##_update(hash,                       \
-                                       exchange_state->k_value,               \
-                                       exchange_state->k_value_len) ||        \
-               !libssh2_sha##digest_type##_update(hash,                       \
-                                       exchange_state->h_sig_comp,            \
-                                       SHA##digest_type##_DIGEST_LENGTH)) {   \
-                LIBSSH2_FREE(session, value);                                 \
-                (value) = NULL;                                               \
-                break;                                                        \
-            }                                                                 \
-            if(len > 0) {                                                     \
-                if(!libssh2_sha##digest_type##_update(hash, value, len)) {    \
-                    LIBSSH2_FREE(session, value);                             \
-                    (value) = NULL;                                           \
-                    break;                                                    \
-                }                                                             \
-            }                                                                 \
-            else {                                                            \
-                if(!libssh2_sha##digest_type##_update(hash,                   \
-                                                      (version), 1) ||        \
-                   !libssh2_sha##digest_type##_update(hash,                   \
-                                                session->session_id,          \
-                                                session->session_id_len)) {   \
-                    LIBSSH2_FREE(session, value);                             \
-                    (value) = NULL;                                           \
-                    break;                                                    \
-                }                                                             \
-            }                                                                 \
-            if(!libssh2_sha##digest_type##_final(hash, (value) + len)) {      \
-                LIBSSH2_FREE(session, value);                                 \
-                (value) = NULL;                                               \
-                break;                                                        \
-            }                                                                 \
-            len += SHA##digest_type##_DIGEST_LENGTH;                          \
+    do {                                                                      \
+        libssh2_sha##digest_type##_ctx hash;                                  \
+        size_t len = 0;                                                       \
+        if(!(value)) {                                                        \
+            (value) = LIBSSH2_ALLOC(session,                                  \
+                                    (reqlen) +                                \
+                                    SHA##digest_type##_DIGEST_LENGTH);        \
         }                                                                     \
-} while(0)
+        if(value)                                                             \
+            while(len < (size_t)(reqlen)) {                                   \
+                if(!libssh2_sha##digest_type##_init(&hash) ||                 \
+                   !libssh2_sha##digest_type##_update(hash,                   \
+                                           exchange_state->k_value,           \
+                                           exchange_state->k_value_len) ||    \
+                   !libssh2_sha##digest_type##_update(hash,                   \
+                                         exchange_state->h_sig_comp,          \
+                                         SHA##digest_type##_DIGEST_LENGTH)) { \
+                    LIBSSH2_FREE(session, value);                             \
+                    (value) = NULL;                                           \
+                    break;                                                    \
+                }                                                             \
+                if(len > 0) {                                                 \
+                    if(!libssh2_sha##digest_type##_update(hash,               \
+                                                          value, len)) {      \
+                        LIBSSH2_FREE(session, value);                         \
+                        (value) = NULL;                                       \
+                        break;                                                \
+                    }                                                         \
+                }                                                             \
+                else {                                                        \
+                    if(!libssh2_sha##digest_type##_update(hash,               \
+                                                          version, 1) ||      \
+                       !libssh2_sha##digest_type##_update(hash,               \
+                                                  session->session_id,        \
+                                                  session->session_id_len)) { \
+                        LIBSSH2_FREE(session, value);                         \
+                        (value) = NULL;                                       \
+                        break;                                                \
+                    }                                                         \
+                }                                                             \
+                if(!libssh2_sha##digest_type##_final(hash, (value) + len)) {  \
+                    LIBSSH2_FREE(session, value);                             \
+                    (value) = NULL;                                           \
+                    break;                                                    \
+                }                                                             \
+                len += SHA##digest_type##_DIGEST_LENGTH;                      \
+            }                                                                 \
+    } while(0)
 
 /*
  * @note The following are wrapper functions used by diffie_hellman_sha_algo().
@@ -278,7 +280,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
         }
         *(--fprint) = '\0';
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Server's MD5 Fingerprint: %s", fingerprint));
+                        "Server's MD5 Fingerprint: %s", fingerprint));
     }
 #endif /* LIBSSH2DEBUG */
 #endif /* ! LIBSSH2_MD5 */
@@ -306,7 +308,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
         }
         *(--fprint) = '\0';
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Server's SHA1 Fingerprint: %s", fingerprint));
+                        "Server's SHA1 Fingerprint: %s", fingerprint));
     }
 #endif /* LIBSSH2DEBUG */
 
@@ -332,8 +334,8 @@ static int process_host_key(LIBSSH2_SESSION *session,
                                SHA256_DIGEST_LENGTH, &base64Fingerprint);
         if(base64Fingerprint) {
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Server's SHA256 Fingerprint: %s",
-                           base64Fingerprint));
+                            "Server's SHA256 Fingerprint: %s",
+                            base64Fingerprint));
             LIBSSH2_FREE(session, base64Fingerprint);
         }
     }
@@ -346,7 +348,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
                               session->server_hostkey_len,
                               &session->server_hostkey_abstract)) {
         return _libssh2_error(session, LIBSSH2_ERROR_HOSTKEY_INIT,
-                             "Unable to initialize hostkey importer");
+                              "Unable to initialize hostkey importer");
     }
 
     return 0;
@@ -381,8 +383,8 @@ static int finish_kex(LIBSSH2_SESSION *session,
         session->session_id = LIBSSH2_ALLOC(session, digest_len);
         if(!session->session_id) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
-                                 "Unable to allocate buffer for "
-                                 "SHA digest");
+                                  "Unable to allocate buffer for "
+                                  "SHA digest");
         }
         memcpy(session->session_id, exchange_state->h_sig_comp, digest_len);
         session->session_id_len = digest_len;
@@ -435,7 +437,7 @@ static int finish_kex(LIBSSH2_SESSION *session,
         }
     }
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Client to Server IV and Key calculated"));
+                    "Client to Server IV and Key calculated"));
 
     if(session->remote.crypt->dtor) {
         /* Cleanup any existing cipher */
@@ -480,7 +482,7 @@ static int finish_kex(LIBSSH2_SESSION *session,
         }
     }
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Server to Client IV and Key calculated"));
+                    "Server to Client IV and Key calculated"));
 
     if(session->local.mac->dtor) {
         session->local.mac->dtor(session, &session->local.mac_abstract);
@@ -506,7 +508,7 @@ static int finish_kex(LIBSSH2_SESSION *session,
         }
     }
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Client to Server HMAC Key calculated"));
+                    "Client to Server HMAC Key calculated"));
 
     if(session->remote.mac->dtor) {
         session->remote.mac->dtor(session, &session->remote.mac_abstract);
@@ -532,7 +534,7 @@ static int finish_kex(LIBSSH2_SESSION *session,
         }
     }
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Server to Client HMAC Key calculated"));
+                    "Server to Client HMAC Key calculated"));
 
     /* Initialize compression for each direction */
 
@@ -548,7 +550,7 @@ static int finish_kex(LIBSSH2_SESSION *session,
         }
     }
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Client to Server compression initialized"));
+                    "Client to Server compression initialized"));
 
     if(session->remote.comp && session->remote.comp->dtor) {
         session->remote.comp->dtor(session, 0, &session->remote.comp_abstract);
@@ -561,7 +563,7 @@ static int finish_kex(LIBSSH2_SESSION *session,
         }
     }
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Server to Client compression initialized"));
+                    "Server to Client compression initialized"));
 
     return 0;
 }
@@ -724,7 +726,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX, "Sending KEX packet %u",
-                       (unsigned int)packet_type_init));
+                        (unsigned int)packet_type_init));
         exchange_state->state = libssh2_NB_state_created;
     }
 
@@ -750,8 +752,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             int burn_type;
 
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Waiting for badly guessed KEX packet "
-                           "(to be ignored)"));
+                            "Waiting for badly guessed KEX packet "
+                            "(to be ignored)"));
             burn_type =
                 _libssh2_packet_burn(session, &exchange_state->burn_state);
             if(burn_type == LIBSSH2_ERROR_EAGAIN) {
@@ -765,8 +767,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             session->burn_optimistic_kexinit = 0;
 
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Burnt packet of type: %02x",
-                           (unsigned int)burn_type));
+                            "Burnt packet of type: %02x",
+                            (unsigned int)burn_type));
         }
 
         exchange_state->state = libssh2_NB_state_sent1;
@@ -960,8 +962,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 
         if(err) {
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Failed hostkey sig_verify(): %s: %d",
-                           session->hostkey->name, err));
+                            "Failed hostkey sig_verify(): %s: %d",
+                            session->hostkey->name, err));
             ret = _libssh2_error(session, LIBSSH2_ERROR_HOSTKEY_SIGN,
                                  "Unable to verify hostkey signature "
                                  "DH-SHA");
@@ -969,7 +971,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Sending NEWKEYS message"));
+                        "Sending NEWKEYS message"));
         exchange_state->c = SSH_MSG_NEWKEYS;
 
         exchange_state->state = libssh2_NB_state_sent2;
@@ -1049,7 +1051,7 @@ static int kex_method_diffie_hellman_group1_sha1_key_exchange(
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group1 Key Exchange"));
+                        "Initiating Diffie-Hellman Group1 Key Exchange"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1146,7 +1148,7 @@ static int kex_method_diffie_hellman_group14_key_exchange(
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group14 Key Exchange"));
+                        "Initiating Diffie-Hellman Group14 Key Exchange"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1262,7 +1264,7 @@ static int kex_method_diffie_hellman_group16_sha512_key_exchange(
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group16 Key Exchange"));
+                        "Initiating Diffie-Hellman Group16 Key Exchange"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1398,7 +1400,7 @@ static int kex_method_diffie_hellman_group18_sha512_key_exchange(
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group18 Key Exchange"));
+                        "Initiating Diffie-Hellman Group18 Key Exchange"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1437,7 +1439,7 @@ static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
         _libssh2_htonu32(key_state->request + 9, LIBSSH2_DH_GEX_MAXGROUP);
         key_state->request_len = 13;
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group-Exchange SHA1"));
+                        "Initiating Diffie-Hellman Group-Exchange SHA1"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1563,7 +1565,7 @@ static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
         _libssh2_htonu32(key_state->request + 9, LIBSSH2_DH_GEX_MAXGROUP);
         key_state->request_len = 13;
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating Diffie-Hellman Group-Exchange SHA256"));
+                        "Initiating Diffie-Hellman Group-Exchange SHA256"));
 
         key_state->state = libssh2_NB_state_created;
     }
@@ -1716,102 +1718,101 @@ static int kex_session_hybrid_curve_type(const char *name,
  * string   Q_S, server's ephemeral public key octet string
  * mpint    K,   shared secret
  */
-#define LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(digest_type)            \
-do {                                                                         \
-    libssh2_sha##digest_type##_ctx ctx;                                      \
-    int hok;                                                                 \
-    if(!libssh2_sha##digest_type##_init(&ctx)) {                             \
-        rc = -1;                                                             \
-        break;                                                               \
-    }                                                                        \
-    hok = 1;                                                                 \
-    if(session->local.banner) {                                              \
-        _libssh2_htonu32(exchange_state->h_sig_comp,                         \
-            (uint32_t)(strlen((char *)session->local.banner) - 2));          \
-        hok &= libssh2_sha##digest_type##_update(ctx,                        \
-                                                 exchange_state->h_sig_comp, \
-                                                 4);                         \
-        hok &= libssh2_sha##digest_type##_update(ctx,                        \
-                                              (char *)session->local.banner, \
-                                       strlen((char *)session->local.banner) \
-                                       - 2);                                 \
-    }                                                                        \
-    else {                                                                   \
-        _libssh2_htonu32(exchange_state->h_sig_comp,                         \
-                         sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);            \
-        hok &= libssh2_sha##digest_type##_update(ctx,                        \
-                                          exchange_state->h_sig_comp, 4);    \
-        hok &= libssh2_sha##digest_type##_update(ctx,                        \
-                                                 LIBSSH2_SSH_DEFAULT_BANNER, \
-                                          sizeof(LIBSSH2_SSH_DEFAULT_BANNER) \
-                                          - 1);                              \
-    }                                                                        \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-        (uint32_t)strlen((char *)session->remote.banner));                   \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx, session->remote.banner,    \
-                                   strlen((char *)session->remote.banner));  \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     (uint32_t)session->local.kexinit_len);                  \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             session->local.kexinit,         \
-                                             session->local.kexinit_len);    \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     (uint32_t)session->remote.kexinit_len);                 \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             session->remote.kexinit,        \
-                                             session->remote.kexinit_len);   \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     session->server_hostkey_len);                           \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             session->server_hostkey,        \
-                                             session->server_hostkey_len);   \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     (uint32_t)public_key_len);                              \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             public_key,                     \
-                                             public_key_len);                \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     (uint32_t)server_public_key_len);                       \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             server_public_key,              \
-                                             server_public_key_len);         \
-                                                                             \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->k_value,        \
-                                             exchange_state->k_value_len);   \
-                                                                             \
-    if(!hok ||                                                               \
-       !libssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp)) { \
-        rc = -1;                                                             \
-        break;                                                               \
-    }                                                                        \
-                                                                             \
-    if(session->hostkey->                                                    \
-        sig_verify(session, exchange_state->h_sig,                           \
-                   exchange_state->h_sig_len, exchange_state->h_sig_comp,    \
-                   SHA##digest_type##_DIGEST_LENGTH,                         \
-                   &session->server_hostkey_abstract)) {                     \
-        rc = -1;                                                             \
-    }                                                                        \
-} while(0)
+#define LIBSSH2_KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(digest_type)             \
+    do {                                                                      \
+        libssh2_sha##digest_type##_ctx ctx;                                   \
+        int hok;                                                              \
+        if(!libssh2_sha##digest_type##_init(&ctx)) {                          \
+            rc = -1;                                                          \
+            break;                                                            \
+        }                                                                     \
+        hok = 1;                                                              \
+        if(session->local.banner) {                                           \
+            _libssh2_htonu32(exchange_state->h_sig_comp,                      \
+                (uint32_t)(strlen((char *)session->local.banner) - 2));       \
+            hok &= libssh2_sha##digest_type##_update(ctx,                     \
+                                              exchange_state->h_sig_comp, 4); \
+            hok &= libssh2_sha##digest_type##_update(ctx,                     \
+                                  (char *)session->local.banner,              \
+                                  strlen((char *)session->local.banner) - 2); \
+        }                                                                     \
+        else {                                                                \
+            _libssh2_htonu32(exchange_state->h_sig_comp,                      \
+                             sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);         \
+            hok &= libssh2_sha##digest_type##_update(ctx,                     \
+                                              exchange_state->h_sig_comp, 4); \
+            hok &= libssh2_sha##digest_type##_update(ctx,                     \
+                                     LIBSSH2_SSH_DEFAULT_BANNER,              \
+                                     sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1); \
+        }                                                                     \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+            (uint32_t)strlen((char *)session->remote.banner));                \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                     session->remote.banner,                  \
+                                     strlen((char *)session->remote.banner)); \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         (uint32_t)session->local.kexinit_len);               \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                 session->local.kexinit,      \
+                                                 session->local.kexinit_len); \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         (uint32_t)session->remote.kexinit_len);              \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                session->remote.kexinit,      \
+                                                session->remote.kexinit_len); \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         session->server_hostkey_len);                        \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                session->server_hostkey,      \
+                                                session->server_hostkey_len); \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         (uint32_t)public_key_len);                           \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                 public_key,                  \
+                                                 public_key_len);             \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         (uint32_t)server_public_key_len);                    \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                 server_public_key,           \
+                                                 server_public_key_len);      \
+                                                                              \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                exchange_state->k_value,      \
+                                                exchange_state->k_value_len); \
+                                                                              \
+        if(!hok ||                                                            \
+           !libssh2_sha##digest_type##_final(ctx,                             \
+                                             exchange_state->h_sig_comp)) {   \
+            rc = -1;                                                          \
+            break;                                                            \
+        }                                                                     \
+                                                                              \
+        if(session->hostkey->sig_verify(session, exchange_state->h_sig,       \
+                                        exchange_state->h_sig_len,            \
+                                        exchange_state->h_sig_comp,           \
+                                        SHA##digest_type##_DIGEST_LENGTH,     \
+                                        &session->server_hostkey_abstract)) { \
+            rc = -1;                                                          \
+        }                                                                     \
+    } while(0)
 
 #if LIBSSH2_MLKEM
 
@@ -1830,105 +1831,104 @@ do {                                                                         \
  * string   Q_S, server's ephemeral public key octet string
  * mpint    K,   shared secret
  */
-#define LIBSSH2_KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY(digest_type)        \
-do {                                                                         \
-    libssh2_sha##digest_type##_ctx ctx;                                      \
-    int hok;                                                                 \
-    if(!libssh2_sha##digest_type##_init(&ctx)) {                             \
-        rc = -1;                                                             \
-        break;                                                               \
-    }                                                                        \
-    hok = 1;                                                                 \
-    if(session->local.banner) {                                              \
-        _libssh2_htonu32(exchange_state->h_sig_comp,                         \
-            (uint32_t)(strlen((char *)session->local.banner) - 2));          \
-        hok &= libssh2_sha##digest_type##_update(ctx,                        \
-                                                 exchange_state->h_sig_comp, \
-                                                 4);                         \
-        hok &= libssh2_sha##digest_type##_update(ctx,                        \
-                                              (char *)session->local.banner, \
-                                       strlen((char *)session->local.banner) \
-                                       - 2);                                 \
-    }                                                                        \
-    else {                                                                   \
-        _libssh2_htonu32(exchange_state->h_sig_comp,                         \
-                         sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);            \
-        hok &= libssh2_sha##digest_type##_update(ctx,                        \
-                                          exchange_state->h_sig_comp, 4);    \
-        hok &= libssh2_sha##digest_type##_update(ctx,                        \
-                                                 LIBSSH2_SSH_DEFAULT_BANNER, \
-                                          sizeof(LIBSSH2_SSH_DEFAULT_BANNER) \
-                                          - 1);                              \
-    }                                                                        \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-        (uint32_t)strlen((char *)session->remote.banner));                   \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx, session->remote.banner,    \
-                                   strlen((char *)session->remote.banner));  \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     (uint32_t)session->local.kexinit_len);                  \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             session->local.kexinit,         \
-                                             session->local.kexinit_len);    \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     (uint32_t)session->remote.kexinit_len);                 \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             session->remote.kexinit,        \
-                                             session->remote.kexinit_len);   \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     session->server_hostkey_len);                           \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             session->server_hostkey,        \
-                                             session->server_hostkey_len);   \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     (uint32_t)(public_pq_key_len + public_t_key_len));      \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             public_pq_key,                  \
-                                             public_pq_key_len);             \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             public_t_key,                   \
-                                             public_t_key_len);              \
-                                                                             \
-    _libssh2_htonu32(exchange_state->h_sig_comp,                             \
-                     (uint32_t)server_public_key_len);                       \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->h_sig_comp, 4); \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             server_public_key,              \
-                                             server_public_key_len);         \
-                                                                             \
-    hok &= libssh2_sha##digest_type##_update(ctx,                            \
-                                             exchange_state->k_value,        \
-                                             exchange_state->k_value_len);   \
-                                                                             \
-    if(!hok ||                                                               \
-       !libssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp)) { \
-        rc = -1;                                                             \
-        break;                                                               \
-    }                                                                        \
-                                                                             \
-    if(session->hostkey->                                                    \
-        sig_verify(session, exchange_state->h_sig,                           \
-                   exchange_state->h_sig_len, exchange_state->h_sig_comp,    \
-                   SHA##digest_type##_DIGEST_LENGTH,                         \
-                   &session->server_hostkey_abstract)) {                     \
-        rc = -1;                                                             \
-    }                                                                        \
-} while(0)
+#define LIBSSH2_KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY(digest_type)         \
+    do {                                                                      \
+        libssh2_sha##digest_type##_ctx ctx;                                   \
+        int hok;                                                              \
+        if(!libssh2_sha##digest_type##_init(&ctx)) {                          \
+            rc = -1;                                                          \
+            break;                                                            \
+        }                                                                     \
+        hok = 1;                                                              \
+        if(session->local.banner) {                                           \
+            _libssh2_htonu32(exchange_state->h_sig_comp,                      \
+                (uint32_t)(strlen((char *)session->local.banner) - 2));       \
+            hok &= libssh2_sha##digest_type##_update(ctx,                     \
+                                              exchange_state->h_sig_comp, 4); \
+            hok &= libssh2_sha##digest_type##_update(ctx,                     \
+                                  (char *)session->local.banner,              \
+                                  strlen((char *)session->local.banner) - 2); \
+        }                                                                     \
+        else {                                                                \
+            _libssh2_htonu32(exchange_state->h_sig_comp,                      \
+                             sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);         \
+            hok &= libssh2_sha##digest_type##_update(ctx,                     \
+                                              exchange_state->h_sig_comp, 4); \
+            hok &= libssh2_sha##digest_type##_update(ctx,                     \
+                                     LIBSSH2_SSH_DEFAULT_BANNER,              \
+                                     sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1); \
+        }                                                                     \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+            (uint32_t)strlen((char *)session->remote.banner));                \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                     session->remote.banner,                  \
+                                     strlen((char *)session->remote.banner)); \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         (uint32_t)session->local.kexinit_len);               \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                 session->local.kexinit,      \
+                                                 session->local.kexinit_len); \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         (uint32_t)session->remote.kexinit_len);              \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                session->remote.kexinit,      \
+                                                session->remote.kexinit_len); \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         session->server_hostkey_len);                        \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                session->server_hostkey,      \
+                                                session->server_hostkey_len); \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         (uint32_t)(public_pq_key_len + public_t_key_len));   \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                 public_pq_key,               \
+                                                 public_pq_key_len);          \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                 public_t_key,                \
+                                                 public_t_key_len);           \
+                                                                              \
+        _libssh2_htonu32(exchange_state->h_sig_comp,                          \
+                         (uint32_t)server_public_key_len);                    \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                              exchange_state->h_sig_comp, 4); \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                 server_public_key,           \
+                                                 server_public_key_len);      \
+                                                                              \
+        hok &= libssh2_sha##digest_type##_update(ctx,                         \
+                                                exchange_state->k_value,      \
+                                                exchange_state->k_value_len); \
+                                                                              \
+        if(!hok ||                                                            \
+           !libssh2_sha##digest_type##_final(ctx,                             \
+                                             exchange_state->h_sig_comp)) {   \
+            rc = -1;                                                          \
+            break;                                                            \
+        }                                                                     \
+                                                                              \
+        if(session->hostkey->sig_verify(session, exchange_state->h_sig,       \
+                                        exchange_state->h_sig_len,            \
+                                        exchange_state->h_sig_comp,           \
+                                        SHA##digest_type##_DIGEST_LENGTH,     \
+                                        &session->server_hostkey_abstract)) { \
+            rc = -1;                                                          \
+        }                                                                     \
+    } while(0)
 
 #endif
 
@@ -2209,7 +2209,7 @@ static int kex_method_ecdh_key_exchange(
         key_state->request_len = key_state->public_key_oct_len + 5;
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating ECDH SHA2 NISTP256"));
+                        "Initiating ECDH SHA2 NISTP256"));
 
         key_state->state = libssh2_NB_state_sent;
     }
@@ -2633,7 +2633,7 @@ static int kex_method_mlkem_nistp_key_exchange(
                                  key_state->public_key_oct_len + 5;
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating mlkem-nistp hybrid SHA2"));
+                        "Initiating mlkem-nistp hybrid SHA2"));
 
         key_state->state = libssh2_NB_state_sent;
     }
@@ -2924,7 +2924,7 @@ static int kex_method_curve25519_key_exchange(
         key_state->request_len = LIBSSH2_ED25519_KEY_LEN + 5;
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating curve25519 SHA2"));
+                        "Initiating curve25519 SHA2"));
 
         key_state->state = libssh2_NB_state_sent;
     }
@@ -3244,7 +3244,7 @@ static int kex_method_mlkem768x25519_key_exchange(
                                  LIBSSH2_ED25519_KEY_LEN + 5;
 
         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                       "Initiating mlkem768x25519 SHA2"));
+                        "Initiating mlkem768x25519 SHA2"));
 
         key_state->state = libssh2_NB_state_sent;
     }
@@ -3631,37 +3631,37 @@ static int kexinit(LIBSSH2_SESSION *session)
             unsigned char *p = data + 21; /* type(1) + cookie(16) + len(4) */
 
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent KEX: %.*s", (int)kex_len, p));
+                            "Sent KEX: %.*s", (int)kex_len, p));
             p += kex_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent HOSTKEY: %.*s", (int)hostkey_len, p));
+                            "Sent HOSTKEY: %.*s", (int)hostkey_len, p));
             p += hostkey_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent CRYPT_CS: %.*s", (int)crypt_cs_len, p));
+                            "Sent CRYPT_CS: %.*s", (int)crypt_cs_len, p));
             p += crypt_cs_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent CRYPT_SC: %.*s", (int)crypt_sc_len, p));
+                            "Sent CRYPT_SC: %.*s", (int)crypt_sc_len, p));
             p += crypt_sc_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent MAC_CS: %.*s", (int)mac_cs_len, p));
+                            "Sent MAC_CS: %.*s", (int)mac_cs_len, p));
             p += mac_cs_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent MAC_SC: %.*s", (int)mac_sc_len, p));
+                            "Sent MAC_SC: %.*s", (int)mac_sc_len, p));
             p += mac_sc_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent COMP_CS: %.*s", (int)comp_cs_len, p));
+                            "Sent COMP_CS: %.*s", (int)comp_cs_len, p));
             p += comp_cs_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent COMP_SC: %.*s", (int)comp_sc_len, p));
+                            "Sent COMP_SC: %.*s", (int)comp_sc_len, p));
             p += comp_sc_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent LANG_CS: %.*s", (int)lang_cs_len, p));
+                            "Sent LANG_CS: %.*s", (int)lang_cs_len, p));
             p += lang_cs_len + 4;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent LANG_SC: %.*s", (int)lang_sc_len, p));
+                            "Sent LANG_SC: %.*s", (int)lang_sc_len, p));
             p += lang_sc_len;
             _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Sent first_kex_packet_follows: %02x", p[0]));
+                            "Sent first_kex_packet_follows: %02x", p[0]));
         }
 #endif /* LIBSSH2DEBUG */
 
@@ -4180,29 +4180,29 @@ static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,
 #endif
 
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Agreed on KEX method: %s",
-                   session->kex->name));
+                    "Agreed on KEX method: %s",
+                    session->kex->name));
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Agreed on HOSTKEY method: %s",
-                   session->hostkey->name));
+                    "Agreed on HOSTKEY method: %s",
+                    session->hostkey->name));
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Agreed on CRYPT_CS method: %s",
-                   session->local.crypt->name));
+                    "Agreed on CRYPT_CS method: %s",
+                    session->local.crypt->name));
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Agreed on CRYPT_SC method: %s",
-                   session->remote.crypt->name));
+                    "Agreed on CRYPT_SC method: %s",
+                    session->remote.crypt->name));
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Agreed on MAC_CS method: %s",
-                   session->local.mac->name));
+                    "Agreed on MAC_CS method: %s",
+                    session->local.mac->name));
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Agreed on MAC_SC method: %s",
-                   session->remote.mac->name));
+                    "Agreed on MAC_SC method: %s",
+                    session->remote.mac->name));
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Agreed on COMP_CS method: %s",
-                   session->local.comp->name));
+                    "Agreed on COMP_CS method: %s",
+                    session->local.comp->name));
     _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                   "Agreed on COMP_SC method: %s",
-                   session->remote.comp->name));
+                    "Agreed on COMP_SC method: %s",
+                    session->remote.comp->name));
 
     return 0;
 }

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -381,8 +381,7 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
     if(port >= 0) {
         int len = snprintf(hostbuff, sizeof(hostbuff), "[%s]:%d", hostp, port);
         if(len < 0 || len >= (int)sizeof(hostbuff)) {
-            _libssh2_error(hosts->session,
-                           LIBSSH2_ERROR_BUFFER_TOO_SMALL,
+            _libssh2_error(hosts->session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                            "Known-host write buffer too small");
             return LIBSSH2_KNOWNHOST_CHECK_FAILURE;
         }

--- a/src/misc.c
+++ b/src/misc.c
@@ -117,7 +117,7 @@ int _libssh2_error_flags(LIBSSH2_SESSION *session, int errcode,
            a debug output for this */
         return errcode;
     _libssh2_debug((session, LIBSSH2_TRACE_ERROR, "%d - %s", session->err_code,
-                   session->err_msg));
+                    session->err_msg));
 #endif
 
     return errcode;
@@ -222,22 +222,24 @@ ssize_t _libssh2_send(libssh2_socket_t socket,
 
 uint32_t _libssh2_ntohu32(const unsigned char *buf)
 {
-    return ((uint32_t)buf[0] << 24)
-         | ((uint32_t)buf[1] << 16)
-         | ((uint32_t)buf[2] << 8)
-         | ((uint32_t)buf[3]);
+    return
+        ((uint32_t)buf[0] << 24) |
+        ((uint32_t)buf[1] << 16) |
+        ((uint32_t)buf[2] << 8)  |
+        ((uint32_t)buf[3]);
 }
 
 libssh2_uint64_t _libssh2_ntohu64(const unsigned char *buf)
 {
-    return ((libssh2_uint64_t)buf[0] << 56)
-         | ((libssh2_uint64_t)buf[1] << 48)
-         | ((libssh2_uint64_t)buf[2] << 40)
-         | ((libssh2_uint64_t)buf[3] << 32)
-         | ((libssh2_uint64_t)buf[4] << 24)
-         | ((libssh2_uint64_t)buf[5] << 16)
-         | ((libssh2_uint64_t)buf[6] <<  8)
-         | ((libssh2_uint64_t)buf[7]);
+    return
+        ((libssh2_uint64_t)buf[0] << 56) |
+        ((libssh2_uint64_t)buf[1] << 48) |
+        ((libssh2_uint64_t)buf[2] << 40) |
+        ((libssh2_uint64_t)buf[3] << 32) |
+        ((libssh2_uint64_t)buf[4] << 24) |
+        ((libssh2_uint64_t)buf[5] << 16) |
+        ((libssh2_uint64_t)buf[6] <<  8) |
+        ((libssh2_uint64_t)buf[7]);
 }
 
 void _libssh2_htonu32(unsigned char *buf, uint32_t value)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -92,8 +92,7 @@ static int hmac_init(libssh2_hmac_ctx *ctx,
 #endif
 
 #if LIBSSH2_MD5
-int _libssh2_hmac_md5_init(libssh2_hmac_ctx *ctx,
-                           void *key, size_t keylen)
+int _libssh2_hmac_md5_init(libssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
 #ifdef USE_OPENSSL_3
     return hmac_init(ctx, key, keylen, OSSL_DIGEST_NAME_MD5);
@@ -850,16 +849,16 @@ int _libssh2_ecdsa_curve_name_with_octal_new(libssh2_ecdsa_ctx **ec_ctx,
 }
 
 #ifdef USE_OPENSSL_3
-#define LIBSSH2_ECDSA_VERIFY(digest_type)                               \
-    do {                                                                \
-        unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];           \
-        if(libssh2_sha##digest_type(m, m_len, hash) == 0) {             \
-            ret = EVP_PKEY_verify_init(ctx);                            \
-            if(ret > 0) {                                               \
-                ret = EVP_PKEY_verify(ctx, der, der_len, hash,          \
-                                     SHA##digest_type##_DIGEST_LENGTH); \
-            }                                                           \
-        }                                                               \
+#define LIBSSH2_ECDSA_VERIFY(digest_type)                                \
+    do {                                                                 \
+        unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];            \
+        if(libssh2_sha##digest_type(m, m_len, hash) == 0) {              \
+            ret = EVP_PKEY_verify_init(ctx);                             \
+            if(ret > 0) {                                                \
+                ret = EVP_PKEY_verify(ctx, der, der_len, hash,           \
+                                      SHA##digest_type##_DIGEST_LENGTH); \
+            }                                                            \
+        }                                                                \
     } while(0)
 #else
 #define LIBSSH2_ECDSA_VERIFY(digest_type)                               \
@@ -1297,7 +1296,7 @@ static int gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
     size_t key_len;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from RSA private key envelope"));
+                    "Computing public key from RSA private key envelope"));
 
 #ifdef USE_OPENSSL_3
     rsa = pk;
@@ -1437,7 +1436,7 @@ static int gen_publickey_from_rsa_openssh_priv_data(
     libssh2_rsa_ctx *rsa = NULL;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing RSA keys from private key data"));
+                    "Computing RSA keys from private key data"));
 
     /* public key data */
     if(_libssh2_get_bignum_bytes(decrypted, &n, &nlen)) {
@@ -1486,7 +1485,7 @@ static int gen_publickey_from_rsa_openssh_priv_data(
                           coeff, (unsigned long)coefflen);
     if(rc) {
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Could not create RSA private key"));
+                        "Could not create RSA private key"));
         goto fail;
     }
 
@@ -1733,7 +1732,7 @@ static int gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
     size_t key_len;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from DSA private key envelope"));
+                    "Computing public key from DSA private key envelope"));
 
 #ifdef USE_OPENSSL_3
     dsa = pk;
@@ -1798,7 +1797,7 @@ static int gen_publickey_from_dsa_openssh_priv_data(
     libssh2_dsa_ctx *dsa = NULL;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing DSA keys from private key data"));
+                    "Computing DSA keys from private key data"));
 
     if(_libssh2_get_bignum_bytes(decrypted, &p, &plen)) {
         _libssh2_error(session, LIBSSH2_ERROR_PROTO, "DSA no p");
@@ -1833,7 +1832,7 @@ static int gen_publickey_from_dsa_openssh_priv_data(
                           priv_key, (unsigned long)priv_len);
     if(rc) {
         _libssh2_debug((session, LIBSSH2_ERROR_PROTO,
-                       "Could not create DSA private key"));
+                        "Could not create DSA private key"));
         goto fail;
     }
 
@@ -2099,7 +2098,7 @@ static int gen_publickey_from_ed_evp(LIBSSH2_SESSION *session,
     unsigned char *bufPos = NULL;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from ED private key envelope"));
+                    "Computing public key from ED private key envelope"));
 
     methodBuf = LIBSSH2_ALLOC(session, sizeof(methodName) - 1);
     if(!methodBuf) {
@@ -2169,7 +2168,7 @@ static int gen_publickey_from_ed25519_openssh_priv_data(
     unsigned char *p;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing ED25519 keys from private key data"));
+                    "Computing ED25519 keys from private key data"));
 
     if(_libssh2_get_string(decrypted, &pub_key, &tmp_len) ||
        tmp_len != LIBSSH2_ED25519_KEY_LEN) {
@@ -2205,7 +2204,7 @@ static int gen_publickey_from_ed25519_openssh_priv_data(
             memcpy(comment + tmp_len, "\0", 1);
 
             _libssh2_debug((session, LIBSSH2_TRACE_AUTH, "Key comment: %s",
-                           comment));
+                            comment));
 
             LIBSSH2_FREE(session, comment);
         }
@@ -2224,8 +2223,8 @@ static int gen_publickey_from_ed25519_openssh_priv_data(
 
     if(ret == 0) {
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Computing public key from ED25519 "
-                       "private key envelope"));
+                        "Computing public key from ED25519 "
+                        "private key envelope"));
 
         method_buf = LIBSSH2_ALLOC(session, 11); /* ssh-ed25519. */
         if(!method_buf) {
@@ -2314,7 +2313,7 @@ static int gen_publickey_from_sk_ed25519_openssh_priv_data(
     unsigned char *p;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing sk-ED25519 keys from private key data"));
+                    "Computing sk-ED25519 keys from private key data"));
 
     if(_libssh2_get_string(decrypted, &pub_key, &tmp_len) ||
        tmp_len != LIBSSH2_ED25519_KEY_LEN) {
@@ -2356,8 +2355,8 @@ static int gen_publickey_from_sk_ed25519_openssh_priv_data(
 
     if(ret == 0) {
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Computing public key from ED25519 "
-                       "private key envelope"));
+                        "Computing public key from ED25519 "
+                        "private key envelope"));
 
         /* sk-ssh-ed25519@openssh.com. */
         method_buf = LIBSSH2_ALLOC(session, strlen(key_type));
@@ -3462,7 +3461,7 @@ static int gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
 
 #ifdef USE_OPENSSL_3
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from EC private key envelope"));
+                    "Computing public key from EC private key envelope"));
 
     type = _libssh2_ecdsa_get_curve_type(pk);
 #else
@@ -3472,7 +3471,7 @@ static int gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     BN_CTX *bn_ctx = NULL;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from EC private key envelope"));
+                    "Computing public key from EC private key envelope"));
 
     bn_ctx = BN_CTX_new();
     if(!bn_ctx)
@@ -3514,7 +3513,7 @@ static int gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
     }
     else {
         _libssh2_debug((session, LIBSSH2_TRACE_ERROR,
-                       "Unsupported EC private key type"));
+                        "Unsupported EC private key type"));
         rc = -1;
         goto clean_exit;
     }
@@ -3631,7 +3630,7 @@ static int gen_publickey_from_ecdsa_openssh_priv_data(
 #endif
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing ECDSA keys from private key data"));
+                    "Computing ECDSA keys from private key data"));
 
     if(_libssh2_get_string(decrypted, &curve, &curvelen) ||
         curvelen == 0) {
@@ -3771,7 +3770,7 @@ static int gen_publickey_from_sk_ecdsa_openssh_priv_data(
     libssh2_ecdsa_ctx *ec_key = NULL;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Extracting ECDSA-SK public key"));
+                    "Extracting ECDSA-SK public key"));
 
     if(_libssh2_get_string(decrypted, &curve, &curvelen) ||
         curvelen == 0) {
@@ -4594,8 +4593,7 @@ static int pub_priv_openssh_keyfile(LIBSSH2_SESSION *session,
         rc = gen_publickey_from_rsa_openssh_priv_data(session, decrypted,
                                                       method, method_len,
                                                       pubkeydata,
-                                                      pubkeydata_len,
-                                                      NULL);
+                                                      pubkeydata_len, NULL);
     }
 #endif
 #if LIBSSH2_DSA
@@ -4603,8 +4601,7 @@ static int pub_priv_openssh_keyfile(LIBSSH2_SESSION *session,
         rc = gen_publickey_from_dsa_openssh_priv_data(session, decrypted,
                                                       method, method_len,
                                                       pubkeydata,
-                                                      pubkeydata_len,
-                                                      NULL);
+                                                      pubkeydata_len, NULL);
     }
 #endif
 #if LIBSSH2_ECDSA
@@ -4649,8 +4646,8 @@ int _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     int rc;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from private key file: %s",
-                   privatekey));
+                    "Computing public key from private key file: %s",
+                    privatekey));
 
     bp = BIO_new_file(privatekey, "r");
     if(!bp) {
@@ -4827,36 +4824,41 @@ static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
     }
 #endif
 #if LIBSSH2_ECDSA
-{
-    libssh2_curve_type type;
+    {
+        libssh2_curve_type type;
 
-    if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0) {
-        rc = gen_publickey_from_sk_ecdsa_openssh_priv_data(session, decrypted,
-                                                           method, method_len,
-                                                           pubkeydata,
-                                                           pubkeydata_len,
-                                                           NULL, NULL,
-                                                           NULL, NULL,
-                                                (libssh2_ecdsa_ctx **)key_ctx);
-    }
-    else if(_libssh2_ecdsa_curve_type_from_name((const char *)buf, &type)
-        == 0) {
-        if(!key_type || strcmp("ssh-ecdsa", key_type) == 0) {
-            rc = gen_publickey_from_ecdsa_openssh_priv_data(session, type,
-                                                            decrypted,
-                                                            method, method_len,
-                                                            pubkeydata,
-                                                            pubkeydata_len,
+        if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com",
+                  (const char *)buf) == 0) {
+            rc = gen_publickey_from_sk_ecdsa_openssh_priv_data(session,
+                                                               decrypted,
+                                                               method,
+                                                               method_len,
+                                                               pubkeydata,
+                                                               pubkeydata_len,
+                                                               NULL, NULL,
+                                                               NULL, NULL,
                                                 (libssh2_ecdsa_ctx **)key_ctx);
         }
+        else if(_libssh2_ecdsa_curve_type_from_name((const char *)buf, &type)
+                == 0) {
+            if(!key_type || strcmp("ssh-ecdsa", key_type) == 0) {
+                rc = gen_publickey_from_ecdsa_openssh_priv_data(session, type,
+                                                                decrypted,
+                                                                method,
+                                                                method_len,
+                                                                pubkeydata,
+                                                                pubkeydata_len,
+                                                (libssh2_ecdsa_ctx **)key_ctx);
+            }
+        }
     }
-}
 #endif
 
     if(rc == LIBSSH2_ERROR_FILE)
         rc = _libssh2_error(session, LIBSSH2_ERROR_FILE,
-                         "Unable to extract public key from private key file: "
-                         "invalid/unrecognized private key file format");
+                            "Unable to extract public key from private key "
+                            "file: invalid/unrecognized private key "
+                            "file format");
 
     if(decrypted)
         _libssh2_string_buf_free(session, decrypted);
@@ -4960,8 +4962,9 @@ static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
 
     if(rc == LIBSSH2_ERROR_FILE)
         rc = _libssh2_error(session, LIBSSH2_ERROR_FILE,
-                         "Unable to extract public key from private key file: "
-                         "invalid/unrecognized private key file format");
+                            "Unable to extract public key from private key "
+                            "file: invalid/unrecognized private key "
+                            "file format");
 
     if(decrypted)
         _libssh2_string_buf_free(session, decrypted);
@@ -4991,7 +4994,7 @@ int _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 #endif
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from private key."));
+                    "Computing public key from private key."));
 
     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
     if(!bp)
@@ -5095,7 +5098,7 @@ int _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
     EVP_PKEY *pk;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Computing public key from private key."));
+                    "Computing public key from private key."));
 
     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
     if(!bp)

--- a/src/packet.c
+++ b/src/packet.c
@@ -124,11 +124,11 @@ static inline int packet_queue_listener(
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Remote received connection from %.*s:%u to %.*s:%u",
-                       listen_state->shost_len, listen_state->shost,
-                       listen_state->sport,
-                       listen_state->host_len, listen_state->host,
-                       listen_state->port));
+                        "Remote received connection from %.*s:%u to %.*s:%u",
+                        listen_state->shost_len, listen_state->shost,
+                        listen_state->sport,
+                        listen_state->host_len, listen_state->host,
+                        listen_state->port));
 
         listen_state->state = libssh2_NB_state_allocated;
     }
@@ -149,7 +149,7 @@ static inline int packet_queue_listener(
                         /* Queue is full */
                         failure_code = SSH_OPEN_RESOURCE_SHORTAGE;
                         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                                       "Listener queue full, ignoring"));
+                                        "Listener queue full, ignoring"));
                         listen_state->state = libssh2_NB_state_sent;
                         break;
                     }
@@ -199,13 +199,13 @@ static inline int packet_queue_listener(
                     channel->local.packet_size = listen_state->packet_size;
 
                     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                                   "Connection queued: channel %u/%u "
-                                   "win %u/%u packet %u/%u",
-                                   channel->local.id, channel->remote.id,
-                                   channel->local.window_size,
-                                   channel->remote.window_size,
-                                   channel->local.packet_size,
-                                   channel->remote.packet_size));
+                                    "Connection queued: channel %u/%u "
+                                    "win %u/%u packet %u/%u",
+                                    channel->local.id, channel->remote.id,
+                                    channel->local.window_size,
+                                    channel->remote.window_size,
+                                    channel->local.packet_size,
+                                    channel->remote.packet_size));
 
                     p = listen_state->packet;
                     *(p++) = SSH_MSG_CHANNEL_OPEN_CONFIRMATION;
@@ -348,9 +348,9 @@ static inline int packet_x11_open(
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "X11 Connection Received from %s:%u on channel %u",
-                       x11open_state->shost, x11open_state->sport,
-                       x11open_state->sender_channel));
+                        "X11 Connection Received from %s:%u on channel %u",
+                        x11open_state->shost, x11open_state->sport,
+                        x11open_state->sender_channel));
 
         x11open_state->state = libssh2_NB_state_allocated;
     }
@@ -393,13 +393,13 @@ static inline int packet_x11_open(
             channel->local.packet_size = x11open_state->packet_size;
 
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "X11 Connection established: channel %u/%u "
-                           "win %u/%u packet %u/%u",
-                           channel->local.id, channel->remote.id,
-                           channel->local.window_size,
-                           channel->remote.window_size,
-                           channel->local.packet_size,
-                           channel->remote.packet_size));
+                            "X11 Connection established: channel %u/%u "
+                            "win %u/%u packet %u/%u",
+                            channel->local.id, channel->remote.id,
+                            channel->local.window_size,
+                            channel->remote.window_size,
+                            channel->local.packet_size,
+                            channel->remote.packet_size));
             p = x11open_state->packet;
             *(p++) = SSH_MSG_CHANNEL_OPEN_CONFIRMATION;
             _libssh2_store_u32(&p, channel->remote.id);
@@ -511,8 +511,8 @@ static inline int packet_authagent_open(
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                       "Auth Agent Connection Received on channel %u",
-                       authagent_state->sender_channel));
+                        "Auth Agent Connection Received on channel %u",
+                        authagent_state->sender_channel));
 
         authagent_state->state = libssh2_NB_state_allocated;
     }
@@ -557,13 +557,13 @@ static inline int packet_authagent_open(
             channel->local.packet_size = authagent_state->packet_size;
 
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Auth Agent Connection established: channel "
-                           "%u/%u win %u/%u packet %u/%u",
-                           channel->local.id, channel->remote.id,
-                           channel->local.window_size,
-                           channel->remote.window_size,
-                           channel->local.packet_size,
-                           channel->remote.packet_size));
+                            "Auth Agent Connection established: channel "
+                            "%u/%u win %u/%u packet %u/%u",
+                            channel->local.id, channel->remote.id,
+                            channel->local.window_size,
+                            channel->remote.window_size,
+                            channel->local.packet_size,
+                            channel->remote.packet_size));
 
             p = authagent_state->packet;
             *(p++) = SSH_MSG_CHANNEL_OPEN_CONFIRMATION;
@@ -658,8 +658,8 @@ int _libssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
     switch(session->packAdd_state) {
     case libssh2_NB_state_idle:
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "Packet type %u received, length=%ld",
-                       (unsigned int)msg, (long)datalen));
+                        "Packet type %u received, length=%ld",
+                        (unsigned int)msg, (long)datalen));
 
         if((macstate == LIBSSH2_MAC_INVALID) &&
            (!session->macerror ||
@@ -784,9 +784,9 @@ int _libssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                 }
 
                 _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                               "Disconnect(%d): %.*s(%.*s)", reason,
-                               (int)message_len, message,
-                               (int)language_len, language));
+                                "Disconnect(%d): %.*s(%.*s)", reason,
+                                (int)message_len, message,
+                                (int)language_len, language));
             }
 
             LIBSSH2_FREE(session, data);
@@ -842,7 +842,7 @@ int _libssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
             }
 
             _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                           "Debug Packet: %.*s", (int)message_len, message));
+                            "Debug Packet: %.*s", (int)message_len, message));
             LIBSSH2_FREE(session, data);
             session->packAdd_state = libssh2_NB_state_idle;
             return 0;
@@ -886,9 +886,10 @@ int _libssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
 
                     if(name && value) {
                         _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                                       "Server to Client extension %.*s: %.*s",
-                                       (int)name_len, name,
-                                       (int)value_len, value));
+                                        "Server to Client extension "
+                                        "%.*s: %.*s",
+                                        (int)name_len, name,
+                                        (int)value_len, value));
                     }
 
                     if(name && name_len == 15 &&
@@ -933,8 +934,9 @@ int _libssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                 if((len <= (UINT_MAX - 6)) && (datalen >= (6 + len))) {
                     want_reply = data[5 + len];
                     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                                   "Received global request type %.*s (wr %X)",
-                                   (int)len, data + 5, want_reply));
+                                    "Received global request type "
+                                    "%.*s (wr %X)",
+                                    (int)len, data + 5, want_reply));
                 }
 
                 if(want_reply) {
@@ -993,11 +995,11 @@ libssh2_packet_add_jump_point5:
                     stream_id = _libssh2_ntohu32(data + 5);
 
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                               "%ld bytes packet_add() for %u/%u/%u",
-                               (long)(datalen - data_head),
-                               channelp->local.id,
-                               channelp->remote.id,
-                               stream_id));
+                                "%ld bytes packet_add() for %u/%u/%u",
+                                (long)(datalen - data_head),
+                                channelp->local.id,
+                                channelp->remote.id,
+                                stream_id));
             }
 #endif
             if((channelp->remote.extended_data_ignore_mode ==
@@ -1007,8 +1009,8 @@ libssh2_packet_add_jump_point5:
                 LIBSSH2_FREE(session, data);
 
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                              "Ignoring extended data and refunding %ld bytes",
-                               (long)(datalen - 13)));
+                                "Ignoring extended data and refunding "
+                                "%ld bytes", (long)(datalen - 13)));
                 if(channelp->read_avail + datalen - data_head >=
                    channelp->remote.window_size)
                     datalen = channelp->remote.window_size -
@@ -1017,11 +1019,11 @@ libssh2_packet_add_jump_point5:
                 channelp->remote.window_size -= (uint32_t)(datalen -
                                                            data_head);
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                               "shrinking window size by %ld bytes to %u, "
-                               "read_avail %ld",
-                               (long)(datalen - data_head),
-                               channelp->remote.window_size,
-                               (long)channelp->read_avail));
+                                "shrinking window size by %ld bytes to %u, "
+                                "read_avail %ld",
+                                (long)(datalen - data_head),
+                                channelp->remote.window_size,
+                                (long)channelp->read_avail));
 
                 session->packAdd_channelp = channelp;
 
@@ -1083,10 +1085,10 @@ libssh2_packet_add_jump_point1:
             channelp->read_avail += datalen - data_head;
 
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "increasing read_avail by %ld bytes to %ld/%u",
-                           (long)(datalen - data_head),
-                           (long)channelp->read_avail,
-                           channelp->remote.window_size));
+                            "increasing read_avail by %ld bytes to %ld/%u",
+                            (long)(datalen - data_head),
+                            (long)channelp->read_avail,
+                            channelp->remote.window_size));
 
             break;
 
@@ -1105,9 +1107,9 @@ libssh2_packet_add_jump_point1:
                 ;
             else {
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                               "EOF received for channel %u/%u",
-                               channelp->local.id,
-                               channelp->remote.id));
+                                "EOF received for channel %u/%u",
+                                channelp->local.id,
+                                channelp->remote.id));
                 channelp->remote.eof = 1;
             }
             LIBSSH2_FREE(session, data);
@@ -1154,8 +1156,9 @@ libssh2_packet_add_jump_point1:
                 }
 
                 _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                               "Channel %u received request type %.*s (wr %X)",
-                               channel, (int)len, request, want_reply));
+                                "Channel %u received request type "
+                                "%.*s (wr %X)",
+                                channel, (int)len, request, want_reply));
 
                 if(len == strlen("exit-status") &&
                    !memcmp("exit-status", request, strlen("exit-status"))) {
@@ -1267,9 +1270,9 @@ clean_exit:
                 return 0;
             }
             _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                           "Close received for channel %u/%u",
-                           channelp->local.id,
-                           channelp->remote.id));
+                            "Close received for channel %u/%u",
+                            channelp->local.id,
+                            channelp->remote.id));
 
             channelp->remote.close = 1;
             channelp->remote.eof = 1;
@@ -1386,7 +1389,7 @@ libssh2_packet_add_jump_authagent:
             LIBSSH2_ALLOC(session, sizeof(struct packet));
         if(!packetp) {
             _libssh2_debug((session, LIBSSH2_ERROR_ALLOC,
-                           "memory for packet"));
+                            "memory for packet"));
             LIBSSH2_FREE(session, data);
             session->packAdd_state = libssh2_NB_state_idle;
             return LIBSSH2_ERROR_ALLOC;
@@ -1411,7 +1414,7 @@ libssh2_packet_add_jump_authagent:
              * let's just call back into ourselves
              */
             _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                           "Renegotiating Keys"));
+                            "Renegotiating Keys"));
 
             session->packAdd_state = libssh2_NB_state_sent2;
         }
@@ -1455,8 +1458,8 @@ int _libssh2_packet_ask(LIBSSH2_SESSION *session, unsigned char packet_type,
     struct packet *packet = _libssh2_list_first(&session->packets);
 
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                   "Looking for packet of type: %u",
-                   (unsigned int)packet_type));
+                    "Looking for packet of type: %u",
+                    (unsigned int)packet_type));
 
     while(packet) {
         if(packet->data[0] == packet_type &&
@@ -1601,7 +1604,7 @@ int _libssh2_packet_burn(LIBSSH2_SESSION *session,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "Blocking until packet becomes available to burn"));
+                        "Blocking until packet becomes available to burn"));
         *state = libssh2_NB_state_created;
     }
 

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -43,12 +43,12 @@
 #include "channel.h"
 #include "session.h"
 
-#define LIBSSH2_PUBLICKEY_VERSION               2
+#define LIBSSH2_PUBLICKEY_VERSION 2
 
 /* Numericised response codes -- Not IETF, just local representation */
-#define LIBSSH2_PUBLICKEY_RESPONSE_STATUS       0
-#define LIBSSH2_PUBLICKEY_RESPONSE_VERSION      1
-#define LIBSSH2_PUBLICKEY_RESPONSE_PUBLICKEY    2
+#define LIBSSH2_PUBLICKEY_RESPONSE_STATUS    0
+#define LIBSSH2_PUBLICKEY_RESPONSE_VERSION   1
+#define LIBSSH2_PUBLICKEY_RESPONSE_PUBLICKEY 2
 
 struct publickey_code_list {
     const char *name;
@@ -296,7 +296,7 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
         session->pkeyInit_channel = NULL;
 
         _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                       "Initializing publickey subsystem"));
+                        "Initializing publickey subsystem"));
 
         session->pkeyInit_state = libssh2_NB_state_allocated;
     }
@@ -373,8 +373,8 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
         session->pkeyInit_buffer_sent = 0;
 
         _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                       "Sending publickey advertising version %d support",
-                       (int)LIBSSH2_PUBLICKEY_VERSION));
+                        "Sending publickey advertising version %d support",
+                        (int)LIBSSH2_PUBLICKEY_VERSION));
 
         session->pkeyInit_state = libssh2_NB_state_sent2;
     }
@@ -497,15 +497,15 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
                 if(session->pkeyInit_pkey->version >
                    LIBSSH2_PUBLICKEY_VERSION) {
                     _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                                   "Truncate remote publickey version "
-                                   "from %u",
-                                   session->pkeyInit_pkey->version));
+                                    "Truncate remote publickey version "
+                                    "from %u",
+                                    session->pkeyInit_pkey->version));
                     session->pkeyInit_pkey->version =
                         LIBSSH2_PUBLICKEY_VERSION;
                 }
                 _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                               "Enabling publickey subsystem version %u",
-                               session->pkeyInit_pkey->version));
+                                "Enabling publickey subsystem version %u",
+                                session->pkeyInit_pkey->version));
                 LIBSSH2_FREE(session, session->pkeyInit_data);
                 session->pkeyInit_data = NULL;
                 session->pkeyInit_state = libssh2_NB_state_idle;
@@ -587,7 +587,7 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
         pkey->add_packet = NULL;
 
         _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                       "Adding %s publickey", name));
+                        "Adding %s publickey", name));
 
         if(pkey->version == 1) {
             for(i = 0; i < num_attrs; i++) {
@@ -669,9 +669,9 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                       "Sending publickey \"add\" packet: "
-                       "type=%s blob_len=%ld num_attrs=%ld",
-                       name, blob_len, num_attrs));
+                        "Sending publickey \"add\" packet: "
+                        "type=%s blob_len=%ld num_attrs=%ld",
+                        name, blob_len, num_attrs));
 
         pkey->add_state = libssh2_NB_state_created;
     }
@@ -756,9 +756,9 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
         pkey->remove_s += blob_len;
 
         _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                       "Sending publickey \"remove\" packet: "
-                       "type=%s blob_len=%ld",
-                       name, blob_len));
+                        "Sending publickey \"remove\" packet: "
+                        "type=%s blob_len=%ld",
+                        name, blob_len));
 
         pkey->remove_state = libssh2_NB_state_created;
     }
@@ -827,7 +827,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
         pkey->listFetch_s += sizeof("list") - 1;
 
         _libssh2_debug((session, LIBSSH2_TRACE_PUBLICKEY,
-                       "Sending publickey \"list\" packet"));
+                        "Sending publickey \"list\" packet"));
 
         pkey->listFetch_state = libssh2_NB_state_created;
     }

--- a/src/scp.c
+++ b/src/scp.c
@@ -309,8 +309,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
         }
 
         snprintf((char *)session->scpRecv_command,
-                 session->scpRecv_command_len,
-                 "scp -%sf ", sb ? "p" : "");
+                 session->scpRecv_command_len, "scp -%sf ", sb ? "p" : "");
 
         cmd_len = strlen((char *)session->scpRecv_command);
 
@@ -333,7 +332,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
         session->scpRecv_command_len = cmd_len;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SCP,
-                       "Opening channel for SCP receive"));
+                        "Opening channel for SCP receive"));
 
         session->scpRecv_state = libssh2_NB_state_created;
     }
@@ -462,9 +461,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                     /* zero terminate the error */
                     err_msg[err_len] = 0;
 
-                    _libssh2_debug((session, LIBSSH2_TRACE_SCP,
-                                   "got %02x %s", session->scpRecv_response[0],
-                                   err_msg));
+                    _libssh2_debug((session, LIBSSH2_TRACE_SCP, "got %02x %s",
+                                    session->scpRecv_response[0], err_msg));
 
                     _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                                    "Failed to recv file");
@@ -474,32 +472,26 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
 
                 if((session->scpRecv_response_len > 1) &&
-                    ((session->
-                      scpRecv_response[session->scpRecv_response_len - 1] <
-                      '0') ||
-                     (session->
-                      scpRecv_response[session->scpRecv_response_len - 1] >
-                      '9')) &&
-                    (session->
-                     scpRecv_response[session->scpRecv_response_len - 1] !=
-                     ' ') &&
-                    (session->
-                     scpRecv_response[session->scpRecv_response_len - 1] !=
-                     '\r') &&
-                    (session->
-                     scpRecv_response[session->scpRecv_response_len - 1] !=
-                     '\n')) {
+                   ((session->scpRecv_response[session->scpRecv_response_len -
+                                               1] < '0') ||
+                    (session->scpRecv_response[session->scpRecv_response_len -
+                                               1] > '9')) &&
+                   (session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != ' ') &&
+                   (session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != '\r') &&
+                   (session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != '\n')) {
                     _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                                    "Invalid data in SCP response");
                     goto scp_recv_error;
                 }
 
                 if((session->scpRecv_response_len < 9) ||
-                   (session->
-                        scpRecv_response[session->scpRecv_response_len - 1] !=
-                        '\n')) {
+                   (session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != '\n')) {
                     if(session->scpRecv_response_len ==
-                        LIBSSH2_SCP_RESPONSE_BUFLEN) {
+                       LIBSSH2_SCP_RESPONSE_BUFLEN) {
                         /* You had your chance */
                         _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                                        "Unterminated response from "
@@ -513,12 +505,11 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
 
                 /* We're guaranteed not to go under response_len == 0 by the
                    logic above */
-                while((session->
-                        scpRecv_response[session->scpRecv_response_len - 1] ==
-                        '\r') ||
-                       (session->
-                        scpRecv_response[session->scpRecv_response_len - 1] ==
-                        '\n'))
+                while(
+                    (session->scpRecv_response[session->scpRecv_response_len -
+                                               1] == '\r') ||
+                    (session->scpRecv_response[session->scpRecv_response_len -
+                                               1] == '\n'))
                     session->scpRecv_response_len--;
                 session->scpRecv_response[session->scpRecv_response_len] =
                     '\0';
@@ -589,9 +580,9 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
 
                 _libssh2_debug((session, LIBSSH2_TRACE_SCP,
-                               "mtime = %ld, atime = %ld",
-                               session->scpRecv_mtime,
-                               session->scpRecv_atime));
+                                "mtime = %ld, atime = %ld",
+                                session->scpRecv_mtime,
+                                session->scpRecv_atime));
 
                 /* We *should* check that atime.usec is valid, but why let
                    that stop use? */
@@ -641,26 +632,22 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
 
                 if((session->scpRecv_response_len > 1) &&
-                    (session->
-                     scpRecv_response[session->scpRecv_response_len - 1] !=
-                     '\r') &&
-                    (session->
-                     scpRecv_response[session->scpRecv_response_len - 1] !=
-                     '\n') &&
-                    (session->
-                     scpRecv_response[session->scpRecv_response_len - 1]
-                     < 32)) {
+                   (session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != '\r') &&
+                   (session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != '\n') &&
+                   (session->scpRecv_response[session->scpRecv_response_len -
+                                              1] < 32)) {
                     _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                                    "Invalid data in SCP response");
                     goto scp_recv_error;
                 }
 
                 if((session->scpRecv_response_len < 7) ||
-                   (session->
-                    scpRecv_response[session->scpRecv_response_len - 1] !=
-                    '\n')) {
+                   (session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != '\n')) {
                     if(session->scpRecv_response_len ==
-                        LIBSSH2_SCP_RESPONSE_BUFLEN) {
+                       LIBSSH2_SCP_RESPONSE_BUFLEN) {
                         /* You had your chance */
                         _libssh2_error(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                                        "Unterminated response "
@@ -674,12 +661,11 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
 
                 /* We're guaranteed not to go under response_len == 0 by the
                    logic above */
-                while((session->
-                        scpRecv_response[session->scpRecv_response_len - 1] ==
-                        '\r') ||
-                      (session->
-                       scpRecv_response[session->scpRecv_response_len - 1] ==
-                        '\n')) {
+                while(
+                    (session->scpRecv_response[session->scpRecv_response_len -
+                                               1] == '\r') ||
+                    (session->scpRecv_response[session->scpRecv_response_len -
+                                               1] == '\n')) {
                     session->scpRecv_response_len--;
                 }
                 session->scpRecv_response[session->scpRecv_response_len] =
@@ -751,8 +737,9 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                     goto scp_recv_error;
                 }
                 _libssh2_debug((session, LIBSSH2_TRACE_SCP,
-                               "mode = 0%lo size = %ld", session->scpRecv_mode,
-                               (long)session->scpRecv_size));
+                                "mode = 0%lo size = %ld",
+                                session->scpRecv_mode,
+                                (long)session->scpRecv_size));
 
                 /* We *should* check that basename is valid, but why let that
                    stop us? */
@@ -905,7 +892,7 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
         session->scpSend_command_len = cmd_len;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SCP,
-                       "Opening channel for SCP send"));
+                        "Opening channel for SCP send"));
         /* Allocate a channel */
 
         session->scpSend_state = libssh2_NB_state_created;
@@ -988,7 +975,7 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
                          LIBSSH2_SCP_RESPONSE_BUFLEN, "T%ld 0 %ld 0\n",
                          (long)mtime, (long)atime);
             _libssh2_debug((session, LIBSSH2_TRACE_SCP, "Sent %s",
-                           session->scpSend_response));
+                            session->scpSend_response));
         }
 
         session->scpSend_state = libssh2_NB_state_sent2;
@@ -1060,7 +1047,7 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
                      LIBSSH2_INT64_T_FORMAT " %s\n", mode,
                      size, base);
         _libssh2_debug((session, LIBSSH2_TRACE_SCP, "Sent %s",
-                       session->scpSend_response));
+                        session->scpSend_response));
 
         session->scpSend_state = libssh2_NB_state_sent5;
     }

--- a/src/session.c
+++ b/src/session.c
@@ -122,11 +122,11 @@ static int banner_receive(LIBSSH2_SESSION *session)
             if(session->api_block_mode || (ret != -EAGAIN))
                 /* ignore EAGAIN when non-blocking */
                 _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                               "Error recving %d bytes: %ld", 1, (long)-ret));
+                                "Error recving %d bytes: %ld", 1, (long)-ret));
         }
         else
             _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                           "Recved %ld bytes banner", (long)ret));
+                            "Recved %ld bytes banner", (long)ret));
 
         if(ret < 0) {
             if(ret == -EAGAIN) {
@@ -185,7 +185,7 @@ static int banner_receive(LIBSSH2_SESSION *session)
     memcpy(session->remote.banner, session->banner_TxRx_banner, banner_len);
     session->remote.banner[banner_len] = '\0';
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Received Banner: %s",
-                   session->remote.banner));
+                    session->remote.banner));
     return LIBSSH2_ERROR_NONE;
 }
 
@@ -224,7 +224,7 @@ static int banner_send(LIBSSH2_SESSION *session)
             }
 
             _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                           "Sending Banner: %s", banner_dup));
+                            "Sending Banner: %s", banner_dup));
         }
 #endif
 
@@ -240,15 +240,15 @@ static int banner_send(LIBSSH2_SESSION *session)
                        LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(ret < 0)
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Error sending %ld bytes: %ld",
-                       (long)(banner_len - session->banner_TxRx_total_send),
-                       (long)-ret));
+                        "Error sending %ld bytes: %ld",
+                        (long)(banner_len - session->banner_TxRx_total_send),
+                        (long)-ret));
     else
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Sent %ld/%ld bytes at %p+%ld", (long)ret,
-                       (long)(banner_len - session->banner_TxRx_total_send),
-                       (const void *)banner,
-                       (long)session->banner_TxRx_total_send));
+                        "Sent %ld/%ld bytes at %p+%ld", (long)ret,
+                        (long)(banner_len - session->banner_TxRx_total_send),
+                        (const void *)banner,
+                        (long)session->banner_TxRx_total_send));
 
     if(ret != (ssize_t)(banner_len - session->banner_TxRx_total_send)) {
         if(ret >= 0 || ret == -EAGAIN) {
@@ -393,7 +393,7 @@ int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
     /* first zero terminate like this so that the debug output is nice */
     session->local.banner[banner_len] = '\0';
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Setting local Banner: %s",
-                   session->local.banner));
+                    session->local.banner));
     session->local.banner[banner_len++] = '\r';
     session->local.banner[banner_len++] = '\n';
     session->local.banner[banner_len] = '\0';
@@ -458,7 +458,7 @@ LIBSSH2_SESSION *libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
                                           for the scp subsystem */
         session->kex = NULL;
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "New session resource allocated"));
+                        "New session resource allocated"));
         _libssh2_init_if_needed();
     }
     return session;
@@ -531,7 +531,7 @@ libssh2_cb_generic *libssh2_session_callback_set2(LIBSSH2_SESSION *session,
         return oldcb;
     }
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Setting Callback %d",
-                   cbtype));
+                    cbtype));
 
     return NULL;
 }
@@ -601,7 +601,7 @@ int _libssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
 
     if(!dir) {
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Nothing to wait for in wait_socket"));
+                        "Nothing to wait for in wait_socket"));
         /* To avoid that we hang below just because there's nothing set to
            wait for, we timeout on 1 second to also avoid busy-looping
            during this condition */
@@ -721,7 +721,7 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 
     if(session->startup_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "session_startup for socket %ld", (long)sock));
+                        "session_startup for socket %ld", (long)sock));
         if(LIBSSH2_INVALID_SOCKET == sock) {
             /* Did we forget something? */
             return _libssh2_error(session, LIBSSH2_ERROR_BAD_SOCKET,
@@ -781,7 +781,7 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 
     if(session->startup_state == libssh2_NB_state_sent2) {
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "Requesting userauth service"));
+                        "Requesting userauth service"));
 
         /* Request the userauth service */
         session->startup_service[0] = SSH_MSG_SERVICE_REQUEST;
@@ -892,8 +892,8 @@ static int session_free(LIBSSH2_SESSION *session)
 
     if(session->free_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "Freeing session resource %p",
-                       (void *)session->remote.banner));
+                        "Freeing session resource %p",
+                        (void *)session->remote.banner));
 
         session->free_state = libssh2_NB_state_created;
     }
@@ -1106,7 +1106,7 @@ static int session_free(LIBSSH2_SESSION *session)
     while((pkg = _libssh2_list_first(&session->packets)) != NULL) {
         packets_left++;
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "packet left with id %d", pkg->data[0]));
+                        "packet left with id %d", pkg->data[0]));
         /* unlink the node */
         _libssh2_list_remove(&pkg->node);
 
@@ -1116,14 +1116,14 @@ static int session_free(LIBSSH2_SESSION *session)
     }
     (void)packets_left;
     _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                   "Extra packets left %d", packets_left));
+                    "Extra packets left %d", packets_left));
 
     if(session->socket_prev_blockstate) {
         /* if the socket was previously blocking, put it back so */
         rc = session_nonblock(session->socket_fd, 0);
         if(rc) {
             _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                           "unable to reset socket's blocking state"));
+                            "unable to reset socket's blocking state"));
         }
     }
 
@@ -1166,8 +1166,8 @@ static int session_disconnect(LIBSSH2_SESSION *session, int reason,
 
     if(session->disconnect_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS,
-                       "Disconnecting: reason=%d, desc=%s, lang=%s", reason,
-                       description, lang));
+                        "Disconnecting: reason=%d, desc=%s, lang=%s", reason,
+                        description, lang));
         if(description)
             descr_len = strlen(description);
 
@@ -1409,7 +1409,7 @@ int _libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
 {
     int bl = session->api_block_mode;
     _libssh2_debug((session, LIBSSH2_TRACE_CONN,
-                   "Setting blocking mode %s", blocking ? "ON" : "OFF"));
+                    "Setting blocking mode %s", blocking ? "ON" : "OFF"));
     session->api_block_mode = blocking;
 
     return bl;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -132,9 +132,8 @@ static void remove_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
                                                               request_id);
     if(zombie) {
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Removing request ID %u from the list of "
-                       "zombie requests",
-                       request_id));
+                        "Removing request ID %u from the list of "
+                        "zombie requests", request_id));
 
         _libssh2_list_remove(&zombie->node);
         LIBSSH2_FREE(session, zombie);
@@ -148,7 +147,7 @@ static int add_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
     struct sftp_zombie_requests *zombie;
 
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                   "Marking request ID %u as a zombie request", request_id));
+                    "Marking request ID %u as a zombie request", request_id));
 
     zombie = LIBSSH2_ALLOC(sftp->channel->session,
                            sizeof(struct sftp_zombie_requests));
@@ -177,8 +176,8 @@ static int sftp_packet_add(LIBSSH2_SFTP *sftp,
     }
 
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                   "Received packet type %u (len %lu)",
-                   (unsigned int)data[0], (unsigned long)data_len));
+                    "Received packet type %u (len %lu)",
+                    (unsigned int)data[0], (unsigned long)data_len));
 
     /*
      * Experience shows that if we mess up EAGAIN handling somewhere or
@@ -225,7 +224,7 @@ static int sftp_packet_add(LIBSSH2_SFTP *sftp,
     request_id = _libssh2_ntohu32(&data[1]);
 
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Received packet id %d",
-                   request_id));
+                    request_id));
 
     /* Don't add the packet if it answers a request we've given up on. */
     if((data[0] == SSH_FXP_STATUS || data[0] == SSH_FXP_DATA) &&
@@ -283,10 +282,10 @@ static int sftp_packet_read(LIBSSH2_SFTP *sftp)
         packet = sftp->partial_packet;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "partial read cont, len: %u", sftp->partial_len));
+                        "partial read cont, len: %u", sftp->partial_len));
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "partial read cont, already recvd: %lu",
-                       (unsigned long)sftp->partial_received));
+                        "partial read cont, already recvd: %lu",
+                        (unsigned long)sftp->partial_received));
         LIBSSH2_FALLTHROUGH();
     default:
         if(!packet) {
@@ -334,8 +333,8 @@ static int sftp_packet_read(LIBSSH2_SFTP *sftp)
                                       "Invalid SFTP packet size");
 
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                           "Data begin - Packet Length: %lu",
-                           (unsigned long)sftp->partial_len));
+                            "Data begin - Packet Length: %lu",
+                            (unsigned long)sftp->partial_len));
             packet = LIBSSH2_ALLOC(session, sftp->partial_len);
             if(!packet)
                 return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -498,12 +497,12 @@ static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
     }
 
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Requiring packet %u id %u",
-                   (unsigned int)packet_type, request_id));
+                    (unsigned int)packet_type, request_id));
 
     if(sftp_packet_ask(sftp, packet_type, request_id, data, data_len) == 0) {
         /* The right packet was available in the packet brigade */
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %u",
-                       (unsigned int)packet_type));
+                        (unsigned int)packet_type));
 
         if(*data_len < required_size) {
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
@@ -521,7 +520,7 @@ static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
         if(!sftp_packet_ask(sftp, packet_type, request_id, data, data_len)) {
             /* The right packet was available in the packet brigade */
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Got %d",
-                           (unsigned int)packet_type));
+                            (unsigned int)packet_type));
 
             if(*data_len < required_size) {
                 return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
@@ -774,7 +773,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
 
     if(session->sftpInit_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Initializing SFTP subsystem"));
+                        "Initializing SFTP subsystem"));
 
         /*
          * The 'sftpInit_sftp' and 'sftpInit_channel' struct fields within the
@@ -861,9 +860,9 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         session->sftpInit_sent = 0; /* nothing's sent yet */
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Sending FXP_INIT packet advertising "
-                       "version %d support",
-                       (int)LIBSSH2_SFTP_VERSION));
+                        "Sending FXP_INIT packet advertising "
+                        "version %d support",
+                        (int)LIBSSH2_SFTP_VERSION));
 
         session->sftpInit_state = libssh2_NB_state_sent2;
     }
@@ -947,13 +946,13 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
 
     if(sftp_handle->version > LIBSSH2_SFTP_VERSION) {
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Truncating remote SFTP version from %u",
-                       sftp_handle->version));
+                        "Truncating remote SFTP version from %u",
+                        sftp_handle->version));
         sftp_handle->version = LIBSSH2_SFTP_VERSION;
     }
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                   "Enabling SFTP version %u compatibility",
-                   sftp_handle->version));
+                    "Enabling SFTP version %u compatibility",
+                    sftp_handle->version));
     while(buf.dataptr < endp) {
         unsigned char *extname, *extdata;
         size_t extname_len, extdata_len;
@@ -1193,7 +1192,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Sending %s open request",
-                       open_file ? "file" : "directory"));
+                        open_file ? "file" : "directory"));
 
         sftp->open_state = libssh2_NB_state_created;
     }
@@ -1275,7 +1274,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
 
             if(LIBSSH2_FX_OK == sftp->last_errno) {
                 _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                               "got HANDLE FXOK"));
+                                "got HANDLE FXOK"));
 
                 LIBSSH2_FREE(session, data);
 
@@ -1305,8 +1304,8 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
                 _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                "Failed opening remote file");
                 _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                               "got FXP_STATUS %d",
-                               sftp->last_errno));
+                                "got FXP_STATUS %d",
+                                sftp->last_errno));
                 LIBSSH2_FREE(session, data);
                 return NULL;
             }
@@ -1351,7 +1350,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
         fp->u.file.offset_sent = 0;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Open command successful"));
+                        "Open command successful"));
         return fp;
     }
     return NULL;
@@ -1569,9 +1568,9 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                more packets */
             count -= LIBSSH2_MIN(size, count);
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                           "read request id %d sent (offset: %lu, size: %lu)",
-                           request_id, (unsigned long)chunk->offset,
-                           (unsigned long)chunk->len));
+                            "read request id %d sent (offset: %lu, size: %lu)",
+                            request_id, (unsigned long)chunk->offset,
+                            (unsigned long)chunk->len));
         }
         LIBSSH2_FALLTHROUGH();
     case libssh2_NB_state_sent:
@@ -1924,8 +1923,8 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
 
 end:
             _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                           "libssh2_sftp_readdir_ex() return %lu",
-                           (unsigned long)filename_len));
+                            "libssh2_sftp_readdir_ex() return %lu",
+                            (unsigned long)filename_len));
             return (ssize_t)filename_len;
         }
 
@@ -1948,7 +1947,7 @@ end:
 
     if(sftp->readdir_state == libssh2_NB_state_created) {
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Reading entries from directory handle"));
+                        "Reading entries from directory handle"));
         retcode = _libssh2_channel_write(channel, 0, sftp->readdir_packet,
                                          packet_len);
         if(retcode == LIBSSH2_ERROR_EAGAIN) {
@@ -2006,7 +2005,7 @@ end:
 
     num_names = _libssh2_ntohu32(data + 5);
     _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "%u entries returned",
-                   num_names));
+                    num_names));
     if(!num_names) {
         LIBSSH2_FREE(session, data);
         return 0;
@@ -2426,7 +2425,7 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
         sftp->last_errno = LIBSSH2_FX_OK;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Issuing %s command",
-                       setstat ? "set-stat" : "stat"));
+                        setstat ? "set-stat" : "stat"));
         s = sftp->fstat_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->fstat_packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -2788,7 +2787,7 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
         sftp->last_errno = LIBSSH2_FX_OK;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Unlinking %s", filename));
+                        "Unlinking %s", filename));
         s = sftp->unlink_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->unlink_packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -2916,7 +2915,7 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Renaming %s to %s",
-                       source_filename, dest_filename));
+                        source_filename, dest_filename));
         sftp->rename_s = sftp->rename_packet =
             LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->rename_packet) {
@@ -3072,7 +3071,7 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
 
     if(sftp->posix_rename_state == libssh2_NB_state_idle) {
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Issuing posix_rename command"));
+                        "Issuing posix_rename command"));
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3198,7 +3197,7 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
         sftp->last_errno = LIBSSH2_FX_OK;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Getting file system statistics"));
+                        "Getting file system statistics"));
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3345,7 +3344,7 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
         sftp->last_errno = LIBSSH2_FX_OK;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Getting file system statistics of %s", path));
+                        "Getting file system statistics of %s", path));
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3496,7 +3495,7 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
         sftp->last_errno = LIBSSH2_FX_OK;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP,
-                       "Creating directory %s with mode 0%lo", path, mode));
+                        "Creating directory %s with mode 0%lo", path, mode));
         s = packet = LIBSSH2_ALLOC(session, packet_len);
         if(!packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3610,7 +3609,7 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
         sftp->last_errno = LIBSSH2_FX_OK;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "Removing directory: %s",
-                       path));
+                        path));
         s = sftp->rmdir_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->rmdir_packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3723,9 +3722,10 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
         sftp->last_errno = LIBSSH2_FX_OK;
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "%s %s",
-                       (stat_type == LIBSSH2_SFTP_SETSTAT) ? "Set-statting" :
-                       (stat_type ==
-                        LIBSSH2_SFTP_LSTAT ? "LStatting" : "Statting"), path));
+                        (stat_type == LIBSSH2_SFTP_SETSTAT) ? "Set-statting" :
+                        (stat_type ==
+                         LIBSSH2_SFTP_LSTAT ? "LStatting" : "Statting"),
+                        path));
         s = sftp->stat_packet = LIBSSH2_ALLOC(session, packet_len);
         if(!sftp->stat_packet) {
             return _libssh2_error(session, LIBSSH2_ERROR_ALLOC,
@@ -3902,11 +3902,11 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
         }
 
         _libssh2_debug((session, LIBSSH2_TRACE_SFTP, "%s %s on %s",
-                       (link_type ==
-                        LIBSSH2_SFTP_SYMLINK) ? "Creating" : "Reading",
-                       (link_type ==
-                        LIBSSH2_SFTP_REALPATH) ? "realpath" : "symlink",
-                       path));
+                        (link_type ==
+                         LIBSSH2_SFTP_SYMLINK) ? "Creating" : "Reading",
+                        (link_type ==
+                         LIBSSH2_SFTP_REALPATH) ? "realpath" : "symlink",
+                        path));
 
         _libssh2_store_u32(&s, packet_len - 4);
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -227,7 +227,7 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
                                         p->payload + p->total_num - mac_len,
                                         mac_len)) {
                 _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                               "Failed MAC check"));
+                                "Failed MAC check"));
                 session->fullpacket_macstate = LIBSSH2_MAC_INVALID;
             }
             else if(etm) {
@@ -409,7 +409,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION *session)
          * is done!
          */
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Redirecting into the"
-                       " key re-exchange from _libssh2_transport_read"));
+                        " key re-exchange from _libssh2_transport_read"));
         rc = _libssh2_kex_exchange(session, 1, &session->startup_key_state);
         if(rc)
             return rc;
@@ -497,15 +497,15 @@ int _libssh2_transport_read(LIBSSH2_SESSION *session)
                     return LIBSSH2_ERROR_EAGAIN;
                 }
                 _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                               "Error recving %ld bytes (got %ld)",
-                               (long)(PACKETBUFSIZE - remainbuf),
-                               (long)-nread));
+                                "Error recving %ld bytes (got %ld)",
+                                (long)(PACKETBUFSIZE - remainbuf),
+                                (long)-nread));
                 return LIBSSH2_ERROR_SOCKET_RECV;
             }
             _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                           "Recved %ld/%ld bytes to %p+%ld", (long)nread,
-                           (long)(PACKETBUFSIZE - remainbuf), (void *)p->buf,
-                           (long)remainbuf));
+                            "Recved %ld/%ld bytes to %p+%ld", (long)nread,
+                            (long)(PACKETBUFSIZE - remainbuf), (void *)p->buf,
+                            (long)remainbuf));
 
             debugdump(session, "libssh2_transport_read() raw",
                       &p->buf[remainbuf], nread);
@@ -559,7 +559,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION *session)
                                             &session->remote.crypt_abstract);
 
                 if(rc != LIBSSH2_ERROR_NONE) {
-                    p->total_num = 0;   /* no packet buffer available */
+                    p->total_num = 0; /* no packet buffer available */
                     if(p->payload)
                         LIBSSH2_FREE(session, p->payload);
                     p->payload = NULL;
@@ -927,7 +927,7 @@ static int send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
            make the caller really notice his/hers flaw, we return error for
            this case */
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Address is different, returning EAGAIN"));
+                        "Address is different, returning EAGAIN"));
         return LIBSSH2_ERROR_EAGAIN;
     }
 
@@ -940,12 +940,12 @@ static int send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
                       LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(rc < 0)
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Error sending %ld bytes: %ld",
-                       (long)length, (long)-rc));
+                        "Error sending %ld bytes: %ld",
+                        (long)length, (long)-rc));
     else {
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Sent %ld/%ld bytes at %p+%lu", (long)rc, (long)length,
-                       (void *)p->outbuf, (unsigned long)p->osent));
+                        "Sent %ld/%ld bytes at %p+%lu", (long)rc, (long)length,
+                        (void *)p->outbuf, (unsigned long)p->osent));
         debugdump(session, "libssh2_transport_write send()",
                   &p->outbuf[p->osent], rc);
     }
@@ -1028,7 +1028,7 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
         /* Don't write any new packets if we're still in the middle of a key
          * exchange. */
         _libssh2_debug((session, LIBSSH2_TRACE_TRANS, "Redirecting into the"
-                       " key re-exchange from _libssh2_transport_send"));
+                        " key re-exchange from _libssh2_transport_send"));
         rc = _libssh2_kex_exchange(session, 1, &session->startup_key_state);
         if(rc)
             return rc;
@@ -1120,8 +1120,8 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
 
     /* Plain math: (4 + 1 + packet_length + padding_length) % blocksize == 0 */
 
-    packet_length = data_len + 1 + 4;   /* 1 is for padding_length field
-                                           4 for the packet_length field */
+    packet_length = data_len + 1 + 4; /* 1 is for padding_length field
+                                         4 for the packet_length field */
     /* subtract 4 bytes of the packet_length field when padding AES-GCM
        or with ETM */
     crypt_offset = (etm || auth_len ||
@@ -1281,12 +1281,12 @@ int _libssh2_transport_send(LIBSSH2_SESSION *session,
                        LIBSSH2_SOCKET_SEND_FLAGS(session));
     if(ret < 0)
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Error sending %ld bytes: %ld",
-                       (long)total_length, (long)-ret));
+                        "Error sending %ld bytes: %ld",
+                        (long)total_length, (long)-ret));
     else {
         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
-                       "Sent %ld/%ld bytes at %p",
-                       (long)ret, (long)total_length, (void *)p->outbuf));
+                        "Sent %ld/%ld bytes at %p",
+                        (long)ret, (long)total_length, (void *)p->outbuf));
         debugdump(session, "libssh2_transport_write send()", p->outbuf, ret);
     }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -192,8 +192,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                    banner_len);
             session->userauth_banner[banner_len] = '\0';
             _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                           "Banner: %s",
-                           session->userauth_banner));
+                            "Banner: %s", session->userauth_banner));
             LIBSSH2_FREE(session, session->userauth_list_data);
             session->userauth_list_data = NULL;
             /* SSH_MSG_USERAUTH_BANNER has been handled */
@@ -245,8 +244,8 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                 methods_len);
         session->userauth_list_data[methods_len] = '\0';
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Permitted auth methods: %s",
-                       session->userauth_list_data));
+                        "Permitted auth methods: %s",
+                        session->userauth_list_data));
     }
 
     session->userauth_list_state = libssh2_NB_state_idle;
@@ -359,7 +358,7 @@ static int userauth_password(LIBSSH2_SESSION *session,
         /* 'password' is sent separately */
 
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Attempting to login using password authentication"));
+                        "Attempting to login using password authentication"));
 
         session->userauth_pswd_state = libssh2_NB_state_created;
     }
@@ -414,7 +413,7 @@ password_response:
 
             if(session->userauth_pswd_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
                 _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                               "Password authentication successful"));
+                                "Password authentication successful"));
                 LIBSSH2_FREE(session, session->userauth_pswd_data);
                 session->userauth_pswd_data = NULL;
                 session->state |= LIBSSH2_STATE_AUTHENTICATED;
@@ -424,7 +423,7 @@ password_response:
             else if(session->userauth_pswd_data[0] ==
                     SSH_MSG_USERAUTH_FAILURE) {
                 _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                               "Password authentication failed"));
+                                "Password authentication failed"));
                 LIBSSH2_FREE(session, session->userauth_pswd_data);
                 session->userauth_pswd_data = NULL;
                 session->userauth_pswd_state = libssh2_NB_state_idle;
@@ -456,7 +455,7 @@ password_response:
                (session->userauth_pswd_state == libssh2_NB_state_sent2)) {
                 if(session->userauth_pswd_state == libssh2_NB_state_sent1) {
                     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                                   "Password change required"));
+                                    "Password change required"));
                     LIBSSH2_FREE(session, session->userauth_pswd_data);
                     session->userauth_pswd_data = NULL;
                 }
@@ -680,7 +679,7 @@ static int file_read_publickey(LIBSSH2_SESSION *session,
     size_t tmp_len;
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH, "Loading public key file: %s",
-                   pubkeyfile));
+                    pubkeyfile));
     /* Read Public Key */
     fd = fopen(pubkeyfile, "rb");
     if(!fd) {
@@ -813,7 +812,7 @@ static int file_read_privatekey(LIBSSH2_SESSION *session,
         libssh2_hostkey_methods();
 
     _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                   "Loading private key file: %s", privkeyfile));
+                    "Loading private key file: %s", privkeyfile));
     *hostkey_method = NULL;
     *hostkey_abstract = NULL;
     while(*hostkey_methods_avail && (*hostkey_methods_avail)->name) {
@@ -853,8 +852,8 @@ struct privkey_mem {
 
 static int sign_frommemory(LIBSSH2_SESSION *session,
                            unsigned char **sig, size_t *sig_len,
-                          const unsigned char *data, size_t data_len,
-                          void **abstract)
+                           const unsigned char *data, size_t data_len,
+                           void **abstract)
 {
     struct privkey_mem *pk_mem = (struct privkey_mem *)(*abstract);
     const struct hostkey_method *privkeyobj;
@@ -985,7 +984,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
             }
             else {
                 _libssh2_debug((session, LIBSSH2_ERROR_ALLOC,
-                               "Unable to allocate ecdsa-sk signature."));
+                                "Unable to allocate ecdsa-sk signature."));
                 rc = LIBSSH2_ERROR_ALLOC;
             }
         }
@@ -1003,7 +1002,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
             }
             else {
                 _libssh2_debug((session, LIBSSH2_ERROR_ALLOC,
-                               "Unable to allocate ed25519-sk signature."));
+                                "Unable to allocate ed25519-sk signature."));
                 rc = LIBSSH2_ERROR_ALLOC;
             }
         }
@@ -1024,7 +1023,8 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
     }
     else {
         _libssh2_debug((session, LIBSSH2_ERROR_DECRYPT,
-                       "sign_callback failed or returned invalid signature."));
+                        "sign_callback failed or "
+                        "returned invalid signature."));
         *sig_len = 0;
     }
 
@@ -1210,7 +1210,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         LIBSSH2_FREE(session, sig);
 
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Attempting hostbased authentication"));
+                        "Attempting hostbased authentication"));
 
         session->userauth_host_state = libssh2_NB_state_created;
     }
@@ -1262,7 +1262,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
 
         if(session->userauth_host_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
             _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                           "Hostbased authentication successful"));
+                            "Hostbased authentication successful"));
             /* We are us and we've proved it. */
             LIBSSH2_FREE(session, session->userauth_host_data);
             session->userauth_host_data = NULL;
@@ -1637,10 +1637,9 @@ retry_auth:
 
         if(session->userauth_pblc_method_len &&
            session->userauth_pblc_method) {
-            _libssh2_debug((session, LIBSSH2_TRACE_KEX,
-                           "Signing using %.*s",
-                           (int)session->userauth_pblc_method_len,
-                           session->userauth_pblc_method));
+            _libssh2_debug((session, LIBSSH2_TRACE_KEX, "Signing using %.*s",
+                            (int)session->userauth_pblc_method_len,
+                            session->userauth_pblc_method));
         }
 
         /*
@@ -1688,7 +1687,7 @@ retry_auth:
         _libssh2_store_str(&s, (const char *)pubkeydata, pubkeydata_len);
 
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Attempting publickey authentication"));
+                        "Attempting publickey authentication"));
 
         session->userauth_pblc_state = libssh2_NB_state_created;
     }
@@ -1736,7 +1735,7 @@ retry_auth:
 
         if(session->userauth_pblc_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
             _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                           "Pubkey authentication prematurely successful"));
+                            "Pubkey authentication prematurely successful"));
             /*
              * God help any SSH server that allows an UNVERIFIED
              * public key to validate the user
@@ -1887,7 +1886,7 @@ retry_auth:
         LIBSSH2_FREE(session, sig);
 
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Attempting publickey authentication -- phase 2"));
+                        "Attempting publickey authentication -- phase 2"));
 
         session->userauth_pblc_s = s;
         session->userauth_pblc_state = libssh2_NB_state_sent2;
@@ -1935,7 +1934,7 @@ retry_auth:
 
     if(session->userauth_pblc_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Publickey authentication successful"));
+                        "Publickey authentication successful"));
         /* We are us and we've proved it. */
         LIBSSH2_FREE(session, session->userauth_pblc_data);
         session->userauth_pblc_data = NULL;
@@ -2213,7 +2212,7 @@ static int userauth_keyboard_interactive(
         _libssh2_store_u32(&s, 0);
 
         _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                       "Attempting keyboard-interactive authentication"));
+                        "Attempting keyboard-interactive authentication"));
 
         session->userauth_kybd_state = libssh2_NB_state_created;
     }
@@ -2262,8 +2261,8 @@ static int userauth_keyboard_interactive(
 
             if(session->userauth_kybd_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
                 _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                               "Keyboard-interactive "
-                               "authentication successful"));
+                                "Keyboard-interactive "
+                                "authentication successful"));
                 LIBSSH2_FREE(session, session->userauth_kybd_data);
                 session->userauth_kybd_data = NULL;
                 session->state |= LIBSSH2_STATE_AUTHENTICATED;
@@ -2273,7 +2272,7 @@ static int userauth_keyboard_interactive(
 
             if(session->userauth_kybd_data[0] == SSH_MSG_USERAUTH_FAILURE) {
                 _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                               "Keyboard-interactive authentication failed"));
+                                "Keyboard-interactive authentication failed"));
                 LIBSSH2_FREE(session, session->userauth_kybd_data);
                 session->userauth_kybd_data = NULL;
                 session->userauth_kybd_state = libssh2_NB_state_idle;
@@ -2300,8 +2299,8 @@ static int userauth_keyboard_interactive(
                               &session->abstract);
 
             _libssh2_debug((session, LIBSSH2_TRACE_AUTH,
-                           "Keyboard-interactive response callback function"
-                           " invoked"));
+                            "Keyboard-interactive response callback function"
+                            " invoked"));
 
             session->userauth_kybd_packet_len =
                 1    /* byte      SSH_MSG_USERAUTH_INFO_RESPONSE */


### PR DESCRIPTION
Mostly via clang-format.

Follow-up to 63e59481fa92b8b234e7ae7a2f7da45d1ac8e1ac #1936

---

https://github.com/libssh2/libssh2/pull/1938/files?w=1
