### PR TITLE
sftp.c: Replace LIBSSH2_ERROR_BUFFER_TOO_SMALL with LIBSSH2_ERROR_PROTO

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1825,13 +1825,13 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                 names_packet_len -= 4;
             }
             else {
-                filename_len = (size_t)LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+                filename_len = (size_t)LIBSSH2_ERROR_PROTO;
                 goto end;
             }
 
             filename_len = real_filename_len;
             if(filename_len >= buffer_maxlen) {
-                filename_len = (size_t)LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+                filename_len = (size_t)LIBSSH2_ERROR_PROTO;
                 goto end;
             }
 
@@ -1843,7 +1843,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                 names_packet_len -= real_filename_len;
             }
             else {
-                filename_len = (size_t)LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+                filename_len = (size_t)LIBSSH2_ERROR_PROTO;
                 goto end;
             }
 
@@ -1853,7 +1853,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                 names_packet_len -= 4;
             }
             else {
-                filename_len = (size_t)LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+                filename_len = (size_t)LIBSSH2_ERROR_PROTO;
                 goto end;
             }
 
@@ -1862,7 +1862,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
 
                 if(longentry_len >= longentry_maxlen ||
                    longentry_len > names_packet_len) {
-                    filename_len = (size_t)LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+                    filename_len = (size_t)LIBSSH2_ERROR_PROTO;
                     goto end;
                 }
 
@@ -1875,7 +1875,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                 names_packet_len -= real_longentry_len;
             }
             else {
-                filename_len = (size_t)LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+                filename_len = (size_t)LIBSSH2_ERROR_PROTO;
                 goto end;
             }
 
@@ -1890,7 +1890,7 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                 names_packet_len -= attr_len;
             }
             else {
-                filename_len = (size_t)LIBSSH2_ERROR_BUFFER_TOO_SMALL;
+                filename_len = (size_t)LIBSSH2_ERROR_PROTO;
                 goto end;
             }
 


### PR DESCRIPTION
Return protocol errors instead of buffer too small errors in the cases where the buffer contents are invalid.

Credit: Will Cosgrove