### PR TITLE
src: drop redundant parentheses

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -311,12 +311,12 @@ channel_error:
 
         /* Clear out packets meant for this channel */
         ssh2_htonu32(channel_id, session->open_channel->local.id);
-        while((ssh2_packet_ask(session, SSH_MSG_CHANNEL_DATA,
-                               &session->open_data, &session->open_data_len, 1,
-                               channel_id, 4) >= 0) ||
-              (ssh2_packet_ask(session, SSH_MSG_CHANNEL_EXTENDED_DATA,
-                               &session->open_data, &session->open_data_len, 1,
-                               channel_id, 4) >= 0)) {
+        while(ssh2_packet_ask(session, SSH_MSG_CHANNEL_DATA,
+                              &session->open_data, &session->open_data_len, 1,
+                              channel_id, 4) >= 0 ||
+              ssh2_packet_ask(session, SSH_MSG_CHANNEL_EXTENDED_DATA,
+                              &session->open_data, &session->open_data_len, 1,
+                              channel_id, 4) >= 0) {
             SSH2_FREE(session, session->open_data);
             session->open_data = NULL;
         }
@@ -588,7 +588,7 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
             ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
             return NULL;
         }
-        else if(rc || (data_len < 1)) {
+        else if(rc || data_len < 1) {
             ssh2_err(session, LIBSSH2_ERROR_PROTO, "Unknown");
             session->fwdLstn_state = ssh2_NB_state_idle;
             return NULL;
@@ -1588,10 +1588,10 @@ int ssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
 
             packet_type = packet->data[0];
 
-            if(((packet_type == SSH_MSG_CHANNEL_DATA) ||
-                (packet_type == SSH_MSG_CHANNEL_EXTENDED_DATA)) &&
-               ((packet->data_len >= 5) &&
-                (ssh2_ntohu32(packet->data + 1) == channel->local.id))) {
+            if((packet_type == SSH_MSG_CHANNEL_DATA ||
+                packet_type == SSH_MSG_CHANNEL_EXTENDED_DATA) &&
+               (packet->data_len >= 5 &&
+                ssh2_ntohu32(packet->data + 1) == channel->local.id)) {
                 /* It is our channel at least */
                 int packet_stream_id;
 
@@ -1607,12 +1607,12 @@ int ssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
                                     "Unexpected packet length");
                 }
 
-                if((streamid == LIBSSH2_CHANNEL_FLUSH_ALL) ||
-                   ((packet_type == SSH_MSG_CHANNEL_EXTENDED_DATA) &&
-                    ((streamid == LIBSSH2_CHANNEL_FLUSH_EXTENDED_DATA) ||
-                     (streamid == packet_stream_id))) ||
-                   ((packet_type == SSH_MSG_CHANNEL_DATA) &&
-                    (streamid == 0))) {
+                if(streamid == LIBSSH2_CHANNEL_FLUSH_ALL ||
+                   (packet_type == SSH_MSG_CHANNEL_EXTENDED_DATA &&
+                    (streamid == LIBSSH2_CHANNEL_FLUSH_EXTENDED_DATA ||
+                     streamid == packet_stream_id)) ||
+                   (packet_type == SSH_MSG_CHANNEL_DATA &&
+                    streamid == 0)) {
                     size_t bytes_to_flush = packet->data_len -
                         packet->data_head;
 
@@ -1955,7 +1955,7 @@ ssize_t ssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
               (long)buflen, channel->local.id, channel->remote.id, stream_id));
 
     /* expand the receiving window first if it has become too narrow */
-    if((channel->read_state == ssh2_NB_state_jump1) ||
+    if(channel->read_state == ssh2_NB_state_jump1 ||
        (channel->remote.window_size <
         channel->remote.window_size_initial / 4 * 3 + buflen)) {
 
@@ -1980,11 +1980,11 @@ ssize_t ssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
         rc = ssh2_transport_read(session);
     } while(rc > 0);
 
-    if((rc < 0) && (rc != LIBSSH2_ERROR_EAGAIN))
+    if(rc < 0 && rc != LIBSSH2_ERROR_EAGAIN)
         return ssh2_err(session, rc, "transport read");
 
     read_packet = ssh2_list_first(&session->packets);
-    while(read_packet && (bytes_read < buflen)) {
+    while(read_packet && bytes_read < buflen) {
         /* previously this loop condition also checked for
            !channel->remote.close but we cannot let it do this:
 
@@ -2020,17 +2020,18 @@ ssize_t ssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
          * enabled and data was available
          */
         if((stream_id &&
-            (readpkt->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA) &&
-            (channel->local.id == channel->read_local_id) &&
-            (readpkt->data_len >= 9) &&
-            (stream_id == (int)ssh2_ntohu32(readpkt->data + 5))) ||
-           (!stream_id && (readpkt->data[0] == SSH_MSG_CHANNEL_DATA) &&
-            (channel->local.id == channel->read_local_id)) ||
+            readpkt->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA &&
+            channel->local.id == channel->read_local_id &&
+            readpkt->data_len >= 9 &&
+            stream_id == (int)ssh2_ntohu32(readpkt->data + 5)) ||
            (!stream_id &&
-            (readpkt->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA) &&
-            (channel->local.id == channel->read_local_id) &&
-            (channel->remote.extended_data_ignore_mode ==
-             LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE))) {
+            readpkt->data[0] == SSH_MSG_CHANNEL_DATA &&
+            channel->local.id == channel->read_local_id) ||
+           (!stream_id &&
+            readpkt->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA &&
+            channel->local.id == channel->read_local_id &&
+            channel->remote.extended_data_ignore_mode ==
+                LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE)) {
 
             /* figure out much more data we want to read */
             bytes_want = buflen - bytes_read;
@@ -2162,18 +2163,18 @@ size_t ssh2_channel_packet_data_len(LIBSSH2_CHANNEL *channel, int stream_id)
          * enabled and data was available
          */
         if((stream_id &&
-            (read_packet->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA) &&
-            (channel->local.id == read_local_id) &&
-            (read_packet->data_len >= 9) &&
-            (stream_id == (int)ssh2_ntohu32(read_packet->data + 5))) ||
+            read_packet->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA &&
+            channel->local.id == read_local_id &&
+            read_packet->data_len >= 9 &&
+            stream_id == (int)ssh2_ntohu32(read_packet->data + 5)) ||
            (!stream_id &&
-            (read_packet->data[0] == SSH_MSG_CHANNEL_DATA) &&
-            (channel->local.id == read_local_id)) ||
+            read_packet->data[0] == SSH_MSG_CHANNEL_DATA &&
+            channel->local.id == read_local_id) ||
            (!stream_id &&
-            (read_packet->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA) &&
-            (channel->local.id == read_local_id) &&
-            (channel->remote.extended_data_ignore_mode ==
-             LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE))) {
+            read_packet->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA &&
+            channel->local.id == read_local_id &&
+            channel->remote.extended_data_ignore_mode ==
+                LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE)) {
             return read_packet->data_len - read_packet->data_head;
         }
 
@@ -2230,7 +2231,7 @@ ssize_t ssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
             rc = ssh2_transport_read(session);
         while(rc > 0);
 
-        if((rc < 0) && (rc != LIBSSH2_ERROR_EAGAIN)) {
+        if(rc < 0 && rc != LIBSSH2_ERROR_EAGAIN) {
             return ssh2_err(channel->session, rc,
                             "Failure while draining incoming flow");
         }
@@ -2403,10 +2404,10 @@ int libssh2_channel_eof(LIBSSH2_CHANNEL *channel)
             continue;
         }
 
-        if(((packet->data[0] == SSH_MSG_CHANNEL_DATA) ||
-            (packet->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA)) &&
-           ((packet->data_len >= 5) &&
-            (channel->local.id == ssh2_ntohu32(packet->data + 1)))) {
+        if((packet->data[0] == SSH_MSG_CHANNEL_DATA ||
+            packet->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA) &&
+           (packet->data_len >= 5 &&
+            channel->local.id == ssh2_ntohu32(packet->data + 1))) {
             /* There is data waiting to be read yet, mask the EOF status */
             return 0;
         }
@@ -2441,7 +2442,7 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
             break;
         }
 
-        if((channel->remote.window_size == channel->read_avail) &&
+        if(channel->remote.window_size == channel->read_avail &&
            session->api_block_mode)
             return ssh2_err(session, LIBSSH2_ERROR_CHANNEL_WINDOW_FULL,
                             "Receiving channel window has been exhausted");
@@ -2673,10 +2674,10 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
 
     /* Clear out packets meant for this channel */
     ssh2_htonu32(channel_id, channel->local.id);
-    while((ssh2_packet_ask(session, SSH_MSG_CHANNEL_DATA, &data,
-                           &data_len, 1, channel_id, 4) >= 0) ||
-          (ssh2_packet_ask(session, SSH_MSG_CHANNEL_EXTENDED_DATA, &data,
-                           &data_len, 1, channel_id, 4) >= 0)) {
+    while(ssh2_packet_ask(session, SSH_MSG_CHANNEL_DATA, &data,
+                          &data_len, 1, channel_id, 4) >= 0 ||
+          ssh2_packet_ask(session, SSH_MSG_CHANNEL_EXTENDED_DATA, &data,
+                          &data_len, 1, channel_id, 4) >= 0) {
         SSH2_FREE(session, data);
     }
 
@@ -2802,10 +2803,10 @@ unsigned long libssh2_channel_window_read_ex(
 
             packet_type = packet->data[0];
 
-            if(((packet_type == SSH_MSG_CHANNEL_DATA) ||
-                (packet_type == SSH_MSG_CHANNEL_EXTENDED_DATA)) &&
-               ((packet->data_len >= 5) &&
-                (ssh2_ntohu32(packet->data + 1) == channel->local.id))) {
+            if((packet_type == SSH_MSG_CHANNEL_DATA ||
+                packet_type == SSH_MSG_CHANNEL_EXTENDED_DATA) &&
+               (packet->data_len >= 5 &&
+                ssh2_ntohu32(packet->data + 1) == channel->local.id)) {
                 bytes_queued += packet->data_len - packet->data_head;
             }
 

--- a/src/comp.c
+++ b/src/comp.c
@@ -193,7 +193,7 @@ static int comp_method_zlib_comp(LIBSSH2_SESSION *session,
 
     status = deflate(strm, Z_PARTIAL_FLUSH);
 
-    if((status == Z_OK) && (strm->avail_out > 0)) {
+    if(status == Z_OK && strm->avail_out > 0) {
         *dest_len = out_maxlen - strm->avail_out;
         return 0;
     }

--- a/src/kex.c
+++ b/src/kex.c
@@ -3666,7 +3666,7 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
     left = end_haystack - s;
 
     /* Needle at start of haystack */
-    if((strncmp((char *)haystack, (const char *)needle, needle_len) == 0) &&
+    if(strncmp((char *)haystack, (const char *)needle, needle_len) == 0 &&
        (needle_len == haystack_len || haystack[needle_len] == ',')) {
         return haystack;
     }
@@ -3677,7 +3677,7 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
     while((s = (unsigned char *)memchr((char *)s, ',', left)) != NULL) {
         /* Advance buffer past coma if we can */
         left = end_haystack - s;
-        if((left >= 1) && (left <= haystack_len) && (left > needle_len)) {
+        if(left >= 1 && left <= haystack_len && left > needle_len) {
             s++;
             left--;
         }
@@ -3686,7 +3686,7 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
         }
 
         /* Needle at X position */
-        if((strncmp((char *)s, (const char *)needle, needle_len) == 0) &&
+        if(strncmp((char *)s, (const char *)needle, needle_len) == 0 &&
            (((s - haystack) + needle_len) == haystack_len ||
             s[needle_len] == ',')) {
             return s;
@@ -3701,8 +3701,8 @@ static const struct common_method *kex_get_method_by_name(
     const struct common_method **methodlist)
 {
     while(*methodlist) {
-        if((strlen((*methodlist)->name) == name_len) &&
-           (strncmp((*methodlist)->name, name, name_len) == 0)) {
+        if(strlen((*methodlist)->name) == name_len &&
+           strncmp((*methodlist)->name, name, name_len) == 0) {
             return *methodlist;
         }
         methodlist++;
@@ -3739,11 +3739,11 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session,
 
                 /* OK so far, but does it suit our purposes? (Encrypting
                    vs Signing) */
-                if(((kex_flags & KEX_METHOD_FLAG_REQ_ENC_HOSTKEY) == 0) ||
+                if((kex_flags & KEX_METHOD_FLAG_REQ_ENC_HOSTKEY) == 0 ||
                    method->encrypt) {
                     /* Either this hostkey can do encryption or this kex
                        does not require it */
-                    if(((kex_flags & KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY) == 0) ||
+                    if((kex_flags & KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY) == 0 ||
                        method->sig_verify) {
                         /* Either this hostkey can do signing or this kex
                            does not require it */
@@ -3758,18 +3758,18 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    while(hostkeyp && (*hostkeyp) && (*hostkeyp)->name) {
+    while(hostkeyp && *hostkeyp && (*hostkeyp)->name) {
         s = ssh2_kex_agree_instr(hostkey, hostkey_len,
                                  (const unsigned char *)(*hostkeyp)->name,
                                  strlen((*hostkeyp)->name));
         if(s) {
             /* OK so far, but does it suit our purposes? (Encrypting vs
                Signing) */
-            if(((kex_flags & KEX_METHOD_FLAG_REQ_ENC_HOSTKEY) == 0) ||
+            if((kex_flags & KEX_METHOD_FLAG_REQ_ENC_HOSTKEY) == 0 ||
                (*hostkeyp)->encrypt) {
                 /* Either this hostkey can do encryption or this kex
                    does not require it */
-                if(((kex_flags & KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY) == 0) ||
+                if((kex_flags & KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY) == 0 ||
                    (*hostkeyp)->sig_verify) {
                     /* Either this hostkey can do signing or this kex
                        does not require it */
@@ -3824,7 +3824,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
                 if(kex_agree_hostkey(session, method->flags, hostkey,
                                      hostkey_len) == 0) {
                     session->kex = method;
-                    if(session->burn_optimistic_kexinit && (kex == q)) {
+                    if(session->burn_optimistic_kexinit && kex == q) {
                         /* Server sent an optimistic packet, and client agrees
                          * with preference cancel burning the first KEX_INIT
                          * packet that comes in */
@@ -3850,7 +3850,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
             if(kex_agree_hostkey(session, (*kexp)->flags, hostkey,
                                  hostkey_len) == 0) {
                 session->kex = *kexp;
-                if(session->burn_optimistic_kexinit && (kex == s)) {
+                if(session->burn_optimistic_kexinit && kex == s) {
                     /* Server sent an optimistic packet, and client agrees
                      * with preference cancel burning the first KEX_INIT
                      * packet that comes in */

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -225,8 +225,8 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         entry->key = ptr;
     }
 
-    if(key_type_name && ((typemask & LIBSSH2_KNOWNHOST_KEY_MASK) ==
-                         LIBSSH2_KNOWNHOST_KEY_UNKNOWN)) {
+    if(key_type_name && (typemask & LIBSSH2_KNOWNHOST_KEY_MASK) ==
+                        LIBSSH2_KNOWNHOST_KEY_UNKNOWN) {
         entry->key_type_name = SSH2_ALLOC(hosts->session, key_type_len + 1);
         if(!entry->key_type_name) {
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_ALLOC,
@@ -555,7 +555,7 @@ int libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
     struct known_host *node;
 
     /* check that this was retrieved the right way or get out */
-    if(!entry || (entry->magic != KNOWNHOST_MAGIC))
+    if(!entry || entry->magic != KNOWNHOST_MAGIC)
         return ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL,
                         "Invalid host information");
 
@@ -615,7 +615,7 @@ static int oldstyle_hostline(LIBSSH2_KNOWNHOSTS *hosts,
 
         /* when we get to the start or see a comma coming up, add the host
            name to the collection */
-        if((name == host) || (*(name - 1) == ',')) {
+        if(name == host || *(name - 1) == ',') {
 
             char hostbuf[256];
 
@@ -664,7 +664,7 @@ static int hashed_hostline(LIBSSH2_KNOWNHOSTS *hosts,
     hostlen -= 3; /* deduct the marker */
 
     /* this is where the salt starts, find the end of it */
-    for(p = salt; *p && (*p != '|'); p++)
+    for(p = salt; *p && *p != '|'; p++)
         ;
 
     if(*p == '|') {
@@ -750,7 +750,7 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
 
     default:
         key_type_name = key;
-        while(keylen && *key && (*key != ' ') && (*key != '\t')) {
+        while(keylen && *key && *key != ' ' && *key != '\t') {
             key++;
             keylen--;
         }
@@ -774,7 +774,7 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
             key_type = LIBSSH2_KNOWNHOST_KEY_UNKNOWN;
 
         /* skip whitespaces */
-        while(keylen && ((*key == ' ') || (*key == '\t'))) {
+        while(keylen && (*key == ' ' || *key == '\t')) {
             key++;
             keylen--;
         }
@@ -784,7 +784,7 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
 
         /* move over key */
         while(commentlen && *comment &&
-              (*comment != ' ') && (*comment != '\t')) {
+              *comment != ' ' && *comment != '\t') {
             comment++;
             commentlen--;
         }
@@ -798,7 +798,7 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
 
         /* skip whitespaces */
         while(commentlen && *comment &&
-              ((*comment == ' ') || (*comment == '\t'))) {
+              (*comment == ' ' || *comment == '\t')) {
             comment++;
             commentlen--;
         }
@@ -806,7 +806,7 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
     }
 
     /* Figure out host format */
-    if((hostlen < 3) || memcmp(host, "|1|", 3)) {
+    if(hostlen < 3 || memcmp(host, "|1|", 3)) {
         /* old style plain text: [name]([,][name])*
 
            for the sake of simplicity, we add them as separate hosts with the
@@ -867,12 +867,12 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
     cp = line;
 
     /* skip leading whitespaces */
-    while(len && ((*cp == ' ') || (*cp == '\t'))) {
+    while(len && (*cp == ' ' || *cp == '\t')) {
         cp++;
         len--;
     }
 
-    if(!len || !*cp || (*cp == '#') || (*cp == '\n'))
+    if(!len || !*cp || *cp == '#' || *cp == '\n')
         /* comment or empty line */
         return LIBSSH2_ERROR_NONE;
 
@@ -880,7 +880,7 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
     hostp = cp;
 
     /* move over the host to the separator */
-    while(len && *cp && (*cp != ' ') && (*cp != '\t')) {
+    while(len && *cp && *cp != ' ' && *cp != '\t') {
         cp++;
         len--;
     }
@@ -888,7 +888,7 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
     hostlen = cp - hostp;
 
     /* the key starts after the whitespaces */
-    while(len && *cp && ((*cp == ' ') || (*cp == '\t'))) {
+    while(len && *cp && (*cp == ' ' || *cp == '\t')) {
         cp++;
         len--;
     }
@@ -901,7 +901,7 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
     keylen = len;
 
     /* check if the line (key) ends with a newline and if so kill it */
-    while(len && *cp && (*cp != '\n')) {
+    while(len && *cp && *cp != '\n') {
         cp++;
         len--;
     }

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -102,7 +102,7 @@
 #ifdef _WIN32
 /* Detect Windows App environment which has a restricted access
    to the Win32 APIs. */
-#  if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
+#  if (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602) || \
   defined(WINAPI_FAMILY)
 #    include <winapifamily.h>
 #    if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -132,7 +132,7 @@
 #endif
 
 #if (defined(__GNUC__) || defined(__clang__)) && \
-    defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+    defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && \
     !defined(LIBSSH2_NO_FMT_CHECKS)
 #ifdef __MINGW_PRINTF_FORMAT
 #define SSH2_PRINTF(fmt, arg) \
@@ -1237,7 +1237,7 @@ size_t plain_method(char *method, size_t method_len);
 #define SSH2_ARRAYSIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 /* define to output the libssh2_int64_t type in a *printf() */
-#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER >= 1800))
+#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER >= 1800)
 #define SSH2_INT64_T_FORMAT PRId64
 #elif defined(_WIN32)
 #define SSH2_INT64_T_FORMAT "I64d"

--- a/src/misc.c
+++ b/src/misc.c
@@ -96,7 +96,7 @@ int ssh2_err_flags(LIBSSH2_SESSION *session, int errcode,
     session->err_code = errcode;
     session->err_flags = 0;
 
-    if(errmsg && ((errflags & SSH2_ERR_FLAG_DUP) != 0)) {
+    if(errmsg && (errflags & SSH2_ERR_FLAG_DUP) != 0) {
         size_t len = strlen(errmsg);
         char *copy = SSH2_ALLOC(session, len + 1);
         if(copy) {
@@ -112,7 +112,7 @@ int ssh2_err_flags(LIBSSH2_SESSION *session, int errcode,
         session->err_msg = errmsg;
 
 #ifdef LIBSSH2DEBUG
-    if((errcode == LIBSSH2_ERROR_EAGAIN) && !session->api_block_mode)
+    if(errcode == LIBSSH2_ERROR_EAGAIN && !session->api_block_mode)
         /* if this is EAGAIN and we are in non-blocking mode, do not generate
            a debug output for this */
         return errcode;
@@ -962,7 +962,7 @@ int ssh2_check_length(struct string_buf *buf, size_t requested_len)
 {
     unsigned char *endp = &buf->data[buf->len];
     size_t left = endp - buf->dataptr;
-    return (requested_len <= left) && (left <= buf->len);
+    return requested_len <= left && left <= buf->len;
 }
 
 int ssh2_eob(struct string_buf *buf)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1383,10 +1383,8 @@ static int rsa_new_additional_parameters(ssh2_rsa_ctx *rsa)
         goto out;
     }
 
-    if((BN_sub(aux, q, BN_value_one()) == 0) ||
-       (BN_mod(dmq1, d, aux, ctx) == 0) ||
-       (BN_sub(aux, p, BN_value_one()) == 0) ||
-       (BN_mod(dmp1, d, aux, ctx) == 0)) {
+    if(BN_sub(aux, q, BN_value_one()) == 0 || BN_mod(dmq1, d, aux, ctx) == 0 ||
+       BN_sub(aux, p, BN_value_one()) == 0 || BN_mod(dmp1, d, aux, ctx) == 0) {
         rc = -1;
         goto out;
     }
@@ -4189,7 +4187,7 @@ int ssh2_ecdh_gen_k(ssh2_bn **k, ssh2_ec_key *private_key,
 
     size_t out_len = 0;
 
-    if(!k || !(*k) || server_public_key_len <= 0)
+    if(!k || !*k || server_public_key_len <= 0)
         return -1;
 
     bn_ctx = BN_CTX_new();

--- a/src/packet.c
+++ b/src/packet.c
@@ -135,10 +135,10 @@ static inline int packet_queue_listener(
 
     if(listen_state->state != ssh2_NB_state_sent) {
         while(listn) {
-            if((listn->port == (int)listen_state->port) &&
-               (strlen(listn->host) == listen_state->host_len) &&
-               (memcmp(listn->host, listen_state->host,
-                       listen_state->host_len) == 0)) {
+            if(listn->port == (int)listen_state->port &&
+               strlen(listn->host) == listen_state->host_len &&
+               memcmp(listn->host, listen_state->host,
+                      listen_state->host_len) == 0) {
                 /* This is our listener */
                 LIBSSH2_CHANNEL *channel = NULL;
                 listen_state->channel = NULL;
@@ -648,7 +648,7 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                   "Packet type %u received, length=%ld",
                   (unsigned int)msg, (long)datalen));
 
-        if((macstate == SSH2_MAC_INVALID) &&
+        if(macstate == SSH2_MAC_INVALID &&
            (!session->macerror ||
             SSH2_MACERROR(session, (char *)data, datalen))) {
             /* Bad MAC input, but no callback set or non-zero return from the
@@ -915,7 +915,7 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
             if(datalen >= 5) {
                 want_reply = 0;
                 len = ssh2_ntohu32(data + 1);
-                if((len <= (UINT_MAX - 6)) && (datalen >= (6 + len))) {
+                if(len <= (UINT_MAX - 6) && datalen >= (6 + len)) {
                     want_reply = data[5 + len];
                     ssh2_deb((session, LIBSSH2_TRACE_CONN,
                               "Received global request type %.*s (wr %X)",
@@ -1267,11 +1267,10 @@ clean_exit:
         case SSH_MSG_CHANNEL_OPEN:
             if(datalen < 17)
                 ;
-            else if((datalen >= (strlen("forwarded-tcpip") + 5)) &&
-                    (strlen("forwarded-tcpip") ==
-                     ssh2_ntohu32(data + 1)) &&
-                    (memcmp(data + 5, "forwarded-tcpip",
-                            strlen("forwarded-tcpip")) == 0)) {
+            else if(datalen >= (strlen("forwarded-tcpip") + 5) &&
+                    strlen("forwarded-tcpip") == ssh2_ntohu32(data + 1) &&
+                    memcmp(data + 5, "forwarded-tcpip",
+                           strlen("forwarded-tcpip")) == 0) {
 
                 /* init the state struct */
                 memset(&session->packAdd_Qlstn_state, 0,
@@ -1282,9 +1281,9 @@ ssh2_packet_add_jump_point2:
                 rc = packet_queue_listener(session, data, datalen,
                                            &session->packAdd_Qlstn_state);
             }
-            else if((datalen >= (strlen("x11") + 5)) &&
-                    ((strlen("x11")) == ssh2_ntohu32(data + 1)) &&
-                    (memcmp(data + 5, "x11", strlen("x11")) == 0)) {
+            else if(datalen >= (strlen("x11") + 5) &&
+                    strlen("x11") == ssh2_ntohu32(data + 1) &&
+                    memcmp(data + 5, "x11", strlen("x11")) == 0) {
 
                 /* init the state struct */
                 memset(&session->packAdd_x11open_state, 0,
@@ -1295,11 +1294,11 @@ ssh2_packet_add_jump_point3:
                 rc = packet_x11_open(session, data, datalen,
                                      &session->packAdd_x11open_state);
             }
-            else if((datalen >= (strlen("auth-agent@openssh.com") + 5)) &&
-                    (strlen("auth-agent@openssh.com") ==
-                     ssh2_ntohu32(data + 1)) &&
-                    (memcmp(data + 5, "auth-agent@openssh.com",
-                            strlen("auth-agent@openssh.com")) == 0)) {
+            else if(datalen >= (strlen("auth-agent@openssh.com") + 5) &&
+                    strlen("auth-agent@openssh.com") ==
+                        ssh2_ntohu32(data + 1) &&
+                    memcmp(data + 5, "auth-agent@openssh.com",
+                           strlen("auth-agent@openssh.com")) == 0) {
 
                 /* init the state struct */
                 memset(&session->packAdd_authagent_state, 0,
@@ -1433,9 +1432,9 @@ int ssh2_packet_ask(LIBSSH2_SESSION *session, unsigned char packet_type,
 
     while(packet) {
         if(packet->data[0] == packet_type &&
-           (packet->data_len >= (match_ofs + match_len)) &&
+           packet->data_len >= (match_ofs + match_len) &&
            (!match_buf ||
-            (memcmp(packet->data + match_ofs, match_buf, match_len) == 0))) {
+            memcmp(packet->data + match_ofs, match_buf, match_len) == 0)) {
             *data = packet->data;
             *data_len = packet->data_len;
 
@@ -1629,7 +1628,7 @@ int ssh2_packet_requirev(LIBSSH2_SESSION *session,
 
     while(session->socket_state != SSH2_SOCKET_DISCONNECTED) {
         int ret = ssh2_transport_read(session);
-        if((ret < 0) && (ret != LIBSSH2_ERROR_EAGAIN)) {
+        if(ret < 0 && ret != LIBSSH2_ERROR_EAGAIN) {
             state->start = 0;
             return ret;
         }

--- a/src/pem.c
+++ b/src/pem.c
@@ -561,8 +561,8 @@ static int ssh2_openssh_pem_parse_data(LIBSSH2_SESSION *session,
         }
 
         if(strcmp((const char *)kdfname, "bcrypt") == 0 && passphrase) {
-            if((ssh2_get_string(&kdf_buf, &salt, &salt_len)) ||
-               (ssh2_get_u32(&kdf_buf, &rounds) != 0)) {
+            if(ssh2_get_string(&kdf_buf, &salt, &salt_len) ||
+               ssh2_get_u32(&kdf_buf, &rounds) != 0) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                "kdf contains unexpected values");
                 goto out;

--- a/src/scp.c
+++ b/src/scp.c
@@ -403,10 +403,9 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
         session->scpRecv_state = ssh2_NB_state_sent2;
     }
 
-    if((session->scpRecv_state == ssh2_NB_state_sent2) ||
-       (session->scpRecv_state == ssh2_NB_state_sent3)) {
-        while(sb && (session->scpRecv_response_len <
-                     SSH2_SCP_RESPONSE_BUFLEN)) {
+    if(session->scpRecv_state == ssh2_NB_state_sent2 ||
+       session->scpRecv_state == ssh2_NB_state_sent3) {
+        while(sb && session->scpRecv_response_len < SSH2_SCP_RESPONSE_BUFLEN) {
             unsigned char *s, *p;
 
             if(session->scpRecv_state == ssh2_NB_state_sent2) {
@@ -467,25 +466,25 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                     goto scp_recv_error;
                 }
 
-                if((session->scpRecv_response_len > 1) &&
-                   ((session->scpRecv_response[session->scpRecv_response_len -
-                                               1] < '0') ||
-                    (session->scpRecv_response[session->scpRecv_response_len -
-                                               1] > '9')) &&
+                if(session->scpRecv_response_len > 1 &&
                    (session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != ' ') &&
-                   (session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != '\r') &&
-                   (session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != '\n')) {
+                                               1] < '0' ||
+                    session->scpRecv_response[session->scpRecv_response_len -
+                                               1] > '9') &&
+                   session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != ' ' &&
+                   session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != '\r' &&
+                   session->scpRecv_response[session->scpRecv_response_len -
+                                              1] != '\n') {
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid data in SCP response");
                     goto scp_recv_error;
                 }
 
-                if((session->scpRecv_response_len < 9) ||
-                   (session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != '\n')) {
+                if(session->scpRecv_response_len < 9 ||
+                   session->scpRecv_response[session->scpRecv_response_len -
+                                             1] != '\n') {
                     if(session->scpRecv_response_len ==
                        SSH2_SCP_RESPONSE_BUFLEN) {
                         /* You had your chance */
@@ -519,7 +518,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 s = session->scpRecv_response + 1;
 
                 p = (unsigned char *)strchr((char *)s, ' ');
-                if(!p || ((p - s) <= 0)) {
+                if(!p || (p - s) <= 0) {
                     /* No spaces or space in the wrong spot */
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid response from SCP server, "
@@ -532,7 +531,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 session->scpRecv_mtime = strtol((char *)s, NULL, 10);
 
                 s = (unsigned char *)strchr((char *)p, ' ');
-                if(!s || ((s - p) <= 0)) {
+                if(!s || (s - p) <= 0) {
                     /* No spaces or space in the wrong spot */
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid response from SCP server, "
@@ -543,7 +542,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 /* Ignore mtime.usec */
                 s++;
                 p = (unsigned char *)strchr((char *)s, ' ');
-                if(!p || ((p - s) <= 0)) {
+                if(!p || (p - s) <= 0) {
                     /* No spaces or space in the wrong spot */
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid response from SCP server, "
@@ -593,8 +592,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
         session->scpRecv_state = ssh2_NB_state_sent5;
     }
 
-    if((session->scpRecv_state == ssh2_NB_state_sent5) ||
-       (session->scpRecv_state == ssh2_NB_state_sent6)) {
+    if(session->scpRecv_state == ssh2_NB_state_sent5 ||
+       session->scpRecv_state == ssh2_NB_state_sent6) {
         while(session->scpRecv_response_len < SSH2_SCP_RESPONSE_BUFLEN) {
             char *s, *p, *e = NULL;
 
@@ -624,21 +623,21 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                     goto scp_recv_error;
                 }
 
-                if((session->scpRecv_response_len > 1) &&
-                   (session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != '\r') &&
-                   (session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != '\n') &&
-                   (session->scpRecv_response[session->scpRecv_response_len -
-                                              1] < 32)) {
+                if(session->scpRecv_response_len > 1 &&
+                   session->scpRecv_response[session->scpRecv_response_len -
+                                             1] != '\r' &&
+                   session->scpRecv_response[session->scpRecv_response_len -
+                                             1] != '\n' &&
+                   session->scpRecv_response[session->scpRecv_response_len -
+                                             1] < 32) {
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid data in SCP response");
                     goto scp_recv_error;
                 }
 
-                if((session->scpRecv_response_len < 7) ||
-                   (session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != '\n')) {
+                if(session->scpRecv_response_len < 7 ||
+                   session->scpRecv_response[session->scpRecv_response_len -
+                                             1] != '\n') {
                     if(session->scpRecv_response_len ==
                        SSH2_SCP_RESPONSE_BUFLEN) {
                         /* You had your chance */
@@ -654,10 +653,10 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 /* We are guaranteed not to go under response_len == 0 by the
                    logic above */
                 while(
-                    (session->scpRecv_response[session->scpRecv_response_len -
-                                               1] == '\r') ||
-                    (session->scpRecv_response[session->scpRecv_response_len -
-                                               1] == '\n')) {
+                    session->scpRecv_response[session->scpRecv_response_len -
+                                              1] == '\r' ||
+                    session->scpRecv_response[session->scpRecv_response_len -
+                                              1] == '\n') {
                     session->scpRecv_response_len--;
                 }
                 session->scpRecv_response[session->scpRecv_response_len] =
@@ -673,7 +672,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 s = (char *)session->scpRecv_response + 1;
 
                 p = strchr(s, ' ');
-                if(!p || ((p - s) <= 0)) {
+                if(!p || (p - s) <= 0) {
                     /* No spaces or space in the wrong spot */
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid response from SCP server, "
@@ -691,7 +690,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
 
                 s = strchr(p, ' ');
-                if(!s || ((s - p) <= 0)) {
+                if(!s || (s - p) <= 0) {
                     /* No spaces or space in the wrong spot */
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid response from SCP server, "

--- a/src/scp.c
+++ b/src/scp.c
@@ -468,15 +468,15 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
 
                 if(session->scpRecv_response_len > 1 &&
                    (session->scpRecv_response[session->scpRecv_response_len -
-                                               1] < '0' ||
+                                              1] < '0' ||
                     session->scpRecv_response[session->scpRecv_response_len -
-                                               1] > '9') &&
+                                              1] > '9') &&
                    session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != ' ' &&
+                                             1] != ' ' &&
                    session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != '\r' &&
+                                             1] != '\r' &&
                    session->scpRecv_response[session->scpRecv_response_len -
-                                              1] != '\n') {
+                                             1] != '\n') {
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid data in SCP response");
                     goto scp_recv_error;

--- a/src/session.c
+++ b/src/session.c
@@ -112,9 +112,9 @@ static int banner_receive(LIBSSH2_SESSION *session)
         banner_len = session->banner_TxRx_total_send;
     }
 
-    while((banner_len < sizeof(session->banner_TxRx_banner)) &&
-          ((banner_len == 0) ||
-           (session->banner_TxRx_banner[banner_len - 1] != '\n'))) {
+    while(banner_len < sizeof(session->banner_TxRx_banner) &&
+          (banner_len == 0 ||
+           session->banner_TxRx_banner[banner_len - 1] != '\n')) {
         char c = '\0';
 
         /* no incoming block yet! */
@@ -165,8 +165,8 @@ static int banner_receive(LIBSSH2_SESSION *session)
     }
 
     while(banner_len &&
-          ((session->banner_TxRx_banner[banner_len - 1] == '\n') ||
-           (session->banner_TxRx_banner[banner_len - 1] == '\r'))) {
+          (session->banner_TxRx_banner[banner_len - 1] == '\n' ||
+           session->banner_TxRx_banner[banner_len - 1] == '\r')) {
         banner_len--;
     }
 
@@ -1835,7 +1835,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
         }
 #endif /* !HAVE_POLL && !HAVE_SELECT -- timeout (and by extension
         * timeout_remaining) is equal to 0 */
-    } while((timeout_remaining > 0) && !active_fds);
+    } while(timeout_remaining > 0 && !active_fds);
 
     return active_fds;
 }

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -457,9 +457,9 @@ static int sftp_packet_ask(LIBSSH2_SFTP *sftp, unsigned char packet_type,
     /* Special consideration when getting VERSION packet */
 
     while(packet) {
-        if((packet->data[0] == packet_type) &&
-           ((packet_type == SSH_FXP_VERSION) ||
-            (packet->request_id == request_id))) {
+        if(packet->data[0] == packet_type &&
+           (packet_type == SSH_FXP_VERSION ||
+            packet->request_id == request_id)) {
 
             /* Match! Fetch the data */
             *data = packet->data;
@@ -569,7 +569,7 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
         }
 
         rc = sftp_packet_read(sftp);
-        if((rc < 0) && (rc != LIBSSH2_ERROR_EAGAIN)) {
+        if(rc < 0 && rc != LIBSSH2_ERROR_EAGAIN) {
             sftp->requirev_start = 0;
             return rc;
         }
@@ -1858,7 +1858,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                 goto end;
             }
 
-            if(longentry && (longentry_maxlen > 1)) {
+            if(longentry && longentry_maxlen > 1) {
                 longentry_len = real_longentry_len;
 
                 if(longentry_len >= longentry_maxlen ||
@@ -3814,8 +3814,9 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
 
     if(link_type == LIBSSH2_SFTP_SYMLINK) {
 
-        if((target_len + 4 < target_len) ||
-           (packet_len + (4 + target_len) < packet_len)) {
+        /* FIXME: possible incorrect/impossible bounds checks: */
+        if((target_len + 4) < target_len ||
+           (packet_len + 4 + target_len) < packet_len) {
             return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                             "Input too large (2) sftp_symlink");
         }
@@ -3827,7 +3828,7 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
     if(sftp->symlink_state == ssh2_NB_state_idle) {
         sftp->last_errno = LIBSSH2_FX_OK;
 
-        if((sftp->version < 3) && (link_type != LIBSSH2_SFTP_REALPATH)) {
+        if(sftp->version < 3 && link_type != LIBSSH2_SFTP_REALPATH) {
             return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                             "Server does not support SYMLINK or READLINK");
         }

--- a/src/transport.c
+++ b/src/transport.c
@@ -99,7 +99,7 @@ static void debugdump(LIBSSH2_SESSION *session,
         buffer[used++] = ':';
         buffer[used++] = ' ';
 
-        for(c = 0; (c < width) && (i + c < size); c++) {
+        for(c = 0; c < width && (i + c) < size; c++) {
             buffer[used++] = isprint(ptr[i + c]) ?
                 ptr[i + c] : UNPRINTABLE_CHAR;
         }
@@ -490,7 +490,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
             if(nread <= 0) {
                 /* check if this is due to EAGAIN and return the special
                    return code if so, error out normally otherwise */
-                if((nread < 0) && (nread == -EAGAIN)) {
+                if(nread < 0 && nread == -EAGAIN) {
                     session->socket_block_directions |=
                         LIBSSH2_SESSION_BLOCK_INBOUND;
                     return LIBSSH2_ERROR_EAGAIN;
@@ -918,7 +918,7 @@ static int send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
     }
 
     /* send as much as possible of the existing packet */
-    if((data != p->odata) || (data_len != p->olen)) {
+    if(data != p->odata || data_len != p->olen) {
         /* When we are about to complete the sending of a packet, it is vital
            that the caller does not try to send a new/different packet since
            we do not add this one up until the previous one has been sent. To

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -153,7 +153,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                      "Would block requesting userauth list");
             return NULL;
         }
-        else if(rc || (session->userauth_list_data_len < 1)) {
+        else if(rc || session->userauth_list_data_len < 1) {
             ssh2_err(session, rc, "Failed getting response");
             session->userauth_list_state = ssh2_NB_state_idle;
             return NULL;
@@ -207,7 +207,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                          "Would block requesting userauth list");
                 return NULL;
             }
-            else if(rc || (session->userauth_list_data_len < 1)) {
+            else if(rc || session->userauth_list_data_len < 1) {
                 ssh2_err(session, rc, "Failed getting response");
                 session->userauth_list_state = ssh2_NB_state_idle;
                 return NULL;
@@ -381,9 +381,9 @@ static int userauth_password(LIBSSH2_SESSION *session,
 
 password_response:
 
-    if((session->userauth_pswd_state == ssh2_NB_state_sent) ||
-       (session->userauth_pswd_state == ssh2_NB_state_sent1) ||
-       (session->userauth_pswd_state == ssh2_NB_state_sent2)) {
+    if(session->userauth_pswd_state == ssh2_NB_state_sent ||
+       session->userauth_pswd_state == ssh2_NB_state_sent1 ||
+       session->userauth_pswd_state == ssh2_NB_state_sent2) {
         if(session->userauth_pswd_state == ssh2_NB_state_sent) {
             rc = ssh2_packet_requirev(session, reply_codes,
                                       &session->userauth_pswd_data,
@@ -436,14 +436,14 @@ password_response:
                             "Unexpected packet size");
         }
 
-        if((session->userauth_pswd_data[0] ==
-            SSH_MSG_USERAUTH_PASSWD_CHANGEREQ) ||
-           (session->userauth_pswd_data0 ==
-            SSH_MSG_USERAUTH_PASSWD_CHANGEREQ)) {
+        if(session->userauth_pswd_data[0] ==
+           SSH_MSG_USERAUTH_PASSWD_CHANGEREQ ||
+           session->userauth_pswd_data0 ==
+           SSH_MSG_USERAUTH_PASSWD_CHANGEREQ) {
             session->userauth_pswd_data0 = SSH_MSG_USERAUTH_PASSWD_CHANGEREQ;
 
-            if((session->userauth_pswd_state == ssh2_NB_state_sent1) ||
-               (session->userauth_pswd_state == ssh2_NB_state_sent2)) {
+            if(session->userauth_pswd_state == ssh2_NB_state_sent1 ||
+               session->userauth_pswd_state == ssh2_NB_state_sent2) {
                 if(session->userauth_pswd_state == ssh2_NB_state_sent1) {
                     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                               "Password change required"));
@@ -1698,7 +1698,7 @@ retry_auth:
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         }
-        else if(rc || (session->userauth_pblc_data_len < 1)) {
+        else if(rc || session->userauth_pblc_data_len < 1) {
             SSH2_FREE(session, session->userauth_pblc_packet);
             session->userauth_pblc_packet = NULL;
             SSH2_FREE(session, session->userauth_pblc_method);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -43,7 +43,7 @@
 #ifdef LIBSSH2_WINCNG
 
 /* required for cross-compilation against the w64 mingw-runtime package */
-#if defined(_WIN32_WINNT) && (_WIN32_WINNT < 0x0600)
+#if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
 #undef _WIN32_WINNT
 #endif
 #ifndef _WIN32_WINNT

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1125,8 +1125,7 @@ static int wcng_bn_ltob(unsigned char *pbInput,
     }
 
     pbOutput[0] = 0;
-    for(index = 0; ((index + offset) < cbOutput) &&
-                   (index < cbInput); index++) {
+    for(index = 0; (index + offset) < cbOutput && index < cbInput; index++) {
         pbOutput[index + offset] = pbInput[length - index];
     }
 
@@ -1234,7 +1233,7 @@ static ULONG wcng_bn_size(const unsigned char *bignum, ULONG length)
     length--;
 
     offset = 0;
-    while(!(*(bignum + offset)) && (offset < length))
+    while(!*(bignum + offset) && offset < length)
         offset++;
 
     length++;

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -43,7 +43,7 @@
 #define SSH2_CRYPTO_ENGINE libssh2_wincng
 
 /* required for cross-compilation against the w64 mingw-runtime package */
-#if defined(_WIN32_WINNT) && (_WIN32_WINNT < 0x0600)
+#if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
 #undef _WIN32_WINNT
 #endif
 #ifndef _WIN32_WINNT


### PR DESCRIPTION
From compound expressions. Most code doesn't use parantheses in these
cases. Drop the outliers.

Also from preprocessor expressions.
