### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -1105,7 +1105,7 @@ static int hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
 /*
  * Initialize the server hostkey cert
  */
-static int hostkey_method_ssh_ed25519_cert_init(
+static int hostkey_method_ssh_ed25519_init_cert(
     LIBSSH2_SESSION *session,
     const unsigned char *hostkey_data,
     size_t hostkey_data_len,
@@ -1294,7 +1294,7 @@ static const struct hostkey_method hostkey_method_ssh_ed25519 = {
 static const struct hostkey_method hostkey_method_ssh_ed25519_cert = {
     "ssh-ed25519-cert-v01@openssh.com",
     SHA256_DIGEST_LENGTH,
-    hostkey_method_ssh_ed25519_cert_init,
+    hostkey_method_ssh_ed25519_init_cert,
     hostkey_method_ssh_ed25519_initPEM,
     hostkey_method_ssh_ed25519_initPEMFromMemory,
     hostkey_method_ssh_ed25519_sig_verify,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -1145,7 +1145,7 @@ static int hostkey_method_ssh_ed25519_init_cert(
 
     /*
      * we cannot check for eob here because certs
-     * have more meta data we don't read
+     * have more meta data we do not read
      */
 
     if(ssh2_ed25519_new_public(&ctx, session, key, key_len) != 0) {

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -117,13 +117,12 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
      * tell mbedTLS to expect no padding on the cipher layer. Only call
      * set_padding_mode for CBC ciphers since other modes (CTR, stream)
      * are not applicable and causes an error. */
-    if(!ret) {
-        if(algo == MBEDTLS_CIPHER_AES_128_CBC ||
-           algo == MBEDTLS_CIPHER_AES_192_CBC ||
-           algo == MBEDTLS_CIPHER_AES_256_CBC ||
-           algo == MBEDTLS_CIPHER_DES_EDE3_CBC) {
-            ret = mbedtls_cipher_set_padding_mode(h, MBEDTLS_PADDING_NONE);
-        }
+    if(!ret &&
+       (algo == MBEDTLS_CIPHER_AES_128_CBC ||
+        algo == MBEDTLS_CIPHER_AES_192_CBC ||
+        algo == MBEDTLS_CIPHER_AES_256_CBC ||
+        algo == MBEDTLS_CIPHER_DES_EDE3_CBC)) {
+      ret = mbedtls_cipher_set_padding_mode(h, MBEDTLS_PADDING_NONE);
     }
 
     if(!ret)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -122,7 +122,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
         algo == MBEDTLS_CIPHER_AES_192_CBC ||
         algo == MBEDTLS_CIPHER_AES_256_CBC ||
         algo == MBEDTLS_CIPHER_DES_EDE3_CBC)) {
-      ret = mbedtls_cipher_set_padding_mode(h, MBEDTLS_PADDING_NONE);
+        ret = mbedtls_cipher_set_padding_mode(h, MBEDTLS_PADDING_NONE);
     }
 
     if(!ret)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -179,13 +179,13 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 }
 
 int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,
-                        mbedtls_md_type_t mdtype,
+                        mbedtls_md_type_t md_type,
                         const unsigned char *key, size_t keylen)
 {
     const mbedtls_md_info_t *md_info;
     int ret, hmac;
 
-    md_info = mbedtls_md_info_from_type(mdtype);
+    md_info = mbedtls_md_info_from_type(md_type);
     if(!md_info)
         return 0;
 
@@ -214,12 +214,12 @@ int ssh2_mbed_hash_final(mbedtls_md_context_t *ctx, unsigned char *hash)
 }
 
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   mbedtls_md_type_t mdtype, unsigned char *hash)
+                   mbedtls_md_type_t md_type, unsigned char *hash)
 {
     const mbedtls_md_info_t *md_info;
     int ret;
 
-    md_info = mbedtls_md_info_from_type(mdtype);
+    md_info = mbedtls_md_info_from_type(md_type);
     if(!md_info)
         return 0;
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -207,11 +207,11 @@ int ssh2_random(unsigned char *buf, size_t len);
 #endif
 
 int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,
-                        mbedtls_md_type_t mdtype,
+                        mbedtls_md_type_t md_type,
                         const unsigned char *key, size_t keylen);
 int ssh2_mbed_hash_final(mbedtls_md_context_t *ctx, unsigned char *hash);
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   mbedtls_md_type_t mdtype, unsigned char *hash);
+                   mbedtls_md_type_t md_type, unsigned char *hash);
 
 /*******************************************************************/
 /*

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -304,8 +304,6 @@ int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
 #define ssh2_hmac_ctx HMAC_CTX *
 #endif /* USE_OPENSSL_3 */
 
-#define ssh2_crypto_exit()
-
 #if LIBSSH2_RSA
 #ifdef USE_OPENSSL_3
 #define ssh2_rsa_ctx          EVP_PKEY

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -52,10 +52,9 @@
 
 #ifdef OS400_DEBUG
 /* In debug mode, all system library errors cause an exception. */
-#define set_EC_length(ec, length)  ((ec).Bytes_Provided =      \
-                                    (ec).Bytes_Available = 0)
+#define set_EC_length(ec, len) ((ec).Bytes_Provided = ec).Bytes_Available = 0)
 #else
-#define set_EC_length(ec, length)  ((ec).Bytes_Provided = (length))
+#define set_EC_length(ec, len) ((ec).Bytes_Provided = (len))
 #endif
 
 /* Ensure va_list operations are not on an array. */

--- a/src/session.c
+++ b/src/session.c
@@ -1695,7 +1695,6 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 #ifdef HAVE_POLL
         {
             struct timeval tv_begin, tv_end;
-
             gettimeofday(&tv_begin, NULL);
             sysret = poll(sockets, nfds, (int)timeout_remaining);
             gettimeofday(&tv_end, NULL);
@@ -1753,11 +1752,9 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 #endif
         {
             struct timeval tv_begin, tv_end;
-
             gettimeofday(&tv_begin, NULL);
             sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
             gettimeofday(&tv_end, NULL);
-
             timeout_remaining -= (tv_end.tv_sec - tv_begin.tv_sec) * 1000;
             timeout_remaining -= (tv_end.tv_usec - tv_begin.tv_usec) / 1000;
         }

--- a/src/session.c
+++ b/src/session.c
@@ -276,32 +276,22 @@ static int banner_send(LIBSSH2_SESSION *session)
 static int session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
                             int nonblock /* TRUE or FALSE */ )
 {
-#ifdef HAVE_O_NONBLOCK
-    /* most recent unix versions */
-    int flags;
-
-    flags = fcntl(sockfd, F_GETFL, 0);
+#ifdef HAVE_O_NONBLOCK  /* most recent unix versions */
+    int flags = fcntl(sockfd, F_GETFL, 0);
     if(nonblock)
         return fcntl(sockfd, F_SETFL, flags | O_NONBLOCK);
     else
         return fcntl(sockfd, F_SETFL, flags & (~O_NONBLOCK));
-#elif defined(HAVE_FIONBIO)
-    /* older unix versions and VMS */
-    int flags;
-
-    flags = nonblock;
+#elif defined(HAVE_FIONBIO)  /* older unix versions and VMS */
+    int flags = nonblock;
     return ioctl(sockfd, FIONBIO, &flags);
-#elif defined(HAVE_IOCTLSOCKET_CASE)
-    /* presumably for Amiga */
+#elif defined(HAVE_IOCTLSOCKET_CASE)  /* presumably for Amiga */
     return IoctlSocket(sockfd, FIONBIO, (long)nonblock);
-#elif defined(HAVE_SO_NONBLOCK)
-    /* BeOS */
+#elif defined(HAVE_SO_NONBLOCK)  /* BeOS */
     long b = nonblock ? 1 : 0;
     return setsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 #elif defined(_WIN32)
-    unsigned long flags;
-
-    flags = nonblock;
+    unsigned long flags = nonblock;
     return ioctlsocket(sockfd, FIONBIO, &flags);
 #else
     (void)sockfd;
@@ -315,30 +305,22 @@ static int session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
  */
 static int get_socket_nonblocking(libssh2_socket_t sockfd)
 {                                 /* operate on this */
-#ifdef HAVE_O_NONBLOCK
-    /* most recent unix versions */
+#ifdef HAVE_O_NONBLOCK  /* most recent unix versions */
     int flags = fcntl(sockfd, F_GETFL, 0);
-
     if(flags == -1) {
-        /* Assume blocking on error */
-        return 1;
+        return 1;  /* Assume blocking on error */
     }
     return (flags & O_NONBLOCK);
-#elif defined(HAVE_SO_NONBLOCK)
-    /* BeOS */
+#elif defined(HAVE_SO_NONBLOCK)  /* BeOS */
     long b;
     if(getsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b))) {
-        /* Assume blocking on error */
-        return 1;
+        return 1;  /* Assume blocking on error */
     }
     return (int)b;
-#elif defined(SO_STATE) && defined(__VMS)
-    /* VMS TCP/IP Services */
-
+#elif defined(SO_STATE) && defined(__VMS)  /* VMS TCP/IP Services */
     size_t sockstat = 0;
     int callstat = 0;
     size_t size = sizeof(int);
-
     callstat = getsockopt(sockfd, SOL_SOCKET, SO_STATE,
                           (char *)&sockstat, &size);
     if(callstat == -1) {
@@ -354,8 +336,7 @@ static int get_socket_nonblocking(libssh2_socket_t sockfd)
 
     if(getsockopt(sockfd, SOL_SOCKET, SO_ERROR,
                   (void *)&option_value, &option_len)) {
-        /* Assume blocking on error */
-        return 1;
+        return 1;  /* Assume blocking on error */
     }
     return (int)option_value;
 #else

--- a/src/session.c
+++ b/src/session.c
@@ -1346,8 +1346,7 @@ int libssh2_session_flag(LIBSSH2_SESSION *session, int flag, int value)
         session->flag.quote_paths = value;
         break;
     default:
-        /* unknown flag */
-        return LIBSSH2_ERROR_INVAL;
+        return LIBSSH2_ERROR_INVAL;  /* unknown flag */
     }
 
     return LIBSSH2_ERROR_NONE;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2000,8 +2000,7 @@ static int wcng_publickey_from_point(IN wcng_ecc_keytype keytype,
         NULL,
         BCRYPT_ECCPUBLIC_BLOB,
         key,
-        (PUCHAR)ecc_blob,
-        (ULONG)ecc_blob_len,
+        (PUCHAR)ecc_blob, (ULONG)ecc_blob_len,
         0);
     if(!BCRYPT_SUCCESS(status)) {
         result = LIBSSH2_ERROR_PUBLICKEY_PROTOCOL;
@@ -2068,8 +2067,7 @@ static int wcng_privatekey_from_point(IN wcng_ecc_keytype keytype,
         NULL,
         BCRYPT_ECCPRIVATE_BLOB,
         key,
-        (PUCHAR)ecc_blob,
-        (ULONG)ecc_blob_len,
+        (PUCHAR)ecc_blob, (ULONG)ecc_blob_len,
         0);
     if(!BCRYPT_SUCCESS(status)) {
         result = LIBSSH2_ERROR_PUBLICKEY_PROTOCOL;
@@ -2120,8 +2118,7 @@ static int wcng_uncompressed_point_from_publickey(
         NULL,
         BCRYPT_ECCPUBLIC_BLOB,
         NULL,
-        0,
-        &ecc_blob_len,
+        0, &ecc_blob_len,
         0);
     if(BCRYPT_SUCCESS(status) && ecc_blob_len > 0) {
         ecc_blob = SSH2_ALLOC(session, ecc_blob_len);
@@ -2134,8 +2131,7 @@ static int wcng_uncompressed_point_from_publickey(
             NULL,
             BCRYPT_ECCPUBLIC_BLOB,
             (PUCHAR)ecc_blob,
-            ecc_blob_len,
-            &ecc_blob_len,
+            ecc_blob_len, &ecc_blob_len,
             0);
     }
 

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -446,7 +446,7 @@ static int read_file(const char *path, char **out_buffer, size_t *out_len)
         return 1;
     }
 
-    if(1 != fread(buffer, (size_t)len, 1, fp)) {
+    if(fread(buffer, (size_t)len, 1, fp) != 1) {
         fclose(fp);
         free(buffer);
         fprintf(stderr, "Could not read file into memory.\n");


### PR DESCRIPTION
- hostkey: contraction in comment.
- hostkey: rename local function for consistency.
- mbedtls: merge nested `if`s.
- mbedtls: rename `mdtype` to `md_type` to match majority use.
- openssl.h: drop duplicate `#define`.
- os400qc3: shorten a macro arg name to unfold line.
- session: drop newlines to sync two sibling blocks.
- session: inline comments and assignments.
- tests: move reference value to right side of `if` expression.
- wincng: unfold pointer and length args into the same line.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
