### PR TITLE
openssl: simplify debug-logging comment field in `ed25519_openssh_priv_to_pubkey()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1926,17 +1926,9 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto clean_exit;
     }
 
-    if(tmp_len > 0) {
-        char *comment = SSH2_CALLOC(session, tmp_len + 1);
-        if(comment) {
-            memcpy(comment, buf, tmp_len);
-            comment[tmp_len] = '\0';
-
-            ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Key comment: %s",
-                      comment));
-
-            SSH2_FREE(session, comment);
-        }
+    if(tmp_len > 0 && comment) {
+        ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Key comment: %.*s",
+                  (int)tmp_len, comment));
     }
 
     /* Padding */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1930,8 +1930,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         unsigned char *comment = SSH2_CALLOC(session, tmp_len + 1);
         if(comment) {
             memcpy(comment, buf, tmp_len);
-            /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-            memcpy(comment + tmp_len, "\0", 1);
+            comment[tmp_len] = '\0';
 
             ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Key comment: %s",
                       comment));

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1927,7 +1927,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
     if(tmp_len > 0) {
-        unsigned char *comment = SSH2_CALLOC(session, tmp_len + 1);
+        char *comment = SSH2_CALLOC(session, tmp_len + 1);
         if(comment) {
             memcpy(comment, buf, tmp_len);
             comment[tmp_len] = '\0';

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1926,7 +1926,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto clean_exit;
     }
 
-    if(tmp_len > 0 && tmp_len <= INT_MAX && buf) {
+    if(tmp_len > 0 && tmp_len <= INT_MAX) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Key comment: %.*s",
                   (int)tmp_len, buf));
     }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1926,9 +1926,9 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto clean_exit;
     }
 
-    if(tmp_len > 0 && comment) {
+    if(tmp_len > 0 && buf) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Key comment: %.*s",
-                  (int)tmp_len, comment));
+                  (int)tmp_len, buf));
     }
 
     /* Padding */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1926,7 +1926,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto clean_exit;
     }
 
-    if(tmp_len > 0 && buf) {
+    if(tmp_len > 0 && tmp_len <= INT_MAX && buf) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Key comment: %.*s",
                   (int)tmp_len, buf));
     }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1926,10 +1926,9 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto clean_exit;
     }
 
-    if(tmp_len > 0 && tmp_len <= INT_MAX) {
+    if(tmp_len > 0 && tmp_len <= INT_MAX)
         ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Key comment: %.*s",
                   (int)tmp_len, buf));
-    }
 
     /* Padding */
     i = 1;


### PR DESCRIPTION
To avoid memalloc, memcpy, memcpy-ing a single nul-terminator, and a
local clang-tidy warning suppression.

Reported by GitHub Code Quality
