### PR TITLE
src: drop redundant `LIBSSH2_API` attribute from definitions

### DIFF
--- a/os400/ccsid.c
+++ b/os400/ccsid.c
@@ -219,7 +219,6 @@ static char *convert_ccsid(LIBSSH2_SESSION *session,
     return outstring->string;
 }
 
-LIBSSH2_API
 char *libssh2_from_ccsid(LIBSSH2_SESSION *session,
                          libssh2_string_cache **cache, unsigned short ccsid,
                          const char *string, ssize_t inlen, size_t *outlen)
@@ -228,7 +227,6 @@ char *libssh2_from_ccsid(LIBSSH2_SESSION *session,
                          outlen);
 }
 
-LIBSSH2_API
 char *libssh2_to_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
                        unsigned short ccsid, const char *string, ssize_t inlen,
                        size_t *outlen)
@@ -237,7 +235,6 @@ char *libssh2_to_ccsid(LIBSSH2_SESSION *session, libssh2_string_cache **cache,
                          outlen);
 }
 
-LIBSSH2_API
 void libssh2_release_string_cache(LIBSSH2_SESSION *session,
                                   libssh2_string_cache **cache)
 {

--- a/src/agent.c
+++ b/src/agent.c
@@ -1061,7 +1061,6 @@ static struct libssh2_agent_publickey *agent_publickey_to_external(
 /*
  * Init an ssh-agent handle. Returns the pointer to the handle.
  */
-LIBSSH2_API
 LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_AGENT *agent;
@@ -1091,7 +1090,6 @@ LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API
 int libssh2_agent_connect(LIBSSH2_AGENT *agent)
 {
     int i, rc = -1;
@@ -1109,7 +1107,6 @@ int libssh2_agent_connect(LIBSSH2_AGENT *agent)
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API
 int libssh2_agent_list_identities(LIBSSH2_AGENT *agent)
 {
     memset(&agent->transctx, 0, sizeof(agent->transctx));
@@ -1128,7 +1125,6 @@ int libssh2_agent_list_identities(LIBSSH2_AGENT *agent)
  * 1 if end of public keys
  * [negative] on errors
  */
-LIBSSH2_API
 int libssh2_agent_get_identity(LIBSSH2_AGENT *agent,
                                struct libssh2_agent_publickey **store,
                                struct libssh2_agent_publickey *prev)
@@ -1158,7 +1154,6 @@ int libssh2_agent_get_identity(LIBSSH2_AGENT *agent,
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API
 int libssh2_agent_userauth(LIBSSH2_AGENT *agent,
                            const char *username,
                            struct libssh2_agent_publickey *identity)
@@ -1186,7 +1181,6 @@ int libssh2_agent_userauth(LIBSSH2_AGENT *agent,
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API
 int libssh2_agent_sign(LIBSSH2_AGENT *agent,
                        struct libssh2_agent_publickey *identity,
                        unsigned char **sig,
@@ -1235,7 +1229,6 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
  *
  * Returns 0 if succeeded, or a negative value for error.
  */
-LIBSSH2_API
 int libssh2_agent_disconnect(LIBSSH2_AGENT *agent)
 {
     if(agent->ops && agent->fd != LIBSSH2_INVALID_SOCKET)
@@ -1247,7 +1240,6 @@ int libssh2_agent_disconnect(LIBSSH2_AGENT *agent)
  * Free an ssh-agent handle.  This function also frees the internal
  * collection of public keys.
  */
-LIBSSH2_API
 void libssh2_agent_free(LIBSSH2_AGENT *agent)
 {
     /* Allow connection freeing when the socket has lost its connection */
@@ -1265,7 +1257,6 @@ void libssh2_agent_free(LIBSSH2_AGENT *agent)
 /*
  * Allows a custom agent socket path beyond SSH_AUTH_SOCK env
  */
-LIBSSH2_API
 void libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
 {
     if(agent->identity_agent_path) {
@@ -1287,7 +1278,6 @@ void libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
 /*
  * Returns the custom agent socket path if set
  */
-LIBSSH2_API
 const char *libssh2_agent_get_identity_path(LIBSSH2_AGENT *agent)
 {
     return agent->identity_agent_path;

--- a/src/channel.c
+++ b/src/channel.c
@@ -332,7 +332,6 @@ channel_error:
 /*
  * Establish a generic session channel
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_channel_open_ex(LIBSSH2_SESSION *session,
                                          const char *channel_type,
                                          unsigned int channel_type_len,
@@ -415,7 +414,6 @@ static LIBSSH2_CHANNEL *channel_direct_tcpip(LIBSSH2_SESSION *session,
 /*
  * Tunnel TCP/IP connect through the SSH session to direct host/port
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_channel_direct_tcpip_ex(LIBSSH2_SESSION *session,
                                                  const char *host, int port,
                                                  const char *shost, int sport)
@@ -490,7 +488,6 @@ static LIBSSH2_CHANNEL *channel_direct_streamlocal(LIBSSH2_SESSION *session,
 /*
  * Tunnel TCP/IP connect through the SSH session to direct UNIX socket
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_channel_direct_streamlocal_ex(
     LIBSSH2_SESSION *session,
     const char *socket_path, const char *shost, int sport)
@@ -659,7 +656,6 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
 /*
  * Bind a port on the remote host and listen for connections
  */
-LIBSSH2_API
 LIBSSH2_LISTENER *libssh2_channel_forward_listen_ex(LIBSSH2_SESSION *session,
                                                     const char *host,
                                                     int port, int *bound_port,
@@ -768,7 +764,6 @@ int ssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
  *
  * Return 0 on success, LIBSSH2_ERROR_EAGAIN if would block, -1 on error
  */
-LIBSSH2_API
 int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
 {
     int rc;
@@ -818,7 +813,6 @@ static LIBSSH2_CHANNEL *channel_forward_accept(LIBSSH2_LISTENER *listener)
 /*
  * Accept a connection
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_channel_forward_accept(LIBSSH2_LISTENER *listener)
 {
     LIBSSH2_CHANNEL *ptr;
@@ -935,7 +929,6 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
 /*
  * Set an environment variable prior to requesting a shell/program/subsystem
  */
-LIBSSH2_API
 int libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
                               const char *varname, unsigned int varname_len,
                               const char *value, unsigned int value_len)
@@ -1152,7 +1145,6 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
  * listener on the remote side. Once the channel is closed, the agent
  * listener continues to exist.
  */
-LIBSSH2_API
 int libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel)
 {
     int rc;
@@ -1201,7 +1193,6 @@ int libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel)
 /*
  * Duh... Request a PTY
  */
-LIBSSH2_API
 int libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel, const char *term,
                                    unsigned int term_len, const char *modes,
                                    unsigned int modes_len,
@@ -1274,7 +1265,6 @@ static int channel_request_pty_size(LIBSSH2_CHANNEL *channel, int width,
     return retcode;
 }
 
-LIBSSH2_API
 int libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel,
                                         int width, int height,
                                         int width_px, int height_px)
@@ -1425,7 +1415,6 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
 /*
  * Request X11 forwarding
  */
-LIBSSH2_API
 int libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel, int single_connection,
                                const char *auth_proto, const char *auth_cookie,
                                int screen_number)
@@ -1547,7 +1536,6 @@ int ssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
 /*
  * Primitive for libssh2_channel_(shell|exec|subsystem)
  */
-LIBSSH2_API
 int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                     const char *request,
                                     unsigned int request_len,
@@ -1570,7 +1558,6 @@ int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
  * Set a channel's BEHAVIOR blocking on or off. The socket remains non-
  * blocking.
  */
-LIBSSH2_API
 void libssh2_channel_set_blocking(LIBSSH2_CHANNEL *channel, int blocking)
 {
     if(channel)
@@ -1671,7 +1658,6 @@ int ssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
  * Flush data from one (or all) stream
  * Returns number of bytes flushed, or negative on failure
  */
-LIBSSH2_API
 int libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel, int streamid)
 {
     int rc;
@@ -1689,7 +1675,6 @@ int libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel, int streamid)
  * return error values in case of errors so we return a zero if channel is
  * NULL.
  */
-LIBSSH2_API
 int libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel)
 {
     if(!channel)
@@ -1706,7 +1691,6 @@ int libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel)
  * corresponding string parameter is NULL.  Returns LIBSSH2_ERROR_NONE
  * on success, or an API error code.
  */
-LIBSSH2_API
 int libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
                                     char **exitsignal,
                                     size_t *exitsignal_len,
@@ -1845,7 +1829,6 @@ int ssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
  * Note that it might return EAGAIN too which is highly stupid.
  *
  */
-LIBSSH2_API
 unsigned long libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
                                                     unsigned long adjustment,
                                                     unsigned char force)
@@ -1876,7 +1859,6 @@ unsigned long libssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
  *
  * Returns the "normal" error code: 0 for success, negative for failure.
  */
-LIBSSH2_API
 int libssh2_channel_receive_window_adjust2(LIBSSH2_CHANNEL *channel,
                                            unsigned long adjustment,
                                            unsigned char force,
@@ -1918,7 +1900,6 @@ int ssh2_channel_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode)
     return 0;
 }
 
-LIBSSH2_API
 int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
                                           int ignore_mode)
 {
@@ -1941,7 +1922,6 @@ int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
  * standard data? [everything via _read()]? (MERGE) Ignore it entirely [toss
  * out packets as they come in]? (IGNORE)
  */
-LIBSSH2_API
 void libssh2_channel_handle_extended_data(LIBSSH2_CHANNEL *channel,
                                           int ignore_mode)
 {
@@ -2123,7 +2103,6 @@ ssize_t ssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
  * receive a full buffer's wort of contents. An application may choose to
  * adjust the receive window more to increase transfer performance.
  */
-LIBSSH2_API
 ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id,
                                 char *buf, size_t buflen)
 {
@@ -2343,7 +2322,6 @@ ssize_t ssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
 /*
  * Send data to a channel
  */
-LIBSSH2_API
 ssize_t libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
                                  const char *buf, size_t buflen)
 {
@@ -2388,7 +2366,6 @@ static int channel_send_eof(LIBSSH2_CHANNEL *channel)
 /*
  * Send EOF on channel
  */
-LIBSSH2_API
 int libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel)
 {
     int rc;
@@ -2403,7 +2380,6 @@ int libssh2_channel_send_eof(LIBSSH2_CHANNEL *channel)
 /*
  * Read channel's eof status
  */
-LIBSSH2_API
 int libssh2_channel_eof(LIBSSH2_CHANNEL *channel)
 {
     LIBSSH2_SESSION *session;
@@ -2488,7 +2464,6 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
 /*
  * Awaiting channel EOF
  */
-LIBSSH2_API
 int libssh2_channel_wait_eof(LIBSSH2_CHANNEL *channel)
 {
     int rc;
@@ -2581,7 +2556,6 @@ int ssh2_channel_close(LIBSSH2_CHANNEL *channel)
 /*
  * Close a channel
  */
-LIBSSH2_API
 int libssh2_channel_close(LIBSSH2_CHANNEL *channel)
 {
     int rc;
@@ -2638,7 +2612,6 @@ static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
 /*
  * Awaiting channel close after EOF
  */
-LIBSSH2_API
 int libssh2_channel_wait_closed(LIBSSH2_CHANNEL *channel)
 {
     int rc;
@@ -2781,7 +2754,6 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
  *
  * Returns 0 on success, negative on failure
  */
-LIBSSH2_API
 int libssh2_channel_free(LIBSSH2_CHANNEL *channel)
 {
     int rc;
@@ -2800,7 +2772,6 @@ int libssh2_channel_free(LIBSSH2_CHANNEL *channel)
  * read window_size_initial (if passed) is populated with the
  * window_size_initial as defined by the channel_open request
  */
-LIBSSH2_API
 unsigned long libssh2_channel_window_read_ex(
     LIBSSH2_CHANNEL *channel,
     unsigned long *read_avail, /* FIXME: -> size_t */
@@ -2853,7 +2824,6 @@ unsigned long libssh2_channel_window_read_ex(
  * passed) is populated with the size of the initial window as defined by
  * the channel_open request
  */
-LIBSSH2_API
 unsigned long libssh2_channel_window_write_ex(
     LIBSSH2_CHANNEL *channel,
     unsigned long *window_size_initial)
@@ -2937,7 +2907,6 @@ static int channel_signal(LIBSSH2_CHANNEL *channel,
     return retcode;
 }
 
-LIBSSH2_API
 int libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
                               const char *signame, size_t signame_len)
 {

--- a/src/global.c
+++ b/src/global.c
@@ -43,7 +43,6 @@
 static int s_initialized = 0;
 static int s_init_flags = 0;
 
-LIBSSH2_API
 int libssh2_init(int flags)
 {
     if(s_initialized == 0 && !(flags & LIBSSH2_INIT_NO_CRYPTO)) {
@@ -56,7 +55,6 @@ int libssh2_init(int flags)
     return 0;
 }
 
-LIBSSH2_API
 void libssh2_exit(void)
 {
     if(s_initialized == 0)

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -1303,7 +1303,6 @@ const struct hostkey_method **ssh2_hostkey_methods(void)
  * Length of buffer is determined by hash type
  * i.e. MD5 == 16, SHA1 == 20, SHA256 == 32
  */
-LIBSSH2_API
 const char *libssh2_hostkey_hash(LIBSSH2_SESSION *session, int hash_type)
 {
     switch(hash_type) {
@@ -1384,7 +1383,6 @@ static int hostkey_type(const unsigned char *hostkey, size_t len)
 /*
  * Returns the server key and length.
  */
-LIBSSH2_API
 const char *libssh2_session_hostkey(LIBSSH2_SESSION *session, size_t *len,
                                     int *type)
 {

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -42,7 +42,6 @@
 
 /* Keep-alive stuff. */
 
-LIBSSH2_API
 void libssh2_keepalive_config(LIBSSH2_SESSION *session,
                               int want_reply,
                               unsigned int interval)
@@ -54,7 +53,6 @@ void libssh2_keepalive_config(LIBSSH2_SESSION *session,
     session->keepalive_want_reply = want_reply ? 1 : 0;
 }
 
-LIBSSH2_API
 int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 {
     time_t now;

--- a/src/kex.c
+++ b/src/kex.c
@@ -4279,7 +4279,6 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
 /*
  * Set preferred method
  */
-LIBSSH2_API
 int libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
                                 const char *prefs)
 {
@@ -4425,7 +4424,6 @@ int libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
  * returns a number of returned algorithms (a positive number) on success,
  * a negative number on failure
  */
-LIBSSH2_API
 int libssh2_session_supported_algs(LIBSSH2_SESSION *session,
                                    int method_type,
                                    const char ***algs)

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -86,7 +86,6 @@ static void free_host(LIBSSH2_SESSION *session, struct known_host *entry)
 /*
  * Init a collection of known hosts. Returns the pointer to a collection.
  */
-LIBSSH2_API
 LIBSSH2_KNOWNHOSTS *libssh2_knownhost_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_KNOWNHOSTS *knh =
@@ -287,7 +286,6 @@ error:
  * The keylen parameter may be omitted (zero) if the key is provided as a
  * NULL-terminated base64-encoded string.
  */
-LIBSSH2_API
 int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
                           const char *host, const char *salt,
                           const char *key, size_t keylen,
@@ -323,7 +321,6 @@ int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
  * The keylen parameter may be omitted (zero) if the key is provided as a
  * NULL-terminated base64-encoded string.
  */
-LIBSSH2_API
 int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
                            const char *host, const char *salt,
                            const char *key, size_t keylen,
@@ -511,7 +508,6 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
  * LIBSSH2_KNOWNHOST_CHECK_MATCH
  * LIBSSH2_KNOWNHOST_CHECK_MISMATCH
  */
-LIBSSH2_API
 int libssh2_knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                             const char *host, const char *key, size_t keylen,
                             int typemask,
@@ -541,7 +537,6 @@ int libssh2_knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
  * LIBSSH2_KNOWNHOST_CHECK_MATCH
  * LIBSSH2_KNOWNHOST_CHECK_MISMATCH
  */
-LIBSSH2_API
 int libssh2_knownhost_checkp(LIBSSH2_KNOWNHOSTS *hosts,
                              const char *host, int port,
                              const char *key, size_t keylen,
@@ -554,7 +549,6 @@ int libssh2_knownhost_checkp(LIBSSH2_KNOWNHOSTS *hosts,
 /*
  * Remove a host from the collection of known hosts.
  */
-LIBSSH2_API
 int libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
                           struct libssh2_knownhost *entry)
 {
@@ -584,7 +578,6 @@ int libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
 /*
  * Free an entire collection of known hosts.
  */
-LIBSSH2_API
 void libssh2_knownhost_free(LIBSSH2_KNOWNHOSTS *hosts)
 {
     struct known_host *node;
@@ -857,7 +850,6 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
  * 'ssh-rsa' [base64-encoded-key]
  *
  */
-LIBSSH2_API
 int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
                                const char *line, size_t len, int type)
 {
@@ -931,7 +923,6 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
  *
  * Returns a negative value for error or number of successfully added hosts.
  */
-LIBSSH2_API
 int libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
                                const char *filename, int type)
 {
@@ -1137,7 +1128,6 @@ static int knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
  * Note that this function returns LIBSSH2_ERROR_BUFFER_TOO_SMALL if the given
  * output buffer is too small to hold the desired output.
  */
-LIBSSH2_API
 int libssh2_knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
                                 struct libssh2_knownhost *known,
                                 char *buffer, size_t buflen,
@@ -1158,7 +1148,6 @@ int libssh2_knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
 /*
  * Write hosts+key pairs to the given file.
  */
-LIBSSH2_API
 int libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
                                 const char *filename, int type)
 {
@@ -1209,7 +1198,6 @@ int libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
  * 1 if end of hosts
  * [negative] on errors
  */
-LIBSSH2_API
 int libssh2_knownhost_get(LIBSSH2_KNOWNHOSTS *hosts,
                           struct libssh2_knownhost **store,
                           struct libssh2_knownhost *prev)

--- a/src/misc.c
+++ b/src/misc.c
@@ -365,7 +365,6 @@ static const short base64_reverse_table[256] = {
 /*
  * Legacy public function. (DEPRECATED, DO NOT USE!)
  */
-LIBSSH2_API
 int libssh2_base64_decode(LIBSSH2_SESSION *session,
                           char **dest, unsigned int *dest_len,
                           const char *src, unsigned int src_len)
@@ -517,7 +516,6 @@ size_t ssh2_base64_encode(LIBSSH2_SESSION *session,
 }
 /* ---- End of Base64 Encoding ---- */
 
-LIBSSH2_API
 void libssh2_free(LIBSSH2_SESSION *session, void *ptr)
 {
     SSH2_FREE(session, ptr);
@@ -526,14 +524,12 @@ void libssh2_free(LIBSSH2_SESSION *session, void *ptr)
 #ifdef LIBSSH2DEBUG
 #include <stdarg.h>
 
-LIBSSH2_API
 int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     session->showmask = bitmask;
     return 0;
 }
 
-LIBSSH2_API
 int libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
                              libssh2_trace_handler_func callback)
 {
@@ -614,7 +610,6 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
 }
 
 #else
-LIBSSH2_API
 int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     (void)session;
@@ -622,7 +617,6 @@ int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
     return 0;
 }
 
-LIBSSH2_API
 int libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
                              libssh2_trace_handler_func callback)
 {

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -537,7 +537,6 @@ err_exit:
 /*
  * Startup the publickey subsystem
  */
-LIBSSH2_API
 LIBSSH2_PUBLICKEY *libssh2_publickey_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_PUBLICKEY *ptr;
@@ -549,7 +548,6 @@ LIBSSH2_PUBLICKEY *libssh2_publickey_init(LIBSSH2_SESSION *session)
 /*
  * Add a new public key entry
  */
-LIBSSH2_API
 int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
                              const unsigned char *name, unsigned long name_len,
                              const unsigned char *blob, unsigned long blob_len,
@@ -698,7 +696,6 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
  * Remove an existing publickey so that authentication can no longer be
  * performed using it
  */
-LIBSSH2_API
 int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
                                 const unsigned char *name,
                                 unsigned long name_len,
@@ -784,7 +781,6 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
 /*
  * Fetch a list of supported public key from a server
  */
-LIBSSH2_API
 int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                                  unsigned long *num_keys,
                                  libssh2_publickey_list **pkey_list)
@@ -1176,7 +1172,6 @@ err_exit:
 /*
  * Free a previously fetched list of public keys
  */
-LIBSSH2_API
 void libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
                                  libssh2_publickey_list *pkey_list)
 {
@@ -1202,7 +1197,6 @@ void libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
 /*
  * Shutdown the publickey subsystem
  */
-LIBSSH2_API
 int libssh2_publickey_shutdown(LIBSSH2_PUBLICKEY *pkey)
 {
     LIBSSH2_SESSION *session;

--- a/src/scp.c
+++ b/src/scp.c
@@ -780,7 +780,6 @@ scp_recv_error:
  * larger than 2 GB, but is unable to report the proper size on platforms
  * where the st_size member of struct stat is limited to 2 GB (e.g. windows).
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path,
                                   struct stat *sb)
 {
@@ -813,7 +812,6 @@ LIBSSH2_CHANNEL *libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path,
  * Open a channel and request a remote file via SCP.  This supports files > 2GB
  * on platforms that support it.
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
                                    libssh2_struct_stat *sb)
 {
@@ -1130,7 +1128,6 @@ scp_send_error:
  *
  * Send a file using SCP. Old API.
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_scp_send_ex(LIBSSH2_SESSION *session,
                                      const char *path, int mode,
                                      size_t size,
@@ -1147,7 +1144,6 @@ LIBSSH2_CHANNEL *libssh2_scp_send_ex(LIBSSH2_SESSION *session,
 /*
  * Send a file using SCP
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_scp_send64(LIBSSH2_SESSION *session,
                                     const char *path, int mode,
                                     libssh2_int64_t size,

--- a/src/session.c
+++ b/src/session.c
@@ -371,7 +371,6 @@ static int get_socket_nonblocking(libssh2_socket_t sockfd)
 /*
  * Set the local banner to use in the server handshake.
  */
-LIBSSH2_API
 int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
 {
     size_t banner_len = banner ? strlen(banner) : 0;
@@ -407,7 +406,6 @@ int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
 /*
  * Set the local banner. DEPRECATED VERSION
  */
-LIBSSH2_API
 int libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner)
 {
     return libssh2_session_banner_set(session, banner);
@@ -421,7 +419,6 @@ int libssh2_banner_set(LIBSSH2_SESSION *session, const char *banner)
  * callbacks An additional pointer value may be optionally passed to be sent
  * to the callbacks (so they know who's asking)
  */
-LIBSSH2_API
 LIBSSH2_SESSION *libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
                                          LIBSSH2_FREE_FUNC(*my_free),
                                          LIBSSH2_REALLOC_FUNC(*my_realloc),
@@ -474,7 +471,6 @@ LIBSSH2_SESSION *libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type"
 #endif
-LIBSSH2_API
 libssh2_cb_generic *libssh2_session_callback_set2(LIBSSH2_SESSION *session,
                                                   int cbtype,
                                                   libssh2_cb_generic *callback)
@@ -559,7 +555,6 @@ libssh2_cb_generic *libssh2_session_callback_set2(LIBSSH2_SESSION *session,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
-LIBSSH2_API
 void *libssh2_session_callback_set(LIBSSH2_SESSION *session,
                                    int cbtype, void *callback)
 {
@@ -850,7 +845,6 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
  *
  * Returns: 0 on success, or non-zero on failure
  */
-LIBSSH2_API
 int libssh2_session_handshake(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 {
     int rc;
@@ -870,7 +864,6 @@ int libssh2_session_handshake(LIBSSH2_SESSION *session, libssh2_socket_t sock)
  *
  * Returns: 0 on success, or non-zero on failure
  */
-LIBSSH2_API
 int libssh2_session_startup(LIBSSH2_SESSION *session, int sock)
 {
     return libssh2_session_handshake(session, (libssh2_socket_t)sock);
@@ -1144,7 +1137,6 @@ static int session_free(LIBSSH2_SESSION *session)
  * Frees the memory allocated to the session
  * Also closes and frees any channels attached to this session
  */
-LIBSSH2_API
 int libssh2_session_free(LIBSSH2_SESSION *session)
 {
     int rc;
@@ -1205,7 +1197,6 @@ static int session_disconnect(LIBSSH2_SESSION *session, int reason,
     return 0;
 }
 
-LIBSSH2_API
 int libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
                                   const char *description, const char *lang)
 {
@@ -1224,7 +1215,6 @@ int libssh2_session_disconnect_ex(LIBSSH2_SESSION *session, int reason,
  * NOTE: Currently lang_cs and lang_sc are ALWAYS set to empty string
  * regardless of actual negotiation Strings should NOT be freed
  */
-LIBSSH2_API
 const char *libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
 {
     /* All methods have char *name as their first element */
@@ -1286,7 +1276,6 @@ const char *libssh2_session_methods(LIBSSH2_SESSION *session, int method_type)
 /*
  * Retrieve a pointer to the abstract property
  */
-LIBSSH2_API
 void **libssh2_session_abstract(LIBSSH2_SESSION *session)
 {
     return &session->abstract;
@@ -1297,7 +1286,6 @@ void **libssh2_session_abstract(LIBSSH2_SESSION *session)
  * non-zero then the string placed into errmsg must be freed by the calling
  * program. Otherwise it is assumed to be owned by libssh2
  */
-LIBSSH2_API
 int libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
                                int *errmsg_len, int want_buf)
 {
@@ -1349,7 +1337,6 @@ int libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
 /*
  * Returns error code
  */
-LIBSSH2_API
 int libssh2_session_last_errno(LIBSSH2_SESSION *session)
 {
     return session->err_code;
@@ -1362,7 +1349,6 @@ int libssh2_session_last_errno(LIBSSH2_SESSION *session)
  * language wrappers (i.e. Python or Perl) that may extend the library
  * features while still relying on its error reporting mechanism.
  */
-LIBSSH2_API
 int libssh2_session_set_last_error(LIBSSH2_SESSION *session,
                                    int errcode, const char *errmsg)
 {
@@ -1374,7 +1360,6 @@ int libssh2_session_set_last_error(LIBSSH2_SESSION *session,
  *
  * Return error code.
  */
-LIBSSH2_API
 int libssh2_session_flag(LIBSSH2_SESSION *session, int flag, int value)
 {
     switch(flag) {
@@ -1414,7 +1399,6 @@ int ssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
  * Set a channel's blocking mode on or off, similar to a socket's
  * fcntl(fd, F_SETFL, O_NONBLOCK); type command
  */
-LIBSSH2_API
 void libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
 {
     (void)ssh2_session_set_blocking(session, blocking);
@@ -1423,7 +1407,6 @@ void libssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking)
 /*
  * Returns a session's blocking mode on or off
  */
-LIBSSH2_API
 int libssh2_session_get_blocking(LIBSSH2_SESSION *session)
 {
     return session->api_block_mode;
@@ -1433,7 +1416,6 @@ int libssh2_session_get_blocking(LIBSSH2_SESSION *session)
  * Set a session's timeout (in msec) for blocking mode,
  * or 0 to disable timeouts.
  */
-LIBSSH2_API
 void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
 {
     session->api_timeout = timeout;
@@ -1442,7 +1424,6 @@ void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
 /*
  * Returns a session's timeout, or 0 if disabled
  */
-LIBSSH2_API
 long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
 {
     return session->api_timeout;
@@ -1452,7 +1433,6 @@ long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
  * Set a session's timeout (in sec) when reading packets,
  * or 0 to use default of 60 seconds.
  */
-LIBSSH2_API
 void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
 {
     if(timeout <= 0) {
@@ -1464,7 +1444,6 @@ void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
 /*
  * Returns a session's timeout. Default is 60 seconds.
  */
-LIBSSH2_API
 long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
 {
     return session->packet_read_timeout;
@@ -1474,7 +1453,6 @@ long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
  * Returns 0 if no data is waiting on channel,
  * non-0 if data is available
  */
-LIBSSH2_API
 int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
 {
     LIBSSH2_SESSION *session;
@@ -1532,7 +1510,6 @@ static inline int poll_listener_queued(LIBSSH2_LISTENER *listener)
 /*
  * Poll sockets, channels, and listeners for activity
  */
-LIBSSH2_API
 int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 {
     long timeout_remaining;
@@ -1869,7 +1846,6 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
  * Returns SSH2_SOCKET_BLOCK_INBOUND if recv() blocked
  * or SSH2_SOCKET_BLOCK_OUTBOUND if send() blocked
  */
-LIBSSH2_API
 int libssh2_session_block_directions(LIBSSH2_SESSION *session)
 {
     return session->socket_block_directions;
@@ -1878,7 +1854,6 @@ int libssh2_session_block_directions(LIBSSH2_SESSION *session)
 /*
  * Get the remote banner (server ID string)
  */
-LIBSSH2_API
 const char *libssh2_session_banner_get(LIBSSH2_SESSION *session)
 {
     /* to avoid a coredump when session is NULL */

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1008,7 +1008,6 @@ sftp_init_error:
 /*
  * Startup an SFTP session
  */
-LIBSSH2_API
 LIBSSH2_SFTP *libssh2_sftp_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_SFTP *ptr;
@@ -1102,7 +1101,6 @@ static int sftp_shutdown(LIBSSH2_SFTP *sftp)
 /*
  * Shuts down the SFTP subsystem
  */
-LIBSSH2_API
 int libssh2_sftp_shutdown(LIBSSH2_SFTP *sftp)
 {
     int rc;
@@ -1342,7 +1340,6 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
     return NULL;
 }
 
-LIBSSH2_API
 LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
                                           const char *filename,
                                           unsigned int filename_len,
@@ -1360,7 +1357,6 @@ LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex(LIBSSH2_SFTP *sftp,
     return hnd;
 }
 
-LIBSSH2_API
 LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(LIBSSH2_SFTP *sftp,
                                             const char *filename,
                                             size_t filename_len,
@@ -1776,7 +1772,6 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
 /*
  * Read from an SFTP file handle
  */
-LIBSSH2_API
 ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                           char *buffer, size_t buffer_maxlen)
 {
@@ -2009,7 +2004,6 @@ end:
 /*
  * Read from an SFTP directory handle
  */
-LIBSSH2_API
 int libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle,
                             char *buffer, size_t buffer_maxlen,
                             char *longentry, size_t longentry_maxlen,
@@ -2274,7 +2268,6 @@ static ssize_t sftp_write(LIBSSH2_SFTP_HANDLE *handle, const char *buffer,
 /*
  * Write data to a file handle
  */
-LIBSSH2_API
 ssize_t libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle,
                            const char *buffer, size_t count)
 {
@@ -2376,7 +2369,6 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
 /*
  * Commit data on the handle to disk.
  */
-LIBSSH2_API
 int libssh2_sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
 {
     int rc;
@@ -2498,7 +2490,6 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
 /*
  * Get or Set stat on a file
  */
-LIBSSH2_API
 int libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
                           LIBSSH2_SFTP_ATTRIBUTES *attrs, int setstat)
 {
@@ -2513,7 +2504,6 @@ int libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
 /*
  * Set the read/write pointer to an arbitrary position within the file
  */
-LIBSSH2_API
 void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle, libssh2_uint64_t offset)
 {
     if(!handle)
@@ -2539,7 +2529,6 @@ void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle, libssh2_uint64_t offset)
 /*
  * Set the read/write pointer to an arbitrary position within the file
  */
-LIBSSH2_API
 void libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset)
 {
     libssh2_sftp_seek64(handle, (libssh2_uint64_t)offset);
@@ -2548,7 +2537,6 @@ void libssh2_sftp_seek(LIBSSH2_SFTP_HANDLE *handle, size_t offset)
 /*
  * Return the current read/write pointer's offset
  */
-LIBSSH2_API
 size_t libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle)
 {
     if(!handle)
@@ -2563,7 +2551,6 @@ size_t libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle)
 /*
  * Return the current read/write pointer's offset
  */
-LIBSSH2_API
 libssh2_uint64_t libssh2_sftp_tell64(LIBSSH2_SFTP_HANDLE *handle)
 {
     if(!handle)
@@ -2730,7 +2717,6 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
  * Close a file or directory handle
  * Also frees handle resource and unlinks it from the SFTP structure
  */
-LIBSSH2_API
 int libssh2_sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
 {
     int rc;
@@ -2838,7 +2824,6 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
 /*
  * Delete a file from the remote server
  */
-LIBSSH2_API
 int libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp,
                            const char *filename, unsigned int filename_len)
 {
@@ -2986,7 +2971,6 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
 /*
  * Rename a file on the remote server
  */
-LIBSSH2_API
 int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
                            const char *source_filename,
                            unsigned int source_filename_len,
@@ -3119,7 +3103,6 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
  * Rename a file on the remote server using the posix-rename@openssh.com
  * extension.
  */
-LIBSSH2_API
 int libssh2_sftp_posix_rename_ex(LIBSSH2_SFTP *sftp,
                                  const char *source_filename,
                                  size_t source_filename_len,
@@ -3269,7 +3252,6 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
  * Get filesystem space and inode utilization (requires fstatvfs@openssh.com
  * support on the server)
  */
-LIBSSH2_API
 int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
                           LIBSSH2_SFTP_STATVFS *st)
 {
@@ -3415,7 +3397,6 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
  * Get filesystem space and inode utilization (requires statvfs@openssh.com
  * support on the server)
  */
-LIBSSH2_API
 int libssh2_sftp_statvfs(LIBSSH2_SFTP *sftp,
                          const char *path, size_t path_len,
                          LIBSSH2_SFTP_STATVFS *st)
@@ -3539,7 +3520,6 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
 /*
  * Create an SFTP directory
  */
-LIBSSH2_API
 int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
                           const char *path, unsigned int path_len, long mode)
 {
@@ -3647,7 +3627,6 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
 /*
  * Remove a directory
  */
-LIBSSH2_API
 int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
                           const char *path, unsigned int path_len)
 {
@@ -3791,7 +3770,6 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
 /*
  * Stat a file or symbolic link
  */
-LIBSSH2_API
 int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                          const char *path, unsigned int path_len,
                          int stat_type, LIBSSH2_SFTP_ATTRIBUTES *attrs)
@@ -3998,7 +3976,6 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
 /*
  * Read or set a symlink
  */
-LIBSSH2_API
 int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                             const char *path, unsigned int path_len,
                             char *target, unsigned int target_len,
@@ -4016,7 +3993,6 @@ int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
 /*
  * Returns the last error code reported by SFTP
  */
-LIBSSH2_API
 unsigned long libssh2_sftp_last_error(LIBSSH2_SFTP *sftp)
 {
     if(!sftp)
@@ -4028,7 +4004,6 @@ unsigned long libssh2_sftp_last_error(LIBSSH2_SFTP *sftp)
 /*
  * Return the channel of sftp, then caller can control the channel's behavior.
  */
-LIBSSH2_API
 LIBSSH2_CHANNEL *libssh2_sftp_get_channel(LIBSSH2_SFTP *sftp)
 {
     if(!sftp)

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -256,7 +256,6 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
  * Not a common configuration for any SSH server though
  * username should be NULL, or a null-terminated string
  */
-LIBSSH2_API
 char *libssh2_userauth_list(LIBSSH2_SESSION *session,
                             const char *username, unsigned int username_len)
 {
@@ -271,7 +270,6 @@ char *libssh2_userauth_list(LIBSSH2_SESSION *session,
  * When no such message is sent by server or if no authentication attempt has
  * been made, this function returns LIBSSH2_ERROR_MISSING_USERAUTH_BANNER.
  */
-LIBSSH2_API
 int libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
 {
     if(!session)
@@ -292,7 +290,6 @@ int libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
  * Returns: 0 if not yet authenticated
  *          1 if already authenticated
  */
-LIBSSH2_API
 int libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
 {
     return (session->state & SSH2_STATE_AUTHENTICATED) ? 1 : 0;
@@ -555,7 +552,6 @@ password_response:
 /*
  * Plain ol' login
  */
-LIBSSH2_API
 int libssh2_userauth_password_ex(
     LIBSSH2_SESSION *session,
     const char *username, unsigned int username_len,
@@ -917,7 +913,6 @@ static int sign_fromfile(LIBSSH2_SESSION *session,
     return 0;
 }
 
-LIBSSH2_API
 int libssh2_sign_sk(LIBSSH2_SESSION *session,
                     unsigned char **sig, size_t *sig_len,
                     const unsigned char *data, size_t data_len,
@@ -1269,7 +1264,6 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
 /*
  * Authenticate using a keypair found in the named files
  */
-LIBSSH2_API
 int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
                                            const char *username,
                                            unsigned int username_len,
@@ -2041,7 +2035,6 @@ static int userauth_publickey_fromfile(LIBSSH2_SESSION *session,
 /*
  * Authenticate using a keypair from memory
  */
-LIBSSH2_API
 int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
                                           const char *username,
                                           size_t username_len,
@@ -2072,7 +2065,6 @@ int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
 /*
  * Authenticate using a keypair found in the named files
  */
-LIBSSH2_API
 int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
                                            const char *username,
                                            unsigned int username_len,
@@ -2098,7 +2090,6 @@ int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
 /*
  * Authenticate using an external callback function
  */
-LIBSSH2_API
 int libssh2_userauth_publickey(
     LIBSSH2_SESSION *session,
     const char *username,
@@ -2385,7 +2376,6 @@ cleanup:
 /*
  * Authenticate using a challenge-response authentication
  */
-LIBSSH2_API
 int libssh2_userauth_keyboard_interactive_ex(
     LIBSSH2_SESSION *session,
     const char *username, unsigned int username_len,
@@ -2401,7 +2391,6 @@ int libssh2_userauth_keyboard_interactive_ex(
 /*
  * Authenticate using an external callback function
  */
-LIBSSH2_API
 int libssh2_userauth_publickey_sk(
     LIBSSH2_SESSION *session,
     const char *username, size_t username_len,

--- a/src/version.c
+++ b/src/version.c
@@ -39,7 +39,6 @@
 
 #include "libssh2_priv.h"
 
-LIBSSH2_API
 const char *libssh2_version(int req_version_num)
 {
     if(req_version_num <= LIBSSH2_VERSION_NUM)
@@ -47,7 +46,6 @@ const char *libssh2_version(int req_version_num)
     return NULL; /* this is not a suitable library! */
 }
 
-LIBSSH2_API
 libssh2_crypto_engine_t libssh2_crypto_engine(void)
 {
     return SSH2_CRYPTO_ENGINE;


### PR DESCRIPTION
The attributes have an effect on the prototype only, it's not necessary
to set it on function definitions. It may have had a role of which
functions are public, but this is easy to spot by their `libssh2_`
prefixes, esp. after #1961.
