### PR TITLE
tidy-up: misc

### DIFF
--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -442,7 +442,7 @@ the public key is returned in `public'.
 0 is returned upon success, else -1.
 
 int libssh2_dh_secret(libssh2_dh_ctx *dhctx, libssh2_bn *secret,
-                      libssh2_bn *f, libssh2_bn *p, libssh2_bn_ctx * bnctx)
+                      libssh2_bn *f, libssh2_bn *p, libssh2_bn_ctx *bnctx)
 Computes the Diffie-Hellman secret from the previously created context `*dhctx',
 the public key `f' from the other party and the same prime `p' used at
 context creation. The result is stored in `secret'.
@@ -473,10 +473,10 @@ libssh2_bn
 Type of multiple precision numbers (aka bignumbers or huge integers) for the
 crypto library.
 
-libssh2_bn * _libssh2_bn_init(void);
+libssh2_bn *_libssh2_bn_init(void);
 Creates a multiple precision number (preset to zero).
 
-libssh2_bn * _libssh2_bn_init_from_bin(void);
+libssh2_bn *_libssh2_bn_init_from_bin(void);
 Create a multiple precision number intended to be set by the
 _libssh2_bn_from_bin() function (see below). Unlike _libssh2_bn_init(), this
 code may be a dummy initializer if the _libssh2_bn_from_bin() actually
@@ -496,8 +496,8 @@ int _libssh2_bn_set_word(libssh2_bn *bn, unsigned long val);
 Sets the value of bn to val.
 Returns 1 on success, 0 otherwise.
 
-libssh2_bn * _libssh2_bn_from_bin(libssh2_bn *bn, int len,
-                                   const unsigned char *val);
+libssh2_bn *_libssh2_bn_from_bin(libssh2_bn *bn, int len,
+                                 const unsigned char *val);
 Converts the positive integer in big-endian form of length len at val
 into a libssh2_bn and place it in bn. If bn is NULL, a new libssh2_bn is
 created.
@@ -660,8 +660,8 @@ LIBSSH2_RSA_SHA2
 #define as 1 if the crypto library supports RSA SHA2 256/512, else 0.
 If defined as 0, the rest of this section can be omitted.
 
-int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION * session,
-                           libssh2_rsa_ctx * rsactx,
+int _libssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
+                           libssh2_rsa_ctx *rsactx,
                            const unsigned char *hash,
                            size_t hash_len,
                            unsigned char **signature,
@@ -694,7 +694,7 @@ Signature buffer must be allocated from the given session.
 Returns 0 if OK, else -1.
 Note: this procedure is optional: if provided, it MUST be defined as a macro.
 
-int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsa,
+int _libssh2_rsa_sha2_verify(libssh2_rsa_ctx *rsa,
                              size_t hash_len,
                              const unsigned char *sig,
                              size_t sig_len,
@@ -801,7 +801,7 @@ Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
 int _libssh2_ecdsa_new_private(libssh2_ecdsa_ctx **ec_ctx,
-                               LIBSSH2_SESSION * session,
+                               LIBSSH2_SESSION *session,
                                const char *filename,
                                const unsigned char *passphrase);
 Reads an ECDSA private key from PEM file filename into a new ECDSA context.
@@ -809,8 +809,8 @@ Must call _libssh2_init_if_needed().
 Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx ** ec_ctx,
-                                          LIBSSH2_SESSION * session,
+int _libssh2_ecdsa_new_private_frommemory(libssh2_ecdsa_ctx **ec_ctx,
+                                          LIBSSH2_SESSION *session,
                                           const char *filedata,
                                           size_t filedata_len,
                                           const unsigned char *passphrase);
@@ -830,7 +830,7 @@ Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
 int _libssh2_ecdsa_new_openssh_private(libssh2_ecdsa_ctx **ec_ctx,
-                                       LIBSSH2_SESSION * session,
+                                       LIBSSH2_SESSION *session,
                                        const char *filename,
                                        const unsigned char *passphrase);
 Reads a PEM-encoded ECDSA private key from file filename encrypted with
@@ -962,9 +962,9 @@ int _libssh2_random(unsigned char *buf, size_t len);
 Store len random bytes at buf.
 Returns 0 if OK, else -1.
 
-const char * _libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
-                                                    unsigned char *key_method,
-                                                    size_t key_method_len);
+const char *_libssh2_supported_key_sign_algorithms(LIBSSH2_SESSION *session,
+                                                   unsigned char *key_method,
+                                                   size_t key_method_len);
 
 This function is for implementing key hash upgrading as defined in RFC 8332.
 

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -93,8 +93,8 @@ extern "C" {
 #endif
 
 #ifdef _WIN32
-# include <basetsd.h>
-# include <winsock2.h>
+#include <basetsd.h>
+#include <winsock2.h>
 #endif
 
 #include <stddef.h>
@@ -104,19 +104,19 @@ extern "C" {
 
 /* Allow alternate API prefix from CFLAGS or calling app */
 #ifndef LIBSSH2_API
-# if defined(_WIN32) && defined(LIBSSH2_EXPORTS)
-#  ifdef LIBSSH2_LIBRARY
-#   define LIBSSH2_API __declspec(dllexport)
+#  if defined(_WIN32) && defined(LIBSSH2_EXPORTS)
+#    ifdef LIBSSH2_LIBRARY
+#      define LIBSSH2_API __declspec(dllexport)
+#    else
+#      define LIBSSH2_API __declspec(dllimport)
+#    endif /* LIBSSH2_LIBRARY */
 #  else
-#   define LIBSSH2_API __declspec(dllimport)
-#  endif /* LIBSSH2_LIBRARY */
-# else
-#  define LIBSSH2_API
-# endif /* _WIN32 && LIBSSH2_EXPORTS */
+#    define LIBSSH2_API
+#  endif /* _WIN32 && LIBSSH2_EXPORTS */
 #endif /* !LIBSSH2_API */
 
 #ifdef HAVE_SYS_UIO_H
-# include <sys/uio.h>
+#include <sys/uio.h>
 #endif
 
 #include <stdint.h>

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -68,9 +68,9 @@
    would break backwards compatibility.
 */
 #ifdef HAVE_POLL
-# include <poll.h>
+#include <poll.h>
 #elif defined(HAVE_SELECT) && defined(HAVE_SYS_SELECT_H)
-# include <sys/select.h>
+#include <sys/select.h>
 #endif
 
 /* Needed for struct iovec on some platforms */
@@ -102,14 +102,14 @@
 #ifdef _WIN32
 /* Detect Windows App environment which has a restricted access
    to the Win32 APIs. */
-# if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
+#  if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
   defined(WINAPI_FAMILY)
-#  include <winapifamily.h>
-#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
-     !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#    define LIBSSH2_WINDOWS_UWP
+#    include <winapifamily.h>
+#    if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
+       !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#      define LIBSSH2_WINDOWS_UWP
+#    endif
 #  endif
-# endif
 #endif
 
 #ifndef FALSE

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -952,9 +952,9 @@ struct _LIBSSH2_SESSION {
 /* session.flag helpers */
 #ifdef MSG_NOSIGNAL
 #define LIBSSH2_SOCKET_SEND_FLAGS(session)         \
-    (((session)->flag.sigpipe) ? 0 : MSG_NOSIGNAL)
+    ((session)->flag.sigpipe ? 0 : MSG_NOSIGNAL)
 #define LIBSSH2_SOCKET_RECV_FLAGS(session)         \
-    (((session)->flag.sigpipe) ? 0 : MSG_NOSIGNAL)
+    ((session)->flag.sigpipe ? 0 : MSG_NOSIGNAL)
 #else
 /* If MSG_NOSIGNAL isn't defined we're SOL on blocking SIGPIPE */
 #define LIBSSH2_SOCKET_SEND_FLAGS(session) 0

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -28,21 +28,21 @@
 #define HAVE_SNPRINTF
 
 #ifdef __MINGW32__
-# define HAVE_UNISTD_H
-# define HAVE_INTTYPES_H
-# define HAVE_SYS_TIME_H
-# define HAVE_GETTIMEOFDAY
-# define HAVE_STRTOLL
-#elif defined(_MSC_VER)
-# if _MSC_VER >= 1800
+#  define HAVE_UNISTD_H
 #  define HAVE_INTTYPES_H
+#  define HAVE_SYS_TIME_H
+#  define HAVE_GETTIMEOFDAY
 #  define HAVE_STRTOLL
-# else
-#  define HAVE_STRTOI64
-# endif
-# if _MSC_VER < 1900
-#  undef HAVE_SNPRINTF
-# endif
+#elif defined(_MSC_VER)
+#  if _MSC_VER >= 1800
+#    define HAVE_INTTYPES_H
+#    define HAVE_STRTOLL
+#  else
+#    define HAVE_STRTOI64
+#  endif
+#  if _MSC_VER < 1900
+#    undef HAVE_SNPRINTF
+#  endif
 #endif
 
 #endif /* HAVE_CONFIG_H */
@@ -62,32 +62,32 @@
 #endif
 
 #ifdef __MINGW32__
-# undef _FILE_OFFSET_BITS
-# define _FILE_OFFSET_BITS 64
+#  undef _FILE_OFFSET_BITS
+#  define _FILE_OFFSET_BITS 64
 #elif defined(_MSC_VER)
-# ifndef _CRT_SECURE_NO_WARNINGS
-# define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv() */
-# endif
-# if !defined(LIBSSH2_LIBRARY) || defined(LIBSSH2_TESTS)
-   /* apply to examples and tests only */
-#  ifndef _CRT_NONSTDC_NO_DEPRECATE
-#  define _CRT_NONSTDC_NO_DEPRECATE  /* for write() */
+#  ifndef _CRT_SECURE_NO_WARNINGS
+#  define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv() */
 #  endif
-#  ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#  define _WINSOCK_DEPRECATED_NO_WARNINGS  /* for inet_addr() */
+#  if !defined(LIBSSH2_LIBRARY) || defined(LIBSSH2_TESTS)
+    /* apply to examples and tests only */
+#    ifndef _CRT_NONSTDC_NO_DEPRECATE
+#    define _CRT_NONSTDC_NO_DEPRECATE  /* for write() */
+#    endif
+#    ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
+#    define _WINSOCK_DEPRECATED_NO_WARNINGS  /* for inet_addr() */
+#    endif
+     /* we cannot access our internal snprintf() implementation in examples and
+        tests when linking to a shared libssh2. */
+#    if _MSC_VER < 1900
+#      undef HAVE_SNPRINTF
+#      define HAVE_SNPRINTF
+#      define snprintf _snprintf
+#    endif
 #  endif
-   /* we cannot access our internal snprintf() implementation in examples and
-      tests when linking to a shared libssh2. */
 #  if _MSC_VER < 1900
-#   undef HAVE_SNPRINTF
-#   define HAVE_SNPRINTF
-#   define snprintf _snprintf
-#  endif
-# endif
-# if _MSC_VER < 1900
 /* Silence bogus warning C4127: conditional expression is constant */
 #  pragma warning(disable:4127)
-# endif
+#  endif
 #endif
 
 #endif /* _WIN32 */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -393,7 +393,7 @@ struct libssh2_wincng_cipher_ctx {
 struct libssh2_wincng_cipher_type {
     BCRYPT_ALG_HANDLE *phAlg;
     ULONG dwKeyLength;
-    int useIV;      /* TODO: Convert to bool when a C89 compatible bool type
+    int useIV;      /* TODO: Convert to bool when a C89-compatible bool type
                        is defined */
     int ctrMode;
 };


### PR DESCRIPTION
- fix indentation for PP directives.
- drop redundant parentheses.
- typo in comment.
- HACKING-CRYPTO: fix stray spaces and indent.
