### PR TITLE
GHA: merge BSD into a single matrix, add MidnightBSD, bump and extend FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,7 +1103,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests', options: '--with-crypto=/usr/local' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests', options: '--with-crypto-prefix=/usr/local' }
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', crypto: 'openssl', desc: 'openssl' }
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL', desc: 'gnutls !runtests' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , crypto: 'OpenSSL', desc: 'openssl !runtests' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1128,39 +1128,38 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            # https://github.com/DragonFlyBSD/DPorts
-            cmd='pkg install -y autoconf automake libtool libgcrypt'
+            # shellcheck disable=SC2181
+            while [ $? = 0 ]; do
+              for i in 1 2 3; do
+                # https://github.com/DragonFlyBSD/DPorts
+                if sudo pkg install -y autoconf automake libtool libgcrypt; then
+                  break 2
+                else
+                  echo "Error: wait to try again: $i"
+                  sleep 10
+                fi
+              done
+              false Too many retries
+            done
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              cmd='pkg install -y cmake-core ninja'
+              sudo pkg install -y cmake-core ninja
             else
-              cmd='pkg install -y autoconf automake gettext libtool'
+              sudo pkg install -y autoconf automake gettext libtool
             fi
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            cmd="mport -q install cmake-core ninja | grep -E '(Downloading.+100|Installing)' || true"
+            sudo mport -q install cmake-core ninja | grep -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
-            cmd='pkgin -y install cmake ninja-build'
+            sudo pkgin -y install cmake ninja-build
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
             # https://www.openbsd.org/faq/faq15.html
-            cmd='pkg_add cmake ninja'
+            sudo pkg_add cmake ninja
           fi
-          # shellcheck disable=SC2181
-          while [ $? = 0 ]; do
-            for i in 1 2 3; do
-              if sudo $cmd; then
-                break 2
-              else
-                echo "Error: wait to try again: $i"
-                sleep 10
-              fi
-            done
-            false Too many retries
-          done
 
       - name: 'autoreconf'
         if: ${{ matrix.build == 'autotools' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1097,16 +1097,17 @@ jobs:
       CC: '${{ matrix.cc }}'
       MAKEFLAGS: -j 3
       MATRIX_BUILD: '${{ matrix.build }}'
+      MATRIX_CRYPTO: '${{ matrix.crypto }}'
       MATRIX_OS: '${{ matrix.os }}'
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests' }
-          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl' }
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls !runtests' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc'  , desc: 'openssl !runtests' }
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl !runtests' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests' }
+          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', crypto: 'openssl', desc: 'openssl' }
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL', desc: 'gnutls !runtests' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , crypto: 'OpenSSL', desc: 'openssl !runtests' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc'  , crypto: 'OpenSSL', desc: 'openssl !runtests' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL', desc: 'libressl !runtests' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1116,7 +1117,7 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_BUILD MATRIX_OS'
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_BUILD MATRIX_CRYPTO MATRIX_OS'
           operating_system: '${{ matrix.os }}'
           version: '${{ matrix.version }}'
           architecture: '${{ matrix.arch }}'
@@ -1127,7 +1128,7 @@ jobs:
             # shellcheck disable=SC2181
             while [ $? = 0 ]; do
               for i in 1 2 3; do
-                if sudo pkg install -y autoconf automake libtool; then
+                if sudo pkg install -y autoconf automake libtool libgcrypt; then
                   break 2
                 else
                   echo "Error: wait to try again: $i"
@@ -1167,14 +1168,14 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DENABLE_WERROR=ON \
               -DENABLE_DEBUG_LOGGING=ON \
-              -DCRYPTO_BACKEND=OpenSSL \
+              -DCRYPTO_BACKEND=${MATRIX_CRYPTO} \
               -DBUILD_STATIC_LIBS=OFF \
               -DRUN_DOCKER_TESTS=OFF \
               -DRUN_SSHD_TESTS=OFF
           else
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
-              --with-crypto=openssl \
+              --with-crypto=${MATRIX_CRYPTO} \
               --disable-docker-tests \
               --disable-dependency-tracking
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1102,20 +1102,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc',
-              desc: 'libgcrypt !runtests', options: '--with-crypto=libgcrypt --with-libgcrypt-prefix=/usr/local' }
-          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang',
-              desc: 'openssl'            , options: '--with-crypto=openssl' }
-          - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang',
-              desc: 'openssl !runtests'  , options: '-DCRYPTO_BACKEND=OpenSSL' }
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang',
-              desc: 'gnutls !runtests'   , options: '-DCRYPTO_BACKEND=OpenSSL' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc',
-              desc: 'openssl !runtests'  , options: '-DCRYPTO_BACKEND=OpenSSL' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc',
-              desc: 'openssl !runtests'  , options: '-DCRYPTO_BACKEND=OpenSSL' }
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang',
-              desc: 'libressl !runtests' , options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'libgcrypt !runtests',
+              options: '--with-crypto=libgcrypt --with-libgcrypt-prefix=/usr/local' }
+          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
+              options: '--with-crypto=openssl' }
+          - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl !runtests',
+              options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls !runtests',
+              options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests',
+              options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc'  , desc: 'openssl !runtests',
+              options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl !runtests',
+              options: '-DCRYPTO_BACKEND=OpenSSL' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1087,7 +1087,7 @@ jobs:
           fi
 
   build_netbsd:
-    name: 'NetBSD (CM, openssl, clang)'
+    name: 'NetBSD (CM, openssl, gcc)'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1098,11 +1098,12 @@ jobs:
       MAKEFLAGS: -j 3
       MATRIX_BUILD: '${{ matrix.build }}'
       MATRIX_CRYPTO: '${{ matrix.crypto }}'
+      MATRIX_OPTIONS: '${{ matrix.options }}'
       MATRIX_OS: '${{ matrix.os }}'
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests', options: '--with-crypto=/usr/local' }
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', crypto: 'openssl', desc: 'openssl' }
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL', desc: 'gnutls !runtests' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , crypto: 'OpenSSL', desc: 'openssl !runtests' }
@@ -1117,7 +1118,7 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_BUILD MATRIX_CRYPTO MATRIX_OS'
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_BUILD MATRIX_CRYPTO MATRIX_OPTIONS MATRIX_OS'
           operating_system: '${{ matrix.os }}'
           version: '${{ matrix.version }}'
           architecture: '${{ matrix.arch }}'
@@ -1171,13 +1172,15 @@ jobs:
               -DCRYPTO_BACKEND=${MATRIX_CRYPTO} \
               -DBUILD_STATIC_LIBS=OFF \
               -DRUN_DOCKER_TESTS=OFF \
-              -DRUN_SSHD_TESTS=OFF
+              -DRUN_SSHD_TESTS=OFF \
+              ${MATRIX_OPTIONS}
           else
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               --with-crypto=${MATRIX_CRYPTO} \
               --disable-docker-tests \
-              --disable-dependency-tracking
+              --disable-dependency-tracking \
+              ${MATRIX_OPTIONS}
           fi
 
       - name: 'configure log'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,7 +1103,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests', options: '--with-libgcrypt-prefix=/usr/local' }
+         - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests', 
+              options: '--with-libgcrypt-prefix=/usr/local' }
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', crypto: 'openssl', desc: 'openssl' }
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL', desc: 'gnutls !runtests' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , crypto: 'OpenSSL', desc: 'openssl !runtests' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,13 +1103,14 @@ jobs:
     strategy:
       matrix:
         include:
-         - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests', 
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests',
               options: '--with-libgcrypt-prefix=/usr/local' }
-          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', crypto: 'openssl', desc: 'openssl' }
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL', desc: 'gnutls !runtests' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , crypto: 'OpenSSL', desc: 'openssl !runtests' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc'  , crypto: 'OpenSSL', desc: 'openssl !runtests' }
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL', desc: 'libressl !runtests' }
+          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', crypto: 'openssl'  , desc: 'openssl' }
+          - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', crypto: 'openssl'  , desc: 'openssl !runtests' }
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL'  , desc: 'gnutls !runtests' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , crypto: 'OpenSSL'  , desc: 'openssl !runtests' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc'  , crypto: 'OpenSSL'  , desc: 'openssl !runtests' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL'  , desc: 'libressl !runtests' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1127,38 +1128,39 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            # shellcheck disable=SC2181
-            while [ $? = 0 ]; do
-              for i in 1 2 3; do
-                # https://github.com/DragonFlyBSD/DPorts
-                if sudo pkg install -y autoconf automake libtool libgcrypt; then
-                  break 2
-                else
-                  echo "Error: wait to try again: $i"
-                  sleep 10
-                fi
-              done
-              false Too many retries
-            done
+            # https://github.com/DragonFlyBSD/DPorts
+            cmd='pkg install -y autoconf automake libtool libgcrypt'
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              sudo pkg install -y cmake-core ninja
+              cmd='pkg install -y cmake-core ninja'
             else
-              sudo pkg install -y autoconf automake gettext libtool
+              cmd='pkg install -y autoconf automake gettext libtool'
             fi
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            sudo mport -q install cmake-core ninja | grep -E '(Downloading.+100|Installing)' || true
+            cmd="mport -q install cmake-core ninja | grep -E '(Downloading.+100|Installing)' || true"
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake ninja-build
+            cmd='pkgin -y install cmake ninja-build'
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
             # https://www.openbsd.org/faq/faq15.html
-            sudo pkg_add cmake ninja
+            cmd='pkg_add cmake ninja'
           fi
+          # shellcheck disable=SC2181
+          while [ $? = 0 ]; do
+            for i in 1 2 3; do
+              if sudo $cmd; then
+                break 2
+              else
+                echo "Error: wait to try again: $i"
+                sleep 10
+              fi
+            done
+            false Too many retries
+          done
 
       - name: 'autoreconf'
         if: ${{ matrix.build == 'autotools' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1133,19 +1133,8 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            # shellcheck disable=SC2181
-            while [ $? = 0 ]; do
-              for i in 1 2 3; do
-                # https://github.com/DragonFlyBSD/DPorts
-                if sudo pkg install -y autoconf automake libtool libgcrypt; then
-                  break 2
-                else
-                  echo "Error: wait to try again: $i"
-                  sleep 10
-                fi
-              done
-              false Too many retries
-            done
+            # https://github.com/DragonFlyBSD/DPorts
+            sudo pkg install -y autoconf automake libtool libgcrypt
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1097,7 +1097,6 @@ jobs:
       CC: '${{ matrix.cc }}'
       MAKEFLAGS: -j 3
       MATRIX_BUILD: '${{ matrix.build }}'
-      MATRIX_CRYPTO: '${{ matrix.crypto }}'
       MATRIX_OPTIONS: '${{ matrix.options }}'
       MATRIX_OS: '${{ matrix.os }}'
     strategy:
@@ -1126,7 +1125,7 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_BUILD MATRIX_CRYPTO MATRIX_OPTIONS MATRIX_OS'
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_BUILD MATRIX_OPTIONS MATRIX_OS'
           operating_system: '${{ matrix.os }}'
           version: '${{ matrix.version }}'
           architecture: '${{ matrix.arch }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1086,60 +1086,73 @@ jobs:
             make -C bld check V=1 || { cat bld/tests/*.log; false; }
           fi
 
-  build_netbsd:
-    name: 'NetBSD (CM, openssl, gcc)'
+  cross:
+    name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.cc }} ${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: cpa.sh {0}  # zizmor: ignore[misfeature]
+    env:
+      CC: '${{ matrix.cc }}'
+      MAKEFLAGS: -j 3
+      MATRIX_BUILD: '${{ matrix.build }}'
+      MATRIX_OS: '${{ matrix.os }}'
     strategy:
-      fail-fast: false
       matrix:
-        arch: ['x86_64', 'arm64']
+        include:
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests' }
+          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl' }
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls !runtests' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc'  , desc: 'openssl !runtests' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl !runtests' }
+      fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: 'cmake'
-        uses: cross-platform-actions/action@233156312992f3f169d8d0c633c21d12a5d30455 # v1.0.0
+
+      - name: 'setup VM'
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          operating_system: 'netbsd'
-          version: '10.1'
-          architecture: ${{ matrix.arch }}
-          run: |
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_BUILD MATRIX_OS'
+          operating_system: '${{ matrix.os }}'
+          version: '${{ matrix.version }}'
+          architecture: '${{ matrix.arch }}'
+
+      - name: 'install prereqs'
+        run: |
+          if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
+            sudo pkg install -y autoconf automake libtool
+          elif [ "${MATRIX_OS}" = 'freebsd' ]; then
+            # https://ports.freebsd.org/
+            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+              tools='cmake-core ninja'
+            else
+              tools='autoconf automake gettext libtool'
+            fi
+            sudo pkg install -y ${tools}
+          elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
+            # https://app.midnightbsd.org/
+            # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
+            sudo mport -q install cmake-core ninja | grep -E '(Downloading.+100|Installing)' || true
+          elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install cmake ninja-build
-            cmake -B bld -G Ninja \
-              -DCMAKE_UNITY_BUILD=ON \
-              -DENABLE_WERROR=ON \
-              -DENABLE_DEBUG_LOGGING=ON \
-              -DCRYPTO_BACKEND=OpenSSL \
-              -DBUILD_STATIC_LIBS=OFF \
-              -DRUN_DOCKER_TESTS=OFF \
-              -DRUN_SSHD_TESTS=OFF \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            cmake --build bld
-
-  build_openbsd:
-    name: 'OpenBSD (CM, libressl, clang)'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['x86_64']
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: 'cmake'
-        uses: cross-platform-actions/action@233156312992f3f169d8d0c633c21d12a5d30455 # v1.0.0
-        with:
-          operating_system: 'openbsd'
-          version: '7.7'
-          architecture: ${{ matrix.arch }}
-          run: |
+          elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
+            # https://www.openbsd.org/faq/faq15.html
             sudo pkg_add cmake ninja
-            pkg_info || true
+          fi
+
+      - name: 'autoreconf'
+        if: ${{ matrix.build == 'autotools' }}
+        run: autoreconf -fi
+
+      - name: 'configure'
+        run: |
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON \
               -DENABLE_WERROR=ON \
@@ -1147,40 +1160,36 @@ jobs:
               -DCRYPTO_BACKEND=OpenSSL \
               -DBUILD_STATIC_LIBS=OFF \
               -DRUN_DOCKER_TESTS=OFF \
-              -DRUN_SSHD_TESTS=OFF \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            cmake --build bld
-
-  build_freebsd:
-    name: 'FreeBSD (AM, openssl, clang)'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      CC: clang
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['x86_64']
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: 'autotools'
-        uses: cross-platform-actions/action@233156312992f3f169d8d0c633c21d12a5d30455 # v1.0.0
-        with:
-          operating_system: 'freebsd'
-          version: '14.3'
-          architecture: ${{ matrix.arch }}
-          environment_variables: 'CC'
-          run: |
-            # https://ports.freebsd.org/
-            sudo pkg install -y autoconf automake gettext libtool
-            autoreconf -fi
+              -DRUN_SSHD_TESTS=OFF
+          else
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               --with-crypto=openssl \
               --disable-docker-tests \
-              --disable-dependency-tracking \
-              || { tail -n 1000 config.log; false; }
-            make -j3
+              --disable-dependency-tracking
+          fi
+
+      - name: 'configure log'
+        if: ${{ !cancelled() }}
+        run: cat bld/config.log bld/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+
+      - name: 'build'
+        run: |
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake --build bld
+          else
+            make -C bld
+          fi
+
+      - name: 'run tests'
+        if: ${{ matrix.arch == 'x86_64' && !contains(matrix.desc, '!runtests') }}  # Slow on emulated CPU
+        run: |
+          export TFLAGS='-j8'
+          if [ "${MATRIX_OS}" = 'openbsd' ]; then
+            TFLAGS="$TFLAGS !2707"  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
+          fi
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake --build bld --verbose --target test-ci
+          else
             make check V=1 || { cat tests/*.log; false; }
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1129,6 +1129,7 @@ jobs:
             # shellcheck disable=SC2181
             while [ $? = 0 ]; do
               for i in 1 2 3; do
+                # https://github.com/DragonFlyBSD/DPorts
                 if sudo pkg install -y autoconf automake libtool libgcrypt; then
                   break 2
                 else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1124,7 +1124,18 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            sudo pkg install -y autoconf automake libtool
+            # shellcheck disable=SC2181
+            while [[ $? == 0 ]]; do
+              for i in 1 2 3; do
+                if sudo pkg install -y autoconf automake libtool; then
+                  break 2
+                else
+                  echo "Error: wait to try again: $i"
+                  sleep 10
+                fi
+              done
+              false Too many retries
+            done
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1128,11 +1128,10 @@ jobs:
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              tools='cmake-core ninja'
+              sudo pkg install -y cmake-core ninja
             else
-              tools='autoconf automake gettext libtool'
+              sudo pkg install -y autoconf automake gettext libtool
             fi
-            sudo pkg install -y ${tools}
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,7 +1103,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests', options: '--with-crypto-prefix=/usr/local' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests', options: '--with-libgcrypt-prefix=/usr/local' }
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', crypto: 'openssl', desc: 'openssl' }
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL', desc: 'gnutls !runtests' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , crypto: 'OpenSSL', desc: 'openssl !runtests' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,14 +1103,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , crypto: 'libgcrypt', desc: 'libgcrypt !runtests',
-              options: '--with-libgcrypt-prefix=/usr/local' }
-          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', crypto: 'openssl'  , desc: 'openssl' }
-          - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', crypto: 'openssl'  , desc: 'openssl !runtests' }
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL'  , desc: 'gnutls !runtests' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , crypto: 'OpenSSL'  , desc: 'openssl !runtests' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc'  , crypto: 'OpenSSL'  , desc: 'openssl !runtests' }
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', crypto: 'OpenSSL'  , desc: 'libressl !runtests' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc',
+              desc: 'libgcrypt !runtests', options: '--with-crypto=libgcrypt --with-libgcrypt-prefix=/usr/local' }
+          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang',
+              desc: 'openssl'            , options: '--with-crypto=openssl' }
+          - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang',
+              desc: 'openssl !runtests'  , options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang',
+              desc: 'gnutls !runtests'   , options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc',
+              desc: 'openssl !runtests'  , options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc',
+              desc: 'openssl !runtests'  , options: '-DCRYPTO_BACKEND=OpenSSL' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang',
+              desc: 'libressl !runtests' , options: '-DCRYPTO_BACKEND=OpenSSL' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1172,7 +1178,6 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DENABLE_WERROR=ON \
               -DENABLE_DEBUG_LOGGING=ON \
-              -DCRYPTO_BACKEND=${MATRIX_CRYPTO} \
               -DBUILD_STATIC_LIBS=OFF \
               -DRUN_DOCKER_TESTS=OFF \
               -DRUN_SSHD_TESTS=OFF \
@@ -1180,7 +1185,6 @@ jobs:
           else
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
-              --with-crypto=${MATRIX_CRYPTO} \
               --disable-docker-tests \
               --disable-dependency-tracking \
               ${MATRIX_OPTIONS}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1201,5 +1201,5 @@ jobs:
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target test-ci
           else
-            make check V=1 || { cat tests/*.log; false; }
+            make -C bld check V=1 || { cat tests/*.log; false; }
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1125,7 +1125,7 @@ jobs:
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
             # shellcheck disable=SC2181
-            while [[ $? == 0 ]]; do
+            while [ $? = 0 ]; do
               for i in 1 2 3; do
                 if sudo pkg install -y autoconf automake libtool; then
                   break 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1102,8 +1102,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'libgcrypt !runtests',
-              options: '--with-crypto=libgcrypt --with-libgcrypt-prefix=/usr/local' }
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               options: '--with-crypto=openssl' }
           - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl !runtests',


### PR DESCRIPTION
- bump cross-platform-actions to v1.1.0.
- merge separate BSD jobs into a single one with matrix.
- split job steps into ones used in other jobs.
- add MidnightBSD to the matrix.
- bump Intel FreeBSD job from v14.3 to v15.0.
- add FreeBSD arm64 cmake job, with v14.3 for good perf.
- also tried DragonFlyBSD (with Libgcrypt), but its package server 
  turned out to be unreliable, even with retries.
  https://github.com/libssh2/libssh2/actions/runs/26153190559/job/76925798213?pr=1948
