### PR TITLE
crypto: ECDSA build tidy ups

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -159,6 +159,11 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
 #endif
 
 #if LIBSSH2_ECDSA
+/* Maximum uncompressed EC point length for NIST P-521:
+ * two 521-bit coordinates rounded up to bytes, plus 1-byte format prefix.
+ */
+#define EC_MAX_POINT_LEN ((((521 + 7) / 8) * 2) + 1)
+
 int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
                                          const unsigned char *k,
                                          size_t k_len,

--- a/src/kex.c
+++ b/src/kex.c
@@ -1679,8 +1679,7 @@ static int kex_session_hybrid_curve_type(const char *name,
 }
 #endif
 
-#if LIBSSH2_ECDSA
-
+#if LIBSSH2_ECDSA || LIBSSH2_ED25519
 /*
  * Macro that create and verifies EC SHA hash with a given digest bytes
  *
@@ -1790,8 +1789,11 @@ static int kex_session_hybrid_curve_type(const char *name,
         }                                                                     \
     } while(0)
 
-#if LIBSSH2_MLKEM
+#endif /* LIBSSH2_ECDSA || LIBSSH2_ED25519 */
 
+#if LIBSSH2_ECDSA
+
+#if LIBSSH2_MLKEM
 /*
  * Macro that create and verifies HYBRID (EC+PQ) SHA hash with a given
  * digest bytes
@@ -1905,7 +1907,7 @@ static int kex_session_hybrid_curve_type(const char *name,
         }                                                                     \
     } while(0)
 
-#endif
+#endif /* LIBSSH2_MLKEM */
 
 /*
  * returns the EC curve type by name used in key exchange

--- a/src/kex.c
+++ b/src/kex.c
@@ -1654,7 +1654,6 @@ dh_gex_clean_exit:
 }
 
 #if (LIBSSH2_ECDSA || LIBSSH2_ED25519) && LIBSSH2_MLKEM
-
 /*
  * returns the EC curve type by name used in hybrid key exchange
  */
@@ -1680,7 +1679,6 @@ static int kex_session_hybrid_curve_type(const char *name,
 
     return 0;
 }
-
 #endif
 
 #if LIBSSH2_ECDSA

--- a/src/kex.c
+++ b/src/kex.c
@@ -1669,13 +1669,11 @@ static int kex_session_hybrid_curve_type(const char *name,
         type = SSH2_EC_CURVE_NISTP256;
     else if(!strcmp(name, "mlkem1024nistp384-sha384"))
         type = SSH2_EC_CURVE_NISTP384;
-    else {
+    else
         return -1;
-    }
 
-    if(out_type) {
+    if(out_type)
         *out_type = type;
-    }
 
     return 0;
 }

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -149,7 +149,6 @@
 #define ssh2_dsa_free(dsactx) gcry_sexp_release(dsactx)
 
 #if LIBSSH2_ECDSA
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 #else
 #define ssh2_ec_key void
 #endif

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -148,11 +148,6 @@
 #define ssh2_dsa_ctx          struct gcry_sexp
 #define ssh2_dsa_free(dsactx) gcry_sexp_release(dsactx)
 
-#if LIBSSH2_ECDSA
-#else
-#define ssh2_ec_key void
-#endif
-
 #define SSH2_CIPHER_T(name)   int name
 #define ssh2_cipher_ctx       gcry_cipher_hd_t
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -369,7 +369,9 @@ struct key_exchange_state_low {
     unsigned char *data;
     size_t request_len;
     size_t data_len;
+#if LIBSSH2_ECDSA
     ssh2_ec_key *private_key;       /* SSH2 ecdh private key */
+#endif
     unsigned char *public_key_oct;  /* SSH2 ecdh public key octal value */
     size_t public_key_oct_len;      /* SSH2 ecdh public key octal value
                                        length */

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -228,9 +228,6 @@ void ssh2_rsa_free(ssh2_rsa_ctx *ctx);
  */
 
 #if LIBSSH2_ECDSA
-
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
-
 typedef enum {
 #ifdef MBEDTLS_ECP_DP_SECP256R1_ENABLED
     SSH2_EC_CURVE_NISTP256 = MBEDTLS_ECP_DP_SECP256R1,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -250,8 +250,6 @@ typedef enum {
 #define ssh2_ec_key mbedtls_ecp_keypair
 
 void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx);
-#else
-#define ssh2_ec_key void
 #endif /* LIBSSH2_ECDSA */
 
 /*******************************************************************/

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -330,8 +330,6 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #endif /* LIBSSH2_DSA */
 
 #if LIBSSH2_ECDSA
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
-
 #ifdef USE_OPENSSL_3
 #define ssh2_ecdsa_ctx            EVP_PKEY
 #define ssh2_ecdsa_free(ecdsactx) EVP_PKEY_free(ecdsactx)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -345,8 +345,6 @@ typedef enum {
     SSH2_EC_CURVE_NISTP384 = NID_secp384r1,
     SSH2_EC_CURVE_NISTP521 = NID_secp521r1
 } ssh2_curve_type;
-#else /* !LIBSSH2_ECDSA */
-#define ssh2_ec_key void
 #endif /* LIBSSH2_ECDSA */
 
 #if LIBSSH2_ED25519

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -196,7 +196,6 @@
 #define SHA512_DIGEST_LENGTH 64
 
 #if LIBSSH2_ECDSA
-#define EC_MAX_POINT_LEN ((528 * 2 / 8) + 1)
 #else
 #define ssh2_ec_key void
 #endif

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -195,11 +195,6 @@
 #define SHA384_DIGEST_LENGTH 48
 #define SHA512_DIGEST_LENGTH 64
 
-#if LIBSSH2_ECDSA
-#else
-#define ssh2_ec_key void
-#endif
-
 /*******************************************************************
  *
  * OS/400 QC3 crypto-library backend: global handles structures.

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -276,11 +276,6 @@ void ssh2_dsa_free(ssh2_dsa_ctx *dsa);
  */
 
 #if LIBSSH2_ECDSA
-/* Maximum uncompressed EC point length for NIST P-521:
- * two 521-bit coordinates rounded up to bytes, plus 1-byte format prefix.
- */
-#define EC_MAX_POINT_LEN ((((521 + 7) / 8) * 2) + 1)
-
 typedef enum {
     SSH2_EC_CURVE_NISTP256 = 0,
     SSH2_EC_CURVE_NISTP384 = 1,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -291,8 +291,6 @@ struct wcng_ecdsa_ctx {
 #define ssh2_ec_key    struct wcng_ecdsa_ctx
 
 void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx);
-#else
-#define ssh2_ec_key void
 #endif
 
 /*******************************************************************/


### PR DESCRIPTION
- deduplicate `EC_MAX_POINT_LEN()` macros into `crypto.h`.
- drop dummy `ssh2_ec_key` type from no-ECDSA builds.
- adjust guards to allow building with no-ECDSA no-MLKEM.
- drop a few blocks around single-instructions.
