### PR TITLE
Check for lang_cs and lang_sc values #2016

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -4045,7 +4045,7 @@ static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,
                              size_t data_len)
 {
     unsigned char *kex, *hostkey, *crypt_cs, *crypt_sc, *comp_cs, *comp_sc,
-        *mac_cs, *mac_sc;
+        *mac_cs, *mac_sc, *tmp;
     size_t kex_len, hostkey_len, crypt_cs_len, crypt_sc_len, comp_cs_len;
     size_t comp_sc_len, mac_cs_len, mac_sc_len;
     struct string_buf buf;
@@ -4077,6 +4077,12 @@ static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,
     if(ssh2_get_string(&buf, &comp_cs, &comp_cs_len))
         return -1;
     if(ssh2_get_string(&buf, &comp_sc, &comp_sc_len))
+        return -1;
+
+    /* read lang_cs and lang_sc but are unused */
+    if(_libssh2_get_string(&buf, &tmp, NULL))
+        return -1;
+    if(_libssh2_get_string(&buf, &tmp, NULL))
         return -1;
 
     /* If the server sent an optimistic packet, assume that it guessed wrong.

--- a/src/kex.c
+++ b/src/kex.c
@@ -4080,9 +4080,9 @@ static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,
         return -1;
 
     /* read lang_cs and lang_sc but are unused */
-    if(_libssh2_get_string(&buf, &tmp, NULL))
+    if(ssh2_get_string(&buf, &tmp, NULL))
         return -1;
-    if(_libssh2_get_string(&buf, &tmp, NULL))
+    if(ssh2_get_string(&buf, &tmp, NULL))
         return -1;
 
     /* If the server sent an optimistic packet, assume that it guessed wrong.


### PR DESCRIPTION
Read lang_cs and lang_sc key exchange values according to [RFC]( https://datatracker.ietf.org/doc/html/rfc4253#section-7.1) even if they are empty from most servers. #2016.

Credit: afldl from github
Fixes #2016
