### PR TITLE
pem, wincng: fix checking for OpenSSH PEM magic string

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -445,19 +445,18 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
     decoded.dataptr = (unsigned char *)f;
     decoded.len = f_len;
 
-    if(decoded.len < strlen(AUTH_MAGIC)) {
+    if(decoded.len < sizeof(AUTH_MAGIC)) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "key too short");
         goto out;
     }
 
-    if(strncmp((const char *)decoded.dataptr, AUTH_MAGIC,
-               strlen(AUTH_MAGIC))) {
+    if(memcmp((const char *)decoded.dataptr, AUTH_MAGIC, sizeof(AUTH_MAGIC))) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                        "key auth magic mismatch");
         goto out;
     }
 
-    decoded.dataptr += strlen(AUTH_MAGIC) + 1;
+    decoded.dataptr += sizeof(AUTH_MAGIC);
 
     if(ssh2_get_string(&decoded, &ciphername, &tmp_len) || tmp_len == 0) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "ciphername is missing");

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2778,7 +2778,9 @@ int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **key,
     }
 
     /* Read OPENSSL_PRIVATEKEY_AUTH_MAGIC */
-    if(strncmp(data, OPENSSL_PRIVATEKEY_AUTH_MAGIC, data_len)) {
+    if(data_len < sizeof(OPENSSL_PRIVATEKEY_AUTH_MAGIC) ||
+       memcmp(data, OPENSSL_PRIVATEKEY_AUTH_MAGIC,
+              sizeof(OPENSSL_PRIVATEKEY_AUTH_MAGIC))) {
         result = -1;
         goto cleanup;
     }
@@ -2786,7 +2788,7 @@ int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **key,
     data_buffer.len = data_len;
     data_buffer.data = (unsigned char *)SSH2_UNCONST(data);
     data_buffer.dataptr = data_buffer.data +
-                          strlen(OPENSSL_PRIVATEKEY_AUTH_MAGIC) + 1;
+                          sizeof(OPENSSL_PRIVATEKEY_AUTH_MAGIC);
 
     /* Read ciphername, should be 'none' as we do not support passphrases */
     result = ssh2_match_string(&data_buffer, "none");


### PR DESCRIPTION
To make sure the null-terminator is present after the magic string.

Refs:
https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key
https://anongit.mindrot.org/openssh.git/tree/PROTOCOL.key

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2014#discussion_r3388667557
Bug: https://github.com/libssh2/libssh2/pull/2014#discussion_r3388667497

Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315
Follow-up to 03092292597ac601c3f9f0c267ecb145dda75e4e #248

---

Original reports:

pem.c:
`decoded.dataptr` is advanced by `strlen(AUTH_MAGIC) + 1` but the preceding length check only enforces `decoded.len >= strlen(AUTH_MAGIC)`. If the decoded key is truncated to exactly `strlen(AUTH_MAGIC)` bytes (or missing the required NUL after the magic), this will move `dataptr` past the end of the buffer and later pointer subtraction in `ssh2_check_length()` becomes undefined behavior. Please require at least `strlen(AUTH_MAGIC)+1` bytes and validate the NUL terminator before incrementing.

wincng.c:
The auth-magic check can succeed for truncated input because it compares only `data_len` bytes; if `data_len` is shorter than the required `strlen(OPENSSL_PRIVATEKEY_AUTH_MAGIC)+1`, `strncmp()` may return 0 and the code will still advance `data_buffer.dataptr` past the end of `data`. That can lead to undefined behavior when later parsing reads from the buffer. Please enforce a minimum length and validate the required NUL terminator before incrementing the pointer.
