### PR TITLE
docs: add missing man page for `libssh2_channel_signal()`

### DIFF
--- a/docs/Makefile.inc
+++ b/docs/Makefile.inc
@@ -53,6 +53,7 @@ man_MANS = \
   libssh2_channel_setenv.3 \
   libssh2_channel_setenv_ex.3 \
   libssh2_channel_shell.3 \
+  libssh2_channel_signal.3 \
   libssh2_channel_signal_ex.3 \
   libssh2_channel_subsystem.3 \
   libssh2_channel_wait_closed.3 \

--- a/docs/libssh2_channel_signal.md
+++ b/docs/libssh2_channel_signal.md
@@ -1,0 +1,36 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_channel_signal
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_channel_get_exit_signal(3)
+  - libssh2_channel_open_ex(3)
+  - libssh2_channel_signal_ex(3)
+---
+
+# NAME
+
+libssh2_channel_signal - convenience macro for *libssh2_channel_signal_ex(3)* calls
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+int libssh2_channel_signal(LIBSSH2_CHANNEL *channel, const char *signame)
+~~~
+
+# DESCRIPTION
+
+This is a macro defined in a public libssh2 header file that is using the
+underlying function *libssh2_channel_signal_ex(3)*.
+
+# RETURN VALUE
+
+See *libssh2_channel_signal_ex(3)*
+
+# AVAILABILITY
+
+Added in libssh2 1.11.0

--- a/docs/libssh2_channel_signal_ex.md
+++ b/docs/libssh2_channel_signal_ex.md
@@ -7,11 +7,12 @@ Source: libssh2
 See-also:
   - libssh2_channel_get_exit_signal(3)
   - libssh2_channel_open_ex(3)
+  - libssh2_channel_signal(3)
 ---
 
 # NAME
 
-libssh2_channel_signal_ex -- Send a signal to process previously opened on channel.
+libssh2_channel_signal_ex - Send a signal to process previously opened on channel.
 
 # SYNOPSIS
 
@@ -41,3 +42,7 @@ There is also a macro *libssh2_channel_signal(channel, signame)* that supplies t
 
 Normal channel error codes.
 LIBSSH2_ERROR_EAGAIN when it would block.
+
+# AVAILABILITY
+
+Added in libssh2 1.11.0


### PR DESCRIPTION
Also:
- add availability section.
- replace an emdash with single dash to sync with other pages.

Follow-up to a4544c0117867d5cc0830497b1626f810ccc0743 #672 #991
