### PR TITLE
GHA: bump runner to ubuntu-26.04 in most jobs, clang-tidy to v22

### DIFF
--- a/.github/workflows/appveyor_docker.yml
+++ b/.github/workflows/appveyor_docker.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   daemon:
     name: 'Daemon'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     env:
       SSH_HOST: '${{ github.event.inputs.ssh_host }}'

--- a/.github/workflows/appveyor_status.yml
+++ b/.github/workflows/appveyor_status.yml
@@ -38,7 +38,7 @@ permissions: {}
 jobs:
   split:
     name: 'split'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: ${{ github.event.sender.login == 'appveyor[bot]' }}
     permissions:
       statuses: write  # To update build statuses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,7 +1015,7 @@ jobs:
           grep -F '#define' bld/src/libssh2_config.h | sort || true
 
       - name: 'build'
-        run: cmake --build bld --parallel 5 --target package --config Release
+        run: cmake --build bld --target package --config Release
 
       - name: 'tests'
         # UWP binaries require a CRT DLL that is not found. Static CRT not supported.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-24.04-arm, macos-latest, windows-2022]
+        image: [ubuntu-26.04-arm, macos-latest, windows-2022]
     steps:
       - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         if: ${{ contains(matrix.image, 'windows') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,7 @@ jobs:
         timeout-minutes: 2
         run: |
           pkgs=''
+          [ "${MATRIX_COMPILER}" = 'clang' ] && pkgs+=' clang-22'
           [ "${MATRIX_COMPILER}" = 'clang-tidy' ] && pkgs+=' clang-22 clang-tidy-22'
           [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ] && pkgs+=" libgcrypt-dev:${MATRIX_ARCH}"
           [ "${MATRIX_CRYPTO}" = 'OpenSSL' ] && pkgs+=" libssl-dev:${MATRIX_ARCH}"
@@ -549,6 +550,9 @@ jobs:
         env:
           MATRIX_COMPILER: '${{ matrix.compiler }}'
         run: |
+          if [ "${MATRIX_COMPILER}" = 'clang' ]; then
+            export CC=clang-22
+          fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             if [ "${MATRIX_CRYPTO}" = 'AWS-LC' ] || \
                [ "${MATRIX_CRYPTO}" = 'BoringSSL' ] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
 
   build_linux:
     name: 'linux'
-    runs-on: ubuntu-26.04
+    runs-on: ${{ matrix.compiler == 'clang-tidy' && 'ubuntu-26.04' || (matrix.image || 'ubuntu-latest') }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -260,6 +260,7 @@ jobs:
             crypto: mbedTLS-from-source
             build: 'CM'
             zlib: 'ON'
+            image: ubuntu-26.04
           - compiler: gcc
             arch: amd64
             crypto: OpenSSL
@@ -287,21 +288,25 @@ jobs:
             crypto: OpenSSL-3-no-deprecated
             build: 'CM'
             zlib: 'ON'
+            image: ubuntu-26.04
           - compiler: gcc
             arch: amd64
             crypto: OpenSSL-111-from-source
             build: 'CM'
             zlib: 'ON'
+            image: ubuntu-26.04
           - compiler: clang
             arch: amd64
             crypto: wolfSSL-from-source
             build: 'CM'
             zlib: 'ON'
+            image: ubuntu-26.04
           - compiler: clang
             arch: amd64
             crypto: wolfSSL-from-source-prev
             build: 'CM'
             zlib: 'ON'
+            image: ubuntu-26.04
     env:
       CC: ${{ matrix.compiler == 'clang-tidy' && 'clang' || matrix.compiler }}
       MATRIX_ARCH: '${{ matrix.arch }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1011,7 +1011,7 @@ jobs:
           grep -F '#define' bld/src/libssh2_config.h | sort || true
 
       - name: 'build'
-        run: cmake --build bld --target package --config Release
+        run: cmake --build bld --parallel 2 --target package --config Release
 
       - name: 'tests'
         # UWP binaries require a CRT DLL that is not found. Static CRT not supported.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
         timeout-minutes: 2
         run: |
           pkgs=''
-          [ "${MATRIX_COMPILER}" = 'clang-tidy' ] && pkgs+=' clang-20 clang-tidy-20'
+          [ "${MATRIX_COMPILER}" = 'clang-tidy' ] && pkgs+=' clang-22 clang-tidy-22'
           [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ] && pkgs+=" libgcrypt-dev:${MATRIX_ARCH}"
           [ "${MATRIX_CRYPTO}" = 'OpenSSL' ] && pkgs+=" libssl-dev:${MATRIX_ARCH}"
           [ "${MATRIX_CRYPTO}" = 'wolfSSL' ] && pkgs+=" libwolfssl-dev:${MATRIX_ARCH}"
@@ -568,8 +568,8 @@ jobs:
               cflags+=' -m32'
             fi
             if [ "${MATRIX_COMPILER}" = 'clang-tidy' ]; then
-              options+=' -DLIBSSH2_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-20'
-              options+=' -DCMAKE_C_COMPILER=clang-20'
+              options+=' -DLIBSSH2_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-22'
+              options+=' -DCMAKE_C_COMPILER=clang-22'
             fi
             if [[ "${MATRIX_CRYPTO}" =~ ^(OpenSSL|Libgcrypt|mbedTLS|wolfSSL)$ && "${MATRIX_COMPILER}" != 'clang-tidy' && "${MATRIX_ZLIB}" = 'ON' ]]; then
               options+=' -DCMAKE_C_STANDARD=90'
@@ -676,7 +676,7 @@ jobs:
       - name: 'install packages'
         timeout-minutes: 2
         env:
-          INSTALL_PACKAGES: ${{ matrix.compiler == 'clang-tidy' && 'clang-20 clang-tidy-20' || '' }}
+          INSTALL_PACKAGES: ${{ matrix.compiler == 'clang-tidy' && 'clang-22 clang-tidy-22' || '' }}
         run: |
           sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo sed -i '/azure/d' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
@@ -697,9 +697,9 @@ jobs:
         run: |
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             if [ "${MATRIX_COMPILER}" = 'clang-tidy' ]; then
-              options+=' -DLIBSSH2_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-20'
-              options+=' -DCMAKE_C_COMPILER=clang-20'
-              options+=" -DCMAKE_RC_COMPILER=llvm-windres-$(clang-20 -dumpversion | cut -d '.' -f 1)"
+              options+=' -DLIBSSH2_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-22'
+              options+=' -DCMAKE_C_COMPILER=clang-22'
+              options+=" -DCMAKE_RC_COMPILER=llvm-windres-$(clang-22 -dumpversion | cut -d '.' -f 1)"
             else
               options+=" -DCMAKE_C_COMPILER=${TRIPLET}-gcc"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   check_style:
     name: 'style-check'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,7 +36,7 @@ jobs:
 
   linters:
     name: 'linters'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -227,7 +227,7 @@ jobs:
 
   build_linux:
     name: 'linux'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -660,7 +660,7 @@ jobs:
 
   build_linux_cross_mingw64:
     name: "linux -> mingw-w64, ${{ matrix.build }} ${{ matrix.compiler }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -1125,7 +1125,7 @@ jobs:
 
   cross:
     name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.cc }} ${{ matrix.desc }} ${{ matrix.arch }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,6 @@ jobs:
         timeout-minutes: 2
         run: |
           pkgs=''
-          [ "${MATRIX_COMPILER}" = 'clang' ] && pkgs+=' clang-22'
           [ "${MATRIX_COMPILER}" = 'clang-tidy' ] && pkgs+=' clang-22 clang-tidy-22'
           [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ] && pkgs+=" libgcrypt-dev:${MATRIX_ARCH}"
           [ "${MATRIX_CRYPTO}" = 'OpenSSL' ] && pkgs+=" libssl-dev:${MATRIX_ARCH}"
@@ -550,9 +549,6 @@ jobs:
         env:
           MATRIX_COMPILER: '${{ matrix.compiler }}'
         run: |
-          if [ "${MATRIX_COMPILER}" = 'clang' ]; then
-            export CC=clang-22
-          fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             if [ "${MATRIX_CRYPTO}" = 'AWS-LC' ] || \
                [ "${MATRIX_CRYPTO}" = 'BoringSSL' ] || \

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   Fuzzing:
     name: 'Fuzzing'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     steps:
     - name: 'Build Fuzzers'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
   gha:
     if: ${{ github.repository_owner == 'libssh2' || github.event_name != 'schedule' }}
     name: 'GHA'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       security-events: write  # To create/update security events
     steps:
@@ -49,7 +49,7 @@ jobs:
   c:
     if: ${{ github.repository_owner == 'libssh2' || github.event_name != 'schedule' }}
     name: 'C'
-    runs-on: ${{ matrix.platform == 'Linux' && 'ubuntu-latest' || 'windows-2022' }}
+    runs-on: ${{ matrix.platform == 'Linux' && 'ubuntu-26.04' || 'windows-2022' }}
     permissions:
       security-events: write  # To create/update security events
     strategy:

--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   build-and-push:
     name: 'Image build and push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       contents: read   # To comply with https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images
       packages: write  # To create/update container

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -335,9 +335,6 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #define ssh2_ecdsa_ctx            EC_KEY
 #define ssh2_ecdsa_free(ecdsactx) EC_KEY_free(ecdsactx)
 #define ssh2_ec_key               EC_KEY
-#  if OPENSSL_VERSION_NUMBER < 0x20000000L
-#    warning "OpenSSL 1.1.1 + ECDSA compiled"
-#  endif
 #endif
 
 typedef enum {

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -335,6 +335,9 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #define ssh2_ecdsa_ctx            EC_KEY
 #define ssh2_ecdsa_free(ecdsactx) EC_KEY_free(ecdsactx)
 #define ssh2_ec_key               EC_KEY
+#  if OPENSSL_VERSION_NUMBER < 0x20000000L
+#    warning "OpenSSL 1.1.1 + ECDSA compiled"
+#  endif
 #endif
 
 typedef enum {


### PR DESCRIPTION
Keep ubuntu-24.04 for Linux jobs using system packages for more 
variation.

Also bump clang-tidy jobs to v22 (from v20, also up from the default v21
preinstalled on ubuntu-26.04.)

---

The MSVC `--parallel` patch tested in this PR was deliberately not
merged to master. Maybe later if this turns out to be a permanent
issue. It also need for experiments to avoid the slowdown caused by
reducing it to 1 or 2 (need to figure out the maximum that still fixes
the MSBuild breakage.)

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
