### PR TITLE
src: verify `_libssh2_store_bignum2_bytes()` success

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -535,6 +535,7 @@ typedef struct _LIBSSH2_POLLFD {
 #define LIBSSH2_ERROR_MAC_FAILURE               (-52)
 #define LIBSSH2_ERROR_HASH_INIT                 (-53)
 #define LIBSSH2_ERROR_HASH_CALC                 (-54)
+#define LIBSSH2_ERROR_STORE_OVERFLOW            (-55)
 
 /* this is a define to provide the old (<= 1.2.7) name */
 #define LIBSSH2_ERROR_BANNER_NONE LIBSSH2_ERROR_BANNER_RECV

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -984,6 +984,9 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
                     _libssh2_debug((session, LIBSSH2_ERROR_STORE_OVERFLOW,
                                     "Too large write."));
                     rc = LIBSSH2_ERROR_STORE_OVERFLOW;
+                    LIBSSH2_FREE(session, *sig);
+                    *sig = NULL;
+                    *sig_len = 0;
                     p = NULL;
                 }
             }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -984,7 +984,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
                     _libssh2_debug((session, LIBSSH2_ERROR_STORE_OVERFLOW,
                                     "Too large write."));
                     rc = LIBSSH2_ERROR_STORE_OVERFLOW;
-                    p = 0;
+                    p = NULL;
                 }
             }
             else {

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -970,17 +970,21 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
 
                 _libssh2_store_u32(&p, 0);
 
-                _libssh2_store_bignum2_bytes(&p,
-                                             sig_info.sig_r,
-                                             sig_info.sig_r_len);
+                if(_libssh2_store_bignum2_bytes(&p,
+                                                sig_info.sig_r,
+                                                sig_info.sig_r_len) &&
+                   _libssh2_store_bignum2_bytes(&p,
+                                                sig_info.sig_s,
+                                                sig_info.sig_s_len)) {
+                    *sig_len = p - *sig;
 
-                _libssh2_store_bignum2_bytes(&p,
-                                             sig_info.sig_s,
-                                             sig_info.sig_s_len);
-
-                *sig_len = p - *sig;
-
-                _libssh2_store_u32(&x, (uint32_t)(*sig_len - 4));
+                    _libssh2_store_u32(&x, (uint32_t)(*sig_len - 4));
+                }
+                else {
+                    _libssh2_debug((session, LIBSSH2_ERROR_STORE_OVERFLOW,
+                                    "Too large write."));
+                    rc = LIBSSH2_ERROR_STORE_OVERFLOW;
+                }
             }
             else {
                 _libssh2_debug((session, LIBSSH2_ERROR_ALLOC,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -984,6 +984,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
                     _libssh2_debug((session, LIBSSH2_ERROR_STORE_OVERFLOW,
                                     "Too large write."));
                     rc = LIBSSH2_ERROR_STORE_OVERFLOW;
+                    p = 0;
                 }
             }
             else {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3043,6 +3043,12 @@ int _libssh2_wincng_ecdsa_sign(IN LIBSSH2_SESSION *session,
     }
 
 cleanup:
+    if(result != LIBSSH2_ERROR_NONE && *signature) {
+        LIBSSH2_FREE(session, *signature);
+        *signature = NULL;
+        *signature_len = 0;
+    }
+
     if(cng_signature) {
         free(cng_signature);
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3027,17 +3027,20 @@ int _libssh2_wincng_ecdsa_sign(IN LIBSSH2_SESSION *session,
     *signature = LIBSSH2_ALLOC(session, signature_maxlen);
     signature_ptr = *signature;
 
-    _libssh2_store_bignum2_bytes(
-        &signature_ptr,
-        cng_signature,
-        cng_signature_len / 2);
-
-    _libssh2_store_bignum2_bytes(
-        &signature_ptr,
-        cng_signature + (cng_signature_len / 2),
-        cng_signature_len / 2);
-
-    *signature_len = signature_ptr - *signature;
+    if(_libssh2_store_bignum2_bytes(&signature_ptr,
+                                    cng_signature,
+                                    cng_signature_len / 2) &&
+       _libssh2_store_bignum2_bytes(&signature_ptr,
+                                    cng_signature + (cng_signature_len / 2),
+                                    cng_signature_len / 2)) {
+        *signature_len = signature_ptr - *signature;
+    }
+    else {
+        _libssh2_debug((session, LIBSSH2_ERROR_STORE_OVERFLOW,
+                        "Too large write."));
+        result = LIBSSH2_ERROR_STORE_OVERFLOW;
+        goto cleanup;
+    }
 
 cleanup:
     if(cng_signature) {


### PR DESCRIPTION
In userauth and wincng.

Also:
- fix pre-existing memory leak on a `_libssh2_wincng_ecdsa_sign()` error
  branch.

Follow-up to ebf644fb6a6e609dd05a5cb4c070e74ac3e85322 #1025
