### PR TITLE
tidy-up: drop stray comparisons with literal zero

### DIFF
--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    if(fstat(fileno(local), &fileinfo) != 0) {
+    if(fstat(fileno(local), &fileinfo)) {
         fprintf(stderr, "error: could not stat file %s\n", loclfile);
         fclose(local);
         return 1;

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    if(fstat(fileno(local), &fileinfo) != 0) {
+    if(fstat(fileno(local), &fileinfo)) {
         fprintf(stderr, "error: could not stat file %s\n", loclfile);
         fclose(local);
         return 1;

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
     }
     libssh2_knownhost_free(nh);
 
-    if(strlen(password) != 0) {
+    if(strlen(password)) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN)

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -203,7 +203,7 @@ int main(int argc, char *argv[])
     }
     libssh2_knownhost_free(nh);
 
-    if(strlen(password) != 0) {
+    if(strlen(password)) {
         /* We could authenticate via password */
         while((rc = libssh2_userauth_password(session, username, password)) ==
               LIBSSH2_ERROR_EAGAIN)

--- a/example/x11.c
+++ b/example/x11.c
@@ -109,7 +109,7 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
      */
     display = getenv("DISPLAY");
     if(display) {
-        if(strncmp(display, "unix:", 5) == 0 || display[0] == ':') {
+        if(!strncmp(display, "unix:", 5) || display[0] == ':') {
             const char *ptr;
             char *temp_buff;
             int display_port;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -771,15 +771,15 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
         return -1;
 
     if(type == SSH2_EC_CURVE_NISTP256 &&
-       strncmp((char *)domain, "nistp256", 8) != 0) {
+       strncmp((char *)domain, "nistp256", 8)) {
         return -1;
     }
     else if(type == SSH2_EC_CURVE_NISTP384 &&
-            strncmp((char *)domain, "nistp384", 8) != 0) {
+            strncmp((char *)domain, "nistp384", 8)) {
         return -1;
     }
     else if(type == SSH2_EC_CURVE_NISTP521 &&
-            strncmp((char *)domain, "nistp521", 8) != 0) {
+            strncmp((char *)domain, "nistp521", 8)) {
         return -1;
     }
 

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -86,16 +86,16 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
 
     /* we accept one of 3 header types */
 #if LIBSSH2_RSA_SHA1
-    if(type_len == 7 && strncmp("ssh-rsa", (char *)type, 7) == 0) {
+    if(type_len == 7 && !strncmp("ssh-rsa", (char *)type, 7)) {
         /* ssh-rsa */
     }
     else
 #endif
 #if LIBSSH2_RSA_SHA2
-    if(type_len == 12 && strncmp("rsa-sha2-256", (char *)type, 12) == 0) {
+    if(type_len == 12 && !strncmp("rsa-sha2-256", (char *)type, 12)) {
         /* rsa-sha2-256 */
     }
-    else if(type_len == 12 && strncmp("rsa-sha2-512", (char *)type, 12) == 0) {
+    else if(type_len == 12 && !strncmp("rsa-sha2-512", (char *)type, 12)) {
         /* rsa-sha2-512 */
     }
     else
@@ -754,13 +754,13 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
     if(ssh2_get_string(&buf, &type_str, &len) || len != 19)
         return -1;
 
-    if(strncmp((char *)type_str, "ecdsa-sha2-nistp256", 19) == 0) {
+    if(!strncmp((char *)type_str, "ecdsa-sha2-nistp256", 19)) {
         type = SSH2_EC_CURVE_NISTP256;
     }
-    else if(strncmp((char *)type_str, "ecdsa-sha2-nistp384", 19) == 0) {
+    else if(!strncmp((char *)type_str, "ecdsa-sha2-nistp384", 19)) {
         type = SSH2_EC_CURVE_NISTP384;
     }
-    else if(strncmp((char *)type_str, "ecdsa-sha2-nistp521", 19) == 0) {
+    else if(!strncmp((char *)type_str, "ecdsa-sha2-nistp521", 19)) {
         type = SSH2_EC_CURVE_NISTP521;
     }
     else {

--- a/src/kex.c
+++ b/src/kex.c
@@ -1659,9 +1659,9 @@ static int kex_session_hybrid_curve_type(const char *name,
     if(!name)
         return -1;
 
-    if(strcmp(name, "mlkem768nistp256-sha256") == 0)
+    if(!strcmp(name, "mlkem768nistp256-sha256"))
         type = SSH2_EC_CURVE_NISTP256;
-    else if(strcmp(name, "mlkem1024nistp384-sha384") == 0)
+    else if(!strcmp(name, "mlkem1024nistp384-sha384"))
         type = SSH2_EC_CURVE_NISTP384;
     else {
         return -1;
@@ -1915,11 +1915,11 @@ static int kex_session_ecdh_curve_type(const char *name,
     if(!name)
         return -1;
 
-    if(strcmp(name, "ecdh-sha2-nistp256") == 0)
+    if(!strcmp(name, "ecdh-sha2-nistp256"))
         type = SSH2_EC_CURVE_NISTP256;
-    else if(strcmp(name, "ecdh-sha2-nistp384") == 0)
+    else if(!strcmp(name, "ecdh-sha2-nistp384"))
         type = SSH2_EC_CURVE_NISTP384;
-    else if(strcmp(name, "ecdh-sha2-nistp521") == 0)
+    else if(!strcmp(name, "ecdh-sha2-nistp521"))
         type = SSH2_EC_CURVE_NISTP521;
     else {
         return -1;
@@ -3666,7 +3666,7 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
     left = end_haystack - s;
 
     /* Needle at start of haystack */
-    if(strncmp((char *)haystack, (const char *)needle, needle_len) == 0 &&
+    if(!strncmp((char *)haystack, (const char *)needle, needle_len) &&
        (needle_len == haystack_len || haystack[needle_len] == ',')) {
         return haystack;
     }
@@ -3686,7 +3686,7 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
         }
 
         /* Needle at X position */
-        if(strncmp((char *)s, (const char *)needle, needle_len) == 0 &&
+        if(!strncmp((char *)s, (const char *)needle, needle_len) &&
            (((s - haystack) + needle_len) == haystack_len ||
             s[needle_len] == ',')) {
             return s;
@@ -3702,7 +3702,7 @@ static const struct common_method *kex_get_method_by_name(
 {
     while(*methodlist) {
         if(strlen((*methodlist)->name) == name_len &&
-           strncmp((*methodlist)->name, name, name_len) == 0) {
+           !strncmp((*methodlist)->name, name, name_len)) {
             return *methodlist;
         }
         methodlist++;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -873,7 +873,7 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_RSA_SHA2
     if(key_method_len == 7 &&
-       memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
+       !memcmp(key_method, "ssh-rsa", key_method_len)) {
         return "rsa-sha2-512,rsa-sha2-256"
 #if LIBSSH2_RSA_SHA1
             ",ssh-rsa"

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1213,12 +1213,12 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
     fp = fopen(filename, "rb");
     if(!fp)
         goto cleanup;
-    if(fseek(fp, 0, SEEK_END) != 0)
+    if(fseek(fp, 0, SEEK_END))
         goto cleanup;
     file_size = ftell(fp);
     if(file_size < 0 || file_size > (1024 * 1024))
         goto cleanup;
-    if(fseek(fp, 0, SEEK_SET) != 0)
+    if(fseek(fp, 0, SEEK_SET))
         goto cleanup;
     data_len = (size_t)file_size;
     if(data_len == 0)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1105,11 +1105,11 @@ static int mbed_ecdsa_curve_type_from_name(const char *name,
     if(!name || strlen(name) != 19)
         return -1;
 
-    if(strcmp(name, "ecdsa-sha2-nistp256") == 0)
+    if(!strcmp(name, "ecdsa-sha2-nistp256"))
         type = SSH2_EC_CURVE_NISTP256;
-    else if(strcmp(name, "ecdsa-sha2-nistp384") == 0)
+    else if(!strcmp(name, "ecdsa-sha2-nistp384"))
         type = SSH2_EC_CURVE_NISTP384;
-    else if(strcmp(name, "ecdsa-sha2-nistp521") == 0)
+    else if(!strcmp(name, "ecdsa-sha2-nistp521"))
         type = SSH2_EC_CURVE_NISTP521;
     else {
         return -1;
@@ -1387,7 +1387,7 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_RSA_SHA2
     if(key_method_len == 7 &&
-       memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
+       !memcmp(key_method, "ssh-rsa", key_method_len)) {
         return "rsa-sha2-512,rsa-sha2-256"
 #if LIBSSH2_RSA_SHA1
             ",ssh-rsa"

--- a/src/misc.c
+++ b/src/misc.c
@@ -871,7 +871,7 @@ int ssh2_match_string(struct string_buf *buf, const char *match)
     unsigned char *out;
     size_t len = 0;
     if(ssh2_get_string(buf, &out, &len) || len != strlen(match) ||
-       strncmp((char *)out, match, strlen(match)) != 0) {
+       strncmp((char *)out, match, strlen(match))) {
         return -1;
     }
     return 0;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -655,11 +655,11 @@ int ssh2_ecdsa_curve_type_from_name(const char *name,
     if(!name || strlen(name) != 19)
         return -1;
 
-    if(strcmp(name, "ecdsa-sha2-nistp256") == 0)
+    if(!strcmp(name, "ecdsa-sha2-nistp256"))
         type = SSH2_EC_CURVE_NISTP256;
-    else if(strcmp(name, "ecdsa-sha2-nistp384") == 0)
+    else if(!strcmp(name, "ecdsa-sha2-nistp384"))
         type = SSH2_EC_CURVE_NISTP384;
-    else if(strcmp(name, "ecdsa-sha2-nistp521") == 0)
+    else if(!strcmp(name, "ecdsa-sha2-nistp521"))
         type = SSH2_EC_CURVE_NISTP521;
     else
         return -1;
@@ -1343,7 +1343,7 @@ static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
         return -1;
     }
 
-    if(strcmp("ssh-rsa", (const char *)buf) == 0)
+    if(!strcmp("ssh-rsa", (const char *)buf))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
                                              NULL, NULL, NULL, NULL, rsa);
     else
@@ -1657,7 +1657,7 @@ static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
         return -1;
     }
 
-    if(strcmp("ssh-dss", (const char *)buf) == 0)
+    if(!strcmp("ssh-dss", (const char *)buf))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
                                              NULL, NULL, NULL, NULL, dsa);
     else
@@ -2202,7 +2202,7 @@ int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
         return -1;
     }
 
-    if(strcmp("ssh-ed25519", (const char *)buf) == 0)
+    if(!strcmp("ssh-ed25519", (const char *)buf))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
                                                  NULL, NULL, NULL, NULL, &ctx);
     else
@@ -2264,7 +2264,7 @@ int ssh2_ed25519_new_private_sk(ssh2_ed25519_ctx **ed_ctx,
         return -1;
     }
 
-    if(strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) == 0)
+    if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf))
         rc = ossl_ed25519_openssh_sk_priv_to_pubkey(session, decrypted,
                                                     NULL, NULL, NULL, NULL,
                                                     flags, application,
@@ -3523,7 +3523,7 @@ static int ossl_ecdsa_sk_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
         return -1;
     }
 
-    if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0)
+    if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf))
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
                                                   NULL, NULL, NULL, NULL,
                                                   flags, application,
@@ -4089,21 +4089,21 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
     (void)pubkeydata_len;
 
 #if LIBSSH2_ED25519
-    if(strcmp("ssh-ed25519", (const char *)buf) == 0)
+    if(!strcmp("ssh-ed25519", (const char *)buf))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
                                                  method, method_len,
                                                  pubkeydata, pubkeydata_len,
                                                  NULL);
 #endif
 #if LIBSSH2_RSA
-    if(strcmp("ssh-rsa", (const char *)buf) == 0)
+    if(!strcmp("ssh-rsa", (const char *)buf))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
                                              method, method_len,
                                              pubkeydata, pubkeydata_len,
                                              NULL);
 #endif
 #if LIBSSH2_DSA
-    if(strcmp("ssh-dss", (const char *)buf) == 0)
+    if(!strcmp("ssh-dss", (const char *)buf))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
                                              method, method_len,
                                              pubkeydata, pubkeydata_len,
@@ -4258,15 +4258,15 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
     (void)pubkeydata_len;
 
 #if LIBSSH2_ED25519
-    if(strcmp("ssh-ed25519", (const char *)buf) == 0 &&
-       (!key_type || strcmp("ssh-ed25519", key_type) == 0))
+    if(!strcmp("ssh-ed25519", (const char *)buf) &&
+       (!key_type || !strcmp("ssh-ed25519", key_type)))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
                                                  method, method_len,
                                                  pubkeydata, pubkeydata_len,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 
-    if(strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) == 0 &&
-       (!key_type || strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0))
+    if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) &&
+       (!key_type || !strcmp("sk-ssh-ed25519@openssh.com", key_type)))
         rc = ossl_ed25519_openssh_sk_priv_to_pubkey(session, decrypted,
                                                     method, method_len,
                                                     pubkeydata, pubkeydata_len,
@@ -4274,30 +4274,30 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 #endif
 #if LIBSSH2_RSA
-    if(strcmp("ssh-rsa", (const char *)buf) == 0 &&
-       (!key_type || strcmp("ssh-rsa", key_type) == 0))
+    if(!strcmp("ssh-rsa", (const char *)buf) &&
+       (!key_type || !strcmp("ssh-rsa", key_type)))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
                                              method, method_len,
                                              pubkeydata, pubkeydata_len,
                                              (ssh2_rsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_DSA
-    if(strcmp("ssh-dss", (const char *)buf) == 0 &&
-       (!key_type || strcmp("ssh-dss", key_type) == 0))
+    if(!strcmp("ssh-dss", (const char *)buf) &&
+       (!key_type || !strcmp("ssh-dss", key_type)))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
                                              method, method_len,
                                              pubkeydata, pubkeydata_len,
                                              (ssh2_dsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_ECDSA
-    if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0)
+    if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf))
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
                                                   method, method_len,
                                                   pubkeydata, pubkeydata_len,
                                                   NULL, NULL, NULL, NULL,
                                                   (ssh2_ecdsa_ctx **)key_ctx);
     else if(ssh2_ecdsa_curve_type_from_name((const char *)buf, &type) == 0 &&
-            (!key_type || strcmp("ssh-ecdsa", key_type) == 0))
+            (!key_type || !strcmp("ssh-ecdsa", key_type)))
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
                                                method, method_len,
                                                pubkeydata, pubkeydata_len,
@@ -4374,9 +4374,9 @@ static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
     (void)handle_len;
 
 #if LIBSSH2_ED25519
-    if(strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) == 0) {
+    if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf)) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ED25519;
-        if(!key_type || strcmp("sk-ssh-ed25519@openssh.com", key_type) == 0)
+        if(!key_type || !strcmp("sk-ssh-ed25519@openssh.com", key_type))
             rc = ossl_ed25519_openssh_sk_priv_to_pubkey(session, decrypted,
                                                         method, method_len,
                                                         pubkeydata,
@@ -4387,7 +4387,7 @@ static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
     }
 #endif
 #if LIBSSH2_ECDSA
-    if(strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf) == 0) {
+    if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf)) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ECDSA_256;
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
                                                   method, method_len,
@@ -4593,11 +4593,9 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_RSA_SHA2
     if((key_method_len == 7 &&
-        memcmp(key_method, "ssh-rsa", key_method_len) == 0) ||
+        !memcmp(key_method, "ssh-rsa", key_method_len)) ||
        (key_method_len == 28 &&
-        memcmp(key_method, "ssh-rsa-cert-v01@openssh.com",
-               key_method_len) == 0)
-       ) {
+        !memcmp(key_method, "ssh-rsa-cert-v01@openssh.com", key_method_len))) {
         return "rsa-sha2-512,rsa-sha2-256"
 #if LIBSSH2_RSA_SHA1
             ",ssh-rsa"

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2439,7 +2439,7 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
     (void)session;
 
     if(key_method_len == 7 &&
-       memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
+       !memcmp(key_method, "ssh-rsa", key_method_len)) {
         return "rsa-sha2-512,rsa-sha2-256"
 #if LIBSSH2_RSA_SHA1
             ",ssh-rsa"

--- a/src/packet.c
+++ b/src/packet.c
@@ -137,8 +137,8 @@ static SSH2_INLINE int packet_queue_listener(
         while(listn) {
             if(listn->port == (int)listen_state->port &&
                strlen(listn->host) == listen_state->host_len &&
-               memcmp(listn->host, listen_state->host,
-                      listen_state->host_len) == 0) {
+               !memcmp(listn->host, listen_state->host,
+                       listen_state->host_len)) {
                 /* This is our listener */
                 LIBSSH2_CHANNEL *channel = NULL;
                 listen_state->channel = NULL;
@@ -878,7 +878,7 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                     }
 
                     if(name && name_len == 15 &&
-                       memcmp(name, "server-sig-algs", 15) == 0) {
+                       !memcmp(name, "server-sig-algs", 15)) {
                         if(session->server_sign_algorithms) {
                             SSH2_FREE(session,
                                       session->server_sign_algorithms);
@@ -1269,8 +1269,8 @@ clean_exit:
                 ;
             else if(datalen >= (strlen("forwarded-tcpip") + 5) &&
                     strlen("forwarded-tcpip") == ssh2_ntohu32(data + 1) &&
-                    memcmp(data + 5, "forwarded-tcpip",
-                           strlen("forwarded-tcpip")) == 0) {
+                    !memcmp(data + 5, "forwarded-tcpip",
+                            strlen("forwarded-tcpip"))) {
 
                 /* init the state struct */
                 memset(&session->packAdd_Qlstn_state, 0,
@@ -1283,7 +1283,7 @@ ssh2_packet_add_jump_point2:
             }
             else if(datalen >= (strlen("x11") + 5) &&
                     strlen("x11") == ssh2_ntohu32(data + 1) &&
-                    memcmp(data + 5, "x11", strlen("x11")) == 0) {
+                    !memcmp(data + 5, "x11", strlen("x11"))) {
 
                 /* init the state struct */
                 memset(&session->packAdd_x11open_state, 0,
@@ -1297,8 +1297,8 @@ ssh2_packet_add_jump_point3:
             else if(datalen >= (strlen("auth-agent@openssh.com") + 5) &&
                     strlen("auth-agent@openssh.com") ==
                         ssh2_ntohu32(data + 1) &&
-                    memcmp(data + 5, "auth-agent@openssh.com",
-                           strlen("auth-agent@openssh.com")) == 0) {
+                    !memcmp(data + 5, "auth-agent@openssh.com",
+                            strlen("auth-agent@openssh.com"))) {
 
                 /* init the state struct */
                 memset(&session->packAdd_authagent_state, 0,
@@ -1434,7 +1434,7 @@ int ssh2_packet_ask(LIBSSH2_SESSION *session, unsigned char packet_type,
         if(packet->data[0] == packet_type &&
            packet->data_len >= (match_ofs + match_len) &&
            (!match_buf ||
-            memcmp(packet->data + match_ofs, match_buf, match_len) == 0)) {
+            !memcmp(packet->data + match_ofs, match_buf, match_len))) {
             *data = packet->data;
             *data_len = packet->data_len;
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -196,7 +196,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
     }
 
     if(passphrase &&
-       memcmp(line, crypt_annotation, strlen(crypt_annotation)) == 0) {
+       !memcmp(line, crypt_annotation, strlen(crypt_annotation))) {
         const struct crypt_method **all_methods, *cur_method;
         int i;
 
@@ -209,8 +209,8 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         /* !checksrc! disable EQUALSNULL 1 */
         while((cur_method = *all_methods++) != NULL) {
             if(*cur_method->pem_annotation &&
-               memcmp(line, cur_method->pem_annotation,
-                      strlen(cur_method->pem_annotation)) == 0) {
+               !memcmp(line, cur_method->pem_annotation,
+                       strlen(cur_method->pem_annotation))) {
                 method = cur_method;
                 memcpy(iv, line + strlen(method->pem_annotation) + 1,
                        2 * method->iv_len);
@@ -528,8 +528,8 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
         all_methods = ssh2_crypt_methods();
         /* !checksrc! disable EQUALSNULL 1 */
         while((cur_method = *all_methods++) != NULL) {
-            if(*cur_method->name && memcmp(ciphername, cur_method->name,
-                                           strlen(cur_method->name)) == 0) {
+            if(*cur_method->name && !memcmp(ciphername, cur_method->name,
+                                            strlen(cur_method->name))) {
                 method = cur_method;
             }
         }
@@ -559,7 +559,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(strcmp((const char *)kdfname, "bcrypt") == 0 && passphrase) {
+        if(!strcmp((const char *)kdfname, "bcrypt") && passphrase) {
             if(ssh2_get_string(&kdf_buf, &salt, &salt_len) ||
                ssh2_get_u32(&kdf_buf, &rounds) != 0) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -651,8 +651,8 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
 
             /* for the AES GCM methods, the 16 byte authentication tag is
              * appended to the encrypted key */
-            if(strcmp(method->name, "aes256-gcm@openssh.com") == 0 ||
-               strcmp(method->name, "aes128-gcm@openssh.com") == 0) {
+            if(!strcmp(method->name, "aes256-gcm@openssh.com") ||
+               !strcmp(method->name, "aes128-gcm@openssh.com")) {
                 if(!ssh2_check_length(&decoded, 16)) {
                     ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                    "GCM auth tag missing");

--- a/src/pem.c
+++ b/src/pem.c
@@ -115,7 +115,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     long file_size;
     size_t filedata_len;
 
-    if(fseek(fp, 0L, SEEK_END) != 0) {
+    if(fseek(fp, 0L, SEEK_END)) {
         ssh2_err(session, LIBSSH2_ERROR_FILE,
                  "Bad seek to file end in PEM parsing");
         goto out;
@@ -136,7 +136,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
                  "Input too large in PEM parsing");
         goto out;
     }
-    if(fseek(fp, 0L, SEEK_SET) != 0) {
+    if(fseek(fp, 0L, SEEK_SET)) {
         ssh2_err(session, LIBSSH2_ERROR_FILE, "Bad seek to 0 in PEM parsing");
         goto out;
     }
@@ -189,7 +189,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
 
         if(!*line)
             break;
-    } while(strcmp(line, headerbegin) != 0);
+    } while(strcmp(line, headerbegin));
 
     if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
         return -1;
@@ -264,7 +264,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
             ret = -1;
             goto out;
         }
-    } while(strcmp(line, headerend) != 0);
+    } while(strcmp(line, headerend));
 
     if(!b64data) {
         return -1;
@@ -451,7 +451,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
     }
 
     if(strncmp((const char *)decoded.dataptr, AUTH_MAGIC,
-               strlen(AUTH_MAGIC)) != 0) {
+               strlen(AUTH_MAGIC))) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                        "key auth magic mismatch");
         goto out;
@@ -480,20 +480,20 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
     }
 
     if((!passphrase || strlen((const char *)passphrase) == 0) &&
-       strcmp((const char *)ciphername, "none") != 0) {
+       strcmp((const char *)ciphername, "none")) {
         /* passphrase required */
         ret = LIBSSH2_ERROR_KEYFILE_AUTH_FAILED;
         goto out;
     }
 
-    if(strcmp((const char *)kdfname, "none") != 0 &&
-       strcmp((const char *)kdfname, "bcrypt") != 0) {
+    if(strcmp((const char *)kdfname, "none") &&
+       strcmp((const char *)kdfname, "bcrypt")) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "unknown cipher");
         goto out;
     }
 
     if(!strcmp((const char *)kdfname, "none") &&
-       strcmp((const char *)ciphername, "none") != 0) {
+       strcmp((const char *)ciphername, "none")) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "invalid format");
         goto out;
     }
@@ -522,7 +522,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
     decrypted.data = decrypted.dataptr = buf;
     decrypted.len = tmp_len;
 
-    if(ciphername && strcmp((const char *)ciphername, "none") != 0) {
+    if(ciphername && strcmp((const char *)ciphername, "none")) {
         const struct crypt_method **all_methods, *cur_method;
 
         all_methods = ssh2_crypt_methods();
@@ -748,7 +748,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
         if(readline(line, LINE_SIZE, fp)) {
             return -1;
         }
-    } while(strcmp(line, OPENSSH_HEADER_BEGIN) != 0);
+    } while(strcmp(line, OPENSSH_HEADER_BEGIN));
 
     if(readline(line, LINE_SIZE, fp)) {
         return -1;
@@ -778,7 +778,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
             ret = -1;
             goto out;
         }
-    } while(strcmp(line, OPENSSH_HEADER_END) != 0);
+    } while(strcmp(line, OPENSSH_HEADER_END));
 
     if(!b64data) {
         return -1;
@@ -824,7 +824,7 @@ int ssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
         if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
             return -1;
         }
-    } while(strcmp(line, OPENSSH_HEADER_BEGIN) != 0);
+    } while(strcmp(line, OPENSSH_HEADER_BEGIN));
 
     *line = '\0';
 
@@ -857,7 +857,7 @@ int ssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
             ret = -1;
             goto out;
         }
-    } while(strcmp(line, OPENSSH_HEADER_END) != 0);
+    } while(strcmp(line, OPENSSH_HEADER_END));
 
     if(!b64data)
         return ssh2_err(session, LIBSSH2_ERROR_PROTO,

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -200,7 +200,7 @@ static int publickey_response_id(unsigned char **pdata, size_t data_len)
 
     while(codes->name) {
         if((unsigned long)codes->name_len == response_len &&
-           strncmp(codes->name, (char *)data, response_len) == 0) {
+           !strncmp(codes->name, (char *)data, response_len)) {
             *pdata = data + response_len;
             return codes->code;
         }
@@ -580,8 +580,7 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
             for(i = 0; i < num_attrs; i++) {
                 /* Search for a comment attribute */
                 if(attrs[i].name_len == (sizeof("comment") - 1) &&
-                   strncmp(attrs[i].name, "comment",
-                           sizeof("comment") - 1) == 0) {
+                   !strncmp(attrs[i].name, "comment", sizeof("comment") - 1)) {
                     comment = (const unsigned char *)attrs[i].value;
                     comment_len = attrs[i].value_len;
                     break;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -977,7 +977,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
             SSH2_FREE(session, extversion_str);
         }
         if(extname_len == 24 &&
-           strncmp("posix-rename@openssh.com", (char *)extname, 24) == 0) {
+           !strncmp("posix-rename@openssh.com", (char *)extname, 24)) {
             sftp_handle->posix_rename_version = extversion;
         }
     }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -756,8 +756,8 @@ static int memory_read_privatekey(LIBSSH2_SESSION *session,
     *hostkey_abstract = NULL;
     while(*hostkey_methods_avail && (*hostkey_methods_avail)->name) {
         if((*hostkey_methods_avail)->initPEMFromMemory &&
-           strncmp((*hostkey_methods_avail)->name, (const char *)method,
-                   method_len) == 0) {
+           !strncmp((*hostkey_methods_avail)->name, (const char *)method,
+                    method_len)) {
             *hostkey_method = *hostkey_methods_avail;
             break;
         }
@@ -799,8 +799,8 @@ static int file_read_privatekey(LIBSSH2_SESSION *session,
     *hostkey_abstract = NULL;
     while(*hostkey_methods_avail && (*hostkey_methods_avail)->name) {
         if((*hostkey_methods_avail)->initPEM &&
-           strncmp((*hostkey_methods_avail)->name, (const char *)method,
-                   method_len) == 0) {
+           !strncmp((*hostkey_methods_avail)->name, (const char *)method,
+                    method_len)) {
             *hostkey_method = *hostkey_methods_avail;
             break;
         }
@@ -1418,7 +1418,7 @@ static int key_sign_algorithm(LIBSSH2_SESSION *session,
             int SSH_BUG_SIGTYPE = is_version_less_than_78(remote_ver);
             if(SSH_BUG_SIGTYPE &&
                *key_method && *key_method_len == method_len &&
-               memcmp(*key_method, method, method_len) == 0) {
+               !memcmp(*key_method, method, method_len)) {
                 return LIBSSH2_ERROR_NONE;
             }
         }
@@ -1447,7 +1447,7 @@ static int key_sign_algorithm(LIBSSH2_SESSION *session,
             f = strchr(a, ',');
             f_len = f ? (size_t)(f - a) : strlen(a);
 
-            if(f_len == p_len && memcmp(a, s, p_len) == 0) {
+            if(f_len == p_len && !memcmp(a, s, p_len)) {
 
                 if(i != filtered_algs) {
                     memcpy(i, ",", 1);
@@ -1480,7 +1480,7 @@ static int key_sign_algorithm(LIBSSH2_SESSION *session,
             f = strchr(a, ',');
             f_len = f ? (size_t)(f - a) : strlen(a);
 
-            if(f_len == p_len && memcmp(a, s, p_len) == 0) {
+            if(f_len == p_len && !memcmp(a, s, p_len)) {
                 /* found a match, upgrade key method */
                 match = s;
                 match_len = p_len;
@@ -1495,7 +1495,7 @@ static int key_sign_algorithm(LIBSSH2_SESSION *session,
 
     if(match) {
         if(*key_method && *key_method_len == method_len &&
-           memcmp(*key_method, method, method_len) == 0) {
+           !memcmp(*key_method, method, method_len)) {
             SSH2_FREE(session, *key_method);
             *key_method = SSH2_ALLOC(session, match_len + suffix_len);
             if(*key_method) {
@@ -1832,12 +1832,12 @@ retry_auth:
             plain_method((char *)session->userauth_pblc_method,
                          session->userauth_pblc_method_len);
 
-        if(strncmp((const char *)session->userauth_pblc_method,
-                   "sk-ecdsa-sha2-nistp256@openssh.com",
-                   session->userauth_pblc_method_len) == 0 ||
-           strncmp((const char *)session->userauth_pblc_method,
-                   "sk-ssh-ed25519@openssh.com",
-                   session->userauth_pblc_method_len) == 0) {
+        if(!strncmp((const char *)session->userauth_pblc_method,
+                    "sk-ecdsa-sha2-nistp256@openssh.com",
+                    session->userauth_pblc_method_len) ||
+           !strncmp((const char *)session->userauth_pblc_method,
+                    "sk-ssh-ed25519@openssh.com",
+                    session->userauth_pblc_method_len)) {
             ssh2_store_u32(&s,
                            (uint32_t)(4 + session->userauth_pblc_method_len +
                                       sig_len));

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2460,7 +2460,7 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
     }
 
     for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
-        if(strcmp(name, wcng_ecdsa_algs[curve].name) == 0) {
+        if(!strcmp(name, wcng_ecdsa_algs[curve].name)) {
             *out_curve = (ssh2_curve_type)curve;
             return LIBSSH2_ERROR_NONE;
         }
@@ -2778,7 +2778,7 @@ int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **key,
     }
 
     /* Read OPENSSL_PRIVATEKEY_AUTH_MAGIC */
-    if(strncmp(data, OPENSSL_PRIVATEKEY_AUTH_MAGIC, data_len) != 0) {
+    if(!strncmp(data, OPENSSL_PRIVATEKEY_AUTH_MAGIC, data_len)) {
         result = -1;
         goto cleanup;
     }
@@ -3742,7 +3742,7 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_RSA_SHA2
     if(key_method_len == 7 &&
-       memcmp(key_method, "ssh-rsa", key_method_len) == 0) {
+       !memcmp(key_method, "ssh-rsa", key_method_len)) {
         return "rsa-sha2-512,rsa-sha2-256"
 #if LIBSSH2_RSA_SHA1
             ",ssh-rsa"

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2778,7 +2778,7 @@ int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **key,
     }
 
     /* Read OPENSSL_PRIVATEKEY_AUTH_MAGIC */
-    if(!strncmp(data, OPENSSL_PRIVATEKEY_AUTH_MAGIC, data_len)) {
+    if(strncmp(data, OPENSSL_PRIVATEKEY_AUTH_MAGIC, data_len)) {
         result = -1;
         goto cleanup;
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -394,7 +394,7 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     /* 0.0.0.0 is returned by Docker for Windows, because the container
        is reachable from anywhere. We cannot connect to 0.0.0.0,
        instead we assume localhost and try to connect to 127.0.0.1. */
-    if(ip_address && strcmp(ip_address, "0.0.0.0") == 0) {
+    if(ip_address && !strcmp(ip_address, "0.0.0.0")) {
         free(ip_address);
         ip_address = libssh2_strdup("127.0.0.1");
     }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -123,7 +123,7 @@ LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err)
     if(crypt) {
         char const * const *sk;
         for(sk = skip_crypt; *sk; ++sk) {
-            if(strcmp(*sk, crypt) == 0) {
+            if(!strcmp(*sk, crypt)) {
                 fprintf(stderr, "unsupported crypt algorithm (%s) skipped.\n",
                                 crypt);
                 *skipped = 1;
@@ -135,7 +135,7 @@ LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err)
     if(mac) {
         char const * const *sk;
         for(sk = skip_mac; *sk; ++sk) {
-            if(strcmp(*sk, mac) == 0) {
+            if(!strcmp(*sk, mac)) {
                 fprintf(stderr, "unsupported MAC algorithm (%s) skipped.\n",
                                 mac);
                 *skipped = 1;
@@ -471,7 +471,7 @@ int test_auth_pubkey(LIBSSH2_SESSION *session, int flags,
     const char *userauth_list;
 
     /* Ignore our hard-wired Dockerfile user when not running under Docker */
-    if(!openssh_fixture_have_docker() && strcmp(username, "libssh2") == 0) {
+    if(!openssh_fixture_have_docker() && !strcmp(username, "libssh2")) {
         username = getenv("USER");
         if(!username) {
 #ifdef _WIN32

--- a/tests/test_auth_keyboard_info_request.c
+++ b/tests/test_auth_keyboard_info_request.c
@@ -283,7 +283,7 @@ static int test_case(int num,
         return 1;
     }
 
-    if(strcmp(expected.last_error_message, message) != 0) {
+    if(strcmp(expected.last_error_message, message)) {
         fprintf(stdout,
                 "Test case %d: expected last error message to be "
                 "\"%s\" got \"%s\"\n",

--- a/tests/test_hostkey.c
+++ b/tests/test_hostkey.c
@@ -65,7 +65,7 @@ int test(LIBSSH2_SESSION *session)
         return 1;
     }
 
-    if(memcmp(hostkey, expected_hostkey, len) != 0) {
+    if(memcmp(hostkey, expected_hostkey, len)) {
         fprintf(stderr, "Hostkeys do not match\n");
         return 1;
     }

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -99,7 +99,7 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha256_hash, SHA256_HASH_SIZE, buf, BUFSIZ);
 
-        if(strcmp(buf, EXPECTED_ED25519_SHA256_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_ED25519_SHA256_HASH_DIGEST)) {
             fprintf(stderr,
                     "ED25519 SHA256 hash not as expected - digest %s != %s\n",
                     buf, EXPECTED_ED25519_SHA256_HASH_DIGEST);
@@ -118,7 +118,7 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(md5_hash, MD5_HASH_SIZE, buf, BUFSIZ);
 
-        if(strcmp(buf, EXPECTED_ECDSA_MD5_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_ECDSA_MD5_HASH_DIGEST)) {
             fprintf(stderr,
                     "ECDSA MD5 hash not as expected - digest %s != %s\n",
                     buf, EXPECTED_ECDSA_MD5_HASH_DIGEST);
@@ -135,7 +135,7 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha1_hash, SHA1_HASH_SIZE, buf, BUFSIZ);
 
-        if(strcmp(buf, EXPECTED_ECDSA_SHA1_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_ECDSA_SHA1_HASH_DIGEST)) {
             fprintf(stderr,
                     "ECDSA SHA1 hash not as expected - digest %s != %s\n",
                     buf, EXPECTED_ECDSA_SHA1_HASH_DIGEST);
@@ -152,7 +152,7 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha256_hash, SHA256_HASH_SIZE, buf, BUFSIZ);
 
-        if(strcmp(buf, EXPECTED_ECDSA_SHA256_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_ECDSA_SHA256_HASH_DIGEST)) {
             fprintf(stderr,
                     "ECDSA SHA256 hash not as expected - digest %s != %s\n",
                     buf, EXPECTED_ECDSA_SHA256_HASH_DIGEST);
@@ -171,7 +171,7 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(md5_hash, MD5_HASH_SIZE, buf, BUFSIZ);
 
-        if(strcmp(buf, EXPECTED_RSA_MD5_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_RSA_MD5_HASH_DIGEST)) {
             fprintf(stderr,
                     "MD5 hash not as expected - digest %s != %s\n",
                     buf, EXPECTED_RSA_MD5_HASH_DIGEST);
@@ -188,7 +188,7 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha1_hash, SHA1_HASH_SIZE, buf, BUFSIZ);
 
-        if(strcmp(buf, EXPECTED_RSA_SHA1_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_RSA_SHA1_HASH_DIGEST)) {
             fprintf(stderr,
                     "SHA1 hash not as expected - digest %s != %s\n",
                     buf, EXPECTED_RSA_SHA1_HASH_DIGEST);
@@ -205,7 +205,7 @@ int test(LIBSSH2_SESSION *session)
 
         calculate_digest(sha256_hash, SHA256_HASH_SIZE, buf, BUFSIZ);
 
-        if(strcmp(buf, EXPECTED_RSA_SHA256_HASH_DIGEST) != 0) {
+        if(strcmp(buf, EXPECTED_RSA_SHA256_HASH_DIGEST)) {
             fprintf(stderr,
                     "SHA256 hash not as expected - digest %s != %s\n",
                     buf, EXPECTED_RSA_SHA256_HASH_DIGEST);

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -54,7 +54,7 @@ static int test_ssh2_base64_decode(LIBSSH2_SESSION *session)
     if(ret)
         return ret;
 
-    if(datalen != 5 || strcmp(data, "fnord") != 0) {
+    if(datalen != 5 || strcmp(data, "fnord")) {
         fprintf(stderr, "ssh2_base64_decode() failed (%d, %.*s)\n",
                 (int)datalen, (int)datalen, data);
         return 1;

--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -328,9 +328,9 @@ static int convertman(char *filespec, FILE *hlp, int base_level,
             case 'S':
                 if(*(m + 1) == 'H') {
                     *h++ = '\n';
-                    if(strncmp(m + 3, "NAME", 4) == 0 ||
-                       strncmp(m + 3, "SYNOPSIS", 8) == 0 ||
-                       strncmp(m + 3, "DESCRIPTION", 11) == 0) {
+                    if(!strncmp(m + 3, "NAME", 4)  ||
+                       !strncmp(m + 3, "SYNOPSIS", 8) ||
+                       !strncmp(m + 3, "DESCRIPTION", 11)) {
                         while(*m != '\n' && *m != '\r')
                             ++m;
                         mode = 0;


### PR DESCRIPTION
Drop from:
- strcmp, strncmp, strlen, memcmp, fseek, fstat
