### PR TITLE
knownhost: fix memleaks on error paths in `knownhost_add()` type SHA1

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -165,12 +165,16 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
             goto error;
 
         if(!ptr || ptrlen == 0) {
+            if(ptr)
+                SSH2_FREE(hosts->session, ptr);
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL,
                           "Base64 decoded value is invalid");
             goto error;
         }
 
         if(!salt) {
+            if(ptr)
+                SSH2_FREE(hosts->session, ptr);
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL, "Salt is NULL");
             goto error;
         }
@@ -186,6 +190,8 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
             goto error;
 
         if(!ptr || ptrlen == 0) {
+            if(ptr)
+                SSH2_FREE(hosts->session, ptr);
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL,
                           "Base64 decoded value is invalid");
             goto error;


### PR DESCRIPTION
Reported-by: Ze Sheng (Aisle Research)
Fixes #1957