### PR TITLE
libssh2_sign_sk: add `LIBSSH2_API` attribute, document availability

### DIFF
--- a/docs/libssh2_sign_sk.md
+++ b/docs/libssh2_sign_sk.md
@@ -95,3 +95,7 @@ pass in the PIN, or a function pointer to retrieve the PIN.
 # RETURN VALUE
 
 Return 0 on success or negative on failure.
+
+# AVAILABILITY
+
+Added in libssh2 1.11.0

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -370,24 +370,6 @@ typedef struct _LIBSSH2_LISTENER                    LIBSSH2_LISTENER;
 typedef struct _LIBSSH2_KNOWNHOSTS                  LIBSSH2_KNOWNHOSTS;
 typedef struct _LIBSSH2_AGENT                       LIBSSH2_AGENT;
 
-/* SK signature callback */
-typedef struct _LIBSSH2_PRIVKEY_SK {
-    int algorithm;
-    uint8_t flags;
-    const char *application;
-    const unsigned char *key_handle;
-    size_t handle_len;
-    LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback);
-    void **orig_abstract;
-} LIBSSH2_PRIVKEY_SK;
-
-int libssh2_sign_sk(LIBSSH2_SESSION *session,
-                    unsigned char **sig,
-                    size_t *sig_len,
-                    const unsigned char *data,
-                    size_t data_len,
-                    void **abstract);
-
 #ifndef LIBSSH2_NO_DEPRECATED
 typedef struct _LIBSSH2_POLLFD {
     unsigned char type; /* LIBSSH2_POLLFD_* below */
@@ -757,6 +739,24 @@ LIBSSH2_API int libssh2_userauth_publickey_sk(
     const char *passphrase,
     LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback),
     void **abstract);
+
+/* SK signature callback */
+typedef struct _LIBSSH2_PRIVKEY_SK {
+    int algorithm;
+    uint8_t flags;
+    const char *application;
+    const unsigned char *key_handle;
+    size_t handle_len;
+    LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback);
+    void **orig_abstract;
+} LIBSSH2_PRIVKEY_SK;
+
+LIBSSH2_API int libssh2_sign_sk(LIBSSH2_SESSION *session,
+                                unsigned char **sig,
+                                size_t *sig_len,
+                                const unsigned char *data,
+                                size_t data_len,
+                                void **abstract);
 
 #ifndef LIBSSH2_NO_DEPRECATED
 LIBSSH2_DEPRECATED(1.2.0, "Use system poll() or select()")

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -752,10 +752,8 @@ typedef struct _LIBSSH2_PRIVKEY_SK {
 } LIBSSH2_PRIVKEY_SK;
 
 LIBSSH2_API int libssh2_sign_sk(LIBSSH2_SESSION *session,
-                                unsigned char **sig,
-                                size_t *sig_len,
-                                const unsigned char *data,
-                                size_t data_len,
+                                unsigned char **sig, size_t *sig_len,
+                                const unsigned char *data, size_t data_len,
                                 void **abstract);
 
 #ifndef LIBSSH2_NO_DEPRECATED

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -931,6 +931,7 @@ static int sign_fromfile(LIBSSH2_SESSION *session,
     return 0;
 }
 
+LIBSSH2_API
 int libssh2_sign_sk(LIBSSH2_SESSION *session,
                     unsigned char **sig, size_t *sig_len,
                     const unsigned char *data, size_t data_len,


### PR DESCRIPTION
Based on it having a public man page, it was likely meant to be a public
function. Mark it `LIBSSH2_API` to export it from the DLL on Windows.

Also move its public prototype next to userauth functions, since its 
implemented in userauth.c (though not using the namespace).

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698

---

/cc @MichaelBuckley 