### PR TITLE
pem.c: Add additional bounds checks to read_asn1_length #2011

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -887,12 +887,15 @@ static int read_asn1_length(const unsigned char *data,
 
     if(*len >= 0x80) {
         lenlen = *len & 0x7F;
-        *len = data[1];
         if(1 + lenlen > datalen) {
             return -1;
         }
+        *len = data[1];
         if(lenlen > 1) {
             *len <<= 8;
+            if(2 + lenlen > datalen) {
+                return -1;
+            }
             *len |= data[2];
         }
     }


### PR DESCRIPTION
Make sure data is not read out of bounds. 

Credit: afldl on github