### PR TITLE
docker-bridge.ps1: update AppVeyor CI external IP detection endpoint

### DIFF
--- a/scripts/appveyor/docker-bridge.ps1
+++ b/scripts/appveyor/docker-bridge.ps1
@@ -19,7 +19,7 @@ elseif($ip.StartsWith('10.0.')) {
 }
 
 # get external IP
-$extip = (New-Object Net.WebClient).DownloadString('https://www.appveyor.com/tools/my-ip.aspx').Trim()
+$extip = (New-Object Net.WebClient).DownloadString('https://checkip.amazonaws.com/').Trim()
 
 # allow inbound traffic
 New-NetFirewallRule -DisplayName 'SSH via RDP port' -Direction Inbound -Action Allow -Protocol TCP -LocalPort 22,3389


### PR DESCRIPTION
To fix detecting true external IP after AppVeyor servers moved behind
Cloudflare on 2026-06-01.

Thanks-to: Feodor Fitsner

Refs:
https://github.com/appveyor/ci/commit/4ceb9edec1a3fc399e4fbea447f1409c9add461d
https://github.com/libssh2/libssh2/pull/1947#issuecomment-4663567348
https://github.com/libssh2/libssh2/pull/1947#issuecomment-4663596228

Bug:
https://github.com/libssh2/libssh2/pull/1947#issuecomment-4662191546
https://github.com/libssh2/libssh2/pull/1947#issuecomment-4663379375
