### PR TITLE
agent: return error on OOM in `libssh2_agent_sign()`

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1219,10 +1219,12 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
         return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
     }
 
-    agent->session->userauth_pblc_method_len = method_len;
     agent->session->userauth_pblc_method = SSH2_ALLOC(agent->session,
                                                       method_len);
+    if(!agent->session->userauth_pblc_method)
+        return LIBSSH2_ERROR_ALLOC;
 
+    agent->session->userauth_pblc_method_len = method_len;
     memcpy(agent->session->userauth_pblc_method, method, method_len);
 
     rc = agent_sign(agent->session, sig, s_len, data, d_len, &abstract);


### PR DESCRIPTION
Also: set `userauth_pblc_method_len` in the internal structure only if
the allocation succeeded.

Reported by GitHub Code Quality

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
