### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -323,7 +323,7 @@ This release includes the following enhancements and bugfixes:
 - packet: improve bounds checking in exit-signal sig name handling (590cdfe7 #1859)
 - packet: honor buffer length when passing to `_libssh2_debug()` (8c22b959 #1786)
 - packet: Fix possible heap overflow in SSH_MSG_CHANNEL_REQUEST #1815 (83072b0e #1816 #1815)
-- packet: create NULL-terminated string for shost in packet_queue_listener() (f66dfc4a #1761)
+- packet: create null-terminated string for shost in packet_queue_listener() (f66dfc4a #1761)
 - packet: move size check to before size manipulation (a93359ad #1704)
 - packet: authagent_open: fix failure packet length (31ec5a8b #1701)
 - packet: fix type mismatch in "reason code" (13a71451 #1706)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -140,7 +140,7 @@ test_script:
         if($env:CMAKE_GENERATE -like '*WinCNG*') {
           $env:FIXTURE_TRACE_ALL_CONNECT = '1'
         }
-        $env:OPENSSH_SERVER_IMAGE=[string] (& bash -c "echo ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)")
+        $env:OPENSSH_SERVER_IMAGE = [string] (& bash -c "echo ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)")
         cd _bld; ctest -VV -C $($env:CMAKE_CONFIGURATION) --output-on-failure --timeout 900
       }
 

--- a/docs/libssh2_channel_receive_window_adjust.md
+++ b/docs/libssh2_channel_receive_window_adjust.md
@@ -34,7 +34,7 @@ adjustment amount is queued for a later packet.
 # RETURN VALUE
 
 Returns the new size of the receive window (as understood by remote end). Note
-that the window value sent over the wire is strictly 32bit, but this API is
+that the window value sent over the wire is strictly 32-bit, but this API is
 made to return a 'long' which may not be 32-bit on all platforms.
 
 # ERRORS

--- a/docs/libssh2_poll.md
+++ b/docs/libssh2_poll.md
@@ -22,7 +22,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout);
 
 # DESCRIPTION
 
-This function is deprecated. Do note use. We encourage users to instead use
+This function is deprecated. Do not use. We encourage users to instead use
 the *poll(3)* or *select(3)* functions to check for socket activity or
 when specific sockets are ready to get received from or send to.
 

--- a/docs/libssh2_poll_channel_read.md
+++ b/docs/libssh2_poll_channel_read.md
@@ -22,7 +22,7 @@ int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended);
 
 # DESCRIPTION
 
-This function is deprecated. Do note use.
+This function is deprecated. Do not use.
 
 *libssh2_poll_channel_read(3)* checks to see if data is available in the
 *channel*'s read buffer. No attempt is made with this method to see if

--- a/docs/libssh2_scp_recv2.md
+++ b/docs/libssh2_scp_recv2.md
@@ -19,7 +19,7 @@ libssh2_scp_recv2 - request a remote file via SCP
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
-                                   struct_stat *sb);
+                                   struct stat *sb);
 ~~~
 
 # DESCRIPTION

--- a/docs/libssh2_session_free.md
+++ b/docs/libssh2_session_free.md
@@ -5,7 +5,7 @@ Title: libssh2_session_free
 Section: 3
 Source: libssh2
 See-also:
-  - libssh2_session_disconnect_ex(3)
+  - libssh2_session_disconnect(3)
   - libssh2_session_disconnect_ex(3)
   - libssh2_session_init_ex(3)
 ---

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1075,7 +1075,7 @@ LIBSSH2_API LIBSSH2_KNOWNHOSTS *libssh2_knownhost_init(
  * pre-hashed when checking for it in the libssh2_knownhost_check() function.
  *
  * The keylen parameter may be omitted (zero) if the key is provided as a
- * NULL-terminated base64-encoded string.
+ * null-terminated base64-encoded string.
  */
 
 /* host format (2 bits) */
@@ -1137,9 +1137,8 @@ LIBSSH2_API int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
  * pre-hashed when checking for it in the libssh2_knownhost_check() function.
  *
  * The keylen parameter may be omitted (zero) if the key is provided as a
- * NULL-terminated base64-encoded string.
+ * null-terminated base64-encoded string.
  */
-
 LIBSSH2_API int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
                                        const char *host,
                                        const char *salt,

--- a/scripts/badwords.txt
+++ b/scripts/badwords.txt
@@ -125,3 +125,4 @@ However,:rephrase?
 the the:the
 with with:with
 ---Will
+---will@

--- a/scripts/badwords.txt
+++ b/scripts/badwords.txt
@@ -104,6 +104,7 @@ will:rewrite to present tense
 63 bit:63-bit
 64 bit:64-bit
 128 bit:128-bit
+256 bit:256-bit
 8-bits:8 bits
 16-bits:16 bits
 32-bits:32 bits

--- a/scripts/badwords.txt
+++ b/scripts/badwords.txt
@@ -27,6 +27,7 @@ null terminate:null-terminate
 zero terminate:null-terminate
 nul terminated:null-terminated
 null terminated:null-terminated
+NULL-terminated=null-terminated
 zero terminated:null-terminated
 nul terminator:null-terminator
 null terminator:null-terminator

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -41,7 +41,7 @@
  *
  * One modification from official pbkdf2. Instead of outputting key material
  * linearly, we mix it. pbkdf2 has a known weakness where if one uses it to
- * generate (i.e.) 512 bits of key material for use as two 256 bit keys, an
+ * generate (i.e.) 512 bits of key material for use as two 256-bit keys, an
  * attacker can merely run once through the outer loop below, but the user
  * always runs it twice. Shuffling output bytes requires computing the
  * entirety of the key material to assemble any subkey. This is something a

--- a/src/channel.c
+++ b/src/channel.c
@@ -1671,7 +1671,7 @@ int libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel, int streamid)
 
 /*
  * Return the channel's program exit status. Note that the actual protocol
- * provides the full 32bit this function returns.  We cannot abuse it to
+ * provides the full 32-bit this function returns.  We cannot abuse it to
  * return error values in case of errors so we return a zero if channel is
  * NULL.
  */

--- a/src/cipher-chachapoly.c
+++ b/src/cipher-chachapoly.c
@@ -29,7 +29,7 @@ int chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n);
 int chachapoly_init(struct chachapoly_ctx *ctx, const unsigned char *key,
                     size_t keylen)
 {
-    if(keylen != (32 + 32)) /* 2 x 256 bit keys */
+    if(keylen != (32 + 32)) /* 2 x 256-bit keys */
         return LIBSSH2_ERROR_INVAL;
     chacha_keysetup(&ctx->main_ctx, key, 256);
     chacha_keysetup(&ctx->header_ctx, key + 32, 256);

--- a/src/cipher-chachapoly.h
+++ b/src/cipher-chachapoly.h
@@ -23,7 +23,7 @@
 #include "chacha.h"
 #include "poly1305.h"
 
-#define CHACHA_KEYLEN   32 /* Only 256 bit keys used here */
+#define CHACHA_KEYLEN   32 /* Only 256-bit keys used here */
 
 struct chachapoly_ctx {
     struct chacha_ctx main_ctx, header_ctx;

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -144,7 +144,7 @@ static const struct crypt_method crypt_method_aes256_gcm = {
     "",
     16,                         /* blocksize */
     12,                         /* initial value length */
-    32,                         /* secret length -- 32*8 == 256bit */
+    32,                         /* secret length -- 32*8 == 256-bit */
     16,                         /* length of the authentication tag */
     SSH2_CRYPT_FLAG_INTEGRATED_MAC | SSH2_CRYPT_FLAG_PKTLEN_AAD,
     &crypt_init,
@@ -159,7 +159,7 @@ static const struct crypt_method crypt_method_aes128_gcm = {
     "",
     16,                         /* blocksize */
     12,                         /* initial value length */
-    16,                         /* secret length -- 16*8 == 128bit */
+    16,                         /* secret length -- 16*8 == 128-bit */
     16,                         /* length of the authentication tag */
     SSH2_CRYPT_FLAG_INTEGRATED_MAC | SSH2_CRYPT_FLAG_PKTLEN_AAD,
     &crypt_init,
@@ -176,7 +176,7 @@ static const struct crypt_method crypt_method_aes128_ctr = {
     "",
     16,                         /* blocksize */
     16,                         /* initial value length */
-    16,                         /* secret length -- 16*8 == 128bit */
+    16,                         /* secret length -- 16*8 == 128-bit */
     0,                          /* length of the authentication tag */
     0,                          /* flags */
     &crypt_init,
@@ -191,7 +191,7 @@ static const struct crypt_method crypt_method_aes192_ctr = {
     "",
     16,                         /* blocksize */
     16,                         /* initial value length */
-    24,                         /* secret length -- 24*8 == 192bit */
+    24,                         /* secret length -- 24*8 == 192-bit */
     0,                          /* length of the authentication tag */
     0,                          /* flags */
     &crypt_init,
@@ -206,7 +206,7 @@ static const struct crypt_method crypt_method_aes256_ctr = {
     "",
     16,                         /* blocksize */
     16,                         /* initial value length */
-    32,                         /* secret length -- 32*8 == 256bit */
+    32,                         /* secret length -- 32*8 == 256-bit */
     0,                          /* length of the authentication tag */
     0,                          /* flags */
     &crypt_init,
@@ -223,7 +223,7 @@ static const struct crypt_method crypt_method_aes128_cbc = {
     "DEK-Info: AES-128-CBC",
     16,                         /* blocksize */
     16,                         /* initial value length */
-    16,                         /* secret length -- 16*8 == 128bit */
+    16,                         /* secret length -- 16*8 == 128-bit */
     0,                          /* length of the authentication tag */
     0,                          /* flags */
     &crypt_init,
@@ -238,7 +238,7 @@ static const struct crypt_method crypt_method_aes192_cbc = {
     "DEK-Info: AES-192-CBC",
     16,                         /* blocksize */
     16,                         /* initial value length */
-    24,                         /* secret length -- 24*8 == 192bit */
+    24,                         /* secret length -- 24*8 == 192-bit */
     0,                          /* length of the authentication tag */
     0,                          /* flags */
     &crypt_init,
@@ -253,7 +253,7 @@ static const struct crypt_method crypt_method_aes256_cbc = {
     "DEK-Info: AES-256-CBC",
     16,                         /* blocksize */
     16,                         /* initial value length */
-    32,                         /* secret length -- 32*8 == 256bit */
+    32,                         /* secret length -- 32*8 == 256-bit */
     0,                          /* length of the authentication tag */
     0,                          /* flags */
     &crypt_init,
@@ -269,7 +269,7 @@ static const struct crypt_method crypt_method_rijndael_cbc_lysator_liu_se = {
     "DEK-Info: AES-256-CBC",
     16,                         /* blocksize */
     16,                         /* initial value length */
-    32,                         /* secret length -- 32*8 == 256bit */
+    32,                         /* secret length -- 32*8 == 256-bit */
     0,                          /* length of the authentication tag */
     0,                          /* flags */
     &crypt_init,

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -285,7 +285,7 @@ error:
  * pre-hashed when checking for it in the libssh2_knownhost_check() function.
  *
  * The keylen parameter may be omitted (zero) if the key is provided as a
- * NULL-terminated base64-encoded string.
+ * null-terminated base64-encoded string.
  */
 int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
                           const char *host, const char *salt,
@@ -319,7 +319,7 @@ int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
  * pre-hashed when checking for it in the libssh2_knownhost_check() function.
  *
  * The keylen parameter may be omitted (zero) if the key is provided as a
- * NULL-terminated base64-encoded string.
+ * null-terminated base64-encoded string.
  */
 int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
                            const char *host, const char *salt,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -770,7 +770,7 @@ struct _LIBSSH2_SESSION {
     void *tracehandler_context; /* context for the trace handler */
 #endif
 
-    /* State variables used in libssh2_banner_send() */
+    /* State variables used in banner_receive()/banner_send() */
     ssh2_NB_states banner_TxRx_state;
     char banner_TxRx_banner[8192];
     ssize_t banner_TxRx_total_send;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -520,7 +520,7 @@ struct _LIBSSH2_CHANNEL {
     ssh2_NB_states close_state;
     unsigned char close_packet[5];
 
-    /* State variables used in libssh2_channel_wait_closedeof() */
+    /* State variables used in channel_wait_eof() */
     ssh2_NB_states wait_eof_state;
 
     /* State variables used in libssh2_channel_wait_closed() */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -768,10 +768,10 @@ static int memory_read_privatekey(LIBSSH2_SESSION *session,
                         "No handler for specified private key");
     }
 
-    if((*hostkey_method)->
-        initPEMFromMemory(session, privkeyfiledata, privkeyfiledata_len,
-                          (const unsigned char *)passphrase,
-                          hostkey_abstract)) {
+    if((*hostkey_method)->initPEMFromMemory(session, privkeyfiledata,
+                                            privkeyfiledata_len,
+                                            (const unsigned char *)passphrase,
+                                            hostkey_abstract)) {
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Unable to initialize private key from memory");
     }
@@ -811,9 +811,9 @@ static int file_read_privatekey(LIBSSH2_SESSION *session,
                         "No handler for specified private key");
     }
 
-    if((*hostkey_method)->
-        initPEM(session, privkeyfile, (const unsigned char *)passphrase,
-                hostkey_abstract)) {
+    if((*hostkey_method)->initPEM(session, privkeyfile,
+                                  (const unsigned char *)passphrase,
+                                  hostkey_abstract)) {
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Unable to initialize private key from file");
     }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1009,8 +1009,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
     }
     else {
         ssh2_deb((session, LIBSSH2_ERROR_DECRYPT,
-                  "sign_callback failed or "
-                  "returned invalid signature."));
+                  "sign_callback failed or returned invalid signature."));
         *sig_len = 0;
     }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -744,9 +744,8 @@ int ssh2_random(unsigned char *buf, size_t len)
  * Windows CNG backend: Hash functions
  */
 
-int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx,
-                        BCRYPT_ALG_HANDLE hAlg, ULONG hashlen,
-                        unsigned char *key, ULONG keylen)
+int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
+                        ULONG hashlen, unsigned char *key, ULONG keylen)
 {
     BCRYPT_HASH_HANDLE hHash;
     unsigned char *pbHashObject;
@@ -818,8 +817,7 @@ int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash)
 }
 
 int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
-                   BCRYPT_ALG_HANDLE hAlg,
-                   unsigned char *hash, ULONG hashlen)
+                   BCRYPT_ALG_HANDLE hAlg, unsigned char *hash, ULONG hashlen)
 {
     struct wcng_hash_ctx ctx;
     int ret;

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -258,16 +258,13 @@ struct wcng_hash_ctx {
     (ssh2_wcng_hash_final(&(ctx), hash) == 0)
 #endif
 
-int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx,
-                        BCRYPT_ALG_HANDLE hAlg, ULONG hashlen,
-                        unsigned char *key, ULONG keylen);
+int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
+                        ULONG hashlen, unsigned char *key, ULONG keylen);
 int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
                           const void *data, ULONG datalen);
-int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx,
-                         unsigned char *hash);
+int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash);
 int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
-                   BCRYPT_ALG_HANDLE hAlg,
-                   unsigned char *hash, ULONG hashlen);
+                   BCRYPT_ALG_HANDLE hAlg, unsigned char *hash, ULONG hashlen);
 
 /*
  * Windows CNG backend: HMAC functions

--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -541,7 +541,7 @@ int main(int argc, char **argv)
             }
             if(basechange) {
                 basechange = 0;
-                i = i + 1;
+                ++i;
             }
         }
         else {


### PR DESCRIPTION
- fix typos in comments and documentation.
- fix references to non-existing functions in comments.
- libssh2_session_free: fix see-also reference on man page.
- libssh2_scp_recv2: fix typo in prototype on man page.
- man2help: use increment operator.
- badwords: extend with new words and an exclusion.
- userauth: unfold string.
- clang-format and manual formatting.
