### PR TITLE
src: fix stray `fprintf()` calls, make checksrc verify

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ DISTCLEANFILES =
 
 VMSFILES = vms/libssh2_make_example.dcl vms/libssh2_make_help.dcl \
   vms/libssh2_make_kit.dcl vms/libssh2_make_lib.dcl vms/man2help.c \
-  vms/readme.vms vms/libssh2_config.h
+  vms/readme.vms vms/libssh2_config.h vms/.checksrc
 
 WIN32FILES = src/libssh2.rc
 

--- a/example/.checksrc
+++ b/example/.checksrc
@@ -1,0 +1,4 @@
+# Copyright (C) The libssh2 project and its contributors.
+# SPDX-License-Identifier: BSD-3-Clause
+
+allowfunc fprintf

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 AUTOMAKE_OPTIONS = foreign nostdinc
 
-EXTRA_DIST = CMakeLists.txt
+EXTRA_DIST = .checksrc CMakeLists.txt
 
 # Get noinst_PROGRAMS variable
 include Makefile.inc

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -20,7 +20,6 @@ my @options = (
     "-aCreateFileA",
     "-afclose",
     "-afopen",
-    "-afprintf",
     "-afree",
     "-afstat",
     "-amalloc",
@@ -60,7 +59,7 @@ my $anyfailed = 0;
 for my $dir (@dirs) {
     if($is_git) {
         @files = ();
-        open(O, '-|', 'git', 'ls-files', "$dir/*.[ch]") || die; push @files, <O>; close(O);
+        open(O, '-|', 'git', 'ls-files', ":(glob)$dir/*.[ch]") || die; push @files, <O>; close(O);
         chomp(@files);
     }
     else {

--- a/src/misc.c
+++ b/src/misc.c
@@ -607,6 +607,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         (session->tracehandler)(session, session->tracehandler_context, buffer,
                                 msglen);
     else
+        /* !checksrc! disable BANNEDFUNC 1 */
         fprintf(stderr, "%s\n", buffer);
 }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -85,8 +85,9 @@ int ssh2_err_flags(LIBSSH2_SESSION *session, int errcode,
                    const char *errmsg, int errflags)
 {
     if(!session) {
-        if(errmsg)
-            fprintf(stderr, "Session is NULL, error: %s\n", errmsg);
+        ssh2_deb((session, LIBSSH2_TRACE_ERROR,
+                 "ssh2_err_flags: session is NULL, error: %s",
+                 errmsg ? errmsg : "<null>"));
         return errcode;
     }
 

--- a/src/session.c
+++ b/src/session.c
@@ -711,7 +711,8 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
     int rc;
 
     if(!session) {
-        fprintf(stderr, "Session is NULL, error: %i\n", LIBSSH2_ERROR_PROTO);
+        ssh2_deb((session, LIBSSH2_TRACE_TRANS,
+                  "session_startup: session is NULL"));
         return LIBSSH2_ERROR_PROTO;
     }
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -74,6 +74,7 @@ static void debugdump(LIBSSH2_SESSION *session,
         (session->tracehandler)(session, session->tracehandler_context,
                                 buffer, used);
     else
+        /* !checksrc! disable BANNEDFUNC 1 */
         fprintf(stderr, "%s", buffer);
 
     for(i = 0; i < size; i += width) {
@@ -109,6 +110,7 @@ static void debugdump(LIBSSH2_SESSION *session,
             (session->tracehandler)(session, session->tracehandler_context,
                                     buffer, used);
         else
+            /* !checksrc! disable BANNEDFUNC 1 */
             fprintf(stderr, "%s\n", buffer);
     }
 }

--- a/tests/.checksrc
+++ b/tests/.checksrc
@@ -1,0 +1,4 @@
+# Copyright (C) The libssh2 project and its contributors.
+# SPDX-License-Identifier: BSD-3-Clause
+
+allowfunc fprintf

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -59,6 +59,7 @@ librunner_la_SOURCES = \
   openssh_fixture.c openssh_fixture.h
 
 EXTRA_DIST = \
+  .checksrc \
   CMakeLists.txt \
   key_dsa \
   key_dsa.pub \

--- a/vms/.checksrc
+++ b/vms/.checksrc
@@ -1,0 +1,4 @@
+# Copyright (C) The libssh2 project and its contributors.
+# SPDX-License-Identifier: BSD-3-Clause
+
+allowfunc fprintf


### PR DESCRIPTION
Replace with `ssh2_deb()`.

Also:
- adjust checksrc options to verify.
- checksrc-all.pl: fix an issue preventing picking up `tests/.checksrc`.

Follow-up to c090b696c6b4aa3dd9d2c34b7a6db258c36e8d4b #1556
Follow-up to af1e591eeec4fbb47e1e050a562d5d5237d3c563 #796
