### PR TITLE
build: improve in-source `inline` detection, drop from `./configure`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,7 +403,6 @@ AC_FUNC_ALLOCA
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
-AC_C_INLINE
 
 CURL_CHECK_NONBLOCKING_SOCKET
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -174,13 +174,26 @@ int ssh2_gettimeofday(struct timeval *tp, void *tzp);
 #endif
 #endif
 
-/* "inline" keyword is valid only with C++ engine! */
-#ifdef __GNUC__
-#undef inline
-#define inline __inline__
+#ifdef SSH2_INLINE
+/* 'SSH2_INLINE' defined, use as-is */
+#elif defined(inline)
+#  define SSH2_INLINE inline /* 'inline' defined, assumed correct */
+#elif defined(__cplusplus)
+/* The code is compiled with C++ compiler.
+   C++ always supports 'inline'. */
+#  define SSH2_INLINE inline /* 'inline' keyword supported */
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+/* C99 (and later) supports 'inline' keyword */
+#  define SSH2_INLINE inline /* 'inline' keyword supported */
+#elif defined(__GNUC__) && __GNUC__ >= 3
+/* GCC supports '__inline__' as an extension */
+#  define SSH2_INLINE __inline__
 #elif defined(_MSC_VER)
-#undef inline
-#define inline __inline
+#  define SSH2_INLINE __inline
+#else
+/* Probably 'inline' is not supported by compiler.
+   Define to the empty string to be on the safe side. */
+#  define SSH2_INLINE /* empty */
 #endif
 
 /* 3DS does not seem to have iovec */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -236,7 +236,7 @@ static unsigned char *write_bn(unsigned char *buf, const BIGNUM *bn,
 #endif
 
 #ifdef USE_OPENSSL_3
-static inline void swap_bytes(unsigned char *buf, unsigned long len)
+static SSH2_INLINE void swap_bytes(unsigned char *buf, unsigned long len)
 {
 #if !defined(WORDS_BIGENDIAN) || !WORDS_BIGENDIAN
     unsigned long i, j;

--- a/src/packet.c
+++ b/src/packet.c
@@ -60,7 +60,7 @@
 /*
  * Queue a connection request for a listener
  */
-static inline int packet_queue_listener(
+static SSH2_INLINE int packet_queue_listener(
     LIBSSH2_SESSION *session,
     unsigned char *data, size_t datalen,
     struct packet_queue_listener_state *listen_state)
@@ -269,9 +269,10 @@ static inline int packet_queue_listener(
 /*
  * Accept a forwarded X11 connection
  */
-static inline int packet_x11_open(LIBSSH2_SESSION *session,
-                                  unsigned char *data, size_t datalen,
-                                  struct packet_x11_open_state *x11open_state)
+static SSH2_INLINE int packet_x11_open(
+    LIBSSH2_SESSION *session,
+    unsigned char *data, size_t datalen,
+    struct packet_x11_open_state *x11open_state)
 {
     uint32_t failure_code = SSH_OPEN_CONNECT_FAILED;
     /* 17 = packet_type(1) + channel(4) + reason(4) + descr(4) + lang(4) */
@@ -460,7 +461,7 @@ x11_exit:
 /*
  * Open a connection to authentication agent
  */
-static inline int packet_authagent_open(
+static SSH2_INLINE int packet_authagent_open(
     LIBSSH2_SESSION *session,
     unsigned char *data, size_t datalen,
     struct packet_authagent_state *authagent_state)

--- a/src/session.c
+++ b/src/session.c
@@ -1495,7 +1495,7 @@ int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
  * Returns 0 if writing to channel would block,
  * non-0 if data can be written without blocking
  */
-static inline int poll_channel_write(LIBSSH2_CHANNEL *channel)
+static SSH2_INLINE int poll_channel_write(LIBSSH2_CHANNEL *channel)
 {
     return channel->local.window_size ? 1 : 0;
 }
@@ -1504,7 +1504,7 @@ static inline int poll_channel_write(LIBSSH2_CHANNEL *channel)
  * Returns 0 if no connections are waiting to be accepted
  * non-0 if one or more connections are available
  */
-static inline int poll_listener_queued(LIBSSH2_LISTENER *listener)
+static SSH2_INLINE int poll_listener_queued(LIBSSH2_LISTENER *listener)
 {
     return ssh2_list_first(&listener->queue) ? 1 : 0;
 }


### PR DESCRIPTION
To make it work better and work the same for both build systems.

Also: replace redefining system symbol by using local macro 
`SSH2_INLINE`.

Credits-to: Evgeny Grin (Karlson2k)

Ref: https://github.com/curl/curl/commit/cbe41d151d6a100c1f045eaf37ff06b2b2a7b382
Ref: https://github.com/curl/curl/pull/12897
