### PR TITLE
openssl: fix leaking ECDSA bignum buffer in non-OpenSSL3 builds

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3252,6 +3252,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
 
     BN_bin2bn(exponent, (int)exponentlen, bn_exponent);
     rc = (EC_KEY_set_private_key(ec_key, bn_exponent) != 1);
+    BN_free(bn_exponent);
 #endif
 
     if(rc == 0 && ec_key && pubkeydata && method) {


### PR DESCRIPTION
Reported-by: Ze Sheng (Aisle Research)
Fixes #2079

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
