### PR TITLE
wincng: fix leaking `hAlgAES_ECB` handle on deinit

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -696,6 +696,8 @@ void ssh2_crypto_exit(void)
 #endif
     if(ssh2_wcng.hAlgAES_CBC)
         (void)BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgAES_CBC, 0);
+    if(ssh2_wcng.hAlgAES_ECB)
+        (void)BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgAES_ECB, 0);
 #if LIBSSH2_RC4
     if(ssh2_wcng.hAlgRC4_NA)
         (void)BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgRC4_NA, 0);


### PR DESCRIPTION
Spotted by GitHub Code Quality

Follow-up to 2de14f8f9ac6bb48c0ec596fd501bcec11cedbfc
