### PR TITLE
checksrc: extend to ossfuzz, reduce scope of exceptions

### DIFF
--- a/example/.checksrc
+++ b/example/.checksrc
@@ -5,3 +5,4 @@ allowfunc accept
 allowfunc atoi
 allowfunc fprintf
 allowfunc fstat
+allowfunc printf

--- a/example/.checksrc
+++ b/example/.checksrc
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 allowfunc accept
+allowfunc atoi
 allowfunc fprintf

--- a/example/.checksrc
+++ b/example/.checksrc
@@ -1,4 +1,5 @@
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
+allowfunc accept
 allowfunc fprintf

--- a/example/.checksrc
+++ b/example/.checksrc
@@ -8,3 +8,4 @@ allowfunc fstat
 allowfunc printf
 allowfunc recv
 allowfunc send
+allowfunc strdup

--- a/example/.checksrc
+++ b/example/.checksrc
@@ -6,3 +6,5 @@ allowfunc atoi
 allowfunc fprintf
 allowfunc fstat
 allowfunc printf
+allowfunc recv
+allowfunc send

--- a/example/.checksrc
+++ b/example/.checksrc
@@ -4,3 +4,4 @@
 allowfunc accept
 allowfunc atoi
 allowfunc fprintf
+allowfunc fstat

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -23,7 +23,6 @@ my @options = (
     "-asnprintf",
     "-asocket",
     "-astrdup",
-    "-astrtok",
 );
 
 my @files;

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -13,7 +13,6 @@ use Cwd 'abs_path';
 my @options = (
     "-i4", "-m79",
     "-AFIXME", "-AERRNOVAR",
-    "-aatoi",
     "-acalloc",
     "-aclose",
     "-aCreateFileA",

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -25,7 +25,6 @@ my @options = (
     "-astrdup",
     "-astrtok",
     "-astrtol",
-    "-avsnprintf",
 );
 
 my @files;

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -20,8 +20,6 @@ my @options = (
     "-afree",
     "-amalloc",
     "-arealloc",
-    "-arecv",
-    "-asend",
     "-asnprintf",
     "-asocket",
     "-asocketpair",

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -18,7 +18,6 @@ my @options = (
     "-afclose",
     "-afopen",
     "-afree",
-    "-afstat",
     "-amalloc",
     "-aprintf",
     "-arealloc",

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -24,7 +24,6 @@ my @options = (
     "-asocket",
     "-astrdup",
     "-astrtok",
-    "-astrtol",
 );
 
 my @files;

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -22,7 +22,6 @@ my @options = (
     "-arealloc",
     "-asnprintf",
     "-asocket",
-    "-asocketpair",
     "-astrdup",
     "-astrtok",
     "-astrtol",
@@ -32,7 +31,7 @@ my @options = (
 my @files;
 my $is_git = 0;
 if(system('git rev-parse --is-inside-work-tree >/dev/null 2>&1') == 0) {
-    open(O, '-|', 'git', 'ls-files', '*.[ch]') || die; push @files, <O>; close(O);
+    open(O, '-|', 'git', 'ls-files', '*.[ch]', '*.cc') || die; push @files, <O>; close(O);
     $is_git = 1;
 }
 else {
@@ -52,7 +51,7 @@ my $anyfailed = 0;
 for my $dir (@dirs) {
     if($is_git) {
         @files = ();
-        open(O, '-|', 'git', 'ls-files', ":(glob)$dir/*.[ch]") || die; push @files, <O>; close(O);
+        open(O, '-|', 'git', 'ls-files', ":(glob)$dir/*.[ch]", ":(glob)$dir/*.cc") || die; push @files, <O>; close(O);
         chomp(@files);
     }
     else {

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -19,7 +19,6 @@ my @options = (
     "-afopen",
     "-afree",
     "-amalloc",
-    "-aprintf",
     "-arealloc",
     "-arecv",
     "-asend",

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -22,7 +22,6 @@ my @options = (
     "-arealloc",
     "-asnprintf",
     "-asocket",
-    "-astrdup",
 );
 
 my @files;

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -13,7 +13,6 @@ use Cwd 'abs_path';
 my @options = (
     "-i4", "-m79",
     "-AFIXME", "-AERRNOVAR",
-    "-aaccept",
     "-aatoi",
     "-acalloc",
     "-aclose",

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -15,7 +15,6 @@ my @options = (
     "-AFIXME", "-AERRNOVAR",
     "-acalloc",
     "-aclose",
-    "-aCreateFileA",
     "-afclose",
     "-afopen",
     "-afree",

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -35,10 +35,10 @@ if(system('git rev-parse --is-inside-work-tree >/dev/null 2>&1') == 0) {
     $is_git = 1;
 }
 else {
-    find(sub { if(/\.[ch]$/) { push(@files, $File::Find::name) } }, ('.'));
+    find(sub { if(/\.([ch]|cc)$/) { push(@files, $File::Find::name) } }, ('.'));
 }
 if(@ARGV) {
-    find(sub { if(/\.[ch]$/) { push(@files, $File::Find::name) } }, @ARGV);
+    find(sub { if(/\.([ch]|cc)$/) { push(@files, $File::Find::name) } }, @ARGV);
 }
 
 @files = grep !/\/CMakeFiles\//, @files;
@@ -55,7 +55,7 @@ for my $dir (@dirs) {
         chomp(@files);
     }
     else {
-        @files = glob("$dir/*.[ch]");
+        @files = glob("$dir/*.[ch] $dir/*.cc");
     }
     if(@files && system("$scripts_dir/checksrc.pl", @options, @files) != 0) {
         $anyfailed = 1;

--- a/src/agent.c
+++ b/src/agent.c
@@ -260,6 +260,7 @@ static int agent_connect_openssh(LIBSSH2_AGENT *agent)
          * uncomment the following line to enable support within the Win32
          * OpenSSH code.
          */
+        /* !checksrc! disable BANNEDFUNC 1 */
         pipe = CreateFileA(path, GENERIC_READ | GENERIC_WRITE, 0, NULL,
                            OPEN_EXISTING,
                            /* FILE_FLAG_OVERLAPPED | */

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -570,6 +570,7 @@ static void report(uint32_t data[], uint16_t len)
 {
     int i;
     for(i = 0; i < len; i += 2)
+        /* !checksrc! disable BANNEDFUNC 1 */
         printf("Block %d: 0x%08lx 0x%08lx.\n",
                i / 2, (unsigned long)data[i], (unsigned long)data[i + 1]);
 }
@@ -593,15 +594,18 @@ int main(void)
     blf_enc(&c, data, 5);
     blf_dec(&c, data, 1);
     blf_dec(&c, data + 2, 4);
+    /* !checksrc! disable BANNEDFUNC 1 */
     printf("Should read as 0 - 9.\n");
     report(data, 10);
 
     /* Second test */
     blf_key(&c, (uint8_t *)key2, (uint16_t)strlen(key2));
     blf_enc(&c, data2, 1);
+    /* !checksrc! disable BANNEDFUNC 1 */
     printf("\nShould read as: 0x324ed0fe 0xf413a203.\n");
     report(data2, 2);
     blf_dec(&c, data2, 1);
+    /* !checksrc! disable BANNEDFUNC 1 */
     printf("\nShould read as: 0x424c4f57 0x46495348.\n");
     report(data2, 2);
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -75,6 +75,7 @@ int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
     if(cp_max_len < 2)
         return 0;
     va_start(args, fmt);
+    /* !checksrc! disable BANNEDFUNC 1 */
     n = vsnprintf(cp, cp_max_len, fmt, args);
     va_end(args);
     return (n < (int)cp_max_len) ? n : (int)(cp_max_len - 1);
@@ -595,6 +596,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
+        /* !checksrc! disable BANNEDFUNC 1 */
         len = vsnprintf(buffer + msglen, buflen, format, vargs);
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop

--- a/src/scp.c
+++ b/src/scp.c
@@ -528,6 +528,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
 
                 *(p++) = '\0';
                 /* Make sure we do not get fooled by leftover values */
+                /* !checksrc! disable BANNEDFUNC 1 */
                 session->scpRecv_mtime = strtol((char *)s, NULL, 10);
 
                 s = (unsigned char *)strchr((char *)p, ' ');
@@ -552,6 +553,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
 
                 *p = '\0';
                 /* Make sure we do not get fooled by leftover values */
+                /* !checksrc! disable BANNEDFUNC 1 */
                 session->scpRecv_atime = strtol((char *)s, NULL, 10);
 
                 /* SCP ACK */
@@ -682,6 +684,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
 
                 *(p++) = '\0';
                 /* Make sure we do not get fooled by leftover values */
+                /* !checksrc! disable BANNEDFUNC 1 */
                 session->scpRecv_mode = strtol(s, &e, 8);
                 if(e && *e) {
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -972,6 +972,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
             }
             memcpy(extversion_str, extdata, extdata_len);
             extversion_str[extdata_len] = '\0';
+            /* !checksrc! disable BANNEDFUNC 1 */
             extversion = (uint32_t)strtol(extversion_str, NULL, 10);
             SSH2_FREE(session, extversion_str);
         }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1348,10 +1348,12 @@ static int is_version_less_than_78(const char *version)
     if(!version)
         return 0;
 
+    /* !checksrc! disable BANNEDFUNC 1 */
     major = strtol(version, &endptr_major, 10);
     if(!endptr_major || *endptr_major != '.')
         return 0; /* Not a valid number */
 
+    /* !checksrc! disable BANNEDFUNC 1 */
     minor = strtol(endptr_major + 1, &endptr_minor, 10);
     if(!endptr_minor || endptr_minor == endptr_major + 1)
         return 0; /* Not a valid number */

--- a/tests/.checksrc
+++ b/tests/.checksrc
@@ -3,3 +3,4 @@
 
 allowfunc fprintf
 allowfunc printf
+allowfunc vsnprintf

--- a/tests/.checksrc
+++ b/tests/.checksrc
@@ -1,6 +1,7 @@
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
+allowfunc atoi
 allowfunc fprintf
 allowfunc printf
 allowfunc vsnprintf

--- a/tests/.checksrc
+++ b/tests/.checksrc
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 allowfunc fprintf
+allowfunc printf

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -32,8 +32,11 @@ int main(int argc, char **argv)
         crypto_str = "(unrecognized)";
     }
 
-    printf("libssh2 test: |%s|%s|%s|\n", argv[0],
-                                         libssh2_version(0), crypto_str);
+    puts("libssh2 test:");
+    puts(argv[0]);
+    puts(libssh2_version(0));
+    puts(crypto_str);
+    puts("---");
 
     return 0;
 }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -54,7 +54,7 @@
 #endif
 
 #include <stdio.h>
-#include <stdlib.h>
+#include <stdlib.h>  /* for atoi() */
 #include <stdarg.h>
 #include <ctype.h>
 
@@ -413,7 +413,7 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     }
 
     sin.sin_family = AF_INET;
-    sin.sin_port = htons((unsigned short)strtol(port_string, NULL, 0));
+    sin.sin_port = htons(atoi(port_string));
     sin.sin_addr.s_addr = hostaddr;
 
     for(counter = 0; counter < 3; ++counter) {

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -413,7 +413,7 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     }
 
     sin.sin_family = AF_INET;
-    sin.sin_port = htons(atoi(port_string));
+    sin.sin_port = htons((unsigned short)atoi(port_string));
     sin.sin_addr.s_addr = hostaddr;
 
     for(counter = 0; counter < 3; ++counter) {

--- a/tests/ossfuzz/.checksrc
+++ b/tests/ossfuzz/.checksrc
@@ -1,0 +1,7 @@
+# Copyright (C) The libssh2 project and its contributors.
+# SPDX-License-Identifier: BSD-3-Clause
+
+allowfunc fprintf
+allowfunc printf
+allowfunc send
+allowfunc socketpair

--- a/tests/ossfuzz/Makefile.am
+++ b/tests/ossfuzz/Makefile.am
@@ -34,4 +34,4 @@ ssh2_client_fuzzer_LDFLAGS = $(AM_LDFLAGS) -static
 libstandaloneengine_a_SOURCES = standaloneengine.cc
 libstandaloneengine_a_CXXFLAGS = $(AM_CXXFLAGS)
 
-EXTRA_DIST = CMakeLists.txt ossfuzz.sh
+EXTRA_DIST = .checksrc CMakeLists.txt ossfuzz.sh

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -8,7 +8,7 @@
 #include "runner.h"
 #include "openssh_fixture.h"
 
-#include <stdlib.h>  /* for getenv() */
+#include <stdlib.h>  /* for atoi(), getenv() */
 
 /* set in Dockerfile */
 static const char *username = "libssh2";
@@ -81,7 +81,7 @@ int test(LIBSSH2_SESSION *session)
 
     env = getenv("FIXTURE_XFER_COUNT");
     if(env) {
-        xfer_count = (unsigned long)strtol(env, NULL, 0);
+        xfer_count = (unsigned long)atoi(env);
         fprintf(stderr, "Custom xfer_count: %lu\n", xfer_count);
     }
 

--- a/vms/.checksrc
+++ b/vms/.checksrc
@@ -4,4 +4,5 @@
 allowfunc atoi
 allowfunc fprintf
 allowfunc printf
+allowfunc strdup
 allowfunc strtok

--- a/vms/.checksrc
+++ b/vms/.checksrc
@@ -1,4 +1,5 @@
 # Copyright (C) The libssh2 project and its contributors.
 # SPDX-License-Identifier: BSD-3-Clause
 
+allowfunc atoi
 allowfunc fprintf

--- a/vms/.checksrc
+++ b/vms/.checksrc
@@ -4,3 +4,4 @@
 allowfunc atoi
 allowfunc fprintf
 allowfunc printf
+allowfunc strtok

--- a/vms/.checksrc
+++ b/vms/.checksrc
@@ -3,3 +3,4 @@
 
 allowfunc atoi
 allowfunc fprintf
+allowfunc printf


### PR DESCRIPTION
Replace a few calls in tests to reduce exceptions.
