### PR TITLE
openssl: refactor static function names, move to `ossl_` namespace

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -184,32 +184,32 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 #endif
 }
 
-static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
-                                          void **key_ctx,
-                                          const char *key_type,
-                                          unsigned char **method,
-                                          size_t *method_len,
-                                          unsigned char **pubkeydata,
-                                          size_t *pubkeydata_len,
-                                          const char *privatekeydata,
-                                          size_t privatekeydata_len,
-                                          const unsigned char *passphrase);
+static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
+                                      void **key_ctx,
+                                      const char *key_type,
+                                      unsigned char **method,
+                                      size_t *method_len,
+                                      unsigned char **pubkeydata,
+                                      size_t *pubkeydata_len,
+                                      const char *privatekeydata,
+                                      size_t privatekeydata_len,
+                                      const unsigned char *passphrase);
 
-static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
-                                        void **key_ctx,
-                                        const char *key_type,
-                                        unsigned char **method,
-                                        size_t *method_len,
-                                        unsigned char **pubkeydata,
-                                        size_t *pubkeydata_len,
-                                        int *algorithm,
-                                        unsigned char *flags,
-                                        const char **application,
-                                        const unsigned char **key_handle,
-                                        size_t *handle_len,
-                                        const char *privatekeydata,
-                                        size_t privatekeydata_len,
-                                        const unsigned char *passphrase);
+static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
+                                         void **key_ctx,
+                                         const char *key_type,
+                                         unsigned char **method,
+                                         size_t *method_len,
+                                         unsigned char **pubkeydata,
+                                         size_t *pubkeydata_len,
+                                         int *algorithm,
+                                         unsigned char *flags,
+                                         const char **application,
+                                         const unsigned char **key_handle,
+                                         size_t *handle_len,
+                                         const char *privatekeydata,
+                                         size_t privatekeydata_len,
+                                         const unsigned char *passphrase);
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
 static unsigned char *ossl_write_bn(unsigned char *buf, const BIGNUM *bn,
@@ -1142,18 +1142,18 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 #endif
     BIO_free(bp);
     if(!*rsa)
-        rc = pub_priv_openssh_keyfilememory(session, (void **)rsa,
-                                            "ssh-rsa",
-                                            NULL, NULL, NULL, NULL,
-                                            filedata, filedata_len,
-                                            passphrase);
+        rc = ossl_key_from_openssh_blob(session, (void **)rsa,
+                                        "ssh-rsa",
+                                        NULL, NULL, NULL, NULL,
+                                        filedata, filedata_len,
+                                        passphrase);
 
     return rc;
 }
 
-static unsigned char *gen_publickey_from_rsa(LIBSSH2_SESSION *session,
-                                             ssh2_rsa_ctx *rsa,
-                                             size_t *key_len)
+static unsigned char *ossl_rsa_to_pubkey(LIBSSH2_SESSION *session,
+                                         ssh2_rsa_ctx *rsa,
+                                         size_t *key_len)
 {
     int e_bytes, n_bytes;
     unsigned long len;
@@ -1215,12 +1215,12 @@ fail:
     return key;
 }
 
-static int gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
-                                      unsigned char **method,
-                                      size_t *method_len,
-                                      unsigned char **pubkeydata,
-                                      size_t *pubkeydata_len,
-                                      EVP_PKEY *pk)
+static int ossl_rsa_to_pubkey_evp(LIBSSH2_SESSION *session,
+                                  unsigned char **method,
+                                  size_t *method_len,
+                                  unsigned char **pubkeydata,
+                                  size_t *pubkeydata_len,
+                                  EVP_PKEY *pk)
 {
     ssh2_rsa_ctx *rsa = NULL;
     unsigned char *key;
@@ -1245,7 +1245,7 @@ static int gen_publickey_from_rsa_evp(LIBSSH2_SESSION *session,
         goto alloc_error;
     }
 
-    key = gen_publickey_from_rsa(session, rsa, &key_len);
+    key = ossl_rsa_to_pubkey(session, rsa, &key_len);
     if(!key) {
         goto alloc_error;
     }
@@ -1280,7 +1280,7 @@ alloc_error:
 }
 
 #ifndef USE_OPENSSL_3
-static int rsa_new_additional_parameters(ssh2_rsa_ctx *rsa)
+static int ossl_rsa_additional_params_new(ssh2_rsa_ctx *rsa)
 {
     BN_CTX *ctx = NULL;
     BIGNUM *aux = NULL;
@@ -1351,14 +1351,13 @@ out:
 }
 #endif /* !USE_OPENSSL_3 */
 
-static int gen_publickey_from_rsa_openssh_priv_data(
-    LIBSSH2_SESSION *session,
-    struct string_buf *decrypted,
-    unsigned char **method,
-    size_t *method_len,
-    unsigned char **pubkeydata,
-    size_t *pubkeydata_len,
-    ssh2_rsa_ctx **rsa_ctx)
+static int ossl_rsa_to_pubkey_openssh_priv_data(LIBSSH2_SESSION *session,
+                                                struct string_buf *decrypted,
+                                                unsigned char **method,
+                                                size_t *method_len,
+                                                unsigned char **pubkeydata,
+                                                size_t *pubkeydata_len,
+                                                ssh2_rsa_ctx **rsa_ctx)
 {
     int rc = 0;
     size_t nlen, elen, dlen, plen, qlen, coefflen, commentlen;
@@ -1421,7 +1420,7 @@ static int gen_publickey_from_rsa_openssh_priv_data(
 
 #ifndef USE_OPENSSL_3
     if(rsa)
-        rc = rsa_new_additional_parameters(rsa);
+        rc = ossl_rsa_additional_params_new(rsa);
 #endif
 
     if(rsa && pubkeydata && method) {
@@ -1432,8 +1431,8 @@ static int gen_publickey_from_rsa_openssh_priv_data(
         EVP_PKEY_set1_RSA(pk, rsa);
 #endif
 
-        rc = gen_publickey_from_rsa_evp(session, method, method_len,
-                                        pubkeydata, pubkeydata_len, pk);
+        rc = ossl_rsa_to_pubkey_evp(session, method, method_len,
+                                    pubkeydata, pubkeydata_len, pk);
 
 #ifndef USE_OPENSSL_3
         if(pk)
@@ -1457,10 +1456,10 @@ fail:
                     "Unable to allocate memory for private key data");
 }
 
-static int rsa_new_openssh_private(ssh2_rsa_ctx **rsa,
-                                   LIBSSH2_SESSION *session,
-                                   const char *filename,
-                                   const unsigned char *passphrase)
+static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
+                                     LIBSSH2_SESSION *session,
+                                     const char *filename,
+                                     const unsigned char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -1497,9 +1496,8 @@ static int rsa_new_openssh_private(ssh2_rsa_ctx **rsa,
     }
 
     if(strcmp("ssh-rsa", (const char *)buf) == 0) {
-        rc = gen_publickey_from_rsa_openssh_priv_data(session, decrypted,
-                                                      NULL, NULL,
-                                                      NULL, NULL, rsa);
+        rc = ossl_rsa_to_pubkey_openssh_priv_data(session, decrypted,
+                                                  NULL, NULL, NULL, NULL, rsa);
     }
     else {
         rc = -1;
@@ -1532,7 +1530,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
 #endif
     BIO_free(bp);
     if(!*rsa)
-        rc = rsa_new_openssh_private(rsa, session, filename, passphrase);
+        rc = ossl_rsa_openssh_priv_new(rsa, session, filename, passphrase);
 
     return rc;
 }
@@ -1561,18 +1559,18 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
 #endif
     BIO_free(bp);
     if(!*dsa)
-        rc = pub_priv_openssh_keyfilememory(session, (void **)dsa,
-                                            "ssh-dsa",
-                                            NULL, NULL, NULL, NULL,
-                                            filedata, filedata_len,
-                                            passphrase);
+        rc = ossl_key_from_openssh_blob(session, (void **)dsa,
+                                        "ssh-dsa",
+                                        NULL, NULL, NULL, NULL,
+                                        filedata, filedata_len,
+                                        passphrase);
 
     return rc;
 }
 
-static unsigned char *gen_publickey_from_dsa(LIBSSH2_SESSION *session,
-                                             ssh2_dsa_ctx *dsa,
-                                             size_t *key_len)
+static unsigned char *ossl_dsa_to_pubkey(LIBSSH2_SESSION *session,
+                                         ssh2_dsa_ctx *dsa,
+                                         size_t *key_len)
 {
     int p_bytes, q_bytes, g_bytes, k_bytes;
     unsigned long len;
@@ -1645,12 +1643,12 @@ fail:
     return key;
 }
 
-static int gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
-                                      unsigned char **method,
-                                      size_t *method_len,
-                                      unsigned char **pubkeydata,
-                                      size_t *pubkeydata_len,
-                                      EVP_PKEY *pk)
+static int ossl_dsa_to_pubkey_evp(LIBSSH2_SESSION *session,
+                                  unsigned char **method,
+                                  size_t *method_len,
+                                  unsigned char **pubkeydata,
+                                  size_t *pubkeydata_len,
+                                  EVP_PKEY *pk)
 {
     ssh2_dsa_ctx *dsa = NULL;
     unsigned char *key;
@@ -1675,7 +1673,7 @@ static int gen_publickey_from_dsa_evp(LIBSSH2_SESSION *session,
         goto alloc_error;
     }
 
-    key = gen_publickey_from_dsa(session, dsa, &key_len);
+    key = ossl_dsa_to_pubkey(session, dsa, &key_len);
     if(!key) {
         goto alloc_error;
     }
@@ -1708,14 +1706,13 @@ alloc_error:
                     "Unable to allocate memory for private key data");
 }
 
-static int gen_publickey_from_dsa_openssh_priv_data(
-    LIBSSH2_SESSION *session,
-    struct string_buf *decrypted,
-    unsigned char **method,
-    size_t *method_len,
-    unsigned char **pubkeydata,
-    size_t *pubkeydata_len,
-    ssh2_dsa_ctx **dsa_ctx)
+static int ossl_dsa_to_pubkey_openssh_priv_data(LIBSSH2_SESSION *session,
+                                                struct string_buf *decrypted,
+                                                unsigned char **method,
+                                                size_t *method_len,
+                                                unsigned char **pubkeydata,
+                                                size_t *pubkeydata_len,
+                                                ssh2_dsa_ctx **dsa_ctx)
 {
     int rc = 0;
     size_t plen, qlen, glen, pub_len, priv_len;
@@ -1770,8 +1767,8 @@ static int gen_publickey_from_dsa_openssh_priv_data(
         EVP_PKEY_set1_DSA(pk, dsa);
 #endif
 
-        rc = gen_publickey_from_dsa_evp(session, method, method_len,
-                                        pubkeydata, pubkeydata_len, pk);
+        rc = ossl_dsa_to_pubkey_evp(session, method, method_len,
+                                    pubkeydata, pubkeydata_len, pk);
 
 #ifndef USE_OPENSSL_3
         if(pk)
@@ -1795,10 +1792,10 @@ fail:
                     "Unable to allocate memory for private key data");
 }
 
-static int dsa_new_openssh_private(ssh2_dsa_ctx **dsa,
-                                   LIBSSH2_SESSION *session,
-                                   const char *filename,
-                                   const unsigned char *passphrase)
+static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
+                                     LIBSSH2_SESSION *session,
+                                     const char *filename,
+                                     const unsigned char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -1835,9 +1832,8 @@ static int dsa_new_openssh_private(ssh2_dsa_ctx **dsa,
     }
 
     if(strcmp("ssh-dss", (const char *)buf) == 0) {
-        rc = gen_publickey_from_dsa_openssh_priv_data(session, decrypted,
-                                                      NULL, NULL,
-                                                      NULL, NULL, dsa);
+        rc = ossl_dsa_to_pubkey_openssh_priv_data(session, decrypted,
+                                                  NULL, NULL, NULL, NULL, dsa);
     }
     else {
         rc = -1;
@@ -1870,7 +1866,7 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
 #endif
     BIO_free(bp);
     if(!*dsa)
-        rc = dsa_new_openssh_private(dsa, session, filename, passphrase);
+        rc = ossl_dsa_openssh_priv_new(dsa, session, filename, passphrase);
 
     return rc;
 }
@@ -1899,11 +1895,11 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
 #endif
     BIO_free(bp);
     if(!*ec_ctx)
-        rc = pub_priv_openssh_keyfilememory(session, (void **)ec_ctx,
-                                            "ssh-ecdsa",
-                                            NULL, NULL, NULL, NULL,
-                                            filedata, filedata_len,
-                                            passphrase);
+        rc = ossl_key_from_openssh_blob(session, (void **)ec_ctx,
+                                        "ssh-ecdsa",
+                                        NULL, NULL, NULL, NULL,
+                                        filedata, filedata_len,
+                                        passphrase);
 
     return rc;
 }
@@ -1919,13 +1915,13 @@ int ssh2_ecdsa_new_private_frommemory_sk(ssh2_ecdsa_ctx **ec_ctx,
                                          const unsigned char *passphrase)
 {
     int algorithm;
-    return sk_pub_openssh_keyfilememory(session, (void **)ec_ctx,
-                                        "sk-ecdsa-sha2-nistp256@openssh.com",
-                                        NULL, NULL, NULL, NULL,
-                                        &algorithm, flags, application,
-                                        key_handle, handle_len,
-                                        filedata, filedata_len,
-                                        passphrase);
+    return ossl_key_sk_from_openssh_blob(session, (void **)ec_ctx,
+                                         "sk-ecdsa-sha2-nistp256@openssh.com",
+                                         NULL, NULL, NULL, NULL,
+                                         &algorithm, flags, application,
+                                         key_handle, handle_len,
+                                         filedata, filedata_len,
+                                         passphrase);
 }
 
 #endif /* LIBSSH2_ECDSA */
@@ -1998,12 +1994,12 @@ clean_exit:
     return rc;
 }
 
-static int gen_publickey_from_ed_evp(LIBSSH2_SESSION *session,
-                                     unsigned char **method,
-                                     size_t *method_len,
-                                     unsigned char **pubkeydata,
-                                     size_t *pubkeydata_len,
-                                     EVP_PKEY *pk)
+static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session,
+                                      unsigned char **method,
+                                      size_t *method_len,
+                                      unsigned char **pubkeydata,
+                                      size_t *pubkeydata_len,
+                                      EVP_PKEY *pk)
 {
     const char methodName[] = "ssh-ed25519";
     unsigned char *methodBuf = NULL;
@@ -2065,14 +2061,13 @@ fail:
     return -1;
 }
 
-static int gen_publickey_from_ed25519_openssh_priv_data(
-    LIBSSH2_SESSION *session,
-    struct string_buf *decrypted,
-    unsigned char **method,
-    size_t *method_len,
-    unsigned char **pubkeydata,
-    size_t *pubkeydata_len,
-    ssh2_ed25519_ctx **out_ctx)
+static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
+                                               struct string_buf *decrypted,
+                                               unsigned char **method,
+                                               size_t *method_len,
+                                               unsigned char **pubkeydata,
+                                               size_t *pubkeydata_len,
+                                               ssh2_ed25519_ctx **out_ctx)
 {
     ssh2_ed25519_ctx *ctx = NULL;
     unsigned char *method_buf = NULL;
@@ -2201,7 +2196,7 @@ clean_exit:
     return -1;
 }
 
-static int gen_publickey_from_sk_ed25519_openssh_priv_data(
+static int ossl_ed25519_openssh_sk_priv_to_pubkey(
     LIBSSH2_SESSION *session,
     struct string_buf *decrypted,
     unsigned char **method,
@@ -2389,10 +2384,8 @@ int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
     }
 
     if(strcmp("ssh-ed25519", (const char *)buf) == 0) {
-        rc = gen_publickey_from_ed25519_openssh_priv_data(session, decrypted,
-                                                          NULL, NULL,
-                                                          NULL, NULL,
-                                                          &ctx);
+        rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
+                                                 NULL, NULL, NULL, NULL, &ctx);
     }
     else {
         rc = -1;
@@ -2456,15 +2449,11 @@ int ssh2_ed25519_new_private_sk(ssh2_ed25519_ctx **ed_ctx,
     }
 
     if(strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) == 0) {
-        rc = gen_publickey_from_sk_ed25519_openssh_priv_data(session,
-                                                             decrypted,
-                                                             NULL, NULL,
-                                                             NULL, NULL,
-                                                             flags,
-                                                             application,
-                                                             key_handle,
-                                                             handle_len,
-                                                             &ctx);
+        rc = ossl_ed25519_openssh_sk_priv_to_pubkey(session, decrypted,
+                                                    NULL, NULL, NULL, NULL,
+                                                    flags, application,
+                                                    key_handle, handle_len,
+                                                    &ctx);
     }
     else {
         rc = -1;
@@ -2511,11 +2500,11 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
         }
     }
 
-    return pub_priv_openssh_keyfilememory(session, (void **)ed_ctx,
-                                          "ssh-ed25519",
-                                          NULL, NULL, NULL, NULL,
-                                          filedata, filedata_len,
-                                          passphrase);
+    return ossl_key_from_openssh_blob(session, (void **)ed_ctx,
+                                      "ssh-ed25519",
+                                      NULL, NULL, NULL, NULL,
+                                      filedata, filedata_len,
+                                      passphrase);
 }
 
 int ssh2_ed25519_new_private_frommemory_sk(ssh2_ed25519_ctx **ed_ctx,
@@ -2529,13 +2518,13 @@ int ssh2_ed25519_new_private_frommemory_sk(ssh2_ed25519_ctx **ed_ctx,
                                            const unsigned char *passphrase)
 {
     int algorithm;
-    return sk_pub_openssh_keyfilememory(session, (void **)ed_ctx,
-                                        "sk-ssh-ed25519@openssh.com",
-                                        NULL, NULL, NULL, NULL,
-                                        &algorithm, flags, application,
-                                        key_handle, handle_len,
-                                        filedata, filedata_len,
-                                        passphrase);
+    return ossl_key_sk_from_openssh_blob(session, (void **)ed_ctx,
+                                         "sk-ssh-ed25519@openssh.com",
+                                         NULL, NULL, NULL, NULL,
+                                         &algorithm, flags, application,
+                                         key_handle, handle_len,
+                                         filedata, filedata_len,
+                                         passphrase);
 }
 
 int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,
@@ -3341,13 +3330,13 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out)
 
 #if LIBSSH2_ECDSA
 
-static int gen_publickey_from_ec_evp(LIBSSH2_SESSION *session,
-                                     unsigned char **method,
-                                     size_t *method_len,
-                                     unsigned char **pubkeydata,
-                                     size_t *pubkeydata_len,
-                                     int is_sk,
-                                     EVP_PKEY *pk)
+static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
+                                    unsigned char **method,
+                                    size_t *method_len,
+                                    unsigned char **pubkeydata,
+                                    size_t *pubkeydata_len,
+                                    int is_sk,
+                                    EVP_PKEY *pk)
 {
     int rc = 0;
     unsigned char *p;
@@ -3505,15 +3494,14 @@ clean_exit:
     return -1;
 }
 
-static int gen_publickey_from_ecdsa_openssh_priv_data(
-    LIBSSH2_SESSION *session,
-    ssh2_curve_type curve_type,
-    struct string_buf *decrypted,
-    unsigned char **method,
-    size_t *method_len,
-    unsigned char **pubkeydata,
-    size_t *pubkeydata_len,
-    ssh2_ecdsa_ctx **ec_ctx)
+static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
+                                             ssh2_curve_type curve_type,
+                                             struct string_buf *decrypted,
+                                             unsigned char **method,
+                                             size_t *method_len,
+                                             unsigned char **pubkeydata,
+                                             size_t *pubkeydata_len,
+                                             ssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
     size_t curvelen, exponentlen, pointlen;
@@ -3613,9 +3601,8 @@ static int gen_publickey_from_ecdsa_openssh_priv_data(
         EVP_PKEY_set1_EC_KEY(pk, ec_key);
 #endif
 
-        rc = gen_publickey_from_ec_evp(session, method, method_len,
-                                       pubkeydata, pubkeydata_len,
-                                       0, pk);
+        rc = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
+                                      pubkeydata, pubkeydata_len, 0, pk);
 
 #ifndef USE_OPENSSL_3
         if(pk)
@@ -3647,7 +3634,7 @@ fail:
     return rc;
 }
 
-static int gen_publickey_from_sk_ecdsa_openssh_priv_data(
+static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     LIBSSH2_SESSION *session,
     struct string_buf *decrypted,
     unsigned char **method,
@@ -3719,9 +3706,8 @@ static int gen_publickey_from_sk_ecdsa_openssh_priv_data(
         EVP_PKEY_set1_EC_KEY(pk, ec_key);
 #endif
 
-        rc = gen_publickey_from_ec_evp(session, method, method_len,
-                                       pubkeydata, pubkeydata_len,
-                                       1, pk);
+        rc = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
+                                      pubkeydata, pubkeydata_len, 1, pk);
 
 #ifndef USE_OPENSSL_3
         if(pk)
@@ -3778,10 +3764,10 @@ fail:
     return rc;
 }
 
-static int ecdsa_new_openssh_private(ssh2_ecdsa_ctx **ec_ctx,
-                                     LIBSSH2_SESSION *session,
-                                     const char *filename,
-                                     const unsigned char *passphrase)
+static int ecossl_dsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
+                                       LIBSSH2_SESSION *session,
+                                       const char *filename,
+                                       const unsigned char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -3821,10 +3807,8 @@ static int ecdsa_new_openssh_private(ssh2_ecdsa_ctx **ec_ctx,
     rc = ssh2_ecdsa_curve_type_from_name((const char *)buf, &type);
 
     if(rc == 0) {
-        rc = gen_publickey_from_ecdsa_openssh_priv_data(session, type,
-                                                        decrypted,
-                                                        NULL, NULL,
-                                                        NULL, NULL, ec_ctx);
+        rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
+                                               NULL, NULL, NULL, NULL, ec_ctx);
     }
     else {
         rc = -1;
@@ -3836,14 +3820,14 @@ static int ecdsa_new_openssh_private(ssh2_ecdsa_ctx **ec_ctx,
     return rc;
 }
 
-static int ecdsa_new_openssh_private_sk(ssh2_ecdsa_ctx **ec_ctx,
-                                        uint8_t *flags,
-                                        const char **application,
-                                        const unsigned char **key_handle,
-                                        size_t *handle_len,
-                                        LIBSSH2_SESSION *session,
-                                        const char *filename,
-                                        const unsigned char *passphrase)
+static int ecossl_dsa_openssh_priv_new_sk(ssh2_ecdsa_ctx **ec_ctx,
+                                          uint8_t *flags,
+                                          const char **application,
+                                          const unsigned char **key_handle,
+                                          size_t *handle_len,
+                                          LIBSSH2_SESSION *session,
+                                          const char *filename,
+                                          const unsigned char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -3880,15 +3864,11 @@ static int ecdsa_new_openssh_private_sk(ssh2_ecdsa_ctx **ec_ctx,
     }
 
     if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0) {
-        rc = gen_publickey_from_sk_ecdsa_openssh_priv_data(session,
-                                                           decrypted,
-                                                           NULL, NULL,
-                                                           NULL, NULL,
-                                                           flags,
-                                                           application,
-                                                           key_handle,
-                                                           handle_len,
-                                                           ec_ctx);
+        rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
+                                                  NULL, NULL, NULL, NULL,
+                                                  flags, application,
+                                                  key_handle, handle_len,
+                                                  ec_ctx);
     }
     else {
         rc = -1;
@@ -3921,7 +3901,7 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
 #endif
     BIO_free(bp);
     if(!*ec_ctx)
-        rc = ecdsa_new_openssh_private(ec_ctx, session, filename, passphrase);
+        rc = ecossl_dsa_openssh_priv_new(ec_ctx, session, filename, passphrase);
 
     return rc;
 }
@@ -3951,9 +3931,9 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
 #endif
     BIO_free(bp);
     if(!*ec_ctx)
-        rc = ecdsa_new_openssh_private_sk(ec_ctx, flags, application,
-                                          key_handle, handle_len, session,
-                                          filename, passphrase);
+        rc = ecossl_dsa_openssh_priv_new_sk(ec_ctx, flags, application,
+                                            key_handle, handle_len, session,
+                                            filename, passphrase);
 
     return rc;
 }
@@ -4408,13 +4388,13 @@ clean_exit:
 
 #endif /* LIBSSH2_ED25519 */
 
-static int pub_priv_openssh_keyfile(LIBSSH2_SESSION *session,
-                                    unsigned char **method,
-                                    size_t *method_len,
-                                    unsigned char **pubkeydata,
-                                    size_t *pubkeydata_len,
-                                    const char *privatekey,
-                                    const char *passphrase)
+static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
+                                      unsigned char **method,
+                                      size_t *method_len,
+                                      unsigned char **pubkeydata,
+                                      size_t *pubkeydata_len,
+                                      const char *privatekey,
+                                      const char *passphrase)
 {
     FILE *fp;
     unsigned char *buf = NULL;
@@ -4461,42 +4441,35 @@ static int pub_priv_openssh_keyfile(LIBSSH2_SESSION *session,
     (void)pubkeydata_len;
 
 #if LIBSSH2_ED25519
-    if(strcmp("ssh-ed25519", (const char *)buf) == 0) {
-        rc = gen_publickey_from_ed25519_openssh_priv_data(session, decrypted,
-                                                          method, method_len,
-                                                          pubkeydata,
-                                                          pubkeydata_len,
-                                                          NULL);
-    }
+    if(strcmp("ssh-ed25519", (const char *)buf) == 0)
+        rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
+                                                 method, method_len,
+                                                 pubkeydata, pubkeydata_len,
+                                                 NULL);
 #endif
 #if LIBSSH2_RSA
-    if(strcmp("ssh-rsa", (const char *)buf) == 0) {
-        rc = gen_publickey_from_rsa_openssh_priv_data(session, decrypted,
-                                                      method, method_len,
-                                                      pubkeydata,
-                                                      pubkeydata_len, NULL);
-    }
+    if(strcmp("ssh-rsa", (const char *)buf) == 0)
+        rc = ossl_rsa_to_pubkey_openssh_priv_data(session, decrypted,
+                                                  method, method_len,
+                                                  pubkeydata, pubkeydata_len,
+                                                  NULL);
 #endif
 #if LIBSSH2_DSA
-    if(strcmp("ssh-dss", (const char *)buf) == 0) {
-        rc = gen_publickey_from_dsa_openssh_priv_data(session, decrypted,
-                                                      method, method_len,
-                                                      pubkeydata,
-                                                      pubkeydata_len, NULL);
-    }
+    if(strcmp("ssh-dss", (const char *)buf) == 0)
+        rc = ossl_dsa_to_pubkey_openssh_priv_data(session, decrypted,
+                                                  method, method_len,
+                                                  pubkeydata, pubkeydata_len,
+                                                  NULL);
 #endif
 #if LIBSSH2_ECDSA
     {
         ssh2_curve_type type;
 
-        if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0) {
-            rc = gen_publickey_from_ecdsa_openssh_priv_data(session, type,
-                                                            decrypted,
-                                                            method, method_len,
-                                                            pubkeydata,
-                                                            pubkeydata_len,
-                                                            NULL);
-        }
+        if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0)
+            rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
+                                                   method, method_len,
+                                                   pubkeydata, pubkeydata_len,
+                                                   NULL);
     }
 #endif
 
@@ -4541,11 +4514,10 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     if(!pk) {
 
         /* Try OpenSSH format */
-        rc = pub_priv_openssh_keyfile(session,
-                                      method,
-                                      method_len,
-                                      pubkeydata, pubkeydata_len,
-                                      privatekey, passphrase);
+        rc = ossl_key_from_openssh_file(session,
+                                        method, method_len,
+                                        pubkeydata, pubkeydata_len,
+                                        privatekey, passphrase);
         if(rc) {
             return ssh2_err(session, LIBSSH2_ERROR_FILE,
                             "Unable to extract public key "
@@ -4566,26 +4538,26 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     switch(pktype) {
 #if LIBSSH2_ED25519
     case EVP_PKEY_ED25519:
-        st = gen_publickey_from_ed_evp(session, method, method_len, pubkeydata,
-                                       pubkeydata_len, pk);
+        st = ossl_ed25519_evp_to_pubkey(session, method, method_len,
+                                        pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_ED25519 */
 #if LIBSSH2_RSA
     case EVP_PKEY_RSA:
-        st = gen_publickey_from_rsa_evp(session, method, method_len,
-                                        pubkeydata, pubkeydata_len, pk);
+        st = ossl_rsa_to_pubkey_evp(session, method, method_len,
+                                    pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_RSA */
 #if LIBSSH2_DSA
     case EVP_PKEY_DSA:
-        st = gen_publickey_from_dsa_evp(session, method, method_len,
-                                        pubkeydata, pubkeydata_len, pk);
+        st = ossl_dsa_to_pubkey_evp(session, method, method_len,
+                                    pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_DSA */
 #if LIBSSH2_ECDSA
     case EVP_PKEY_EC:
-        st = gen_publickey_from_ec_evp(session, method, method_len, pubkeydata,
-                                       pubkeydata_len, 0, pk);
+        st = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
+                                      pubkeydata, pubkeydata_len, 0, pk);
         break;
 #endif /* LIBSSH2_ECDSA */
     default:
@@ -4599,20 +4571,23 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     return st;
 }
 
-static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
-                                          void **key_ctx,
-                                          const char *key_type,
-                                          unsigned char **method,
-                                          size_t *method_len,
-                                          unsigned char **pubkeydata,
-                                          size_t *pubkeydata_len,
-                                          const char *privatekeydata,
-                                          size_t privatekeydata_len,
-                                          const unsigned char *passphrase)
+static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
+                                      void **key_ctx,
+                                      const char *key_type,
+                                      unsigned char **method,
+                                      size_t *method_len,
+                                      unsigned char **pubkeydata,
+                                      size_t *pubkeydata_len,
+                                      const char *privatekeydata,
+                                      size_t privatekeydata_len,
+                                      const unsigned char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
+#if LIBSSH2_ECDSA
+    ssh2_curve_type type;
+#endif
 
     if(key_ctx)
         *key_ctx = NULL;
@@ -4649,82 +4624,60 @@ static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_ED25519
     if(strcmp("ssh-ed25519", (const char *)buf) == 0) {
-        if(!key_type || strcmp("ssh-ed25519", key_type) == 0) {
-            rc = gen_publickey_from_ed25519_openssh_priv_data(session,
-                                                              decrypted,
-                                                              method,
-                                                              method_len,
-                                                              pubkeydata,
-                                                              pubkeydata_len,
+        if(!key_type || strcmp("ssh-ed25519", key_type) == 0)
+            rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
+                                                     method, method_len,
+                                                     pubkeydata,
+                                                     pubkeydata_len,
                                                  (ssh2_ed25519_ctx **)key_ctx);
-        }
     }
 
     if(strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) == 0) {
-        if(!key_type ||
-           strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0) {
-            rc = gen_publickey_from_sk_ed25519_openssh_priv_data(session,
-                                                                 decrypted,
-                                                                 method,
-                                                                 method_len,
-                                                                 pubkeydata,
-                                                                pubkeydata_len,
-                                                                 NULL, NULL,
-                                                                 NULL, NULL,
+        if(!key_type || strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0)
+            rc = ossl_ed25519_openssh_sk_priv_to_pubkey(session, decrypted,
+                                                        method, method_len,
+                                                        pubkeydata,
+                                                        pubkeydata_len,
+                                                        NULL, NULL,NULL, NULL,
                                                  (ssh2_ed25519_ctx **)key_ctx);
-        }
     }
 #endif
 #if LIBSSH2_RSA
     if(strcmp("ssh-rsa", (const char *)buf) == 0) {
-        if(!key_type || strcmp("ssh-rsa", key_type) == 0) {
-            rc = gen_publickey_from_rsa_openssh_priv_data(session, decrypted,
-                                                          method, method_len,
-                                                          pubkeydata,
-                                                          pubkeydata_len,
+        if(!key_type || strcmp("ssh-rsa", key_type) == 0)
+            rc = ossl_rsa_to_pubkey_openssh_priv_data(session, decrypted,
+                                                      method, method_len,
+                                                      pubkeydata,
+                                                      pubkeydata_len,
                                                      (ssh2_rsa_ctx **)key_ctx);
-        }
     }
 #endif
 #if LIBSSH2_DSA
     if(strcmp("ssh-dss", (const char *)buf) == 0) {
-        if(!key_type || strcmp("ssh-dss", key_type) == 0) {
-            rc = gen_publickey_from_dsa_openssh_priv_data(session, decrypted,
-                                                          method, method_len,
-                                                          pubkeydata,
-                                                          pubkeydata_len,
+        if(!key_type || strcmp("ssh-dss", key_type) == 0)
+            rc = ossl_dsa_to_pubkey_openssh_priv_data(session, decrypted,
+                                                      method, method_len,
+                                                      pubkeydata,
+                                                      pubkeydata_len,
                                                      (ssh2_dsa_ctx **)key_ctx);
-        }
     }
 #endif
 #if LIBSSH2_ECDSA
-    {
-        ssh2_curve_type type;
-
-        if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com",
-                  (const char *)buf) == 0) {
-            rc = gen_publickey_from_sk_ecdsa_openssh_priv_data(session,
-                                                               decrypted,
-                                                               method,
-                                                               method_len,
-                                                               pubkeydata,
-                                                               pubkeydata_len,
-                                                               NULL, NULL,
-                                                               NULL, NULL,
+    if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0) {
+        rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
+                                                  method, method_len,
+                                                  pubkeydata,
+                                                  pubkeydata_len,
+                                                  NULL, NULL, NULL, NULL,
+                                                  (ssh2_ecdsa_ctx **)key_ctx);
+    }
+    else if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0) {
+        if(!key_type || strcmp("ssh-ecdsa", key_type) == 0)
+            rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
+                                                   method, method_len,
+                                                   pubkeydata,
+                                                   pubkeydata_len,
                                                    (ssh2_ecdsa_ctx **)key_ctx);
-        }
-        else if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type)
-                == 0) {
-            if(!key_type || strcmp("ssh-ecdsa", key_type) == 0) {
-                rc = gen_publickey_from_ecdsa_openssh_priv_data(session, type,
-                                                                decrypted,
-                                                                method,
-                                                                method_len,
-                                                                pubkeydata,
-                                                                pubkeydata_len,
-                                                   (ssh2_ecdsa_ctx **)key_ctx);
-            }
-        }
     }
 #endif
 
@@ -4739,21 +4692,21 @@ static int pub_priv_openssh_keyfilememory(LIBSSH2_SESSION *session,
     return rc;
 }
 
-static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
-                                        void **key_ctx,
-                                        const char *key_type,
-                                        unsigned char **method,
-                                        size_t *method_len,
-                                        unsigned char **pubkeydata,
-                                        size_t *pubkeydata_len,
-                                        int *algorithm,
-                                        unsigned char *flags,
-                                        const char **application,
-                                        const unsigned char **key_handle,
-                                        size_t *handle_len,
-                                        const char *privatekeydata,
-                                        size_t privatekeydata_len,
-                                        const unsigned char *passphrase)
+static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
+                                         void **key_ctx,
+                                         const char *key_type,
+                                         unsigned char **method,
+                                         size_t *method_len,
+                                         unsigned char **pubkeydata,
+                                         size_t *pubkeydata_len,
+                                         int *algorithm,
+                                         unsigned char *flags,
+                                         const char **application,
+                                         const unsigned char **key_handle,
+                                         size_t *handle_len,
+                                         const char *privatekeydata,
+                                         size_t privatekeydata_len,
+                                         const unsigned char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;
@@ -4802,16 +4755,12 @@ static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ED25519;
         if(!key_type ||
            strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0) {
-            rc = gen_publickey_from_sk_ed25519_openssh_priv_data(session,
-                                                                 decrypted,
-                                                                 method,
-                                                                 method_len,
-                                                                 pubkeydata,
-                                                                pubkeydata_len,
-                                                                 flags,
-                                                                 application,
-                                                                 key_handle,
-                                                                 handle_len,
+            rc = ossl_ed25519_openssh_sk_priv_to_pubkey(session, decrypted,
+                                                        method, method_len,
+                                                        pubkeydata,
+                                                        pubkeydata_len,
+                                                        flags, application,
+                                                        key_handle, handle_len,
                                                  (ssh2_ed25519_ctx **)key_ctx);
         }
     }
@@ -4819,15 +4768,12 @@ static int sk_pub_openssh_keyfilememory(LIBSSH2_SESSION *session,
 #if LIBSSH2_ECDSA
     if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ECDSA_256;
-        rc = gen_publickey_from_sk_ecdsa_openssh_priv_data(session, decrypted,
-                                                           method, method_len,
-                                                           pubkeydata,
-                                                           pubkeydata_len,
-                                                           flags,
-                                                           application,
-                                                           key_handle,
-                                                           handle_len,
-                                                   (ssh2_ecdsa_ctx **)key_ctx);
+        rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
+                                                  method, method_len,
+                                                  pubkeydata, pubkeydata_len,
+                                                  flags, application,
+                                                  key_handle, handle_len,
+                                                  (ssh2_ecdsa_ctx **)key_ctx);
     }
 #endif
 
@@ -4879,15 +4825,11 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 
     if(!pk) {
         /* Try OpenSSH format */
-        st = pub_priv_openssh_keyfilememory(session,
-                                            NULL, NULL,
-                                            method,
-                                            method_len,
-                                            pubkeydata,
-                                            pubkeydata_len,
-                                            privatekeydata,
-                                            privatekeydata_len,
-                                            (const unsigned char *)passphrase);
+        st = ossl_key_from_openssh_blob(session, NULL, NULL,
+                                        method, method_len,
+                                        pubkeydata, pubkeydata_len,
+                                        privatekeydata, privatekeydata_len,
+                                        (const unsigned char *)passphrase);
         if(st == 0)
             return 0;
 
@@ -4913,26 +4855,26 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     switch(pktype) {
 #if LIBSSH2_ED25519
     case EVP_PKEY_ED25519:
-        st = gen_publickey_from_ed_evp(session, method, method_len,
-                                       pubkeydata, pubkeydata_len, pk);
+        st = ossl_ed25519_evp_to_pubkey(session, method, method_len,
+                                        pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_ED25519 */
 #if LIBSSH2_RSA
     case EVP_PKEY_RSA:
-        st = gen_publickey_from_rsa_evp(session, method, method_len,
-                                        pubkeydata, pubkeydata_len, pk);
+        st = ossl_rsa_to_pubkey_evp(session, method, method_len,
+                                    pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_RSA */
 #if LIBSSH2_DSA
     case EVP_PKEY_DSA:
-        st = gen_publickey_from_dsa_evp(session, method, method_len,
-                                        pubkeydata, pubkeydata_len, pk);
+        st = ossl_dsa_to_pubkey_evp(session, method, method_len,
+                                    pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_DSA */
 #if LIBSSH2_ECDSA
     case EVP_PKEY_EC:
-        st = gen_publickey_from_ec_evp(session, method, method_len,
-                                       pubkeydata, pubkeydata_len, 0, pk);
+        st = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
+                                      pubkeydata, pubkeydata_len, 0, pk);
         break;
 #endif /* LIBSSH2_ECDSA */
     default:
@@ -4977,19 +4919,13 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 
     if(!pk) {
         /* Try OpenSSH format */
-        st = sk_pub_openssh_keyfilememory(session, NULL, NULL,
-                                          method,
-                                          method_len,
-                                          pubkeydata,
-                                          pubkeydata_len,
-                                          algorithm,
-                                          flags,
-                                          application,
-                                          key_handle,
-                                          handle_len,
-                                          privatekeydata,
-                                          privatekeydata_len,
-                                          (const unsigned char *)passphrase);
+        st = ossl_key_sk_from_openssh_blob(session, NULL, NULL,
+                                           method, method_len,
+                                           pubkeydata, pubkeydata_len,
+                                           algorithm, flags, application,
+                                           key_handle, handle_len,
+                                           privatekeydata, privatekeydata_len,
+                                           (const unsigned char *)passphrase);
     }
 
     return st;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4421,32 +4421,36 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
     (void)pubkeydata_len;
 
 #if LIBSSH2_ED25519
-    if(strcmp("ssh-ed25519", (const char *)buf) == 0)
+    if(strcmp("ssh-ed25519", (const char *)buf) == 0) {
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
                                                  method, method_len,
                                                  pubkeydata, pubkeydata_len,
                                                  NULL);
+    }
 #endif
 #if LIBSSH2_RSA
-    if(strcmp("ssh-rsa", (const char *)buf) == 0)
+    if(strcmp("ssh-rsa", (const char *)buf) == 0) {
         rc = ossl_rsa_to_pubkey_openssh_priv_data(session, decrypted,
                                                   method, method_len,
                                                   pubkeydata, pubkeydata_len,
                                                   NULL);
+    }
 #endif
 #if LIBSSH2_DSA
-    if(strcmp("ssh-dss", (const char *)buf) == 0)
+    if(strcmp("ssh-dss", (const char *)buf) == 0) {
         rc = ossl_dsa_to_pubkey_openssh_priv_data(session, decrypted,
                                                   method, method_len,
                                                   pubkeydata, pubkeydata_len,
                                                   NULL);
+    }
 #endif
 #if LIBSSH2_ECDSA
-    if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0)
+    if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0) {
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
                                                method, method_len,
                                                pubkeydata, pubkeydata_len,
                                                NULL);
+    }
 #endif
 
     if(decrypted)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3877,7 +3877,8 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
 #endif
     BIO_free(bp);
     if(!*ec_ctx)
-        rc = ecossl_dsa_openssh_priv_new(ec_ctx, session, filename, passphrase);
+        rc = ecossl_dsa_openssh_priv_new(ec_ctx, session, filename,
+                                         passphrase);
 
     return rc;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3740,7 +3740,7 @@ fail:
     return rc;
 }
 
-static int ecossl_dsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
+static int ossl_ecdsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
                                        LIBSSH2_SESSION *session,
                                        const char *filename,
                                        const unsigned char *passphrase)
@@ -3796,7 +3796,7 @@ static int ecossl_dsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
     return rc;
 }
 
-static int ecossl_dsa_openssh_priv_new_sk(ssh2_ecdsa_ctx **ec_ctx,
+static int ossl_ecdsa_sk_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
                                           uint8_t *flags,
                                           const char **application,
                                           const unsigned char **key_handle,
@@ -3877,7 +3877,7 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
 #endif
     BIO_free(bp);
     if(!*ec_ctx)
-        rc = ecossl_dsa_openssh_priv_new(ec_ctx, session, filename,
+        rc = ossl_ecdsa_openssh_priv_new(ec_ctx, session, filename,
                                          passphrase);
 
     return rc;
@@ -3908,7 +3908,7 @@ int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
 #endif
     BIO_free(bp);
     if(!*ec_ctx)
-        rc = ecossl_dsa_openssh_priv_new_sk(ec_ctx, flags, application,
+        rc = ossl_ecdsa_sk_openssh_priv_new(ec_ctx, flags, application,
                                             key_handle, handle_len, session,
                                             filename, passphrase);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -400,10 +400,8 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 #endif /* USE_OPENSSL_3 */
 }
 
-int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
-                         size_t hash_len,
-                         const unsigned char *sig,
-                         size_t sig_len,
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
+                         const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
 #ifdef USE_OPENSSL_3
@@ -478,8 +476,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
 
 #if LIBSSH2_RSA_SHA1
 int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
-                         const unsigned char *sig,
-                         size_t sig_len,
+                         const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
     return ssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH, sig, sig_len, m,
@@ -752,8 +749,7 @@ int ssh2_ecdsa_curve_type_from_name(const char *name,
  * Creates a new public key given an octal string, length and type
  */
 int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
-                                         const unsigned char *k,
-                                         size_t k_len,
+                                         const unsigned char *k, size_t k_len,
                                          ssh2_curve_type curve)
 {
     int ret = 0;
@@ -977,9 +973,8 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
 #define EVP_MAX_BLOCK_LENGTH 32
 #endif
 
-int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
-                      int encrypt, unsigned char *block, size_t blocksize,
-                      int firstlast)
+int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo), int encrypt,
+                      unsigned char *block, size_t blocksize, int firstlast)
 {
     unsigned char buf[EVP_MAX_BLOCK_LENGTH];
     int ret = 1;
@@ -1122,8 +1117,7 @@ static int ossl_passphrase_cb(char *buf, int size, int rwflag,
 #if LIBSSH2_RSA
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
-                                    const char *filedata,
-                                    size_t filedata_len,
+                                    const char *filedata, size_t filedata_len,
                                     const unsigned char *passphrase)
 {
     int rc = 0;
@@ -1150,8 +1144,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 }
 
 static unsigned char *ossl_rsa_to_pubkey(LIBSSH2_SESSION *session,
-                                         ssh2_rsa_ctx *rsa,
-                                         size_t *key_len)
+                                         ssh2_rsa_ctx *rsa, size_t *key_len)
 {
     int e_bytes, n_bytes;
     unsigned long len;
@@ -1565,8 +1558,7 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
 }
 
 static unsigned char *ossl_dsa_to_pubkey(LIBSSH2_SESSION *session,
-                                         ssh2_dsa_ctx *dsa,
-                                         size_t *key_len)
+                                         ssh2_dsa_ctx *dsa, size_t *key_len)
 {
     int p_bytes, q_bytes, g_bytes, k_bytes;
     unsigned long len;
@@ -2546,8 +2538,7 @@ int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,
 
 #if LIBSSH2_MLKEM
 
-int ssh2_mlkem_new(LIBSSH2_SESSION *session,
-                   int ml_kem_size,
+int ssh2_mlkem_new(LIBSSH2_SESSION *session, int ml_kem_size,
                    unsigned char **out_public_key,
                    unsigned char **out_private_key)
 {
@@ -2632,10 +2623,8 @@ clean_exit:
     return rc;
 }
 
-int ssh2_mlkem_get_sk(unsigned char *out_shared_key,
-                      int ml_kem_size,
-                      uint8_t *private_key,
-                      uint8_t *server_ciphertext)
+int ssh2_mlkem_get_sk(unsigned char *out_shared_key, int ml_kem_size,
+                      uint8_t *private_key, uint8_t *server_ciphertext)
 {
     int rc = -1;
     EVP_PKEY *client_key = NULL;
@@ -2711,10 +2700,8 @@ clean_exit:
 #endif
 
 #if LIBSSH2_RSA
-int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
-                       ssh2_rsa_ctx *rsactx,
-                       const unsigned char *hash,
-                       size_t hash_len,
+int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session, ssh2_rsa_ctx *rsactx,
+                       const unsigned char *hash, size_t hash_len,
                        unsigned char **signature, size_t *signature_len)
 {
     int ret = -1;
@@ -2797,10 +2784,8 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
 }
 
 #if LIBSSH2_RSA_SHA1
-int ssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
-                       ssh2_rsa_ctx *rsactx,
-                       const unsigned char *hash,
-                       size_t hash_len,
+int ssh2_rsa_sha1_sign(LIBSSH2_SESSION *session, ssh2_rsa_ctx *rsactx,
+                       const unsigned char *hash, size_t hash_len,
                        unsigned char **signature, size_t *signature_len)
 {
     return ssh2_rsa_sha2_sign(session, rsactx, hash, hash_len,
@@ -3323,8 +3308,7 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out)
 #if LIBSSH2_ECDSA
 
 static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                    unsigned char **method,
-                                    size_t *method_len,
+                                    unsigned char **method, size_t *method_len,
                                     unsigned char **pubkeydata,
                                     size_t *pubkeydata_len,
                                     int is_sk,
@@ -4630,7 +4614,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                                         method, method_len,
                                                         pubkeydata,
                                                         pubkeydata_len,
-                                                        NULL, NULL,NULL, NULL,
+                                                        NULL, NULL, NULL, NULL,
                                                  (ssh2_ed25519_ctx **)key_ctx);
     }
 #endif
@@ -4784,8 +4768,7 @@ static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
 #endif
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method,
-                                size_t *method_len,
+                                unsigned char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4604,42 +4604,46 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_ED25519
     if(strcmp("ssh-ed25519", (const char *)buf) == 0) {
-        if(!key_type || strcmp("ssh-ed25519", key_type) == 0)
+        if(!key_type || strcmp("ssh-ed25519", key_type) == 0) {
             rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
                                                      method, method_len,
                                                      pubkeydata,
                                                      pubkeydata_len,
                                                  (ssh2_ed25519_ctx **)key_ctx);
+        }
     }
 
     if(strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) == 0) {
-        if(!key_type || strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0)
+        if(!key_type || strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0) {
             rc = ossl_ed25519_openssh_sk_priv_to_pubkey(session, decrypted,
                                                         method, method_len,
                                                         pubkeydata,
                                                         pubkeydata_len,
                                                         NULL, NULL, NULL, NULL,
                                                  (ssh2_ed25519_ctx **)key_ctx);
+        }
     }
 #endif
 #if LIBSSH2_RSA
     if(strcmp("ssh-rsa", (const char *)buf) == 0) {
-        if(!key_type || strcmp("ssh-rsa", key_type) == 0)
+        if(!key_type || strcmp("ssh-rsa", key_type) == 0) {
             rc = ossl_rsa_to_pubkey_openssh_priv_data(session, decrypted,
                                                       method, method_len,
                                                       pubkeydata,
                                                       pubkeydata_len,
                                                      (ssh2_rsa_ctx **)key_ctx);
+        }
     }
 #endif
 #if LIBSSH2_DSA
     if(strcmp("ssh-dss", (const char *)buf) == 0) {
-        if(!key_type || strcmp("ssh-dss", key_type) == 0)
+        if(!key_type || strcmp("ssh-dss", key_type) == 0) {
             rc = ossl_dsa_to_pubkey_openssh_priv_data(session, decrypted,
                                                       method, method_len,
                                                       pubkeydata,
                                                       pubkeydata_len,
                                                      (ssh2_dsa_ctx **)key_ctx);
+        }
     }
 #endif
 #if LIBSSH2_ECDSA
@@ -4652,12 +4656,13 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                                   (ssh2_ecdsa_ctx **)key_ctx);
     }
     else if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0) {
-        if(!key_type || strcmp("ssh-ecdsa", key_type) == 0)
+        if(!key_type || strcmp("ssh-ecdsa", key_type) == 0) {
             rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
                                                    method, method_len,
                                                    pubkeydata,
                                                    pubkeydata_len,
                                                    (ssh2_ecdsa_ctx **)key_ctx);
+        }
     }
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4377,6 +4377,9 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
     int rc = 0;
+#if LIBSSH2_ECDSA
+    ssh2_curve_type type;
+#endif
 
     if(!session) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
@@ -4439,15 +4442,11 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
                                                   NULL);
 #endif
 #if LIBSSH2_ECDSA
-    {
-        ssh2_curve_type type;
-
-        if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0)
-            rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
-                                                   method, method_len,
-                                                   pubkeydata, pubkeydata_len,
-                                                   NULL);
-    }
+    if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0)
+        rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
+                                               method, method_len,
+                                               pubkeydata, pubkeydata_len,
+                                               NULL);
 #endif
 
     if(decrypted)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4745,8 +4745,7 @@ static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
 #if LIBSSH2_ED25519
     if(strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) == 0) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ED25519;
-        if(!key_type ||
-           strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0) {
+        if(!key_type || strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0) {
             rc = ossl_ed25519_openssh_sk_priv_to_pubkey(session, decrypted,
                                                         method, method_len,
                                                         pubkeydata,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1142,11 +1142,9 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 #endif
     BIO_free(bp);
     if(!*rsa)
-        rc = ossl_key_from_openssh_blob(session, (void **)rsa,
-                                        "ssh-rsa",
+        rc = ossl_key_from_openssh_blob(session, (void **)rsa, "ssh-rsa",
                                         NULL, NULL, NULL, NULL,
-                                        filedata, filedata_len,
-                                        passphrase);
+                                        filedata, filedata_len, passphrase);
 
     return rc;
 }
@@ -1559,11 +1557,9 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
 #endif
     BIO_free(bp);
     if(!*dsa)
-        rc = ossl_key_from_openssh_blob(session, (void **)dsa,
-                                        "ssh-dsa",
+        rc = ossl_key_from_openssh_blob(session, (void **)dsa, "ssh-dsa",
                                         NULL, NULL, NULL, NULL,
-                                        filedata, filedata_len,
-                                        passphrase);
+                                        filedata, filedata_len, passphrase);
 
     return rc;
 }
@@ -1895,11 +1891,9 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
 #endif
     BIO_free(bp);
     if(!*ec_ctx)
-        rc = ossl_key_from_openssh_blob(session, (void **)ec_ctx,
-                                        "ssh-ecdsa",
+        rc = ossl_key_from_openssh_blob(session, (void **)ec_ctx, "ssh-ecdsa",
                                         NULL, NULL, NULL, NULL,
-                                        filedata, filedata_len,
-                                        passphrase);
+                                        filedata, filedata_len, passphrase);
 
     return rc;
 }
@@ -2500,11 +2494,9 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
         }
     }
 
-    return ossl_key_from_openssh_blob(session, (void **)ed_ctx,
-                                      "ssh-ed25519",
+    return ossl_key_from_openssh_blob(session, (void **)ed_ctx, "ssh-ed25519",
                                       NULL, NULL, NULL, NULL,
-                                      filedata, filedata_len,
-                                      passphrase);
+                                      filedata, filedata_len, passphrase);
 }
 
 int ssh2_ed25519_new_private_frommemory_sk(ssh2_ed25519_ctx **ed_ctx,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1342,13 +1342,13 @@ out:
 }
 #endif /* !USE_OPENSSL_3 */
 
-static int ossl_rsa_to_pubkey_openssh_priv_data(LIBSSH2_SESSION *session,
-                                                struct string_buf *decrypted,
-                                                unsigned char **method,
-                                                size_t *method_len,
-                                                unsigned char **pubkeydata,
-                                                size_t *pubkeydata_len,
-                                                ssh2_rsa_ctx **rsa_ctx)
+static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
+                                           struct string_buf *decrypted,
+                                           unsigned char **method,
+                                           size_t *method_len,
+                                           unsigned char **pubkeydata,
+                                           size_t *pubkeydata_len,
+                                           ssh2_rsa_ctx **rsa_ctx)
 {
     int rc = 0;
     size_t nlen, elen, dlen, plen, qlen, coefflen, commentlen;
@@ -1487,8 +1487,8 @@ static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
     }
 
     if(strcmp("ssh-rsa", (const char *)buf) == 0) {
-        rc = ossl_rsa_to_pubkey_openssh_priv_data(session, decrypted,
-                                                  NULL, NULL, NULL, NULL, rsa);
+        rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
+                                             NULL, NULL, NULL, NULL, rsa);
     }
     else {
         rc = -1;
@@ -1694,13 +1694,13 @@ alloc_error:
                     "Unable to allocate memory for private key data");
 }
 
-static int ossl_dsa_to_pubkey_openssh_priv_data(LIBSSH2_SESSION *session,
-                                                struct string_buf *decrypted,
-                                                unsigned char **method,
-                                                size_t *method_len,
-                                                unsigned char **pubkeydata,
-                                                size_t *pubkeydata_len,
-                                                ssh2_dsa_ctx **dsa_ctx)
+static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
+                                           struct string_buf *decrypted,
+                                           unsigned char **method,
+                                           size_t *method_len,
+                                           unsigned char **pubkeydata,
+                                           size_t *pubkeydata_len,
+                                           ssh2_dsa_ctx **dsa_ctx)
 {
     int rc = 0;
     size_t plen, qlen, glen, pub_len, priv_len;
@@ -1820,8 +1820,8 @@ static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
     }
 
     if(strcmp("ssh-dss", (const char *)buf) == 0) {
-        rc = ossl_dsa_to_pubkey_openssh_priv_data(session, decrypted,
-                                                  NULL, NULL, NULL, NULL, dsa);
+        rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
+                                             NULL, NULL, NULL, NULL, dsa);
     }
     else {
         rc = -1;
@@ -4430,18 +4430,18 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
 #endif
 #if LIBSSH2_RSA
     if(strcmp("ssh-rsa", (const char *)buf) == 0) {
-        rc = ossl_rsa_to_pubkey_openssh_priv_data(session, decrypted,
-                                                  method, method_len,
-                                                  pubkeydata, pubkeydata_len,
-                                                  NULL);
+        rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
+                                             method, method_len,
+                                             pubkeydata, pubkeydata_len,
+                                             NULL);
     }
 #endif
 #if LIBSSH2_DSA
     if(strcmp("ssh-dss", (const char *)buf) == 0) {
-        rc = ossl_dsa_to_pubkey_openssh_priv_data(session, decrypted,
-                                                  method, method_len,
-                                                  pubkeydata, pubkeydata_len,
-                                                  NULL);
+        rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
+                                             method, method_len,
+                                             pubkeydata, pubkeydata_len,
+                                             NULL);
     }
 #endif
 #if LIBSSH2_ECDSA
@@ -4627,22 +4627,20 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
 #if LIBSSH2_RSA
     if(strcmp("ssh-rsa", (const char *)buf) == 0) {
         if(!key_type || strcmp("ssh-rsa", key_type) == 0) {
-            rc = ossl_rsa_to_pubkey_openssh_priv_data(session, decrypted,
-                                                      method, method_len,
-                                                      pubkeydata,
-                                                      pubkeydata_len,
-                                                     (ssh2_rsa_ctx **)key_ctx);
+            rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
+                                                 method, method_len,
+                                                 pubkeydata, pubkeydata_len,
+                                                 (ssh2_rsa_ctx **)key_ctx);
         }
     }
 #endif
 #if LIBSSH2_DSA
     if(strcmp("ssh-dss", (const char *)buf) == 0) {
         if(!key_type || strcmp("ssh-dss", key_type) == 0) {
-            rc = ossl_dsa_to_pubkey_openssh_priv_data(session, decrypted,
-                                                      method, method_len,
-                                                      pubkeydata,
-                                                      pubkeydata_len,
-                                                     (ssh2_dsa_ctx **)key_ctx);
+            rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
+                                                 method, method_len,
+                                                 pubkeydata, pubkeydata_len,
+                                                 (ssh2_dsa_ctx **)key_ctx);
         }
     }
 #endif
@@ -4650,8 +4648,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
     if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0) {
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
                                                   method, method_len,
-                                                  pubkeydata,
-                                                  pubkeydata_len,
+                                                  pubkeydata, pubkeydata_len,
                                                   NULL, NULL, NULL, NULL,
                                                   (ssh2_ecdsa_ctx **)key_ctx);
     }
@@ -4659,8 +4656,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
         if(!key_type || strcmp("ssh-ecdsa", key_type) == 0) {
             rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
                                                    method, method_len,
-                                                   pubkeydata,
-                                                   pubkeydata_len,
+                                                   pubkeydata, pubkeydata_len,
                                                    (ssh2_ecdsa_ctx **)key_ctx);
         }
     }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1206,7 +1206,7 @@ fail:
     return key;
 }
 
-static int ossl_rsa_to_pubkey_evp(LIBSSH2_SESSION *session,
+static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
                                   unsigned char **method,
                                   size_t *method_len,
                                   unsigned char **pubkeydata,
@@ -1422,7 +1422,7 @@ static int ossl_rsa_to_pubkey_openssh_priv_data(LIBSSH2_SESSION *session,
         EVP_PKEY_set1_RSA(pk, rsa);
 #endif
 
-        rc = ossl_rsa_to_pubkey_evp(session, method, method_len,
+        rc = ossl_rsa_evp_to_pubkey(session, method, method_len,
                                     pubkeydata, pubkeydata_len, pk);
 
 #ifndef USE_OPENSSL_3
@@ -1631,7 +1631,7 @@ fail:
     return key;
 }
 
-static int ossl_dsa_to_pubkey_evp(LIBSSH2_SESSION *session,
+static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
                                   unsigned char **method,
                                   size_t *method_len,
                                   unsigned char **pubkeydata,
@@ -1755,7 +1755,7 @@ static int ossl_dsa_to_pubkey_openssh_priv_data(LIBSSH2_SESSION *session,
         EVP_PKEY_set1_DSA(pk, dsa);
 #endif
 
-        rc = ossl_dsa_to_pubkey_evp(session, method, method_len,
+        rc = ossl_dsa_evp_to_pubkey(session, method, method_len,
                                     pubkeydata, pubkeydata_len, pk);
 
 #ifndef USE_OPENSSL_3
@@ -4524,13 +4524,13 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 #endif /* LIBSSH2_ED25519 */
 #if LIBSSH2_RSA
     case EVP_PKEY_RSA:
-        st = ossl_rsa_to_pubkey_evp(session, method, method_len,
+        st = ossl_rsa_evp_to_pubkey(session, method, method_len,
                                     pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_RSA */
 #if LIBSSH2_DSA
     case EVP_PKEY_DSA:
-        st = ossl_dsa_to_pubkey_evp(session, method, method_len,
+        st = ossl_dsa_evp_to_pubkey(session, method, method_len,
                                     pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_DSA */
@@ -4844,13 +4844,13 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 #endif /* LIBSSH2_ED25519 */
 #if LIBSSH2_RSA
     case EVP_PKEY_RSA:
-        st = ossl_rsa_to_pubkey_evp(session, method, method_len,
+        st = ossl_rsa_evp_to_pubkey(session, method, method_len,
                                     pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_RSA */
 #if LIBSSH2_DSA
     case EVP_PKEY_DSA:
-        st = ossl_dsa_to_pubkey_evp(session, method, method_len,
+        st = ossl_dsa_evp_to_pubkey(session, method, method_len,
                                     pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_DSA */


### PR DESCRIPTION
Also:
- shorten names where possible.
- refactor name to hopefully make them easier to grasp.
- move `ssh2_curve_type` declaration out of blocks to align with sibling
  `if`s and more ~~vertical~~ horizontal space.
- reflow

```
gen_publickey_from_rsa                          -> ossl_rsa_to_pubkey
gen_publickey_from_rsa_evp                      -> ossl_rsa_evp_to_pubkey
rsa_new_additional_parameters                   -> ossl_rsa_additional_params_new
gen_publickey_from_rsa_openssh_priv_data        -> ossl_rsa_openssh_priv_to_pubkey
rsa_new_openssh_private                         -> ossl_rsa_openssh_priv_new
gen_publickey_from_dsa                          -> ossl_dsa_to_pubkey
gen_publickey_from_dsa_evp                      -> ossl_dsa_evp_to_pubkey
gen_publickey_from_dsa_openssh_priv_data        -> ossl_dsa_openssh_priv_to_pubkey
dsa_new_openssh_private                         -> ossl_dsa_openssh_priv_new
gen_publickey_from_ed_evp                       -> ossl_ed25519_evp_to_pubkey
gen_publickey_from_ed25519_openssh_priv_data    -> ossl_ed25519_openssh_priv_to_pubkey
gen_publickey_from_sk_ed25519_openssh_priv_data -> ossl_ed25519_openssh_sk_priv_to_pubkey
gen_publickey_from_ec_evp                       -> ossl_ecdsa_evp_to_pubkey
gen_publickey_from_ecdsa_openssh_priv_data      -> ossl_ecdsa_openssh_priv_to_pubkey
gen_publickey_from_sk_ecdsa_openssh_priv_data   -> ossl_ecdsa_sk_openssh_priv_to_pubkey
ecdsa_new_openssh_private                       -> ossl_ecdsa_openssh_priv_new
ecdsa_new_openssh_private_sk                    -> ossl_ecdsa_sk_openssh_priv_new
sk_pub_openssh_keyfilememory                    -> ossl_key_sk_from_openssh_blob
pub_priv_openssh_keyfilememory                  -> ossl_key_from_openssh_blob
pub_priv_openssh_keyfile                        -> ossl_key_from_openssh_file
```

---

https://github.com/libssh2/libssh2/pull/2003/files?w=1

- [x] maybe shorten `pubkey` to `pubk`? → no real gain.
