### PR TITLE
GHA: drop Azure Ubuntu mirror, instead of deprioritizing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
             sha256sum pkg.bin && sha256sum pkg.bin | grep -qwF -- "${OLD_CMAKE_SHA256_WIN_INTEL}" && unzip -q pkg.bin && rm -f pkg.bin
             printf '%s' ~/cmake-"${OLD_CMAKE_VERSION}"-win64-x64/bin/cmake.exe > ~/old-cmake-path.txt
           elif [[ "${MATRIX_IMAGE}" = *'ubuntu'* ]]; then
-            sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+            sudo sed -i '/azure/d' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
             sudo apt-get -o Dpkg::Use-Pty=0 install libgcrypt-dev libssl-dev libwolfssl-dev
             /home/linuxbrew/.linuxbrew/bin/brew install mbedtls@3
             cd ~
@@ -332,7 +332,7 @@ jobs:
         timeout-minutes: 2
         run: |
           sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+          sudo sed -i '/azure/d' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
           sudo dpkg --add-architecture "${MATRIX_ARCH}"
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install gcc-multilib build-essential zlib1g-dev:"${MATRIX_ARCH}"
@@ -346,7 +346,7 @@ jobs:
           [ "${MATRIX_CRYPTO}" = 'OpenSSL' ] && pkgs+=" libssl-dev:${MATRIX_ARCH}"
           [ "${MATRIX_CRYPTO}" = 'wolfSSL' ] && pkgs+=" libwolfssl-dev:${MATRIX_ARCH}"
           if [ -n "${pkgs}" ]; then
-            sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+            sudo sed -i '/azure/d' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
             sudo apt-get -o Dpkg::Use-Pty=0 install ${pkgs}
           fi
 
@@ -674,7 +674,7 @@ jobs:
         env:
           INSTALL_PACKAGES: ${{ matrix.compiler == 'clang-tidy' && 'clang-20 clang-tidy-20' || '' }}
         run: |
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+          sudo sed -i '/azure/d' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
           sudo apt-get -o Dpkg::Use-Pty=0 install gcc-mingw-w64-x86-64-win32 ${INSTALL_PACKAGES}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Drop the Azure Ubuntu mirror, instead of only deprioritizing it. Not
fixing much, but makes failures shorter and possibly easier to diagnose.

With this it also removes the only cleartext HTTP package source.

---

Example:
```
[...]
After this operation, 720 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang-cpp20 amd64 1:20.1.2-0ubuntu1~24.04.2 [14.3 MB]
Get:3 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang-common-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2 [782 kB]
Get:4 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-linker-tools amd64 1:20.1.2-0ubuntu1~24.04.2 [1340 kB]
Get:5 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang1-20 amd64 1:20.1.2-0ubuntu1~24.04.2 [8318 kB]
Get:6 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-20 amd64 1:20.1.2-0ubuntu1~24.04.2 [77.7 kB]
Ign:7 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-tools-20 amd64 1:20.1.2-0ubuntu1~24.04.2
Get:8 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-tidy-20 amd64 1:20.1.2-0ubuntu1~24.04.2 [2071 kB]
Get:9 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang-rt-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2 [4086 kB]
Get:10 https://archive.ubuntu.com/ubuntu noble/universe amd64 libwolfssl42t64 amd64 5.6.6-1.3build1 [912 kB]
Get:11 https://archive.ubuntu.com/ubuntu noble/universe amd64 libwolfssl-dev amd64 5.6.6-1.3build1 [1354 kB]
Ign:12 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-runtime amd64 1:20.1.2-0ubuntu1~24.04.2
Ign:7 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 clang-tools-20 amd64 1:20.1.2-0ubuntu1~24.04.2
Err:7 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-tools-20 amd64 1:20.1.2-0ubuntu1~24.04.2
  404  Not Found [IP: 172.66.152.176 443]
Ign:13 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20 amd64 1:20.1.2-0ubuntu1~24.04.2
Ign:12 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-runtime amd64 1:20.1.2-0ubuntu1~24.04.2
Err:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-runtime amd64 1:20.1.2-0ubuntu1~24.04.2
  404  Not Found [IP: 172.66.152.176 443]
Ign:14 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-tools amd64 1:20.1.2-0ubuntu1~24.04.2
Ign:13 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20 amd64 1:20.1.2-0ubuntu1~24.04.2
Err:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20 amd64 1:20.1.2-0ubuntu1~24.04.2
  404  Not Found [IP: 172.66.152.176 443]
Ign:15 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2
Ign:14 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-tools amd64 1:20.1.2-0ubuntu1~24.04.2
Err:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-tools amd64 1:20.1.2-0ubuntu1~24.04.2
  404  Not Found [IP: 172.66.152.176 443]
Ign:15 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2
Err:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2
  404  Not Found [IP: 172.66.152.176 443]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-20/clang-tools-20_20.1.2-0ubuntu1%7e24.04.2_amd64.deb  404  Not Found [IP: 172.66.152.176 443]
Fetched 33.2 MB in 2s (13.5 MB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-20/llvm-20-runtime_20.1.2-0ubuntu1%7e24.04.2_amd64.deb  404  Not Found [IP: 172.66.152.176 443]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-20/llvm-20_20.1.2-0ubuntu1%7e24.04.2_amd64.deb  404  Not Found [IP: 172.66.152.176 443]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-20/llvm-20-tools_20.1.2-0ubuntu1%7e24.04.2_amd64.deb  404  Not Found [IP: 172.66.152.176 443]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-20/llvm-20-dev_20.1.2-0ubuntu1%7e24.04.2_amd64.deb  404  Not Found [IP: 172.66.152.176 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
Ref: https://github.com/libssh2/libssh2/actions/runs/27656154846/job/81792643777?pr=2073

After this patch, still broken:
```
[...]
After this operation, 712 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [93 B]
Get:2 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang-cpp20 amd64 1:20.1.2-0ubuntu1~24.04.2 [14.3 MB]
Get:3 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang-common-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2 [782 kB]
Get:4 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-linker-tools amd64 1:20.1.2-0ubuntu1~24.04.2 [1340 kB]
Get:5 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang1-20 amd64 1:20.1.2-0ubuntu1~24.04.2 [8318 kB]
Ign:6 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-20 amd64 1:20.1.2-0ubuntu1~24.04.2
Get:7 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-tools-20 amd64 1:20.1.2-0ubuntu1~24.04.2 [9587 kB]
Get:8 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 clang-tidy-20 amd64 1:20.1.2-0ubuntu1~24.04.2 [2071 kB]
Get:9 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 libclang-rt-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2 [4086 kB]
Get:10 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-runtime amd64 1:20.1.2-0ubuntu1~24.04.2 [558 kB]
Get:11 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20 amd64 1:20.1.2-0ubuntu1~24.04.2 [19.8 MB]
Get:12 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-tools amd64 1:20.1.2-0ubuntu1~24.04.2 [515 kB]
Ign:13 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2
Err:6 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 clang-20 amd64 1:20.1.2-0ubuntu1~24.04.2
  404  Not Found [IP: 104.20.28.246 443]
Err:13 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 llvm-20-dev amd64 1:20.1.2-0ubuntu1~24.04.2
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-20/clang-20_20.1.2-0ubuntu1%7e24.04.2_amd64.deb  404  Not Found [IP: 104.20.28.246 443]
  404  Not Found [IP: 104.20.28.246 443]
Fetched 61.3 MB in 2s (30.9 MB/s)
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-20/llvm-20-dev_20.1.2-0ubuntu1%7e24.04.2_amd64.deb  404  Not Found [IP: 104.20.28.246 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
Ref: https://github.com/libssh2/libssh2/actions/runs/27657242752/job/81793936028?pr=2074

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
