### PR TITLE
session: fix potential memleak in `session_free()`

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1089,9 +1089,11 @@ static int session_free(LIBSSH2_SESSION *session)
     }
 
     /* Free payload buffer */
-    if(session->packet.total_num) {
+    if(session->packet.payload) {
         SSH2_FREE(session, session->packet.payload);
+        session->packet.payload = NULL;
     }
+    session->packet.total_num = 0;
 
     /* Cleanup all remaining packets */
     /* !checksrc! disable EQUALSNULL 1 */


### PR DESCRIPTION
Reported-by: Ze Sheng (Aisle Research)
Fixes #1956
Follow-up to 92d686fe197db4eedb574730df766a7d1f683dd1