### PR TITLE
build: update picky warning options, fix fallouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,7 +938,7 @@ jobs:
 
   build_msvc:
     name: 'msvc'
-    runs-on: windows-2022
+    runs-on: '${{ matrix.image }}'
     timeout-minutes: 10
     defaults:
       run:
@@ -947,13 +947,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { arch: x64  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'OFF', zlib: 'OFF', unity: 'ON' }
-          - { arch: x64  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'ON' , shared: 'ON' , zlib: 'OFF', unity: 'ON' }
-          - { arch: x64  , plat: windows, crypto: OpenSSL, wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
-          - { arch: x64  , plat: uwp    , crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
-          - { arch: arm64, plat: windows, crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
-          - { arch: arm64, plat: uwp    , crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
-          - { arch: x86  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
+          - { image: 'windows-2022'       , arch: x64  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'OFF', zlib: 'OFF', unity: 'ON' }
+          - { image: 'windows-2025-vs2026', arch: x64  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'ON' , shared: 'ON' , zlib: 'OFF', unity: 'ON' }
+          - { image: 'windows-2022'       , arch: x64  , plat: windows, crypto: OpenSSL, wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
+          - { image: 'windows-2022'       , arch: x64  , plat: uwp    , crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
+          - { image: 'windows-2025-vs2026', arch: arm64, plat: windows, crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
+          - { image: 'windows-2022'       , arch: arm64, plat: uwp    , crypto: WinCNG , wincng_ecdsa: 'ON' , log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
+          - { image: 'windows-2022'       , arch: x86  , plat: windows, crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -961,6 +961,7 @@ jobs:
 
       - name: 'configure'
         env:
+          MATRIX_IMAGE: '${{ matrix.image }}'
           MATRIX_ARCH: '${{ matrix.arch }}'
           MATRIX_CRYPTO: '${{ matrix.crypto }}'
           MATRIX_PLAT: '${{ matrix.plat }}'
@@ -977,6 +978,9 @@ jobs:
             options+=' -DCMAKE_SYSTEM_VERSION=10.0'
           else
             system='Windows'
+          fi
+          if [[ "${MATRIX_IMAGE}" = *'windows-2025'* ]]; then
+            options+=' -DUSE_NSIS=OFF'
           fi
           [ "${MATRIX_CRYPTO}" = 'WinCNG' ] && options+=" -DENABLE_ECDSA_WINCNG=${MATRIX_WINCND_ECDSA}"
           cmake -B bld ${options} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -980,7 +980,7 @@ jobs:
             system='Windows'
           fi
           if [[ "${MATRIX_IMAGE}" = *'windows-2025'* ]]; then
-            options+=' -DUSE_NSIS=OFF'
+            options+=' -DCPACK_GENERATOR=TGZ'
           fi
           [ "${MATRIX_CRYPTO}" = 'WinCNG' ] && options+=" -DENABLE_ECDSA_WINCNG=${MATRIX_WINCND_ECDSA}"
           cmake -B bld ${options} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -980,7 +980,7 @@ jobs:
             system='Windows'
           fi
           if [[ "${MATRIX_IMAGE}" = *'windows-2025'* ]]; then
-            options+=' -DCPACK_GENERATOR=TGZ'
+            options+=' -DCPACK_BINARY_NSIS=OFF'  # NSIS not preinstalled on windows-2025 images
           fi
           [ "${MATRIX_CRYPTO}" = 'WinCNG' ] && options+=" -DENABLE_ECDSA_WINCNG=${MATRIX_WINCND_ECDSA}"
           cmake -B bld ${options} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -980,7 +980,7 @@ jobs:
             system='Windows'
           fi
           if [[ "${MATRIX_IMAGE}" = *'windows-2025'* ]]; then
-            options+=' -DCPACK_BINARY_NSIS=OFF'  # NSIS not preinstalled on windows-2025 images
+            options+=' -DCPACK_GENERATOR=TGZ'
           fi
           [ "${MATRIX_CRYPTO}" = 'WinCNG' ] && options+=" -DENABLE_ECDSA_WINCNG=${MATRIX_WINCND_ECDSA}"
           cmake -B bld ${options} \

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -219,7 +219,11 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           fi
           AC_MSG_RESULT([clang '$compiler_num' (raw: '$fullclangver' / '$clangver')])
 
-          tmp_CFLAGS="-pedantic"
+          if test "$compiler_num" -ge "302"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pedantic])
+          else
+            tmp_CFLAGS="$tmp_CFLAGS -pedantic"
+          fi
           if test "$want_werror" = "yes"; then
             LIBSSH2_CFLAG_EXTRAS="$LIBSSH2_CFLAG_EXTRAS -pedantic-errors"
           fi
@@ -287,6 +291,11 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
           fi
 
+          dnl Only clang 3.1 or later
+          if test "$compiler_num" -ge "301"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [format-non-iso])
+          fi
+
           dnl Only clang 3.2 or later
           if test "$compiler_num" -ge "302"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [enum-conversion])
@@ -328,28 +337,46 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
               tmp_CFLAGS="$tmp_CFLAGS -Wno-varargs"
             fi
           fi
+
           dnl clang 7 or later
           if test "$compiler_num" -ge "700"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [assign-enum])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [extra-semi-stmt])
           fi
+
           dnl clang 10 or later
           if test "$compiler_num" -ge "1000"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"  # we have silencing markup for clang 10.0 and above only
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [xor-used-as-pow])
           fi
+
+          dnl clang 13 or later
+          if test "$compiler_num" -ge "1300"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-function-type])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [reserved-identifier]) # Keep it before -Wno-reserved-macro-identifier
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-reserved-macro-identifier"  # Sometimes such external macros need to be set
+          fi
+
+          dnl clang 16 or later
+          #if test "$compiler_num" -ge "1600"; then
+          #  tmp_CFLAGS="$tmp_CFLAGS -Wno-unsafe-buffer-usage"
+          #fi
+
           dnl clang 17 or later
           if test "$compiler_num" -ge "1700"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-function-type-strict])  # with Apple clang it requires 16.0 or above
           fi
+
           dnl clang 19 or later
           if test "$compiler_num" -ge "1901"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-signedness"
           fi
+
           dnl clang 20 or later
           if test "$compiler_num" -ge "2001"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [array-compare])
           fi
+
           dnl clang 21 or later
           if test "$compiler_num" -ge "2101"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [c++-hidden-decl])
@@ -413,7 +440,11 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           fi
         else dnl $ICC = yes
           dnl this is a set of options we believe *ALL* gcc versions support:
-          tmp_CFLAGS="-pedantic"
+          if test "$compiler_num" -ge "408"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pedantic])
+          else
+            tmp_CFLAGS="$tmp_CFLAGS -pedantic"
+          fi
           if test "$want_werror" = "yes"; then
             LIBSSH2_CFLAG_EXTRAS="$LIBSSH2_CFLAG_EXTRAS -pedantic-errors"
           fi

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -599,7 +599,11 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
 
           dnl Only gcc 15 or later
           if test "$compiler_num" -ge "1500"; then
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [leading-whitespace=spaces])
+            dnl AC_FUNC_ALLOCA is incompatible with this option. It triggers
+            dnl detecting macro STACK_DIRECTION (which we do not use here).
+            dnl autoconf (as of v2.73) puts this macro into libssh2_config.h
+            dnl indented by tabs.
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [leading-whitespace=spaces])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [trailing-whitespace=any])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unterminated-string-initialization])
           fi

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -198,9 +198,10 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           clangvhi=`echo $clangver | cut -d . -f1`
           clangvlo=`echo $clangver | cut -d . -f2`
           compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
-          if test "$appleclang" = '1' && test "$oldapple" = '0'; then
+          if test "$appleclang" = "1" && test "$oldapple" = "0"; then
             dnl Starting with Xcode 7 / clang 3.7, Apple clang does not tell its upstream version
-            if   test "$compiler_num" -ge '1700'; then compiler_num='1901'
+            if   test "$compiler_num" -ge '2604'; then compiler_num='2101'
+            elif test "$compiler_num" -ge '1700'; then compiler_num='1901'
             elif test "$compiler_num" -ge '1600'; then compiler_num='1700'
             elif test "$compiler_num" -ge '1500'; then compiler_num='1600'
             elif test "$compiler_num" -ge '1400'; then compiler_num='1400'
@@ -225,7 +226,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [all extra])
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pointer-arith write-strings])
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shadow])
-          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [inline nested-externs])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [nested-externs])
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-declarations])
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-prototypes])
           tmp_CFLAGS="$tmp_CFLAGS -Wno-long-long"
@@ -249,6 +250,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [address])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [attributes])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [bad-function-cast])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-qual])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [div-by-zero format-security])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [empty-body])
@@ -280,7 +282,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
 
           dnl Only clang 3.0 or later
           if test "$compiler_num" -ge "300"; then
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-qual])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conditional-uninitialized])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [language-extension-token])
             tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
           fi
@@ -320,8 +322,8 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           dnl Only clang 3.9 or later
           if test "$compiler_num" -ge "309"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [comma])
-            # avoid the varargs warning, fixed in 4.0
-            # https://bugs.llvm.org/show_bug.cgi?id=29140
+            dnl avoid the varargs warning, fixed in 4.0
+            dnl https://bugs.llvm.org/show_bug.cgi?id=29140
             if test "$compiler_num" -lt "400"; then
               tmp_CFLAGS="$tmp_CFLAGS -Wno-varargs"
             fi
@@ -335,6 +337,31 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           if test "$compiler_num" -ge "1000"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"  # we have silencing markup for clang 10.0 and above only
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [xor-used-as-pow])
+          fi
+          dnl clang 17 or later
+          if test "$compiler_num" -ge "1700"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-function-type-strict])  # with Apple clang it requires 16.0 or above
+          fi
+          dnl clang 19 or later
+          if test "$compiler_num" -ge "1901"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wformat-signedness"
+          fi
+          dnl clang 20 or later
+          if test "$compiler_num" -ge "2001"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [array-compare])
+          fi
+          dnl clang 21 or later
+          if test "$compiler_num" -ge "2101"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [c++-hidden-decl])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [implicit-int-enum-cast])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [jump-misses-init])
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-implicit-void-ptr-cast"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [tentative-definition-compat])
+            if test "$curl_cv_native_windows" = "yes"; then
+              tmp_CFLAGS="$tmp_CFLAGS -Wno-c++-keyword"  # `wchar_t` triggers it on Windows
+            else
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [c++-keyword])
+            fi
           fi
 
           case "$CFLAGS" in
@@ -390,15 +417,30 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           if test "$want_werror" = "yes"; then
             LIBSSH2_CFLAG_EXTRAS="$LIBSSH2_CFLAG_EXTRAS -pedantic-errors"
           fi
+
+          dnl Set of options we believe *ALL* gcc versions support:
           CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [all])
           tmp_CFLAGS="$tmp_CFLAGS -W"
-          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pointer-arith write-strings])
+
+          dnl Only gcc 1.4 or later
+          if test "$compiler_num" -ge "104"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pointer-arith write-strings])
+            dnl If not cross-compiling with a gcc older than 3.0
+            if test "$cross_compiling" != "yes" ||
+              test "$compiler_num" -ge "300"; then
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused shadow])
+            fi
+          fi
 
           dnl Only gcc 2.7 or later
           if test "$compiler_num" -ge "207"; then
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [inline nested-externs])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-declarations])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-prototypes])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [nested-externs])
+            dnl If not cross-compiling with a gcc older than 3.0
+            if test "$cross_compiling" != "yes" ||
+              test "$compiler_num" -ge "300"; then
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-declarations])
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-prototypes])
+            fi
           fi
 
           dnl Only gcc 2.95 or later
@@ -425,7 +467,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             dnl on i686-Linux as it gives us heaps with false positives.
             dnl Also, on gcc 4.0.X it is totally unbearable and complains all
             dnl over making it unusable for generic purposes. Let's not use it.
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused shadow])
+            tmp_CFLAGS="$tmp_CFLAGS"
           fi
 
           dnl Only gcc 3.3 or later
@@ -445,12 +487,18 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             tmp_CFLAGS="$tmp_CFLAGS -Wstrict-aliasing=3"
           fi
 
-          dnl Only gcc 4.1 or later (possibly earlier)
+          dnl Only gcc 4.1 or later
           if test "$compiler_num" -ge "401"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [attributes])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [div-by-zero format-security])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-field-initializers])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-noreturn])
+            case $host in
+              *-*-msys*)
+                ;;
+              *)
+                CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-noreturn])  # Seen to clash with libtool-generated stub code
+                ;;
+            esac
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code unused-parameter])
           # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [padded])           # Not used: We cannot change public structs
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pragmas])
@@ -488,8 +536,9 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [jump-misses-init])
             dnl Only Windows targets
             case $host_os in
-              mingw*)
-                tmp_CFLAGS="$tmp_CFLAGS -Wno-pedantic-ms-format"
+              cygwin*)
+                dnl Silence warning in 'lt_fatal' libtool function
+                tmp_CFLAGS="$tmp_CFLAGS -Wno-suggest-attribute=noreturn"
                 ;;
             esac
           fi
@@ -508,6 +557,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           dnl Only gcc 5 or later
           if test "$compiler_num" -ge "500"; then
             tmp_CFLAGS="$tmp_CFLAGS -Warray-bounds=2"
+            tmp_CFLAGS="$tmp_CFLAGS -Wformat-signedness"
           fi
 
           dnl Only gcc 6 or later
@@ -545,6 +595,13 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           if test "$compiler_num" -ge "1300"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [enum-int-mismatch])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [xor-used-as-pow])
+          fi
+
+          dnl Only gcc 15 or later
+          if test "$compiler_num" -ge "1500"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [leading-whitespace=spaces])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [trailing-whitespace=any])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unterminated-string-initialization])
           fi
 
           for flag in $CPPFLAGS; do

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -354,7 +354,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           if test "$compiler_num" -ge "1300"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-function-type])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [reserved-identifier]) # Keep it before -Wno-reserved-macro-identifier
-            # tmp_CFLAGS="$tmp_CFLAGS -Wno-reserved-macro-identifier"  # Sometimes such external macros need to be set
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-reserved-macro-identifier"  # Sometimes such external macros need to be set
           fi
 
           dnl clang 16 or later

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -679,6 +679,57 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
 
 ]) dnl end of AC_DEFUN()
 
+dnl CURL_CONVERT_INCLUDE_TO_ISYSTEM
+dnl -------------------------------------------------
+dnl Changes standard include paths present in CFLAGS
+dnl and CPPFLAGS into isystem include paths. This is
+dnl done to prevent GNUC from generating warnings on
+dnl headers from these locations, although on ancient
+dnl GNUC versions these warnings are not silenced.
+
+AC_DEFUN([CURL_CONVERT_INCLUDE_TO_ISYSTEM], [
+  AC_REQUIRE([CURL_SHFUNC_SQUEEZE])
+  AC_REQUIRE([CURL_CHECK_COMPILER_CLANG])
+  AC_MSG_CHECKING([convert -I options to -isystem])
+  if test "$compiler_id" = "GNU_C" ||
+     test "$compiler_id" = "CLANG" ||
+     test "$compiler_id" = "APPLECLANG"; then
+    AC_MSG_RESULT([yes])
+    tmp_has_include="no"
+    tmp_chg_FLAGS="$CFLAGS"
+    for word1 in $tmp_chg_FLAGS; do
+      case "$word1" in
+        -I*)
+          tmp_has_include="yes"
+          ;;
+      esac
+    done
+    if test "$tmp_has_include" = "yes"; then
+      tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/^-I/ -isystem /g'`
+      tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/ -I/ -isystem /g'`
+      CFLAGS="$tmp_chg_FLAGS"
+      squeeze CFLAGS
+    fi
+    tmp_has_include="no"
+    tmp_chg_FLAGS="$CPPFLAGS"
+    for word1 in $tmp_chg_FLAGS; do
+      case "$word1" in
+        -I*)
+          tmp_has_include="yes"
+          ;;
+      esac
+    done
+    if test "$tmp_has_include" = "yes"; then
+      tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/^-I/ -isystem /g'`
+      tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/ -I/ -isystem /g'`
+      CPPFLAGS="$tmp_chg_FLAGS"
+      squeeze CPPFLAGS
+    fi
+  else
+    AC_MSG_RESULT([no])
+  fi
+])
+
 dnl CURL_ADD_COMPILER_WARNINGS (WARNING-LIST, NEW-WARNINGS)
 dnl -------------------------------------------------------
 dnl Contents of variable WARNING-LIST and NEW-WARNINGS are

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -354,7 +354,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
           if test "$compiler_num" -ge "1300"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-function-type])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [reserved-identifier]) # Keep it before -Wno-reserved-macro-identifier
-            tmp_CFLAGS="$tmp_CFLAGS -Wno-reserved-macro-identifier"  # Sometimes such external macros need to be set
+            # tmp_CFLAGS="$tmp_CFLAGS -Wno-reserved-macro-identifier"  # Sometimes such external macros need to be set
           fi
 
           dnl clang 16 or later

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -197,7 +197,7 @@ if(PICKY_COMPILER)
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0))
         list(APPEND _picky_enable
-          -Wno-unsafe-buffer-usage         # clang 16.0            appleclang 15.0
+        # -Wno-unsafe-buffer-usage         # clang 16.0            appleclang 15.0
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0) OR

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -182,8 +182,8 @@ if(PICKY_COMPILER)
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13.1))
         list(APPEND _picky_enable
           -Wcast-function-type             # clang 13.0            appleclang 13.1
-        # -Wreserved-identifier            # clang 13.0            appleclang 13.1  # Keep it before -Wno-reserved-macro-identifier
-        #   -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
+          -Wreserved-identifier            # clang 13.0            appleclang 13.1  # Keep it before -Wno-reserved-macro-identifier
+            -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0) OR

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -32,7 +32,9 @@ if(MSVC)
 endif()
 
 if(PICKY_COMPILER)
-  if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+  # Leave disabled for GCC <4.6, because they lack #pragma features to silence locally.
+  if((CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.6) OR
+     CMAKE_C_COMPILER_ID MATCHES "Clang")
 
     # https://clang.llvm.org/docs/DiagnosticsReference.html
     # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
@@ -47,9 +49,15 @@ if(PICKY_COMPILER)
       set(_picky_enable "-W")
     endif()
 
-    list(APPEND _picky_enable
-      -Wall -pedantic
-    )
+    list(APPEND _picky_enable "-Wall")
+
+    if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 3.2) OR
+       (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.2) OR
+       CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.8)
+      list(APPEND _picky_enable "-Wpedantic")  # clang  3.2  gcc  4.8  appleclang  4.2
+    else()
+      list(APPEND _picky_enable "-pedantic")
+    endif()
 
     # ----------------------------------
     # Add new options here, if in doubt:
@@ -57,12 +65,14 @@ if(PICKY_COMPILER)
     set(_picky_detect
     )
 
+    # Notes: -Wno-* options should ideally be disabled at their precise cutoff versions,
+    #        to suppress undesired warnings in case -Weverything is passed as a custom option.
+
     # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.95 or later.
     list(APPEND _picky_enable
       -Wbad-function-cast                  # clang  2.7  gcc  2.95
       -Wconversion                         # clang  2.7  gcc  2.95
-      -Winline                             # clang  1.0  gcc  1.0
       -Wmissing-declarations               # clang  1.0  gcc  2.7
       -Wmissing-prototypes                 # clang  1.0  gcc  1.0
       -Wnested-externs                     # clang  1.0  gcc  2.7
@@ -81,7 +91,7 @@ if(PICKY_COMPILER)
       -Waddress                            # clang  2.7  gcc  4.3
       -Wattributes                         # clang  2.7  gcc  4.1
       -Wcast-align                         # clang  1.0  gcc  4.2
-      -Wcast-qual                          # clang  3.0  gcc  3.4.6
+      -Wcast-qual                          # clang  2.7  gcc  3.4.6
       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
       -Wdiv-by-zero                        # clang  2.7  gcc  4.1
       -Wempty-body                         # clang  2.7  gcc  4.3
@@ -109,9 +119,10 @@ if(PICKY_COMPILER)
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
       list(APPEND _picky_enable
         ${_picky_common_old}
+        -Wconditional-uninitialized        # clang  3.0
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
-        -Wformat=2                         # clang  3.0  gcc  4.8
+        -Wformat=2                         # clang  2.7  gcc  4.8
       )
       if(NOT MSVC)
         list(APPEND _picky_enable
@@ -119,6 +130,21 @@ if(PICKY_COMPILER)
         )
       endif()
       # Enable based on compiler version
+      if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 3.1)
+        if(NOT MSVC)
+          list(APPEND _picky_enable
+            -Wformat-non-iso               # clang  3.1            appleclang  3.1
+          )
+        endif()
+      endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 3.3) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0))
+        list(APPEND _picky_enable
+          -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.2  g++ 11.0
+          -Wmissing-variable-declarations  # clang  3.2            appleclang  4.2
+          -Wsometimes-uninitialized        # clang  3.2            appleclang  4.2
+        )
+      endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 3.6) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 6.1))
         list(APPEND _picky_enable
@@ -134,7 +160,7 @@ if(PICKY_COMPILER)
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 3.9) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 8.1))
         list(APPEND _picky_enable
-          -Wcomma                          # clang  3.9            appleclang  8.3
+          -Wcomma                          # clang  3.9            appleclang  8.1
           -Wmissing-variable-declarations  # clang  3.2            appleclang  4.6
         )
       endif()
@@ -146,11 +172,65 @@ if(PICKY_COMPILER)
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0) OR
-         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0))
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12))
         list(APPEND _picky_enable
           -Wimplicit-fallthrough           # clang  4.0  gcc  7.0  appleclang  9.0  # We do silencing for clang 10.0 and above only
           -Wxor-used-as-pow                # clang 10.0  gcc 13.0  appleclang 12.0
         )
+      endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13.1))
+        list(APPEND _picky_enable
+          -Wcast-function-type             # clang 13.0            appleclang 13.1
+        # -Wreserved-identifier            # clang 13.0            appleclang 13.1  # Keep it before -Wno-reserved-macro-identifier
+        #   -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
+        )
+      endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.3))
+        if(CMAKE_GENERATOR STREQUAL "FASTBuild")
+          list(APPEND _picky_enable
+            -Wno-gnu-line-marker           # clang 15.0            appleclang 14.0.3
+          )
+        endif()
+      endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0))
+        list(APPEND _picky_enable
+          -Wno-unsafe-buffer-usage         # clang 16.0            appleclang 15.0
+        )
+      endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0))
+        list(APPEND _picky_enable
+          -Wcast-function-type-strict      # clang 16.0            appleclang 16.0
+        )
+      endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 19.1) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0))
+        list(APPEND _picky_enable
+          -Wformat-signedness             # clang 19.1  gcc  5.1  appleclang 17.0  # In clang-cl enums are signed ints by default
+        )
+      endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 21.1) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 26.4))
+        list(APPEND _picky_enable
+          -Warray-compare                  # clang 20.1  gcc 12.0  appleclang 26.4
+          -Wc++-hidden-decl                # clang 21.1            appleclang 26.4
+          -Wimplicit-int-enum-cast         # clang 21.1
+          -Wjump-misses-init               # clang 21.1  gcc  4.5  appleclang 26.4
+          -Wno-implicit-void-ptr-cast      # clang 21.1            appleclang 26.4
+          -Wtentative-definition-compat    # clang 21.1            appleclang 26.4
+        )
+        if(WIN32)
+          list(APPEND _picky_enable
+            -Wno-c++-keyword               # clang 21.1            appleclang 26.4  # `wchar_t` triggers it on Windows
+          )
+        else()
+          list(APPEND _picky_enable
+            -Wc++-keyword                  # clang 21.1            appleclang 26.4
+          )
+        endif()
       endif()
     else()  # gcc
       # Enable based on compiler version
@@ -167,7 +247,7 @@ if(PICKY_COMPILER)
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.5)
         list(APPEND _picky_enable
-          -Wjump-misses-init               #             gcc  4.5
+          -Wjump-misses-init               # clang 21.1  gcc  4.5  appleclang 26.4
         )
         if(MINGW)
           list(APPEND _picky_enable
@@ -178,23 +258,24 @@ if(PICKY_COMPILER)
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.8)
         list(APPEND _picky_enable
           -Wdouble-promotion               # clang  3.6  gcc  4.6  appleclang  6.1
-          -Wformat=2                       # clang  3.0  gcc  4.8
+          -Wformat=2                       # clang  2.7  gcc  4.8
           -Wlogical-op                     #             gcc  4.4
           -Wtrampolines                    #             gcc  4.6
         )
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
         list(APPEND _picky_enable
-          -Warray-bounds=2                 # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
+          -Warray-bounds=2                 # clang  2.9  gcc  5.0 (clang default: -Warray-bounds)
+          -Wformat-signedness              # clang 19.1  gcc  5.1  appleclang 17.0
         )
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0)
         list(APPEND _picky_enable
           -Wduplicated-cond                #             gcc  6.0
-          -Wnull-dereference               # clang  3.0  gcc  6.0 (clang default)
+          -Wnull-dereference               # clang  2.9  gcc  6.0 (clang default)
             -fdelete-null-pointer-checks
           -Wshift-negative-value           # clang  3.7  gcc  6.0 (clang default)
-          -Wshift-overflow=2               # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
+          -Wshift-overflow=2               # clang  2.9  gcc  6.0 (clang default: -Wshift-overflow)
           -Wunused-const-variable          # clang  3.4  gcc  6.0  appleclang  5.1
         )
       endif()
@@ -211,24 +292,34 @@ if(PICKY_COMPILER)
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
         list(APPEND _picky_enable
           -Warith-conversion               #             gcc 10.0
-          -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
+          -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.2  g++ 11.0
         )
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
         list(APPEND _picky_enable
-          -Warray-compare                  # clang 20.0  gcc 12.0
+          -Warray-compare                  # clang 20.1  gcc 12.0  appleclang 26.4
           -Wenum-int-mismatch              #             gcc 13.0
           -Wxor-used-as-pow                # clang 10.0  gcc 13.0  appleclang 12.0
         )
       endif()
+      if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0)
+        list(APPEND _picky_enable
+          -Wleading-whitespace=spaces      #             gcc 15.0
+          -Wtrailing-whitespace=any        #             gcc 15.0
+          -Wunterminated-string-initialization  #        gcc 15.0
+        )
+      endif()
     endif()
 
-    #
+    # Assemble list of flags
 
     set(_picky_skipped "")
     foreach(_ccopt IN LISTS _picky_enable)
-      string(REGEX MATCH "-W([a-z0-9-]+)" _ccmatch "${_ccopt}")
-      if(_ccmatch AND CMAKE_C_FLAGS MATCHES "-Wno-${CMAKE_MATCH_1}" AND NOT _ccopt STREQUAL "-Wall" AND NOT _ccopt MATCHES "^-Wno-")
+      string(REGEX MATCH "-W([a-z0-9+-]+)" _ccmatch "${_ccopt}")
+      string(REPLACE "+" "\\+" _cmake_match_1 "${CMAKE_MATCH_1}")  # escape '+' to make it a valid regex
+      if(_ccmatch AND "${CMAKE_C_FLAGS} " MATCHES "-Wno-${_cmake_match_1} " AND
+         NOT _ccopt STREQUAL "-Wall" AND
+         NOT _ccopt MATCHES "^-Wno-")
         string(APPEND _picky_skipped " ${_ccopt}")
       else()
         list(APPEND _picky "${_ccopt}")
@@ -249,7 +340,7 @@ if(PICKY_COMPILER)
         list(APPEND _picky "${_ccopt}")
       endif()
     endforeach()
-  elseif(MSVC AND MSVC_VERSION LESS_EQUAL 1944)  # Skip for untested/unreleased newer versions
+  elseif(MSVC AND MSVC_VERSION LESS_EQUAL 1951)  # Skip for untested/unreleased newer versions
     list(APPEND _picky "-Wall")
     list(APPEND _picky "-wd4061")  # enumerator 'A' in switch of enum 'B' is not explicitly handled by a case label
     list(APPEND _picky "-wd4191")  # 'type cast': unsafe conversion from 'FARPROC' to 'void (__cdecl *)(void)'
@@ -258,7 +349,7 @@ if(PICKY_COMPILER)
     list(APPEND _picky "-wd4548")  # expression before comma has no effect; expected expression with side-effect (in FD_SET())
     list(APPEND _picky "-wd4574")  # 'M' is defined to be '0': did you mean to use '#if M'? (in ws2tcpip.h)
     list(APPEND _picky "-wd4668")  # 'M' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif' (in winbase.h)
-    list(APPEND _picky "-wd4710")  # 'snprintf': function not inlined
+    list(APPEND _picky "-wd4710")  # 'fprintf'/'printf'/'sscanf': function not inlined (in tests, with VS2022+ Release)
     list(APPEND _picky "-wd4711")  # function 'A' selected for automatic inline expansion
     # volatile access of '<expression>' is subject to /volatile:<iso|ms> setting;
     #   consider using __iso_volatile_load/store intrinsic functions (ARM64)

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -183,7 +183,7 @@ if(PICKY_COMPILER)
         list(APPEND _picky_enable
           -Wcast-function-type             # clang 13.0            appleclang 13.1
           -Wreserved-identifier            # clang 13.0            appleclang 13.1  # Keep it before -Wno-reserved-macro-identifier
-          # -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
+            -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0) OR

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -183,7 +183,7 @@ if(PICKY_COMPILER)
         list(APPEND _picky_enable
           -Wcast-function-type             # clang 13.0            appleclang 13.1
           -Wreserved-identifier            # clang 13.0            appleclang 13.1  # Keep it before -Wno-reserved-macro-identifier
-            -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
+          # -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0) OR

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -349,7 +349,7 @@ if(PICKY_COMPILER)
     list(APPEND _picky "-wd4548")  # expression before comma has no effect; expected expression with side-effect (in FD_SET())
     list(APPEND _picky "-wd4574")  # 'M' is defined to be '0': did you mean to use '#if M'? (in ws2tcpip.h)
     list(APPEND _picky "-wd4668")  # 'M' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif' (in winbase.h)
-    list(APPEND _picky "-wd4710")  # 'fprintf'/'printf'/'snprintf'/'sscanf'/...: function not inlined (in examples/tests, with VS2022+ Release)
+    list(APPEND _picky "-wd4710")  # '*printf'/'sscanf'/...: function not inlined (in examples/tests, with VS2022+ Release)
     list(APPEND _picky "-wd4711")  # function 'A' selected for automatic inline expansion
     # volatile access of '<expression>' is subject to /volatile:<iso|ms> setting;
     #   consider using __iso_volatile_load/store intrinsic functions (ARM64)

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -349,7 +349,7 @@ if(PICKY_COMPILER)
     list(APPEND _picky "-wd4548")  # expression before comma has no effect; expected expression with side-effect (in FD_SET())
     list(APPEND _picky "-wd4574")  # 'M' is defined to be '0': did you mean to use '#if M'? (in ws2tcpip.h)
     list(APPEND _picky "-wd4668")  # 'M' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif' (in winbase.h)
-  # list(APPEND _picky "-wd4710")  # 'fprintf'/'printf'/'sscanf': function not inlined (in examples/tests, with VS2022+ Release)
+    list(APPEND _picky "-wd4710")  # 'fprintf'/'printf'/'snprintf'/'sscanf'/...: function not inlined (in examples/tests, with VS2022+ Release)
     list(APPEND _picky "-wd4711")  # function 'A' selected for automatic inline expansion
     # volatile access of '<expression>' is subject to /volatile:<iso|ms> setting;
     #   consider using __iso_volatile_load/store intrinsic functions (ARM64)

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -183,7 +183,7 @@ if(PICKY_COMPILER)
         list(APPEND _picky_enable
           -Wcast-function-type             # clang 13.0            appleclang 13.1
           -Wreserved-identifier            # clang 13.0            appleclang 13.1  # Keep it before -Wno-reserved-macro-identifier
-            -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
+          # -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0) OR
@@ -349,7 +349,7 @@ if(PICKY_COMPILER)
     list(APPEND _picky "-wd4548")  # expression before comma has no effect; expected expression with side-effect (in FD_SET())
     list(APPEND _picky "-wd4574")  # 'M' is defined to be '0': did you mean to use '#if M'? (in ws2tcpip.h)
     list(APPEND _picky "-wd4668")  # 'M' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif' (in winbase.h)
-    list(APPEND _picky "-wd4710")  # 'fprintf'/'printf'/'sscanf': function not inlined (in examples/tests, with VS2022+ Release)
+  # list(APPEND _picky "-wd4710")  # 'fprintf'/'printf'/'sscanf': function not inlined (in examples/tests, with VS2022+ Release)
     list(APPEND _picky "-wd4711")  # function 'A' selected for automatic inline expansion
     # volatile access of '<expression>' is subject to /volatile:<iso|ms> setting;
     #   consider using __iso_volatile_load/store intrinsic functions (ARM64)

--- a/cmake/PickyWarnings.cmake
+++ b/cmake/PickyWarnings.cmake
@@ -349,7 +349,7 @@ if(PICKY_COMPILER)
     list(APPEND _picky "-wd4548")  # expression before comma has no effect; expected expression with side-effect (in FD_SET())
     list(APPEND _picky "-wd4574")  # 'M' is defined to be '0': did you mean to use '#if M'? (in ws2tcpip.h)
     list(APPEND _picky "-wd4668")  # 'M' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif' (in winbase.h)
-    list(APPEND _picky "-wd4710")  # 'fprintf'/'printf'/'sscanf': function not inlined (in tests, with VS2022+ Release)
+    list(APPEND _picky "-wd4710")  # 'fprintf'/'printf'/'sscanf': function not inlined (in examples/tests, with VS2022+ Release)
     list(APPEND _picky "-wd4711")  # function 'A' selected for automatic inline expansion
     # volatile access of '<expression>' is subject to /volatile:<iso|ms> setting;
     #   consider using __iso_volatile_load/store intrinsic functions (ARM64)

--- a/configure.ac
+++ b/configure.ac
@@ -406,6 +406,8 @@ AC_C_CONST
 
 CURL_CHECK_NONBLOCKING_SOCKET
 
+CURL_CONVERT_INCLUDE_TO_ISYSTEM
+
 missing_required_deps=0
 
 if test "${libz_errors}" != ""; then

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -261,7 +261,7 @@ int main(int argc, char *argv[])
     sftp_handle = libssh2_sftp_open(sftp_session, sftppath,
                                     LIBSSH2_FXF_READ, 0);
     if(!sftp_handle) {
-        fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+        fprintf(stderr, "Unable to open file with SFTP: %lu\n",
                 libssh2_sftp_last_error(sftp_session));
         goto shutdown;
     }

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -224,7 +224,7 @@ int main(int argc, char *argv[])
                                         LIBSSH2_FXF_READ, 0);
         if(!sftp_handle) {
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-                fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                fprintf(stderr, "Unable to open file with SFTP: %lu\n",
                         libssh2_sftp_last_error(sftp_session));
                 goto shutdown;
             }

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
                                     LIBSSH2_SFTP_S_IRGRP |
                                     LIBSSH2_SFTP_S_IROTH);
     if(!sftp_handle) {
-        fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+        fprintf(stderr, "Unable to open file with SFTP: %lu\n",
                 libssh2_sftp_last_error(sftp_session));
         goto shutdown;
     }
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
 
     fprintf(stderr, "libssh2_sftp_open() a handle for APPEND\n");
     if(!sftp_handle) {
-        fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+        fprintf(stderr, "Unable to open file with SFTP: %lu\n",
                 libssh2_sftp_last_error(sftp_session));
         goto shutdown;
     }

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -245,7 +245,7 @@ int main(int argc, char *argv[])
                                         LIBSSH2_FXF_READ, 0);
         if(!sftp_handle) {
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-                fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+                fprintf(stderr, "Unable to open file with SFTP: %lu\n",
                         libssh2_sftp_last_error(sftp_session));
                 goto shutdown;
             }

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
                                     LIBSSH2_SFTP_S_IRGRP |
                                     LIBSSH2_SFTP_S_IROTH);
     if(!sftp_handle) {
-        fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+        fprintf(stderr, "Unable to open file with SFTP: %lu\n",
                 libssh2_sftp_last_error(sftp_session));
         goto shutdown;
     }

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
                                         LIBSSH2_SFTP_S_IROTH);
         if(!sftp_handle &&
            libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+            fprintf(stderr, "Unable to open file with SFTP: %lu\n",
                     libssh2_sftp_last_error(sftp_session));
             goto shutdown;
         }

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -240,7 +240,7 @@ int main(int argc, char *argv[])
                                         LIBSSH2_SFTP_S_IROTH);
         if(!sftp_handle &&
            libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-            fprintf(stderr, "Unable to open file with SFTP: %ld\n",
+            fprintf(stderr, "Unable to open file with SFTP: %lu\n",
                     libssh2_sftp_last_error(sftp_session));
             goto shutdown;
         }

--- a/example/x11.c
+++ b/example/x11.c
@@ -59,16 +59,16 @@ struct chan_X11_list {
 };
 
 static struct chan_X11_list *gp_x11_chan = NULL;
-static struct termios _saved_tio;
+static struct termios s_saved_tio;
 
-static int _raw_mode(void)
+static int raw_mode(void)
 {
     int rc;
     struct termios tio;
 
     rc = tcgetattr(fileno(stdin), &tio);
     if(rc != -1) {
-        _saved_tio = tio;
+        s_saved_tio = tio;
         /* do the equivalent of cfmakeraw() manually, to build on Solaris */
         tio.c_iflag &= ~(tcflag_t)(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR |
                                    IGNCR | ICRNL | IXON);
@@ -81,10 +81,10 @@ static int _raw_mode(void)
     return rc;
 }
 
-static int _normal_mode(void)
+static int normal_mode(void)
 {
     int rc;
-    rc = tcsetattr(fileno(stdin), TCSADRAIN, &_saved_tio);
+    rc = tcsetattr(fileno(stdin), TCSADRAIN, &s_saved_tio);
     return rc;
 }
 
@@ -407,7 +407,7 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
 
-    rc = _raw_mode();
+    rc = raw_mode();
     if(rc) {
         fprintf(stderr, "Failed to enter raw mode\n");
         goto shutdown;
@@ -546,7 +546,7 @@ shutdown:
 
     fprintf(stderr, "all done\n");
 
-    _normal_mode();
+    normal_mode();
 
     libssh2_exit();
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -46,7 +46,7 @@
 
 #include <termios.h>
 
-#define _PATH_UNIX_X "/tmp/.X11-unix/X%d"
+#define PATH_UNIX_X "/tmp/.X11-unix/X%d"
 
 /*
  * Chained list that contains channels and associated X11 socket for each X11
@@ -130,7 +130,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
             memset(&addr, 0, sizeof(addr));
             addr.sun_family = AF_UNIX;
             snprintf(addr.sun_path, sizeof(addr.sun_path),
-                     _PATH_UNIX_X, display_port);
+                     PATH_UNIX_X, display_port);
             rc = connect(sock, (struct sockaddr *)&addr, sizeof(addr));
 
             if(rc != -1) {

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -224,6 +224,10 @@ typedef off_t libssh2_struct_stat_size;
 
 /* for pre-existing ones: !checksrc! disable TYPEDEFSTRUCT all */
 
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 typedef struct _LIBSSH2_USERAUTH_KBDINT_PROMPT
 {
     unsigned char *text;
@@ -245,6 +249,9 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
     unsigned char *sig_s;
     size_t sig_s_len;
 } LIBSSH2_SK_SIG_INFO;
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 /* 'publickey' authentication callback */
 #define LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(name) \
@@ -364,13 +371,24 @@ typedef struct _LIBSSH2_SK_SIG_INFO {
 #define LIBSSH2_FLAG_COMPRESS       2
 #define LIBSSH2_FLAG_QUOTE_PATHS    3
 
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 typedef struct _LIBSSH2_SESSION                     LIBSSH2_SESSION;
 typedef struct _LIBSSH2_CHANNEL                     LIBSSH2_CHANNEL;
 typedef struct _LIBSSH2_LISTENER                    LIBSSH2_LISTENER;
 typedef struct _LIBSSH2_KNOWNHOSTS                  LIBSSH2_KNOWNHOSTS;
 typedef struct _LIBSSH2_AGENT                       LIBSSH2_AGENT;
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 #ifndef LIBSSH2_NO_DEPRECATED
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 typedef struct _LIBSSH2_POLLFD {
     unsigned char type; /* LIBSSH2_POLLFD_* below */
 
@@ -385,6 +403,9 @@ typedef struct _LIBSSH2_POLLFD {
     unsigned long events; /* Requested Events */
     unsigned long revents; /* Returned Events */
 } LIBSSH2_POLLFD;
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 /* Poll FD Descriptor Types */
 #define LIBSSH2_POLLFD_SOCKET       1
@@ -742,6 +763,10 @@ LIBSSH2_API int libssh2_userauth_publickey_sk(
     LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback),
     void **abstract);
 
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 /* SK signature callback */
 typedef struct _LIBSSH2_PRIVKEY_SK {
     int algorithm;
@@ -752,6 +777,9 @@ typedef struct _LIBSSH2_PRIVKEY_SK {
     LIBSSH2_USERAUTH_SK_SIGN_FUNC(*sign_callback);
     void **orig_abstract;
 } LIBSSH2_PRIVKEY_SK;
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 LIBSSH2_API int libssh2_sign_sk(LIBSSH2_SESSION *session,
                                 unsigned char **sig, size_t *sig_len,

--- a/include/libssh2_publickey.h
+++ b/include/libssh2_publickey.h
@@ -50,6 +50,10 @@
 
 #include "libssh2.h"
 
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 typedef struct _LIBSSH2_PUBLICKEY               LIBSSH2_PUBLICKEY;
 
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
@@ -72,6 +76,9 @@ typedef struct _libssh2_publickey_list {
     unsigned long num_attrs;
     libssh2_publickey_attribute *attrs; /* free me */
 } libssh2_publickey_list;
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 /* Generally use the first macro here, but if both name and value are string
    literals, you can use _fast() to take advantage of preprocessing */

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -57,11 +57,6 @@ extern "C" {
  */
 #define LIBSSH2_SFTP_VERSION        3
 
-typedef struct _LIBSSH2_SFTP                LIBSSH2_SFTP;
-typedef struct _LIBSSH2_SFTP_HANDLE         LIBSSH2_SFTP_HANDLE;
-typedef struct _LIBSSH2_SFTP_ATTRIBUTES     LIBSSH2_SFTP_ATTRIBUTES;
-typedef struct _LIBSSH2_SFTP_STATVFS        LIBSSH2_SFTP_STATVFS;
-
 /* Flags for open_ex() */
 #define LIBSSH2_SFTP_OPENFILE           0
 #define LIBSSH2_SFTP_OPENDIR            1
@@ -95,6 +90,15 @@ typedef struct _LIBSSH2_SFTP_STATVFS        LIBSSH2_SFTP_STATVFS;
 #define LIBSSH2_SFTP_ST_RDONLY              0x00000001
 #define LIBSSH2_SFTP_ST_NOSUID              0x00000002
 
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+typedef struct _LIBSSH2_SFTP                LIBSSH2_SFTP;
+typedef struct _LIBSSH2_SFTP_HANDLE         LIBSSH2_SFTP_HANDLE;
+typedef struct _LIBSSH2_SFTP_ATTRIBUTES     LIBSSH2_SFTP_ATTRIBUTES;
+typedef struct _LIBSSH2_SFTP_STATVFS        LIBSSH2_SFTP_STATVFS;
+
 struct _LIBSSH2_SFTP_ATTRIBUTES {
     /* If flags & ATTR_* bit is set, then the value in this struct is
      * meaningful otherwise it should be ignored
@@ -120,6 +124,9 @@ struct _LIBSSH2_SFTP_STATVFS {
     libssh2_uint64_t  f_flag;     /* mount flags */
     libssh2_uint64_t  f_namemax;  /* maximum filename length */
 };
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 /* SFTP filetypes */
 #define LIBSSH2_SFTP_TYPE_REGULAR           1

--- a/src/channel.c
+++ b/src/channel.c
@@ -147,7 +147,7 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
                sizeof(session->open_packet_requirev_state));
 
         ssh2_deb((session, LIBSSH2_TRACE_CONN,
-                  "Opening Channel - win %d pack %d",
+                  "Opening Channel - win %u pack %u",
                   window_size, packet_size));
         session->open_channel = SSH2_CALLOC(session, sizeof(LIBSSH2_CHANNEL));
         if(!session->open_channel) {

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -839,12 +839,12 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = gcry_mpi_new(0);                   /* Random from client */
 }
 
-int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                           ssh2_bn *p, int group_order)
 {
     /* Generate x and e */
     gcry_mpi_randomize(*dhctx, group_order * 8 - 1, GCRY_VERY_STRONG_RANDOM);
-    gcry_mpi_powm(public, g, *dhctx, p);
+    gcry_mpi_powm(pub, g, *dhctx, p);
     return 0;
 }
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -202,12 +202,12 @@
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx struct gcry_mpi *
-#define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
-    ssh2_lgcr_dh_key_pair(dhctx, public, g, p, group_order)
+#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
+    ssh2_lgcr_dh_key_pair(dhctx, pub, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_lgcr_dh_secret(dhctx, secret, f, p)
 
-int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                           ssh2_bn *p, int group_order);
 int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                         ssh2_bn *p);

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -456,6 +456,10 @@ struct channel_data {
     char close, eof, extended_data_ignore_mode;
 };
 
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 struct _LIBSSH2_CHANNEL {
     struct list_node node;
 
@@ -578,6 +582,9 @@ struct _LIBSSH2_LISTENER {
     unsigned char *chanFwdCncl_data;
     size_t chanFwdCncl_data_len;
 };
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 struct endpoint_data {
     unsigned char *banner;
@@ -639,6 +646,10 @@ struct transportpacket {
     size_t osent;           /* number of bytes already sent */
 };
 
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 struct _LIBSSH2_PUBLICKEY {
     LIBSSH2_CHANNEL *channel;
     uint32_t version;
@@ -665,6 +676,9 @@ struct _LIBSSH2_PUBLICKEY {
     unsigned char *listFetch_data;
     size_t listFetch_data_len;
 };
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 #define SSH2_SCP_RESPONSE_BUFLEN     256
 
@@ -674,6 +688,10 @@ struct flags {
     int quote_paths; /* LIBSSH2_FLAG_QUOTE_PATHS */
 };
 
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 struct _LIBSSH2_SESSION {
     /* Memory management callbacks */
     void *abstract;
@@ -955,6 +973,9 @@ struct _LIBSSH2_SESSION {
     /* Configurable timeout for packets. Replaces LIBSSH2_READ_TIMEOUT */
     long packet_read_timeout;
 };
+#if defined(__clang__) && __clang_major__ >= 13
+#pragma clang diagnostic pop
+#endif
 
 /* session.state bits */
 #define SSH2_STATE_INITIAL_KEX     0x00000001

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -62,8 +62,15 @@
 #endif
 
 #ifdef __MINGW32__
+#  if defined(__clang__) && __clang_major__ >= 13
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wreserved-macro-identifier"
+#  endif
 #  undef _FILE_OFFSET_BITS
 #  define _FILE_OFFSET_BITS 64
+#  if defined(__clang__) && __clang_major__ >= 13
+#  pragma clang diagnostic pop
+#  endif
 #elif defined(_MSC_VER)
 #  ifndef _CRT_SECURE_NO_WARNINGS
 #  define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv() */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -846,12 +846,12 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = ssh2_mbed_bn_init(); /* Random from client */
 }
 
-int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                           ssh2_bn *p, int group_order)
 {
     /* Generate x and e */
     mbed_bn_random(*dhctx, group_order * 8 - 1, 0, -1);
-    mbedtls_mpi_exp_mod(public, g, *dhctx, p, NULL);
+    mbedtls_mpi_exp_mod(pub, g, *dhctx, p, NULL);
     return 0;
 }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -148,7 +148,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 {
     int ret;
     unsigned char *output;
-    size_t osize, olen, finish_olen;
+    size_t osize;
 
     (void)encrypt;
     (void)algo;
@@ -158,6 +158,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
     output = (unsigned char *)mbedtls_calloc(osize, sizeof(char));
     if(output) {
+        size_t olen = 0, finish_olen = 0;
+
         ret = mbedtls_cipher_reset(ctx);
 
         if(!ret)
@@ -590,6 +592,7 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
     else {
         ssh2_err(session, LIBSSH2_ERROR_PROTO,
                  "Unsupported hash digest length");
+        md_type = 0;
         ret = -1;
     }
     if(ret == 0)
@@ -1101,7 +1104,6 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx)
 static int mbed_ecdsa_curve_type_from_name(const char *name,
                                            ssh2_curve_type *out_type)
 {
-    int ret = 0;
     ssh2_curve_type type;
 
     if(!name || strlen(name) != 19)
@@ -1114,14 +1116,14 @@ static int mbed_ecdsa_curve_type_from_name(const char *name,
     else if(strcmp(name, "ecdsa-sha2-nistp521") == 0)
         type = SSH2_EC_CURVE_NISTP521;
     else {
-        ret = -1;
+        return -1;
     }
 
-    if(ret == 0 && out_type) {
+    if(out_type) {
         *out_type = type;
     }
 
-    return ret;
+    return 0;
 }
 
 static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -320,12 +320,12 @@ void ssh2_mbed_bn_free(ssh2_bn *bn);
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx mbedtls_mpi *
-#define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
-    ssh2_mbed_dh_key_pair(dhctx, public, g, p, group_order)
+#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
+    ssh2_mbed_dh_key_pair(dhctx, pub, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_mbed_dh_secret(dhctx, secret, f, p)
 
-int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                           ssh2_bn *p, int group_order);
 int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                         ssh2_bn *p);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -48,6 +48,11 @@
 
 #ifdef USE_OPENSSL_3
 #define USE_PEM_READ_BIO_PRIVATEKEY
+#else
+#if defined(__clang__) && __clang_major__ >= 16
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-strict"
+#endif
 #endif
 
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
@@ -5150,5 +5155,11 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
     return NULL;
 }
+
+#ifndef USE_OPENSSL_3
+#if defined(__clang__) && __clang_major__ >= 16
+#pragma clang diagnostic pop
+#endif
+#endif
 
 #endif /* LIBSSH2_OPENSSL || LIBSSH2_WOLFSSL */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -5092,12 +5092,12 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = BN_new(); /* Random from client */
 }
 
-int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                           ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
     /* Generate x and e */
     BN_rand(*dhctx, group_order * 8 - 1, 0, -1);
-    BN_mod_exp(public, g, *dhctx, p, bnctx);
+    BN_mod_exp(pub, g, *dhctx, p, bnctx);
     return 0;
 }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -435,11 +435,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
         ret = ssh2_ossl_sha512(m, m_len, hash);
     }
     else {
-/* silence:
-   warning C4701: potentially uninitialized local variable 'nid_type' used */
-#ifdef _MSC_VER
         nid_type = 0;
-#endif
         ret = -1; /* unsupported digest */
     }
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -434,12 +434,12 @@ int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val);
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx BIGNUM *
-#define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
-    ssh2_ossl_dh_key_pair(dhctx, public, g, p, group_order, bnctx)
+#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
+    ssh2_ossl_dh_key_pair(dhctx, pub, g, p, group_order, bnctx)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_ossl_dh_secret(dhctx, secret, f, p, bnctx)
 
-int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                           ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx);
 int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                         ssh2_bn *p, ssh2_bn_ctx *bnctx);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1248,7 +1248,7 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     memset((char *)dhctx, 0, sizeof(*dhctx));
 }
 
-int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
+int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
                               ssh2_bn *g, ssh2_bn *p, int group_order)
 {
     struct asn1Element *prime;
@@ -1292,7 +1292,7 @@ int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
     asn1delete(pkcs3);
     if(errcode.Bytes_Available)
         return -1;
-    return ssh2_bn_from_bin(public, pubkeylen, (unsigned char *)pubkey);
+    return ssh2_bn_from_bin(pub, pubkeylen, (unsigned char *)pubkey);
 }
 
 int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -340,12 +340,12 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
 #define SSH2_DH_MAX_MODULUS_BITS 2048
 
 #define ssh2_dh_ctx struct os400qc3_dh_ctx
-#define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
-    ssh2_os400qc3_dh_key_pair(dhctx, public, g, p, group_order)
+#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
+    ssh2_os400qc3_dh_key_pair(dhctx, pub, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_os400qc3_dh_secret(dhctx, secret, f, p)
 
-int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public,
+int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
                               ssh2_bn *g, ssh2_bn *p, int group_order);
 int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
                             ssh2_bn *f, ssh2_bn *p);

--- a/src/packet.c
+++ b/src/packet.c
@@ -772,7 +772,7 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                 }
 
                 ssh2_deb((session, LIBSSH2_TRACE_TRANS,
-                          "Disconnect(%d): %.*s(%.*s)", reason,
+                          "Disconnect(%u): %.*s(%.*s)", reason,
                           (int)message_len, message, (int)language_len,
                           language));
             }

--- a/src/packet.c
+++ b/src/packet.c
@@ -125,9 +125,9 @@ static SSH2_INLINE int packet_queue_listener(
 
         ssh2_deb((session, LIBSSH2_TRACE_CONN,
                   "Remote received connection from %.*s:%u to %.*s:%u",
-                  listen_state->shost_len, listen_state->shost,
+                  (int)listen_state->shost_len, listen_state->shost,
                   listen_state->sport,
-                  listen_state->host_len, listen_state->host,
+                  (int)listen_state->host_len, listen_state->host,
                   listen_state->port));
 
         listen_state->state = ssh2_NB_state_allocated;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -657,7 +657,7 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
 
         ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY,
                   "Sending publickey \"add\" packet: "
-                  "type=%s blob_len=%ld num_attrs=%ld",
+                  "type=%s blob_len=%lu num_attrs=%lu",
                   name, blob_len, num_attrs));
 
         pkey->add_state = ssh2_NB_state_created;
@@ -743,7 +743,7 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
 
         ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY,
                   "Sending publickey \"remove\" packet: "
-                  "type=%s blob_len=%ld", name, blob_len));
+                  "type=%s blob_len=%lu", name, blob_len));
 
         pkey->remove_state = ssh2_NB_state_created;
     }

--- a/src/scp.c
+++ b/src/scp.c
@@ -725,7 +725,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                     goto scp_recv_error;
                 }
                 ssh2_deb((session, LIBSSH2_TRACE_SCP, "mode = 0%lo size = %ld",
-                          session->scpRecv_mode,
+                          (unsigned long)session->scpRecv_mode,
                           (long)session->scpRecv_size));
 
                 /* We *should* check that basename is valid, but why let that
@@ -1026,7 +1026,8 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
         session->scpSend_response_len =
             snprintf((char *)session->scpSend_response,
                      SSH2_SCP_RESPONSE_BUFLEN,
-                     "C0%o %" SSH2_INT64_T_FORMAT " %s\n", mode, size, base);
+                     "C0%o %" SSH2_INT64_T_FORMAT " %s\n",
+                     (unsigned int)mode, size, base);
         ssh2_deb((session, LIBSSH2_TRACE_SCP, "Sent %s",
                   session->scpSend_response));
 

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -222,7 +222,7 @@ static int sftp_packet_add(LIBSSH2_SFTP *sftp,
 
     request_id = ssh2_ntohu32(&data[1]);
 
-    ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Received packet id %d",
+    ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Received packet id %u",
               request_id));
 
     /* Do not add the packet if it answers a request we have given up on. */
@@ -515,7 +515,7 @@ static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
         /* data was read, check the queue again */
         if(!sftp_packet_ask(sftp, packet_type, request_id, data, data_len)) {
             /* The right packet was available in the packet brigade */
-            ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Got %d",
+            ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Got %u",
                       (unsigned int)packet_type));
 
             if(*data_len < required_size) {
@@ -1288,7 +1288,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
             if(badness) {
                 ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                          "Failed opening remote file");
-                ssh2_deb((session, LIBSSH2_TRACE_SFTP, "got FXP_STATUS %d",
+                ssh2_deb((session, LIBSSH2_TRACE_SFTP, "got FXP_STATUS %u",
                           sftp->last_errno));
                 SSH2_FREE(session, data);
                 return NULL;
@@ -1548,7 +1548,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                more packets */
             count -= SSH2_MIN(size, count);
             ssh2_deb((session, LIBSSH2_TRACE_SFTP,
-                      "read request id %d sent (offset: %lu, size: %lu)",
+                      "read request id %u sent (offset: %lu, size: %lu)",
                       request_id, (unsigned long)chunk->offset,
                       (unsigned long)chunk->len));
         }
@@ -3450,7 +3450,8 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
         sftp->last_errno = LIBSSH2_FX_OK;
 
         ssh2_deb((session, LIBSSH2_TRACE_SFTP,
-                  "Creating directory %s with mode 0%lo", path, mode));
+                  "Creating directory %s with mode 0%lo",
+                  path, (unsigned long)mode));
         s = packet = SSH2_ALLOC(session, packet_len);
         if(!packet) {
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,

--- a/src/transport.c
+++ b/src/transport.c
@@ -78,7 +78,7 @@ static void debugdump(LIBSSH2_SESSION *session,
 
     for(i = 0; i < size; i += width) {
 
-        used = snprintf(buffer, sizeof(buffer), "%04lx: ", (long)i);
+        used = snprintf(buffer, sizeof(buffer), "%04lx: ", (unsigned long)i);
 
         /* hex not disabled, show it */
         for(c = 0; c < width; c++) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3428,9 +3428,8 @@ static int wcng_round_down(int number, int multiple)
 /* Generates a Diffie-Hellman key pair using base `g', prime `p' and the given
  * `group_order'. Can use the given big number context `bnctx' if needed.  The
  * private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
- * the public key is returned in `public'.  0 is returned upon success, else
- * -1.  */
-int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+ * the public key is returned in `pub'. 0 is returned upon success, else -1. */
+int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                           ssh2_bn *p, int group_order)
 {
     const int hasAlgDHwithKDF = ssh2_wcng.hasAlgDHwithKDF;
@@ -3505,7 +3504,7 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
         key_length_bytes = 0;
         if(hasAlgDHwithKDF == 1) {
             /* Now we need to extract the public portion of the key so that we
-             * set it in the `public` bignum to satisfy our caller.
+             * set it in the `pub` bignum to satisfy our caller.
              * First measure up the size of the required buffer. */
             key_type = BCRYPT_DH_PUBLIC_BLOB;
         }
@@ -3549,7 +3548,7 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
         /* BCRYPT_DH_PUBLIC_BLOB corresponds to a BCRYPT_DH_KEY_BLOB header
          * followed by the Modulus, Generator and Public data. Those components
          * each have equal size, specified by dh_key_blob->cbKey. */
-        if(wcng_bn_resize(public, dh_key_blob->cbKey)) {
+        if(wcng_bn_resize(pub, dh_key_blob->cbKey)) {
             if(hasAlgDHwithKDF == 1) {
                 /* We have no private data, because raw KDF is supported */
                 free(dh_key_blob);
@@ -3561,9 +3560,8 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
         }
 
         /* Copy the public key data into the public bignum data buffer */
-        memcpy(public->bignum, (unsigned char *)dh_key_blob +
-                               sizeof(*dh_key_blob) +
-                               2 * dh_key_blob->cbKey,
+        memcpy(pub->bignum, (unsigned char *)dh_key_blob +
+                            sizeof(*dh_key_blob) + 2 * dh_key_blob->cbKey,
                dh_key_blob->cbKey);
 
         if(dh_key_blob->dwMagic == BCRYPT_DH_PRIVATE_MAGIC) {
@@ -3607,7 +3605,7 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
         return -1;
     if(wcng_bn_random(dhctx->dh_privbn, (group_order * 8) - 1, 0, -1))
         return -1;
-    if(wcng_bn_mod_exp(public, g, dhctx->dh_privbn, p))
+    if(wcng_bn_mod_exp(pub, g, dhctx->dh_privbn, p))
         return -1;
 
     return 0;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1874,7 +1874,7 @@ static int wcng_ecdsa_decode_uncompressed_point(
         if(wcng_ecdsa_algs[curve].point_length ==
            (encoded_point_len - 1) / 2) {
 
-            point->curve = curve;
+            point->curve = (ssh2_curve_type)curve;
 
             point->x = encoded_point + 1;
             point->x_len = wcng_ecdsa_algs[curve].point_length;
@@ -2470,7 +2470,7 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
 
     for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
         if(strcmp(name, wcng_ecdsa_algs[curve].name) == 0) {
-            *out_curve = curve;
+            *out_curve = (ssh2_curve_type)curve;
             return LIBSSH2_ERROR_NONE;
         }
     }

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -441,12 +441,12 @@ struct wcng_dh_ctx {
 };
 
 #define ssh2_dh_ctx struct wcng_dh_ctx
-#define ssh2_dh_key_pair(dhctx, public, g, p, group_order, bnctx) \
-    ssh2_wcng_dh_key_pair(dhctx, public, g, p, group_order)
+#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
+    ssh2_wcng_dh_key_pair(dhctx, pub, g, p, group_order)
 #define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
     ssh2_wcng_dh_secret(dhctx, secret, f, p)
 
-int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *public, ssh2_bn *g,
+int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                           ssh2_bn *p, int group_order);
 int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                         ssh2_bn *p);

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -58,8 +58,10 @@
 #include <stdarg.h>
 #include <ctype.h>
 
-#if defined(_WIN32) && defined(_WIN64)
+#ifdef _WIN64
 #define LIBSSH2_SOCKET_MASK "%llu"
+#elif defined(_WIN32)
+#define LIBSSH2_SOCKET_MASK "%u"
 #else
 #define LIBSSH2_SOCKET_MASK "%d"
 #endif

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -59,7 +59,7 @@
 #include <ctype.h>
 
 #if defined(_WIN32) && defined(_WIN64)
-#define LIBSSH2_SOCKET_MASK "%lld"
+#define LIBSSH2_SOCKET_MASK "%llu"
 #else
 #define LIBSSH2_SOCKET_MASK "%d"
 #endif

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -418,7 +418,7 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
         if(connect(sock, (struct sockaddr *)(&sin),
                    sizeof(struct sockaddr_in))) {
             fprintf(stderr,
-                    "Connection to %s:%s attempt #%d failed: retrying...\n",
+                    "Connection to %s:%s attempt #%u failed: retrying...\n",
                     ip_address, port_string, counter);
             portable_sleep(1 + 2 * counter);
         }

--- a/tests/test_hostkey.c
+++ b/tests/test_hostkey.c
@@ -50,7 +50,7 @@ int test(LIBSSH2_SESSION *session)
                                 strlen(EXPECTED_RSA_HOSTKEY));
     }
     else {
-        fprintf(stderr, "Unexpected type of hostkey: %i\n", type);
+        fprintf(stderr, "Unexpected type of hostkey: %d\n", type);
         return 1;
     }
 
@@ -60,7 +60,7 @@ int test(LIBSSH2_SESSION *session)
     }
 
     if(len != expected_len) {
-        fprintf(stderr, "Hostkey does not have the expected length %ld!=%ld\n",
+        fprintf(stderr, "Hostkey does not have the expected length %lu!=%lu\n",
                 (unsigned long)len, (unsigned long)expected_len);
         return 1;
     }

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
         if(connect(sock, (struct sockaddr *)(&sin),
                    sizeof(struct sockaddr_in))) {
             fprintf(stderr,
-                    "Connection to %s:%d attempt #%d failed: retrying...\n",
+                    "Connection to %s:%d attempt #%u failed: retrying...\n",
                     hostname, port_number, counter);
             portable_sleep(1 + 2 * counter);
         }


### PR DESCRIPTION
- sync picky compiler warning options with curl:
  - update version mappings for latest Apple clang.
  - replace `-pedantic` with `-Wpedantic` on newer toolchains.
  - adjust warning cutoff versions.
  - enable new picky warnings.
  - unlock picky warnings for most recent MSVC.
- GHA: bump some MSVC jobs to to VS2026.

Fix fallouts:
- configure: replace `-I` with `-isystem` for dependency headers.
  Notably it silences picky warnings otherwise found in 3rd-party
  headers, e.g. `-Wreserved-identifier` in `gpg-error.h`, 
  `openssl/lhash.h`, `wolfssl/wolfcrypt/hmac.h`, or
  `-Wcast-function-type-strict` in `openssl/rsa.h`.
  It also aligns autotools builds with CMake (and curl builds).
  Logic copied from curl.
- example/x11: fix to not use reserved symbols.
- include, src/libssh2_priv.h: silence `-Wreserved-identifier` locally.
  May be fixed for real in a future patch.
- avoid using reserved C++ keyword `public`.
- openssl: silence `-Wcast-function-type-strict` locally for
  non-OpenSSL3 builds.
- mbedtls, openssl: fix potentially uninitialized variable warnings.
  (extend to all compilers from MSVC in openssl)
- fix `LIBSSH2_SOCKET_MASK` signedness on Windows.
- wincng: apply casts from `int` to `enum` to silence 
  `-Wimplicit-int-enum-cast`.
- configure: disable `-Wleading-whitespace=spaces` to due
  incompatibility with `AC_FUNC_ALLOCA`.
- packet: fix to pass `int` as mask length.
- fix `-Wformat-signedness`.
- src/libssh2_priv.h: silence `-Wreserved-macro-identifier` locally for
  mingw-w64 builds.
- GHA: add workaround for missing NSIS on windows-2025 runner images.

---

- [x] try fixing function pointer confusion in non-OpenSSL3 builds. → separate PR. #1991
- [x] try real fix for the underscored public struct symbols.
  By renaming them. They are not officially documented symbols, but
  may cause breakage if a dependent happens is using them. → separate PR, needs decision
  There is real-life use: https://github.com/search?q=struct+_LIBSSH2_SESSION&type=code&p=3 https://codesearch.debian.net/search?q=_LIBSSH2_SESSION&literal=1
  So pbly a renaming and keeping around compatibility macros.
- [x] verify if newly added warnings are in sync between AM/CM.
