### PR TITLE
configure: drop redundant gcc-specific `-isystem` logic

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -639,18 +639,6 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unterminated-string-initialization])
           fi
 
-          for flag in $CPPFLAGS; do
-            case "$flag" in
-             -I*)
-               dnl Include path, provide a -isystem option for the same dir
-               dnl to prevent warnings in those dirs. The -isystem was not
-               dnl reliable on earlier gcc versions.
-               add=`echo $flag | sed 's/^-I/-isystem /g'`
-               tmp_CFLAGS="$tmp_CFLAGS $add"
-               ;;
-            esac
-          done
-
     fi dnl $ICC = no
 
     CFLAGS="$CFLAGS $tmp_CFLAGS"


### PR DESCRIPTION
Turns out the logic was there but for gcc only. Drop in favor of the
more generic solution merged recently.

Follow-up to 04ecdb22fe9b092ba49f1562b5f79a9acdeedb8b #1972