### PR TITLE
openssl: fix server host key memleak on handshake failure

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -907,11 +907,12 @@ static int session_free(LIBSSH2_SESSION *session)
                               &session->startup_key_state.key_state_low);
     }
 
+    /* hostkey */
+    if(session->hostkey && session->hostkey->dtor) {
+        session->hostkey->dtor(session, &session->server_hostkey_abstract);
+    }
+
     if(session->state & SSH2_STATE_NEWKEYS) {
-        /* hostkey */
-        if(session->hostkey && session->hostkey->dtor) {
-            session->hostkey->dtor(session, &session->server_hostkey_abstract);
-        }
 
         /* Client to Server */
         /* crypt */


### PR DESCRIPTION
Reported-by: Ze Sheng (Aisle Research)
Fixes #2080

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
