### PR TITLE
misc: assume POSIX `EWOULDBLOCK` macro is defined

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -172,10 +172,8 @@ ssize_t ssh2_recv(libssh2_socket_t socket, void *buffer, size_t length,
            Solaris and HP-UX */
         if(sockerr == ENOENT)
             return -EAGAIN;
-#ifdef EWOULDBLOCK /* For VMS and other special unixes */
         if(sockerr == EWOULDBLOCK)
             return -EAGAIN;
-#endif
         return -sockerr;
     }
     return rc;
@@ -200,10 +198,8 @@ ssize_t ssh2_send(libssh2_socket_t socket,
            so the caller should try again */
         if(sockerr == EINTR)
             return -EAGAIN;
-#ifdef EWOULDBLOCK /* For VMS and other special unixes */
         if(sockerr == EWOULDBLOCK)
             return -EAGAIN;
-#endif
         return -sockerr;
     }
     return rc;


### PR DESCRIPTION
As per commit history this macro was originally introduced for VMS, then
extended to all platforms defining it. Based on curl source code, this
macro is safe to assume without a guard.

Follow-up to 92f76866a81883db86e7595c0b86181b25cabbfa #172 #171
Follow-up to c511177d396046860a8320aa0d05d054142cefd5

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
