### PR TITLE
agent: fix NULL deref on OOM in `libssh2_agent_set_identity_path()`

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1277,9 +1277,11 @@ void libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
         size_t path_len = strlen(path);
         if(path_len < SIZE_MAX - 1) {
             char *path_buf = SSH2_ALLOC(agent->session, path_len + 1);
-            memcpy(path_buf, path, path_len);
-            path_buf[path_len] = '\0';
-            agent->identity_agent_path = path_buf;
+            if(path_buf) {
+                memcpy(path_buf, path, path_len);
+                path_buf[path_len] = '\0';
+                agent->identity_agent_path = path_buf;
+            }
         }
     }
 }


### PR DESCRIPTION

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
