### PR TITLE
agent: fix bounds checks, and potential OOB access on 32-bit platforms in `agent_sign()`

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -753,8 +753,8 @@ static int agent_sign(LIBSSH2_SESSION *session,
     uint32_t sign_flags = 0;
 
     len = 1 + 4 + 4 + 4;  /* fixed parts */
-    if(identity->external.blob_len > SIZE_MAX - len ||
-       data_len > SIZE_MAX - len - identity->external.blob_len) {
+    if(identity->external.blob_len > UINT32_MAX - len ||
+       data_len > UINT32_MAX - len - identity->external.blob_len) {
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Agent sign request too large");
     }
@@ -800,11 +800,6 @@ static int agent_sign(LIBSSH2_SESSION *session,
     /* if no agent has been connected, bail out */
     if(!agent->ops)
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "agent not connected");
-
-    /* cannot pass more than 32-bit size on the wire */
-    if(transctx->request_len > UINT32_MAX)
-        return ssh2_err(session, LIBSSH2_ERROR_BAD_USE,
-                        "agent request too large");
 
     rc = agent->ops->transact(agent, transctx);
     if(rc) {

--- a/src/agent.c
+++ b/src/agent.c
@@ -746,13 +746,11 @@ static int agent_sign(LIBSSH2_SESSION *session,
     LIBSSH2_AGENT *agent = (LIBSSH2_AGENT *)(*abstract);
     struct agent_transaction_ctx *transctx = &agent->transctx;
     struct agent_publickey *identity = agent->identity;
-    size_t len;
-    size_t method_len;
+    size_t len, method_len, plain_len;
     unsigned char *s;
     int rc;
     unsigned char *method_name = NULL;
     uint32_t sign_flags = 0;
-    size_t plain_len;
 
     len = 1 + 4 + 4 + 4;  /* fixed parts */
     if(identity->external.blob_len > SIZE_MAX - len ||

--- a/src/agent.c
+++ b/src/agent.c
@@ -876,11 +876,13 @@ static int agent_sign(LIBSSH2_SESSION *session,
     }
 
     *sig_len = ssh2_ntohu32(s);
+    len -= 4;
+    s += 4;
+
     if(len < *sig_len) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
-    s += 4;
 
     *sig = SSH2_ALLOC(session, *sig_len);
     if(!*sig) {

--- a/src/agent.c
+++ b/src/agent.c
@@ -801,7 +801,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     if(!agent->ops)
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "agent not connected");
 
-    /* cannot pass more than a 32-bit size on the wire */
+    /* cannot pass more than 32-bit size on the wire */
     if(transctx->request_len > UINT32_MAX)
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE,
                         "agent request too large");

--- a/src/agent.c
+++ b/src/agent.c
@@ -752,7 +752,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     int rc;
     unsigned char *method_name = NULL;
     uint32_t sign_flags = 0;
-    ssize_t plain_len;
+    size_t plain_len;
 
     len = 1 + 4 + 4 + 4;  /* fixed parts */
     if(identity->external.blob_len > SIZE_MAX - len ||

--- a/src/agent.c
+++ b/src/agent.c
@@ -883,7 +883,6 @@ static int agent_sign(LIBSSH2_SESSION *session,
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
-    len -= 4;
     s += 4;
 
     *sig = SSH2_ALLOC(session, *sig_len);

--- a/src/agent.c
+++ b/src/agent.c
@@ -747,7 +747,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     struct agent_transaction_ctx *transctx = &agent->transctx;
     struct agent_publickey *identity = agent->identity;
     size_t len;
-    ssize_t method_len;
+    size_t method_len;
     unsigned char *s;
     int rc;
     unsigned char *method_name = NULL;
@@ -863,7 +863,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
                              session->userauth_pblc_method_len);
 
     /* check to see if we match requested */
-    if(((size_t)method_len != session->userauth_pblc_method_len &&
+    if((method_len != session->userauth_pblc_method_len &&
         method_len != plain_len) ||
        memcmp(method_name, session->userauth_pblc_method, method_len)) {
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Agent sign method %.*s",

--- a/src/agent.c
+++ b/src/agent.c
@@ -746,13 +746,21 @@ static int agent_sign(LIBSSH2_SESSION *session,
     LIBSSH2_AGENT *agent = (LIBSSH2_AGENT *)(*abstract);
     struct agent_transaction_ctx *transctx = &agent->transctx;
     struct agent_publickey *identity = agent->identity;
-    ssize_t len = 1 + 4 + identity->external.blob_len + 4 + data_len + 4;
+    ssize_t len;
     ssize_t method_len;
     unsigned char *s;
     int rc;
     unsigned char *method_name = NULL;
     uint32_t sign_flags = 0;
     ssize_t plain_len;
+
+    len = 1 + 4 + 4 + 4;  /* fixed parts */
+    if(identity->external.blob_len > SIZE_MAX - len ||
+       data_len > SIZE_MAX - len - identity->external.blob_len) {
+        return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                        "Agent sign request too large");
+    }
+    len += identity->external.blob_len + data_len;
 
     /* Create a request to sign the data */
     if(transctx->state == agent_NB_state_init) {
@@ -868,8 +876,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     }
     *sig_len = ssh2_ntohu32(s);
     s += 4;
-    len -= *sig_len;
-    if(len < 0) {
+    if(*sig_len > (size_t)len) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }

--- a/src/agent.c
+++ b/src/agent.c
@@ -746,7 +746,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     LIBSSH2_AGENT *agent = (LIBSSH2_AGENT *)(*abstract);
     struct agent_transaction_ctx *transctx = &agent->transctx;
     struct agent_publickey *identity = agent->identity;
-    ssize_t len;
+    size_t len;
     ssize_t method_len;
     unsigned char *s;
     int rc;

--- a/src/agent.c
+++ b/src/agent.c
@@ -799,13 +799,14 @@ static int agent_sign(LIBSSH2_SESSION *session,
     if(*transctx->request != SSH2_AGENTC_SIGN_REQUEST)
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "illegal request");
 
+    /* if no agent has been connected, bail out */
     if(!agent->ops)
-        /* if no agent has been connected, bail out */
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "agent not connected");
 
+    /* cannot pass more than a 32-bit size on the wire */
     if(transctx->request_len > UINT32_MAX)
-        /* cannot pass more than a 32-bit size on the wire */
-        return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "agent request too large");
+        return ssh2_err(session, LIBSSH2_ERROR_BAD_USE,
+                        "agent request too large");
 
     rc = agent->ops->transact(agent, transctx);
     if(rc) {

--- a/src/agent.c
+++ b/src/agent.c
@@ -812,8 +812,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
 
     len = transctx->response_len;
     s = transctx->response;
-    len--;
-    if(len < 0) {
+    if(len < 1) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
@@ -821,26 +820,27 @@ static int agent_sign(LIBSSH2_SESSION *session,
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
+    len--;
     s++;
 
     /* Skip the entire length of the signature */
-    len -= 4;
-    if(len < 0) {
+    if(len < 4) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
+    len -= 4;
     s += 4;
 
     /* Skip signing method */
-    len -= 4;
-    if(len < 0) {
+    if(len < 4) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
-    method_len = ssh2_ntohu32(s);
+    len -= 4;
     s += 4;
-    len -= method_len;
-    if(len < 0) {
+
+    method_len = ssh2_ntohu32(s);
+    if(len < method_len) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
@@ -852,6 +852,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
         goto error;
     }
     memcpy(method_name, s, method_len);
+    len -= method_len;
     s += method_len;
 
     plain_len = plain_method((char *)session->userauth_pblc_method,
@@ -869,17 +870,18 @@ static int agent_sign(LIBSSH2_SESSION *session,
     }
 
     /* Read the signature */
-    len -= 4;
-    if(len < 0) {
+    if(len < 4) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
+
     *sig_len = ssh2_ntohu32(s);
-    s += 4;
-    if(*sig_len > (size_t)len) {
+    if(len < *sig_len) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
+    len -= 4;
+    s += 4;
 
     *sig = SSH2_ALLOC(session, *sig_len);
     if(!*sig) {

--- a/src/agent.c
+++ b/src/agent.c
@@ -803,6 +803,10 @@ static int agent_sign(LIBSSH2_SESSION *session,
         /* if no agent has been connected, bail out */
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "agent not connected");
 
+    if(transctx->request_len > UINT32_MAX)
+        /* cannot pass more than a 32-bit size on the wire */
+        return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "agent request too large");
+
     rc = agent->ops->transact(agent, transctx);
     if(rc) {
         goto error;

--- a/src/agent.c
+++ b/src/agent.c
@@ -834,10 +834,12 @@ static int agent_sign(LIBSSH2_SESSION *session,
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;
     }
+
+    /* method length */
+    method_len = ssh2_ntohu32(s);
     len -= 4;
     s += 4;
 
-    method_len = ssh2_ntohu32(s);
     if(len < method_len) {
         rc = LIBSSH2_ERROR_AGENT_PROTOCOL;
         goto error;


### PR DESCRIPTION
Also limit payload to `UINT32_MAX`, since the protocol uses 32-bit value
to store the size. (I'd guess a lower, sane limit may be even better.)

Reported-by: afldl on github
Fixes #2021
