### PR TITLE
wincng: fix leaking `*secret` on error in `ssh2_ecdh_gen_k()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2435,6 +2435,7 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **secret,
 cleanup:
     if(result != LIBSSH2_ERROR_NONE && *secret) {
         ssh2_wcng_bn_free(*secret);
+        *secret = NULL;
     }
 
     if(result != LIBSSH2_ERROR_NONE && agreed_secret_handle) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2433,7 +2433,7 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **secret,
     result = LIBSSH2_ERROR_NONE;
 
 cleanup:
-    if(result != LIBSSH2_ERROR_NONE && agreed_secret_handle) {
+    if(result != LIBSSH2_ERROR_NONE && *secret) {
         ssh2_wcng_bn_free(*secret);
     }
 


### PR DESCRIPTION
Also reset `*secret` return value on error.

Reported by GitHub Code Quality
