### PR TITLE
pem: fix `readline_memory()` to detect end of input, not skip chars

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -90,15 +90,12 @@ static int readline_memory(char *line, size_t line_size,
 
     line[len] = '\0';
 
-    if(*filedata_offset < filedata_len) {
-        if(filedata[*filedata_offset] == '\r')
-            *filedata_offset += 1;
-        if(filedata[*filedata_offset] == '\n')
-            *filedata_offset += 1;
-        return 0;
-    }
+    if(*filedata_offset < filedata_len && filedata[*filedata_offset] == '\r')
+        *filedata_offset += 1;
+    if(*filedata_offset < filedata_len && filedata[*filedata_offset] == '\n')
+        *filedata_offset += 1;
 
-    return -1;
+    return (*filedata_offset < filedata_len || len) ? 0 : -1;
 }
 
 #define LINE_SIZE 128

--- a/src/pem.c
+++ b/src/pem.c
@@ -91,18 +91,10 @@ static int readline_memory(char *line, size_t line_size,
     line[len] = '\0';
 
     if(*filedata_offset < filedata_len) {
-        if(filedata[*filedata_offset] == '\r') {
+        if(filedata[*filedata_offset] == '\r')
             *filedata_offset += 1;
-            if(*filedata_offset < filedata_len &&
-               filedata[*filedata_offset] == '\n')
-                *filedata_offset += 1;
-        }
-        else if(filedata[*filedata_offset] == '\n') {
+        if(filedata[*filedata_offset] == '\n')
             *filedata_offset += 1;
-            if(*filedata_offset < filedata_len &&
-               filedata[*filedata_offset] == '\r')
-                *filedata_offset += 1;
-        }
         return 0;
     }
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -89,12 +89,7 @@ static int readline_memory(char *line, size_t line_size,
     }
 
     line[len] = '\0';
-
-    if(*filedata_offset < filedata_len &&
-       (filedata[*filedata_offset] == '\n' ||
-        filedata[*filedata_offset] == '\r')) {
-        *filedata_offset += 1;
-    }
+    *filedata_offset += 1;
 
     return 0;
 }

--- a/src/pem.c
+++ b/src/pem.c
@@ -89,7 +89,12 @@ static int readline_memory(char *line, size_t line_size,
     }
 
     line[len] = '\0';
-    *filedata_offset += 1;
+
+    if(*filedata_offset < filedata_len &&
+       (filedata[*filedata_offset] == '\n' ||
+        filedata[*filedata_offset] == '\r')) {
+        *filedata_offset += 1;
+    }
 
     return 0;
 }

--- a/src/pem.c
+++ b/src/pem.c
@@ -89,9 +89,24 @@ static int readline_memory(char *line, size_t line_size,
     }
 
     line[len] = '\0';
-    *filedata_offset += 1;
 
-    return 0;
+    if(*filedata_offset < filedata_len) {
+        if(filedata[*filedata_offset] == '\r') {
+            *filedata_offset += 1;
+            if(*filedata_offset < filedata_len &&
+               filedata[*filedata_offset] == '\n')
+                *filedata_offset += 1;
+        }
+        else if(filedata[*filedata_offset] == '\n') {
+            *filedata_offset += 1;
+            if(*filedata_offset < filedata_len &&
+               filedata[*filedata_offset] == '\r')
+                *filedata_offset += 1;
+        }
+        return 0;
+    }
+
+    return -1;
 }
 
 #define LINE_SIZE 128
@@ -186,7 +201,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
             return -1;
         }
-    } while(*line && strcmp(line, headerbegin));
+    } while(strcmp(line, headerbegin));
 
     if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
         return -1;
@@ -261,7 +276,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
             ret = -1;
             goto out;
         }
-    } while(*line && strcmp(line, headerend));
+    } while(strcmp(line, headerend));
 
     if(!b64data) {
         return -1;

--- a/src/pem.c
+++ b/src/pem.c
@@ -95,7 +95,7 @@ static int readline_memory(char *line, size_t line_size,
     if(*filedata_offset < filedata_len && filedata[*filedata_offset] == '\n')
         *filedata_offset += 1;
 
-    return (*filedata_offset < filedata_len || len) ? 0 : -1;
+    return *filedata_offset > off ? 0 : -1;
 }
 
 #define LINE_SIZE 128

--- a/src/pem.c
+++ b/src/pem.c
@@ -186,10 +186,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
             return -1;
         }
-
-        if(!*line)
-            break;
-    } while(strcmp(line, headerbegin));
+    } while(*line && strcmp(line, headerbegin));
 
     if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
         return -1;
@@ -264,7 +261,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
             ret = -1;
             goto out;
         }
-    } while(strcmp(line, headerend));
+    } while(*line && strcmp(line, headerend));
 
     if(!b64data) {
         return -1;


### PR DESCRIPTION
- fix to not skip character after lines longer than 128 bytes.
  Reported by GitHub Code Quality

- swallow newline characters at the end of the line.

- fix infinite loop with certain inputs.
  Make the function return error if the whole input has been consumed
  (vs. always success before this patch).
  Also drop a recently added `*line` check in favor of the above.
  Reported-by: afldl on github
  Fixes #2013
  Follow-up to 141b035617f7818f94fe825ebb99222e84d6ea36 #1746

Remaining differences noted in `readline()` (not touched in this PR):
- it returns newline characters in `line` in cases.
  E.g. with input `"abcdefghijklmno\rpqrstuvwxyz01234567890"`
- it does not empty the return buffer on EOF.

---

```c
int main(void)
{
    const char *filedata = "abcdefghijklmnopqrstuvwxyz01234567890";
    char line[20] = { 0 };
    int r;
    size_t pos = 0;
    r = readline_memory(line, 20, filedata, strlen(filedata), &pos); printf("|%d|%s", r, line);
    r = readline_memory(line, 20, filedata, strlen(filedata), &pos); printf("|%d|%s", r, line);
    r = readline_memory(line, 20, filedata, strlen(filedata), &pos); printf("|%d|%s", r, line);
    r = readline_memory(line, 20, filedata, strlen(filedata), &pos); printf("|%d|%s", r, line);
}
```

Original report:
The offset is unconditionally incremented even when no newline/carriage return is found. If the loop exits because `len == line_size - 1`, this skips a valid character. Consider only incrementing when a line terminator is actually consumed from the input.