### PR TITLE
mbedtls: drop redundant check for version 3+

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -471,11 +471,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     if(!*rsa)
         return -1;
 
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
     mbedtls_rsa_init(*rsa);
-#else
-    mbedtls_rsa_init(*rsa, MBEDTLS_RSA_PKCS_V15, 0);
-#endif
 
     /*
     mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"


### PR DESCRIPTION
The check for version 3+ is redundant after bumping the minimum to 3.1.

Follow-up to f63f68b3500ed924115d0dc39bae212cde42a87f #1727
Follow-up to 7419595ad89f5b93aef01ffc3e3b13c1090190b6 #1822
