### PR TITLE
wincng: validate arguments in `wcng_reverse_bytes()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -82,9 +82,6 @@
 #endif
 #endif
 
-#ifndef STATUS_INVALID_PARAMETER
-#define STATUS_INVALID_PARAMETER ((NTSTATUS)0xC000000D)
-#endif
 #ifndef STATUS_NOT_SUPPORTED
 #define STATUS_NOT_SUPPORTED ((NTSTATUS)0xC00000BB)
 #endif
@@ -137,17 +134,11 @@ static void wcng_memcpy_with_be_padding(unsigned char *dest, ULONG dest_len,
     memcpy((dest + dest_len) - src_len, src, src_len);
 }
 
-static int wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
+static void wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
 {
-    PUCHAR start, end;
-
-    if(!buffer)
-        return -1;
-    }
-
-    if(buffer_len >= 2) {
-        start = buffer;
-        end = buffer + buffer_len - 1;
+    if(buffer && buffer_len >= 2) {
+        PUCHAR start = buffer;
+        PUCHAR end = buffer + buffer_len - 1;
         while(start < end) {
             unsigned char tmp = *end;
             *end = *start;
@@ -156,8 +147,6 @@ static int wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
             end--;
         }
     }
-
-    return 0;
 }
 
 /*******************************************************************/
@@ -2441,10 +2430,7 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **secret,
      * raw secret, so we need to swap it to big endian order.
      */
 
-    if(wcng_reverse_bytes((*secret)->bignum, secret_len)) {
-        result = LIBSSH2_ERROR_INVAL;
-        goto cleanup;
-    }
+    wcng_reverse_bytes((*secret)->bignum, secret_len);
 
     result = LIBSSH2_ERROR_NONE;
 
@@ -3709,10 +3695,7 @@ int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
         /* Counter to all the other data in the BCrypt APIs, the raw secret is
          * returned to us in host byte order, so we need to swap it to big
          * endian order. */
-        if(wcng_reverse_bytes(secret->bignum, secret->length)) {
-            status = (NTSTATUS)STATUS_INVALID_PARAMETER;
-            goto out;
-        }
+        wcng_reverse_bytes(secret->bignum, secret->length);
 
         status = 0;
         ssh2_wcng.hasAlgDHwithKDF = 1;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -82,6 +82,9 @@
 #endif
 #endif
 
+#ifndef STATUS_INVALID_PARAMETER
+#define STATUS_INVALID_PARAMETER ((NTSTATUS)0xC000000D)
+#endif
 #ifndef STATUS_NOT_SUPPORTED
 #define STATUS_NOT_SUPPORTED ((NTSTATUS)0xC00000BB)
 #endif
@@ -2437,7 +2440,7 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **secret,
      */
 
     if(wcng_reverse_bytes((*secret)->bignum, secret_len)) {
-        result = LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+        result = LIBSSH2_ERROR_INVAL;
         goto cleanup;
     }
 
@@ -3705,7 +3708,7 @@ int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
          * returned to us in host byte order, so we need to swap it to big
          * endian order. */
         if(wcng_reverse_bytes(secret->bignum, secret->length)) {
-            status = (NTSTATUS)STATUS_NO_MEMORY;
+            status = (NTSTATUS)STATUS_INVALID_PARAMETER;
             goto out;
         }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -134,10 +134,16 @@ static void wcng_memcpy_with_be_padding(unsigned char *dest, ULONG dest_len,
     memcpy((dest + dest_len) - src_len, src, src_len);
 }
 
-static void wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
+static int wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
 {
-    PUCHAR start = buffer;
-    PUCHAR end = buffer + buffer_len - 1;
+    PUCHAR start, end;
+
+    if(!buffer || buffer_len < 2) {
+        return -1;
+    }
+
+    start = buffer;
+    end = buffer + buffer_len - 1;
     while(start < end) {
         unsigned char tmp = *end;
         *end = *start;
@@ -145,6 +151,8 @@ static void wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
         start++;
         end--;
     }
+
+    return 0;
 }
 
 /*******************************************************************/
@@ -2428,7 +2436,10 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **secret,
      * raw secret, so we need to swap it to big endian order.
      */
 
-    wcng_reverse_bytes((*secret)->bignum, secret_len);
+    if(wcng_reverse_bytes((*secret)->bignum, secret_len)) {
+        result = LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+        goto cleanup;
+    }
 
     result = LIBSSH2_ERROR_NONE;
 
@@ -3693,7 +3704,10 @@ int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
         /* Counter to all the other data in the BCrypt APIs, the raw secret is
          * returned to us in host byte order, so we need to swap it to big
          * endian order. */
-        wcng_reverse_bytes(secret->bignum, secret->length);
+        if(wcng_reverse_bytes(secret->bignum, secret->length)) {
+            status = (NTSTATUS)STATUS_NO_MEMORY;
+            goto out;
+        }
 
         status = 0;
         ssh2_wcng.hasAlgDHwithKDF = 1;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -141,18 +141,20 @@ static int wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
 {
     PUCHAR start, end;
 
-    if(!buffer || buffer_len < 2) {
+    if(!buffer)
         return -1;
     }
 
-    start = buffer;
-    end = buffer + buffer_len - 1;
-    while(start < end) {
-        unsigned char tmp = *end;
-        *end = *start;
-        *start = tmp;
-        start++;
-        end--;
+    if(buffer_len >= 2) {
+        start = buffer;
+        end = buffer + buffer_len - 1;
+        while(start < end) {
+            unsigned char tmp = *end;
+            *end = *start;
+            *start = tmp;
+            start++;
+            end--;
+        }
     }
 
     return 0;


### PR DESCRIPTION
It seems unlikely this could have been causing an issue in practice.

Spotted by Copilot

Ref: https://github.com/libssh2/libssh2/pull/2035#discussion_r3392241733

---

https://github.com/libssh2/libssh2/pull/2037/files?w=1
