### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -830,9 +830,9 @@ dnl the code was bad, try a different program now, test 2
 #include <unistd.h>
 #include <stropts.h>
 ]], [[
-/* FIONBIO source test (old-style unix) */
- int socket;
- int flags = ioctl(socket, FIONBIO, &flags);
+  /* FIONBIO source test (old-style unix) */
+  int socket;
+  int flags = ioctl(socket, FIONBIO, &flags);
 ]])],[
 dnl FIONBIO test was good
 nonblock="FIONBIO"
@@ -845,9 +845,9 @@ dnl the code was bad, try a different program now, test 3
 /* headers for IoctlSocket test (Amiga?) */
 #include <sys/ioctl.h>
 ]], [[
-/* IoctlSocket source code */
- int socket;
- int flags = IoctlSocket(socket, FIONBIO, (long)1);
+  /* IoctlSocket source code */
+  int socket;
+  int flags = IoctlSocket(socket, FIONBIO, (long)1);
 ]])],[
 dnl ioctlsocket test was good
 nonblock="IoctlSocket"
@@ -855,8 +855,8 @@ AC_DEFINE(HAVE_IOCTLSOCKET_CASE, 1, [use Ioctlsocket() for non-blocking sockets]
 ],[
 dnl Ioctlsocket did not compile, do test 4!
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-/* headers for SO_NONBLOCK test (BeOS) */
-#include <socket.h>
+    /* headers for SO_NONBLOCK test (BeOS) */
+    #include <socket.h>
 ]], [[
 /* SO_NONBLOCK source code */
  long b = 1;
@@ -943,7 +943,7 @@ AC_DEFUN([CURL_CONFIGURE_REENTRANT], [
     AC_LANG_PROGRAM([[
     ]],[[
       #ifdef _REENTRANT
-        int dummy=1;
+        int dummy = 1;
       #else
         force compilation error
       #endif

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -113,7 +113,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_CLANG], [
     AC_MSG_RESULT([yes])
     AC_MSG_CHECKING([if compiler is xlclang])
     CURL_CHECK_DEF([__ibmxl__], [], [silent])
-    if test "$curl_cv_have_def___ibmxl__" = "yes" ; then
+    if test "$curl_cv_have_def___ibmxl__" = "yes"; then
       dnl IBM's almost-compatible clang version
       AC_MSG_RESULT([yes])
       compiler_id="XLCLANG"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,5 +1,6 @@
-# Copyright (C) The libssh2 project and its contributors.
-# SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright (C) The libssh2 project and its contributors.
+dnl SPDX-License-Identifier: BSD-3-Clause
+
 dnl CURL_CPP_P
 dnl
 dnl Check if $cpp -P should be used for extract define values due to gcc 5

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,9 @@
-# Copyright (C) The libssh2 project and its contributors.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-#
+dnl Copyright (C) The libssh2 project and its contributors.
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl
 
-# AC_PREREQ(2.59)
+dnl AC_PREREQ(2.59)
 AC_INIT([libssh2],[-],[libssh2-devel@lists.haxx.se])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src])
@@ -29,9 +29,9 @@ AC_MSG_RESULT($LIBSSH2_VERSION)
 
 AC_SUBST(LIBSSH2_VERSION)
 
-# Check for the OS.
-# Daniel's note: this should not be necessary and we need to work to
-# get this removed.
+dnl Check for the OS.
+dnl Daniel's note: this should not be necessary and we need to work to
+dnl get this removed.
 AC_CANONICAL_HOST
 case "$host" in
   *-mingw*)
@@ -51,10 +51,10 @@ esac
 dnl Our configure and build reentrant settings
 CURL_CONFIGURE_REENTRANT
 
-# Some systems (Solaris?) have socket() in -lsocket.
+dnl Some systems (Solaris?) have socket() in -lsocket.
 AC_SEARCH_LIBS(socket, socket)
 
-# Solaris has inet_addr() in -lnsl.
+dnl Solaris has inet_addr() in -lnsl.
 AC_SEARCH_LIBS(inet_addr, nsl)
 
 AC_SUBST(LIBS)
@@ -82,7 +82,7 @@ LT_LANG([Windows Resource])
 dnl check for windows.h
 case $host in
   *-*-msys | *-*-cygwin* | *-*-cegcc*)
-    # These are POSIX-like systems using BSD-like sockets API.
+    dnl These are POSIX-like systems using BSD-like sockets API.
     ;;
   *)
     AC_CHECK_HEADERS([windows.h], [have_windows_h=yes], [have_windows_h=no])
@@ -165,7 +165,7 @@ else
   test "$found_crypto_str" = "" && found_crypto_str="$found_crypto"
 fi
 
-# ECDSA support with WinCNG
+dnl ECDSA support with WinCNG
 AC_ARG_ENABLE(ecdsa-wincng,
   AS_HELP_STRING([--enable-ecdsa-wincng],
     WinCNG ECDSA support (requires Windows 10 or later)),
@@ -176,7 +176,7 @@ else
   wincng_ecdsa=no
 fi
 
-# libz
+dnl libz
 
 AC_ARG_WITH([libz],
   AS_HELP_STRING([--with-libz],[Use libz for compression]),
@@ -210,9 +210,9 @@ fi
 
 AC_SUBST(LIBSSH2_PC_REQUIRES_PRIVATE)
 
-#
-# Optional Settings
-#
+dnl
+dnl Optional Settings
+dnl
 AC_ARG_ENABLE(clear-memory,
   AS_HELP_STRING([--disable-clear-memory],[Disable clearing of memory before being freed]),
   [CLEAR_MEMORY=$enableval])
@@ -306,21 +306,21 @@ AC_ARG_ENABLE([deprecated],
     [with_deprecated="yes"]
 )
 
-# Run Docker tests?
+dnl Run Docker tests?
 AC_ARG_ENABLE([docker-tests],
   [AS_HELP_STRING([--disable-docker-tests],
     [Do not run tests requiring Docker])],
   [run_docker_tests=no], [run_docker_tests=yes])
 AM_CONDITIONAL([RUN_DOCKER_TESTS], [test "x$run_docker_tests" != "xno"])
 
-# Run sshd tests?
+dnl Run sshd tests?
 AC_ARG_ENABLE([sshd-tests],
   [AS_HELP_STRING([--disable-sshd-tests],
     [Do not run tests requiring sshd])],
   [run_sshd_tests=no], [run_sshd_tests=yes])
 AM_CONDITIONAL([RUN_SSHD_TESTS], [test "x$run_sshd_tests" != "xno"])
 
-# Build example applications?
+dnl Build example applications?
 AC_MSG_CHECKING([whether to build example applications])
 AC_ARG_ENABLE([examples-build],
 AS_HELP_STRING([--enable-examples-build], [Build example applications (this is the default)])
@@ -338,19 +338,19 @@ AS_HELP_STRING([--disable-examples-build], [Do not build example applications]),
 AC_MSG_RESULT($build_examples)
 AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$build_examples" != "xno"])
 
-# Build OSS fuzzing targets?
+dnl Build OSS fuzzing targets?
 AC_ARG_ENABLE([ossfuzzers],
   [AS_HELP_STRING([--enable-ossfuzzers],
     [Whether to generate the fuzzers for OSS-Fuzz])],
   [have_ossfuzzers=yes], [have_ossfuzzers=no])
 AM_CONDITIONAL([USE_OSSFUZZERS], [test "x$have_ossfuzzers" = "xyes"])
 
-# Set the correct flags for the given fuzzing engine.
+dnl Set the correct flags for the given fuzzing engine.
 AC_SUBST([LIB_FUZZING_ENGINE])
 AM_CONDITIONAL([USE_OSSFUZZ_FLAG], [test "x$LIB_FUZZING_ENGINE" = "x-fsanitize=fuzzer"])
 AM_CONDITIONAL([USE_OSSFUZZ_STATIC], [test -f "$LIB_FUZZING_ENGINE"])
 
-# Checks for header files.
+dnl Checks for header files.
 AC_CHECK_HEADERS([unistd.h sys/uio.h])
 AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/ioctl.h sys/time.h])
 AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
@@ -400,7 +400,7 @@ fi
 
 AC_FUNC_ALLOCA
 
-# Checks for typedefs, structures, and compiler characteristics.
+dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 
 CURL_CHECK_NONBLOCKING_SOCKET
@@ -428,9 +428,9 @@ AM_CONDITIONAL([HAVE_WINDRES],
 
 AM_CONDITIONAL([HAVE_LIB_STATIC], [test "x$enable_static" != "xno"])
 
-# Configure parameters
+dnl Configure parameters
 
-# Append crypto lib
+dnl Append crypto lib
 if   test "$found_crypto" = "openssl"; then
   LIBS="${LIBS} ${LTLIBSSL}"
 elif test "$found_crypto" = "wolfssl"; then

--- a/configure.ac
+++ b/configure.ac
@@ -271,8 +271,8 @@ AS_HELP_STRING([--disable-hidden-symbols],[Leave all symbols with default visibi
     ;;
   *)
     AC_MSG_CHECKING([whether $CC supports it])
-    if test "$GCC" = yes ; then
-      if $CC --help --verbose 2>&1 | grep fvisibility= > /dev/null ; then
+    if test "$GCC" = yes; then
+      if $CC --help --verbose 2>&1 | grep fvisibility= > /dev/null; then
         AC_MSG_RESULT(yes)
         AC_DEFINE(LIBSSH2_API, [__attribute__ ((visibility ("default")))], [to make a symbol visible])
         CFLAGS="$CFLAGS -fvisibility=hidden"
@@ -282,7 +282,7 @@ AS_HELP_STRING([--disable-hidden-symbols],[Leave all symbols with default visibi
 
     else
       dnl Test for SunPro cc
-      if $CC 2>&1 | grep flags >/dev/null && $CC -flags | grep xldscope= >/dev/null ; then
+      if $CC 2>&1 | grep flags >/dev/null && $CC -flags | grep xldscope= >/dev/null; then
         AC_MSG_RESULT(yes)
         AC_DEFINE(LIBSSH2_API, [__global], [to make a symbol visible])
         CFLAGS="$CFLAGS -xldscope=hidden"

--- a/configure.ac
+++ b/configure.ac
@@ -279,7 +279,6 @@ AS_HELP_STRING([--disable-hidden-symbols],[Leave all symbols with default visibi
       else
          AC_MSG_RESULT(no)
        fi
-
     else
       dnl Test for SunPro cc
       if $CC 2>&1 | grep flags >/dev/null && $CC -flags | grep xldscope= >/dev/null; then

--- a/configure.ac
+++ b/configure.ac
@@ -387,7 +387,7 @@ if test "$ac_cv_func_select" != "yes"; then
     #include <winsock2.h>
     #endif
     ]], [[
-      select(0,(fd_set *)NULL,(fd_set *)NULL,(fd_set *)NULL,(struct timeval *)NULL);
+      select(0, (fd_set *)NULL, (fd_set *)NULL, (fd_set *)NULL, (struct timeval *)NULL);
     ]])],[
       AC_MSG_RESULT([yes])
       HAVE_SELECT="1"

--- a/docs/libssh2_session_banner_set.md
+++ b/docs/libssh2_session_banner_set.md
@@ -26,7 +26,7 @@ int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner);
 
 *session* - Session instance as returned by libssh2_session_init_ex(3)
 
-*banner* - A pointer to a zero-terminated string holding the user defined
+*banner* - A pointer to a null-terminated string holding the user defined
 banner
 
 Set the banner that is sent to the remote host when the SSH session is

--- a/docs/libssh2_sftp_readdir_ex.md
+++ b/docs/libssh2_sftp_readdir_ex.md
@@ -54,10 +54,10 @@ statbuf style data into.
 
 # RETURN VALUE
 
-Number of bytes actually populated into buffer (not counting the terminating
-zero), or negative on failure. It returns LIBSSH2_ERROR_EAGAIN when it would
-otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative number, it is not
-really a failure per se.
+Number of bytes actually populated into buffer (not counting the
+null-terminator), or negative on failure. It returns LIBSSH2_ERROR_EAGAIN when
+it would otherwise block. While LIBSSH2_ERROR_EAGAIN is a negative number, it
+is not really a failure per se.
 
 # BUG
 

--- a/docs/libssh2_sftp_symlink_ex.md
+++ b/docs/libssh2_sftp_symlink_ex.md
@@ -67,8 +67,8 @@ When using LIBSSH2_SFTP_SYMLINK, this function returns 0 on success or negative
 on failure.
 
 When using LIBSSH2_SFTP_READLINK or LIBSSH2_SFTP_REALPATH, it returns the
-number of bytes it copied to the target buffer (not including the terminating
-zero) or negative on failure.
+number of bytes it copied to the target buffer (not including the
+null-terminator) or negative on failure.
 
 It returns LIBSSH2_ERROR_EAGAIN when it would otherwise block. While
 LIBSSH2_ERROR_EAGAIN is a negative number, it is not really a failure per se.

--- a/scripts/badwords.txt
+++ b/scripts/badwords.txt
@@ -29,6 +29,7 @@ nul terminated:null-terminated
 null terminated:null-terminated
 NULL-terminated=null-terminated
 zero terminated:null-terminated
+zero-terminated:null-terminated
 nul terminator:null-terminator
 null terminator:null-terminator
 zero terminator:null-terminator

--- a/src/channel.c
+++ b/src/channel.c
@@ -1529,8 +1529,7 @@ int ssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
     }
 
     return ssh2_err(session, LIBSSH2_ERROR_CHANNEL_REQUEST_DENIED,
-                    "Unable to complete request for "
-                    "channel-process-startup");
+                    "Unable to complete request for channel-process-startup");
 }
 
 /*

--- a/src/channel.c
+++ b/src/channel.c
@@ -2825,8 +2825,7 @@ unsigned long libssh2_channel_window_read_ex(
  * the channel_open request
  */
 unsigned long libssh2_channel_window_write_ex(
-    LIBSSH2_CHANNEL *channel,
-    unsigned long *window_size_initial)
+    LIBSSH2_CHANNEL *channel, unsigned long *window_size_initial)
 {
     if(!channel)
         return 0; /* no channel, no window! */
@@ -2855,8 +2854,7 @@ unsigned long libssh2_channel_window_write_ex(
    this section.
  */
 static int channel_signal(LIBSSH2_CHANNEL *channel,
-                          const char *signame,
-                          size_t signame_len)
+                          const char *signame, size_t signame_len)
 {
     LIBSSH2_SESSION *session = channel->session;
     int retcode = LIBSSH2_ERROR_PROTO;

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -211,7 +211,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
             goto error;
         }
         memcpy(entry->key, key, keylen + 1);
-        entry->key[keylen] = 0; /* force a terminating zero trailer */
+        entry->key[keylen] = 0; /* force a null-terminator */
     }
     else {
         /* key is raw, we base64 encode it and store it as such */
@@ -246,7 +246,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
             goto error;
         }
         memcpy(entry->comment, comment, commentlen + 1);
-        entry->comment[commentlen] = 0; /* force a terminating zero trailer */
+        entry->comment[commentlen] = 0; /* force a null-terminator */
         entry->comment_len = commentlen;
     }
     else {

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -137,9 +137,9 @@
      gcry_md_close(ctx), 1)
 #endif
 
-#define ssh2_hmac_ctx gcry_md_hd_t
+#define ssh2_hmac_ctx         gcry_md_hd_t
 
-#define ssh2_crypto_init() gcry_control(GCRYCTL_DISABLE_SECMEM)
+#define ssh2_crypto_init()    gcry_control(GCRYCTL_DISABLE_SECMEM)
 #define ssh2_crypto_exit()
 
 #define ssh2_rsa_ctx          struct gcry_sexp
@@ -154,8 +154,8 @@
 #define ssh2_ec_key void
 #endif
 
-#define SSH2_CIPHER_T(name) int name
-#define ssh2_cipher_ctx     gcry_cipher_hd_t
+#define SSH2_CIPHER_T(name)   int name
+#define ssh2_cipher_ctx       gcry_cipher_hd_t
 
 #define CM(c, m)              (((c) << 8) | (m)) /* ciphermode */
 #define LGCR_CIPHER(c)        ((c) >> 8)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1108,8 +1108,7 @@ void ssh2_crypto_init(void)
 }
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA || LIBSSH2_ED25519
-/* TODO: Optionally call a passphrase callback specified by the
- * calling program
+/* TODO: Optionally call a passphrase callback specified by the calling program
  */
 static int passphrase_cb(char *buf, int size, int rwflag, void *passphrase)
 {

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2213,8 +2213,7 @@ static int gen_publickey_from_ed25519_openssh_priv_data(
 
     if(ret == 0) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
-                  "Computing public key from ED25519 "
-                  "private key envelope"));
+                  "Computing public key from ED25519 private key envelope"));
 
         method_buf = SSH2_ALLOC(session, 11); /* ssh-ed25519. */
         if(!method_buf) {
@@ -2343,8 +2342,7 @@ static int gen_publickey_from_sk_ed25519_openssh_priv_data(
 
     if(ret == 0) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
-                  "Computing public key from ED25519 "
-                  "private key envelope"));
+                  "Computing public key from ED25519 private key envelope"));
 
         /* sk-ssh-ed25519@openssh.com. */
         method_buf = SSH2_ALLOC(session, strlen(key_type));
@@ -4926,8 +4924,7 @@ static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
     if(rc == LIBSSH2_ERROR_FILE)
         rc = ssh2_err(session, LIBSSH2_ERROR_FILE,
                       "Unable to extract public key from private key "
-                      "file: invalid/unrecognized private key "
-                      "file format");
+                      "file: invalid/unrecognized private key file format");
 
     if(decrypted)
         ssh2_string_buf_free(session, decrypted);
@@ -4962,8 +4959,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
     if(!bp)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                        "Unable to allocate memory when"
-                        "computing public key");
+                        "Unable to allocate memory when computing public key");
     (void)BIO_reset(bp);
     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, SSH2_UNCONST(passphrase));
 #ifdef HAVE_SSLERROR_BAD_DECRYPT
@@ -4994,8 +4990,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                             "Wrong passphrase for private key");
 #endif
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
-                        "Unable to extract public key "
-                        "from private key file: "
+                        "Unable to extract public key from private key file: "
                         "Unsupported private key file format");
     }
 
@@ -5032,8 +5027,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 #endif /* LIBSSH2_ECDSA */
     default:
         st = ssh2_err(session, LIBSSH2_ERROR_FILE,
-                      "Unable to extract public key "
-                      "from private key file: "
+                      "Unable to extract public key from private key file: "
                       "Unsupported private key file format");
         break;
     }
@@ -5066,8 +5060,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
     if(!bp)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                        "Unable to allocate memory when"
-                        "computing public key");
+                        "Unable to allocate memory when computing public key");
     (void)BIO_reset(bp);
     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, SSH2_UNCONST(passphrase));
     BIO_free(bp);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2571,10 +2571,8 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
     ssh2_init_if_needed();
 
     if(read_private_key_from_memory((void **)&ctx,
-                                    (pem_read_bio_func)
-                                    &PEM_read_bio_PrivateKey,
-                                    filedata, filedata_len,
-                                    passphrase) == 0) {
+                                   (pem_read_bio_func)&PEM_read_bio_PrivateKey,
+                                    filedata, filedata_len, passphrase) == 0) {
         if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
             ssh2_ed25519_free(ctx);
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,

--- a/src/packet.c
+++ b/src/packet.c
@@ -736,8 +736,7 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                                        "unexpected packet type");
 
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_DISCONNECT,
-                            "strict KEX violation: "
-                            "unexpected packet type");
+                            "strict KEX violation: unexpected packet type");
         }
     }
 

--- a/src/scp.c
+++ b/src/scp.c
@@ -124,7 +124,7 @@
   https://www.grymoire.com/Unix/Csh.html#toc-uh-10
 
   Return value:
-  Length of the resulting string (not counting the terminating '\0'),
+  Length of the resulting string (not counting the null-terminator),
   or 0 in case of errors, e.g. result buffer too small
 
   Note: this function could possible be used elsewhere within libssh2, but

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -2052,7 +2052,6 @@ int libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle,
  *   Introduce an option that disables this sort of "speculative" ahead writing
  *   as there is a risk that it does harm to some app.
  */
-
 static ssize_t sftp_write(LIBSSH2_SFTP_HANDLE *handle, const char *buffer,
                           size_t count)
 {

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -86,10 +86,8 @@
 #define SSH_FXP_EXTENDED                        200
 #define SSH_FXP_EXTENDED_REPLY                  201
 
-/* S_IFREG */
-#define SSH2_SFTP_ATTR_PFILETYPE_FILE           0100000
-/* S_IFDIR */
-#define SSH2_SFTP_ATTR_PFILETYPE_DIR            0040000
+#define SSH2_SFTP_ATTR_PFILETYPE_FILE           0100000  /* S_IFREG */
+#define SSH2_SFTP_ATTR_PFILETYPE_DIR            0040000  /* S_IFDIR */
 
 #define SSH_FXE_STATVFS_ST_RDONLY               0x00000001
 #define SSH_FXE_STATVFS_ST_NOSUID               0x00000002

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -2441,8 +2441,7 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
     }
 
     rc = sftp_packet_requirev(sftp, 2, fstat_responses,
-                              sftp->fstat_request_id, &data,
-                              &data_len, 9);
+                              sftp->fstat_request_id, &data, &data_len, 9);
     if(rc == LIBSSH2_ERROR_EAGAIN)
         return (int)rc;
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
@@ -2922,8 +2921,7 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
     }
 
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
-                             sftp->rename_request_id, &data,
-                             &data_len, 9);
+                             sftp->rename_request_id, &data, &data_len, 9);
     if(rc == LIBSSH2_ERROR_EAGAIN) {
         return (int)rc;
     }
@@ -3197,7 +3195,6 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
 
     rc = sftp_packet_requirev(sftp, 2, responses, sftp->fstatvfs_request_id,
                               &data, &data_len, 9);
-
     if(rc == LIBSSH2_ERROR_EAGAIN) {
         return (int)rc;
     }

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -3821,7 +3821,6 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
 
     if(link_type == LIBSSH2_SFTP_SYMLINK) {
 
-        /* FIXME: possible incorrect/impossible bounds checks: */
         if((target_len + 4) < target_len ||
            (packet_len + 4 + target_len) < packet_len) {
             return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -130,8 +130,8 @@ static void remove_zombie_request(LIBSSH2_SFTP *sftp, uint32_t request_id)
                                                               request_id);
     if(zombie) {
         ssh2_deb((session, LIBSSH2_TRACE_SFTP,
-                  "Removing request ID %u from the list of "
-                  "zombie requests", request_id));
+                  "Removing request ID %u from the list of zombie requests",
+                  request_id));
 
         ssh2_list_remove(&zombie->node);
         SSH2_FREE(session, zombie);
@@ -852,8 +852,8 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         session->sftpInit_sent = 0; /* nothing's sent yet */
 
         ssh2_deb((session, LIBSSH2_TRACE_SFTP,
-                  "Sending FXP_INIT packet advertising "
-                  "version %d support", (int)LIBSSH2_SFTP_VERSION));
+                  "Sending FXP_INIT packet advertising version %d support",
+                  (int)LIBSSH2_SFTP_VERSION));
 
         session->sftpInit_state = ssh2_NB_state_sent2;
     }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1895,8 +1895,7 @@ retry_auth:
                               &session->userauth_pblc_packet_requirev_state);
     if(rc == LIBSSH2_ERROR_EAGAIN) {
         return ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
-                        "Would block waiting for publickey "
-                        "USERAUTH response");
+                        "Would block waiting for publickey USERAUTH response");
     }
     else if(rc || session->userauth_pblc_data_len < 1) {
         session->userauth_pblc_state = ssh2_NB_state_idle;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -404,24 +404,15 @@ typedef enum {
 } wcng_ecc_keytype;
 
 struct ecdsa_algorithm {
-    /* Algorithm name */
-    const char *name;
-
-    /* Key length, in bits */
-    ULONG key_length;
-
-    /* Length of each point, in bytes */
-    ULONG point_length;
-
-    /* Name of CNG algorithm provider, */
-    /* indexed by wcng_ecc_keytype */
-    LPCWSTR provider[2];
-
-    /* Magic for public key import, indexed by wcng_ecc_keytype */
-    ULONG public_import_magic[2];
-
-    /* Magic for private key import, indexed by wcng_ecc_keytype */
-    ULONG private_import_magic[2];
+    const char *name;               /* Algorithm name */
+    ULONG key_length;               /* Key length, in bits */
+    ULONG point_length;             /* Length of each point, in bytes */
+    LPCWSTR provider[2];            /* Name of CNG algorithm provider,
+                                       indexed by wcng_ecc_keytype */
+    ULONG public_import_magic[2];   /* Magic for public key import,
+                                       indexed by wcng_ecc_keytype */
+    ULONG private_import_magic[2];  /* Magic for private key import,
+                                       indexed by wcng_ecc_keytype */
 };
 
 /* Supported algorithms, indexed by ssh2_curve_type */
@@ -2482,12 +2473,9 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
  * Verifies the ECDSA signature of a hashed message
  */
 int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *key,
-                      IN const unsigned char *r,
-                      IN size_t r_len,
-                      IN const unsigned char *s,
-                      IN size_t s_len,
-                      IN const unsigned char *m,
-                      IN size_t m_len)
+                      IN const unsigned char *r, IN size_t r_len,
+                      IN const unsigned char *s, IN size_t s_len,
+                      IN const unsigned char *m, IN size_t m_len)
 {
     int result = LIBSSH2_ERROR_NONE;
     NTSTATUS status;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1978,9 +1978,9 @@ static int wcng_publickey_from_point(IN wcng_ecc_keytype keytype,
         wcng_ecdsa_algs[point->curve].public_import_magic[keytype];
 
     /** Copy x, y */
-    memcpy((PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB),
+    memcpy((char *)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB),
            point->x, point->x_len);
-    memcpy((PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB) + point->x_len,
+    memcpy((char *)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB) + point->x_len,
            point->y, point->y_len);
 
     status = BCryptImportKeyPair(
@@ -2044,11 +2044,11 @@ static int wcng_privatekey_from_point(IN wcng_ecc_keytype keytype,
         wcng_ecdsa_algs[q->curve].private_import_magic[keytype];
 
     /* Copy x, y, d */
-    memcpy((PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB),
+    memcpy((char *)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB),
            q->x, q->x_len);
-    memcpy((PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB) + q->x_len,
+    memcpy((char *)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB) + q->x_len,
            q->y, q->y_len);
-    memcpy((PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB) + q->x_len + q->y_len,
+    memcpy((char *)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB) + q->x_len + q->y_len,
            d, d_len);
 
     status = BCryptImportKeyPair(


### PR DESCRIPTION
- configure: use `dnl`-style comments consistently (where possible).
- configure: drop stray spaces.
- wincng: replace Windows-specific type in `memcpy()` casts.
- drop FIXME added incorrectly in a recent commit.
  Follow-up to ecf39b36345f8baff670a5e0847dc22585b27743 #1984
  Follow-up to ff50682c238875ebef8601c0d6bc2105600422e8 #1679
- replace more synonyms with 'null-terminated'.
- unfold strings, comments and code lines.
- reflow lines, fix indent.

---

https://github.com/libssh2/libssh2/pull/1995/files?w=1
