### PR TITLE
os400: move return type inline, clang-format

### DIFF
--- a/os400/ccsid.c
+++ b/os400/ccsid.c
@@ -50,23 +50,23 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define CCSID_UTF8      1208
-#define CCSID_UTF16BE   13488
-#define STRING_GRANULE  256
-#define MAX_CHAR_SIZE   4
+#define CCSID_UTF8     1208
+#define CCSID_UTF16BE  13488
+#define STRING_GRANULE 256
+#define MAX_CHAR_SIZE  4
 
-#define OFFSET_OF(t, f) ((size_t) ((char *) &((t *) 0)->f - (char *) 0))
+#define OFFSET_OF(t, f) ((size_t)((char *)&((t *)0)->f - (char *)0))
 
-#define ALLOC(s, sz)        ((s) ? SSH2_ALLOC(s, sz) : malloc(sz))
-#define REALLOC(s, p, sz)   ((s) ? SSH2_REALLOC(s, p, sz) : realloc(p, sz))
-#define FREE(s, p)          ((s) ? SSH2_FREE(s, p) : free(p))
+#define ALLOC(s, sz)      ((s) ? SSH2_ALLOC(s, sz) : malloc(sz))
+#define REALLOC(s, p, sz) ((s) ? SSH2_REALLOC(s, p, sz) : realloc(p, sz))
+#define FREE(s, p)        ((s) ? SSH2_FREE(s, p) : free(p))
 
 struct _libssh2_string_cache {
-    libssh2_string_cache *  next;
-    char                    string[1];
+    libssh2_string_cache *next;
+    char string[1];
 };
 
-static const QtqCode_T  utf8code = { CCSID_UTF8 };
+static const QtqCode_T utf8code = { CCSID_UTF8 };
 
 static ssize_t terminator_size(unsigned short ccsid)
 {
@@ -91,9 +91,9 @@ static ssize_t terminator_size(unsigned short ccsid)
 
     /* Convert an UTF-8 NUL to the target CCSID: use the converted size as
        result. */
-    memset((void *) &outcode, 0, sizeof(outcode));
+    memset((void *)&outcode, 0, sizeof(outcode));
     outcode.CCSID = ccsid;
-    cd = QtqIconvOpen(&outcode, (QtqCode_T *) &utf8code);
+    cd = QtqIconvOpen(&outcode, (QtqCode_T *)&utf8code);
     if(cd.return_value == -1)
         return -1;
     inp = "";
@@ -106,10 +106,10 @@ static ssize_t terminator_size(unsigned short ccsid)
     return olen ? olen : -1;
 }
 
-static char *
-convert_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
-              unsigned short outccsid, unsigned short inccsid,
-              const char *instring, ssize_t inlen, size_t *outlen)
+static char *convert_ccsid(LIBSSH2_SESSION *session,
+                           libssh2_string_cache **cache,
+                           unsigned short outccsid, unsigned short inccsid,
+                           const char *instring, ssize_t inlen, size_t *outlen)
 {
     char *inp;
     char *outp;
@@ -141,12 +141,12 @@ convert_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
         return NULL;
 
     /* Prepare conversion parameters. */
-    memset((void *) &incode, 0, sizeof(incode));
-    memset((void *) &outcode, 0, sizeof(outcode));
+    memset((void *)&incode, 0, sizeof(incode));
+    memset((void *)&outcode, 0, sizeof(outcode));
     incode.CCSID = inccsid;
     outcode.CCSID = outccsid;
     curlen = OFFSET_OF(libssh2_string_cache, string);
-    inp = (char *) instring;
+    inp = (char *)instring;
     ilen = inlen;
     buflen = inlen + curlen;
     if(inlen < 0) {
@@ -208,7 +208,7 @@ convert_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
         dst = REALLOC(session, dst, curlen + termsize);
 
     /* Link to cache. */
-    outstring = (libssh2_string_cache *) dst;
+    outstring = (libssh2_string_cache *)dst;
     outstring->next = *cache;
     *cache = outstring;
 
@@ -219,34 +219,34 @@ convert_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
     return outstring->string;
 }
 
-LIBSSH2_API char *
-libssh2_from_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
-                   unsigned short ccsid, const char *string, ssize_t inlen,
-                   size_t *outlen)
+LIBSSH2_API
+char *libssh2_from_ccsid(LIBSSH2_SESSION *session,
+                         libssh2_string_cache **cache, unsigned short ccsid,
+                         const char *string, ssize_t inlen, size_t *outlen)
 {
-    return convert_ccsid(session, cache,
-                         CCSID_UTF8, ccsid, string, inlen, outlen);
+    return convert_ccsid(session, cache, CCSID_UTF8, ccsid, string, inlen,
+                         outlen);
 }
 
-LIBSSH2_API char *
-libssh2_to_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
-                 unsigned short ccsid, const char *string, ssize_t inlen,
-                 size_t *outlen)
+LIBSSH2_API
+char *libssh2_to_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
+                       unsigned short ccsid, const char *string, ssize_t inlen,
+                       size_t *outlen)
 {
-    return convert_ccsid(session, cache,
-                         ccsid, CCSID_UTF8, string, inlen, outlen);
+    return convert_ccsid(session, cache, ccsid, CCSID_UTF8, string, inlen,
+                         outlen);
 }
 
-LIBSSH2_API void
-libssh2_release_string_cache(LIBSSH2_SESSION *session,
-                             libssh2_string_cache **cache)
+LIBSSH2_API
+void libssh2_release_string_cache(LIBSSH2_SESSION *session,
+                                  libssh2_string_cache **cache)
 {
     libssh2_string_cache *p;
 
     if(cache)
         while((p = *cache)) {
             *cache = p->next;
-            FREE(session, (char *) p);
+            FREE(session, (char *)p);
         }
 }
 

--- a/os400/libssh2_ccsid.h
+++ b/os400/libssh2_ccsid.h
@@ -45,19 +45,18 @@
 
 #include "libssh2.h"
 
-typedef struct _libssh2_string_cache    libssh2_string_cache;
+typedef struct _libssh2_string_cache libssh2_string_cache;
 
-LIBSSH2_API char *
-libssh2_from_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
-                   unsigned short ccsid, const char *string, ssize_t inlen,
-                   size_t *outlen);
-LIBSSH2_API char *
-libssh2_to_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
-                 unsigned short ccsid, const char *string, ssize_t inlen,
-                 size_t *outlen);
-LIBSSH2_API void
-libssh2_release_string_cache(LIBSSH2_SESSION *session,
-                             libssh2_string_cache **cache);
+LIBSSH2_API char *libssh2_from_ccsid(LIBSSH2_SESSION *session,
+                                     libssh2_string_cache **cache,
+                                     unsigned short ccsid, const char *string,
+                                     ssize_t inlen, size_t *outlen);
+LIBSSH2_API char *libssh2_to_ccsid(LIBSSH2_SESSION *session,
+                                   libssh2_string_cache **cache,
+                                   unsigned short ccsid, const char *string,
+                                   ssize_t inlen, size_t *outlen);
+LIBSSH2_API void libssh2_release_string_cache(LIBSSH2_SESSION *session,
+                                              libssh2_string_cache **cache);
 
 #endif
 

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -141,7 +141,7 @@
 #define HAVE_SNPRINTF 1
 
 /* Define to the subdirectory in which libtool stores uninstalled libraries.
-*/
+ */
 #define LT_OBJDIR ".libs/"
 
 /* Define to 1 if _REENTRANT preprocessor symbol must be defined. */

--- a/os400/macros.h
+++ b/os400/macros.h
@@ -35,7 +35,7 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  *
-* SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef LIBSSH2_MACROS_H_
@@ -50,86 +50,76 @@
  * This is a helper for languages without a clever preprocessor (ILE/RPG).
  */
 
-LIBSSH2_API LIBSSH2_SESSION * libssh2_session_init(void);
+LIBSSH2_API LIBSSH2_SESSION *libssh2_session_init(void);
 LIBSSH2_API int libssh2_session_disconnect(LIBSSH2_SESSION *session,
                                            const char *description);
 LIBSSH2_API int libssh2_userauth_password(LIBSSH2_SESSION *session,
                                           const char *username,
                                           const char *password);
-LIBSSH2_API int
-libssh2_userauth_publickey_fromfile(LIBSSH2_SESSION *session,
-                                    const char *username,
-                                    const char *publickey,
-                                    const char *privatekey,
-                                    const char *passphrase);
-LIBSSH2_API int
-libssh2_userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
-                                    const char *username,
-                                    const char *publickey,
-                                    const char *privatekey,
-                                    const char *passphrase,
-                                    const char *hostname);
-LIBSSH2_API int
-libssh2_userauth_keyboard_interactive(LIBSSH2_SESSION* session,
-                                      const char *username,
-                                      LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(
-                                                       (*response_callback)));
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_open_session(LIBSSH2_SESSION *session);
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_channel_direct_tcpip(LIBSSH2_SESSION *session, const char *host,
-                             int port);
-LIBSSH2_API LIBSSH2_LISTENER *
-libssh2_channel_forward_listen(LIBSSH2_SESSION *session, int port);
-LIBSSH2_API int
-libssh2_channel_setenv(LIBSSH2_CHANNEL *channel,
-                       const char *varname, const char *value);
-LIBSSH2_API int
-libssh2_channel_request_pty(LIBSSH2_CHANNEL *channel, const char *term);
-LIBSSH2_API int
-libssh2_channel_request_pty_size(LIBSSH2_CHANNEL *channel,
-                                 int width, int height);
-LIBSSH2_API int
-libssh2_channel_x11_req(LIBSSH2_CHANNEL *channel, int screen_number);
-LIBSSH2_API int
-libssh2_channel_signal(LIBSSH2_CHANNEL *channel, const char *signame);
-LIBSSH2_API int
-libssh2_channel_shell(LIBSSH2_CHANNEL *channel);
-LIBSSH2_API int
-libssh2_channel_exec(LIBSSH2_CHANNEL *channel, const char *command);
-LIBSSH2_API int
-libssh2_channel_subsystem(LIBSSH2_CHANNEL *channel, const char *subsystem);
-LIBSSH2_API ssize_t
-libssh2_channel_read(LIBSSH2_CHANNEL *channel, char *buf, size_t buflen);
-LIBSSH2_API ssize_t
-libssh2_channel_read_stderr(LIBSSH2_CHANNEL *channel,
-                            char *buf, size_t buflen);
-LIBSSH2_API unsigned long
-libssh2_channel_window_read(LIBSSH2_CHANNEL *channel);
-LIBSSH2_API ssize_t
-libssh2_channel_write(LIBSSH2_CHANNEL *channel,
-                      const char *buf, size_t buflen);
-LIBSSH2_API ssize_t
-libssh2_channel_write_stderr(LIBSSH2_CHANNEL *channel,
-                             const char *buf, size_t buflen);
-LIBSSH2_API unsigned long
-libssh2_channel_window_write(LIBSSH2_CHANNEL *channel);
-LIBSSH2_API void
-libssh2_channel_ignore_extended_data(LIBSSH2_CHANNEL *channel, int ignore);
+LIBSSH2_API int libssh2_userauth_publickey_fromfile(LIBSSH2_SESSION *session,
+                                                    const char *username,
+                                                    const char *publickey,
+                                                    const char *privatekey,
+                                                    const char *passphrase);
+LIBSSH2_API int libssh2_userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
+                                                    const char *username,
+                                                    const char *publickey,
+                                                    const char *privatekey,
+                                                    const char *passphrase,
+                                                    const char *hostname);
+LIBSSH2_API int libssh2_userauth_keyboard_interactive(
+    LIBSSH2_SESSION *session, const char *username,
+    LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback));
+LIBSSH2_API LIBSSH2_CHANNEL *libssh2_channel_open_session(
+    LIBSSH2_SESSION *session);
+LIBSSH2_API LIBSSH2_CHANNEL *libssh2_channel_direct_tcpip(
+    LIBSSH2_SESSION *session, const char *host, int port);
+LIBSSH2_API LIBSSH2_LISTENER *libssh2_channel_forward_listen(
+    LIBSSH2_SESSION *session, int port);
+LIBSSH2_API int libssh2_channel_setenv(LIBSSH2_CHANNEL *channel,
+                                       const char *varname, const char *value);
+LIBSSH2_API int libssh2_channel_request_pty(LIBSSH2_CHANNEL *channel,
+                                            const char *term);
+LIBSSH2_API int libssh2_channel_request_pty_size(LIBSSH2_CHANNEL *channel,
+                                                 int width, int height);
+LIBSSH2_API int libssh2_channel_x11_req(LIBSSH2_CHANNEL *channel,
+                                        int screen_number);
+LIBSSH2_API int libssh2_channel_signal(LIBSSH2_CHANNEL *channel,
+                                       const char *signame);
+LIBSSH2_API int libssh2_channel_shell(LIBSSH2_CHANNEL *channel);
+LIBSSH2_API int libssh2_channel_exec(LIBSSH2_CHANNEL *channel,
+                                     const char *command);
+LIBSSH2_API int libssh2_channel_subsystem(LIBSSH2_CHANNEL *channel,
+                                          const char *subsystem);
+LIBSSH2_API ssize_t libssh2_channel_read(LIBSSH2_CHANNEL *channel, char *buf,
+                                         size_t buflen);
+LIBSSH2_API ssize_t libssh2_channel_read_stderr(LIBSSH2_CHANNEL *channel,
+                                                char *buf, size_t buflen);
+LIBSSH2_API unsigned long libssh2_channel_window_read(
+    LIBSSH2_CHANNEL *channel);
+LIBSSH2_API ssize_t libssh2_channel_write(LIBSSH2_CHANNEL *channel,
+                                          const char *buf, size_t buflen);
+LIBSSH2_API ssize_t libssh2_channel_write_stderr(LIBSSH2_CHANNEL *channel,
+                                                 const char *buf,
+                                                 size_t buflen);
+LIBSSH2_API unsigned long libssh2_channel_window_write(
+    LIBSSH2_CHANNEL *channel);
+LIBSSH2_API void libssh2_channel_ignore_extended_data(LIBSSH2_CHANNEL *channel,
+                                                      int ignore);
 LIBSSH2_API int libssh2_channel_flush(LIBSSH2_CHANNEL *channel);
 LIBSSH2_API int libssh2_channel_flush_stderr(LIBSSH2_CHANNEL *channel);
-LIBSSH2_API LIBSSH2_CHANNEL *
-libssh2_scp_send(LIBSSH2_SESSION *session,
-                 const char *path, int mode, libssh2_int64_t size);
+LIBSSH2_API LIBSSH2_CHANNEL *libssh2_scp_send(LIBSSH2_SESSION *session,
+                                              const char *path, int mode,
+                                              libssh2_int64_t size);
 
-LIBSSH2_API int
-libssh2_publickey_add(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
-                      const unsigned char *blob, unsigned long blob_len,
-                      char overwrite, unsigned long num_attrs,
-                      const libssh2_publickey_attribute attrs[]);
-LIBSSH2_API int
-libssh2_publickey_remove(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
-                         const unsigned char *blob, unsigned long blob_len);
+LIBSSH2_API int libssh2_publickey_add(
+    LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
+    const unsigned char *blob, unsigned long blob_len, char overwrite,
+    unsigned long num_attrs, const libssh2_publickey_attribute attrs[]);
+LIBSSH2_API int libssh2_publickey_remove(LIBSSH2_PUBLICKEY *pkey,
+                                         const unsigned char *name,
+                                         const unsigned char *blob,
+                                         unsigned long blob_len);
 
 LIBSSH2_API int LIBSSH2_SFTP_S_ISLNK(unsigned long permissions);
 LIBSSH2_API int LIBSSH2_SFTP_S_ISREG(unsigned long permissions);
@@ -138,17 +128,17 @@ LIBSSH2_API int LIBSSH2_SFTP_S_ISCHR(unsigned long permissions);
 LIBSSH2_API int LIBSSH2_SFTP_S_ISBLK(unsigned long permissions);
 LIBSSH2_API int LIBSSH2_SFTP_S_ISFIFO(unsigned long permissions);
 LIBSSH2_API int LIBSSH2_SFTP_S_ISSOCK(unsigned long permissions);
-LIBSSH2_API LIBSSH2_SFTP_HANDLE *
-libssh2_sftp_open(LIBSSH2_SFTP *sftp, const char *filename,
-                  unsigned long flags, long mode);
-LIBSSH2_API LIBSSH2_SFTP_HANDLE *
-libssh2_sftp_opendir(LIBSSH2_SFTP *sftp, const char *path);
-LIBSSH2_API LIBSSH2_SFTP_HANDLE *
-libssh2_sftp_open_r(LIBSSH2_SFTP *sftp, const char *filename,
-                    unsigned long flags, long mode,
-                    LIBSSH2_SFTP_ATTRIBUTES *attrs);
-LIBSSH2_API int libssh2_sftp_readdir(LIBSSH2_SFTP_HANDLE *handle,
-                                     char *buffer, size_t buffer_maxlen,
+LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open(LIBSSH2_SFTP *sftp,
+                                                   const char *filename,
+                                                   unsigned long flags,
+                                                   long mode);
+LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_opendir(LIBSSH2_SFTP *sftp,
+                                                      const char *path);
+LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_r(
+    LIBSSH2_SFTP *sftp, const char *filename, unsigned long flags, long mode,
+    LIBSSH2_SFTP_ATTRIBUTES *attrs);
+LIBSSH2_API int libssh2_sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
+                                     size_t buffer_maxlen,
                                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
 LIBSSH2_API int libssh2_sftp_close(LIBSSH2_SFTP_HANDLE *handle);
 LIBSSH2_API int libssh2_sftp_closedir(LIBSSH2_SFTP_HANDLE *handle);
@@ -161,8 +151,8 @@ LIBSSH2_API int libssh2_sftp_rename(LIBSSH2_SFTP *sftp,
                                     const char *source_filename,
                                     const char *dest_filename);
 LIBSSH2_API int libssh2_sftp_unlink(LIBSSH2_SFTP *sftp, const char *filename);
-LIBSSH2_API int libssh2_sftp_mkdir(LIBSSH2_SFTP *sftp,
-                                   const char *path, long mode);
+LIBSSH2_API int libssh2_sftp_mkdir(LIBSSH2_SFTP *sftp, const char *path,
+                                   long mode);
 LIBSSH2_API int libssh2_sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path);
 LIBSSH2_API int libssh2_sftp_stat(LIBSSH2_SFTP *sftp, const char *path,
                                   LIBSSH2_SFTP_ATTRIBUTES *attrs);

--- a/os400/os400sys.c
+++ b/os400/os400sys.c
@@ -62,7 +62,7 @@
 #include <arpa/inet.h>
 
 #ifdef LIBSSH2_HAVE_ZLIB
-# include <zlib.h>
+#include <zlib.h>
 #endif
 
 /**
@@ -74,9 +74,8 @@
 
 #pragma convert(37)                             /* Restore EBCDIC. */
 
-static int
-convert_sockaddr(struct sockaddr_storage *dstaddr,
-                 const struct sockaddr *srcaddr, int srclen)
+static int convert_sockaddr(struct sockaddr_storage *dstaddr,
+                            const struct sockaddr *srcaddr, int srclen)
 {
     const struct sockaddr_un *srcu;
     struct sockaddr_un *dstu;
@@ -85,23 +84,25 @@ convert_sockaddr(struct sockaddr_storage *dstaddr,
 
     /* Convert a socket address into job CCSID, if needed. */
 
-    if(!srcaddr || srclen < offsetof(struct sockaddr, sa_family) +
-       sizeof(srcaddr->sa_family) || srclen > sizeof(*dstaddr)) {
+    if(!srcaddr ||
+       srclen <
+           offsetof(struct sockaddr, sa_family) + sizeof(srcaddr->sa_family) ||
+       srclen > sizeof(*dstaddr)) {
         errno = EINVAL;
         return -1;
     }
 
-    memcpy((char *) dstaddr, (char *) srcaddr, srclen);
+    memcpy((char *)dstaddr, (char *)srcaddr, srclen);
 
     switch(srcaddr->sa_family) {
 
     case AF_UNIX:
-        srcu = (const struct sockaddr_un *) srcaddr;
-        dstu = (struct sockaddr_un *) dstaddr;
+        srcu = (const struct sockaddr_un *)srcaddr;
+        dstu = (struct sockaddr_un *)dstaddr;
         dstsize = sizeof(*dstaddr) - offsetof(struct sockaddr_un, sun_path);
         srclen -= offsetof(struct sockaddr_un, sun_path);
-        i = QadrtConvertA2E(dstu->sun_path, srcu->sun_path,
-                            dstsize - 1, srclen);
+        i = QadrtConvertA2E(dstu->sun_path, srcu->sun_path, dstsize - 1,
+                            srclen);
         dstu->sun_path[i] = '\0';
         i += offsetof(struct sockaddr_un, sun_path);
         srclen = i;
@@ -110,8 +111,7 @@ convert_sockaddr(struct sockaddr_storage *dstaddr,
     return srclen;
 }
 
-int
-_libssh2_os400_connect(int sd, struct sockaddr *destaddr, int addrlen)
+int _libssh2_os400_connect(int sd, struct sockaddr *destaddr, int addrlen)
 {
     int i;
     struct sockaddr_storage laddr;
@@ -121,13 +121,12 @@ _libssh2_os400_connect(int sd, struct sockaddr *destaddr, int addrlen)
     if(i < 0)
         return -1;
 
-    return connect(sd, (struct sockaddr *) &laddr, i);
+    return connect(sd, (struct sockaddr *)&laddr, i);
 }
 
 #ifdef LIBSSH2_HAVE_ZLIB
-int
-_libssh2_os400_inflateInit_(z_streamp strm,
-                            const char *version, int stream_size)
+int _libssh2_os400_inflateInit_(z_streamp strm, const char *version,
+                                int stream_size)
 {
     char *ebcversion;
     int i;
@@ -143,9 +142,8 @@ _libssh2_os400_inflateInit_(z_streamp strm,
     return inflateInit_(strm, ebcversion, stream_size);
 }
 
-int
-_libssh2_os400_deflateInit_(z_streamp strm, int level,
-                            const char *version, int stream_size)
+int _libssh2_os400_deflateInit_(z_streamp strm, int level, const char *version,
+                                int stream_size)
 {
     char *ebcversion;
     int i;
@@ -160,5 +158,4 @@ _libssh2_os400_deflateInit_(z_streamp strm, int level,
     ebcversion[i] = '\0';
     return deflateInit_(strm, level, ebcversion, stream_size);
 }
-
 #endif


### PR DESCRIPTION
Also:
- drop redundant parentheses from
  `LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC()` arg.
  Follow-up to b6f307dca9ad38657722ab2238c92837164d4f21 #1898

Follow-up to f0279a69b5b3dbd81888047d9c8ec9387c13eee3 #1964
Follow-up to e85ce25b4c8c021f6b4e332b170fee24da1fd06a #1960
Follow-up to 1db408321d510e6d8d2a5e16d996e5c0f6fe8e65 #1938
Follow-up to 63e59481fa92b8b234e7ae7a2f7da45d1ac8e1ac #1936
Follow-up to 6ffb96321cbb04a4d5aade6afc421367ab9aa4e6 #1935

---

https://github.com/libssh2/libssh2/pull/1968/files?w=1
