### PR TITLE
openssl: fix conditions for enabling AES-GCM support

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -180,10 +180,17 @@
 
 /* wolfSSL v5.4.0 is required due to possibly this bug:
    https://github.com/wolfSSL/wolfssl/pull/5205
-   Before this release, all libssh2 tests crash with AES-GCM enabled */
-#if !defined(OPENSSL_NO_AES) || \
-    (defined(LIBSSH2_WOLFSSL) && LIBWOLFSSL_VERSION_HEX >= 0x05004000 && \
-    defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM))
+   Before this release, all libssh2 tests crash with AES-GCM enabled.
+   LibreSSL v3.6.0+ is required. */
+#if defined(LIBSSH2_WOLFSSL) && \
+    (LIBWOLFSSL_VERSION_HEX < 0x05004000 || \
+     !defined(HAVE_AESGCM) || !defined(WOLFSSL_AESGCM_STREAM))
+# define HAVE_NO_AES_GCM
+#elif defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3060000fL
+# define HAVE_NO_AES_GCM
+#endif
+
+#if !defined(OPENSSL_NO_AES) && !defined(HAVE_NO_AES_GCM)
 # define LIBSSH2_AES_GCM 1
 #else
 # define LIBSSH2_AES_GCM 0


### PR DESCRIPTION
Require LibreSSL 3.6.0+. Older versions fail to compile with this:
```
src/openssl.c:861:40: error: use of undeclared identifier 'EVP_CTRL_AEAD_SET_IV_FIXED'
  861 |         rc |= !EVP_CIPHER_CTX_ctrl(*h, EVP_CTRL_AEAD_SET_IV_FIXED, -1, iv);
      |                                        ^
```

Also fix the guard after its previous update to behave as intended.

Follow-up to cea796fc2dd79aa56d56a5e6b0ded36662c6f094 #1668