### PR TITLE
crypto: drop intermediate macros where possible

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -218,6 +218,8 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx);
 int ssh2_ecdsa_curve_type_from_name(const char *name,
                                     ssh2_curve_type *out_type);
 
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx);
+
 #endif /* LIBSSH2_ECDSA */
 
 #if LIBSSH2_ED25519

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -132,6 +132,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     const char *filedata,
                                     size_t filedata_len,
                                     const unsigned char *passphrase);
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
 #endif
 
 #if LIBSSH2_DSA

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -220,11 +220,9 @@ int ssh2_ecdsa_curve_type_from_name(const char *name,
                                     ssh2_curve_type *out_type);
 
 void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx);
-
 #endif /* LIBSSH2_ECDSA */
 
 #if LIBSSH2_ED25519
-
 int ssh2_curve25519_new(LIBSSH2_SESSION *session, uint8_t **out_public_key,
                         uint8_t **out_private_key);
 
@@ -275,7 +273,6 @@ int ssh2_ed25519_new_private_frommemory_sk(
     const char *filedata,
     size_t filedata_len,
     const unsigned char *passphrase);
-
 #endif /* LIBSSH2_ED25519 */
 
 #if LIBSSH2_MLKEM
@@ -288,7 +285,6 @@ int ssh2_mlkem_get_sk(unsigned char *out_shared_key,
                       int ml_kem_size,
                       uint8_t *private_key,
                       uint8_t *server_ciphertext);
-
 #endif /* LIBSSH2_MLKEM */
 
 int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -55,8 +55,6 @@
 #error "no cryptography backend selected"
 #endif
 
-int ssh2_random(unsigned char *buf, size_t len);
-
 /* return: success = 1, error = 0 */
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx);
 #if LIBSSH2_MD5

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -341,4 +341,7 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
                                          unsigned char *key_method,
                                          size_t key_method_len);
 
+void ssh2_dh_init(ssh2_dh_ctx *ctx);
+void ssh2_dh_dtor(ssh2_dh_ctx *ctx);
+
 #endif /* LIBSSH2_CRYPTO_H */

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -132,7 +132,6 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     const char *filedata,
                                     size_t filedata_len,
                                     const unsigned char *passphrase);
-void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
 #endif
 
 #if LIBSSH2_DSA

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -217,8 +217,6 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx);
 
 int ssh2_ecdsa_curve_type_from_name(const char *name,
                                     ssh2_curve_type *out_type);
-
-void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx);
 #endif /* LIBSSH2_ECDSA */
 
 #if LIBSSH2_ED25519

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -55,6 +55,8 @@
 #error "no cryptography backend selected"
 #endif
 
+int ssh2_random(unsigned char *buf, size_t len);
+
 /* return: success = 1, error = 0 */
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx);
 #if LIBSSH2_MD5

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -336,7 +336,7 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
                                          unsigned char *key_method,
                                          size_t key_method_len);
 
-void ssh2_dh_init(ssh2_dh_ctx *ctx);
-void ssh2_dh_dtor(ssh2_dh_ctx *ctx);
+void ssh2_dh_init(ssh2_dh_ctx *dhctx);
+void ssh2_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_CRYPTO_H */

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -294,8 +294,6 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast);
 
-void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
-
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **method,
                           size_t *method_len,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -295,6 +295,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast);
 
+void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
+
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **method,
                           size_t *method_len,

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -834,7 +834,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                     "file: Method unimplemented in libgcrypt backend");
 }
 
-void ssh2_lgcr_dh_init(ssh2_dh_ctx *dhctx)
+void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 {
     *dhctx = gcry_mpi_new(0);                   /* Random from client */
 }
@@ -856,7 +856,7 @@ int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
     return 0;
 }
 
-void ssh2_lgcr_dh_dtor(ssh2_dh_ctx *dhctx)
+void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
 {
     gcry_mpi_release(*dhctx);
     *dhctx = NULL;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -839,8 +839,8 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = gcry_mpi_new(0);                   /* Random from client */
 }
 
-int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order)
+int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+                          ssh2_bn *p, int group_order)
 {
     /* Generate x and e */
     gcry_mpi_randomize(*dhctx, group_order * 8 - 1, GCRY_VERY_STRONG_RANDOM);
@@ -848,8 +848,8 @@ int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
     return 0;
 }
 
-int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p)
+int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                        ssh2_bn *p)
 {
     /* Compute the shared secret */
     gcry_mpi_powm(secret, f, *dhctx, p);

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -219,8 +219,7 @@
     ssh2_lgcr_dh_secret(dhctx, secret, f, p)
 
 int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p,
-                          int group_order);
+                          ssh2_bn *g, ssh2_bn *p, int group_order);
 int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                         ssh2_bn *f, ssh2_bn *p);
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -213,18 +213,15 @@
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx struct gcry_mpi *
-#define ssh2_dh_init(dhctx) ssh2_lgcr_dh_init(dhctx)
 #define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     ssh2_lgcr_dh_key_pair(dhctx, public, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_lgcr_dh_secret(dhctx, secret, f, p)
-#define ssh2_dh_dtor(dhctx) ssh2_lgcr_dh_dtor(dhctx)
-void ssh2_lgcr_dh_init(ssh2_dh_ctx *dhctx);
+
 int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
                           ssh2_bn *g, ssh2_bn *p,
                           int group_order);
 int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                         ssh2_bn *f, ssh2_bn *p);
-void ssh2_lgcr_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_LIBGCRYPT_H */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -72,13 +72,12 @@
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define MD5_DIGEST_LENGTH 16
 #endif
-#define SHA_DIGEST_LENGTH 20
+#define SHA_DIGEST_LENGTH    20
 #define SHA256_DIGEST_LENGTH 32
 #define SHA384_DIGEST_LENGTH 48
 #define SHA512_DIGEST_LENGTH 64
 
-#define ssh2_random(buf, len) \
-    (gcry_randomize(buf, len, GCRY_STRONG_RANDOM), 0)
+#define ssh2_random(buf, len) (gcry_randomize(buf, len, GCRY_STRONG_RANDOM), 0)
 
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
@@ -143,11 +142,11 @@
 #define ssh2_crypto_init() gcry_control(GCRYCTL_DISABLE_SECMEM)
 #define ssh2_crypto_exit()
 
-#define ssh2_rsa_ctx struct    gcry_sexp
-#define ssh2_rsa_free(rsactx)  gcry_sexp_release(rsactx)
+#define ssh2_rsa_ctx          struct gcry_sexp
+#define ssh2_rsa_free(rsactx) gcry_sexp_release(rsactx)
 
-#define ssh2_dsa_ctx struct    gcry_sexp
-#define ssh2_dsa_free(dsactx)  gcry_sexp_release(dsactx)
+#define ssh2_dsa_ctx          struct gcry_sexp
+#define ssh2_dsa_free(dsactx) gcry_sexp_release(dsactx)
 
 #if LIBSSH2_ECDSA
 #define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
@@ -156,11 +155,11 @@
 #endif
 
 #define SSH2_CIPHER_T(name) int name
-#define ssh2_cipher_ctx gcry_cipher_hd_t
+#define ssh2_cipher_ctx     gcry_cipher_hd_t
 
-#define ssh2_gcry_ciphermode(c,m) (((c) << 8) | (m))
-#define ssh2_gcry_cipher(c) ((c) >> 8)
-#define ssh2_gcry_mode(m) ((m) & 0xFF)
+#define ssh2_gcry_ciphermode(c, m) (((c) << 8) | (m))
+#define ssh2_gcry_cipher(c)        ((c) >> 8)
+#define ssh2_gcry_mode(m)          ((m) & 0xFF)
 
 #define ssh2_cipher_aes256ctr \
     ssh2_gcry_ciphermode(GCRY_CIPHER_AES256, GCRY_CIPHER_MODE_CTR)
@@ -187,22 +186,23 @@
 
 #define ssh2_cipher_dtor(ctx) gcry_cipher_close(*(ctx))
 
-#define ssh2_bn struct gcry_mpi
-#define ssh2_bn_ctx int
-#define ssh2_bn_ctx_new() 0
-#define ssh2_bn_ctx_free(bnctx) ((void)0)
-#define ssh2_bn_init() gcry_mpi_new(0)
-#define ssh2_bn_init_from_bin() NULL  /* because gcry_mpi_scan() creates a
-                                         new bignum */
-#define ssh2_bn_set_word(bn, val) gcry_mpi_set_ui(bn, val)
+#define ssh2_bn_ctx                    int /* not used */
+#define ssh2_bn_ctx_new()              0 /* not used */
+#define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
+
+#define ssh2_bn                        struct gcry_mpi
+#define ssh2_bn_init()                 gcry_mpi_new(0)
+#define ssh2_bn_init_from_bin()        NULL  /* because gcry_mpi_scan()
+                                                creates a new bignum */
+#define ssh2_bn_set_word(bn, val)      gcry_mpi_set_ui(bn, val)
 #define ssh2_bn_from_bin(bn, len, val) \
     gcry_mpi_scan(&(bn), GCRYMPI_FMT_USG, val, len, NULL)
 #define ssh2_bn_to_bin(bn, val) \
     gcry_mpi_print(GCRYMPI_FMT_USG, val, ssh2_bn_bytes(bn), NULL, bn)
 #define ssh2_bn_bytes(bn) \
     (gcry_mpi_get_nbits(bn) / 8 + ((gcry_mpi_get_nbits(bn) % 8 == 0) ? 0 : 1))
-#define ssh2_bn_bits(bn) gcry_mpi_get_nbits(bn)
-#define ssh2_bn_free(bn) gcry_mpi_release(bn)
+#define ssh2_bn_bits(bn)               gcry_mpi_get_nbits(bn)
+#define ssh2_bn_free(bn)               gcry_mpi_release(bn)
 
 /* Default generate and safe prime sizes for
    diffie-hellman-group-exchange-sha1 */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -77,8 +77,6 @@
 #define SHA384_DIGEST_LENGTH 48
 #define SHA512_DIGEST_LENGTH 64
 
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
-
 #define ssh2_random(buf, len) \
     (gcry_randomize(buf, len, GCRY_STRONG_RANDOM), 0)
 
@@ -152,6 +150,7 @@
 #define ssh2_dsa_free(dsactx)  gcry_sexp_release(dsactx)
 
 #if LIBSSH2_ECDSA
+#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 #else
 #define ssh2_ec_key void
 #endif

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -218,9 +218,9 @@
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_lgcr_dh_secret(dhctx, secret, f, p)
 
-int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order);
-int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p);
+int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+                          ssh2_bn *p, int group_order);
+int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                        ssh2_bn *p);
 
 #endif /* LIBSSH2_LIBGCRYPT_H */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -60,7 +60,7 @@ static mbedtls_ctr_drbg_context mbed_ctr_drbg;
  * mbedTLS backend: Generic functions
  */
 
-void ssh2_mbed_crypto_init(void)
+void ssh2_crypto_init(void)
 {
     int ret;
 
@@ -74,7 +74,7 @@ void ssh2_mbed_crypto_init(void)
         mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
 }
 
-void ssh2_mbed_crypto_exit(void)
+void ssh2_crypto_exit(void)
 {
     mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
     mbedtls_entropy_free(&mbed_entropy);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -877,11 +877,11 @@ void ssh2_mbed_dh_dtor(ssh2_dh_ctx *dhctx)
  * Creates a local private key based on input curve
  * and returns octal value and octal length
  */
-int ssh2_mbed_ecdsa_create_key(LIBSSH2_SESSION *session,
-                               ssh2_ec_key **out_private_key,
-                               unsigned char **out_public_key_octal,
-                               size_t *out_public_key_octal_len,
-                               ssh2_curve_type curve_type)
+int ssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
+                          ssh2_ec_key **out_private_key,
+                          unsigned char **out_public_key_octal,
+                          size_t *out_public_key_octal_len,
+                          ssh2_curve_type curve_type)
 {
     size_t plen = 0;
 
@@ -922,10 +922,9 @@ failed:
 /*
  * Creates a new public key given an octal string, length and type
  */
-int ssh2_mbed_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
-                                              const unsigned char *k,
-                                              size_t k_len,
-                                              ssh2_curve_type curve)
+int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
+                                         const unsigned char *k, size_t k_len,
+                                         ssh2_curve_type curve)
 {
     *ec_ctx = mbedtls_calloc(1, sizeof(mbedtls_ecp_keypair));
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -728,13 +728,13 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
     return ret;
 }
 
-int ssh2_mbed_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                               unsigned char **method,
-                               size_t *method_len,
-                               unsigned char **pubkeydata,
-                               size_t *pubkeydata_len,
-                               const char *privatekey,
-                               const char *passphrase)
+int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
+                          unsigned char **method,
+                          size_t *method_len,
+                          unsigned char **pubkeydata,
+                          size_t *pubkeydata_len,
+                          const char *privatekey,
+                          const char *passphrase)
 {
     mbedtls_pk_context pkey;
     char buf[1024];
@@ -759,14 +759,14 @@ int ssh2_mbed_pub_priv_keyfile(LIBSSH2_SESSION *session,
     return ret;
 }
 
-int ssh2_mbed_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                     unsigned char **method,
-                                     size_t *method_len,
-                                     unsigned char **pubkeydata,
-                                     size_t *pubkeydata_len,
-                                     const char *privatekeydata,
-                                     size_t privatekeydata_len,
-                                     const char *passphrase)
+int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
+                                unsigned char **method,
+                                size_t *method_len,
+                                unsigned char **pubkeydata,
+                                size_t *pubkeydata_len,
+                                const char *privatekeydata,
+                                size_t privatekeydata_len,
+                                const char *passphrase)
 {
     mbedtls_pk_context pkey;
     char buf[1024];
@@ -810,19 +810,19 @@ int ssh2_mbed_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     return ret;
 }
 
-int ssh2_mbed_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
-                                   unsigned char **method,
-                                   size_t *method_len,
-                                   unsigned char **pubkeydata,
-                                   size_t *pubkeydata_len,
-                                   int *algorithm,
-                                   unsigned char *flags,
-                                   const char **application,
-                                   const unsigned char **key_handle,
-                                   size_t *handle_len,
-                                   const char *privatekeydata,
-                                   size_t privatekeydata_len,
-                                   const char *passphrase)
+int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
+                              unsigned char **method,
+                              size_t *method_len,
+                              unsigned char **pubkeydata,
+                              size_t *pubkeydata_len,
+                              int *algorithm,
+                              unsigned char *flags,
+                              const char **application,
+                              const unsigned char **key_handle,
+                              size_t *handle_len,
+                              const char *privatekeydata,
+                              size_t privatekeydata_len,
+                              const char *passphrase)
 {
     (void)method;
     (void)method_len;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -98,9 +98,8 @@ static void mbed_safe_free(void *buf, size_t len)
     mbedtls_free(buf);
 }
 
-int ssh2_mbed_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
-                          unsigned char *iv, unsigned char *secret,
-                          int encrypt)
+int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
+                     unsigned char *iv, unsigned char *secret, int encrypt)
 {
     const mbedtls_cipher_info_t *cipher_info;
     int ret, op;
@@ -143,9 +142,9 @@ int ssh2_mbed_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
     return ret == 0 ? 0 : -1;
 }
 
-int ssh2_mbed_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
-                           int encrypt, unsigned char *block, size_t blocksize,
-                           int firstlast)
+int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
+                      int encrypt, unsigned char *block, size_t blocksize,
+                      int firstlast)
 {
     int ret;
     unsigned char *output;
@@ -178,11 +177,6 @@ int ssh2_mbed_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         ret = -1;
 
     return ret == 0 ? 0 : -1;
-}
-
-void ssh2_mbed_cipher_dtor(ssh2_cipher_ctx *ctx)
-{
-    mbedtls_cipher_free(ctx);
 }
 
 int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -843,8 +843,8 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = ssh2_mbed_bn_init(); /* Random from client */
 }
 
-int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order)
+int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+                          ssh2_bn *p, int group_order)
 {
     /* Generate x and e */
     mbed_bn_random(*dhctx, group_order * 8 - 1, 0, -1);
@@ -852,8 +852,8 @@ int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
     return 0;
 }
 
-int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p)
+int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                        ssh2_bn *p)
 {
     /* Compute the shared secret */
     mbedtls_mpi_exp_mod(secret, f, *dhctx, p, NULL);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -838,7 +838,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
  * mbedTLS backend: Diffie-Hellman functions
  */
 
-void ssh2_mbed_dh_init(ssh2_dh_ctx *dhctx)
+void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 {
     *dhctx = ssh2_mbed_bn_init(); /* Random from client */
 }
@@ -860,7 +860,7 @@ int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
     return 0;
 }
 
-void ssh2_mbed_dh_dtor(ssh2_dh_ctx *dhctx)
+void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
 {
     ssh2_mbed_bn_free(*dhctx);
     *dhctx = NULL;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -60,7 +60,7 @@ static mbedtls_ctr_drbg_context mbed_ctr_drbg;
  * mbedTLS backend: Generic functions
  */
 
-void ssh2_crypto_init(void)
+void ssh2_mbed_crypto_init(void)
 {
     int ret;
 
@@ -74,7 +74,7 @@ void ssh2_crypto_init(void)
         mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
 }
 
-void ssh2_crypto_exit(void)
+void ssh2_mbed_crypto_exit(void)
 {
     mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
     mbedtls_entropy_free(&mbed_entropy);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -60,7 +60,7 @@ static mbedtls_ctr_drbg_context mbed_ctr_drbg;
  * mbedTLS backend: Generic functions
  */
 
-void ssh2_mbed_init(void)
+void ssh2_crypto_init(void)
 {
     int ret;
 
@@ -74,13 +74,13 @@ void ssh2_mbed_init(void)
         mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
 }
 
-void ssh2_mbed_free(void)
+void ssh2_crypto_exit(void)
 {
     mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
     mbedtls_entropy_free(&mbed_entropy);
 }
 
-int ssh2_mbed_random(unsigned char *buf, size_t len)
+int ssh2_random(unsigned char *buf, size_t len)
 {
     int ret;
     ret = mbedtls_ctr_drbg_random(&mbed_ctr_drbg, buf, len);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -359,16 +359,16 @@ static int mbed_bn_random(ssh2_bn *bn, int bits, int top, int bottom)
  * mbedTLS backend: RSA functions
  */
 
-int ssh2_mbed_rsa_new(ssh2_rsa_ctx **rsa,
-                      const unsigned char *edata, unsigned long elen,
-                      const unsigned char *ndata, unsigned long nlen,
-                      const unsigned char *ddata, unsigned long dlen,
-                      const unsigned char *pdata, unsigned long plen,
-                      const unsigned char *qdata, unsigned long qlen,
-                      const unsigned char *e1data, unsigned long e1len,
-                      const unsigned char *e2data, unsigned long e2len,
-                      const unsigned char *coeffdata,
-                      unsigned long coefflen)
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+                 const unsigned char *edata, unsigned long elen,
+                 const unsigned char *ndata, unsigned long nlen,
+                 const unsigned char *ddata, unsigned long dlen,
+                 const unsigned char *pdata, unsigned long plen,
+                 const unsigned char *qdata, unsigned long qlen,
+                 const unsigned char *e1data, unsigned long e1len,
+                 const unsigned char *e2data, unsigned long e2len,
+                 const unsigned char *coeffdata,
+                 unsigned long coefflen)
 {
     int ret;
     ssh2_rsa_ctx *ctx;
@@ -414,17 +414,17 @@ int ssh2_mbed_rsa_new(ssh2_rsa_ctx **rsa,
     }
 
     if(ret && ctx) {
-        ssh2_mbed_rsa_free(ctx);
+        ssh2_rsa_free(ctx);
         ctx = NULL;
     }
     *rsa = ctx;
     return ret;
 }
 
-int ssh2_mbed_rsa_new_private(ssh2_rsa_ctx **rsa,
-                              LIBSSH2_SESSION *session,
-                              const char *filename,
-                              const unsigned char *passphrase)
+int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
+                         LIBSSH2_SESSION *session,
+                         const char *filename,
+                         const unsigned char *passphrase)
 {
     int ret;
     mbedtls_pk_context pkey;
@@ -454,11 +454,10 @@ int ssh2_mbed_rsa_new_private(ssh2_rsa_ctx **rsa,
     return 0;
 }
 
-int ssh2_mbed_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
-                                         LIBSSH2_SESSION *session,
-                                         const char *filedata,
-                                         size_t filedata_len,
-                                         const unsigned char *passphrase)
+int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
+                                    LIBSSH2_SESSION *session,
+                                    const char *filedata, size_t filedata_len,
+                                    const unsigned char *passphrase)
 {
     int ret;
     mbedtls_pk_context pkey;
@@ -511,12 +510,10 @@ int ssh2_mbed_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     return 0;
 }
 
-int ssh2_mbed_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
-                              size_t hash_len,
-                              const unsigned char *sig,
-                              size_t sig_len,
-                              const unsigned char *m,
-                              size_t m_len)
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
+                         size_t hash_len,
+                         const unsigned char *sig, size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     int ret;
     int md_type;
@@ -557,22 +554,18 @@ int ssh2_mbed_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
     return (ret == 0) ? 0 : -1;
 }
 
-int ssh2_mbed_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
-                              const unsigned char *sig,
-                              size_t sig_len,
-                              const unsigned char *m,
-                              size_t m_len)
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
+                         const unsigned char *sig, size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
-    return ssh2_mbed_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH,
-                                     sig, sig_len, m, m_len);
+    return ssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH,
+                                sig, sig_len, m, m_len);
 }
 
-int ssh2_mbed_rsa_sha2_sign(LIBSSH2_SESSION *session,
-                            ssh2_rsa_ctx *rsactx,
-                            const unsigned char *hash,
-                            size_t hash_len,
-                            unsigned char **signature,
-                            size_t *signature_len)
+int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
+                       ssh2_rsa_ctx *rsactx,
+                       const unsigned char *hash, size_t hash_len,
+                       unsigned char **signature, size_t *signature_len)
 {
     int ret;
     unsigned char *sig;
@@ -616,18 +609,16 @@ int ssh2_mbed_rsa_sha2_sign(LIBSSH2_SESSION *session,
     return (ret == 0) ? 0 : -1;
 }
 
-int ssh2_mbed_rsa_sha1_sign(LIBSSH2_SESSION *session,
-                            ssh2_rsa_ctx *rsactx,
-                            const unsigned char *hash,
-                            size_t hash_len,
-                            unsigned char **signature,
-                            size_t *signature_len)
+int ssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
+                       ssh2_rsa_ctx *rsactx,
+                       const unsigned char *hash, size_t hash_len,
+                       unsigned char **signature, size_t *signature_len)
 {
-    return ssh2_mbed_rsa_sha2_sign(session, rsactx, hash, hash_len,
-                                   signature, signature_len);
+    return ssh2_rsa_sha2_sign(session, rsactx, hash, hash_len,
+                              signature, signature_len);
 }
 
-void ssh2_mbed_rsa_free(ssh2_rsa_ctx *ctx)
+void ssh2_rsa_free(ssh2_rsa_ctx *ctx)
 {
     mbedtls_rsa_free(ctx);
     mbedtls_free(ctx);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -912,7 +912,7 @@ int ssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
 
 failed:
 
-    ssh2_mbed_ecdsa_free(*out_private_key);
+    ssh2_ecdsa_free(*out_private_key);
     mbed_safe_free(*out_public_key_octal, plen);
     *out_private_key = NULL;
 
@@ -947,7 +947,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
 
 failed:
 
-    ssh2_mbed_ecdsa_free(*ec_ctx);
+    ssh2_ecdsa_free(*ec_ctx);
     *ec_ctx = NULL;
 
     return -1;
@@ -957,10 +957,10 @@ failed:
  * Computes the shared secret K given a local private key,
  * remote public key and length
  */
-int ssh2_mbed_ecdh_gen_k(ssh2_bn **k,
-                         ssh2_ec_key *private_key,
-                         const unsigned char *server_public_key,
-                         size_t server_public_key_len)
+int ssh2_ecdh_gen_k(ssh2_bn **k,
+                    ssh2_ec_key *private_key,
+                    const unsigned char *server_public_key,
+                    size_t server_public_key_len)
 {
     mbedtls_ecp_point pubkey;
     int rc = 0;
@@ -1011,10 +1011,10 @@ cleanup:
 /*
  * Verifies the ECDSA signature of a hashed message
  */
-int ssh2_mbed_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
-                           const unsigned char *r, size_t r_len,
-                           const unsigned char *s, size_t s_len,
-                           const unsigned char *m, size_t m_len)
+int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
+                      const unsigned char *r, size_t r_len,
+                      const unsigned char *s, size_t s_len,
+                      const unsigned char *m, size_t m_len)
 {
     mbedtls_mpi pr, ps;
     int rc = -1;
@@ -1081,7 +1081,7 @@ static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx,
 
 failed:
 
-    ssh2_mbed_ecdsa_free(*ctx);
+    ssh2_ecdsa_free(*ctx);
     *ctx = NULL;
 
     return -1;
@@ -1090,7 +1090,7 @@ failed:
 /*
  * returns key curve type that maps to ssh2_curve_type
  */
-ssh2_curve_type ssh2_mbed_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx)
+ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx)
 {
     return (ssh2_curve_type)ec_ctx->MBEDTLS_PRIVATE(grp).id;
 }
@@ -1184,7 +1184,7 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
 
 failed:
 
-    ssh2_mbed_ecdsa_free(*ctx);
+    ssh2_ecdsa_free(*ctx);
     *ctx = NULL;
 
 cleanup:
@@ -1199,10 +1199,10 @@ cleanup:
 /*
  * Creates a new private key given a file path and password
  */
-int ssh2_mbed_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
-                                LIBSSH2_SESSION *session,
-                                const char *filename,
-                                const unsigned char *passphrase)
+int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
+                           LIBSSH2_SESSION *session,
+                           const char *filename,
+                           const unsigned char *passphrase)
 {
     mbedtls_pk_context pkey;
     unsigned char *data = NULL;
@@ -1254,11 +1254,11 @@ cleanup:
 /*
  * Creates a new private key given a file data and password
  */
-int ssh2_mbed_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
-                                           LIBSSH2_SESSION *session,
-                                           const char *filedata,
-                                           size_t filedata_len,
-                                           const unsigned char *passphrase)
+int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
+                                      LIBSSH2_SESSION *session,
+                                      const char *filedata,
+                                      size_t filedata_len,
+                                      const unsigned char *passphrase)
 {
     unsigned char *ntdata;
     mbedtls_pk_context pkey;
@@ -1320,12 +1320,10 @@ done:
 /*
  * Computes the ECDSA signature of a previously-hashed message
  */
-int ssh2_mbed_ecdsa_sign(LIBSSH2_SESSION *session,
-                         ssh2_ecdsa_ctx *ec_ctx,
-                         const unsigned char *hash,
-                         size_t hash_len,
-                         unsigned char **signature,
-                         size_t *signature_len)
+int ssh2_ecdsa_sign(LIBSSH2_SESSION *session,
+                    ssh2_ecdsa_ctx *ec_ctx,
+                    const unsigned char *hash, size_t hash_len,
+                    unsigned char **signature, size_t *signature_len)
 {
     size_t r_len, s_len, tmp_sign_len = 0;
     unsigned char *sp, *tmp_sign = NULL;
@@ -1373,7 +1371,7 @@ cleanup:
     return *signature ? 0 : -1;
 }
 
-void ssh2_mbed_ecdsa_free(ssh2_ecdsa_ctx *ctx)
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx)
 {
     mbedtls_ecdsa_free(ctx);
     mbedtls_free(ctx);

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -108,6 +108,12 @@
  * mbedTLS backend: Generic functions
  */
 
+#define ssh2_crypto_init() ssh2_mbed_crypto_init()
+#define ssh2_crypto_exit() ssh2_mbed_crypto_exit()
+
+void ssh2_mbed_crypto_init(void);
+void ssh2_mbed_crypto_exit(void);
+
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 /*******************************************************************/

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -339,11 +339,6 @@ int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
 ssh2_bn *ssh2_mbed_bn_init(void);
 void ssh2_mbed_bn_free(ssh2_bn *bn);
 
-#if LIBSSH2_ECDSA
-ssh2_curve_type ssh2_mbed_ecdsa_key_get_curve_type(ssh2_ecdsa_ctx *ctx);
-void ssh2_mbed_ecdsa_free(ssh2_ecdsa_ctx *ctx);
-#endif /* LIBSSH2_ECDSA */
-
 void ssh2_mbed_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
                           ssh2_bn *g, ssh2_bn *p, int group_order);

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -110,11 +110,6 @@
  * mbedTLS backend: Generic functions
  */
 
-#define ssh2_crypto_init() ssh2_mbed_init()
-#define ssh2_crypto_exit() ssh2_mbed_free()
-
-#define ssh2_random(buf, len) ssh2_mbed_random(buf, len)
-
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 /*******************************************************************/
@@ -333,11 +328,6 @@ typedef enum {
 /*
  * mbedTLS backend: forward declarations
  */
-
-void ssh2_mbed_init(void);
-void ssh2_mbed_free(void);
-
-int ssh2_mbed_random(unsigned char *buf, size_t len);
 
 void ssh2_mbed_cipher_dtor(ssh2_cipher_ctx *ctx);
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -231,9 +231,9 @@ typedef enum {
 #endif
 } ssh2_curve_type;
 
-# define ssh2_ec_key mbedtls_ecp_keypair
+#define ssh2_ec_key mbedtls_ecp_keypair
 #else
-# define ssh2_ec_key void
+#define ssh2_ec_key void
 #endif /* LIBSSH2_ECDSA */
 
 /*******************************************************************/

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -197,6 +197,13 @@
     ssh2_mbed_hash_final(&(ctx), hash)
 #endif
 
+int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,
+                        mbedtls_md_type_t mdtype,
+                        const unsigned char *key, size_t keylen);
+int ssh2_mbed_hash_final(mbedtls_md_context_t *ctx, unsigned char *hash);
+int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
+                   mbedtls_md_type_t mdtype, unsigned char *hash);
+
 /*******************************************************************/
 /*
  * mbedTLS backend: RSA functions
@@ -303,6 +310,9 @@ typedef enum {
 #define ssh2_bn_free(bn) \
     ssh2_mbed_bn_free(bn)
 
+ssh2_bn *ssh2_mbed_bn_init(void);
+void ssh2_mbed_bn_free(ssh2_bn *bn);
+
 /*******************************************************************/
 /*
  * mbedTLS backend: Diffie-Hellman support.
@@ -323,21 +333,6 @@ typedef enum {
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_mbed_dh_secret(dhctx, secret, f, p)
 #define ssh2_dh_dtor(dhctx) ssh2_mbed_dh_dtor(dhctx)
-
-/*******************************************************************/
-/*
- * mbedTLS backend: forward declarations
- */
-
-int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,
-                        mbedtls_md_type_t mdtype,
-                        const unsigned char *key, size_t keylen);
-int ssh2_mbed_hash_final(mbedtls_md_context_t *ctx, unsigned char *hash);
-int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   mbedtls_md_type_t mdtype, unsigned char *hash);
-
-ssh2_bn *ssh2_mbed_bn_init(void);
-void ssh2_mbed_bn_free(ssh2_bn *bn);
 
 void ssh2_mbed_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -114,6 +114,8 @@
 void ssh2_mbed_crypto_init(void);
 void ssh2_mbed_crypto_exit(void);
 
+int ssh2_random(unsigned char *buf, size_t len);
+
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 /*******************************************************************/

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -210,28 +210,6 @@
  */
 
 #define ssh2_rsa_ctx mbedtls_rsa_context
-#define ssh2_rsa_new(rsactx, e, e_len, n, n_len, \
-                     d, d_len, p, p_len, q, q_len, \
-                     e1, e1_len, e2, e2_len, c, c_len) \
-    ssh2_mbed_rsa_new(rsactx, e, e_len, n, n_len, \
-                      d, d_len, p, p_len, q, q_len, \
-                      e1, e1_len, e2, e2_len, c, c_len)
-#define ssh2_rsa_new_private(rsactx, s, filename, passphrase) \
-    ssh2_mbed_rsa_new_private(rsactx, s, filename, passphrase)
-#define ssh2_rsa_new_private_frommemory(rsactx, s, filedata, \
-                                        filedata_len, passphrase) \
-    ssh2_mbed_rsa_new_private_frommemory(rsactx, s, filedata, \
-                                         filedata_len, passphrase)
-#define ssh2_rsa_sha1_sign(s, rsactx, hash, hash_len, sig, sig_len) \
-    ssh2_mbed_rsa_sha1_sign(s, rsactx, hash, hash_len, sig, sig_len)
-#define ssh2_rsa_sha2_sign(s, rsactx, hash, hash_len, sig, sig_len) \
-    ssh2_mbed_rsa_sha2_sign(s, rsactx, hash, hash_len, sig, sig_len)
-#define ssh2_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len) \
-    ssh2_mbed_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len)
-#define ssh2_rsa_sha2_verify(rsactx, hash_len, sig, sig_len, m, m_len) \
-    ssh2_mbed_rsa_sha2_verify(rsactx, hash_len, sig, sig_len, m, m_len)
-#define ssh2_rsa_free(rsactx) \
-    ssh2_mbed_rsa_free(rsactx)
 
 /*******************************************************************/
 /*
@@ -396,8 +374,6 @@ int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
 
 ssh2_bn *ssh2_mbed_bn_init(void);
 void ssh2_mbed_bn_free(ssh2_bn *bn);
-
-void ssh2_mbed_rsa_free(ssh2_rsa_ctx *ctx);
 
 #if LIBSSH2_ECDSA
 ssh2_curve_type ssh2_mbed_ecdsa_key_get_curve_type(ssh2_ecdsa_ctx *ctx);

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -103,8 +103,6 @@
 #define SHA384_DIGEST_LENGTH   48
 #define SHA512_DIGEST_LENGTH   64
 
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
-
 /*******************************************************************/
 /*
  * mbedTLS backend: Generic functions
@@ -212,6 +210,8 @@
  */
 
 #if LIBSSH2_ECDSA
+
+#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
 typedef enum {
 #ifdef MBEDTLS_ECP_DP_SECP256R1_ENABLED

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -338,13 +338,7 @@ typedef enum {
 /*
  * mbedTLS backend: Cipher functions
  */
-
-#define ssh2_cipher_init(ctx, type, iv, secret, encrypt) \
-    ssh2_mbed_cipher_init(ctx, type, iv, secret, encrypt)
-#define ssh2_cipher_crypt(ctx, type, encrypt, block, blocklen, fl) \
-    ssh2_mbed_cipher_crypt(ctx, type, encrypt, block, blocklen, fl)
-#define ssh2_cipher_dtor(ctx) \
-    ssh2_mbed_cipher_dtor(ctx)
+#define ssh2_cipher_dtor(ctx)  mbedtls_cipher_free(ctx)
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -329,8 +329,6 @@ typedef enum {
  * mbedTLS backend: forward declarations
  */
 
-void ssh2_mbed_cipher_dtor(ssh2_cipher_ctx *ctx);
-
 int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,
                         mbedtls_md_type_t mdtype,
                         const unsigned char *key, size_t keylen);

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -330,9 +330,9 @@ void ssh2_mbed_bn_free(ssh2_bn *bn);
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_mbed_dh_secret(dhctx, secret, f, p)
 
-int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order);
-int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p);
+int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+                          ssh2_bn *p, int group_order);
+int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                        ssh2_bn *p);
 
 #endif /* LIBSSH2_MBEDTLS_H */

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -327,18 +327,14 @@ void ssh2_mbed_bn_free(ssh2_bn *bn);
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx mbedtls_mpi *
-#define ssh2_dh_init(dhctx) ssh2_mbed_dh_init(dhctx)
 #define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     ssh2_mbed_dh_key_pair(dhctx, public, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_mbed_dh_secret(dhctx, secret, f, p)
-#define ssh2_dh_dtor(dhctx) ssh2_mbed_dh_dtor(dhctx)
 
-void ssh2_mbed_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
                           ssh2_bn *g, ssh2_bn *p, int group_order);
 int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                         ssh2_bn *f, ssh2_bn *p);
-void ssh2_mbed_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_MBEDTLS_H */

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -59,49 +59,49 @@
 #include <mbedtls/error.h>
 
 /* Define which features are supported. */
-#define LIBSSH2_MD5             1
+#define LIBSSH2_MD5 1
 
-#define LIBSSH2_HMAC_RIPEMD     1
-#define LIBSSH2_HMAC_SHA256     1
-#define LIBSSH2_HMAC_SHA512     1
+#define LIBSSH2_HMAC_RIPEMD 1
+#define LIBSSH2_HMAC_SHA256 1
+#define LIBSSH2_HMAC_SHA512 1
 
-#define LIBSSH2_AES_CBC         1
-#define LIBSSH2_AES_CTR         1
-#define LIBSSH2_AES_GCM         0
+#define LIBSSH2_AES_CBC 1
+#define LIBSSH2_AES_CTR 1
+#define LIBSSH2_AES_GCM 0
 #ifdef MBEDTLS_CIPHER_BLOWFISH_CBC
-# define LIBSSH2_BLOWFISH       1
+# define LIBSSH2_BLOWFISH 1
 #else
-# define LIBSSH2_BLOWFISH       0
+# define LIBSSH2_BLOWFISH 0
 #endif
 #ifdef MBEDTLS_CIPHER_ARC4_128
-# define LIBSSH2_RC4            1
+# define LIBSSH2_RC4 1
 #else
-# define LIBSSH2_RC4            0
+# define LIBSSH2_RC4 0
 #endif
-#define LIBSSH2_CAST            0
-#define LIBSSH2_3DES            1
+#define LIBSSH2_CAST 0
+#define LIBSSH2_3DES 1
 
-#define LIBSSH2_RSA             1
-#define LIBSSH2_RSA_SHA1        1
-#define LIBSSH2_RSA_SHA2        1
-#define LIBSSH2_DSA             0
+#define LIBSSH2_RSA 1
+#define LIBSSH2_RSA_SHA1 1
+#define LIBSSH2_RSA_SHA2 1
+#define LIBSSH2_DSA 0
 #ifdef MBEDTLS_ECDSA_C
-# define LIBSSH2_ECDSA          1
+# define LIBSSH2_ECDSA 1
 #else
-# define LIBSSH2_ECDSA          0
+# define LIBSSH2_ECDSA 0
 #endif
-#define LIBSSH2_ED25519         0
-#define LIBSSH2_MLKEM           0
+#define LIBSSH2_ED25519 0
+#define LIBSSH2_MLKEM 0
 
 #include "crypto_config.h"
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define MD5_DIGEST_LENGTH      16
+#define MD5_DIGEST_LENGTH 16
 #endif
-#define SHA_DIGEST_LENGTH      20
-#define SHA256_DIGEST_LENGTH   32
-#define SHA384_DIGEST_LENGTH   48
-#define SHA512_DIGEST_LENGTH   64
+#define SHA_DIGEST_LENGTH    20
+#define SHA256_DIGEST_LENGTH 32
+#define SHA384_DIGEST_LENGTH 48
+#define SHA512_DIGEST_LENGTH 64
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -219,6 +219,8 @@ int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
 
 #define ssh2_rsa_ctx mbedtls_rsa_context
 
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
+
 /*******************************************************************/
 /*
  * mbedTLS backend: ECDSA structures

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -247,26 +247,8 @@ typedef enum {
  */
 
 #if LIBSSH2_ECDSA
-
 #define ssh2_ecdsa_ctx mbedtls_ecdsa_context
-#define ssh2_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len) \
-    ssh2_mbed_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len)
-#define ssh2_ecdsa_verify(ctx, r, r_len, s, s_len, m, m_len) \
-    ssh2_mbed_ecdsa_verify(ctx, r, r_len, s, s_len, m, m_len)
-#define ssh2_ecdsa_new_private(ctx, session, filename, passphrase) \
-    ssh2_mbed_ecdsa_new_private(ctx, session, filename, passphrase)
-#define ssh2_ecdsa_new_private_frommemory(ctx, session, filedata, \
-                                          filedata_len, passphrase) \
-    ssh2_mbed_ecdsa_new_private_frommemory(ctx, session, filedata, \
-                                           filedata_len, passphrase)
-#define ssh2_ecdsa_sign(session, ctx, hash, hash_len, sign, sign_len) \
-    ssh2_mbed_ecdsa_sign(session, ctx, hash, hash_len, sign, sign_len)
-#define ssh2_ecdsa_get_curve_type(ctx) \
-    ssh2_mbed_ecdsa_get_curve_type(ctx)
-#define ssh2_ecdsa_free(ctx) \
-    ssh2_mbed_ecdsa_free(ctx)
-
-#endif /* LIBSSH2_ECDSA */
+#endif
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -108,11 +108,8 @@
  * mbedTLS backend: Generic functions
  */
 
-#define ssh2_crypto_init() ssh2_mbed_crypto_init()
-#define ssh2_crypto_exit() ssh2_mbed_crypto_exit()
-
-void ssh2_mbed_crypto_init(void);
-void ssh2_mbed_crypto_exit(void);
+void ssh2_crypto_init(void);
+void ssh2_crypto_exit(void);
 
 int ssh2_random(unsigned char *buf, size_t len);
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -249,12 +249,6 @@ typedef enum {
 #if LIBSSH2_ECDSA
 
 #define ssh2_ecdsa_ctx mbedtls_ecdsa_context
-#define ssh2_ecdsa_create_key(session, privkey, pubkey_octal, \
-                              pubkey_octal_len, curve) \
-    ssh2_mbed_ecdsa_create_key(session, privkey, pubkey_octal, \
-                               pubkey_octal_len, curve)
-#define ssh2_ecdsa_curve_name_with_octal_new(ctx, k, k_len, curve) \
-    ssh2_mbed_ecdsa_curve_name_with_octal_new(ctx, k, k_len, curve)
 #define ssh2_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len) \
     ssh2_mbed_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len)
 #define ssh2_ecdsa_verify(ctx, r, r_len, s, s_len, m, m_len) \

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -216,7 +216,7 @@ int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
 
 #define ssh2_rsa_ctx mbedtls_rsa_context
 
-void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
+void ssh2_rsa_free(ssh2_rsa_ctx *ctx);
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -298,20 +298,6 @@ typedef enum {
 
 /*******************************************************************/
 /*
- * mbedTLS backend: Key functions
- */
-
-#define ssh2_pub_priv_keyfile(s, m, m_len, p, p_len, pk, pw) \
-    ssh2_mbed_pub_priv_keyfile(s, m, m_len, p, p_len, pk, pw)
-#define ssh2_pub_priv_keyfilememory(s, m, m_len, p, p_len, pk, pk_len, pw) \
-    ssh2_mbed_pub_priv_keyfilememory(s, m, m_len, p, p_len, pk, pk_len, pw)
-#define ssh2_sk_pub_keyfilememory(s, m, m_len, p, p_len, alg, app, \
-                                  f, kh, kh_len, pk, pk_len, pw) \
-    ssh2_mbed_sk_pub_keyfilememory(s, m, m_len, p, p_len, alg, app, \
-                                   f, kh, kh_len, pk, pk_len, pw)
-
-/*******************************************************************/
-/*
  * mbedTLS backend: Cipher Context structure
  */
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -248,19 +248,13 @@ typedef enum {
 #endif
 } ssh2_curve_type;
 
+#define ssh2_ecdsa_ctx mbedtls_ecdsa_context
 #define ssh2_ec_key mbedtls_ecp_keypair
+
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx);
 #else
 #define ssh2_ec_key void
 #endif /* LIBSSH2_ECDSA */
-
-/*******************************************************************/
-/*
- * mbedTLS backend: ECDSA functions
- */
-
-#if LIBSSH2_ECDSA
-#define ssh2_ecdsa_ctx mbedtls_ecdsa_context
-#endif
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -293,28 +293,20 @@ typedef enum {
  * mbedTLS backend: BigNumber Support
  */
 
-#define ssh2_bn_ctx int /* not used */
-#define ssh2_bn_ctx_new() 0 /* not used */
-#define ssh2_bn_ctx_free(bnctx) ((void)0) /* not used */
+#define ssh2_bn_ctx                    int /* not used */
+#define ssh2_bn_ctx_new()              0 /* not used */
+#define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
 
-#define ssh2_bn mbedtls_mpi
-
-#define ssh2_bn_init() \
-    ssh2_mbed_bn_init()
-#define ssh2_bn_init_from_bin() \
-    ssh2_mbed_bn_init()
-#define ssh2_bn_set_word(bn, word) \
-    mbedtls_mpi_lset(bn, word)
-#define ssh2_bn_from_bin(bn, len, bin) \
-    mbedtls_mpi_read_binary(bn, bin, len)
+#define ssh2_bn                        mbedtls_mpi
+#define ssh2_bn_init()                 ssh2_mbed_bn_init()
+#define ssh2_bn_init_from_bin()        ssh2_mbed_bn_init()
+#define ssh2_bn_set_word(bn, word)     mbedtls_mpi_lset(bn, word)
+#define ssh2_bn_from_bin(bn, len, bin) mbedtls_mpi_read_binary(bn, bin, len)
 #define ssh2_bn_to_bin(bn, bin) \
     mbedtls_mpi_write_binary(bn, bin, mbedtls_mpi_size(bn))
-#define ssh2_bn_bytes(bn) \
-    mbedtls_mpi_size(bn)
-#define ssh2_bn_bits(bn) \
-    mbedtls_mpi_bitlen(bn)
-#define ssh2_bn_free(bn) \
-    ssh2_mbed_bn_free(bn)
+#define ssh2_bn_bytes(bn)              mbedtls_mpi_size(bn)
+#define ssh2_bn_bits(bn)               mbedtls_mpi_bitlen(bn)
+#define ssh2_bn_free(bn)               ssh2_mbed_bn_free(bn)
 
 ssh2_bn *ssh2_mbed_bn_init(void);
 void ssh2_mbed_bn_free(ssh2_bn *bn);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5098,9 +5098,8 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = BN_new(); /* Random from client */
 }
 
-int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order,
-                          ssh2_bn_ctx *bnctx)
+int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+                          ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
     /* Generate x and e */
     BN_rand(*dhctx, group_order * 8 - 1, 0, -1);
@@ -5108,9 +5107,8 @@ int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
     return 0;
 }
 
-int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p,
-                        ssh2_bn_ctx *bnctx)
+int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                        ssh2_bn *p, ssh2_bn_ctx *bnctx)
 {
     /* Compute the shared secret */
     BN_mod_exp(secret, f, *dhctx, p, bnctx);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5093,7 +5093,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
     return st;
 }
 
-void ssh2_ossl_dh_init(ssh2_dh_ctx *dhctx)
+void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 {
     *dhctx = BN_new(); /* Random from client */
 }
@@ -5117,7 +5117,7 @@ int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
     return 0;
 }
 
-void ssh2_ossl_dh_dtor(ssh2_dh_ctx *dhctx)
+void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
 {
     BN_clear_free(*dhctx);
     *dhctx = NULL;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -250,7 +250,7 @@ static inline void swap_bytes(unsigned char *buf, unsigned long len)
 }
 #endif
 
-int ssh2_random(void *buf, size_t len)
+int ssh2_random(unsigned char *buf, size_t len)
 {
     if(len > INT_MAX) {
         return -1;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1099,7 +1099,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return rc;
 }
 
-void ssh2_ossl_crypto_init(void)
+void ssh2_crypto_init(void)
 {
 #if defined(LIBSSH2_WOLFSSL) && defined(DEBUG_WOLFSSL)
     wolfSSL_Debugging_ON();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1099,7 +1099,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return rc;
 }
 
-void ssh2_crypto_init(void)
+void ssh2_ossl_crypto_init(void)
 {
 #if defined(LIBSSH2_WOLFSSL) && defined(DEBUG_WOLFSSL)
     wolfSSL_Debugging_ON();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -250,7 +250,7 @@ static inline void swap_bytes(unsigned char *buf, unsigned long len)
 }
 #endif
 
-int ssh2_ossl_random(void *buf, size_t len)
+int ssh2_random(void *buf, size_t len)
 {
     if(len > INT_MAX) {
         return -1;
@@ -1099,14 +1099,12 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return rc;
 }
 
-void ssh2_ossl_init(void)
+void ssh2_crypto_init(void)
 {
 #if defined(LIBSSH2_WOLFSSL) && defined(DEBUG_WOLFSSL)
     wolfSSL_Debugging_ON();
 #endif
 }
-
-void ssh2_ossl_exit(void) {}
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA || LIBSSH2_ED25519
 /* TODO: Optionally call a passphrase callback specified by the

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -444,8 +444,4 @@ int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                         ssh2_bn_ctx *bnctx);
 void ssh2_ossl_dh_dtor(ssh2_dh_ctx *dhctx);
 
-const EVP_CIPHER *ssh2_EVP_aes_128_ctr(void);
-const EVP_CIPHER *ssh2_EVP_aes_192_ctr(void);
-const EVP_CIPHER *ssh2_EVP_aes_256_ctr(void);
-
 #endif /* LIBSSH2_OPENSSL_H */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -411,10 +411,11 @@ typedef enum {
 #define ssh2_cipher_dtor(ctx) EVP_CIPHER_CTX_cleanup(ctx)
 #endif
 
-#define ssh2_bn                   BIGNUM
 #define ssh2_bn_ctx               BN_CTX
 #define ssh2_bn_ctx_new()         BN_CTX_new()
 #define ssh2_bn_ctx_free(bnctx)   BN_CTX_free(bnctx)
+
+#define ssh2_bn                   BIGNUM
 #define ssh2_bn_init()            BN_new()
 #define ssh2_bn_init_from_bin()   ssh2_bn_init()
 #define ssh2_bn_set_word(bn, val) !BN_set_word(bn, val)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -439,10 +439,9 @@ int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val);
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_ossl_dh_secret(dhctx, secret, f, p, bnctx)
 
-int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order,
-                          ssh2_bn_ctx *bnctx);
-int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p, ssh2_bn_ctx *bnctx);
+int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+                          ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx);
+int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                        ssh2_bn *p, ssh2_bn_ctx *bnctx);
 
 #endif /* LIBSSH2_OPENSSL_H */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -428,13 +428,11 @@ int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val);
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx BIGNUM *
-#define ssh2_dh_init(dhctx) ssh2_ossl_dh_init(dhctx)
 #define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     ssh2_ossl_dh_key_pair(dhctx, public, g, p, group_order, bnctx)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_ossl_dh_secret(dhctx, secret, f, p, bnctx)
-#define ssh2_dh_dtor(dhctx) ssh2_ossl_dh_dtor(dhctx)
-void ssh2_ossl_dh_init(ssh2_dh_ctx *dhctx);
+
 int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
                           ssh2_bn *g, ssh2_bn *p,
                           int group_order,
@@ -442,6 +440,5 @@ int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
 int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                         ssh2_bn *f, ssh2_bn *p,
                         ssh2_bn_ctx *bnctx);
-void ssh2_ossl_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_OPENSSL_H */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -228,6 +228,8 @@
 
 void ssh2_ossl_crypto_init(void);
 
+int ssh2_random(unsigned char *buf, size_t len);
+
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 #ifdef HAVE_OPAQUE_STRUCTS

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -223,10 +223,8 @@
 
 #include "crypto_config.h"
 
-#define ssh2_crypto_init() ssh2_ossl_crypto_init()
+void ssh2_crypto_init(void);
 #define ssh2_crypto_exit()
-
-void ssh2_ossl_crypto_init(void);
 
 int ssh2_random(unsigned char *buf, size_t len);
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -439,11 +439,9 @@ int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val);
     ssh2_ossl_dh_secret(dhctx, secret, f, p, bnctx)
 
 int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p,
-                          int group_order,
+                          ssh2_bn *g, ssh2_bn *p, int group_order,
                           ssh2_bn_ctx *bnctx);
 int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p,
-                        ssh2_bn_ctx *bnctx);
+                        ssh2_bn *f, ssh2_bn *p, ssh2_bn_ctx *bnctx);
 
 #endif /* LIBSSH2_OPENSSL_H */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -225,8 +225,6 @@
 
 #define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
-#define ssh2_random(buf, len)  ssh2_ossl_random(buf, len)
-
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -328,10 +326,7 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #define ssh2_hmac_ctx HMAC_CTX
 #endif /* USE_OPENSSL_3 */
 
-void ssh2_ossl_init(void);
-void ssh2_ossl_exit(void);
-#define ssh2_crypto_init() ssh2_ossl_init()
-#define ssh2_crypto_exit() ssh2_ossl_exit()
+#define ssh2_crypto_exit()
 
 #if LIBSSH2_RSA
 
@@ -448,8 +443,6 @@ int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                         ssh2_bn *f, ssh2_bn *p,
                         ssh2_bn_ctx *bnctx);
 void ssh2_ossl_dh_dtor(ssh2_dh_ctx *dhctx);
-
-int ssh2_ossl_random(void *buf, size_t len);
 
 const EVP_CIPHER *ssh2_EVP_aes_128_ctr(void);
 const EVP_CIPHER *ssh2_EVP_aes_192_ctr(void);

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -223,6 +223,11 @@
 
 #include "crypto_config.h"
 
+#define ssh2_crypto_init() ssh2_ossl_crypto_init()
+#define ssh2_crypto_exit()
+
+void ssh2_ossl_crypto_init(void);
+
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 #ifdef HAVE_OPAQUE_STRUCTS

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -223,8 +223,6 @@
 
 #include "crypto_config.h"
 
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
-
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 #ifdef HAVE_OPAQUE_STRUCTS
@@ -353,6 +351,8 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #endif /* LIBSSH2_DSA */
 
 #if LIBSSH2_ECDSA
+
+#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
 #ifdef USE_OPENSSL_3
 #define ssh2_ecdsa_ctx            EVP_PKEY

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1243,7 +1243,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
  *
  *******************************************************************/
 
-void ssh2_os400qc3_dh_init(ssh2_dh_ctx *dhctx)
+void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 {
     memset((char *)dhctx, 0, sizeof(*dhctx));
 }
@@ -1318,7 +1318,7 @@ int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
     return ssh2_bn_from_bin(secret, secretbuflen, (unsigned char *)secretbuf);
 }
 
-void ssh2_os400qc3_dh_dtor(ssh2_dh_ctx *dhctx)
+void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
 {
     if(!null_token(dhctx->token)) {
         Qc3DestroyAlgorithmContext(dhctx->token, (char *)&ecnull);

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -348,12 +348,9 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
                             int veccount,
                             const struct iovec vector[],
                             ssh2_rsa_ctx *ctx);
-int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx,
-                              ssh2_bn *public,
-                              ssh2_bn *g,
-                              ssh2_bn *p, int group_order);
-int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx,
-                            ssh2_bn *secret,
+int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
+                              ssh2_bn *g, ssh2_bn *p, int group_order);
+int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                             ssh2_bn *f, ssh2_bn *p);
 
 #endif /* LIBSSH2_OS400QC3_H */

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -190,14 +190,13 @@
 
 #include "crypto_config.h"
 
-#define SHA_DIGEST_LENGTH       20
-#define SHA256_DIGEST_LENGTH    32
-#define SHA384_DIGEST_LENGTH    48
-#define SHA512_DIGEST_LENGTH    64
-
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
+#define SHA_DIGEST_LENGTH    20
+#define SHA256_DIGEST_LENGTH 32
+#define SHA384_DIGEST_LENGTH 48
+#define SHA512_DIGEST_LENGTH 64
 
 #if LIBSSH2_ECDSA
+#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 #else
 #define ssh2_ec_key void
 #endif

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -340,7 +340,7 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
 
 #define SSH2_DH_MAX_MODULUS_BITS 2048
 
-#define ssh2_dh_ctx          struct os400qc3_dh_ctx
+#define ssh2_dh_ctx struct os400qc3_dh_ctx
 #define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     ssh2_os400qc3_dh_key_pair(dhctx, public, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -308,6 +308,13 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_rsa_sha2_512_signv(session, sig, siglen, cnt, vector, ctx) \
     ssh2_os400qc3_rsa_signv(session, Qc3_SHA512, sig, siglen, cnt, vector, ctx)
 
+int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
+                            unsigned char **signature,
+                            size_t *signature_len,
+                            int veccount,
+                            const struct iovec vector[],
+                            ssh2_rsa_ctx *ctx);
+
 /* Default generate and safe prime sizes for diffie-hellman-group-exchange-sha1
    Qc3 is limited to a maximum 2048-bit modulus/key size. */
 #define SSH2_DH_GEX_MINGROUP     1024
@@ -347,12 +354,6 @@ int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx, unsigned char *out);
 int ssh2_os400qc3_hash(const unsigned char *message,
                        unsigned long len, unsigned char *out,
                        unsigned int algo);
-int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
-                            unsigned char **signature,
-                            size_t *signature_len,
-                            int veccount,
-                            const struct iovec vector[],
-                            ssh2_rsa_ctx *ctx);
 
 #endif /* LIBSSH2_OS400QC3_H */
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -274,6 +274,14 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_md5_final(ctx, out)      ssh2_os400qc3_hash_final(&(ctx), out)
 #endif
 
+int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algo);
+int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,
+                              const unsigned char *data, int len);
+int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx, unsigned char *out);
+int ssh2_os400qc3_hash(const unsigned char *message,
+                       unsigned long len, unsigned char *out,
+                       unsigned int algo);
+
 #define ssh2_bn_ctx              int  /* Not used. */
 
 #define ssh2_bn_ctx_new()        0
@@ -347,13 +355,6 @@ int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *v);
 int ssh2_bn_set_word(ssh2_bn *bn, unsigned long val);
 int ssh2_bn_to_bin(ssh2_bn *bn, unsigned char *val);
 void ssh2_os400qc3_crypto_dtor(struct os400qc3_crypto_ctx *x);
-int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algo);
-int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,
-                              const unsigned char *data, int len);
-int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx, unsigned char *out);
-int ssh2_os400qc3_hash(const unsigned char *message,
-                       unsigned long len, unsigned char *out,
-                       unsigned int algo);
 
 #endif /* LIBSSH2_OS400QC3_H */
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -282,9 +282,9 @@ int ssh2_os400qc3_hash(const unsigned char *message,
 
 /* Bignum */
 
-#define ssh2_bn_ctx              int  /* Not used. */
-#define ssh2_bn_ctx_new()        0
-#define ssh2_bn_ctx_free(bnctx)  ((void)0)
+#define ssh2_bn_ctx              int /* not used */
+#define ssh2_bn_ctx_new()        0 /* not used */
+#define ssh2_bn_ctx_free(bnctx)  ((void)0) /* not used */
 
 #define ssh2_bn struct os400qc3_bn
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -317,12 +317,10 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define SSH2_DH_MAX_MODULUS_BITS 2048
 
 #define ssh2_dh_ctx          struct os400qc3_dh_ctx
-#define ssh2_dh_init(dhctx)  ssh2_os400qc3_dh_init(dhctx)
 #define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     ssh2_os400qc3_dh_key_pair(dhctx, public, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_os400qc3_dh_secret(dhctx, secret, f, p)
-#define ssh2_dh_dtor(dhctx)  ssh2_os400qc3_dh_dtor(dhctx)
 
 /*******************************************************************
  *
@@ -351,7 +349,6 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
                             int veccount,
                             const struct iovec vector[],
                             ssh2_rsa_ctx *ctx);
-void ssh2_os400qc3_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx,
                               ssh2_bn *public,
                               ssh2_bn *g,
@@ -359,7 +356,6 @@ int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx,
 int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx,
                             ssh2_bn *secret,
                             ssh2_bn *f, ssh2_bn *p);
-void ssh2_os400qc3_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_OS400QC3_H */
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -334,7 +334,6 @@ unsigned long ssh2_bn_bits(ssh2_bn *bn);
 int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *v);
 int ssh2_bn_set_word(ssh2_bn *bn, unsigned long val);
 int ssh2_bn_to_bin(ssh2_bn *bn, unsigned char *val);
-int ssh2_random(unsigned char *buf, size_t len);
 void ssh2_os400qc3_crypto_dtor(struct os400qc3_crypto_ctx *x);
 int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algo);
 int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -322,6 +322,11 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_os400qc3_dh_secret(dhctx, secret, f, p)
 
+int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
+                              ssh2_bn *g, ssh2_bn *p, int group_order);
+int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
+                            ssh2_bn *f, ssh2_bn *p);
+
 /*******************************************************************
  *
  * OS/400 QC3 crypto-library backend: Support procedure prototypes.
@@ -348,10 +353,6 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
                             int veccount,
                             const struct iovec vector[],
                             ssh2_rsa_ctx *ctx);
-int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                              ssh2_bn *g, ssh2_bn *p, int group_order);
-int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                            ssh2_bn *f, ssh2_bn *p);
 
 #endif /* LIBSSH2_OS400QC3_H */
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -220,8 +220,6 @@ struct os400qc3_bn {  /* Big number. */
     unsigned int length;                    /* Length of bignum (# bytes). */
 };
 
-#define ssh2_bn struct os400qc3_bn
-
 struct os400qc3_cipher {  /* Algorithm description. */
     char *fmt;                              /* Format of Qc3 structure. */
     int algo;                               /* Algorithm identifier. */
@@ -282,13 +280,24 @@ int ssh2_os400qc3_hash(const unsigned char *message,
                        unsigned long len, unsigned char *out,
                        unsigned int algo);
 
-#define ssh2_bn_ctx              int  /* Not used. */
+/* Bignum */
 
+#define ssh2_bn_ctx              int  /* Not used. */
 #define ssh2_bn_ctx_new()        0
 #define ssh2_bn_ctx_free(bnctx)  ((void)0)
 
+#define ssh2_bn struct os400qc3_bn
+
+ssh2_bn *ssh2_bn_init(void);
 #define ssh2_bn_init_from_bin()  ssh2_bn_init()
+int ssh2_bn_set_word(ssh2_bn *bn, unsigned long val);
+int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *v);
+int ssh2_bn_to_bin(ssh2_bn *bn, unsigned char *val);
 #define ssh2_bn_bytes(bn)        ((bn)->length)
+unsigned long ssh2_bn_bits(ssh2_bn *bn);
+void ssh2_bn_free(ssh2_bn *bn);
+
+/* Cipher */
 
 #define SSH2_CIPHER_T(name)   struct os400qc3_cipher name
 #define ssh2_cipher_aes128    {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 16}
@@ -348,12 +357,6 @@ int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
  *
  *******************************************************************/
 
-ssh2_bn *ssh2_bn_init(void);
-void ssh2_bn_free(ssh2_bn *bn);
-unsigned long ssh2_bn_bits(ssh2_bn *bn);
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *v);
-int ssh2_bn_set_word(ssh2_bn *bn, unsigned long val);
-int ssh2_bn_to_bin(ssh2_bn *bn, unsigned char *val);
 void ssh2_os400qc3_crypto_dtor(struct os400qc3_crypto_ctx *x);
 
 #endif /* LIBSSH2_OS400QC3_H */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -709,7 +709,7 @@ void ssh2_wcng_crypto_exit(void)
     memset(&ssh2_wcng, 0, sizeof(ssh2_wcng));
 }
 
-int ssh2_random(void *buf, size_t len)
+int ssh2_random(unsigned char *buf, size_t len)
 {
     int ret;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1615,12 +1615,12 @@ void ssh2_wcng_rsa_free(ssh2_rsa_ctx *rsa)
  */
 
 #if LIBSSH2_DSA
-int ssh2_wcng_dsa_new(ssh2_dsa_ctx **dsa,
-                      const unsigned char *pdata, unsigned long plen,
-                      const unsigned char *qdata, unsigned long qlen,
-                      const unsigned char *gdata, unsigned long glen,
-                      const unsigned char *ydata, unsigned long ylen,
-                      const unsigned char *xdata, unsigned long xlen)
+int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
+                 const unsigned char *pdata, unsigned long plen,
+                 const unsigned char *qdata, unsigned long qlen,
+                 const unsigned char *gdata, unsigned long glen,
+                 const unsigned char *ydata, unsigned long ylen,
+                 const unsigned char *xdata, unsigned long xlen)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_DSA_KEY_BLOB *dsakey;
@@ -1736,12 +1736,12 @@ static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
     }
 
     if(length == 6) {
-        ret = ssh2_wcng_dsa_new(dsa,
-                                rpbDecoded[1], rcbDecoded[1],
-                                rpbDecoded[2], rcbDecoded[2],
-                                rpbDecoded[3], rcbDecoded[3],
-                                rpbDecoded[4], rcbDecoded[4],
-                                rpbDecoded[5], rcbDecoded[5]);
+        ret = ssh2_dsa_new(dsa,
+                           rpbDecoded[1], rcbDecoded[1],
+                           rpbDecoded[2], rcbDecoded[2],
+                           rpbDecoded[3], rcbDecoded[3],
+                           rpbDecoded[4], rcbDecoded[4],
+                           rpbDecoded[5], rcbDecoded[5]);
     }
     else {
         ret = -1;
@@ -1760,10 +1760,10 @@ static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
 }
 #endif /* HAVE_LIBCRYPT32 */
 
-int ssh2_wcng_dsa_new_private(ssh2_dsa_ctx **dsa,
-                              LIBSSH2_SESSION *session,
-                              const char *filename,
-                              const unsigned char *passphrase)
+int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
+                         LIBSSH2_SESSION *session,
+                         const char *filename,
+                         const unsigned char *passphrase)
 {
 #ifdef HAVE_LIBCRYPT32
     unsigned char *pbEncoded;
@@ -1788,11 +1788,10 @@ int ssh2_wcng_dsa_new_private(ssh2_dsa_ctx **dsa,
 #endif /* HAVE_LIBCRYPT32 */
 }
 
-int ssh2_wcng_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
-                                         LIBSSH2_SESSION *session,
-                                         const char *filedata,
-                                         size_t filedata_len,
-                                         const unsigned char *passphrase)
+int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
+                                    LIBSSH2_SESSION *session,
+                                    const char *filedata, size_t filedata_len,
+                                    const unsigned char *passphrase)
 {
 #ifdef HAVE_LIBCRYPT32
     unsigned char *pbEncoded;
@@ -1818,19 +1817,17 @@ int ssh2_wcng_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
 #endif /* HAVE_LIBCRYPT32 */
 }
 
-int ssh2_wcng_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
-                              const unsigned char *sig_fixed,
-                              const unsigned char *m,
-                              size_t m_len)
+int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
+                         const unsigned char *sig_fixed,
+                         const unsigned char *m, size_t m_len)
 {
     return wcng_key_sha_verify(dsa, SHA_DIGEST_LENGTH, sig_fixed,
                                40, m, (ULONG)m_len, 0);
 }
 
-int ssh2_wcng_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
-                            const unsigned char *hash,
-                            size_t hash_len,
-                            unsigned char *sig_fixed)
+int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
+                       const unsigned char *hash, size_t hash_len,
+                       unsigned char *sig_fixed)
 {
     unsigned char *data, *sig;
     ULONG cbData, datalen, siglen;
@@ -1871,7 +1868,7 @@ int ssh2_wcng_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-void ssh2_wcng_dsa_free(ssh2_dsa_ctx *dsa)
+void ssh2_dsa_free(ssh2_dsa_ctx *dsa)
 {
     if(!dsa)
         return;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3154,13 +3154,13 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
 }
 #endif /* HAVE_LIBCRYPT32 */
 
-int ssh2_wcng_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                               unsigned char **method,
-                               size_t *method_len,
-                               unsigned char **pubkeydata,
-                               size_t *pubkeydata_len,
-                               const char *privatekey,
-                               const char *passphrase)
+int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
+                          unsigned char **method,
+                          size_t *method_len,
+                          unsigned char **pubkeydata,
+                          size_t *pubkeydata_len,
+                          const char *privatekey,
+                          const char *passphrase)
 {
 #ifdef HAVE_LIBCRYPT32
     unsigned char *pbEncoded;
@@ -3191,14 +3191,14 @@ int ssh2_wcng_pub_priv_keyfile(LIBSSH2_SESSION *session,
 #endif /* HAVE_LIBCRYPT32 */
 }
 
-int ssh2_wcng_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                     unsigned char **method,
-                                     size_t *method_len,
-                                     unsigned char **pubkeydata,
-                                     size_t *pubkeydata_len,
-                                     const char *privatekeydata,
-                                     size_t privatekeydata_len,
-                                     const char *passphrase)
+int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
+                                unsigned char **method,
+                                size_t *method_len,
+                                unsigned char **pubkeydata,
+                                size_t *pubkeydata_len,
+                                const char *privatekeydata,
+                                size_t privatekeydata_len,
+                                const char *passphrase)
 {
 #ifdef HAVE_LIBCRYPT32
     unsigned char *pbEncoded;
@@ -3231,19 +3231,19 @@ int ssh2_wcng_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 #endif /* HAVE_LIBCRYPT32 */
 }
 
-int ssh2_wcng_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
-                                   unsigned char **method,
-                                   size_t *method_len,
-                                   unsigned char **pubkeydata,
-                                   size_t *pubkeydata_len,
-                                   int *algorithm,
-                                   unsigned char *flags,
-                                   const char **application,
-                                   const unsigned char **key_handle,
-                                   size_t *handle_len,
-                                   const char *privatekeydata,
-                                   size_t privatekeydata_len,
-                                   const char *passphrase)
+int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
+                              unsigned char **method,
+                              size_t *method_len,
+                              unsigned char **pubkeydata,
+                              size_t *pubkeydata_len,
+                              int *algorithm,
+                              unsigned char *flags,
+                              const char **application,
+                              const unsigned char **key_handle,
+                              size_t *handle_len,
+                              const char *privatekeydata,
+                              size_t privatekeydata_len,
+                              const char *passphrase)
 {
     (void)method;
     (void)method_len;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3485,8 +3485,8 @@ static int wcng_round_down(int number, int multiple)
  * private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
  * the public key is returned in `public'.  0 is returned upon success, else
  * -1.  */
-int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order)
+int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+                          ssh2_bn *p, int group_order)
 {
     const int hasAlgDHwithKDF = ssh2_wcng.hasAlgDHwithKDF;
 
@@ -3672,8 +3672,8 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
  * `*dhctx', the public key `f' from the other party and the same prime `p'
  * used at context creation. The result is stored in `secret'.  0 is returned
  * upon success, else -1.  */
-int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p)
+int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                        ssh2_bn *p)
 {
     if(ssh2_wcng.hAlgDH && ssh2_wcng.hasAlgDHwithKDF != -1 &&
        dhctx->dh_handle && dhctx->dh_params && f) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -474,7 +474,7 @@ struct ecdsa_point {
 
 struct wcng_ctx ssh2_wcng;
 
-void ssh2_wcng_crypto_init(void)
+void ssh2_crypto_init(void)
 {
     int ret;
 
@@ -654,7 +654,7 @@ void ssh2_wcng_crypto_init(void)
 #endif
 }
 
-void ssh2_wcng_crypto_exit(void)
+void ssh2_crypto_exit(void)
 {
 #if LIBSSH2_ECDSA
     unsigned int curve;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1249,16 +1249,16 @@ static ULONG wcng_bn_size(const unsigned char *bignum, ULONG length)
  * Windows CNG backend: RSA functions
  */
 
-int ssh2_wcng_rsa_new(ssh2_rsa_ctx **rsa,
-                      const unsigned char *edata, unsigned long elen,
-                      const unsigned char *ndata, unsigned long nlen,
-                      const unsigned char *ddata, unsigned long dlen,
-                      const unsigned char *pdata, unsigned long plen,
-                      const unsigned char *qdata, unsigned long qlen,
-                      const unsigned char *e1data, unsigned long e1len,
-                      const unsigned char *e2data, unsigned long e2len,
-                      const unsigned char *coeffdata,
-                      unsigned long coefflen)
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+                 const unsigned char *edata, unsigned long elen,
+                 const unsigned char *ndata, unsigned long nlen,
+                 const unsigned char *ddata, unsigned long dlen,
+                 const unsigned char *pdata, unsigned long plen,
+                 const unsigned char *qdata, unsigned long qlen,
+                 const unsigned char *e1data, unsigned long e1len,
+                 const unsigned char *e2data, unsigned long e2len,
+                 const unsigned char *coeffdata,
+                 unsigned long coefflen)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_RSAKEY_BLOB *rsakey;
@@ -1425,10 +1425,10 @@ static int wcng_rsa_new_private_parse(ssh2_rsa_ctx **rsa,
 }
 #endif /* HAVE_LIBCRYPT32 */
 
-int ssh2_wcng_rsa_new_private(ssh2_rsa_ctx **rsa,
-                              LIBSSH2_SESSION *session,
-                              const char *filename,
-                              const unsigned char *passphrase)
+int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
+                         LIBSSH2_SESSION *session,
+                         const char *filename,
+                         const unsigned char *passphrase)
 {
 #ifdef HAVE_LIBCRYPT32
     unsigned char *pbEncoded;
@@ -1453,11 +1453,10 @@ int ssh2_wcng_rsa_new_private(ssh2_rsa_ctx **rsa,
 #endif /* HAVE_LIBCRYPT32 */
 }
 
-int ssh2_wcng_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
-                                         LIBSSH2_SESSION *session,
-                                         const char *filedata,
-                                         size_t filedata_len,
-                                         const unsigned char *passphrase)
+int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
+                                    LIBSSH2_SESSION *session,
+                                    const char *filedata, size_t filedata_len,
+                                    const unsigned char *passphrase)
 {
 #ifdef HAVE_LIBCRYPT32
     unsigned char *pbEncoded;
@@ -1484,11 +1483,9 @@ int ssh2_wcng_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 }
 
 #if LIBSSH2_RSA_SHA1
-int ssh2_wcng_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
-                              const unsigned char *sig,
-                              size_t sig_len,
-                              const unsigned char *m,
-                              size_t m_len)
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
+                         const unsigned char *sig, size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     return wcng_key_sha_verify(rsactx, SHA_DIGEST_LENGTH,
                                sig, (ULONG)sig_len,
@@ -1498,12 +1495,10 @@ int ssh2_wcng_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
 #endif
 
 #if LIBSSH2_RSA_SHA2
-int ssh2_wcng_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
-                              size_t hash_len,
-                              const unsigned char *sig,
-                              size_t sig_len,
-                              const unsigned char *m,
-                              size_t m_len)
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
+                         size_t hash_len,
+                         const unsigned char *sig, size_t sig_len,
+                         const unsigned char *m, size_t m_len)
 {
     return wcng_key_sha_verify(rsactx, (ULONG)hash_len,
                                sig, (ULONG)sig_len,
@@ -1572,31 +1567,27 @@ static int wcng_rsa_sha_sign(LIBSSH2_SESSION *session,
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-int ssh2_wcng_rsa_sha1_sign(LIBSSH2_SESSION *session,
-                            ssh2_rsa_ctx *rsactx,
-                            const unsigned char *hash,
-                            size_t hash_len,
-                            unsigned char **signature,
-                            size_t *signature_len)
+int ssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
+                       ssh2_rsa_ctx *rsactx,
+                       const unsigned char *hash, size_t hash_len,
+                       unsigned char **signature, size_t *signature_len)
 {
     return wcng_rsa_sha_sign(session, rsactx,
                              hash, hash_len,
                              signature, signature_len);
 }
 
-int ssh2_wcng_rsa_sha2_sign(LIBSSH2_SESSION *session,
-                            ssh2_rsa_ctx *rsactx,
-                            const unsigned char *hash,
-                            size_t hash_len,
-                            unsigned char **signature,
-                            size_t *signature_len)
+int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
+                       ssh2_rsa_ctx *rsactx,
+                       const unsigned char *hash, size_t hash_len,
+                       unsigned char **signature, size_t *signature_len)
 {
     return wcng_rsa_sha_sign(session, rsactx,
                              hash, hash_len,
                              signature, signature_len);
 }
 
-void ssh2_wcng_rsa_free(ssh2_rsa_ctx *rsa)
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa)
 {
     if(!rsa)
         return;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3645,8 +3645,8 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
             if(!(dhctx->dh_privbn->bignum[dhctx->dh_privbn->length - 1] % 2)) {
                 wcng_safe_free(dh_key_blob, key_length_bytes);
                 /* discard everything first, then try again */
-                ssh2_wcng_dh_dtor(dhctx);
-                ssh2_wcng_dh_init(dhctx);
+                ssh2_dh_dtor(dhctx);
+                ssh2_dh_init(dhctx);
                 continue;
             }
         }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2385,10 +2385,10 @@ cleanup:
  * Computes the shared secret K given a local private key,
  * remote public key and length
  */
-int ssh2_wcng_ecdh_gen_k(OUT ssh2_bn **secret,
-                         IN struct wcng_ecdsa_ctx *privatekey,
-                         IN const unsigned char *server_publickey_encoded,
-                         IN size_t server_publickey_encoded_len)
+int ssh2_ecdh_gen_k(OUT ssh2_bn **secret,
+                    IN ssh2_ecdsa_ctx *privatekey,
+                    IN const unsigned char *server_publickey_encoded,
+                    IN size_t server_publickey_encoded_len)
 {
     int result = LIBSSH2_ERROR_NONE;
     NTSTATUS status;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -474,7 +474,7 @@ struct ecdsa_point {
 
 struct wcng_ctx ssh2_wcng;
 
-void ssh2_crypto_init(void)
+void ssh2_wcng_crypto_init(void)
 {
     int ret;
 
@@ -654,7 +654,7 @@ void ssh2_crypto_init(void)
 #endif
 }
 
-void ssh2_crypto_exit(void)
+void ssh2_wcng_crypto_exit(void)
 {
 #if LIBSSH2_ECDSA
     unsigned int curve;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2247,11 +2247,11 @@ void ssh2_ecdsa_free(IN ssh2_ecdsa_ctx *key)
  * Creates a local private ECDH key based on input curve
  * and returns the public key in uncompressed point encoding.
  */
-int ssh2_wcng_ecdh_create_key(IN LIBSSH2_SESSION *session,
-                              OUT struct wcng_ecdsa_ctx **privatekey,
-                              OUT unsigned char **encoded_publickey,
-                              OUT size_t *encoded_publickey_len,
-                              IN ssh2_curve_type curve)
+int ssh2_ecdsa_create_key(IN LIBSSH2_SESSION *session,
+                          OUT struct wcng_ecdsa_ctx **privatekey,
+                          OUT unsigned char **encoded_publickey,
+                          OUT size_t *encoded_publickey_len,
+                          IN ssh2_curve_type curve)
 {
     int result = LIBSSH2_ERROR_NONE;
     NTSTATUS status;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2233,7 +2233,7 @@ static void wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
 /*
  * Windows CNG backend: ECDSA functions
  */
-void ssh2_wcng_ecdsa_free(IN struct wcng_ecdsa_ctx *key)
+void ssh2_ecdsa_free(IN ssh2_ecdsa_ctx *key)
 {
     if(!key) {
         return;
@@ -2329,8 +2329,8 @@ cleanup:
 /*
  * Creates an ECDSA public key from an uncompressed point.
  */
-int ssh2_wcng_ecdsa_curve_name_with_octal_new(
-    OUT struct wcng_ecdsa_ctx **key,
+int ssh2_ecdsa_curve_name_with_octal_new(
+    OUT ssh2_ecdsa_ctx **key,
     IN const unsigned char *publickey_encoded,
     IN size_t publickey_encoded_len,
     IN ssh2_curve_type curve)
@@ -2521,13 +2521,13 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
 /*
  * Verifies the ECDSA signature of a hashed message
  */
-int ssh2_wcng_ecdsa_verify(IN struct wcng_ecdsa_ctx *key,
-                           IN const unsigned char *r,
-                           IN size_t r_len,
-                           IN const unsigned char *s,
-                           IN size_t s_len,
-                           IN const unsigned char *m,
-                           IN size_t m_len)
+int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *key,
+                      IN const unsigned char *r,
+                      IN size_t r_len,
+                      IN const unsigned char *s,
+                      IN size_t s_len,
+                      IN const unsigned char *m,
+                      IN size_t m_len)
 {
     int result = LIBSSH2_ERROR_NONE;
     NTSTATUS status;
@@ -2544,7 +2544,7 @@ int ssh2_wcng_ecdsa_verify(IN struct wcng_ecdsa_ctx *key,
         r_len,
         s,
         s_len,
-        ssh2_wcng_ecdsa_get_curve_type(key),
+        ssh2_ecdsa_get_curve_type(key),
         &signature_p1363,
         &signature_p1363_len);
     if(result != LIBSSH2_ERROR_NONE) {
@@ -2552,7 +2552,7 @@ int ssh2_wcng_ecdsa_verify(IN struct wcng_ecdsa_ctx *key,
     }
 
     /* Create hash over m */
-    switch(ssh2_wcng_ecdsa_get_curve_type(key)) {
+    switch(ssh2_ecdsa_get_curve_type(key)) {
     case SSH2_EC_CURVE_NISTP256:
         hash_len = 256 / 8;
         hash_alg = ssh2_wcng.hAlgHashSHA256;
@@ -2614,10 +2614,10 @@ cleanup:
 /*
  * Creates a new private key given a file path and password
  */
-int ssh2_wcng_ecdsa_new_private(OUT struct wcng_ecdsa_ctx **key,
-                                IN LIBSSH2_SESSION *session,
-                                IN const char *filename,
-                                IN const unsigned char *passphrase)
+int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **key,
+                           IN LIBSSH2_SESSION *session,
+                           IN const char *filename,
+                           IN const unsigned char *passphrase)
 {
     int result;
 
@@ -2656,7 +2656,7 @@ int ssh2_wcng_ecdsa_new_private(OUT struct wcng_ecdsa_ctx **key,
         goto cleanup;
     }
 
-    result = ssh2_wcng_ecdsa_new_private_frommemory(
+    result = ssh2_ecdsa_new_private_frommemory(
         key,
         session,
         (const char *)data,
@@ -2802,11 +2802,11 @@ cleanup:
  * ECDSA private key files use the decoding defined in PROTOCOL.key
  * in the OpenSSL source tree.
  */
-int ssh2_wcng_ecdsa_new_private_frommemory(OUT struct wcng_ecdsa_ctx **key,
-                                           IN LIBSSH2_SESSION *session,
-                                           IN const char *data,
-                                           IN size_t data_len,
-                                           IN const unsigned char *passphrase)
+int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **key,
+                                      IN LIBSSH2_SESSION *session,
+                                      IN const char *data,
+                                      IN size_t data_len,
+                                      IN const unsigned char *passphrase)
 {
     int result;
 
@@ -2899,12 +2899,12 @@ cleanup:
 /*
  * Computes the ECDSA signature of a previously-hashed message
  */
-int ssh2_wcng_ecdsa_sign(IN LIBSSH2_SESSION *session,
-                         IN struct wcng_ecdsa_ctx *key,
-                         IN const unsigned char *hash,
-                         IN size_t hash_len,
-                         OUT unsigned char **signature,
-                         OUT size_t *signature_len)
+int ssh2_ecdsa_sign(IN LIBSSH2_SESSION *session,
+                    IN struct wcng_ecdsa_ctx *key,
+                    IN const unsigned char *hash,
+                    IN size_t hash_len,
+                    OUT unsigned char **signature,
+                    OUT size_t *signature_len)
 {
     NTSTATUS status;
     int result = LIBSSH2_ERROR_NONE;
@@ -3010,7 +3010,7 @@ cleanup:
 /*
  * returns key curve type that maps to ssh2_curve_type
  */
-ssh2_curve_type ssh2_wcng_ecdsa_get_curve_type(IN struct wcng_ecdsa_ctx *key)
+ssh2_curve_type ssh2_ecdsa_get_curve_type(IN ssh2_ecdsa_ctx *key)
 {
     return key->curve;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2221,14 +2221,14 @@ static void wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
 /*
  * Windows CNG backend: ECDSA functions
  */
-void ssh2_ecdsa_free(IN ssh2_ecdsa_ctx *key)
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx)
 {
-    if(!key) {
+    if(!ctx) {
         return;
     }
 
-    (void)BCryptDestroyKey(key->handle);
-    free(key);
+    (void)BCryptDestroyKey(ctx->handle);
+    free(ctx);
 }
 
 /*

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -198,7 +198,7 @@ static int wcng_bn_random(ssh2_bn *rnd, int bits, int top, int bottom)
     if(!bignum)
         return -1;
 
-    if(ssh2_wcng_random(bignum, length))
+    if(ssh2_random(bignum, length))
         return -1;
 
     /* calculate significant bits in most significant byte */
@@ -474,7 +474,7 @@ struct ecdsa_point {
 
 struct wcng_ctx ssh2_wcng;
 
-void ssh2_wcng_init(void)
+void ssh2_crypto_init(void)
 {
     int ret;
 
@@ -654,7 +654,7 @@ void ssh2_wcng_init(void)
 #endif
 }
 
-void ssh2_wcng_free(void)
+void ssh2_crypto_exit(void)
 {
 #if LIBSSH2_ECDSA
     unsigned int curve;
@@ -709,7 +709,7 @@ void ssh2_wcng_free(void)
     memset(&ssh2_wcng, 0, sizeof(ssh2_wcng));
 }
 
-int ssh2_wcng_random(void *buf, size_t len)
+int ssh2_random(void *buf, size_t len)
 {
     int ret;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3267,9 +3267,8 @@ int ssh2_wcng_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 /*
  * Windows CNG backend: Cipher functions
  */
-int ssh2_wcng_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
-                          unsigned char *iv, unsigned char *secret,
-                          int encrypt)
+int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
+                     unsigned char *iv, unsigned char *secret, int encrypt)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_KEY_DATA_BLOB_HEADER *header;
@@ -3378,9 +3377,9 @@ static void wcng_aes_ctr_increment(unsigned char *ctr, size_t length)
     }
 }
 
-int ssh2_wcng_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
-                           int encrypt, unsigned char *block, size_t blocksize,
-                           int firstlast)
+int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
+                      int encrypt, unsigned char *block, size_t blocksize,
+                      int firstlast)
 {
     unsigned char *pbOutput, *pbInput;
     ULONG cbOutput, cbInput;
@@ -3439,7 +3438,7 @@ int ssh2_wcng_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-void ssh2_wcng_cipher_dtor(ssh2_cipher_ctx *ctx)
+void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
 {
     BCryptDestroyKey(ctx->hKey);
     ctx->hKey = NULL;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3449,7 +3449,7 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
  * Windows CNG backend: Diffie-Hellman support.
  */
 
-void ssh2_wcng_dh_init(ssh2_dh_ctx *dhctx)
+void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 {
     /* Random from client */
     dhctx->dh_handle = NULL;
@@ -3457,7 +3457,7 @@ void ssh2_wcng_dh_init(ssh2_dh_ctx *dhctx)
     dhctx->dh_privbn = NULL;
 }
 
-void ssh2_wcng_dh_dtor(ssh2_dh_ctx *dhctx)
+void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
 {
     if(dhctx->dh_handle) {
         BCryptDestroyKey(dhctx->dh_handle);

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -340,19 +340,6 @@ void ssh2_wcng_ecdsa_free(ssh2_ecdsa_ctx* ctx);
 #define ssh2_ecdsa_free(ecdsactx) \
     ssh2_wcng_ecdsa_free(ecdsactx)
 
-/*
- * Windows CNG backend: Key functions
- */
-
-#define ssh2_pub_priv_keyfile(s, m, m_len, p, p_len, pk, pw) \
-    ssh2_wcng_pub_priv_keyfile(s, m, m_len, p, p_len, pk, pw)
-#define ssh2_pub_priv_keyfilememory(s, m, m_len, p, p_len, pk, pk_len, pw) \
-    ssh2_wcng_pub_priv_keyfilememory(s, m, m_len, p, p_len, pk, pk_len, pw)
-#define ssh2_sk_pub_keyfilememory(s, m, m_len, p, p_len, alg, app, \
-                                  f, kh, kh_len, pk, pk_len, pw) \
-    ssh2_wcng_sk_pub_keyfilememory(s, m, m_len, p, p_len, alg, app, \
-                                   f, kh, kh_len, pk, pk_len, pw)
-
 /*******************************************************************/
 /*
  * Windows CNG backend: Cipher Context structure

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -427,9 +427,4 @@ int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
                    BCRYPT_ALG_HANDLE hAlg,
                    unsigned char *hash, ULONG hashlen);
 
-void ssh2_wcng_rsa_free(ssh2_rsa_ctx *rsa);
-#if LIBSSH2_DSA
-void ssh2_wcng_dsa_free(ssh2_dsa_ctx *dsa);
-#endif
-
 #endif /* LIBSSH2_WINCNG_H */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -301,6 +301,7 @@ struct wcng_key_ctx {
  * Windows CNG backend: ECDSA functions
  */
 
+#if LIBSSH2_ECDSA
 typedef enum {
     SSH2_EC_CURVE_NISTP256 = 0,
     SSH2_EC_CURVE_NISTP384 = 1,
@@ -313,7 +314,6 @@ struct wcng_ecdsa_ctx {
 };
 
 #define ssh2_ecdsa_ctx struct wcng_ecdsa_ctx
-#if LIBSSH2_ECDSA
 #define ssh2_ec_key struct wcng_ecdsa_ctx
 #endif
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -273,22 +273,6 @@ struct wcng_key_ctx {
  */
 
 #define ssh2_dsa_ctx struct wcng_key_ctx
-#define ssh2_dsa_new(dsactx, p, p_len, q, q_len, g, g_len, y, y_len, \
-                     x, x_len) \
-    ssh2_wcng_dsa_new(dsactx, p, p_len, q, q_len, g, g_len, y, y_len, \
-                      x, x_len)
-#define ssh2_dsa_new_private(dsactx, s, filename, passphrase) \
-    ssh2_wcng_dsa_new_private(dsactx, s, filename, passphrase)
-#define ssh2_dsa_new_private_frommemory(dsactx, s, filedata, \
-                                        filedata_len, passphrase) \
-    ssh2_wcng_dsa_new_private_frommemory(dsactx, s, filedata, \
-                                         filedata_len, passphrase)
-#define ssh2_dsa_sha1_sign(dsactx, hash, hash_len, sig) \
-    ssh2_wcng_dsa_sha1_sign(dsactx, hash, hash_len, sig)
-#define ssh2_dsa_sha1_verify(dsactx, sig, m, m_len) \
-    ssh2_wcng_dsa_sha1_verify(dsactx, sig, m, m_len)
-#define ssh2_dsa_free(dsactx) \
-    ssh2_wcng_dsa_free(dsactx)
 
 /*
  * Windows CNG backend: ECDSA functions

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -149,6 +149,8 @@ extern struct wcng_ctx ssh2_wcng;
 void ssh2_wcng_crypto_init(void);
 void ssh2_wcng_crypto_exit(void);
 
+int ssh2_random(unsigned char *buf, size_t len);
+
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 /*******************************************************************/

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -143,11 +143,6 @@ extern struct wcng_ctx ssh2_wcng;
  * Windows CNG backend: Generic functions
  */
 
-#define ssh2_crypto_init() ssh2_wcng_init()
-#define ssh2_crypto_exit() ssh2_wcng_free()
-
-#define ssh2_random(buf, len) ssh2_wcng_random(buf, len)
-
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 /*******************************************************************/
@@ -417,14 +412,5 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
 int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                         ssh2_bn *f, ssh2_bn *p);
 void ssh2_wcng_dh_dtor(ssh2_dh_ctx *dhctx);
-
-/*******************************************************************/
-/*
- * Windows CNG backend: forward declarations
- */
-void ssh2_wcng_init(void);
-void ssh2_wcng_free(void);
-
-int ssh2_wcng_random(void *buf, size_t len);
 
 #endif /* LIBSSH2_WINCNG_H */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -225,6 +225,17 @@ struct wcng_hash_ctx {
     (ssh2_wcng_hash_final(&(ctx), hash) == 0)
 #endif
 
+int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx,
+                        BCRYPT_ALG_HANDLE hAlg, ULONG hashlen,
+                        unsigned char *key, ULONG keylen);
+int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
+                          const void *data, ULONG datalen);
+int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx,
+                         unsigned char *hash);
+int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
+                   BCRYPT_ALG_HANDLE hAlg,
+                   unsigned char *hash, ULONG hashlen);
+
 /*
  * Windows CNG backend: HMAC functions
  */
@@ -415,16 +426,5 @@ void ssh2_wcng_init(void);
 void ssh2_wcng_free(void);
 
 int ssh2_wcng_random(void *buf, size_t len);
-
-int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx,
-                        BCRYPT_ALG_HANDLE hAlg, ULONG hashlen,
-                        unsigned char *key, ULONG keylen);
-int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
-                          const void *data, ULONG datalen);
-int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx,
-                         unsigned char *hash);
-int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
-                   BCRYPT_ALG_HANDLE hAlg,
-                   unsigned char *hash, ULONG hashlen);
 
 #endif /* LIBSSH2_WINCNG_H */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -418,8 +418,6 @@ void ssh2_wcng_rsa_free(ssh2_rsa_ctx *rsa);
 void ssh2_wcng_dsa_free(ssh2_dsa_ctx *dsa);
 #endif
 
-void ssh2_wcng_cipher_dtor(ssh2_cipher_ctx *ctx);
-
 ssh2_bn *ssh2_wcng_bn_init(void);
 int ssh2_wcng_bn_set_word(ssh2_bn *bn, ULONG word);
 ULONG ssh2_wcng_bn_bits(const ssh2_bn *bn);

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -262,11 +262,15 @@ struct wcng_key_ctx {
 
 #define ssh2_rsa_ctx struct wcng_key_ctx
 
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
+
 /*
  * Windows CNG backend: DSA functions
  */
 
 #define ssh2_dsa_ctx struct wcng_key_ctx
+
+void ssh2_dsa_free(ssh2_dsa_ctx *dsa);
 
 /*
  * Windows CNG backend: ECDSA functions

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -104,13 +104,6 @@
 #define SHA384_DIGEST_LENGTH 48
 #define SHA512_DIGEST_LENGTH 64
 
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
-
-#if LIBSSH2_ECDSA
-#else
-#define ssh2_ec_key void
-#endif
-
 /*******************************************************************/
 /*
  * Windows CNG backend: Global context handles
@@ -302,6 +295,8 @@ struct wcng_key_ctx {
  */
 
 #if LIBSSH2_ECDSA
+#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
+
 typedef enum {
     SSH2_EC_CURVE_NISTP256 = 0,
     SSH2_EC_CURVE_NISTP384 = 1,
@@ -315,6 +310,8 @@ struct wcng_ecdsa_ctx {
 
 #define ssh2_ecdsa_ctx struct wcng_ecdsa_ctx
 #define ssh2_ec_key struct wcng_ecdsa_ctx
+#else
+#define ssh2_ec_key void
 #endif
 
 /*******************************************************************/

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -143,6 +143,12 @@ extern struct wcng_ctx ssh2_wcng;
  * Windows CNG backend: Generic functions
  */
 
+#define ssh2_crypto_init() ssh2_wcng_crypto_init()
+#define ssh2_crypto_exit() ssh2_wcng_crypto_exit()
+
+void ssh2_wcng_crypto_init(void);
+void ssh2_wcng_crypto_exit(void);
+
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 /*******************************************************************/

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -316,10 +316,6 @@ struct wcng_ecdsa_ctx {
 #if LIBSSH2_ECDSA
 #define ssh2_ec_key struct wcng_ecdsa_ctx
 #endif
-#define ssh2_ecdsa_create_key(session, privkey, pubkey_octal, \
-                              pubkey_octal_len, curve) \
-    ssh2_wcng_ecdh_create_key(session, privkey, pubkey_octal, \
-                              pubkey_octal_len, curve)
 
 /*******************************************************************/
 /*

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -292,6 +292,8 @@ struct wcng_ecdsa_ctx {
 
 #define ssh2_ecdsa_ctx struct wcng_ecdsa_ctx
 #define ssh2_ec_key    struct wcng_ecdsa_ctx
+
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx);
 #else
 #define ssh2_ec_key void
 #endif

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -143,11 +143,8 @@ extern struct wcng_ctx ssh2_wcng;
  * Windows CNG backend: Generic functions
  */
 
-#define ssh2_crypto_init() ssh2_wcng_crypto_init()
-#define ssh2_crypto_exit() ssh2_wcng_crypto_exit()
-
-void ssh2_wcng_crypto_init(void);
-void ssh2_wcng_crypto_exit(void);
+void ssh2_crypto_init(void);
+void ssh2_crypto_exit(void);
 
 int ssh2_random(unsigned char *buf, size_t len);
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -399,6 +399,7 @@ struct wcng_dh_ctx {
  */
 void ssh2_wcng_init(void);
 void ssh2_wcng_free(void);
+
 int ssh2_wcng_random(void *buf, size_t len);
 
 int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx,
@@ -424,6 +425,7 @@ ULONG ssh2_wcng_bn_bits(const ssh2_bn *bn);
 int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin);
 int ssh2_wcng_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
 void ssh2_wcng_bn_free(ssh2_bn *bn);
+
 void ssh2_wcng_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
                           ssh2_bn *g, ssh2_bn *p, int group_order);

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -334,6 +334,8 @@ struct wcng_cipher_t {
 #define ssh2_cipher_3des      { &ssh2_wcng.hAlg3DES_CBC, 24, 1, 0 }
 #define ssh2_cipher_chacha20  { &ssh2_wcng.hAlgChacha20, 24, 1, 0 }
 
+void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
+
 /*******************************************************************/
 /*
  * Windows CNG backend: BigNumber Context
@@ -400,7 +402,6 @@ struct wcng_dh_ctx {
 };
 
 #define ssh2_dh_ctx struct wcng_dh_ctx
-
 #define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     ssh2_wcng_dh_key_pair(dhctx, public, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -404,9 +404,9 @@ struct wcng_dh_ctx {
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_wcng_dh_secret(dhctx, secret, f, p)
 
-int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order);
-int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p);
+int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+                          ssh2_bn *p, int group_order);
+int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                        ssh2_bn *p);
 
 #endif /* LIBSSH2_WINCNG_H */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -320,8 +320,6 @@ struct wcng_ecdsa_ctx {
                               pubkey_octal_len, curve) \
     ssh2_wcng_ecdh_create_key(session, privkey, pubkey_octal, \
                               pubkey_octal_len, curve)
-#define ssh2_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len) \
-    ssh2_wcng_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len)
 
 /*******************************************************************/
 /*

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -399,18 +399,14 @@ struct wcng_dh_ctx {
 
 #define ssh2_dh_ctx struct wcng_dh_ctx
 
-#define ssh2_dh_init(dhctx) ssh2_wcng_dh_init(dhctx)
 #define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
     ssh2_wcng_dh_key_pair(dhctx, public, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_wcng_dh_secret(dhctx, secret, f, p)
-#define ssh2_dh_dtor(dhctx) ssh2_wcng_dh_dtor(dhctx)
 
-void ssh2_wcng_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
                           ssh2_bn *g, ssh2_bn *p, int group_order);
 int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                         ssh2_bn *f, ssh2_bn *p);
-void ssh2_wcng_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_WINCNG_H */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -361,6 +361,13 @@ struct wcng_bn {
 #define ssh2_bn_free(bn) \
     ssh2_wcng_bn_free(bn)
 
+ssh2_bn *ssh2_wcng_bn_init(void);
+int ssh2_wcng_bn_set_word(ssh2_bn *bn, ULONG word);
+ULONG ssh2_wcng_bn_bits(const ssh2_bn *bn);
+int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin);
+int ssh2_wcng_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
+void ssh2_wcng_bn_free(ssh2_bn *bn);
+
 /*
  * Windows CNG backend: Diffie-Hellman support
  */
@@ -393,6 +400,13 @@ struct wcng_dh_ctx {
     ssh2_wcng_dh_secret(dhctx, secret, f, p)
 #define ssh2_dh_dtor(dhctx) ssh2_wcng_dh_dtor(dhctx)
 
+void ssh2_wcng_dh_init(ssh2_dh_ctx *dhctx);
+int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
+                          ssh2_bn *g, ssh2_bn *p, int group_order);
+int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
+                        ssh2_bn *f, ssh2_bn *p);
+void ssh2_wcng_dh_dtor(ssh2_dh_ctx *dhctx);
+
 /*******************************************************************/
 /*
  * Windows CNG backend: forward declarations
@@ -414,23 +428,8 @@ int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
                    unsigned char *hash, ULONG hashlen);
 
 void ssh2_wcng_rsa_free(ssh2_rsa_ctx *rsa);
-
 #if LIBSSH2_DSA
 void ssh2_wcng_dsa_free(ssh2_dsa_ctx *dsa);
 #endif
-
-ssh2_bn *ssh2_wcng_bn_init(void);
-int ssh2_wcng_bn_set_word(ssh2_bn *bn, ULONG word);
-ULONG ssh2_wcng_bn_bits(const ssh2_bn *bn);
-int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin);
-int ssh2_wcng_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
-void ssh2_wcng_bn_free(ssh2_bn *bn);
-
-void ssh2_wcng_dh_init(ssh2_dh_ctx *dhctx);
-int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
-                          ssh2_bn *g, ssh2_bn *p, int group_order);
-int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                        ssh2_bn *f, ssh2_bn *p);
-void ssh2_wcng_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #endif /* LIBSSH2_WINCNG_H */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -316,29 +316,12 @@ struct wcng_ecdsa_ctx {
 #if LIBSSH2_ECDSA
 #define ssh2_ec_key struct wcng_ecdsa_ctx
 #endif
-void ssh2_wcng_ecdsa_free(ssh2_ecdsa_ctx* ctx);
 #define ssh2_ecdsa_create_key(session, privkey, pubkey_octal, \
                               pubkey_octal_len, curve) \
     ssh2_wcng_ecdh_create_key(session, privkey, pubkey_octal, \
                               pubkey_octal_len, curve)
-#define ssh2_ecdsa_curve_name_with_octal_new(ctx, k, k_len, curve) \
-    ssh2_wcng_ecdsa_curve_name_with_octal_new(ctx, k, k_len, curve)
 #define ssh2_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len) \
     ssh2_wcng_ecdh_gen_k(k, privkey, server_pubkey, server_pubkey_len)
-#define ssh2_ecdsa_verify(ctx, r, r_len, s, s_len, m, m_len) \
-    ssh2_wcng_ecdsa_verify(ctx, r, r_len, s, s_len, m, m_len)
-#define ssh2_ecdsa_new_private(ctx, session, filename, passphrase) \
-    ssh2_wcng_ecdsa_new_private(ctx, session, filename, passphrase)
-#define ssh2_ecdsa_new_private_frommemory(ctx, session, filedata, \
-                                          filedata_len, passphrase) \
-    ssh2_wcng_ecdsa_new_private_frommemory(ctx, session, filedata, \
-                                           filedata_len, passphrase)
-#define ssh2_ecdsa_sign(session, ctx, hash, hash_len, sign, sign_len) \
-    ssh2_wcng_ecdsa_sign(session, ctx, hash, hash_len, sign, sign_len)
-#define ssh2_ecdsa_get_curve_type(ctx) \
-    ssh2_wcng_ecdsa_get_curve_type(ctx)
-#define ssh2_ecdsa_free(ecdsactx) \
-    ssh2_wcng_ecdsa_free(ecdsactx)
 
 /*******************************************************************/
 /*

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -247,26 +247,6 @@ struct wcng_key_ctx {
  */
 
 #define ssh2_rsa_ctx struct wcng_key_ctx
-#define ssh2_rsa_new(rsactx, e, e_len, n, n_len, d, d_len, p, p_len, \
-                     q, q_len, e1, e1_len, e2, e2_len, c, c_len) \
-    ssh2_wcng_rsa_new(rsactx, e, e_len, n, n_len, d, d_len, p, p_len, \
-                      q, q_len, e1, e1_len, e2, e2_len, c, c_len)
-#define ssh2_rsa_new_private(rsactx, s, filename, passphrase) \
-    ssh2_wcng_rsa_new_private(rsactx, s, filename, passphrase)
-#define ssh2_rsa_new_private_frommemory(rsactx, s, filedata, \
-                                        filedata_len, passphrase) \
-    ssh2_wcng_rsa_new_private_frommemory(rsactx, s, filedata, \
-                                         filedata_len, passphrase)
-#define ssh2_rsa_sha1_sign(s, rsactx, hash, hash_len, sig, sig_len) \
-    ssh2_wcng_rsa_sha1_sign(s, rsactx, hash, hash_len, sig, sig_len)
-#define ssh2_rsa_sha2_sign(s, rsactx, hash, hash_len, sig, sig_len) \
-    ssh2_wcng_rsa_sha2_sign(s, rsactx, hash, hash_len, sig, sig_len)
-#define ssh2_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len) \
-    ssh2_wcng_rsa_sha1_verify(rsactx, sig, sig_len, m, m_len)
-#define ssh2_rsa_sha2_verify(rsactx, hash_len, sig, sig_len, m, m_len) \
-    ssh2_wcng_rsa_sha2_verify(rsactx, hash_len, sig, sig_len, m, m_len)
-#define ssh2_rsa_free(rsactx) \
-    ssh2_wcng_rsa_free(rsactx)
 
 /*
  * Windows CNG backend: DSA functions

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -395,17 +395,6 @@ struct wcng_cipher_t {
 #define ssh2_cipher_3des      { &ssh2_wcng.hAlg3DES_CBC, 24, 1, 0 }
 #define ssh2_cipher_chacha20  { &ssh2_wcng.hAlgChacha20, 24, 1, 0 }
 
-/*
- * Windows CNG backend: Cipher functions
- */
-
-#define ssh2_cipher_init(ctx, type, iv, secret, encrypt) \
-    ssh2_wcng_cipher_init(ctx, type, iv, secret, encrypt)
-#define ssh2_cipher_crypt(ctx, type, encrypt, block, blocklen, fl) \
-    ssh2_wcng_cipher_crypt(ctx, type, encrypt, block, blocklen, fl)
-#define ssh2_cipher_dtor(ctx) \
-    ssh2_wcng_cipher_dtor(ctx)
-
 /*******************************************************************/
 /*
  * Windows CNG backend: BigNumber Context

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -99,7 +99,7 @@
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define MD5_DIGEST_LENGTH 16
 #endif
-#define SHA_DIGEST_LENGTH 20
+#define SHA_DIGEST_LENGTH    20
 #define SHA256_DIGEST_LENGTH 32
 #define SHA384_DIGEST_LENGTH 48
 #define SHA512_DIGEST_LENGTH 64
@@ -285,7 +285,7 @@ struct wcng_ecdsa_ctx {
 };
 
 #define ssh2_ecdsa_ctx struct wcng_ecdsa_ctx
-#define ssh2_ec_key struct wcng_ecdsa_ctx
+#define ssh2_ec_key    struct wcng_ecdsa_ctx
 #else
 #define ssh2_ec_key void
 #endif
@@ -337,8 +337,8 @@ struct wcng_cipher_t {
  * Windows CNG backend: BigNumber Context
  */
 
-#define ssh2_bn_ctx int /* not used */
-#define ssh2_bn_ctx_new() 0 /* not used */
+#define ssh2_bn_ctx             int /* not used */
+#define ssh2_bn_ctx_new()       0 /* not used */
 #define ssh2_bn_ctx_free(bnctx) ((void)0) /* not used */
 
 /*******************************************************************/
@@ -357,21 +357,15 @@ struct wcng_bn {
  * Windows CNG backend: BigNumber functions
  */
 
-#define ssh2_bn_init() \
-    ssh2_wcng_bn_init()
-#define ssh2_bn_init_from_bin() \
-    ssh2_bn_init()
-#define ssh2_bn_set_word(bn, word) \
-    ssh2_wcng_bn_set_word(bn, word)
+#define ssh2_bn_init()                 ssh2_wcng_bn_init()
+#define ssh2_bn_init_from_bin()        ssh2_bn_init()
+#define ssh2_bn_set_word(bn, word)     ssh2_wcng_bn_set_word(bn, word)
 #define ssh2_bn_from_bin(bn, len, bin) \
     ssh2_wcng_bn_from_bin(bn, (ULONG)(len), bin)
-#define ssh2_bn_to_bin(bn, bin) \
-    ssh2_wcng_bn_to_bin(bn, bin)
-#define ssh2_bn_bytes(bn) bn->length
-#define ssh2_bn_bits(bn) \
-    ssh2_wcng_bn_bits(bn)
-#define ssh2_bn_free(bn) \
-    ssh2_wcng_bn_free(bn)
+#define ssh2_bn_to_bin(bn, bin)        ssh2_wcng_bn_to_bin(bn, bin)
+#define ssh2_bn_bytes(bn)              ((bn)->length)
+#define ssh2_bn_bits(bn)               ssh2_wcng_bn_bits(bn)
+#define ssh2_bn_free(bn)               ssh2_wcng_bn_free(bn)
 
 ssh2_bn *ssh2_wcng_bn_init(void);
 int ssh2_wcng_bn_set_word(ssh2_bn *bn, ULONG word);


### PR DESCRIPTION
For fewer crypto-namespaced private functions in favor or plain `ssh2_*`
ones, and to reduce macro mappings.                            

Also:
- move related functions/macros declarations next to each other.
- merge `#if LIBSSH2_ECDSA` blocks.
- guard some constants with `LIBSSH2_ECDSA`.
- drop orphan prototypes.
  Follow-up to 076838de2697a4185125bfd601fbcd6e7286bfb6 #1961
  Follow-up to ec0a51db1f69eafa14ead6d17e6aca13075c034b #860
- tidy-up bignum (`ssh2_bn_*`) mapping/declaration blocks.
- formatting/whitespace/unfold/fold fixes/sync along the way.

---

https://github.com/libssh2/libssh2/pull/1971/files?w=1

- [ ] next PR: maybe sync context variables names in low-level
  crypto functions between prototype/definitions/macros, also
  across crypto backends. (to reducing inconsistencies)
  ah, clang-tidy caught some of them in CI.
