### PR TITLE
build: fix two issues when generating `libssh2.pc`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -199,7 +199,11 @@ Try --with-libz-prefix=PATH if you know that you have it."
     fi
   else
     AC_DEFINE(LIBSSH2_HAVE_ZLIB, 1, [Compile in zlib support])
-    LIBSSH2_PC_REQUIRES_PRIVATE="$LIBSSH2_PC_REQUIRES_PRIVATE${LIBSSH2_PC_REQUIRES_PRIVATE:+,}zlib"
+    case $host in
+      dnl Android does not provide zlib.pc
+      *-*-android*) ;;
+      *) LIBSSH2_PC_REQUIRES_PRIVATE="$LIBSSH2_PC_REQUIRES_PRIVATE${LIBSSH2_PC_REQUIRES_PRIVATE:+,}zlib";;
+    esac
     found_libz="yes"
   fi
 fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -291,6 +291,8 @@ if(NOT LIBSSH2_DISABLE_INSTALL)
           else()
             list(APPEND LIBSSH2_PC_LIBS_PRIVATE "${_lib}")
           endif()
+        elseif(_lib MATCHES "^-")  # '-option'
+          list(APPEND LIBSSH2_PC_LIBS_PRIVATE "${_lib}")
         else()
           list(APPEND LIBSSH2_PC_LIBS_PRIVATE "-l${_lib}")
         endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -258,7 +258,7 @@ if(NOT LIBSSH2_DISABLE_INSTALL)
       endif()
       if(_lib STREQUAL OpenSSL::Crypto AND NOT HAVE_BORINGSSL)  # BoringSSL does not provide libcrypto.pc
         set(_modules "libcrypto")
-      elseif(_lib STREQUAL ZLIB::ZLIB)
+      elseif(_lib STREQUAL ZLIB::ZLIB AND NOT ANDROID)  # Android does not provide zlib.pc
         set(_modules "zlib")
       else()
         get_target_property(_modules "${_lib}" INTERFACE_LIBSSH2_PC_MODULES)


### PR DESCRIPTION
- cmake: fix potential non-lib option prefixed with `-l`, resulting in 
  e.g. `-l-pthread`.
  Ref: https://github.com/curl/curl/pull/21654

- omit zlib pkg-config reference for Android.
  Android does not offer a `zlib.pc` pkg-config file.
  Refs:
  https://github.com/curl/curl/commit/7bde6cb9fcdfbb58531d5ac39e7b236ce15c52bf
  https://github.com/curl/curl/pull/21648
