### PR TITLE
Extend event callbacks

### DIFF
--- a/docs/libssh2_channel_abstract.md
+++ b/docs/libssh2_channel_abstract.md
@@ -1,0 +1,32 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_channel_close
+Section: 3
+Source: libssh2
+See-also:
+---
+
+# NAME
+
+libssh2_channel_abstract - get the current abstract value associated with a channel.
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+void**
+libssh2_channel_abstract(LIBSSH2_CHANNEL *channel);
+~~~
+
+# DESCRIPTION
+
+*channel* - active channel stream to get a reference of the abstract value.
+
+
+# RETURN VALUE
+
+Returns a reference address of the abstract of a channel; allowing potentially 
+overriding the existing value with a new value.
+

--- a/docs/libssh2_channel_callback_set.md
+++ b/docs/libssh2_channel_callback_set.md
@@ -1,0 +1,87 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_session_callback_set
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_session_callback_set2(3)
+  - libssh2_listener_callback_set(3)
+---
+
+# NAME
+
+libssh2_channel_callback_set - set a callback function on a channel
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+libssh2_cb_generic *
+libssh2_channel_callback_set(LIBSSH2_CHANNEL *channel,
+                             enum LIBSSH2_CHANNEL_CALLBACKS cbtype, libssh2_cb_generic *callback);
+~~~
+
+# DESCRIPTION
+
+Sets a custom callback handler for a previously initialized session
+object. Callbacks are triggered by the receipt of special packets related to a channel layer. 
+To disable a callback, set it to NULL.
+
+# RETURN VALUE
+
+Pointer to previous callback handler. Returns NULL if no prior callback
+handler was set or the callback type was unknown.
+
+# CALLBACK TYPES
+
+`enum LIBSSH_CHANNEL_CALLBACKS` contains the following values:
+
+## LIBSSH2_CHANNEL_EOF
+
+Channel has process an end of file, the channel's stream is set to end of file before 
+this is called.
+
+The prototype of the callback:
+
+```c
+void eof_callback(LIBSSH2_SESSION *session, void **session_abstract, 
+                  LIBSSH2_CHANNEL *channel, void **channel_abstract ) {
+}
+```
+
+## LIBSSH2_CHANNEL_CLOSE
+
+Channel has processed a close, and is no longer open by the time this callback is implemented.
+Do not use this channel after this event.
+
+
+The prototype of the callback:
+
+```c
+void close_callback(LIBSSH2_SESSION *session, void **session_abstract, 
+                  LIBSSH2_CHANNEL *channel, void **channel_abstract ) {
+}
+```
+
+
+## LIBSSH2_CHANNEL_DATA
+
+Channel has received a data packet.  This is typically forwarded to the application layer to
+handle the channel data received.
+
+Stream is 0 or 1 for `stdout`/`stderr`, but depending on options, 
+`stderr` may be merged into `stdout`
+
+The prototype of the callback:
+
+```c
+void channel_data_callback(LIBSSH2_SESSION *session, void **session_abstract,
+          LIBSSH2_CHANNEL *channel, void **channel_abstract
+          int stream,
+          uint8_t const *buffer,
+          size_t length
+          );
+```
+

--- a/docs/libssh2_listener_abstract.md
+++ b/docs/libssh2_listener_abstract.md
@@ -1,0 +1,32 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_channel_close
+Section: 3
+Source: libssh2
+See-also:
+---
+
+# NAME
+
+libssh2_listener_abstract - get the current abstract value associated with a listener.
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+void**
+libssh2_listener_abstract(LIBSSH2_LISTENER *listener);
+~~~
+
+# DESCRIPTION
+
+*listener* - active remote socket listener to get a reference of the abstract value.
+
+
+# RETURN VALUE
+
+Returns a reference address of the abstract of a listener; allowing potentially 
+overriding the existing value with a new value.
+

--- a/docs/libssh2_listener_callback_set.md
+++ b/docs/libssh2_listener_callback_set.md
@@ -1,0 +1,55 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_session_callback_set
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_session_callback_set2(3)
+  - libssh2_channel_callback_set(3)
+---
+
+# NAME
+
+libssh2_listener_callback_set - set a callback function
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+libssh2_cb_generic *
+libssh2_listener_callback_set(LIBSSH2_SESSION *session,
+                             enum LIBSSH2_LISTENER_CALLBACKS cbtype, libssh2_cb_generic *callback);
+~~~
+
+# DESCRIPTION
+
+Sets a custom callback handler for a previously initialized session
+object. Callbacks are triggered by the receipt of special packets related to a channel layer. 
+To disable a callback, set it to NULL.
+
+# RETURN VALUE
+
+Pointer to previous callback handler. Returns NULL if no prior callback
+handler was set or the callback type was unknown.
+
+
+# CALLBACK TYPES
+
+`enum LIBSSH_CHANNEL_CALLBACKS` contains the following values:
+
+## LIBSSH2_CALLBACK_LISTENER_ACCEPT
+
+A remote socket has accepted a connection, this event passes the newly created
+channel to the callback.
+
+The prototype of the callback:
+
+~~~c
+void listener_accept_callback(LIBSSH2_SESSION *session,    void**session_abstract
+                             , LIBSSH2_LISTENER *listener, void **listener_abstract
+                             , LIBSSH2_CHANNEL* channel  ) {
+}
+~~~
+

--- a/docs/libssh2_read.md
+++ b/docs/libssh2_read.md
@@ -1,0 +1,34 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_read
+Section: 3
+Source: libssh2
+See-also:
+---
+
+# NAME
+
+libssh2_read - trigger any activity on a session.
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+int
+libssh2_read(LIBSSH2_SESSION *session);
+~~~
+
+# DESCRIPTION
+
+Collect a packet into the input queue.  When using event callbacks, this will trigger 
+any queued events, possibly just
+stepping internal states, which create more data to write at the libssh2 level, beyond
+what the application layer cares about.
+
+# RETURN VALUE
+
+Returns packet type added to input queue (0 if nothing added), or a
+negative error number.
+

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -324,6 +324,22 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
     void (name)(LIBSSH2_SESSION *session, void **session_abstract, \
                 LIBSSH2_CHANNEL *channel, void **channel_abstract)
 
+#define LIBSSH2_LISTENER_CONNECT_FUNC(name) \
+    void (name)(LIBSSH2_SESSION *session, void**session_abstract, \
+                LIBSSH2_LISTENER *listener, void **listener_abstract, \
+                LIBSSH2_CHANNEL* channel )
+
+#define LIBSSH2_CHANNEL_EOF_FUNC(name) \
+    void (name)(LIBSSH2_SESSION *session, void **session_abstract, \
+                LIBSSH2_CHANNEL *channel, void **channel_abstract)
+              
+#define LIBSSH2_CHANNEL_DATA_FUNC(name) \
+    void (name)(LIBSSH2_SESSION*session, void **session_abstract, \
+                LIBSSH2_CHANNEL*channel, void **channel_abstract, \
+                int stream,              \
+                const uint8_t*buffer,       \
+                size_t length)
+
 /* I/O callbacks */
 #define LIBSSH2_RECV_FUNC(name)                                         \
     ssize_t (name)(libssh2_socket_t socket,                             \
@@ -363,6 +379,14 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
 #define LIBSSH2_FLAG_SIGPIPE        1
 #define LIBSSH2_FLAG_COMPRESS       2
 #define LIBSSH2_FLAG_QUOTE_PATHS    3
+
+/* libssh2_channel_callback_set() constant */
+#define LIBSSH2_CALLBACK_CHANNEL_EOF   0
+#define LIBSSH2_CALLBACK_CHANNEL_CLOSE 1
+#define LIBSSH2_CALLBACK_CHANNEL_DATA  2
+
+/* libssh2_listener_callback_set() constant */
+#define LIBSSH2_CALLBACK_LISTENER_ACCEPT 0
 
 typedef struct _LIBSSH2_SESSION                     LIBSSH2_SESSION;
 typedef struct _LIBSSH2_CHANNEL                     LIBSSH2_CHANNEL;
@@ -765,6 +789,9 @@ LIBSSH2_API int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds,
                              long timeout);
 #endif
 
+/* External read of any pending transport queued messages */
+LIBSSH2_API int libssh2_read( LIBSSH2_SESSION *session );
+
 /* Channel API */
 #define LIBSSH2_CHANNEL_WINDOW_DEFAULT  (2*1024*1024)
 #define LIBSSH2_CHANNEL_PACKET_DEFAULT  32768
@@ -791,6 +818,18 @@ libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *channel_type,
                             LIBSSH2_CHANNEL_WINDOW_DEFAULT, \
                             LIBSSH2_CHANNEL_PACKET_DEFAULT, NULL, 0)
 
+/* Set callback function on channels */
+LIBSSH2_API libssh2_cb_generic*
+libssh2_channel_callback_set( LIBSSH2_CHANNEL* channel,
+    int cbtype,
+    libssh2_cb_generic* callback );
+
+/*
+ * gets the reference to abstract user data pointer from a channel;
+ * This allows changing the abstract user data content.
+ */
+LIBSSH2_API void** libssh2_channel_abstract( LIBSSH2_CHANNEL* channel );
+
 LIBSSH2_API LIBSSH2_CHANNEL *
 libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session, const char *host,
                                 int port, const char *shost, int sport);
@@ -808,6 +847,17 @@ libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session, const char *host,
                                   int queue_maxsize);
 #define libssh2_channel_forward_listen(session, port) \
     libssh2_channel_forward_listen_ex(session, NULL, port, NULL, 16)
+
+/* Set callback function on listener */
+LIBSSH2_API libssh2_cb_generic* libssh2_listener_callback_set( LIBSSH2_LISTENER* listener,
+	int cbtype,
+	libssh2_cb_generic* callback );
+
+/*
+ * gets the reference to abstract user data pointer from a listener;
+ * This allows changing the abstract user data content.
+ */
+LIBSSH2_API void** libssh2_listener_abstract( LIBSSH2_LISTENER* listener );
 
 LIBSSH2_API int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,10 +57,12 @@ endif()
 option(ENABLE_ZLIB_COMPRESSION "Use zlib for compression" OFF)
 add_feature_info("Compression" ENABLE_ZLIB_COMPRESSION "using zlib for compression")
 if(ENABLE_ZLIB_COMPRESSION)
-  find_package(ZLIB REQUIRED)
+  list(APPEND libssh2_INCLUDE_DIRS ../../zlib-1.3)
+  list(APPEND libssh2_DEFINITIONS "LIBSSH2_HAVE_ZLIB")
+  #find_package(ZLIB REQUIRED)
 
-  list(APPEND LIBSSH2_LIBS ZLIB::ZLIB)
-  list(APPEND _libssh2_definitions "LIBSSH2_HAVE_ZLIB")
+  #list(APPEND LIBSSH2_LIBS ZLIB::ZLIB)
+  #list(APPEND _libssh2_definitions "LIBSSH2_HAVE_ZLIB")
 endif()
 
 list(APPEND LIBSSH2_LIBS ${LIBSSH2_LIBS_SOCKET})
@@ -148,7 +150,9 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_SELECTED})
+if(NOT ${LIB_NAME} STREQUAL ${LIB_SELECTED} )
 add_library(${LIB_NAME} ALIAS ${LIB_SELECTED})
+endif()
 
 ## Installation
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -691,6 +691,21 @@ LIBSSH2_LISTENER *libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session,
     return ptr;
 }
 
+LIBSSH2_API void** libssh2_listener_abstract( LIBSSH2_LISTENER* listener ) {
+    return &listener->abstract;
+}
+
+LIBSSH2_API libssh2_cb_generic* libssh2_listener_callback_set( LIBSSH2_LISTENER* listener, enum LIBSSH2_LISTENER_CALLBACKS callback, libssh2_cb_generic* f ) {
+    libssh2_cb_generic* oldFunc = NULL;
+    switch( callback ) {
+    case LIBSSH2_CALLBACK_LISTENER_ACCEPT:
+        oldFunc = (libssh2_cb_generic*)listener->connect_cb;
+        listener->connect_cb = ( LIBSSH2_LISTERNER_CONNECT_FUNC( ( * ) ) )f;
+        break;
+    }
+    return oldFunc;
+}
+
 /*
  * Stop listening on a remote port and free the listener
  * Toss out any pending (un-accept()ed) connections
@@ -3006,4 +3021,38 @@ int libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
     BLOCK_ADJUST(rc, channel->session,
                  channel_signal(channel, signame, signame_len));
     return rc;
+}
+
+void** libssh2_channel_abstract( LIBSSH2_CHANNEL* channel ) {
+    return &channel->abstract;
+}
+
+libssh2_cb_generic*
+libssh2_channel_callback_set( LIBSSH2_CHANNEL *channel,
+                              enum LIBSSH2_CHANNEL_CALLBACKS cbtype,
+                              libssh2_cb_generic* callback)
+{
+    libssh2_cb_generic* oldcb;
+
+    if(!channel)
+        return NULL;
+
+    switch(cbtype) {
+    case LIBSSH2_CALLBACK_CHANNEL_EOF:
+        oldcb = (libssh2_cb_generic*)channel->close_cb;
+        channel->eof_cb = (LIBSSH2_CHANNEL_EOF_FUNC((*)))callback;
+        break;
+    case LIBSSH2_CALLBACK_CHANNEL_CLOSE:
+        oldcb = (libssh2_cb_generic*)channel->close_cb;
+        channel->close_cb = (LIBSSH2_CHANNEL_CLOSE_FUNC((*)))callback;
+        break;
+    case LIBSSH2_CALLBACK_CHANNEL_DATA:
+        oldcb = (libssh2_cb_generic*)channel->data_cb;
+        channel->data_cb = (LIBSSH2_CHANNEL_DATA_FUNC((*)))callback;
+        break;
+    default:
+        return NULL;
+    }
+
+    return oldcb;
 }

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -276,6 +276,16 @@ struct iovec {
 #define LIBSSH2_CHANNEL_CLOSE(session, channel) \
     channel->close_cb(session, &(session)->abstract, \
                       channel, &(channel)->abstract)
+#define LIBSSH2_CHANNEL_EOF(session, channel) \
+    channel->eof_cb(session, &(session)->abstract, \
+                    channel, &(channel)->abstract) 
+#define LIBSSH2_CHANNEL_DATA(session, channel, stream, buffer, length) \
+    channel->data_cb(session, &(session)->abstract, \
+                     channel, &(channel)->abstract, stream, buffer, length)
+
+#define LIBSSH2_LISTENER_CONNECT(session, listener, channel) \
+    listener->connect_cb(session, &(session)->abstract, \
+                         listener, &(listener)->abstract, channel)
 
 #define LIBSSH2_SEND_FD(session, fd, buffer, length, flags) \
     ((session)->send)(fd, buffer, length, flags, &(session)->abstract)
@@ -463,6 +473,9 @@ struct _LIBSSH2_CHANNEL {
     LIBSSH2_SESSION *session;
 
     void *abstract;
+    
+    LIBSSH2_CHANNEL_DATA_FUNC(*data_cb);
+    LIBSSH2_CHANNEL_EOF_FUNC(*eof_cb);
     LIBSSH2_CHANNEL_CLOSE_FUNC(*close_cb);
 
     /* State variables used in libssh2_channel_setenv_ex() */
@@ -563,6 +576,9 @@ struct _LIBSSH2_LISTENER {
     libssh2_nonblocking_states chanFwdCncl_state;
     unsigned char *chanFwdCncl_data;
     size_t chanFwdCncl_data_len;
+
+    void* abstract;
+    LIBSSH2_LISTENER_CONNECT_FUNC((*connect_cb));
 };
 
 struct endpoint_data {

--- a/src/packet.c
+++ b/src/packet.c
@@ -232,9 +232,16 @@ static inline int packet_queue_listener(
 
                     /* Link the channel into the end of the queue list */
                     if(listen_state->channel) {
-                        _libssh2_list_add(&listn->queue,
-                                          &listen_state->channel->node);
-                        listn->queue_size++;
+                        if(listn->connect_cb) {
+                            /* add channel to session's channel list */
+                            // with callback then channel_forward_accept() doesn't need to be called, so just do the work it did.
+                            _libssh2_list_add( &channel->session->channels, &channel->node );
+                            LIBSSH2_LISTENER_CONNECT( session, listn, channel );
+                        } else {
+                            _libssh2_list_add( &listn->queue,
+                                &listen_state->channel->node );
+                            listn->queue_size++;
+                        }
                     }
 
                     listen_state->state = libssh2_NB_state_idle;
@@ -1111,6 +1118,9 @@ libssh2_packet_add_jump_point1:
                                 channelp->local.id,
                                 channelp->remote.id));
                 channelp->remote.eof = 1;
+                /* post event callback, after channel set to eof state */
+                if(channelp->eof_cb)
+                    LIBSSH2_CHANNEL_EOF( session, channelp );
             }
             LIBSSH2_FREE(session, data);
             session->packAdd_state = libssh2_NB_state_idle;
@@ -1276,7 +1286,9 @@ clean_exit:
 
             channelp->remote.close = 1;
             channelp->remote.eof = 1;
-
+            if(channelp->close_cb)
+                LIBSSH2_CHANNEL_CLOSE( session, channelp );
+ 
             LIBSSH2_FREE(session, data);
             session->packAdd_state = libssh2_NB_state_idle;
             return 0;
@@ -1398,7 +1410,33 @@ libssh2_packet_add_jump_authagent:
         packetp->data_len = datalen;
         packetp->data_head = data_head;
 
-        _libssh2_list_add(&session->packets, &packetp->node);
+        int rc_cb = 0;
+        if( channelp && channelp->data_cb )
+            if( channelp->close_state == libssh2_NB_state_idle ) { /* not closed... */
+                if( ( data[0] == SSH_MSG_CHANNEL_DATA ) || ( data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA ) ) {
+                    /*
+                     * If the packet is channel data, send as default stdin stream.
+                     * if it's extended data, send as stderr stream if the stream id
+                     *    is SSH_EXTENDED_DATA_STDERR, otherwise send as stream id
+                     */
+                    if( ( data[0] == SSH_MSG_CHANNEL_DATA ) ) {
+                        LIBSSH2_CHANNEL_DATA( session, channelp, 0, data + data_head, datalen - data_head );
+                    } else if( ( data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA ) ) {
+                        uint32_t sid = _libssh2_ntohu32( data + 5 );
+                        if( ( sid == SSH_EXTENDED_DATA_STDERR ) ) {
+                            LIBSSH2_CHANNEL_DATA( session, channelp, 1, data + data_head, datalen - data_head );
+                        }  if( ( channelp->remote.extended_data_ignore_mode ==
+                            LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE ) ) {
+                            LIBSSH2_CHANNEL_DATA( session, channelp, sid, data + data_head, datalen - data_head );
+                        }
+                    }
+                    rc_cb = 1;
+                }
+            }
+        /* default action, post to packet queue, otherwise it was already consumed */
+        if( !rc_cb )
+            _libssh2_list_add(&session->packets, &packetp->node);
+        else LIBSSH2_FREE( session, packetp );
 
         session->packAdd_state = libssh2_NB_state_sent1;
     }

--- a/src/transport.c
+++ b/src/transport.c
@@ -974,6 +974,10 @@ static int send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
     return rc < length ? LIBSSH2_ERROR_EAGAIN : LIBSSH2_ERROR_NONE;
 }
 
+int libssh2_read( LIBSSH2_SESSION *session ) {
+    return _libssh2_transport_read( session );
+}
+
 /*
  * Send a packet, encrypting it and adding a MAC code if necessary
  * Returns 0 on success, non-zero on failure.


### PR DESCRIPTION
Adds callbacks to channels for EOF and data events; previously close was the only channel callback; and that callback was only used internally by the sftp module.

``` c
    sftp_handle->channel->abstract = sftp_handle;
    sftp_handle->channel->close_cb = libssh2_sftp_dtor;
```

Added similar registration of callbacks that sessions have.  Added a connect event on the listener, which dispatches a newly connected channel to a callback, which can then set the callbacks on that channel for itself.

Added markdown document pages for the new interfaces.  

