### PR TITLE
misc: clarify C syntax in `ssh2_store_bignum_bytes()`

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -313,7 +313,7 @@ int ssh2_store_bignum_bytes(unsigned char **buf,
     ssh2_store_u32(buf, len_stored + extraByte);
 
     if(extraByte) {
-        **buf = 0;
+        (*buf)[0] = 0;
         *buf += 1;
     }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -313,7 +313,7 @@ int ssh2_store_bignum_bytes(unsigned char **buf,
     ssh2_store_u32(buf, len_stored + extraByte);
 
     if(extraByte) {
-        *buf[0] = 0;
+        (*buf)[0] = 0;
         *buf += 1;
     }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -313,7 +313,7 @@ int ssh2_store_bignum_bytes(unsigned char **buf,
     ssh2_store_u32(buf, len_stored + extraByte);
 
     if(extraByte) {
-        (*buf)[0] = 0;
+        **buf = 0;
         *buf += 1;
     }
 


### PR DESCRIPTION
Functionally the same. To avoid LLMs generating false positives.

Reported-by GitHub Code Quality

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698
