### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/docs/libssh2_sftp_readdir_ex.md
+++ b/docs/libssh2_sftp_readdir_ex.md
@@ -62,7 +62,7 @@ is not really a failure per se.
 # BUG
 
 Passing in a too small buffer for 'buffer' or 'longentry' when receiving data
-only results in libssh2 1.2.7 or earlier to not copy the entire data amount,
+only results in libssh2 1.2.7 or earlier not to copy the entire data amount,
 and it is not possible for the application to tell when it happens!
 
 # ERRORS

--- a/docs/libssh2_sftp_symlink_ex.md
+++ b/docs/libssh2_sftp_symlink_ex.md
@@ -79,7 +79,7 @@ buffer is too small to fit the requested object name.
 # BUG
 
 Passing in a too small buffer when receiving data only results in libssh2
-1.2.7 or earlier to not copy the entire data amount, and it is not possible
+1.2.7 or earlier not to copy the entire data amount, and it is not possible
 for the application to tell when it happens!
 
 # ERRORS

--- a/docs/libssh2_version.md
+++ b/docs/libssh2_version.md
@@ -55,5 +55,5 @@ printf(\&"libssh2 version: %s\&", libssh2_version(0));
 
 # AVAILABILITY
 
-This function was added in libssh2 1.1, in previous versions there way no way
+This function was added in libssh2 1.1, in earlier versions there way no way
 to extract this info in runtime.

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -36,7 +36,7 @@
 #include <string.h>
 
 #ifndef INADDR_NONE
-#define INADDR_NONE (in_addr_t)~0
+#define INADDR_NONE ((in_addr_t)~0)
 #endif
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/scp.c
+++ b/example/scp.c
@@ -9,7 +9,7 @@
 #include <libssh2.h>
 
 #ifdef _WIN32
-#define write(f, b, c)  write(f, b, (unsigned int)(c))
+#define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/scp.c
+++ b/example/scp.c
@@ -171,7 +171,6 @@ int main(int argc, char *argv[])
     }
 
     libssh2_channel_free(channel);
-    channel = NULL;
 
 shutdown:
 

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 
 #ifdef _WIN32
-#define write(f, b, c)  write(f, b, (unsigned int)(c))
+#define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -287,7 +287,6 @@ int main(int argc, char *argv[])
 #endif
 
     libssh2_channel_free(channel);
-    channel = NULL;
 
 shutdown:
 

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -211,7 +211,6 @@ int main(int argc, char *argv[])
     libssh2_channel_wait_closed(channel);
 
     libssh2_channel_free(channel);
-    channel = NULL;
 
 shutdown:
 

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -291,7 +291,6 @@ int main(int argc, char *argv[])
         ;
 
     libssh2_channel_free(channel);
-    channel = NULL;
 
 shutdown:
 

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -15,7 +15,7 @@
 #include <libssh2_sftp.h>
 
 #ifdef _WIN32
-#define write(f, b, c)  write(f, b, (unsigned int)(c))
+#define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -15,7 +15,7 @@
 #include <libssh2_sftp.h>
 
 #ifdef _WIN32
-#define write(f, b, c)  write(f, b, (unsigned int)(c))
+#define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -15,7 +15,7 @@
 #include <libssh2_sftp.h>
 
 #ifdef _WIN32
-#define write(f, b, c)  write(f, b, (unsigned int)(c))
+#define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
 #ifdef HAVE_SYS_SOCKET_H

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -329,10 +329,8 @@ int main(int argc, char *argv[])
     if(libssh2_channel_close(channel))
         fprintf(stderr, "Unable to close channel\n");
 
-    if(channel) {
+    if(channel)
         libssh2_channel_free(channel);
-        channel = NULL;
-    }
 
     /* Other channel types are supported via:
      * libssh2_scp_send64()

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -213,10 +213,8 @@ int main(int argc, char *argv[])
 
 skip_shell:
 
-    if(channel) {
+    if(channel)
         libssh2_channel_free(channel);
-        channel = NULL;
-    }
 
     /* Other channel types are supported via:
      * libssh2_scp_send64()

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -288,7 +288,6 @@ int main(int argc, char *argv[])
     }
 
     libssh2_channel_free(channel);
-    channel = NULL;
 
 shutdown:
 

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -163,8 +163,8 @@ int main(int argc, char *argv[])
 
     nh = libssh2_knownhost_init(session);
     if(!nh) {
-        /* eeek, do cleanup here */
-        return 2;
+        exitcode = 2;
+        goto shutdown;
     }
 
     /* read all hosts from here */
@@ -194,8 +194,9 @@ int main(int argc, char *argv[])
          *****/
     }
     else {
-        /* eeek, do cleanup here */
-        return 3;
+        libssh2_knownhost_free(nh);
+        exitcode = 3;
+        goto shutdown;
     }
     libssh2_knownhost_free(nh);
 
@@ -206,7 +207,7 @@ int main(int argc, char *argv[])
             ;
         if(rc) {
             fprintf(stderr, "Authentication by password failed.\n");
-            return 1;
+            goto shutdown;
         }
     }
 

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -356,7 +356,6 @@ int main(int argc, char *argv[])
                     exitsignal ? exitsignal : "none");
 
         libssh2_channel_free(channel);
-        channel = NULL;
 
         fprintf(stderr, "\nrereads: %d rewrites: %d totwritten %lu\n",
                 rereads, rewrites, (unsigned long)totwritten);

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
         struct libssh2_knownhost *host;
         int check = libssh2_knownhost_checkp(nh, hostname, 22,
                                              fingerprint, len,
-                                             LIBSSH2_KNOWNHOST_TYPE_PLAIN|
+                                             LIBSSH2_KNOWNHOST_TYPE_PLAIN |
                                              LIBSSH2_KNOWNHOST_KEYENC_RAW,
                                              &host);
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
         struct libssh2_knownhost *host;
         int check = libssh2_knownhost_checkp(nh, hostname, 22,
                                              fingerprint, len,
-                                             LIBSSH2_KNOWNHOST_TYPE_PLAIN|
+                                             LIBSSH2_KNOWNHOST_TYPE_PLAIN |
                                              LIBSSH2_KNOWNHOST_KEYENC_RAW,
                                              &host);
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -298,7 +298,6 @@ int main(int argc, char *argv[])
                 exitcode, (long)bytecount);
 
     libssh2_channel_free(channel);
-    channel = NULL;
 
 shutdown:
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     int rc;
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
-    int exitcode;
+    int exitcode = 0;
     char *exitsignal = NULL;
     ssize_t bytecount = 0;
     size_t len;
@@ -167,8 +167,8 @@ int main(int argc, char *argv[])
 
     nh = libssh2_knownhost_init(session);
     if(!nh) {
-        /* eeek, do cleanup here */
-        return 2;
+        exitcode = 2;
+        goto shutdown;
     }
 
     /* read all hosts from here */
@@ -198,8 +198,9 @@ int main(int argc, char *argv[])
          *****/
     }
     else {
-        /* eeek, do cleanup here */
-        return 3;
+        libssh2_knownhost_free(nh);
+        exitcode = 3;
+        goto shutdown;
     }
     libssh2_knownhost_free(nh);
 
@@ -319,5 +320,5 @@ shutdown:
     WSACleanup();
 #endif
 
-    return 0;
+    return exitcode;
 }

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -23,7 +23,7 @@
 #include <string.h>
 
 #ifndef INADDR_NONE
-#define INADDR_NONE (in_addr_t)~0
+#define INADDR_NONE ((in_addr_t)~0)
 #endif
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -36,7 +36,7 @@
 #include <string.h>
 
 #ifndef INADDR_NONE
-#define INADDR_NONE (in_addr_t)~0
+#define INADDR_NONE ((in_addr_t)~0)
 #endif
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";

--- a/example/x11.c
+++ b/example/x11.c
@@ -529,10 +529,8 @@ shutdown:
     if(fds)
         free(fds);
 
-    if(channel) {
+    if(channel)
         libssh2_channel_free(channel);
-        channel = NULL;
-    }
 
     if(session) {
         libssh2_session_disconnect(session, "Normal Shutdown");

--- a/os400/libssh2rpg/libssh2.rpgle.in
+++ b/os400/libssh2rpg/libssh2.rpgle.in
@@ -68,7 +68,7 @@
       * Where XX, YY and ZZ are the main version, release and patch numbers in
       * hexadecimal (using 8 bits each). All three numbers are always
       * represented using two digits.  1.2 would appear as "0x010200" while
-      * version 9.11.7 appears as X'090b07'.
+      * version 9.11.7 appears as "0x090b07".
       *
       * This 6-digit (24 bits) hexadecimal number does not show pre-release
       * number, and it is always a greater number in a more recent release. It

--- a/src/chacha.c
+++ b/src/chacha.c
@@ -76,8 +76,8 @@ void chacha_keysetup(struct chacha_ctx *x, const u8 *k, u32 kbits)
 
 void chacha_ivsetup(struct chacha_ctx *x, const u8 *iv, const u8 *counter)
 {
-    x->input[12] = counter == NULL ? 0 : U8TO32_LITTLE(counter + 0);
-    x->input[13] = counter == NULL ? 0 : U8TO32_LITTLE(counter + 4);
+    x->input[12] = counter ? U8TO32_LITTLE(counter + 0) : 0;
+    x->input[13] = counter ? U8TO32_LITTLE(counter + 4) : 0;
     x->input[14] = U8TO32_LITTLE(iv + 0);
     x->input[15] = U8TO32_LITTLE(iv + 4);
 }

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -260,16 +260,15 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         size_t filedata_len,
                                         const unsigned char *passphrase);
 
-int ssh2_ed25519_new_private_frommemory_sk(
-    ssh2_ed25519_ctx **ed_ctx,
-    unsigned char *flags,
-    const char **application,
-    const unsigned char **key_handle,
-    size_t *handle_len,
-    LIBSSH2_SESSION *session,
-    const char *filedata,
-    size_t filedata_len,
-    const unsigned char *passphrase);
+int ssh2_ed25519_new_private_frommemory_sk(ssh2_ed25519_ctx **ed_ctx,
+                                           unsigned char *flags,
+                                           const char **application,
+                                           const unsigned char **key_handle,
+                                           size_t *handle_len,
+                                           LIBSSH2_SESSION *session,
+                                           const char *filedata,
+                                           size_t filedata_len,
+                                           const unsigned char *passphrase);
 #endif /* LIBSSH2_ED25519 */
 
 #if LIBSSH2_MLKEM

--- a/src/kex.c
+++ b/src/kex.c
@@ -2121,7 +2121,7 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
         }
         else {
             ret = ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
-                           "Unknown SHA digest for EC curve");
+                           "Unrecognized SHA digest for EC curve");
             goto clean_exit;
         }
         ret = finish_kex(session, exchange_state, digest_len, sha_algo_value);
@@ -2158,7 +2158,7 @@ static int kex_method_ecdh_key_exchange(
         rc = kex_session_ecdh_curve_type(session->kex->name, &type);
 
         if(rc) {
-            ret = ssh2_err(session, -1, "Unknown KEX nistp curve type");
+            ret = ssh2_err(session, -1, "Unrecognized KEX nistp curve type");
             goto ecdh_clean_exit;
         }
 
@@ -2218,7 +2218,7 @@ static int kex_method_ecdh_key_exchange(
         rc = kex_session_ecdh_curve_type(session->kex->name, &type);
 
         if(rc) {
-            ret = ssh2_err(session, -1, "Unknown KEX nistp curve type");
+            ret = ssh2_err(session, -1, "Unrecognized KEX nistp curve type");
             goto ecdh_clean_exit;
         }
 
@@ -2312,7 +2312,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
     unsigned char *shared_secret = NULL;
 
     if(kex_session_hybrid_curve_type(session->kex->name, &type)) {
-        ret = ssh2_err(session, -1, "Unknown KEX hybrid nistp curve type");
+        ret = ssh2_err(session, -1,
+                       "Unrecognized KEX hybrid nistp curve type");
         goto clean_exit;
     }
 
@@ -2542,7 +2543,8 @@ static int kex_method_mlkem_nistp_key_exchange(
         unsigned char *s = NULL;
 
         if(kex_session_hybrid_curve_type(session->kex->name, &type)) {
-            ret = ssh2_err(session, -1, "Unknown KEX hybrid nistp curve type");
+            ret = ssh2_err(session, -1,
+                           "Unrecognized KEX hybrid nistp curve type");
             goto clean_exit;
         }
 
@@ -2856,7 +2858,8 @@ static int kex_method_curve25519_key_exchange(
             rc = strcmp(session->kex->name, "curve25519-sha256");
 
         if(rc) {
-            ret = ssh2_err(session, -1, "Unknown KEX curve25519 curve type");
+            ret = ssh2_err(session, -1,
+                           "Unrecognized KEX curve25519 curve type");
             goto clean_exit;
         }
 
@@ -4469,7 +4472,7 @@ int libssh2_session_supported_algs(LIBSSH2_SESSION *session,
 
     default:
         return ssh2_err(session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
-                        "Unknown method type");
+                        "Unrecognized method type");
     } /* switch */
 
     /* weird situation */

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -202,7 +202,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         break;
     default:
         rc = ssh2_err(hosts->session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
-                      "Unknown hostname type");
+                      "Unrecognized hostname type");
         goto error;
     }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -376,10 +376,10 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     ssh2_rsa_ctx *ctx;
 
     ctx = (ssh2_rsa_ctx *)mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
-    if(ctx)
-        mbedtls_rsa_init(ctx);
-    else
+    if(!ctx)
         return -1;
+
+    mbedtls_rsa_init(ctx);
 
     ret = 0;
     if(mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(E)), edata, elen) ||

--- a/src/misc.c
+++ b/src/misc.c
@@ -982,5 +982,5 @@ int ssh2_timingsafe_bcmp(const void *b1, const void *b2, size_t n)
 
     for(; n > 0; n--)
         ret |= *p1++ ^ *p2++;
-    return (ret != 0);
+    return ret != 0;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -201,7 +201,7 @@ static unsigned char *ossl_write_bn(unsigned char *buf, const BIGNUM *bn,
     *p = 0;
     BN_bn2bin(bn, p + 1);
 
-    if(!(*(p + 1) & 0x80))
+    if(!(p[1] & 0x80)) {
         memmove(p, p + 1, --bn_bytes);
 
     ssh2_htonu32(p - 4, bn_bytes);  /* Post write bn size. */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -201,7 +201,7 @@ static unsigned char *ossl_write_bn(unsigned char *buf, const BIGNUM *bn,
     *p = 0;
     BN_bn2bin(bn, p + 1);
 
-    if(!(p[1] & 0x80)) {
+    if(!(p[1] & 0x80))
         memmove(p, p + 1, --bn_bytes);
 
     ssh2_htonu32(p - 4, bn_bytes);  /* Post write bn size. */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -903,7 +903,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo), int encrypt,
             ret = EVP_CIPHER_CTX_ctrl(*ctx, EVP_CTRL_GCM_IV_GEN, 1, lastiv);
 
         if(aadlen)
-            /* Include the 4 byte packet length as AAD */
+            /* Include the 4-byte packet length as AAD */
             ret = EVP_Cipher(*ctx, NULL, block, aadlen);
     }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -136,13 +136,11 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 {
 #ifdef USE_OPENSSL_3
     return EVP_MAC_update(*ctx, data, datalen);
-#else
-#ifdef LIBSSH2_WOLFSSL
-    /* FIXME: upstream bug as of v5.7.0: datalen is int instead of size_t */
+#elif defined(LIBSSH2_WOLFSSL)
+    /* As of wolfSSL v5.9.1 datalen is int, not size_t */
     return HMAC_Update(*ctx, data, (int)datalen);
-#else /* !LIBSSH2_WOLFSSL */
+#else
     return HMAC_Update(*ctx, data, datalen);
-#endif /* LIBSSH2_WOLFSSL */
 #endif
 }
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -309,7 +309,6 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #define ssh2_crypto_exit()
 
 #if LIBSSH2_RSA
-
 #ifdef USE_OPENSSL_3
 #define ssh2_rsa_ctx          EVP_PKEY
 #define ssh2_rsa_free(rsactx) EVP_PKEY_free(rsactx)
@@ -317,11 +316,9 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #define ssh2_rsa_ctx          RSA
 #define ssh2_rsa_free(rsactx) RSA_free(rsactx)
 #endif
-
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
-
 #ifdef USE_OPENSSL_3
 #define ssh2_dsa_ctx          EVP_PKEY
 #define ssh2_dsa_free(rsactx) EVP_PKEY_free(rsactx)
@@ -329,11 +326,9 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #define ssh2_dsa_ctx          DSA
 #define ssh2_dsa_free(dsactx) DSA_free(dsactx)
 #endif
-
 #endif /* LIBSSH2_DSA */
 
 #if LIBSSH2_ECDSA
-
 #define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 
 #ifdef USE_OPENSSL_3

--- a/src/pem.c
+++ b/src/pem.c
@@ -647,7 +647,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
 
             /* No padding */
 
-            /* for the AES GCM methods, the 16 byte authentication tag is
+            /* for the AES-GCM methods, the 16 byte authentication tag is
              * appended to the encrypted key */
             if(!strcmp(method->name, "aes256-gcm@openssh.com") ||
                !strcmp(method->name, "aes128-gcm@openssh.com")) {

--- a/src/pem.c
+++ b/src/pem.c
@@ -647,7 +647,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
 
             /* No padding */
 
-            /* for the AES-GCM methods, the 16 byte authentication tag is
+            /* for the AES-GCM methods, the 16-byte authentication tag is
              * appended to the encrypted key */
             if(!strcmp(method->name, "aes256-gcm@openssh.com") ||
                !strcmp(method->name, "aes128-gcm@openssh.com")) {

--- a/src/pem.c
+++ b/src/pem.c
@@ -561,7 +561,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
             if(ssh2_get_string(&kdf_buf, &salt, &salt_len) ||
                ssh2_get_u32(&kdf_buf, &rounds) != 0) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                               "kdf contains unexpected values");
+                               "KDF contains unexpected values");
                 goto out;
             }
 
@@ -576,7 +576,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
         }
         else {
             ret = ssh2_err(session, LIBSSH2_ERROR_KEYFILE_AUTH_FAILED,
-                           "bcrypted without passphrase");
+                           "bcrypt-encrypted without passphrase");
             goto out;
         }
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -467,7 +467,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
     }
 
     if(ssh2_get_string(&decoded, &kdf, &kdf_len)) {
-        ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "kdf is missing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "KDF is missing");
         goto out;
     }
     else {
@@ -485,7 +485,8 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
 
     if(strcmp((const char *)kdfname, "none") &&
        strcmp((const char *)kdfname, "bcrypt")) {
-        ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "unknown cipher");
+        ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
+                       "unrecognized KDF algorithm");
         goto out;
     }
 

--- a/src/session.h
+++ b/src/session.h
@@ -78,7 +78,7 @@
         int rc;                                                          \
         do {                                                             \
             (ptr) = (x);                                                 \
-            if(!(sess) || !(sess)->api_block_mode || (ptr) != NULL ||    \
+            if(!(sess) || !(sess)->api_block_mode || (ptr) ||            \
                libssh2_session_last_errno(sess) != LIBSSH2_ERROR_EAGAIN) \
                 break;                                                   \
             (rc) = ssh2_wait_socket(sess, entry_time);                   \

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -962,7 +962,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
                 }
                 else {
                     ssh2_deb((session, LIBSSH2_ERROR_STORE_OVERFLOW,
-                              "Too large write."));
+                              "Write operation exceeded buffer size."));
                     rc = LIBSSH2_ERROR_STORE_OVERFLOW;
                     SSH2_FREE(session, *sig);
                     *sig = NULL;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2927,7 +2927,8 @@ int ssh2_ecdsa_sign(IN LIBSSH2_SESSION *session,
         *signature_len = signature_ptr - *signature;
     }
     else {
-        ssh2_deb((session, LIBSSH2_ERROR_STORE_OVERFLOW, "Too large write."));
+        ssh2_deb((session, LIBSSH2_ERROR_STORE_OVERFLOW,
+                  "Write operation exceeded buffer size."));
         result = LIBSSH2_ERROR_STORE_OVERFLOW;
         goto cleanup;
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3707,12 +3707,12 @@ out:
         free(public_blob);
 
         if(status == STATUS_NOT_SUPPORTED && ssh2_wcng.hasAlgDHwithKDF == -1) {
-            goto fb; /* fallback to RSA-based implementation */
+            goto fallback; /* fallback to RSA-based implementation */
         }
         return BCRYPT_SUCCESS(status) ? 0 : -1;
     }
 
-fb:
+fallback:
     /* Compute the shared secret */
     return wcng_bn_mod_exp(secret, f, dhctx->dh_privbn, p);
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1055,8 +1055,7 @@ static int wcng_load_private_memory(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_RSA
     if(ret && tryLoadRSA) {
-        ret = ssh2_pem_parse_memory(session,
-                                    PEM_RSA_HEADER, PEM_RSA_FOOTER,
+        ret = ssh2_pem_parse_memory(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
                                     passphrase,
                                     privatekeydata, privatekeydata_len,
                                     &data, &datalen);
@@ -1067,8 +1066,7 @@ static int wcng_load_private_memory(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_DSA
     if(ret && tryLoadDSA) {
-        ret = ssh2_pem_parse_memory(session,
-                                    PEM_DSA_HEADER, PEM_DSA_FOOTER,
+        ret = ssh2_pem_parse_memory(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
                                     passphrase,
                                     privatekeydata, privatekeydata_len,
                                     &data, &datalen);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3424,10 +3424,10 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
         BCRYPT_DH_PARAMETER_HEADER *dh_params;
         ULONG dh_params_len;
         int status;
-        /* Note that the DH provider requires that keys be multiples of 64 bits
-         * in length. At the time of writing a practical observed group_order
-         * value is 257, so we need to round down to 8 bytes of length (64/8)
-         * in order for kex to succeed */
+        /* The DH provider requires keys to be multiples of 64 bits. Since
+         * group_order can be values like 257, we round down to the nearest
+         * multiple of 8 bytes (64 bits / 8) to meet this requirement for key
+         * exchange success. */
         ULONG key_length_bytes = max((ULONG)wcng_round_down(group_order, 8),
                                      max(g->length, p->length));
         BCRYPT_DH_KEY_BLOB *dh_key_blob;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3336,6 +3336,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             }
             if(BCRYPT_SUCCESS(ret)) {
                 if(algo.ctrMode) {
+                    /* CTR mode intentionally XORs in place:
+                       block = block XOR pbOutput. */
                     /* NOLINTNEXTLINE(readability-suspicious-call-argument) */
                     ssh2_xor_data(block, block, pbOutput, blocksize);
                     wcng_aes_ctr_increment(ctx->pbCtr, ctx->dwCtrLength);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2600,12 +2600,9 @@ int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **key,
         goto cleanup;
     }
 
-    result = ssh2_ecdsa_new_private_frommemory(
-        key,
-        session,
-        (const char *)data,
-        datalen,
-        passphrase);
+    result = ssh2_ecdsa_new_private_frommemory(key, session,
+                                               (const char *)data, datalen,
+                                               passphrase);
     if(result != LIBSSH2_ERROR_NONE) {
         goto cleanup;
     }

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -104,7 +104,7 @@ int test(LIBSSH2_SESSION *session)
             fprintf(stderr, "Unable to read response: %ld\n", (long)err);
         else {
             unsigned int i;
-            for(i = 0; i < (unsigned long)err; ++i) {
+            for(i = 0; i < (unsigned int)err; ++i) {
                 if(buf[i]) {
                     fprintf(stderr, "Bad data received\n");
                     /* Test fails below due to bad data length */

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -119,10 +119,8 @@ int test(LIBSSH2_SESSION *session)
     if(libssh2_channel_close(channel))
         fprintf(stderr, "Unable to close channel\n");
 
-    if(channel) {
+    if(channel)
         libssh2_channel_free(channel);
-        channel = NULL;
-    }
 
 shutdown:
 

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -245,10 +245,8 @@ int main(int argc, char *argv[])
 
 skip_shell:
 
-    if(channel) {
+    if(channel)
         libssh2_channel_free(channel);
-        channel = NULL;
-    }
 
 shutdown:
 

--- a/vms/man2help.c
+++ b/vms/man2help.c
@@ -494,7 +494,7 @@ static int convertmans(char *filespec, char *hlpfilename, int base_level,
 static void print_help(void)
 {
     fprintf(stderr,
-            "Usage: [-a] [-b x] convertman <manfilespec> <helptextfile>\n"
+            "Usage: [-a] [-b x] man2help <manfilespec> <helptextfile>\n"
             "       -a append <manfilespec> to <helptextfile>\n"
             "       -b <baselevel> if no headers found create one "
                        "with level <baselevel>\n"

--- a/vms/readme.vms
+++ b/vms/readme.vms
@@ -26,7 +26,7 @@ Prerequisites
   See the remarks at prerequisites for building the kit
 - HP OPENSSL V1.3 minimal.
   See the remarks at prerequisites for building the kit
-- JEM  ZLIB V1.2-3E1 minimal.
+- JEM ZLIB V1.2-3E1 minimal.
   See the remarks at prerequisites for building the kit
 
 The first three dependencies are tested at installation time, and


### PR DESCRIPTION
- man pages: grammar
- examples: add missing parentheses to macro values
- examples: replace `write()` with `_write()` on Windows.
  (to avoid warnings.)
- examples, tests: drop redundant NULL assigments.
- examples: fix to cleanup on error in ssh2_echo, ssh2_exec.
- libssh2.rpgle.in: make hex notation consistent in comment.
- chacha, session.h: avoid comparison with literal NULL.
- prefer 'unrecognized' vs 'unknown' in error messages.
- mbedtls: sync a code pattern with others in the code in
  `ssh2_rsa_new()`.
- openssl: declutter and update comment for wolfSSL `HMAC_Update()`
  exception. Also drop FIXME as the upstream incompatibility seems
  intentional.
- pem, userauth, wincng: fix, clarify error messages.
- wincng: add explanation for `NOLINT` exception, reword another
  comment.
  (suggested by Copilot)
- misc: drop redundant parentheses.
- test_read: fix a type mismatch.
- openssl: use indexed syntax for readability.
- vms/man2help: fix tool name is help text.
- formatting: reflow, newlines, spaces, comment typos.

Some of these reported by GitHub Code Quality / Copilot.

---

https://github.com/libssh2/libssh2/pull/2042/files?w=1
