### PR TITLE
wincng: revert recent algorithm macro setup update

### DIFF
--- a/src/wincng.h
+++ b/src/wincng.h
@@ -53,18 +53,11 @@
 #include <windows.h>
 #include <bcrypt.h>
 
-#ifdef OPENSSL_NO_MD5
-# define LIBSSH2_MD5 0
-#else
-# define LIBSSH2_MD5 1
-#endif
+#define LIBSSH2_MD5_ENABLE
+#define LIBSSH2_MD5_PEM_ENABLE
+#define LIBSSH2_MD5 1
 
-#if defined(OPENSSL_NO_RIPEMD) || defined(OPENSSL_NO_RMD160)
-# define LIBSSH2_HMAC_RIPEMD 0
-#else
-# define LIBSSH2_HMAC_RIPEMD 1
-#endif
-
+#define LIBSSH2_HMAC_RIPEMD 0
 #define LIBSSH2_HMAC_SHA256 1
 #define LIBSSH2_HMAC_SHA512 1
 
@@ -72,34 +65,14 @@
 #define LIBSSH2_AES_CTR 1
 #define LIBSSH2_AES_GCM 0
 #define LIBSSH2_BLOWFISH 0
+#define LIBSSH2_RC4 1
 #define LIBSSH2_CAST 0
+#define LIBSSH2_3DES 1
 
-#ifdef OPENSSL_NO_RC4
-# define LIBSSH2_RC4 0
-#else
-# define LIBSSH2_RC4 1
-#endif
-
-#ifdef OPENSSL_NO_DES
-# define LIBSSH2_3DES 0
-#else
-# define LIBSSH2_3DES 1
-#endif
-
-#ifdef OPENSSL_NO_RSA
-# define LIBSSH2_RSA 0
-# define LIBSSH2_RSA_SHA1 0
-# define LIBSSH2_RSA_SHA2 0
-#else
-# define LIBSSH2_RSA 1
-# define LIBSSH2_RSA_SHA1 1
-# define LIBSSH2_RSA_SHA2 1
-#endif
-#ifdef OPENSSL_NO_DSA
-# define LIBSSH2_DSA 0
-#else
-# define LIBSSH2_DSA 1
-#endif
+#define LIBSSH2_RSA 1
+#define LIBSSH2_RSA_SHA1 1
+#define LIBSSH2_RSA_SHA2 1
+#define LIBSSH2_DSA 1
 #define LIBSSH2_ED25519 0
 #define LIBSSH2_MLKEM 0
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -53,8 +53,6 @@
 #include <windows.h>
 #include <bcrypt.h>
 
-#define LIBSSH2_MD5_ENABLE
-#define LIBSSH2_MD5_PEM_ENABLE
 #define LIBSSH2_MD5 1
 
 #define LIBSSH2_HMAC_RIPEMD 0


### PR DESCRIPTION
It was incorrect by using OPENSSL-specific macros. Also unnecessary,
because the actual enabling/disabling of algs is made by
`crypto_config.h` after setting up the macros based on what the backend
can support.

It did not cause a functional issue, but it was silly.

Keep the update that dropped `LIBSSH2_MD5_ENABLE` and
`LIBSSH2_MD5_PEM_ENABLE`.

Spotted by GitHub Code Quality

Follow-up to bf3757b99e9d5923c5f3072f2135dbf2e783921f #1985
