### PR TITLE
GHA/appveyor_docker: silence zizmor with settings allowing concurrency

### DIFF
--- a/.github/workflows/appveyor_docker.yml
+++ b/.github/workflows/appveyor_docker.yml
@@ -42,6 +42,10 @@ name: 'AppVeyor Docker Bridge'
       ssh_privkey:
         required: true
 
+concurrency:
+  group: ${{ github.run_id }}
+  cancel-in-progress: false
+
 permissions: {}
 
 env:

--- a/.github/workflows/appveyor_docker.yml
+++ b/.github/workflows/appveyor_docker.yml
@@ -44,7 +44,6 @@ name: 'AppVeyor Docker Bridge'
 
 concurrency:
   group: ${{ github.run_id }}
-  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/appveyor_docker.yml
+++ b/.github/workflows/appveyor_docker.yml
@@ -44,7 +44,7 @@ name: 'AppVeyor Docker Bridge'
 
 concurrency:
   group: ${{ github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions: {}
 


### PR DESCRIPTION
Put each invocation in its own concurrency group, via `run_id`.

Silencing:
```
help[concurrency-limits]: insufficient job-level concurrency limits
  --> .github/workflows/appveyor_docker.yml:29:1
   |
29 | / 'on':
30 | |   workflow_dispatch:
31 | |     inputs:
32 | |       ssh_host:
...  |
42 | |       ssh_privkey:
43 | |         required: true
   | |______________________^ workflow is missing concurrency setting
...
52 |       name: 'Daemon'
   |       -------------- job affected by missing workflow concurrency
   |
   = note: audit confidence → High
   = help: audit documentation → https://docs.zizmor.sh/audits/#concurrency-limits
```
Ref: https://github.com/libssh2/libssh2/actions/runs/27208823858/job/80331881952?pr=2001#step:5:18

Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
Follow-up to 90497ad70a10aabfe6e96995c9f3fdfc21f390c7
Follow-up to b08cfbc99fa4df3459db4e1ccf4263fd260e9b15 #1292

---

Would this work to allow parallel runs?