### PR TITLE
ssh2_mlkem_new: Set public key buffer length correctly

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2423,6 +2423,7 @@ int ssh2_mlkem_new(LIBSSH2_SESSION *session, int ml_kem_size,
 
     if(out_public_key) {
         pub = SSH2_ALLOC(session, pubLen);
+        actualPubLen = pubLen;
         if(!pub)
             goto clean_exit;
 


### PR DESCRIPTION
`actualPubLen` was never set so extracting the public key would fail with buffer too short error.

Credit:
Will Cosgrove