### PR TITLE
REQUIREMENTS.md: recommend wolfSSL/LibreSSL versions with AES-GCM support

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -335,7 +335,7 @@ This release includes the following enhancements and bugfixes:
 - pem: add validation for data length and padding (00b17231 #1797)
 - pem: fix possible double free if key in error cases (2fb5803c #1550 #1549)
 - publickey: fix double-free by transferring ownership of receive_packet (86301ab5 #1699)
-- REQUIREMENTS.txt: set/bump and document minimum versions (772abc7a #1919 #1893)
+- REQUIREMENTS.md: set/bump and document minimum versions (772abc7a #1919 #1893)
 - REUSE: add copyright headers to more files, `.gitignore` updates (4f9e6e0b #1718)
 - scp: fix NULL dereference in path arg of send/recv (992dafbc #1625)
 - scripts: move `maketgz`, `git2news.pl` from root to scripts directory (07ffced7 #1918)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -20,7 +20,7 @@ We aim to support these or later versions.
 
 Building libssh2 requires these or later tool versions:
 
-- clang-tidy     17.0.0 (2023-09-19), recommended: 19.1.0 or later (2024-09-17)
+- clang-tidy     17.0.0 (2023-09-19), recommended: 19.1.0 (2024-09-17)
 - cmake          3.18 (2020-07-15)
 - GNU autoconf   2.59 (2003-11-06)
 - GNU automake   1.7 (2002-09-25)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -9,11 +9,11 @@ SPDX-License-Identifier: BSD-3-Clause
 We aim to support these or later versions.
 
 - Libgcrypt      1.8 (2017-07-18)
-- LibreSSL       2.8.0 (2018-08-04)
+- LibreSSL       2.8.0 (2018-08-04), recommended: 3.6.0 (2022-09-27) for AES-GCM
 - mbedTLS        3.1.0 - 3.6.x (2021-12-15)
 - OpenSSL        1.1.1 (2018-09-11)
 - Windows        Vista 6.0 (2006-11-08 - 2012-04-10)
-- wolfSSL        5.0.0 (2021-11-01)
+- wolfSSL        5.0.0 (2021-11-01), recommended: 5.7.0 (2024-03-20) for AES-GCM
 - zlib           1.2.5.2 (2011-12-11)
 
 ## Build tools

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -13,7 +13,7 @@ We aim to support these or later versions.
 - mbedTLS        3.1.0 - 3.6.x (2021-12-15)
 - OpenSSL        1.1.1 (2018-09-11)
 - Windows        Vista 6.0 (2006-11-08 - 2012-04-10)
-- wolfSSL        5.0.0 (2021-11-01), recommended: 5.7.0 (2024-03-20) for AES-GCM
+- wolfSSL        5.0.0 (2021-11-01), recommended: 5.4.0 (2022-07-11) for AES-GCM
 - zlib           1.2.5.2 (2011-12-11)
 
 ## Build tools

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 We aim to support these or later versions.
 
 - Libgcrypt      1.8 (2017-07-18)
-- LibreSSL       2.8.0 (2018-08-04), recommended: 3.6.0 (2022-10-05) for AES-GCM
+- LibreSSL       2.8.0 (2018-08-06), recommended: 3.6.0 (2022-10-05) for AES-GCM
 - mbedTLS        3.1.0 - 3.6.x (2021-12-15)
 - OpenSSL        1.1.1 (2018-09-11)
 - Windows        Vista 6.0 (2006-11-08 - 2012-04-10)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 We aim to support these or later versions.
 
 - Libgcrypt      1.8 (2017-07-18)
-- LibreSSL       2.8.0 (2018-08-04), recommended: 3.6.0 (2022-09-27) for AES-GCM
+- LibreSSL       2.8.0 (2018-08-04), recommended: 3.6.0 (2022-10-05) for AES-GCM
 - mbedTLS        3.1.0 - 3.6.x (2021-12-15)
 - OpenSSL        1.1.1 (2018-09-11)
 - Windows        Vista 6.0 (2006-11-08 - 2012-04-10)


### PR DESCRIPTION
On this note, LibreSSL 3.7.0+ (2022-12-12) also supports ed25519.

Also fix related filename typo in RELEASE-NOTES, and a date typo.

Refs:
https://www.libressl.org/releases.html
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.6.0-relnotes.txt
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.7.0-relnotes.txt
https://github.com/wolfSSL/wolfssl/releases/tag/v5.4.0-stable
