### PR TITLE
GHA: enable connect trace for OpenSSL3-no-deprecated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,9 @@ jobs:
         env:
           MATRIX_COMPILER: '${{ matrix.compiler }}'
         run: |
+          if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
+            FIXTURE_TRACE_ALL_CONNECT=1  # try closing up on flaky CI failures
+          fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             if [ "${MATRIX_CRYPTO}" = 'AWS-LC' ] || \
                [ "${MATRIX_CRYPTO}" = 'BoringSSL' ] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,7 @@ jobs:
           MATRIX_COMPILER: '${{ matrix.compiler }}'
         run: |
           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
-            FIXTURE_TRACE_ALL_CONNECT=1  # try closing up on flaky CI failures
+            export FIXTURE_TRACE_ALL_CONNECT=1  # try closing up on flaky CI failures
           fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             if [ "${MATRIX_CRYPTO}" = 'AWS-LC' ] || \


### PR DESCRIPTION
Flaky CI failure are more often seen here than in other jobs.
```
libssh2_session_handshake failed (-8): Unable to exchange encryption keys
```
Ref: https://github.com/libssh2/libssh2/actions/runs/27867982831/job/82475138334?pr=2081#step:25:377

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
