### PR TITLE
include: exclude two misspelled macros with `LIBSSH2_NO_DEPRECATED`

### DIFF
--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -208,9 +208,11 @@ struct _LIBSSH2_SFTP_STATVFS {
 #define LIBSSH2_FX_NO_MEDIA                 13UL
 #define LIBSSH2_FX_NO_SPACE_ON_FILESYSTEM   14UL
 #define LIBSSH2_FX_QUOTA_EXCEEDED           15UL
-#define LIBSSH2_FX_UNKNOWN_PRINCIPLE        16UL /* Initial mis-spelling */
+#ifndef LIBSSH2_NO_DEPRECATED
+#define LIBSSH2_FX_UNKNOWN_PRINCIPLE        16UL /* Initial misspelling */
+#define LIBSSH2_FX_LOCK_CONFlICT            17UL /* Initial misspelling */
+#endif
 #define LIBSSH2_FX_UNKNOWN_PRINCIPAL        16UL
-#define LIBSSH2_FX_LOCK_CONFlICT            17UL /* Initial mis-spelling */
 #define LIBSSH2_FX_LOCK_CONFLICT            17UL
 #define LIBSSH2_FX_DIR_NOT_EMPTY            18UL
 #define LIBSSH2_FX_NOT_A_DIRECTORY          19UL


### PR DESCRIPTION
Non-misspelled alternatives available since libssh2 v0.15.0.

In user code replace these two:
```
LIBSSH2_FX_UNKNOWN_PRINCIPLE
LIBSSH2_FX_LOCK_CONFlICT
```
with:
```
LIBSSH2_FX_UNKNOWN_PRINCIPAL
LIBSSH2_FX_LOCK_CONFLICT
```
respectively.

Also fix spelling in comments.

Follow-up to 2b2664bfd4401bebc3e2d82a8b79a34941da3b0a #1977
Follow-up to 4b8db8c1ab3fb21618bca72a671fdf2a5d1ac122
