### PR TITLE
appveyor: really disable building tests for no-test jobs

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -33,7 +33,7 @@ fi
 
 echo "CMake job options: ${CMAKE_GENERATE:-}"
 options=''
-[ "${SKIP_CTEST:-}" != 'yes' ] && options+=' -DBUILD_TESTING=OFF'
+[ "${SKIP_CTEST:-}" = 'yes' ] && options+=' -DBUILD_TESTING=OFF'
 # FIXME: First sshd test sometimes timeouts, subsequent ones almost always fail:
 #        'libssh2_session_handshake failed (-43): Failed getting banner'
 # shellcheck disable=SC2086


### PR DESCRIPTION
Job                                                                  | Before | After
-------------------------------------------------------------------- | ------ | -------
VS2026, OpenSSL 3, x64, Server 2019, clang-cl                        | 1m22s  | 49s
VS2022, OpenSSL 3, x64, Server 2019, Shared-only, docs               | 1m29s  | 52s
VS2015, OpenSSL 1.1, x86, Server 2016, Static-only                   | 2m18s  | 51s
VS2015, OpenSSL 1.1, x64, Server 2012 R2, Shared-only, Debug-logging | 2m9s   | 50s
VS2013, OpenSSL 1.1, x64, Server 2012 R2                             | 54s    | 44s
VS2013, OpenSSL 1.1, x86, Server 2012 R2, Shared-only                | 45s    | 33s
VS2010, WinCNG, x64, Build-only, non-unity, examples, docs           | 49s    | 53s
VS2015, WinCNG, x64, Server 2012 R2                                  | 2mi19s | 1m28s
VS2015, WinCNG, x86, Server 2016                                     | 2mi23s | 51s
Total                                                                | 25m43s | 18m51s

Before: https://ci.appveyor.com/project/libssh2org/libssh2/builds/54220007
After: https://ci.appveyor.com/project/libssh2org/libssh2/builds/54220033

There is delay (between) starting up the jobs, hence the longer total
than the sum of the individual job times. The runtime itself is below 8
minutes after this patch (vs. 15m before, and 27m before #2051). It
looks like the total time is around double the raw runtime.

Follow-up to 39cd3a82c7e07a08c1e218b91e69fd92d4f35ca3 #2051

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
