### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/docs/INSTALL-AUTOTOOLS.md
+++ b/docs/INSTALL-AUTOTOOLS.md
@@ -214,35 +214,35 @@ configuration-related scripts to be executed by `/bin/bash`.
 
 `configure` recognizes the following options to control how it operates.
 
- * `--help`, `-h`
+* `--help`, `-h`
 
-   Print a summary of the options to `configure`, and exit.
+  Print a summary of the options to `configure`, and exit.
 
- * `--version`, `-V`
+* `--version`, `-V`
 
-   Print the version of Autoconf used to generate the `configure` script, and
-   exit.
+  Print the version of Autoconf used to generate the `configure` script, and
+  exit.
 
- * `--cache-file=FILE`
+* `--cache-file=FILE`
 
-   Enable the cache: use and save the results of the tests in FILE,
-   traditionally `config.cache`. FILE defaults to `/dev/null` to disable
-   caching.
+  Enable the cache: use and save the results of the tests in FILE,
+  traditionally `config.cache`. FILE defaults to `/dev/null` to disable
+  caching.
 
- * `--config-cache`, `-C`
+* `--config-cache`, `-C`
 
-   Alias for `--cache-file=config.cache`.
+  Alias for `--cache-file=config.cache`.
 
- * `--quiet`, `--silent`, `-q`
+* `--quiet`, `--silent`, `-q`
 
-   Do not print messages saying which checks are being made. To suppress all
-   normal output, redirect it to `/dev/null` (any error messages are still
-   shown).
+  Do not print messages saying which checks are being made. To suppress all
+  normal output, redirect it to `/dev/null` (any error messages are still
+  shown).
 
- * `--srcdir=DIR`
+* `--srcdir=DIR`
 
-   Look for the package's source code in directory DIR. Usually `configure`
-   can determine that directory automatically.
+  Look for the package's source code in directory DIR. Usually `configure`
+  can determine that directory automatically.
 
 `configure` also accepts some other, not widely useful, options. Run
 `configure --help` for more details.

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -46,47 +46,47 @@ cmake -D<option>=<value> ..
 
 The following options are available:
 
- * `LINT=ON`
+* `LINT=ON`
 
-    Enables running the source code linter when building.
-    Can be `ON` or `OFF`. Default: `OFF`
+   Enables running the source code linter when building.
+   Can be `ON` or `OFF`. Default: `OFF`
 
- * `BUILD_STATIC_LIBS=OFF`
+* `BUILD_STATIC_LIBS=OFF`
 
-    Determines whether to build a libssh2 static library.
-    Can be `ON` or `OFF`. Default: `ON`
+   Determines whether to build a libssh2 static library.
+   Can be `ON` or `OFF`. Default: `ON`
 
- * `BUILD_SHARED_LIBS=OFF`
+* `BUILD_SHARED_LIBS=OFF`
 
-    Determines whether to build a libssh2 shared library (`.dll`/`.so`).
-    Can be `ON` or `OFF`. Default: `ON`
+   Determines whether to build a libssh2 shared library (`.dll`/`.so`).
+   Can be `ON` or `OFF`. Default: `ON`
 
- * `CRYPTO_BACKEND=`
+* `CRYPTO_BACKEND=`
 
-    Chooses a specific cryptography library to use for cryptographic operations.
-    Can be [`OpenSSL`](https://www.openssl-library.org/),
-    [`Libgcrypt`](https://www.gnupg.org/), `WinCNG` (Windows Vista+),
-    [`mbedTLS`](https://www.trustedfirmware.org/projects/mbed-tls/) or blank
-    to use any library available.
+   Chooses a specific cryptography library to use for cryptographic operations.
+   Can be [`OpenSSL`](https://www.openssl-library.org/),
+   [`Libgcrypt`](https://www.gnupg.org/), `WinCNG` (Windows Vista+),
+   [`mbedTLS`](https://www.trustedfirmware.org/projects/mbed-tls/) or blank
+   to use any library available.
 
-    CMake attempts to locate the libraries automatically. For more
-    information, visit:
-    <https://cmake.org/cmake/help/v3.18/manual/cmake-packages.7.html>
+   CMake attempts to locate the libraries automatically. For more
+   information, visit:
+   <https://cmake.org/cmake/help/v3.18/manual/cmake-packages.7.html>
 
- * `ENABLE_ZLIB_COMPRESSION=ON`
+* `ENABLE_ZLIB_COMPRESSION=ON`
 
-    Use [zlib](https://zlib.net/) for payload compression.
-    Can be `ON` or `OFF`. Default: `OFF`
+   Use [zlib](https://zlib.net/) for payload compression.
+   Can be `ON` or `OFF`. Default: `OFF`
 
- * `ENABLE_DEBUG_LOGGING=ON`
+* `ENABLE_DEBUG_LOGGING=ON`
 
-    Enable the libssh2_trace() function for showing debug traces.
-    Can be `ON` or `OFF`. Default: `OFF` in Release, `ON` in `Debug`
+   Enable the libssh2_trace() function for showing debug traces.
+   Can be `ON` or `OFF`. Default: `OFF` in Release, `ON` in `Debug`
 
- * `CLEAR_MEMORY=OFF`
+* `CLEAR_MEMORY=OFF`
 
-    Disable secure zero memory before freeing it (not recommended).
-    Can be `ON` or `OFF`. Default: `ON`
+   Disable secure zero memory before freeing it (not recommended).
+   Can be `ON` or `OFF`. Default: `ON`
 
 ## Using AWS-LC or BoringSSL
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -559,7 +559,7 @@ static int agent_transact_unix(LIBSSH2_AGENT *agent,
         transctx->state = agent_NB_state_request_sent;
     }
 
-    /* Receive the length of a response */
+    /* Receive the length of the response */
     if(transctx->state == agent_NB_state_request_sent) {
         rc = (int)agent_recv_all(agent->session->recv, agent->fd,
                                  buf, sizeof(buf), 0,

--- a/src/agent.c
+++ b/src/agent.c
@@ -1102,7 +1102,7 @@ int libssh2_agent_connect(LIBSSH2_AGENT *agent)
     int i, rc = LIBSSH2_ERROR_METHOD_NOT_SUPPORTED;
     for(i = 0; supported_backends[i].name; i++) {
         agent->ops = supported_backends[i].ops;
-        rc = (agent->ops->connect)(agent);
+        rc = agent->ops->connect(agent);
         if(!rc)
             return LIBSSH2_ERROR_NONE;
     }

--- a/src/misc.c
+++ b/src/misc.c
@@ -61,11 +61,11 @@
 #ifdef LIBSSH2_SNPRINTF
 #include <stdarg.h>
 
-/* Want safe, 'n += snprintf(b + n ...)' like function. If cp_max_len is 1
-* then assume cp is pointing to a null char and do nothing. Returns number
-* number of chars placed in cp excluding the trailing null char. For
-* cp_max_len > 0 the return value is always < cp_max_len; for cp_max_len
-* <= 0 the return value is 0 (and no chars are written to cp). */
+/* Want safe, 'n += snprintf(b + n ...)' like function. If cp_max_len is 1 then
+ * assume cp is pointing to a null char and do nothing. Returns number of chars
+ * placed in cp excluding the trailing null char. For cp_max_len > 0 the return
+ * value is always < cp_max_len; for cp_max_len <= 0 the return value is 0 (and
+ * no chars are written to cp). */
 int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
 {
     va_list args;

--- a/src/pem.c
+++ b/src/pem.c
@@ -617,9 +617,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
 
         if(method->flags & SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET) {
             if(method->crypt(session, 0, decrypted.data,
-                             decrypted.len,
-                             &abstract,
-                             MIDDLE_BLOCK)) {
+                             decrypted.len, &abstract, MIDDLE_BLOCK)) {
                 ret = LIBSSH2_ERROR_DECRYPT;
                 method->dtor(session, &abstract);
                 goto out;
@@ -635,9 +633,7 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
                  * loop.
                  */
                 if(method->crypt(session, 0, decrypted.data + len_decrypted,
-                                 blocksize,
-                                 &abstract,
-                                 MIDDLE_BLOCK)) {
+                                 blocksize, &abstract, MIDDLE_BLOCK)) {
                     ret = LIBSSH2_ERROR_DECRYPT;
                     method->dtor(session, &abstract);
                     goto out;
@@ -658,8 +654,8 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
                     method->dtor(session, &abstract);
                     goto out;
                 }
-                if(method->crypt(session, 0, decoded.dataptr, 16, &abstract,
-                                 LAST_BLOCK)) {
+                if(method->crypt(session, 0, decoded.dataptr,
+                                 16, &abstract, LAST_BLOCK)) {
                     ret = ssh2_err(session, LIBSSH2_ERROR_DECRYPT,
                                    "GCM auth tag invalid");
                     method->dtor(session, &abstract);

--- a/src/transport.c
+++ b/src/transport.c
@@ -1212,9 +1212,9 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
                 /* The INTEGRATED_MAC case always has an extra call below, so
                    it never is LAST_BLOCK up here. */
                 int firstlast = i == 0 ? FIRST_BLOCK :
-                (!CRYPT_FLAG_L(session, INTEGRATED_MAC) &&
-                 (i == packet_length - session->local.crypt->blocksize)
-                 ? LAST_BLOCK : MIDDLE_BLOCK);
+                    (!CRYPT_FLAG_L(session, INTEGRATED_MAC) &&
+                     (i == packet_length - session->local.crypt->blocksize)
+                     ? LAST_BLOCK : MIDDLE_BLOCK);
                 /* In the AAD case, the last block would be only 4 bytes
                    because everything is offset by 4 since the initial
                    packet_length is not encrypted. In this case, combine that

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -276,7 +276,10 @@ void ssh2_dsa_free(ssh2_dsa_ctx *dsa);
  */
 
 #if LIBSSH2_ECDSA
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
+/* Maximum uncompressed EC point length for NIST P-521:
+ * two 521-bit coordinates rounded up to bytes, plus 1-byte format prefix.
+ */
+#define EC_MAX_POINT_LEN ((((521 + 7) / 8) * 2) + 1)
 
 typedef enum {
     SSH2_EC_CURVE_NISTP256 = 0,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -322,8 +322,9 @@ struct wcng_cipher_ctx {
 struct wcng_cipher_t {
     BCRYPT_ALG_HANDLE *phAlg;
     ULONG dwKeyLength;
-    int useIV;      /* TODO: Convert to bool when a C89-compatible bool type
-                       is defined */
+    /* TODO: Convert boolean flags to bool when a C89-compatible bool type is
+             defined */
+    int useIV;
     int ctrMode;
 };
 

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -59,11 +59,11 @@
 #include <ctype.h>
 
 #ifdef _WIN64
-#define LIBSSH2_SOCKET_MASK "%llu"
+#define LIBSSH2_SOCKET_MASK "llu"
 #elif defined(_WIN32)
-#define LIBSSH2_SOCKET_MASK "%u"
+#define LIBSSH2_SOCKET_MASK "u"
 #else
-#define LIBSSH2_SOCKET_MASK "%d"
+#define LIBSSH2_SOCKET_MASK "d"
 #endif
 
 #ifdef LIBSSH2_WINDOWS_UWP
@@ -408,7 +408,7 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if(sock == LIBSSH2_INVALID_SOCKET) {
         fprintf(stderr,
-                "Failed to open socket (" LIBSSH2_SOCKET_MASK ")\n", sock);
+                "Failed to open socket (%" LIBSSH2_SOCKET_MASK ")\n", sock);
         goto cleanup;
     }
 

--- a/vms/readme.vms
+++ b/vms/readme.vms
@@ -68,7 +68,7 @@ Please ignore the following warnings, as the kit is not signed :
 -PCSI-I-NOTSIGNED, product kit is not signed and therefore has no manifest file
 
 Optionally, you can install a backup saveset with some programming examples,
-or a backupo saveset with the complete libssh2 source tree.
+or a backup saveset with the complete libssh2 source tree.
 
 you need to answer 'NO' to the question
 'Do you want the default for all options'.


### PR DESCRIPTION
- INSTALL-AUTOTOOLS.md, INSTALL-CMAKE.md: drop indent from list.
- agent: drop redundant parentheses.
- pem: unfold lines.
- transport: fix indent of continued line.
- wincng: explain/clarify `EC_MAX_POINT_LEN` macro.
- wincng: extend comment scope to two struct members.
- openssh_fixture: move `%` out of `LIBSSH2_SOCKET_MASK` macro.
- fix comment typos.

---

https://github.com/libssh2/libssh2/pull/2069/files?w=1
