### PR TITLE
 tidy-up: miscellaneous

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -697,7 +697,7 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
                       struct list_node *entry)
 {
     /* 'after' is next to 'entry' */
-    bentry->next = after;
+    entry->next = after;
 
     /* entry's prev is then made to be the prev after current has */
     entry->prev = after->prev;

--- a/src/misc.c
+++ b/src/misc.c
@@ -246,9 +246,9 @@ libssh2_uint64_t ssh2_ntohu64(const unsigned char *buf)
 void ssh2_htonu32(unsigned char *buf, uint32_t value)
 {
     buf[0] = (unsigned char)((value >> 24) & 0xFF);
-    buf[1] = (value >> 16) & 0xFF;
-    buf[2] = (value >> 8) & 0xFF;
-    buf[3] = value & 0xFF;
+    buf[1] = (unsigned char)((value >> 16) & 0xFF);
+    buf[2] = (unsigned char)((value >> 8) & 0xFF);
+    buf[3] = (unsigned char)(value & 0xFF);
 }
 
 void ssh2_store_u32(unsigned char **buf, uint32_t value)

--- a/src/misc.c
+++ b/src/misc.c
@@ -694,7 +694,7 @@ void ssh2_list_remove(struct list_node *entry)
 #if 0
 /* insert a node before the given 'after' entry */
 void ssh2_list_insert(struct list_node *after, /* insert before this */
-                          struct list_node *entry)
+                      struct list_node *entry)
 {
     /* 'after' is next to 'entry' */
     bentry->next = after;

--- a/src/misc.c
+++ b/src/misc.c
@@ -820,7 +820,6 @@ void ssh2_string_buf_free(LIBSSH2_SESSION *session, struct string_buf *buf)
         SSH2_FREE(session, buf->data);
 
     SSH2_FREE(session, buf);
-    buf = NULL;
 }
 
 int ssh2_get_byte(struct string_buf *buf, unsigned char *out)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -325,12 +325,11 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     if(EVP_PKEY_fromdata_init(ctx) > 0) {
         ret = EVP_PKEY_fromdata(ctx, rsa, EVP_PKEY_KEYPAIR, params);
     }
+
     if(nbuf)
         OPENSSL_clear_free(nbuf, nlen);
-
     if(ebuf)
         OPENSSL_clear_free(ebuf, elen);
-
     if(dbuf)
         OPENSSL_clear_free(dbuf, dlen);
 

--- a/src/session.c
+++ b/src/session.c
@@ -1658,8 +1658,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                        ((fds[i].revents & LIBSSH2_POLLFD_POLLIN) == 0)) {
                         /* Not yet known to be ready for read */
                         fds[i].revents |=
-                            libssh2_poll_channel_read(fds[i].fd.channel,
-                                                      0) ?
+                            libssh2_poll_channel_read(fds[i].fd.channel, 0) ?
                             LIBSSH2_POLLFD_POLLIN : 0;
                     }
                     if((fds[i].events & LIBSSH2_POLLFD_POLLEXT) &&
@@ -1667,8 +1666,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                        ((fds[i].revents & LIBSSH2_POLLFD_POLLEXT) == 0)) {
                         /* Not yet known to be ready for extended read */
                         fds[i].revents |=
-                            libssh2_poll_channel_read(fds[i].fd.channel,
-                                                      1) ?
+                            libssh2_poll_channel_read(fds[i].fd.channel, 1) ?
                             LIBSSH2_POLLFD_POLLEXT : 0;
                     }
                     if((fds[i].events & LIBSSH2_POLLFD_POLLOUT) &&
@@ -1736,8 +1734,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                 switch(fds[i].type) {
                 case LIBSSH2_POLLFD_SOCKET:
                     fds[i].revents = sockets[i].revents;
-                    sockets[i].revents = 0; /* In case we loop again, be
-                                               nice */
+                    sockets[i].revents = 0; /* Be nice in case we loop again */
                     if(fds[i].revents) {
                         active_fds++;
                     }
@@ -1745,8 +1742,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                 case LIBSSH2_POLLFD_CHANNEL:
                     if(sockets[i].events & POLLIN) {
                         /* Spin session until no data available */
-                        while(ssh2_transport_read(fds[i].fd.
-                                                      channel->session)
+                        while(ssh2_transport_read(fds[i].fd.channel->session)
                               > 0);
                     }
                     if(sockets[i].revents & POLLHUP) {
@@ -1759,8 +1755,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                 case LIBSSH2_POLLFD_LISTENER:
                     if(sockets[i].events & POLLIN) {
                         /* Spin session until no data available */
-                        while(ssh2_transport_read(fds[i].fd.
-                                                      listener->session)
+                        while(ssh2_transport_read(fds[i].fd.listener->session)
                               > 0);
                     }
                     if(sockets[i].revents & POLLHUP) {
@@ -1818,8 +1813,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                     if(FD_ISSET(fds[i].fd.channel->session->socket_fd,
                                 &rfds)) {
                         /* Spin session until no data available */
-                        while(ssh2_transport_read(fds[i].fd.
-                                                      channel->session)
+                        while(ssh2_transport_read(fds[i].fd.channel->session)
                               > 0);
                     }
                     break;
@@ -1828,8 +1822,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                     if(FD_ISSET(fds[i].fd.listener->session->socket_fd,
                                 &rfds)) {
                         /* Spin session until no data available */
-                        while(ssh2_transport_read(fds[i].fd.
-                                                      listener->session)
+                        while(ssh2_transport_read(fds[i].fd.listener->session)
                               > 0);
                     }
                     break;

--- a/src/session.c
+++ b/src/session.c
@@ -1676,7 +1676,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                        ((fds[i].revents & LIBSSH2_POLLFD_POLLOUT) == 0)) {
                         /* Not yet known to be ready for write */
                         fds[i].revents |=
-                            poll_channel_write(fds[i].fd. channel) ?
+                            poll_channel_write(fds[i].fd.channel) ?
                             LIBSSH2_POLLFD_POLLOUT : 0;
                     }
                     if(fds[i].fd.channel->remote.close ||
@@ -1697,7 +1697,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                        ((fds[i].revents & LIBSSH2_POLLFD_POLLIN) == 0)) {
                         /* No connections known of yet */
                         fds[i].revents |=
-                            poll_listener_queued(fds[i].fd. listener) ?
+                            poll_listener_queued(fds[i].fd.listener) ?
                             LIBSSH2_POLLFD_POLLIN : 0;
                     }
                     if(fds[i].fd.listener->session->socket_state ==

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -2,14 +2,11 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <assert.h>
 #include <errno.h>
-#include <stdbool.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
 #include <libssh2.h>
 #include "testinput.h"
 

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -7,7 +7,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <libssh2.h>
+#include "libssh2.h"
 #include "testinput.h"
 
 #define FUZZ_ASSERT(COND)                                      \

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -213,7 +213,7 @@ int test(LIBSSH2_SESSION *session)
         }
     }
     else {
-        fprintf(stderr, "Unexpected type of hostkey: %i\n", type);
+        fprintf(stderr, "Unexpected type of hostkey: %d\n", type);
         return 1;
     }
 

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -6,7 +6,7 @@
  */
 
 #include "libssh2_setup.h"
-#include <libssh2.h>
+#include "libssh2.h"
 
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>


### PR DESCRIPTION
- tests: replace include `<libssh2.h>` with `"libssh2.h"`.
- tests/test_hostkey_hash: replace stray `%i` printf masks with `%d`.
- misc: drop redundant NULL assignment in `ssh2_string_buf_free()`.
- misc: add casts for consistency in `ssh2_ntohu64()`.
- ssh2_client_fuzzer.cc: drop redundant/unused includes.
- fix typos in comment.
- unfold lines.
