### PR TITLE
src: introduce `SSH2_ERRNO()` and use it

### DIFF
--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -22,6 +22,7 @@ my @options = (
     "-arealloc",
     "-asnprintf",
     "-asocket",
+    "-berrno",
 );
 
 my @files;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -343,7 +343,6 @@ while(defined $file) {
     }
     elsif($file =~ /^-b(.*)/) {
         $banfunc{$1} = $1;
-        print STDERR "ban use of \"$1\"\n";
         $file = shift @ARGV;
         next;
     }

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -343,6 +343,7 @@ while(defined $file) {
     }
     elsif($file =~ /^-b(.*)/) {
         $banfunc{$1} = $1;
+        # print STDERR "ban use of \"$1\"\n";
         $file = shift @ARGV;
         next;
     }

--- a/src/agent.c
+++ b/src/agent.c
@@ -41,7 +41,6 @@
 
 #include "libssh2_priv.h"
 
-#include <errno.h>
 #include <stdlib.h>  /* for getenv() */
 
 #ifdef HAVE_SYS_UN_H

--- a/src/misc.c
+++ b/src/misc.c
@@ -45,7 +45,6 @@
 #include <unistd.h>
 #endif
 
-#include <errno.h>
 #include <assert.h>
 
 #ifdef _WIN32
@@ -163,12 +162,7 @@ ssize_t ssh2_recv(libssh2_socket_t socket, void *buffer, size_t length,
 
     rc = SSH2_RECV_LOW(socket, buffer, length, flags);
     if(rc < 0) {
-        int err;
-#ifdef _WIN32
-        err = ssh2_wsa2errno();
-#else
-        err = errno;
-#endif
+        int err = SSH2_ERRNO();
         /* Profiling tools that use SIGPROF can cause EINTR responses.
            recv() does not modify its arguments when it returns EINTR,
            but there may be data waiting, so the caller should try again */
@@ -201,12 +195,7 @@ ssize_t ssh2_send(libssh2_socket_t socket,
 
     rc = SSH2_SEND_LOW(socket, buffer, length, flags);
     if(rc < 0) {
-        int err;
-#ifdef _WIN32
-        err = ssh2_wsa2errno();
-#else
-        err = errno;
-#endif
+        int err = SSH2_ERRNO();
         /* Profiling tools that use SIGPROF can cause EINTR responses.
            send() is defined as not yet sending any data when it returns EINTR,
            so the caller should try again */

--- a/src/misc.h
+++ b/src/misc.h
@@ -39,6 +39,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <errno.h>
+
 #ifdef LIBSSH2_NO_CLEAR_MEMORY
 #define ssh2_explicit_zero(buf, size) \
     do {                              \
@@ -83,6 +85,9 @@ int ssh2_err(LIBSSH2_SESSION *session, int errcode, const char *errmsg);
 #ifdef _WIN32
 /* Convert Win32 WSAGetLastError to errno equivalent */
 int ssh2_wsa2errno(void);
+#define SSH2_ERRNO() ssh2_wsa2errno()
+#else
+#define SSH2_ERRNO() errno
 #endif
 
 void ssh2_list_init(struct list_head *head);

--- a/src/session.c
+++ b/src/session.c
@@ -48,7 +48,6 @@
 #include <unistd.h>
 #endif
 
-#include <errno.h>
 #include <stdlib.h>
 #include <fcntl.h>
 
@@ -684,16 +683,10 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
                         "Timed out waiting on socket");
     }
     if(rc < 0) {
-        int err;
-#ifdef _WIN32
-        err = ssh2_wsa2errno();
-#else
-        err = errno;
-#endif
         /* Profiling tools that use SIGPROF can cause EINTR responses.
            poll() / select() do not set any descriptor states on EINTR,
            but some fds may be ready, so the caller should try again */
-        if(err == EINTR)
+        if(SSH2_ERRNO() == EINTR)
             return 0;
 
         return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,

--- a/src/transport.c
+++ b/src/transport.c
@@ -44,7 +44,6 @@
 
 #include "libssh2_priv.h"
 
-#include <errno.h>
 #include <ctype.h>
 #include <assert.h>
 


### PR DESCRIPTION
To avoid conditional code scattered around the source code.

Also: ban direct use of `errno` via checksrc.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
