### PR TITLE
GHA: do `apt-get update` before `install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,7 @@ jobs:
           [ "${MATRIX_CRYPTO}" = 'wolfSSL' ] && pkgs+=" libwolfssl-dev:${MATRIX_ARCH}"
           if [ -n "${pkgs}" ]; then
             sudo sed -i '/azure/d' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+            sudo apt-get -o Dpkg::Use-Pty=0 update
             sudo apt-get -o Dpkg::Use-Pty=0 install ${pkgs}
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,7 @@ jobs:
           INSTALL_PACKAGES: ${{ matrix.compiler == 'clang-tidy' && 'clang-20 clang-tidy-20' || '' }}
         run: |
           sudo sed -i '/azure/d' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+          sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install gcc-mingw-w64-x86-64-win32 ${INSTALL_PACKAGES}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
To avoid sometimes the preinstalled database going out-of-sync with
files stored on the distro servers, and failing install with `404`.

Follow-up to 74da590dc8c2a549a4ec194cd5f1a956e66e7714 #2074
Follow-up to 00a3b88c51cdb407fbbb347a2e38c5c7d89875ad #1187

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
