### PR TITLE
openssl: free the correct pointers in `ecdsa_sk_openssh_priv_to_pubkey()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3416,12 +3416,12 @@ fail:
         ssh2_ecdsa_free(ec_key);
 
     if(application && *application) {
-        SSH2_FREE(session, (void *)application);
+        SSH2_FREE(session, SSH2_UNCONST(*application));
         *application = NULL;
     }
 
     if(key_handle && *key_handle) {
-        SSH2_FREE(session, (void *)key_handle);
+        SSH2_FREE(session, SSH2_UNCONST(*key_handle));
         *key_handle = NULL;
     }
 


### PR DESCRIPTION
Reported by GitHub Code Quality

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698

---

The cast to `(void *)` before passing `application` to `SSH2_FREE` is incorrect. The variable `application` is of type `const char **`, and casting it to `(void *)` loses type information. The correct parameter should be `SSH2_UNCONST(*application)` to free the allocated memory pointed to by `*application`, similar to line 3154.

The cast to `(void *)` is incorrect. The variable `key_handle` is of type `const unsigned char **`, and you should be freeing the memory pointed to by `*key_handle` instead. Use `SSH2_UNCONST(*key_handle)` as done correctly on line 3159.
