### PR TITLE
openssl: avoid function pointer typdefs and casts

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1115,56 +1115,7 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
 
     return passphrase_len;
 }
-
-#if LIBSSH2_RSA
-#ifdef USE_OPENSSL_3
-#define CB_RSA &PEM_read_bio_PrivateKey
-#else
-#define CB_RSA &PEM_read_bio_RSAPrivateKey
-#endif
-#endif
-#if LIBSSH2_DSA
-#ifdef USE_OPENSSL_3
-#define CB_DSA &PEM_read_bio_PrivateKey
-#else
-#define CB_DSA &PEM_read_bio_DSAPrivateKey
-#endif
-#endif
-#if LIBSSH2_ECDSA
-#ifdef USE_OPENSSL_3
-#define CB_EC &PEM_read_bio_PrivateKey
-#else
-#define CB_EC &PEM_read_bio_ECPrivateKey
-#endif
-#endif
-#if LIBSSH2_ED25519
-#define CB_ED &PEM_read_bio_PrivateKey
-#endif
-
-#define READ_PRIVKEY_FROM_BLOB(ctx, cb, blob, blob_len, passphrase)           \
-    do {                                                                      \
-        BIO *bp = BIO_new_mem_buf(blob, (int)(blob_len));                     \
-        if(bp) {                                                              \
-            *(ctx) = (cb)(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase)); \
-            BIO_free(bp);                                                     \
-        }                                                                     \
-        else                                                                  \
-            *(ctx) = NULL;                                                    \
-    } while(0)
-#endif
-
-#if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
-#define READ_PRIVKEY_FROM_FILE(ctx, cb, filename, passphrase)                 \
-    do {                                                                      \
-        BIO *bp = BIO_new_file(filename, "r");                                \
-        if(bp) {                                                              \
-            *(ctx) = (cb)(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase)); \
-            BIO_free(bp);                                                     \
-        }                                                                     \
-        else                                                                  \
-            *(ctx) = NULL;                                                    \
-    } while(0)
-#endif
+#endif /* LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA || LIBSSH2_ED25519 */
 
 #if LIBSSH2_RSA
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
@@ -1174,10 +1125,21 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     const unsigned char *passphrase)
 {
     int rc = 0;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_BLOB(rsa, CB_RSA, filedata, filedata_len, passphrase);
+    bp = BIO_new_mem_buf(filedata, (int)filedata_len);
+    if(bp) {
+#ifdef USE_OPENSSL_3
+        *rsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                       SSH2_UNCONST(passphrase));
+#else
+        *rsa = PEM_read_bio_RSAPrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#endif
+        BIO_free(bp);
+    }
     if(!*rsa)
         rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
                                             "ssh-rsa",
@@ -1554,10 +1516,21 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          const unsigned char *passphrase)
 {
     int rc = 0;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_FILE(rsa, CB_RSA, filename, passphrase);
+    bp = BIO_new_file(filename, "r");
+    if(bp) {
+#ifdef USE_OPENSSL_3
+        *rsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                       SSH2_UNCONST(passphrase));
+#else
+        *rsa = PEM_read_bio_RSAPrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#endif
+        BIO_free(bp);
+    }
     if(!*rsa)
         rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
 
@@ -1573,10 +1546,21 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
                                     const unsigned char *passphrase)
 {
     int rc = 0;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_BLOB(dsa, CB_DSA, filedata, filedata_len, passphrase);
+    bp = BIO_new_mem_buf(filedata, (int)filedata_len);
+    if(bp) {
+#ifdef USE_OPENSSL_3
+        *dsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                       SSH2_UNCONST(passphrase));
+#else
+        *dsa = PEM_read_bio_DSAPrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#endif
+        BIO_free(bp);
+    }
     if(!*dsa)
         rc = pub_priv_openssh_keyfilememory(session, (void **)dsa,
                                             "ssh-dsa",
@@ -1872,10 +1856,21 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          const unsigned char *passphrase)
 {
     int rc = 0;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_FILE(dsa, CB_DSA, filename, passphrase);
+    bp = BIO_new_file(filename, "r");
+    if(bp) {
+#ifdef USE_OPENSSL_3
+        *dsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                       SSH2_UNCONST(passphrase));
+#else
+        *dsa = PEM_read_bio_DSAPrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#endif
+        BIO_free(bp);
+    }
     if(!*dsa)
         rc = dsa_new_openssh_private(dsa, session, filename, passphrase);
 
@@ -1891,10 +1886,21 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                       const unsigned char *passphrase)
 {
     int rc = 0;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_BLOB(ec_ctx, CB_EC, filedata, filedata_len, passphrase);
+    bp = BIO_new_mem_buf(filedata, (int)filedata_len);
+    if(bp) {
+#ifdef USE_OPENSSL_3
+        *ec_ctx = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#else
+        *ec_ctx = PEM_read_bio_ECPrivateKey(bp, NULL, passphrase_cb,
+                                            SSH2_UNCONST(passphrase));
+#endif
+        BIO_free(bp);
+    }
     if(!*ec_ctx)
         rc = pub_priv_openssh_keyfilememory(session, (void **)ec_ctx,
                                             "ssh-ecdsa",
@@ -2495,19 +2501,25 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         const unsigned char *passphrase)
 {
     ssh2_ed25519_ctx *ctx = NULL;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_BLOB(&ctx, CB_ED, filedata, filedata_len, passphrase);
-    if(ctx) {
-        if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
-            ssh2_ed25519_free(ctx);
-            return ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                            "Private key is not an ED25519 key");
-        }
+    bp = BIO_new_mem_buf(filedata, (int)filedata_len);
+    if(bp) {
+        ctx = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                      SSH2_UNCONST(passphrase));
+        BIO_free(bp);
+        if(ctx) {
+            if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
+                ssh2_ed25519_free(ctx);
+                return ssh2_err(session, LIBSSH2_ERROR_PROTO,
+                                "Private key is not an ED25519 key");
+            }
 
-        *ed_ctx = ctx;
-        return 0;
+            *ed_ctx = ctx;
+            return 0;
+        }
     }
 
     return pub_priv_openssh_keyfilememory(session, (void **)ed_ctx,
@@ -3913,10 +3925,21 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                            const unsigned char *passphrase)
 {
     int rc = 0;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_FILE(ec_ctx, CB_EC, filename, passphrase);
+    bp = BIO_new_file(filename, "r");
+    if(bp) {
+#ifdef USE_OPENSSL_3
+        *ec_ctx = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#else
+        *ec_ctx = PEM_read_bio_ECPrivateKey(bp, NULL, passphrase_cb,
+                                            SSH2_UNCONST(passphrase));
+#endif
+        BIO_free(bp);
+    }
     if(!*ec_ctx)
         rc = ecdsa_new_openssh_private(ec_ctx, session, filename, passphrase);
 
@@ -3933,10 +3956,21 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
                               const unsigned char *passphrase)
 {
     int rc = 0;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_FILE(ec_ctx, CB_EC, filename, passphrase);
+    bp = BIO_new_file(filename, "r");
+    if(bp) {
+#ifdef USE_OPENSSL_3
+        *ec_ctx = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#else
+        *ec_ctx = PEM_read_bio_ECPrivateKey(bp, NULL, passphrase_cb,
+                                            SSH2_UNCONST(passphrase));
+#endif
+        BIO_free(bp);
+    }
     if(!*ec_ctx)
         rc = ecdsa_new_openssh_private_sk(ec_ctx, flags, application,
                                           key_handle, handle_len, session,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4003,8 +4003,7 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                                     filename, passphrase);
 
     if(rc) {
-        return ecdsa_new_openssh_private(ec_ctx, session,
-                                         filename, passphrase);
+        rc = ecdsa_new_openssh_private(ec_ctx, session, filename, passphrase);
     }
 
     return rc;
@@ -4035,14 +4034,9 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
                                     filename, passphrase);
 
     if(rc) {
-        return ecdsa_new_openssh_private_sk(ec_ctx,
-                                            flags,
-                                            application,
-                                            key_handle,
-                                            handle_len,
-                                            session,
-                                            filename,
-                                            passphrase);
+        rc = ecdsa_new_openssh_private_sk(ec_ctx, flags, application,
+                                          key_handle, handle_len, session,
+                                          filename, passphrase);
     }
 
     return rc;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1166,7 +1166,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     size_t filedata_len,
                                     const unsigned char *passphrase)
 {
-    int rc = -1;
+    int rc = 0;
     BIO *bp;
 
     ssh2_init_if_needed();
@@ -1181,7 +1181,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                           SSH2_UNCONST(passphrase));
 #endif
         BIO_free(bp);
-        if(*rsa)
+        if(!*rsa)
             rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
                                                 "ssh-rsa",
                                                 NULL, NULL, NULL, NULL,
@@ -1557,7 +1557,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          const char *filename,
                          const unsigned char *passphrase)
 {
-    int rc = -1;
+    int rc = 0;
     BIO *bp;
 
     ssh2_init_if_needed();
@@ -1572,7 +1572,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                                           SSH2_UNCONST(passphrase));
 #endif
         BIO_free(bp);
-        if(*rsa)
+        if(!*rsa)
             rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
     }
 
@@ -1587,13 +1587,12 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
                                     size_t filedata_len,
                                     const unsigned char *passphrase)
 {
-    int rc = -1;
+    int rc = 0;
 
     ssh2_init_if_needed();
 
     READ_PRIVKEY_FROM_BLOB(dsa, CB_DSA, filedata, filedata_len, passphrase);
-
-    if(*dsa)
+    if(!*dsa)
         rc = pub_priv_openssh_keyfilememory(session, (void **)dsa,
                                             "ssh-dsa",
                                             NULL, NULL, NULL, NULL,
@@ -1887,13 +1886,12 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          const char *filename,
                          const unsigned char *passphrase)
 {
-    int rc = -1;
+    int rc = 0;
 
     ssh2_init_if_needed();
 
     READ_PRIVKEY_FROM_FILE(dsa, CB_DSA, filename, passphrase);
-
-    if(*dsa)
+    if(!*dsa)
         rc = dsa_new_openssh_private(dsa, session, filename, passphrase);
 
     return rc;
@@ -1907,13 +1905,12 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                       size_t filedata_len,
                                       const unsigned char *passphrase)
 {
-    int rc = -1;
+    int rc = 0;
 
     ssh2_init_if_needed();
 
     READ_PRIVKEY_FROM_BLOB(ec_ctx, CB_EC, filedata, filedata_len, passphrase);
-
-    if(*ec_ctx)
+    if(!*ec_ctx)
         rc = pub_priv_openssh_keyfilememory(session, (void **)ec_ctx,
                                             "ssh-ecdsa",
                                             NULL, NULL, NULL, NULL,
@@ -2517,7 +2514,6 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
     ssh2_init_if_needed();
 
     READ_PRIVKEY_FROM_BLOB(&ctx, CB_ED, filedata, filedata_len, passphrase);
-
     if(ctx) {
         if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
             ssh2_ed25519_free(ctx);
@@ -3931,13 +3927,12 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                            const char *filename,
                            const unsigned char *passphrase)
 {
-    int rc = -1;
+    int rc = 0;
 
     ssh2_init_if_needed();
 
     READ_PRIVKEY_FROM_FILE(ec_ctx, CB_EC, filename, passphrase);
-
-    if(*ec_ctx)
+    if(!*ec_ctx)
         rc = ecdsa_new_openssh_private(ec_ctx, session, filename, passphrase);
 
     return rc;
@@ -3952,13 +3947,12 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
                               const char *filename,
                               const unsigned char *passphrase)
 {
-    int rc = -1;
+    int rc = 0;
 
     ssh2_init_if_needed();
 
     READ_PRIVKEY_FROM_FILE(ec_ctx, CB_EC, filename, passphrase);
-
-    if(*ec_ctx)
+    if(!*ec_ctx)
         rc = ecdsa_new_openssh_private_sk(ec_ctx, flags, application,
                                           key_handle, handle_len, session,
                                           filename, passphrase);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1151,7 +1151,7 @@ static int read_private_key_from_memory(void **key_ctx,
                                 SSH2_UNCONST(passphrase));
 
     BIO_free(bp);
-    return (*key_ctx) ? 0 : -1;
+    return *key_ctx ? 0 : -1;
 }
 #endif
 
@@ -1174,7 +1174,7 @@ static int read_private_key_from_file(void **key_ctx,
                                 SSH2_UNCONST(passphrase));
 
     BIO_free(bp);
-    return (*key_ctx) ? 0 : -1;
+    return *key_ctx ? 0 : -1;
 }
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1174,10 +1174,17 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     const unsigned char *passphrase)
 {
     int rc = -1;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_BLOB(rsa, CB_RSA, filedata, filedata_len, passphrase);
+    bp = BIO_new_mem_buf(blob, (int)(blob_len));
+    if(bp) {
+        *(ctx) = CB_RSA(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase));
+        BIO_free(bp);
+    }
+    else
+        *(ctx) = NULL;
 
     if(*rsa)
         rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
@@ -1555,10 +1562,17 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          const unsigned char *passphrase)
 {
     int rc = -1;
+    BIO *bp;
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_FILE(rsa, CB_RSA, filename, passphrase);
+    bp = BIO_new_file(filename, "r");
+    if(bp) {
+        *rsa = CB_RSA(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase));
+        BIO_free(bp);
+    }
+    else
+        *rsa = NULL;
 
     if(*rsa)
         rc = rsa_new_openssh_private(rsa, session, filename, passphrase);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1126,17 +1126,17 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
 }
 
 #if defined(LIBSSH2_WOLFSSL) || defined(LIBRESSL_VERSION_NUMBER)
-typedef EC_KEY *(*pem_read_bio_func)(BIO *, EC_KEY **, pem_password_cb *,
-                                     void *u);
+typedef EC_KEY *(*pem_read_bio_t)(BIO *, EC_KEY **, pem_password_cb *,
+                                  void *u);
 #elif defined(USE_PEM_READ_BIO_PRIVATEKEY)
-typedef EVP_PKEY *(*pem_read_bio_func)(BIO *, EVP_PKEY **, pem_password_cb *,
-                                       void *u);
+typedef EVP_PKEY *(*pem_read_bio_t)(BIO *, EVP_PKEY **, pem_password_cb *,
+                                    void *u);
 #else
-typedef void *(*pem_read_bio_func)(BIO *, void **, pem_password_cb *, void *u);
+typedef void *(*pem_read_bio_t)(BIO *, void **, pem_password_cb *, void *u);
 #endif
 
 static int read_private_key_from_memory(void **key_ctx,
-                                        pem_read_bio_func read_private_key,
+                                        pem_read_bio_t read_private_key,
                                         const char *filedata,
                                         size_t filedata_len,
                                         const unsigned char *passphrase)
@@ -1160,7 +1160,7 @@ static int read_private_key_from_memory(void **key_ctx,
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
 static int read_private_key_from_file(void **key_ctx,
-                                      pem_read_bio_func read_private_key,
+                                      pem_read_bio_t read_private_key,
                                       const char *filename,
                                       const unsigned char *passphrase)
 {
@@ -1191,11 +1191,9 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     int rc;
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_func read_rsa =
-        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
+    pem_read_bio_t read_rsa = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
 #else
-    pem_read_bio_func read_rsa =
-        (pem_read_bio_func)&PEM_read_bio_RSAPrivateKey;
+    pem_read_bio_t read_rsa = (pem_read_bio_t)&PEM_read_bio_RSAPrivateKey;
 #endif
 
     ssh2_init_if_needed();
@@ -1583,11 +1581,9 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
     int rc;
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_func read_rsa =
-        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
+    pem_read_bio_t read_rsa = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
 #else
-    pem_read_bio_func read_rsa =
-        (pem_read_bio_func)&PEM_read_bio_RSAPrivateKey;
+    pem_read_bio_t read_rsa = (pem_read_bio_t)&PEM_read_bio_RSAPrivateKey;
 #endif
 
     ssh2_init_if_needed();
@@ -1614,11 +1610,9 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
     int rc;
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_func read_dsa =
-        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
+    pem_read_bio_t read_dsa = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
 #else
-    pem_read_bio_func read_dsa =
-        (pem_read_bio_func)&PEM_read_bio_DSAPrivateKey;
+    pem_read_bio_t read_dsa = (pem_read_bio_t)&PEM_read_bio_DSAPrivateKey;
 #endif
 
     ssh2_init_if_needed();
@@ -1925,11 +1919,9 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
     int rc;
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_func read_dsa =
-        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
+    pem_read_bio_t read_dsa = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
 #else
-    pem_read_bio_func read_dsa =
-        (pem_read_bio_func)&PEM_read_bio_DSAPrivateKey;
+    pem_read_bio_t read_dsa = (pem_read_bio_t)&PEM_read_bio_DSAPrivateKey;
 #endif
 
     ssh2_init_if_needed();
@@ -1955,11 +1947,9 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
     int rc;
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_func read_ec =
-        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
+    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
 #else
-    pem_read_bio_func read_ec =
-        (pem_read_bio_func)&PEM_read_bio_ECPrivateKey;
+    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_ECPrivateKey;
 #endif
 
     ssh2_init_if_needed();
@@ -2573,7 +2563,7 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
     ssh2_init_if_needed();
 
     if(read_private_key_from_memory((void **)&ctx,
-                                   (pem_read_bio_func)&PEM_read_bio_PrivateKey,
+                                    (pem_read_bio_t)&PEM_read_bio_PrivateKey,
                                     filedata, filedata_len, passphrase) == 0) {
         if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
             ssh2_ed25519_free(ctx);
@@ -3990,11 +3980,9 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
     int rc;
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_func read_ec =
-        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
+    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
 #else
-    pem_read_bio_func read_ec =
-        (pem_read_bio_func)&PEM_read_bio_ECPrivateKey;
+    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_ECPrivateKey;
 #endif
 
     ssh2_init_if_needed();
@@ -4021,11 +4009,9 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
     int rc;
 
 #ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_func read_ec =
-        (pem_read_bio_func)&PEM_read_bio_PrivateKey;
+    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
 #else
-    pem_read_bio_func read_ec =
-        (pem_read_bio_func)&PEM_read_bio_ECPrivateKey;
+    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_ECPrivateKey;
 #endif
 
     ssh2_init_if_needed();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1347,7 +1347,7 @@ out:
 
     return rc;
 }
-#endif /* ndef USE_OPENSSL_3 */
+#endif /* !USE_OPENSSL_3 */
 
 static int gen_publickey_from_rsa_openssh_priv_data(
     LIBSSH2_SESSION *session,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1116,14 +1116,26 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
     return passphrase_len;
 }
 
+#if LIBSSH2_RSA
 #ifdef USE_OPENSSL_3
 #define CB_RSA PEM_read_bio_PrivateKey
-#define CB_DSA PEM_read_bio_PrivateKey
-#define CB_EC  PEM_read_bio_PrivateKey
 #else
 #define CB_RSA PEM_read_bio_RSAPrivateKey
+#endif
+#endif
+#if LIBSSH2_DSA || LIBSSH2_ECDSA || LIBSSH2_ED25519
+#ifdef USE_OPENSSL_3
+#define CB_DSA PEM_read_bio_PrivateKey
+#else
 #define CB_DSA PEM_read_bio_DSAPrivateKey
+#endif
+#endif
+#if LIBSSH2_ECDSA || LIBSSH2_ED25519
+#ifdef USE_OPENSSL_3
+#define CB_EC  PEM_read_bio_PrivateKey
+#else
 #define CB_EC  PEM_read_bio_ECPrivateKey
+#endif
 #endif
 
 #define READ_PRIVKEY_FROM_BLOB(ctx, cb, blob, blob_len, passphrase)           \

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1126,30 +1126,28 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
 #define CB_EC  PEM_read_bio_ECPrivateKey
 #endif
 
-#define READ_PRIVKEY_FROM_BLOB(ctx, cb, blob, blob_len, passphrase)   \
-    do {                                                              \
-        BIO *bp = BIO_new_mem_buf(blob, (int)(blob_len));             \
-        if(bp) {                                                      \
-            *(ctx) = (cb)(bp, NULL, (pem_password_cb *)passphrase_cb, \
-                          SSH2_UNCONST(passphrase));                  \
-            BIO_free(bp);                                             \
-        }                                                             \
-        else                                                          \
-            *(ctx) = NULL;                                            \
+#define READ_PRIVKEY_FROM_BLOB(ctx, cb, blob, blob_len, passphrase)           \
+    do {                                                                      \
+        BIO *bp = BIO_new_mem_buf(blob, (int)(blob_len));                     \
+        if(bp) {                                                              \
+            *(ctx) = (cb)(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase)); \
+            BIO_free(bp);                                                     \
+        }                                                                     \
+        else                                                                  \
+            *(ctx) = NULL;                                                    \
     } while(0)
 #endif
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
-#define READ_PRIVKEY_FROM_FILE(ctx, cb, filename, passphrase)         \
-    do {                                                              \
-        BIO *bp = BIO_new_file(filename, "r");                        \
-        if(bp) {                                                      \
-            *(ctx) = (cb)(bp, NULL, (pem_password_cb *)passphrase_cb, \
-                          SSH2_UNCONST(passphrase));                  \
-            BIO_free(bp);                                             \
-        }                                                             \
-        else                                                          \
-            *(ctx) = NULL;                                            \
+#define READ_PRIVKEY_FROM_FILE(ctx, cb, filename, passphrase)                 \
+    do {                                                                      \
+        BIO *bp = BIO_new_file(filename, "r");                                \
+        if(bp) {                                                              \
+            *(ctx) = (cb)(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase)); \
+            BIO_free(bp);                                                     \
+        }                                                                     \
+        else                                                                  \
+            *(ctx) = NULL;                                                    \
     } while(0)
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -46,15 +46,6 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#ifdef USE_OPENSSL_3
-#define USE_PEM_READ_BIO_PRIVATEKEY
-#else
-#if defined(__clang__) && __clang_major__ >= 16
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-function-type-strict"
-#endif
-#endif
-
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 {
 #ifdef USE_OPENSSL_3
@@ -1125,57 +1116,41 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
     return passphrase_len;
 }
 
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
-typedef EVP_PKEY *(*pem_read_bio_t)(BIO *, EVP_PKEY **, pem_password_cb *,
-                                    void *u);
+#ifdef USE_OPENSSL_3
+#define CB_RSA PEM_read_bio_PrivateKey
+#define CB_DSA PEM_read_bio_PrivateKey
+#define CB_EC  PEM_read_bio_PrivateKey
 #else
-typedef void *(*pem_read_bio_t)(BIO *, void **, pem_password_cb *, void *u);
+#define CB_RSA PEM_read_bio_RSAPrivateKey
+#define CB_DSA PEM_read_bio_DSAPrivateKey
+#define CB_EC  PEM_read_bio_ECPrivateKey
 #endif
 
-static int read_private_key_from_memory(void **key_ctx,
-                                        pem_read_bio_t read_private_key,
-                                        const char *filedata,
-                                        size_t filedata_len,
-                                        const unsigned char *passphrase)
-{
-    BIO *bp;
-
-    *key_ctx = NULL;
-
-    bp = BIO_new_mem_buf(filedata, (int)filedata_len);
-    if(!bp) {
-        return -1;
-    }
-
-    *key_ctx = read_private_key(bp, NULL, (pem_password_cb *)passphrase_cb,
-                                SSH2_UNCONST(passphrase));
-
-    BIO_free(bp);
-    return *key_ctx ? 0 : -1;
-}
+#define READ_PRIVKEY_FROM_BLOB(ctx, cb, blob, blob_len, passphrase)   \
+    do {                                                              \
+        BIO *bp = BIO_new_mem_buf(blob, (int)(blob_len));             \
+        if(bp) {                                                      \
+            *(ctx) = (cb)(bp, NULL, (pem_password_cb *)passphrase_cb, \
+                          SSH2_UNCONST(passphrase));                  \
+            BIO_free(bp);                                             \
+        }                                                             \
+        else                                                          \
+            *(ctx) = NULL;                                            \
+    } while(0)
 #endif
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
-static int read_private_key_from_file(void **key_ctx,
-                                      pem_read_bio_t read_private_key,
-                                      const char *filename,
-                                      const unsigned char *passphrase)
-{
-    BIO *bp;
-
-    *key_ctx = NULL;
-
-    bp = BIO_new_file(filename, "r");
-    if(!bp) {
-        return -1;
-    }
-
-    *key_ctx = read_private_key(bp, NULL, (pem_password_cb *)passphrase_cb,
-                                SSH2_UNCONST(passphrase));
-
-    BIO_free(bp);
-    return *key_ctx ? 0 : -1;
-}
+#define READ_PRIVKEY_FROM_FILE(ctx, cb, filename, passphrase)         \
+    do {                                                              \
+        BIO *bp = BIO_new_file(filename, "r");                        \
+        if(bp) {                                                      \
+            *(ctx) = (cb)(bp, NULL, (pem_password_cb *)passphrase_cb, \
+                          SSH2_UNCONST(passphrase));                  \
+            BIO_free(bp);                                             \
+        }                                                             \
+        else                                                          \
+            *(ctx) = NULL;                                            \
+    } while(0)
 #endif
 
 #if LIBSSH2_RSA
@@ -1185,27 +1160,18 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     size_t filedata_len,
                                     const unsigned char *passphrase)
 {
-    int rc;
-
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_t read_rsa = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
-#else
-    pem_read_bio_t read_rsa = (pem_read_bio_t)&PEM_read_bio_RSAPrivateKey;
-#endif
+    int rc = -1;
 
     ssh2_init_if_needed();
 
-    rc = read_private_key_from_memory((void **)rsa, read_rsa,
-                                      filedata, filedata_len,
-                                      passphrase);
+    READ_PRIVKEY_FROM_BLOB(rsa, CB_RSA, filedata, filedata_len, passphrase);
 
-    if(rc) {
+    if(*rsa)
         rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
                                             "ssh-rsa",
                                             NULL, NULL, NULL, NULL,
                                             filedata, filedata_len,
                                             passphrase);
-    }
 
     return rc;
 }
@@ -1575,23 +1541,14 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          const char *filename,
                          const unsigned char *passphrase)
 {
-    int rc;
-
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_t read_rsa = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
-#else
-    pem_read_bio_t read_rsa = (pem_read_bio_t)&PEM_read_bio_RSAPrivateKey;
-#endif
+    int rc = -1;
 
     ssh2_init_if_needed();
 
-    rc = read_private_key_from_file((void **)rsa, read_rsa,
-                                    filename, passphrase);
+    READ_PRIVKEY_FROM_FILE(rsa, CB_RSA, filename, passphrase);
 
-    if(rc) {
-        rc = rsa_new_openssh_private(rsa, session,
-                                     filename, passphrase);
-    }
+    if(*rsa)
+        rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
 
     return rc;
 }
@@ -1604,27 +1561,18 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
                                     size_t filedata_len,
                                     const unsigned char *passphrase)
 {
-    int rc;
-
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_t read_dsa = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
-#else
-    pem_read_bio_t read_dsa = (pem_read_bio_t)&PEM_read_bio_DSAPrivateKey;
-#endif
+    int rc = -1;
 
     ssh2_init_if_needed();
 
-    rc = read_private_key_from_memory((void **)dsa, read_dsa,
-                                      filedata, filedata_len,
-                                      passphrase);
+    READ_PRIVKEY_FROM_BLOB(dsa, CB_DSA, filedata, filedata_len, passphrase);
 
-    if(rc) {
+    if(*dsa)
         rc = pub_priv_openssh_keyfilememory(session, (void **)dsa,
                                             "ssh-dsa",
                                             NULL, NULL, NULL, NULL,
                                             filedata, filedata_len,
                                             passphrase);
-    }
 
     return rc;
 }
@@ -1913,22 +1861,14 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          const char *filename,
                          const unsigned char *passphrase)
 {
-    int rc;
-
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_t read_dsa = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
-#else
-    pem_read_bio_t read_dsa = (pem_read_bio_t)&PEM_read_bio_DSAPrivateKey;
-#endif
+    int rc = -1;
 
     ssh2_init_if_needed();
 
-    rc = read_private_key_from_file((void **)dsa, read_dsa,
-                                    filename, passphrase);
+    READ_PRIVKEY_FROM_FILE(dsa, CB_DSA, filename, passphrase);
 
-    if(rc) {
+    if(*dsa)
         rc = dsa_new_openssh_private(dsa, session, filename, passphrase);
-    }
 
     return rc;
 }
@@ -1941,27 +1881,18 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                       size_t filedata_len,
                                       const unsigned char *passphrase)
 {
-    int rc;
-
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
-#else
-    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_ECPrivateKey;
-#endif
+    int rc = -1;
 
     ssh2_init_if_needed();
 
-    rc = read_private_key_from_memory((void **)ec_ctx, read_ec,
-                                      filedata, filedata_len,
-                                      passphrase);
+    READ_PRIVKEY_FROM_BLOB(ec_ctx, CB_EC, filedata, filedata_len, passphrase);
 
-    if(rc) {
+    if(*ec_ctx)
         rc = pub_priv_openssh_keyfilememory(session, (void **)ec_ctx,
                                             "ssh-ecdsa",
                                             NULL, NULL, NULL, NULL,
                                             filedata, filedata_len,
                                             passphrase);
-    }
 
     return rc;
 }
@@ -2559,9 +2490,9 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
 
     ssh2_init_if_needed();
 
-    if(read_private_key_from_memory((void **)&ctx,
-                                    (pem_read_bio_t)&PEM_read_bio_PrivateKey,
-                                    filedata, filedata_len, passphrase) == 0) {
+    READ_PRIVKEY_FROM_BLOB(ed_ctx, CB_EC, filedata, filedata_len, passphrase);
+
+    if(!*ed_ctx) {
         if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
             ssh2_ed25519_free(ctx);
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -3974,22 +3905,14 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                            const char *filename,
                            const unsigned char *passphrase)
 {
-    int rc;
-
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
-#else
-    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_ECPrivateKey;
-#endif
+    int rc = -1;
 
     ssh2_init_if_needed();
 
-    rc = read_private_key_from_file((void **)ec_ctx, read_ec,
-                                    filename, passphrase);
+    READ_PRIVKEY_FROM_FILE(ec_ctx, CB_EC, filename, passphrase);
 
-    if(rc) {
+    if(*ec_ctx)
         rc = ecdsa_new_openssh_private(ec_ctx, session, filename, passphrase);
-    }
 
     return rc;
 }
@@ -4003,24 +3926,16 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
                               const char *filename,
                               const unsigned char *passphrase)
 {
-    int rc;
-
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
-    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_PrivateKey;
-#else
-    pem_read_bio_t read_ec = (pem_read_bio_t)&PEM_read_bio_ECPrivateKey;
-#endif
+    int rc = -1;
 
     ssh2_init_if_needed();
 
-    rc = read_private_key_from_file((void **)ec_ctx, read_ec,
-                                    filename, passphrase);
+    READ_PRIVKEY_FROM_FILE(ec_ctx, CB_EC, filename, passphrase);
 
-    if(rc) {
+    if(*ec_ctx)
         rc = ecdsa_new_openssh_private_sk(ec_ctx, flags, application,
                                           key_handle, handle_len, session,
                                           filename, passphrase);
-    }
 
     return rc;
 }
@@ -5125,11 +5040,5 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
     return NULL;
 }
-
-#ifndef USE_OPENSSL_3
-#if defined(__clang__) && __clang_major__ >= 16
-#pragma clang diagnostic pop
-#endif
-#endif
 
 #endif /* LIBSSH2_OPENSSL || LIBSSH2_WOLFSSL */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1178,20 +1178,17 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 
     ssh2_init_if_needed();
 
-    bp = BIO_new_mem_buf(blob, (int)(blob_len));
+    bp = BIO_new_mem_buf(filedata, (int)filedata_len);
     if(bp) {
-        *(ctx) = CB_RSA(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase));
+        *rsa = CB_RSA(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase));
         BIO_free(bp);
+        if(*rsa)
+            rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
+                                                "ssh-rsa",
+                                                NULL, NULL, NULL, NULL,
+                                                filedata, filedata_len,
+                                                passphrase);
     }
-    else
-        *(ctx) = NULL;
-
-    if(*rsa)
-        rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
-                                            "ssh-rsa",
-                                            NULL, NULL, NULL, NULL,
-                                            filedata, filedata_len,
-                                            passphrase);
 
     return rc;
 }
@@ -1570,12 +1567,9 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
     if(bp) {
         *rsa = CB_RSA(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase));
         BIO_free(bp);
+        if(*rsa)
+            rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
     }
-    else
-        *rsa = NULL;
-
-    if(*rsa)
-        rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
 
     return rc;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1125,9 +1125,9 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
     return passphrase_len;
 }
 
-#ifdef LIBSSH2_WOLFSSL
-typedef WOLFSSL_EC_KEY *(*pem_read_bio_func)(BIO *, WOLFSSL_EC_KEY **,
-                                             pem_password_cb *, void *u);
+#if defined(LIBSSH2_WOLFSSL) || defined(LIBRESSL_VERSION_NUMBER)
+typedef EC_KEY *(*pem_read_bio_func)(BIO *, EC_KEY **, pem_password_cb *,
+                                     void *u);
 #elif defined(USE_PEM_READ_BIO_PRIVATEKEY)
 typedef EVP_PKEY *(*pem_read_bio_func)(BIO *, EVP_PKEY **, pem_password_cb *,
                                        void *u);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2503,9 +2503,9 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_BLOB(ed_ctx, CB_ED, filedata, filedata_len, passphrase);
+    READ_PRIVKEY_FROM_BLOB(ctx, CB_ED, filedata, filedata_len, passphrase);
 
-    if(!*ed_ctx) {
+    if(*ctx) {
         if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
             ssh2_ed25519_free(ctx);
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1116,6 +1116,13 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
     return passphrase_len;
 }
 
+#if LIBSSH2_RSA
+#ifdef USE_OPENSSL_3
+#define CB_RSA &PEM_read_bio_PrivateKey
+#else
+#define CB_RSA &PEM_read_bio_RSAPrivateKey
+#endif
+#endif
 #if LIBSSH2_DSA
 #ifdef USE_OPENSSL_3
 #define CB_DSA &PEM_read_bio_PrivateKey
@@ -1167,27 +1174,16 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     const unsigned char *passphrase)
 {
     int rc = 0;
-    BIO *bp;
 
     ssh2_init_if_needed();
 
-    bp = BIO_new_mem_buf(filedata, (int)filedata_len);
-    if(bp) {
-#ifdef USE_OPENSSL_3
-        *rsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
-                                       SSH2_UNCONST(passphrase));
-#else
-        *rsa = PEM_read_bio_RSAPrivateKey(bp, NULL, passphrase_cb,
-                                          SSH2_UNCONST(passphrase));
-#endif
-        BIO_free(bp);
-        if(!*rsa)
-            rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
-                                                "ssh-rsa",
-                                                NULL, NULL, NULL, NULL,
-                                                filedata, filedata_len,
-                                                passphrase);
-    }
+    READ_PRIVKEY_FROM_BLOB(rsa, CB_RSA, filedata, filedata_len, passphrase);
+    if(!*rsa)
+        rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
+                                            "ssh-rsa",
+                                            NULL, NULL, NULL, NULL,
+                                            filedata, filedata_len,
+                                            passphrase);
 
     return rc;
 }
@@ -1558,23 +1554,12 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          const unsigned char *passphrase)
 {
     int rc = 0;
-    BIO *bp;
 
     ssh2_init_if_needed();
 
-    bp = BIO_new_file(filename, "r");
-    if(bp) {
-#ifdef USE_OPENSSL_3
-        *rsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
-                                       SSH2_UNCONST(passphrase));
-#else
-        *rsa = PEM_read_bio_RSAPrivateKey(bp, NULL, passphrase_cb,
-                                          SSH2_UNCONST(passphrase));
-#endif
-        BIO_free(bp);
-        if(!*rsa)
-            rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
-    }
+    READ_PRIVKEY_FROM_FILE(rsa, CB_RSA, filename, passphrase);
+    if(!*rsa)
+        rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
 
     return rc;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1125,10 +1125,7 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
     return passphrase_len;
 }
 
-#if defined(LIBSSH2_WOLFSSL) || defined(LIBRESSL_VERSION_NUMBER)
-typedef EC_KEY *(*pem_read_bio_t)(BIO *, EC_KEY **, pem_password_cb *,
-                                  void *u);
-#elif defined(USE_PEM_READ_BIO_PRIVATEKEY)
+#ifdef USE_PEM_READ_BIO_PRIVATEKEY
 typedef EVP_PKEY *(*pem_read_bio_t)(BIO *, EVP_PKEY **, pem_password_cb *,
                                     void *u);
 #else

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1125,7 +1125,10 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
     return passphrase_len;
 }
 
-#ifdef USE_PEM_READ_BIO_PRIVATEKEY
+#ifdef LIBSSH2_WOLFSSL
+typedef WOLFSSL_EC_KEY *(*pem_read_bio_func)(BIO *, WOLFSSL_EC_KEY **,
+                                             pem_password_cb *, void *u);
+#elif defined(USE_PEM_READ_BIO_PRIVATEKEY)
 typedef EVP_PKEY *(*pem_read_bio_func)(BIO *, EVP_PKEY **, pem_password_cb *,
                                        void *u);
 #else

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1130,7 +1130,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     ssh2_init_if_needed();
 
     bp = BIO_new_mem_buf(filedata, (int)filedata_len);
-    if(bp) {
+    if(bp)
 #ifdef USE_OPENSSL_3
         *rsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
                                        SSH2_UNCONST(passphrase));
@@ -1138,8 +1138,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
         *rsa = PEM_read_bio_RSAPrivateKey(bp, NULL, passphrase_cb,
                                           SSH2_UNCONST(passphrase));
 #endif
-        BIO_free(bp);
-    }
+    BIO_free(bp);
     if(!*rsa)
         rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
                                             "ssh-rsa",
@@ -1521,7 +1520,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
     ssh2_init_if_needed();
 
     bp = BIO_new_file(filename, "r");
-    if(bp) {
+    if(bp)
 #ifdef USE_OPENSSL_3
         *rsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
                                        SSH2_UNCONST(passphrase));
@@ -1529,8 +1528,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
         *rsa = PEM_read_bio_RSAPrivateKey(bp, NULL, passphrase_cb,
                                           SSH2_UNCONST(passphrase));
 #endif
-        BIO_free(bp);
-    }
+    BIO_free(bp);
     if(!*rsa)
         rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
 
@@ -1551,7 +1549,7 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
     ssh2_init_if_needed();
 
     bp = BIO_new_mem_buf(filedata, (int)filedata_len);
-    if(bp) {
+    if(bp)
 #ifdef USE_OPENSSL_3
         *dsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
                                        SSH2_UNCONST(passphrase));
@@ -1559,8 +1557,7 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
         *dsa = PEM_read_bio_DSAPrivateKey(bp, NULL, passphrase_cb,
                                           SSH2_UNCONST(passphrase));
 #endif
-        BIO_free(bp);
-    }
+    BIO_free(bp);
     if(!*dsa)
         rc = pub_priv_openssh_keyfilememory(session, (void **)dsa,
                                             "ssh-dsa",
@@ -1861,7 +1858,7 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
     ssh2_init_if_needed();
 
     bp = BIO_new_file(filename, "r");
-    if(bp) {
+    if(bp)
 #ifdef USE_OPENSSL_3
         *dsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
                                        SSH2_UNCONST(passphrase));
@@ -1869,8 +1866,7 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
         *dsa = PEM_read_bio_DSAPrivateKey(bp, NULL, passphrase_cb,
                                           SSH2_UNCONST(passphrase));
 #endif
-        BIO_free(bp);
-    }
+    BIO_free(bp);
     if(!*dsa)
         rc = dsa_new_openssh_private(dsa, session, filename, passphrase);
 
@@ -1891,7 +1887,7 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
     ssh2_init_if_needed();
 
     bp = BIO_new_mem_buf(filedata, (int)filedata_len);
-    if(bp) {
+    if(bp)
 #ifdef USE_OPENSSL_3
         *ec_ctx = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
                                           SSH2_UNCONST(passphrase));
@@ -1899,8 +1895,7 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
         *ec_ctx = PEM_read_bio_ECPrivateKey(bp, NULL, passphrase_cb,
                                             SSH2_UNCONST(passphrase));
 #endif
-        BIO_free(bp);
-    }
+    BIO_free(bp);
     if(!*ec_ctx)
         rc = pub_priv_openssh_keyfilememory(session, (void **)ec_ctx,
                                             "ssh-ecdsa",
@@ -3930,7 +3925,7 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
     ssh2_init_if_needed();
 
     bp = BIO_new_file(filename, "r");
-    if(bp) {
+    if(bp)
 #ifdef USE_OPENSSL_3
         *ec_ctx = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
                                           SSH2_UNCONST(passphrase));
@@ -3938,8 +3933,7 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
         *ec_ctx = PEM_read_bio_ECPrivateKey(bp, NULL, passphrase_cb,
                                             SSH2_UNCONST(passphrase));
 #endif
-        BIO_free(bp);
-    }
+    BIO_free(bp);
     if(!*ec_ctx)
         rc = ecdsa_new_openssh_private(ec_ctx, session, filename, passphrase);
 
@@ -3961,7 +3955,7 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
     ssh2_init_if_needed();
 
     bp = BIO_new_file(filename, "r");
-    if(bp) {
+    if(bp)
 #ifdef USE_OPENSSL_3
         *ec_ctx = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
                                           SSH2_UNCONST(passphrase));
@@ -3969,8 +3963,7 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
         *ec_ctx = PEM_read_bio_ECPrivateKey(bp, NULL, passphrase_cb,
                                             SSH2_UNCONST(passphrase));
 #endif
-        BIO_free(bp);
-    }
+    BIO_free(bp);
     if(!*ec_ctx)
         rc = ecdsa_new_openssh_private_sk(ec_ctx, flags, application,
                                           key_handle, handle_len, session,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1118,27 +1118,27 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
 
 #if LIBSSH2_RSA
 #ifdef USE_OPENSSL_3
-#define CB_RSA PEM_read_bio_PrivateKey
+#define CB_RSA &PEM_read_bio_PrivateKey
 #else
-#define CB_RSA PEM_read_bio_RSAPrivateKey
+#define CB_RSA &PEM_read_bio_RSAPrivateKey
 #endif
 #endif
 #if LIBSSH2_DSA
 #ifdef USE_OPENSSL_3
-#define CB_DSA PEM_read_bio_PrivateKey
+#define CB_DSA &PEM_read_bio_PrivateKey
 #else
-#define CB_DSA PEM_read_bio_DSAPrivateKey
+#define CB_DSA &PEM_read_bio_DSAPrivateKey
 #endif
 #endif
 #if LIBSSH2_ECDSA
 #ifdef USE_OPENSSL_3
-#define CB_EC PEM_read_bio_PrivateKey
+#define CB_EC &PEM_read_bio_PrivateKey
 #else
-#define CB_EC PEM_read_bio_ECPrivateKey
+#define CB_EC &PEM_read_bio_ECPrivateKey
 #endif
 #endif
 #if LIBSSH2_ED25519
-#define CB_ED PEM_read_bio_PrivateKey
+#define CB_ED &PEM_read_bio_PrivateKey
 #endif
 
 #define READ_PRIVKEY_FROM_BLOB(ctx, cb, blob, blob_len, passphrase)           \

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2516,9 +2516,9 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_BLOB(ctx, CB_ED, filedata, filedata_len, passphrase);
+    READ_PRIVKEY_FROM_BLOB(&ctx, CB_ED, filedata, filedata_len, passphrase);
 
-    if(*ctx) {
+    if(ctx) {
         if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
             ssh2_ed25519_free(ctx);
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -487,7 +487,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                                 m_len);
 }
 #endif
-#endif
+#endif /* LIBSSH_RSA */
 
 #if LIBSSH2_DSA
 int ssh2_dsa_new(ssh2_dsa_ctx **dsactx,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1123,19 +1123,22 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
 #define CB_RSA PEM_read_bio_RSAPrivateKey
 #endif
 #endif
-#if LIBSSH2_DSA || LIBSSH2_ECDSA || LIBSSH2_ED25519
+#if LIBSSH2_DSA
 #ifdef USE_OPENSSL_3
 #define CB_DSA PEM_read_bio_PrivateKey
 #else
 #define CB_DSA PEM_read_bio_DSAPrivateKey
 #endif
 #endif
-#if LIBSSH2_ECDSA || LIBSSH2_ED25519
+#if LIBSSH2_ECDSA
 #ifdef USE_OPENSSL_3
-#define CB_EC  PEM_read_bio_PrivateKey
+#define CB_EC PEM_read_bio_PrivateKey
 #else
-#define CB_EC  PEM_read_bio_ECPrivateKey
+#define CB_EC PEM_read_bio_ECPrivateKey
 #endif
+#endif
+#if LIBSSH2_ED25519
+#define CB_ED PEM_read_bio_PrivateKey
 #endif
 
 #define READ_PRIVKEY_FROM_BLOB(ctx, cb, blob, blob_len, passphrase)           \
@@ -2500,7 +2503,7 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
 
     ssh2_init_if_needed();
 
-    READ_PRIVKEY_FROM_BLOB(ed_ctx, CB_EC, filedata, filedata_len, passphrase);
+    READ_PRIVKEY_FROM_BLOB(ed_ctx, CB_ED, filedata, filedata_len, passphrase);
 
     if(!*ed_ctx) {
         if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1116,13 +1116,6 @@ static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
     return passphrase_len;
 }
 
-#if LIBSSH2_RSA
-#ifdef USE_OPENSSL_3
-#define CB_RSA &PEM_read_bio_PrivateKey
-#else
-#define CB_RSA &PEM_read_bio_RSAPrivateKey
-#endif
-#endif
 #if LIBSSH2_DSA
 #ifdef USE_OPENSSL_3
 #define CB_DSA &PEM_read_bio_PrivateKey
@@ -1180,7 +1173,13 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 
     bp = BIO_new_mem_buf(filedata, (int)filedata_len);
     if(bp) {
-        *rsa = CB_RSA(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase));
+#ifdef USE_OPENSSL_3
+        *rsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                       SSH2_UNCONST(passphrase));
+#else
+        *rsa = PEM_read_bio_RSAPrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#endif
         BIO_free(bp);
         if(*rsa)
             rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
@@ -1565,7 +1564,13 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
 
     bp = BIO_new_file(filename, "r");
     if(bp) {
-        *rsa = CB_RSA(bp, NULL, passphrase_cb, SSH2_UNCONST(passphrase));
+#ifdef USE_OPENSSL_3
+        *rsa = PEM_read_bio_PrivateKey(bp, NULL, passphrase_cb,
+                                       SSH2_UNCONST(passphrase));
+#else
+        *rsa = PEM_read_bio_RSAPrivateKey(bp, NULL, passphrase_cb,
+                                          SSH2_UNCONST(passphrase));
+#endif
         BIO_free(bp);
         if(*rsa)
             rc = rsa_new_openssh_private(rsa, session, filename, passphrase);


### PR DESCRIPTION
Drop local worker functions, to avoid passing around function pointers,
with a local typedef that needs to be different (and matching upstream
exactly) dependening  on crypto backend/version and key type.

Also:
- fix ed25519 callback function for non-OpenSSL3.
  (detected by MSVC after dropping casts.)
- drop local compiler warning silencing.
- tried to use local macros. It saved 30 lines of code, but I opted for
  the simplicity/clarity of duplicating the BIO calls around each call.

Follow-up to 04ecdb22fe9b092ba49f1562b5f79a9acdeedb8b #1972
Follow-up to 784446b6c544575efa267f976c91fffdbe5199d6 #1484
Follow-up to b0ab005fe79260e6e9fe08f8d73b58dd4856943d #1207
Follow-up to 231a97a95f523f2f67dd8d5915ce74f503791bcc

---

https://github.com/libssh2/libssh2/pull/1991/files?w=1
