### PR TITLE
knownhost: fix three out-of-bounds reads in known_hosts parsing

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -216,7 +216,12 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
                           "Unable to allocate memory for key");
             goto error;
         }
-        memcpy(entry->key, key, keylen + 1);
+        /* Copy exactly keylen bytes; the entry is allocated keylen + 1 and
+           null-terminated explicitly below. Reading keylen + 1 bytes here
+           would read one byte past the key data (the trailing separator or
+           NUL), which is out of bounds when the caller's buffer ends right
+           after the key. */
+        memcpy(entry->key, key, keylen);
         entry->key[keylen] = 0; /* force a null-terminator */
     }
     else {
@@ -251,7 +256,11 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
                           "Unable to allocate memory for comment");
             goto error;
         }
-        memcpy(entry->comment, comment, commentlen + 1);
+        /* Copy exactly commentlen bytes; reading commentlen + 1 reads one
+           byte past the comment, which is out of bounds when the comment
+           reaches the end of the caller's buffer. The entry is allocated
+           commentlen + 1 and null-terminated below. */
+        memcpy(entry->comment, comment, commentlen);
         entry->comment[commentlen] = 0; /* force a null-terminator */
         entry->comment_len = commentlen;
     }
@@ -912,8 +921,10 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
         len--;
     }
 
-    /* null-terminate where the newline is */
-    if(*cp == '\n')
+    /* null-terminate where the newline is. Guard the dereference: if the
+       loop above ran out of input (len == 0), cp points one past the buffer
+       and *cp would be an out-of-bounds read. */
+    if(len && *cp == '\n')
         keylen--; /* do not include this in the count */
 
     /* deal with this one host+key line */


### PR DESCRIPTION
## Summary

Fixes three out-of-bounds reads (all the same shape — reading one byte past the caller's buffer) in known_hosts parsing, reachable through the public `libssh2_knownhost_readline()` API. The primary one is the heap over-read reported in #2012, which I confirmed still reproduces on current master (`0391b09d`).

## Background / why it looked stale

In #2012 the report referenced line numbers from an older snapshot. I rebuilt current master from a clean checkout with `-fsanitize=address` and the bug is still there. The reason it's easy to miss: it only triggers through `libssh2_knownhost_readline()` (the in-memory API) with a tightly-sized buffer. Through `libssh2_knownhost_readfile()` the internal `char buf[4092]` stack buffer absorbs the 1-byte over-read, so ASAN stays silent.

## The three fixes

**1. `knownhost_add()` — comment copy (the #2012 crash)**
```c
-    memcpy(entry->comment, comment, commentlen + 1);
+    memcpy(entry->comment, comment, commentlen);
     entry->comment[commentlen] = 0; /* force a null-terminator */
```
In `hostline()`, when a line has no trailing whitespace/comment, the comment pointer lands on the final NUL with `commentlen == 1`, so the `+ 1` read one byte past the allocation.

**2. `knownhost_add()` — key copy (same pattern)**
```c
-    memcpy(entry->key, key, keylen + 1);
+    memcpy(entry->key, key, keylen);
```
Identical latent pattern. Currently in-bounds only because the trailing separator/NUL happens to live inside the line buffer; fixed for consistency so it can't regress.

**3. `libssh2_knownhost_readline()` — `*cp` after the scan loop**
```c
     while(len && *cp && *cp != '\n') { cp++; len--; }
-    if(*cp == '\n')
+    if(len && *cp == '\n')
         keylen--;
```
If the scan loop exited because `len` reached 0 (input not newline/NUL-terminated), `cp` points one past the buffer and `*cp` is an over-read. The `len &&` guard fixes it.

For (1) and (2) the destination is already allocated `len + 1` and explicitly null-terminated on the following line, so dropping the `+ 1` is correct and sufficient.

## Verification

Built clean master (`0391b09d`) with `-fsanitize=address,undefined -fno-omit-frame-pointer -O1`, OpenSSL backend. **Before** this patch the #2012 PoC aborts:
```
==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 2 ... 0 bytes to the right of the 44-byte region
    #1 knownhost_add              src/knownhost.c:254
    #2 oldstyle_hostline          src/knownhost.c:639
    #3 hostline                   src/knownhost.c:821
    #4 libssh2_knownhost_readline src/knownhost.c:920
```
**After** this patch, the following all pass with no sanitizer error:
- the #2012 PoC (`x ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7Pd` in a tight 44-byte buffer) → parses cleanly
- valid line with comment, newline-terminated → comment preserved
- valid line without comment → parses
- valid line with comment, no trailing newline → parses
- non-NUL-terminated buffer (exercises fix #3) → no over-read

Minimal reproducer:
```c
libssh2_init(0);
LIBSSH2_SESSION *s = libssh2_session_init();
LIBSSH2_KNOWNHOSTS *kh = libssh2_knownhost_init(s);
char *buf = malloc(44);
memcpy(buf, "x ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7Pd", 44);
buf[43] = '\0';
libssh2_knownhost_readline(kh, buf, 44, LIBSSH2_KNOWNHOST_FILE_OPENSSH);
```

Happy to split into separate commits/PRs if preferred; kept together because they're the same bug class.

Fixes #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)
