### PR TITLE
tidy-up: drop most `{}` blocks around single-statements

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -188,9 +188,8 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Authentication by public key failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr, "Authentication by public key succeeded.\n");
-            }
         }
         else {
             fprintf(stderr, "No supported authentication methods found.\n");
@@ -291,9 +290,8 @@ int main(int argc, char *argv[])
             while(wr < len) {
                 ssize_t nwritten = libssh2_channel_write(channel, buf + wr,
                                                          (size_t)(len - wr));
-                if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+                if(nwritten == LIBSSH2_ERROR_EAGAIN)
                     continue;
-                }
                 if(nwritten < 0) {
                     fprintf(stderr, "libssh2_channel_write: %ld\n",
                             (long)nwritten);

--- a/example/scp.c
+++ b/example/scp.c
@@ -56,21 +56,16 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         scppath = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -118,9 +113,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -154,14 +148,12 @@ int main(int argc, char *argv[])
         int amount = sizeof(mem);
         ssize_t nread;
 
-        if((fileinfo.st_size - got) < amount) {
+        if((fileinfo.st_size - got) < amount)
             amount = (int)(fileinfo.st_size - got);
-        }
 
         nread = libssh2_channel_read(channel, mem, (size_t)amount);
-        if(nread > 0) {
+        if(nread > 0)
             write(1, mem, (size_t)nread);
-        }
         else if(nread < 0) {
             fprintf(stderr, "libssh2_channel_read() failed: %ld\n",
                     (long)nread);

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -120,21 +120,16 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         scppath = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -191,9 +186,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -251,9 +245,8 @@ int main(int argc, char *argv[])
         do {
             int amount = sizeof(mem);
 
-            if((fileinfo.st_size - got) < amount) {
+            if((fileinfo.st_size - got) < amount)
                 amount = (int)(fileinfo.st_size - got);
-            }
 
             /* loop until we block */
             nread = libssh2_channel_read(channel, mem, (size_t)amount);

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -64,24 +64,18 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         loclfile = argv[4];
-    }
-    if(argc > 5) {
+    if(argc > 5)
         scppath = argv[5];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -141,9 +135,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -179,10 +172,8 @@ int main(int argc, char *argv[])
     fprintf(stderr, "SCP session waiting to send file\n");
     do {
         nread = fread(mem, 1, sizeof(mem), local);
-        if(nread <= 0) {
-            /* end of file */
-            break;
-        }
+        if(nread <= 0)
+            break;  /* end of file */
         ptr = mem;
 
         do {

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -112,24 +112,18 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         loclfile = argv[4];
-    }
-    if(argc > 5) {
+    if(argc > 5)
         scppath = argv[5];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -194,9 +188,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -241,10 +234,8 @@ int main(int argc, char *argv[])
     start = time(NULL);
     do {
         nread = fread(mem, 1, sizeof(mem), local);
-        if(nread <= 0) {
-            /* end of file */
-            break;
-        }
+        if(nread <= 0)
+            break;  /* end of file */
         ptr = mem;
 
         total += (libssh2_struct_stat_size)nread;

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -111,21 +111,16 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         sftppath = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -177,9 +172,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */
@@ -187,27 +181,21 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "password")) {
+        if(strstr(userauthlist, "password"))
             auth_pw |= 1;
-        }
-        if(strstr(userauthlist, "keyboard-interactive")) {
+        if(strstr(userauthlist, "keyboard-interactive"))
             auth_pw |= 2;
-        }
-        if(strstr(userauthlist, "publickey")) {
+        if(strstr(userauthlist, "publickey"))
             auth_pw |= 4;
-        }
 
         /* check for options */
         if(argc > 5) {
-            if((auth_pw & 1) && !strcmp(argv[5], "-p")) {
+            if((auth_pw & 1) && !strcmp(argv[5], "-p"))
                 auth_pw = 1;
-            }
-            if((auth_pw & 2) && !strcmp(argv[5], "-i")) {
+            if((auth_pw & 2) && !strcmp(argv[5], "-i"))
                 auth_pw = 2;
-            }
-            if((auth_pw & 4) && !strcmp(argv[5], "-k")) {
+            if((auth_pw & 4) && !strcmp(argv[5], "-k"))
                 auth_pw = 4;
-            }
         }
 
         if(auth_pw & 1) {
@@ -225,10 +213,9 @@ int main(int argc, char *argv[])
                         "Authentication by keyboard-interactive failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr,
                         "Authentication by keyboard-interactive succeeded.\n");
-            }
         }
         else if(auth_pw & 4) {
             /* Or by public key */
@@ -238,9 +225,8 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Authentication by public key failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr, "Authentication by public key succeeded.\n");
-            }
         }
         else {
             fprintf(stderr, "No supported authentication methods found.\n");
@@ -274,12 +260,10 @@ int main(int argc, char *argv[])
         /* loop until we fail */
         fprintf(stderr, "libssh2_sftp_read().\n");
         nread = libssh2_sftp_read(sftp_handle, mem, sizeof(mem));
-        if(nread > 0) {
+        if(nread > 0)
             write(1, mem, (size_t)nread);
-        }
-        else {
+        else
             break;
-        }
     } while(1);
 
     libssh2_sftp_close(sftp_handle);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -108,18 +108,14 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         username = argv[1];
-    }
-    if(argc > 2) {
+    if(argc > 2)
         password = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         sftppath = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         dest = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -169,9 +165,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     tempstorage = fopen(storage, "wb");
@@ -251,10 +246,8 @@ int main(int argc, char *argv[])
             }
         } while(nread > 0);
 
-        if(nread != LIBSSH2_ERROR_EAGAIN) {
-            /* error or end of file */
-            break;
-        }
+        if(nread != LIBSSH2_ERROR_EAGAIN)
+            break;  /* error or end of file */
 
         timeout.tv_sec = 10;
         timeout.tv_usec = 0;
@@ -306,10 +299,8 @@ int main(int argc, char *argv[])
         do {
             ssize_t nwritten;
             nread = fread(mem, 1, sizeof(mem), tempstorage);
-            if(nread <= 0) {
-                /* end of file */
-                break;
-            }
+            if(nread <= 0)
+                break;  /* end of file */
             ptr = mem;
 
             do {
@@ -321,10 +312,8 @@ int main(int argc, char *argv[])
                 nread -= (size_t)nwritten;
             } while(nwritten >= 0);
 
-            if(nwritten != LIBSSH2_ERROR_EAGAIN) {
-                /* error or end of file */
-                break;
-            }
+            if(nwritten != LIBSSH2_ERROR_EAGAIN)
+                break;  /* error or end of file */
 
             timeout.tv_sec = 10;
             timeout.tv_usec = 0;
@@ -352,9 +341,8 @@ int main(int argc, char *argv[])
         } while(1);
         fprintf(stderr, "SFTP upload done.\n");
     }
-    else {
+    else
         fprintf(stderr, "SFTP failed to open destination path: %s\n", dest);
-    }
 
     libssh2_sftp_shutdown(sftp_session);
 

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -64,24 +64,18 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         loclfile = argv[4];
-    }
-    if(argc > 5) {
+    if(argc > 5)
         sftppath = argv[5];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -139,9 +133,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -202,10 +195,8 @@ int main(int argc, char *argv[])
     fprintf(stderr, "libssh2_sftp_open() is done, now send data.\n");
     do {
         nread = fread(mem, 1, sizeof(mem), local);
-        if(nread <= 0) {
-            /* end of file */
-            break;
-        }
+        if(nread <= 0)
+            break;  /* end of file */
         ptr = mem;
 
         do {

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -56,21 +56,16 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         sftppath = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -119,9 +114,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -56,21 +56,16 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         sftppath = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -119,9 +114,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -120,21 +120,16 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         sftppath = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -192,9 +187,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -271,9 +265,8 @@ int main(int argc, char *argv[])
             total += nread;
             write(1, mem, (size_t)nread);
         }
-        else {
+        else
             break;
-        }
     } while(1);
 
 #ifdef HAVE_GETTIMEOFDAY

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -63,24 +63,18 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         loclfile = argv[4];
-    }
-    if(argc > 5) {
+    if(argc > 5)
         sftppath = argv[5];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -138,9 +132,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -187,10 +180,8 @@ int main(int argc, char *argv[])
     fprintf(stderr, "libssh2_sftp_open() is done, now send data.\n");
     do {
         nread = fread(mem, 1, sizeof(mem), local);
-        if(nread <= 0) {
-            /* end of file */
-            break;
-        }
+        if(nread <= 0)
+            break;  /* end of file */
         ptr = mem;
 
         do {

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -110,24 +110,18 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         loclfile = argv[4];
-    }
-    if(argc > 5) {
+    if(argc > 5)
         sftppath = argv[5];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -187,9 +181,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -249,10 +242,8 @@ int main(int argc, char *argv[])
     start = time(NULL);
     do {
         nread = fread(mem, 1, sizeof(mem), local);
-        if(nread <= 0) {
-            /* end of file */
-            break;
-        }
+        if(nread <= 0)
+            break;  /* end of file */
         ptr = mem;
 
         total += (libssh2_struct_stat_size)nread;
@@ -260,9 +251,9 @@ int main(int argc, char *argv[])
         do {
             /* write data in a loop until we block */
             while((nwritten = libssh2_sftp_write(sftp_handle, ptr, nread)) ==
-                  LIBSSH2_ERROR_EAGAIN) {
+                  LIBSSH2_ERROR_EAGAIN)
                 waitsocket(sock, session);
-            }
+
             if(nwritten < 0)
                 break;
             ptr += nwritten;

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -111,24 +111,18 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         loclfile = argv[4];
-    }
-    if(argc > 5) {
+    if(argc > 5)
         sftppath = argv[5];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -188,9 +182,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -254,8 +247,7 @@ int main(int argc, char *argv[])
         if(nread <= 0) {
             /* end of file */
             if(memuse > 0)
-                /* the previous sending is not finished */
-                nread = 0;
+                nread = 0;  /* the previous sending is not finished */
             else
                 break;
         }
@@ -276,8 +268,7 @@ int main(int argc, char *argv[])
             memuse -= (size_t)nwritten;
         }
         else
-            /* 'mem' was consumed fully */
-            memuse = 0;
+            memuse = 0;  /* 'mem' was consumed fully */
 
     } while(nwritten > 0);
 

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -84,21 +84,16 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         sftppath = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -147,9 +142,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */
@@ -157,27 +151,21 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "password")) {
+        if(strstr(userauthlist, "password"))
             auth_pw |= 1;
-        }
-        if(strstr(userauthlist, "keyboard-interactive")) {
+        if(strstr(userauthlist, "keyboard-interactive"))
             auth_pw |= 2;
-        }
-        if(strstr(userauthlist, "publickey")) {
+        if(strstr(userauthlist, "publickey"))
             auth_pw |= 4;
-        }
 
         /* check for options */
         if(argc > 5) {
-            if((auth_pw & 1) && !strcmp(argv[5], "-p")) {
+            if((auth_pw & 1) && !strcmp(argv[5], "-p"))
                 auth_pw = 1;
-            }
-            if((auth_pw & 2) && !strcmp(argv[5], "-i")) {
+            if((auth_pw & 2) && !strcmp(argv[5], "-i"))
                 auth_pw = 2;
-            }
-            if((auth_pw & 4) && !strcmp(argv[5], "-k")) {
+            if((auth_pw & 4) && !strcmp(argv[5], "-k"))
                 auth_pw = 4;
-            }
         }
 
         if(auth_pw & 1) {
@@ -195,10 +183,9 @@ int main(int argc, char *argv[])
                         "Authentication by keyboard-interactive failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr,
                         "Authentication by keyboard-interactive succeeded.\n");
-            }
         }
         else if(auth_pw & 4) {
             /* Or by public key */
@@ -208,9 +195,8 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Authentication by public key failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr, "Authentication by public key succeeded.\n");
-            }
         }
         else {
             fprintf(stderr, "No supported authentication methods found.\n");
@@ -249,36 +235,29 @@ int main(int argc, char *argv[])
         if(rc > 0) {
             /* rc is the length of the filename in the mem buffer */
 
-            if(longentry[0] != '\0') {
+            if(longentry[0] != '\0')
                 printf("%s\n", longentry);
-            }
             else {
-                if(attrs.flags & LIBSSH2_SFTP_ATTR_PERMISSIONS) {
+                if(attrs.flags & LIBSSH2_SFTP_ATTR_PERMISSIONS)
                     /* this should check what permissions it
                        is and print the output accordingly */
                     printf("--fix----- ");
-                }
-                else {
+                else
                     printf("---------- ");
-                }
 
-                if(attrs.flags & LIBSSH2_SFTP_ATTR_UIDGID) {
+                if(attrs.flags & LIBSSH2_SFTP_ATTR_UIDGID)
                     printf("%4d %4d ", (int)attrs.uid, (int)attrs.gid);
-                }
-                else {
+                else
                     printf("   -    - ");
-                }
 
-                if(attrs.flags & LIBSSH2_SFTP_ATTR_SIZE) {
+                if(attrs.flags & LIBSSH2_SFTP_ATTR_SIZE)
                     printf("%8" LIBSSH2_FILESIZE_MASK " ", attrs.filesize);
-                }
 
                 printf("%s\n", mem);
             }
         }
-        else {
+        else
             break;
-        }
 
     } while(1);
 

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -63,21 +63,16 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         sftppath = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -131,9 +126,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     if(auth_pw) {
@@ -194,35 +188,27 @@ int main(int argc, char *argv[])
         if(rc > 0) {
             /* rc is the length of the filename in the mem buffer */
 
-            if(attrs.flags & LIBSSH2_SFTP_ATTR_PERMISSIONS) {
+            if(attrs.flags & LIBSSH2_SFTP_ATTR_PERMISSIONS)
                 /* this should check what permissions it
                    is and print the output accordingly */
                 printf("--fix----- ");
-            }
-            else {
+            else
                 printf("---------- ");
-            }
 
-            if(attrs.flags & LIBSSH2_SFTP_ATTR_UIDGID) {
+            if(attrs.flags & LIBSSH2_SFTP_ATTR_UIDGID)
                 printf("%4d %4d ", (int)attrs.uid, (int)attrs.gid);
-            }
-            else {
+            else
                 printf("   -    - ");
-            }
 
-            if(attrs.flags & LIBSSH2_SFTP_ATTR_SIZE) {
+            if(attrs.flags & LIBSSH2_SFTP_ATTR_SIZE)
                 printf("%8" LIBSSH2_FILESIZE_MASK " ", attrs.filesize);
-            }
 
             printf("%s\n", mem);
         }
-        else if(rc == LIBSSH2_ERROR_EAGAIN) {
-            /* blocking */
+        else if(rc == LIBSSH2_ERROR_EAGAIN)
             fprintf(stderr, "Blocking\n");
-        }
-        else {
+        else
             break;
-        }
 
     } while(1);
 

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -81,18 +81,14 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -149,9 +145,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */
@@ -159,27 +154,21 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "password")) {
+        if(strstr(userauthlist, "password"))
             auth_pw |= 1;
-        }
-        if(strstr(userauthlist, "keyboard-interactive")) {
+        if(strstr(userauthlist, "keyboard-interactive"))
             auth_pw |= 2;
-        }
-        if(strstr(userauthlist, "publickey")) {
+        if(strstr(userauthlist, "publickey"))
             auth_pw |= 4;
-        }
 
         /* check for options */
         if(argc > 4) {
-            if((auth_pw & 1) && !strcmp(argv[4], "-p")) {
+            if((auth_pw & 1) && !strcmp(argv[4], "-p"))
                 auth_pw = 1;
-            }
-            if((auth_pw & 2) && !strcmp(argv[4], "-i")) {
+            if((auth_pw & 2) && !strcmp(argv[4], "-i"))
                 auth_pw = 2;
-            }
-            if((auth_pw & 4) && !strcmp(argv[4], "-k")) {
+            if((auth_pw & 4) && !strcmp(argv[4], "-k"))
                 auth_pw = 4;
-            }
         }
 
         if(auth_pw & 1) {
@@ -188,9 +177,8 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Authentication by password failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr, "Authentication by password succeeded.\n");
-            }
         }
         else if(auth_pw & 2) {
             /* Or via keyboard-interactive */
@@ -200,10 +188,9 @@ int main(int argc, char *argv[])
                         "Authentication by keyboard-interactive failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr,
                         "Authentication by keyboard-interactive succeeded.\n");
-            }
         }
         else if(auth_pw & 4) {
             /* Or by public key */
@@ -243,9 +230,8 @@ int main(int argc, char *argv[])
                 free(fn1);
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr, "Authentication by public key succeeded.\n");
-            }
             free(fn2);
             free(fn1);
         }
@@ -272,9 +258,8 @@ int main(int argc, char *argv[])
      * an interactive shell.
      */
 #if 0
-    if(libssh2_channel_request_pty(channel, "vanilla")) {
+    if(libssh2_channel_request_pty(channel, "vanilla"))
         fprintf(stderr, "Failed requesting pty\n");
-    }
 #endif
 
     if(argc > 5) {
@@ -318,9 +303,8 @@ int main(int argc, char *argv[])
             ssize_t err = libssh2_channel_read(channel, buf, sizeof(buf));
             if(err < 0)
                 fprintf(stderr, "Unable to read response: %ld\n", (long)err);
-            else {
+            else
                 fwrite(buf, 1, (size_t)err, stdout);
-            }
         }
     }
 

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -54,15 +54,12 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostaddr = inet_addr(argv[1]);
-    }
-    else {
+    else
         hostaddr = htonl(0x7F000001);
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -108,9 +105,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */
@@ -150,11 +146,10 @@ int main(int argc, char *argv[])
                 rc = 1;
                 goto shutdown;
             }
-            if(libssh2_agent_userauth(agent, username, identity)) {
+            if(libssh2_agent_userauth(agent, username, identity))
                 fprintf(stderr, "Authentication with username %s and "
                         "public key %s failed.\n",
                         username, identity->comment);
-            }
             else {
                 fprintf(stderr, "Authentication with username %s and "
                         "public key %s succeeded.\n",

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -111,9 +111,8 @@ int main(int argc, char *argv[])
     hostname = argv[1];
     username = argv[2];
 
-    if(argc > 3) {
+    if(argc > 3)
         commandline = argv[3];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -179,11 +178,10 @@ int main(int argc, char *argv[])
             rc = 1;
             goto shutdown;
         }
-        if(libssh2_agent_userauth(agent, username, identity)) {
+        if(libssh2_agent_userauth(agent, username, identity))
             fprintf(stderr, "Authentication with username %s and "
                     "public key %s failed.\n",
                     username, identity->comment);
-        }
         else {
             fprintf(stderr, "Authentication with username %s and "
                     "public key %s succeeded.\n",
@@ -217,26 +215,26 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Error\n");
         return 1;
     }
+
     while((rc = libssh2_channel_request_auth_agent(channel)) ==
-          LIBSSH2_ERROR_EAGAIN) {
+          LIBSSH2_ERROR_EAGAIN)
         waitsocket(sock, session);
-    }
     if(rc) {
         fprintf(stderr, "Error, could not request auth agent, "
                 "error code %d.\n", rc);
         return 1;
     }
-    else {
+    else
         fprintf(stdout, "Agent forwarding request succeeded.\n");
-    }
+
     while((rc = libssh2_channel_exec(channel, commandline)) ==
-          LIBSSH2_ERROR_EAGAIN) {
+          LIBSSH2_ERROR_EAGAIN)
         waitsocket(sock, session);
-    }
     if(rc) {
         fprintf(stderr, "Error\n");
         return 1;
     }
+
     for(;;) {
         ssize_t nread;
         /* loop until we block */
@@ -251,25 +249,22 @@ int main(int argc, char *argv[])
                     fputc(buffer[i], stderr);
                 fprintf(stderr, "\n");
             }
-            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN) {
+            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN)
                 /* no need to output this for the EAGAIN case */
                 fprintf(stderr, "libssh2_channel_read returned %ld\n",
                         (long)nread);
-            }
         } while(nread > 0);
 
         /* this is due to blocking that would occur otherwise so we loop on
            this condition */
-        if(nread == LIBSSH2_ERROR_EAGAIN) {
+        if(nread == LIBSSH2_ERROR_EAGAIN)
             waitsocket(sock, session);
-        }
         else
             break;
     }
     exitcode = 127;
-    while((rc = libssh2_channel_close(channel)) == LIBSSH2_ERROR_EAGAIN) {
+    while((rc = libssh2_channel_close(channel)) == LIBSSH2_ERROR_EAGAIN)
         waitsocket(sock, session);
-    }
     if(rc == 0) {
         exitcode = libssh2_channel_get_exit_status(channel);
         libssh2_channel_get_exit_signal(channel, &exitsignal,
@@ -278,14 +273,12 @@ int main(int argc, char *argv[])
 
     rc = 0;
 
-    if(exitsignal) {
+    if(exitsignal)
         fprintf(stderr, "\nGot signal: %s\n",
                 exitsignal ? exitsignal : "none");
-    }
-    else {
+    else
         fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
                 exitcode, (long)bytecount);
-    }
 
     libssh2_channel_free(channel);
 

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -105,15 +105,12 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostname = argv[1];  /* must be ip address only */
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -226,10 +223,10 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Error\n");
         return 1;
     }
+
     while((rc = libssh2_channel_exec(channel, commandline)) ==
-          LIBSSH2_ERROR_EAGAIN) {
+          LIBSSH2_ERROR_EAGAIN)
         waitsocket(sock, session);
-    }
     if(rc) {
         fprintf(stderr, "exec error\n");
         return 1;
@@ -309,9 +306,8 @@ int main(int argc, char *argv[])
                         totwritten += (size_t)n;
                         fprintf(stderr, "wrote %ld bytes (%lu in total)",
                                 (long)n, (unsigned long)totwritten);
-                        if(left >= bufsize && (size_t)n != bufsize) {
+                        if(left >= bufsize && (size_t)n != bufsize)
                             fprintf(stderr, " PARTIAL");
-                        }
                         fprintf(stderr, "\n");
                     }
                 }
@@ -319,9 +315,8 @@ int main(int argc, char *argv[])
                     /* all data written, send EOF */
                     rc = libssh2_channel_send_eof(channel);
 
-                    if(rc == LIBSSH2_ERROR_EAGAIN) {
+                    if(rc == LIBSSH2_ERROR_EAGAIN)
                         fprintf(stderr, "send eof again\n");
-                    }
                     else if(rc < 0) {
                         fprintf(stderr, "send eof failed\n");
                         return 1;

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -106,18 +106,14 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    if(argc > 1) {
+    if(argc > 1)
         hostname = argv[1];  /* must be ip address only */
-    }
-    if(argc > 2) {
+    if(argc > 2)
         username = argv[2];
-    }
-    if(argc > 3) {
+    if(argc > 3)
         password = argv[3];
-    }
-    if(argc > 4) {
+    if(argc > 4)
         commandline = argv[4];
-    }
 
     rc = libssh2_init(0);
     if(rc) {
@@ -245,9 +241,8 @@ int main(int argc, char *argv[])
         return 1;
     }
     while((rc = libssh2_channel_exec(channel, commandline)) ==
-          LIBSSH2_ERROR_EAGAIN) {
+          LIBSSH2_ERROR_EAGAIN)
         waitsocket(sock, session);
-    }
     if(rc) {
         fprintf(stderr, "exec error\n");
         return 1;
@@ -266,18 +261,16 @@ int main(int argc, char *argv[])
                     fputc(buffer[i], stderr);
                 fprintf(stderr, "\n");
             }
-            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN) {
+            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN)
                 /* no need to output this for the EAGAIN case */
                 fprintf(stderr, "libssh2_channel_read returned %ld\n",
                         (long)nread);
-            }
         } while(nread > 0);
 
         /* this is due to blocking that would occur otherwise so we loop on
            this condition */
-        if(nread == LIBSSH2_ERROR_EAGAIN) {
+        if(nread == LIBSSH2_ERROR_EAGAIN)
             waitsocket(sock, session);
-        }
         else
             break;
     }

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -212,9 +212,8 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Authentication by public key failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr, "Authentication by public key succeeded.\n");
-            }
         }
         else {
             fprintf(stderr, "No supported authentication methods found.\n");

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -186,9 +186,8 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Authentication by public key failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr, "Authentication by public key succeeded.\n");
-            }
         }
         else {
             fprintf(stderr, "No supported authentication methods found.\n");

--- a/example/x11.c
+++ b/example/x11.c
@@ -240,9 +240,8 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, libssh2_socket_t sock)
             while(wr < nread) {
                 ssize_t nwritten = libssh2_channel_write(channel, buf + wr,
                                                          (size_t)(nread - wr));
-                if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+                if(nwritten == LIBSSH2_ERROR_EAGAIN)
                     continue;
-                }
                 if(nwritten < 0) {
                     free(fds);
                     free(buf);
@@ -261,9 +260,8 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, libssh2_socket_t sock)
     free(fds);
     free(buf);
 
-    if(libssh2_channel_eof(channel) == 1) {
+    if(libssh2_channel_eof(channel) == 1)
         return -1;
-    }
 
     return 0;
 }
@@ -467,10 +465,9 @@ int main(int argc, char *argv[])
                 fwrite(buf, 1, (size_t)nread, stdout);
                 fflush(stdout);
             }
-            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN) {
+            else if(nread < 0 && nread != LIBSSH2_ERROR_EAGAIN)
                 fprintf(stderr, "libssh2_channel_read returned %ld\n",
                         (long)nread);
-            }
         }
 
         /* Looping on X clients */
@@ -503,9 +500,8 @@ int main(int argc, char *argv[])
             while(wr < nread) {
                 ssize_t nwritten = libssh2_channel_write(channel, buf + wr,
                                                          (size_t)(nread - wr));
-                if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+                if(nwritten == LIBSSH2_ERROR_EAGAIN)
                     continue;
-                }
                 if(nwritten < 0) {
                     fprintf(stderr, "libssh2_channel_write returned %ld\n",
                             (long)nwritten);
@@ -516,9 +512,8 @@ int main(int argc, char *argv[])
             }
         }
 
-        if(libssh2_channel_eof(channel) == 1) {
+        if(libssh2_channel_eof(channel) == 1)
             break;
-        }
     }
 
 shutdown:

--- a/example/x11.c
+++ b/example/x11.c
@@ -108,74 +108,72 @@ static void x11_callback(LIBSSH2_SESSION *session, LIBSSH2_CHANNEL *channel,
      * Inspired by x11_connect_display in openssh
      */
     display = getenv("DISPLAY");
-    if(display) {
-        if(!strncmp(display, "unix:", 5) || display[0] == ':') {
-            const char *ptr;
-            char *temp_buff;
-            int display_port;
-            int rc;
-            /* Connect to the local unix domain */
-            ptr = strrchr(display, ':');
-            temp_buff = strdup(ptr + 1);
-            if(!temp_buff) {
-                fprintf(stderr, "failed to strdup().\n");
-                return;
-            }
-            display_port = atoi(temp_buff);
-            free(temp_buff);
+    if(display && (!strncmp(display, "unix:", 5) || display[0] == ':')) {
+        const char *ptr;
+        char *temp_buff;
+        int display_port;
+        int rc;
+        /* Connect to the local unix domain */
+        ptr = strrchr(display, ':');
+        temp_buff = strdup(ptr + 1);
+        if(!temp_buff) {
+            fprintf(stderr, "failed to strdup().\n");
+            return;
+        }
+        display_port = atoi(temp_buff);
+        free(temp_buff);
 
-            sock = socket(AF_UNIX, SOCK_STREAM, 0);
-            if(sock == LIBSSH2_INVALID_SOCKET)
-                return;
-            memset(&addr, 0, sizeof(addr));
-            addr.sun_family = AF_UNIX;
-            snprintf(addr.sun_path, sizeof(addr.sun_path),
-                     PATH_UNIX_X, display_port);
-            rc = connect(sock, (struct sockaddr *)&addr, sizeof(addr));
+        sock = socket(AF_UNIX, SOCK_STREAM, 0);
+        if(sock == LIBSSH2_INVALID_SOCKET)
+            return;
+        memset(&addr, 0, sizeof(addr));
+        addr.sun_family = AF_UNIX;
+        snprintf(addr.sun_path, sizeof(addr.sun_path),
+                 PATH_UNIX_X, display_port);
+        rc = connect(sock, (struct sockaddr *)&addr, sizeof(addr));
 
-            if(rc != -1) {
-                /* Connection Successful */
+        if(rc != -1) {
+            /* Connection Successful */
+            if(!gp_x11_chan) {
+                /* calloc ensures that gp_x11_chan is zero-initialized. */
+                gp_x11_chan = (struct chan_X11_list *)
+                    calloc(1, sizeof(struct chan_X11_list));
                 if(!gp_x11_chan) {
-                    /* calloc ensures that gp_x11_chan is zero-initialized. */
-                    gp_x11_chan = (struct chan_X11_list *)
-                        calloc(1, sizeof(struct chan_X11_list));
-                    if(!gp_x11_chan) {
-                        fprintf(stderr, "failed to calloc().\n");
-                        shutdown(sock, SHUT_RDWR);
-                        LIBSSH2_SOCKET_CLOSE(sock);
-                    }
-                    else {
-                        gp_x11_chan->sock = sock;
-                        gp_x11_chan->chan = channel;
-                        gp_x11_chan->next = NULL;
-                    }
+                    fprintf(stderr, "failed to calloc().\n");
+                    shutdown(sock, SHUT_RDWR);
+                    LIBSSH2_SOCKET_CLOSE(sock);
                 }
                 else {
-                    struct chan_X11_list *chan_new;
-                    struct chan_X11_list *chan_iter;
-                    chan_iter = gp_x11_chan;
-                    while(chan_iter->next)
-                        chan_iter = chan_iter->next;
-                    /* Create the new Node */
-                    chan_new = (struct chan_X11_list *)
-                        calloc(1, sizeof(struct chan_X11_list));
-                    if(!chan_new) {
-                        fprintf(stderr, "failed to calloc().\n");
-                        shutdown(sock, SHUT_RDWR);
-                        LIBSSH2_SOCKET_CLOSE(sock);
-                    }
-                    else {
-                        chan_new->sock = sock;
-                        chan_new->chan = channel;
-                        chan_new->next = NULL;
-                        chan_iter->next = chan_new;
-                    }
+                    gp_x11_chan->sock = sock;
+                    gp_x11_chan->chan = channel;
+                    gp_x11_chan->next = NULL;
                 }
             }
             else {
-                shutdown(sock, SHUT_RDWR);
-                LIBSSH2_SOCKET_CLOSE(sock);
+                struct chan_X11_list *chan_new;
+                struct chan_X11_list *chan_iter;
+                chan_iter = gp_x11_chan;
+                while(chan_iter->next)
+                    chan_iter = chan_iter->next;
+                /* Create the new Node */
+                chan_new = (struct chan_X11_list *)
+                    calloc(1, sizeof(struct chan_X11_list));
+                if(!chan_new) {
+                    fprintf(stderr, "failed to calloc().\n");
+                    shutdown(sock, SHUT_RDWR);
+                    LIBSSH2_SOCKET_CLOSE(sock);
+                }
+                else {
+                    chan_new->sock = sock;
+                    chan_new->chan = channel;
+                    chan_new->next = NULL;
+                    chan_iter->next = chan_new;
+                }
             }
+        }
+        else {
+            shutdown(sock, SHUT_RDWR);
+            LIBSSH2_SOCKET_CLOSE(sock);
         }
     }
 }

--- a/src/agent.c
+++ b/src/agent.c
@@ -750,10 +750,9 @@ static int agent_sign(LIBSSH2_SESSION *session,
 
     len = 1 + 4 + 4 + 4;  /* fixed parts */
     if(identity->external.blob_len > UINT32_MAX - len ||
-       data_len > UINT32_MAX - len - identity->external.blob_len) {
+       data_len > UINT32_MAX - len - identity->external.blob_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Agent sign request too large");
-    }
     len += identity->external.blob_len + data_len;
 
     /* Create a request to sign the data */
@@ -773,14 +772,11 @@ static int agent_sign(LIBSSH2_SESSION *session,
         if(session->userauth_pblc_method_len > 0 &&
            session->userauth_pblc_method) {
             if(session->userauth_pblc_method_len == 12 &&
-               !memcmp(session->userauth_pblc_method, "rsa-sha2-512", 12)) {
+               !memcmp(session->userauth_pblc_method, "rsa-sha2-512", 12))
                 sign_flags = SSH_AGENT_RSA_SHA2_512;
-            }
             else if(session->userauth_pblc_method_len == 12 &&
-                    !memcmp(session->userauth_pblc_method, "rsa-sha2-256",
-                            12)) {
+                    !memcmp(session->userauth_pblc_method, "rsa-sha2-256", 12))
                 sign_flags = SSH_AGENT_RSA_SHA2_256;
-            }
         }
         ssh2_store_u32(&s, sign_flags);
 
@@ -798,9 +794,9 @@ static int agent_sign(LIBSSH2_SESSION *session,
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "agent not connected");
 
     rc = agent->ops->transact(agent, transctx);
-    if(rc) {
+    if(rc)
         goto error;
-    }
+
     SSH2_FREE(session, transctx->request);
     transctx->request = NULL;
 
@@ -1206,15 +1202,13 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
         agent->identity = identity->node;
     }
 
-    if(identity->blob_len < sizeof(uint32_t)) {
+    if(identity->blob_len < sizeof(uint32_t))
         return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-    }
 
     key_kind_len = ssh2_ntohu32(identity->blob);
 
-    if(identity->blob_len < sizeof(uint32_t) + key_kind_len) {
+    if(identity->blob_len < sizeof(uint32_t) + key_kind_len)
         return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-    }
 
     agent->session->userauth_pblc_method = SSH2_ALLOC(agent->session,
                                                       method_len);
@@ -1252,9 +1246,8 @@ int libssh2_agent_disconnect(LIBSSH2_AGENT *agent)
 void libssh2_agent_free(LIBSSH2_AGENT *agent)
 {
     /* Allow connection freeing when the socket has lost its connection */
-    if(agent->fd != LIBSSH2_INVALID_SOCKET) {
+    if(agent->fd != LIBSSH2_INVALID_SOCKET)
         libssh2_agent_disconnect(agent);
-    }
 
     if(agent->identity_agent_path)
         SSH2_FREE(agent->session, agent->identity_agent_path);

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -171,9 +171,8 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
         amt = SSH2_MIN(amt, keylen);
         for(i = 0; i < amt; i++) {
             size_t dest = i * stride + (count - 1);
-            if(dest >= origkeylen) {
+            if(dest >= origkeylen)
                 break;
-            }
             key[dest] = out[i];
         }
         keylen -= i;

--- a/src/chacha.c
+++ b/src/chacha.c
@@ -61,9 +61,8 @@ void chacha_keysetup(struct chacha_ctx *x, const u8 *k, u32 kbits)
         k += 16;
         constants = sigma;
     }
-    else { /* kbits == 128 */
-        constants = tau;
-    }
+    else
+        constants = tau;  /* kbits == 128 */
     x->input[8] = U8TO32_LITTLE(k + 0);
     x->input[9] = U8TO32_LITTLE(k + 4);
     x->input[10] = U8TO32_LITTLE(k + 8);

--- a/src/channel.c
+++ b/src/channel.c
@@ -66,9 +66,8 @@ uint32_t ssh2_channel_nextid(LIBSSH2_SESSION *session)
     channel = ssh2_list_first(&session->channels);
 
     while(channel) {
-        if(channel->local.id > id) {
+        if(channel->local.id > id)
             id = channel->local.id;
-        }
         channel = ssh2_list_next(&channel->node);
     }
 
@@ -629,9 +628,8 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
                     /* append this to the parent's list of listeners */
                     ssh2_list_add(&session->listeners, &listener->node);
 
-                    if(bound_port) {
+                    if(bound_port)
                         *bound_port = listener->port;
-                    }
                 }
             }
 
@@ -712,9 +710,8 @@ int ssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
 
         listener->chanFwdCncl_state = ssh2_NB_state_created;
     }
-    else {
+    else
         packet = listener->chanFwdCncl_data;
-    }
 
     if(listener->chanFwdCncl_state == ssh2_NB_state_created) {
         rc = ssh2_transport_send(session, packet, packet_len, NULL, 0);
@@ -743,9 +740,8 @@ int ssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener)
         LIBSSH2_CHANNEL *next = ssh2_list_next(&queued->node);
 
         rc = ssh2_channel_free(queued);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         queued = next;
     }
     SSH2_FREE(session, listener->host);
@@ -800,10 +796,9 @@ static LIBSSH2_CHANNEL *channel_forward_accept(LIBSSH2_LISTENER *listener)
         return channel;
     }
 
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         ssh2_err(listener->session, LIBSSH2_ERROR_EAGAIN,
                  "Would block waiting for packet");
-    }
     else
         ssh2_err(listener->session, LIBSSH2_ERROR_CHANNEL_UNKNOWN,
                  "Channel not found");
@@ -854,10 +849,9 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
 
         s = channel->setenv_packet =
             SSH2_ALLOC(session, channel->setenv_packet_len);
-        if(!channel->setenv_packet) {
+        if(!channel->setenv_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for setenv packet");
-        }
 
         *(s++) = SSH_MSG_CHANNEL_REQUEST;
         ssh2_store_u32(&s, channel->remote.id);
@@ -898,9 +892,8 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
         rc = ssh2_packet_requirev(session, reply_codes, &data, &data_len,
                                   1, channel->setenv_local_channel, 4,
                                   &channel->setenv_packet_requirev_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         if(rc) {
             channel->setenv_state = ssh2_NB_state_idle;
             return ssh2_err(session, rc,
@@ -963,10 +956,9 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
         /* 41 = packet_type(1) + channel(4) + pty_req_len(4) + "pty_req"(7) +
          * want_reply(1) + term_len(4) + width(4) + height(4) + width_px(4) +
          * height_px(4) + modes_len(4) */
-        if(term_len + modes_len > 256) {
+        if(term_len + modes_len > 256)
             return ssh2_err(session, LIBSSH2_ERROR_INVAL,
                             "term + mode lengths too large");
-        }
 
         channel->reqPTY_packet_len = term_len + modes_len + 41;
 
@@ -1019,9 +1011,8 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
         rc = ssh2_packet_requirev(session, reply_codes, &data, &data_len,
                                   1, channel->reqPTY_local_channel, 4,
                                   &channel->reqPTY_packet_requirev_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc || data_len < 1) {
             channel->reqPTY_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -1058,10 +1049,9 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
         /* Only valid options are "auth-agent-req" and
          * "auth-agent-req_at_openssh.com" so we make sure it is not
          * actually longer than the longest possible. */
-        if(request_str_len > 26) {
+        if(request_str_len > 26)
             return ssh2_err(session, LIBSSH2_ERROR_INVAL,
                             "request_str length too large");
-        }
 
         /*
          *  Length: 24 or 36 = packet_type(1) + channel(4) + req_len(4) +
@@ -1117,9 +1107,8 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
         rc = ssh2_packet_requirev(session, reply_codes, &data, &data_len,
                                   1, channel->req_auth_agent_local_channel, 4,
                                   &channel->req_auth_agent_requirev_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             channel->req_auth_agent_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -1319,10 +1308,9 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
 
         s = channel->reqX11_packet =
             SSH2_ALLOC(session, channel->reqX11_packet_len);
-        if(!channel->reqX11_packet) {
+        if(!channel->reqX11_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for pty-request");
-        }
 
         *(s++) = SSH_MSG_CHANNEL_REQUEST;
         ssh2_store_u32(&s, channel->remote.id);
@@ -1347,14 +1335,13 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
                4 bytes of size (for screen_number) */
             unsigned char buffer[LIBSSH2_X11_RANDOM_COOKIE_LEN / 2];
 
-            if(ssh2_random(buffer, LIBSSH2_X11_RANDOM_COOKIE_LEN / 2)) {
+            if(ssh2_random(buffer, LIBSSH2_X11_RANDOM_COOKIE_LEN / 2))
                 return ssh2_err(session, LIBSSH2_ERROR_RANDGEN,
                                 "Unable to get random bytes "
                                 "for x11-req cookie");
-            }
-            for(i = 0; i < (LIBSSH2_X11_RANDOM_COOKIE_LEN / 2); i++) {
+
+            for(i = 0; i < (LIBSSH2_X11_RANDOM_COOKIE_LEN / 2); i++)
                 snprintf((char *)&s[i * 2], 3, "%02X", buffer[i]);
-            }
         }
         s += cookie_len;
 
@@ -1391,9 +1378,8 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
         rc = ssh2_packet_requirev(session, reply_codes, &data, &data_len,
                                   1, channel->reqX11_local_channel, 4,
                                   &channel->reqX11_packet_requirev_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc || data_len < 1) {
             channel->reqX11_state = ssh2_NB_state_idle;
             return ssh2_err(session, rc,
@@ -1443,10 +1429,9 @@ int ssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
         { SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_FAILURE, 0 };
     int rc;
 
-    if(channel->process_state == ssh2_NB_state_end) {
+    if(channel->process_state == ssh2_NB_state_end)
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE,
                         "Channel can not be reused");
-    }
 
     if(channel->process_state == ssh2_NB_state_idle) {
         /* 10 = packet_type(1) + channel(4) + request_len(4) + want_reply(1) */
@@ -1512,9 +1497,8 @@ int ssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
         rc = ssh2_packet_requirev(session, reply_codes, &data, &data_len,
                                   1, channel->process_local_channel, 4,
                                   &channel->process_packet_requirev_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc || data_len < 1) {
             channel->process_state = ssh2_NB_state_end;
             return ssh2_err(session, rc, "Failed waiting for channel success");
@@ -1594,12 +1578,10 @@ int ssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
                 /* It is our channel at least */
                 int packet_stream_id;
 
-                if(packet_type == SSH_MSG_CHANNEL_DATA) {
+                if(packet_type == SSH_MSG_CHANNEL_DATA)
                     packet_stream_id = 0;
-                }
-                else if(packet->data_len >= 9) {
+                else if(packet->data_len >= 9)
                     packet_stream_id = ssh2_ntohu32(packet->data + 5);
-                }
                 else {
                     channel->flush_state = ssh2_NB_state_idle;
                     return ssh2_err(channel->session, LIBSSH2_ERROR_PROTO,
@@ -1771,9 +1753,8 @@ int ssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
             return 0;
         }
 
-        if(!adjustment && !channel->adjust_queue) {
+        if(!adjustment && !channel->adjust_queue)
             return 0;
-        }
 
         adjustment += channel->adjust_queue;
         channel->adjust_queue = 0;
@@ -1802,13 +1783,11 @@ int ssh2_channel_receive_window_adjust(LIBSSH2_CHANNEL *channel,
                         "packet, deferring");
     }
     else {
-        if(adjustment > UINT32_MAX - channel->remote.window_size) {
+        if(adjustment > UINT32_MAX - channel->remote.window_size)
             return ssh2_err(channel->session, LIBSSH2_ERROR_PROTO,
                             "Window adjust out of bounds");
-        }
-        else {
+        else
             channel->remote.window_size += adjustment;
-        }
     }
 
     channel->adjust_state = ssh2_NB_state_idle;
@@ -2001,10 +1980,9 @@ ssize_t ssh2_channel_read(LIBSSH2_CHANNEL *channel, int stream_id,
             read_packet = read_next;
 
             if(readpkt->data_len != 1 ||
-               readpkt->data[0] != SSH_MSG_REQUEST_FAILURE) {
+               readpkt->data[0] != SSH_MSG_REQUEST_FAILURE)
                 ssh2_deb((channel->session, LIBSSH2_TRACE_ERROR,
                           "Unexpected packet length"));
-            }
 
             continue;
         }
@@ -2173,9 +2151,8 @@ size_t ssh2_channel_packet_data_len(LIBSSH2_CHANNEL *channel, int stream_id)
             read_packet->data[0] == SSH_MSG_CHANNEL_EXTENDED_DATA &&
             channel->local.id == read_local_id &&
             channel->remote.extended_data_ignore_mode ==
-                LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE)) {
+                LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE))
             return read_packet->data_len - read_packet->data_head;
-        }
 
         read_packet = next_packet;
     }
@@ -2230,10 +2207,9 @@ ssize_t ssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
             rc = ssh2_transport_read(session);
         while(rc > 0);
 
-        if(rc < 0 && rc != LIBSSH2_ERROR_EAGAIN) {
+        if(rc < 0 && rc != LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(channel->session, rc,
                             "Failure while draining incoming flow");
-        }
 
         if(channel->local.window_size <= 0) {
             /* there is no room for data so we stop */
@@ -2290,9 +2266,8 @@ ssize_t ssh2_channel_write(LIBSSH2_CHANNEL *channel, int stream_id,
         rc = ssh2_transport_send(session, channel->write_packet,
                                  channel->write_packet_len,
                                  buf, channel->write_bufwrite);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, rc, "Unable to send channel data");
-        }
         else if(rc) {
             channel->write_state = ssh2_NB_state_idle;
             return ssh2_err(session, rc, "Unable to send channel data");
@@ -2354,10 +2329,9 @@ static int channel_send_eof(LIBSSH2_CHANNEL *channel)
         ssh2_err(session, rc, "Would block sending EOF");
         return rc;
     }
-    else if(rc) {
+    else if(rc)
         return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                         "Unable to send EOF on channel");
-    }
     channel->local.eof = 1;
 
     return 0;
@@ -2437,9 +2411,8 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
      * Either the EOF is set or network timeout occurs.
      */
     do {
-        if(channel->remote.eof) {
+        if(channel->remote.eof)
             break;
-        }
 
         if(channel->remote.window_size == channel->read_avail &&
            session->api_block_mode)
@@ -2447,9 +2420,8 @@ static int channel_wait_eof(LIBSSH2_CHANNEL *channel)
                             "Receiving channel window has been exhausted");
 
         rc = ssh2_transport_read(session);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc < 0) {
             channel->wait_eof_state = ssh2_NB_state_idle;
             return ssh2_err(session, rc, "ssh2_transport_read() bailed out");
@@ -2490,9 +2462,8 @@ int ssh2_channel_close(LIBSSH2_CHANNEL *channel)
     if(!channel->local.eof) {
         rc = channel_send_eof(channel);
         if(rc) {
-            if(rc == LIBSSH2_ERROR_EAGAIN) {
+            if(rc == LIBSSH2_ERROR_EAGAIN)
                 return rc;
-            }
             ssh2_err(session, rc,
                      "Unable to send EOF, but closing channel anyway");
         }
@@ -2542,9 +2513,8 @@ int ssh2_channel_close(LIBSSH2_CHANNEL *channel)
 
         /* We call the callback last in this function to make it keep the local
            data as long as EAGAIN is returned. */
-        if(channel->close_cb) {
+        if(channel->close_cb)
             SSH2_CHANNEL_CLOSE(session, channel);
-        }
 
         channel->close_state = ssh2_NB_state_idle;
     }
@@ -2575,11 +2545,10 @@ static int channel_wait_closed(LIBSSH2_CHANNEL *channel)
     LIBSSH2_SESSION *session = channel->session;
     int rc;
 
-    if(!channel->remote.eof) {
+    if(!channel->remote.eof)
         return ssh2_err(session, LIBSSH2_ERROR_INVAL,
                         "libssh2_channel_wait_closed() invoked when "
                         "channel is not in EOF state");
-    }
 
     if(channel->wait_closed_state == ssh2_NB_state_idle) {
         ssh2_deb((session, LIBSSH2_TRACE_CONN,
@@ -2661,9 +2630,8 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
 
     channel->free_state = ssh2_NB_state_idle;
 
-    if(channel->exit_signal) {
+    if(channel->exit_signal)
         SSH2_FREE(session, channel->exit_signal);
-    }
 
     /*
      * channel->remote.close *might* not be set yet, Well...
@@ -2676,14 +2644,12 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
     while(ssh2_packet_ask(session, SSH_MSG_CHANNEL_DATA, &data,
                           &data_len, 1, channel_id, 4) >= 0 ||
           ssh2_packet_ask(session, SSH_MSG_CHANNEL_EXTENDED_DATA, &data,
-                          &data_len, 1, channel_id, 4) >= 0) {
+                          &data_len, 1, channel_id, 4) >= 0)
         SSH2_FREE(session, data);
-    }
 
     /* free "channel_type" */
-    if(channel->channel_type) {
+    if(channel->channel_type)
         SSH2_FREE(session, channel->channel_type);
-    }
 
     /* Unlink from channel list */
     ssh2_list_remove(&channel->node);
@@ -2691,15 +2657,12 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
     /*
      * Make sure all memory used in the state variables are free
      */
-    if(channel->setenv_packet) {
+    if(channel->setenv_packet)
         SSH2_FREE(session, channel->setenv_packet);
-    }
-    if(channel->reqX11_packet) {
+    if(channel->reqX11_packet)
         SSH2_FREE(session, channel->reqX11_packet);
-    }
-    if(channel->process_packet) {
+    if(channel->process_packet)
         SSH2_FREE(session, channel->process_packet);
-    }
 
     /* Free some entries in session-structure, if channel found */
     if(session->open_channel == channel) {
@@ -2780,9 +2743,8 @@ unsigned long libssh2_channel_window_read_ex(
     if(!channel)
         return 0; /* no channel, no window! */
 
-    if(window_size_initial) {
+    if(window_size_initial)
         *window_size_initial = channel->remote.window_size_initial;
-    }
 
     if(read_avail) {
         size_t bytes_queued = 0;
@@ -2830,11 +2792,10 @@ unsigned long libssh2_channel_window_write_ex(
     if(!channel)
         return 0; /* no channel, no window! */
 
-    if(window_size_initial) {
+    if(window_size_initial)
         /* For locally initiated channels this is often 0, so it is not
          * *that* useful as information goes */
         *window_size_initial = channel->local.window_size_initial;
-    }
 
     return channel->local.window_size;
 }

--- a/src/comp.c
+++ b/src/comp.c
@@ -140,23 +140,18 @@ static int comp_method_zlib_init(LIBSSH2_SESSION *session, int compr,
     int status;
 
     strm = SSH2_CALLOC(session, sizeof(z_stream));
-    if(!strm) {
+    if(!strm)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Unable to allocate memory for "
                         "zlib compression/decompression");
-    }
 
     strm->opaque = (voidpf)session;
     strm->zalloc = (alloc_func)comp_method_zlib_alloc;
     strm->zfree = (free_func)comp_method_zlib_free;
-    if(compr) {
-        /* deflate */
+    if(compr)
         status = deflateInit(strm, Z_DEFAULT_COMPRESSION);
-    }
-    else {
-        /* inflate */
+    else
         status = inflateInit(strm);
-    }
 
     if(status != Z_OK) {
         SSH2_FREE(session, strm);

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -445,9 +445,8 @@ static int crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
 
             /* the api expects the size field to already be removed
                from the decrypted packet so we help it out */
-            if(ret == 0) {
+            if(ret == 0)
                 memmove(buf, buf + 4, buf_len - 4);
-            }
         }
     }
 

--- a/src/global.c
+++ b/src/global.c
@@ -45,9 +45,8 @@ static int s_init_flags = 0;
 
 int libssh2_init(int flags)
 {
-    if(s_initialized == 0 && !(flags & LIBSSH2_INIT_NO_CRYPTO)) {
+    if(s_initialized == 0 && !(flags & LIBSSH2_INIT_NO_CRYPTO))
         ssh2_crypto_init();
-    }
 
     s_initialized++;
     s_init_flags |= flags;
@@ -62,10 +61,8 @@ void libssh2_exit(void)
 
     s_initialized--;
 
-    if(s_initialized == 0 &&
-       !(s_init_flags & LIBSSH2_INIT_NO_CRYPTO)) {
+    if(s_initialized == 0 && !(s_init_flags & LIBSSH2_INIT_NO_CRYPTO))
         ssh2_crypto_exit();
-    }
 }
 
 void ssh2_init_if_needed(void)

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -846,9 +846,8 @@ static int hostkey_method_ssh_ecdsa_initPEMFromMemory(
                                             privkeyfiledata,
                                             privkeyfiledata_len,
                                             passphrase);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     if(abstract)
         *abstract = ec_ctx;
@@ -1093,9 +1092,8 @@ static int hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
     if(!ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_ed25519_new_public(&ctx, session, key, key_len) != 0) {
+    if(ssh2_ed25519_new_public(&ctx, session, key, key_len) != 0)
         return -1;
-    }
 
     *abstract = ctx;
 
@@ -1148,9 +1146,8 @@ static int hostkey_method_ssh_ed25519_init_cert(
      * have more meta data we do not read
      */
 
-    if(ssh2_ed25519_new_public(&ctx, session, key, key_len) != 0) {
+    if(ssh2_ed25519_new_public(&ctx, session, key, key_len) != 0)
         return -1;
-    }
 
     *abstract = ctx;
 
@@ -1174,9 +1171,8 @@ static int hostkey_method_ssh_ed25519_initPEM(LIBSSH2_SESSION *session,
     }
 
     ret = ssh2_ed25519_new_private(&ec_ctx, session, privkeyfile, passphrase);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     *abstract = ec_ctx;
 
@@ -1205,9 +1201,8 @@ static int hostkey_method_ssh_ed25519_initPEMFromMemory(
                                               privkeyfiledata,
                                               privkeyfiledata_len,
                                               passphrase);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     if(abstract)
         *abstract = ed_ctx;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -80,9 +80,8 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
     buf.dataptr = buf.data;
     buf.len = hostkey_data_len;
 
-    if(ssh2_get_string(&buf, &type, &type_len)) {
+    if(ssh2_get_string(&buf, &type, &type_len))
         return -1;
-    }
 
     /* we accept one of 3 header types */
 #if LIBSSH2_RSA_SHA1
@@ -119,9 +118,8 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
                     e, (unsigned long)e_len,
                     n, (unsigned long)n_len,
                     NULL, 0, NULL, 0, NULL, 0,
-                    NULL, 0, NULL, 0, NULL, 0)) {
+                    NULL, 0, NULL, 0, NULL, 0))
         return -1;
-    }
 
     *abstract = rsactx;
 
@@ -145,9 +143,8 @@ static int hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION *session,
     }
 
     ret = ssh2_rsa_new_private(&rsactx, session, privkeyfile, passphrase);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     *abstract = rsactx;
 
@@ -175,9 +172,8 @@ static int hostkey_method_ssh_rsa_initPEMFromMemory(
     ret = ssh2_rsa_new_private_frommemory(&rsactx, session,
                                           privkeyfiledata,
                                           privkeyfiledata_len, passphrase);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     *abstract = rsactx;
 
@@ -227,23 +223,19 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SHA_DIGEST_LENGTH];
     ssh2_sha1_ctx ctx;
 
-    if(!ssh2_sha1_init(&ctx)) {
+    if(!ssh2_sha1_init(&ctx))
         return -1;
-    }
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+        if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
-        }
     }
-    if(!ssh2_sha1_final(ctx, hash)) {
+    if(!ssh2_sha1_final(ctx, hash))
         return -1;
-    }
 
     ret = ssh2_rsa_sha1_sign(session, rsactx, hash, SHA_DIGEST_LENGTH,
                              signature, signature_len);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return 0;
 #endif
@@ -297,23 +289,19 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SHA256_DIGEST_LENGTH];
     ssh2_sha256_ctx ctx;
 
-    if(!ssh2_sha256_init(&ctx)) {
+    if(!ssh2_sha256_init(&ctx))
         return -1;
-    }
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_sha256_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+        if(!ssh2_sha256_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
-        }
     }
-    if(!ssh2_sha256_final(ctx, hash)) {
+    if(!ssh2_sha256_final(ctx, hash))
         return -1;
-    }
 
     ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SHA256_DIGEST_LENGTH,
                              signature, signature_len);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return 0;
 #endif
@@ -364,23 +352,19 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SHA512_DIGEST_LENGTH];
     ssh2_sha512_ctx ctx;
 
-    if(!ssh2_sha512_init(&ctx)) {
+    if(!ssh2_sha512_init(&ctx))
         return -1;
-    }
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_sha512_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+        if(!ssh2_sha512_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
-        }
     }
-    if(!ssh2_sha512_final(ctx, hash)) {
+    if(!ssh2_sha512_final(ctx, hash))
         return -1;
-    }
 
     ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SHA512_DIGEST_LENGTH,
                              signature, signature_len);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return 0;
 #endif
@@ -552,9 +536,8 @@ static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
                     q, (unsigned long)q_len,
                     g, (unsigned long)g_len,
                     y, (unsigned long)y_len,
-                    NULL, 0)) {
+                    NULL, 0))
         return -1;
-    }
 
     *abstract = dsactx;
 
@@ -578,9 +561,8 @@ static int hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION *session,
     }
 
     ret = ssh2_dsa_new_private(&dsactx, session, privkeyfile, passphrase);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     *abstract = dsactx;
 
@@ -608,9 +590,8 @@ static int hostkey_method_ssh_dss_initPEMFromMemory(
     ret = ssh2_dsa_new_private_frommemory(&dsactx, session,
                                           privkeyfiledata,
                                           privkeyfiledata_len, passphrase);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     *abstract = dsactx;
 
@@ -629,10 +610,9 @@ static int hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION *session,
     ssh2_dsa_ctx *dsactx = (ssh2_dsa_ctx *)(*abstract);
 
     /* Skip past keyname_len(4) + keyname(7){"ssh-dss"} + signature_len(4) */
-    if(sig_len != 55) {
+    if(sig_len != 55)
         return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                         "Invalid DSS signature length");
-    }
 
     sig += 15;
     sig_len -= 15;
@@ -662,20 +642,17 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
     }
 
     *signature = SSH2_CALLOC(session, 2 * SHA_DIGEST_LENGTH);
-    if(!*signature) {
+    if(!*signature)
         return -1;
-    }
 
     *signature_len = 2 * SHA_DIGEST_LENGTH;
 
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+        if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
-        }
     }
-    if(!ssh2_sha1_final(ctx, hash)) {
+    if(!ssh2_sha1_final(ctx, hash))
         return -1;
-    }
 
     if(ssh2_dsa_sha1_sign(dsactx, hash, SHA_DIGEST_LENGTH, *signature)) {
         SSH2_FREE(session, *signature);
@@ -754,34 +731,27 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
     if(ssh2_get_string(&buf, &type_str, &len) || len != 19)
         return -1;
 
-    if(!strncmp((char *)type_str, "ecdsa-sha2-nistp256", 19)) {
+    if(!strncmp((char *)type_str, "ecdsa-sha2-nistp256", 19))
         type = SSH2_EC_CURVE_NISTP256;
-    }
-    else if(!strncmp((char *)type_str, "ecdsa-sha2-nistp384", 19)) {
+    else if(!strncmp((char *)type_str, "ecdsa-sha2-nistp384", 19))
         type = SSH2_EC_CURVE_NISTP384;
-    }
-    else if(!strncmp((char *)type_str, "ecdsa-sha2-nistp521", 19)) {
+    else if(!strncmp((char *)type_str, "ecdsa-sha2-nistp521", 19))
         type = SSH2_EC_CURVE_NISTP521;
-    }
-    else {
+    else
         return -1;
-    }
 
     if(ssh2_get_string(&buf, &domain, &len) || len != 8)
         return -1;
 
     if(type == SSH2_EC_CURVE_NISTP256 &&
-       strncmp((char *)domain, "nistp256", 8)) {
+       strncmp((char *)domain, "nistp256", 8))
         return -1;
-    }
     else if(type == SSH2_EC_CURVE_NISTP384 &&
-            strncmp((char *)domain, "nistp384", 8)) {
+            strncmp((char *)domain, "nistp384", 8))
         return -1;
-    }
     else if(type == SSH2_EC_CURVE_NISTP521 &&
-            strncmp((char *)domain, "nistp521", 8)) {
+            strncmp((char *)domain, "nistp521", 8))
         return -1;
-    }
 
     /* public key */
     if(ssh2_get_string(&buf, &public_key, &key_len))
@@ -939,18 +909,14 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
     ssh2_curve_type type = ssh2_ecdsa_get_curve_type(ec_ctx);
     int ret = 0;
 
-    if(type == SSH2_EC_CURVE_NISTP256) {
+    if(type == SSH2_EC_CURVE_NISTP256)
         HOSTKEY_METHOD_EC_SIGNV_HASH(256);
-    }
-    else if(type == SSH2_EC_CURVE_NISTP384) {
+    else if(type == SSH2_EC_CURVE_NISTP384)
         HOSTKEY_METHOD_EC_SIGNV_HASH(384);
-    }
-    else if(type == SSH2_EC_CURVE_NISTP521) {
+    else if(type == SSH2_EC_CURVE_NISTP521)
         HOSTKEY_METHOD_EC_SIGNV_HASH(512);
-    }
-    else {
+    else
         return -1;
-    }
 
     return ret;
 }
@@ -1248,9 +1214,8 @@ static int hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
 {
     ssh2_ed25519_ctx *ctx = (ssh2_ed25519_ctx *)(*abstract);
 
-    if(veccount != 1) {
+    if(veccount != 1)
         return -1;
-    }
 
     return ssh2_ed25519_sign(ctx, session, signature, signature_len,
                              (const uint8_t *)datavec[0].iov_base,

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -88,10 +88,9 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
         if(seconds_to_next)
             *seconds_to_next = session->keepalive_interval;
     }
-    else if(seconds_to_next) {
+    else if(seconds_to_next)
         *seconds_to_next = (int)(session->keepalive_last_sent - now) +
             session->keepalive_interval;
-    }
 
     return 0;
 }

--- a/src/kex.c
+++ b/src/kex.c
@@ -112,23 +112,18 @@
 
 static int sha_algo_ctx_init(int sha_algo, void *ctx)
 {
-    if(sha_algo == 512) {
+    if(sha_algo == 512)
         return ssh2_sha512_init((ssh2_sha512_ctx *)ctx);
-    }
-    else if(sha_algo == 384) {
+    else if(sha_algo == 384)
         return ssh2_sha384_init((ssh2_sha384_ctx *)ctx);
-    }
-    else if(sha_algo == 256) {
+    else if(sha_algo == 256)
         return ssh2_sha256_init((ssh2_sha256_ctx *)ctx);
-    }
-    else if(sha_algo == 1) {
+    else if(sha_algo == 1)
         return ssh2_sha1_init((ssh2_sha1_ctx *)ctx);
-    }
-    else {
 #ifdef LIBSSH2DEBUG
+    else
         assert(0);
 #endif
-    }
     return 0;
 }
 
@@ -151,11 +146,10 @@ static int sha_algo_ctx_update(int sha_algo, void *ctx,
         ssh2_sha1_ctx *_ctx = (ssh2_sha1_ctx *)ctx;
         return ssh2_sha1_update(*_ctx, data, len);
     }
-    else {
 #ifdef LIBSSH2DEBUG
+    else
         assert(0);
 #endif
-    }
     return 0;
 }
 
@@ -177,11 +171,10 @@ static int sha_algo_ctx_final(int sha_algo, void *ctx, void *hash)
         ssh2_sha1_ctx *_ctx = (ssh2_sha1_ctx *)ctx;
         return ssh2_sha1_final(*_ctx, hash);
     }
-    else {
 #ifdef LIBSSH2DEBUG
+    else
         assert(0);
 #endif
-    }
     return 0;
 }
 
@@ -191,23 +184,18 @@ static void sha_algo_value_hash(int sha_algo,
                                 unsigned char **data, size_t data_len,
                                 const unsigned char *version)
 {
-    if(sha_algo == 512) {
+    if(sha_algo == 512)
         KEX_METHOD_SHA_VALUE_HASH(512, *data, data_len, version);
-    }
-    else if(sha_algo == 384) {
+    else if(sha_algo == 384)
         KEX_METHOD_SHA_VALUE_HASH(384, *data, data_len, version);
-    }
-    else if(sha_algo == 256) {
+    else if(sha_algo == 256)
         KEX_METHOD_SHA_VALUE_HASH(256, *data, data_len, version);
-    }
-    else if(sha_algo == 1) {
+    else if(sha_algo == 1)
         KEX_METHOD_SHA_VALUE_HASH(1, *data, data_len, version);
-    }
-    else {
 #ifdef LIBSSH2DEBUG
+    else
         assert(0);
 #endif
-    }
 }
 
 static int process_host_key(LIBSSH2_SESSION *session,
@@ -219,18 +207,16 @@ static int process_host_key(LIBSSH2_SESSION *session,
 
     /* Parse reply */
     if(data) {
-        if(data_len < 5) {
+        if(data_len < 5)
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                             "Unexpected packet length");
-        }
         buf->data = data;
         buf->len = data_len;
     }
     else {
-        if(exchange_state->s_packet_len < 5) {
+        if(exchange_state->s_packet_len < 5)
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                             "Unexpected packet length");
-        }
         buf->data = exchange_state->s_packet;
         buf->len = exchange_state->s_packet_len;
     }
@@ -245,10 +231,9 @@ static int process_host_key(LIBSSH2_SESSION *session,
     }
 
     if(ssh2_copy_string(session, buf, &(session->server_hostkey),
-                        &host_key_len)) {
+                        &host_key_len))
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Could not copy host key");
-    }
 
     session->server_hostkey_len = (uint32_t)host_key_len;
 
@@ -259,21 +244,18 @@ static int process_host_key(LIBSSH2_SESSION *session,
         if(ssh2_md5_init(&fingerprint_ctx) &&
            ssh2_md5_update(fingerprint_ctx, session->server_hostkey,
                            session->server_hostkey_len) &&
-           ssh2_md5_final(fingerprint_ctx, session->server_hostkey_md5)) {
+           ssh2_md5_final(fingerprint_ctx, session->server_hostkey_md5))
             session->server_hostkey_md5_valid = TRUE;
-        }
-        else {
+        else
             session->server_hostkey_md5_valid = FALSE;
-        }
     }
 #ifdef LIBSSH2DEBUG
     {
         char fingerprint[MD5_DIGEST_LENGTH * 3 + 1];
         char *fprint = fingerprint;
         int i;
-        for(i = 0; i < MD5_DIGEST_LENGTH; i++, fprint += 3) {
+        for(i = 0; i < MD5_DIGEST_LENGTH; i++, fprint += 3)
             snprintf(fprint, 4, "%02x:", session->server_hostkey_md5[i]);
-        }
         *(--fprint) = '\0';
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Server's MD5 Fingerprint: %s",
                   fingerprint));
@@ -287,21 +269,18 @@ static int process_host_key(LIBSSH2_SESSION *session,
         if(ssh2_sha1_init(&fingerprint_ctx) &&
            ssh2_sha1_update(fingerprint_ctx, session->server_hostkey,
                             session->server_hostkey_len) &&
-           ssh2_sha1_final(fingerprint_ctx, session->server_hostkey_sha1)) {
+           ssh2_sha1_final(fingerprint_ctx, session->server_hostkey_sha1))
             session->server_hostkey_sha1_valid = TRUE;
-        }
-        else {
+        else
             session->server_hostkey_sha1_valid = FALSE;
-        }
     }
 #ifdef LIBSSH2DEBUG
     {
         char fingerprint[SHA1_DIGEST_LENGTH * 3 + 1];
         char *fprint = fingerprint;
         int i;
-        for(i = 0; i < SHA1_DIGEST_LENGTH; i++, fprint += 3) {
+        for(i = 0; i < SHA1_DIGEST_LENGTH; i++, fprint += 3)
             snprintf(fprint, 4, "%02x:", session->server_hostkey_sha1[i]);
-        }
         *(--fprint) = '\0';
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Server's SHA1 Fingerprint: %s",
                   fingerprint));
@@ -315,12 +294,10 @@ static int process_host_key(LIBSSH2_SESSION *session,
            ssh2_sha256_update(fingerprint_ctx, session->server_hostkey,
                               session->server_hostkey_len) &&
            ssh2_sha256_final(fingerprint_ctx,
-                             session->server_hostkey_sha256)) {
+                             session->server_hostkey_sha256))
             session->server_hostkey_sha256_valid = TRUE;
-        }
-        else {
+        else
             session->server_hostkey_sha256_valid = FALSE;
-        }
     }
 #ifdef LIBSSH2DEBUG
     {
@@ -336,15 +313,13 @@ static int process_host_key(LIBSSH2_SESSION *session,
     }
 #endif /* LIBSSH2DEBUG */
 
-    if(!session->hostkey) {
+    if(!session->hostkey)
         return ssh2_err(session, LIBSSH2_ERROR_PROTO, "hostkey is NULL");
-    }
     if(session->hostkey->init(session, session->server_hostkey,
                               session->server_hostkey_len,
-                              &session->server_hostkey_abstract)) {
+                              &session->server_hostkey_abstract))
         return ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                         "Unable to initialize hostkey importer");
-    }
 
     return 0;
 }
@@ -358,12 +333,10 @@ static int finish_kex(LIBSSH2_SESSION *session,
                              &exchange_state->tmp,
                              &exchange_state->tmp_len, 0, NULL, 0,
                              &exchange_state->req_state);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
-    if(rc) {
+    if(rc)
         return ssh2_err(session, rc, "Timed out waiting for NEWKEYS");
-    }
 
     /* The first key exchange has been performed,
        switch to active crypt/comp/mac mode */
@@ -376,19 +349,17 @@ static int finish_kex(LIBSSH2_SESSION *session,
 
     if(!session->session_id) {
         session->session_id = SSH2_ALLOC(session, digest_len);
-        if(!session->session_id) {
+        if(!session->session_id)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate buffer for SHA digest");
-        }
         memcpy(session->session_id, exchange_state->h_sig_comp, digest_len);
         session->session_id_len = digest_len;
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "session_id calculated"));
     }
 
     /* Cleanup any existing cipher */
-    if(session->local.crypt->dtor) {
+    if(session->local.crypt->dtor)
         session->local.crypt->dtor(session, &session->local.crypt_abstract);
-    }
 
     /* Calculate IV/Secret/Key for each direction */
     if(session->local.crypt->init) {
@@ -435,10 +406,9 @@ static int finish_kex(LIBSSH2_SESSION *session,
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Client to Server IV and Key calculated"));
 
-    if(session->remote.crypt->dtor) {
+    if(session->remote.crypt->dtor)
         /* Cleanup any existing cipher */
         session->remote.crypt->dtor(session, &session->remote.crypt_abstract);
-    }
 
     if(session->remote.crypt->init) {
         unsigned char *iv = NULL, *secret = NULL;
@@ -484,9 +454,8 @@ static int finish_kex(LIBSSH2_SESSION *session,
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Server to Client IV and Key calculated"));
 
-    if(session->local.mac->dtor) {
+    if(session->local.mac->dtor)
         session->local.mac->dtor(session, &session->local.mac_abstract);
-    }
 
     if(session->local.mac->init) {
         unsigned char *key = NULL;
@@ -510,9 +479,8 @@ static int finish_kex(LIBSSH2_SESSION *session,
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Client to Server HMAC Key calculated"));
 
-    if(session->remote.mac->dtor) {
+    if(session->remote.mac->dtor)
         session->remote.mac->dtor(session, &session->remote.mac_abstract);
-    }
 
     if(session->remote.mac->init) {
         unsigned char *key = NULL;
@@ -540,28 +508,24 @@ static int finish_kex(LIBSSH2_SESSION *session,
     /* Initialize compression for each direction */
 
     /* Cleanup any existing compression */
-    if(session->local.comp && session->local.comp->dtor) {
+    if(session->local.comp && session->local.comp->dtor)
         session->local.comp->dtor(session, 1, &session->local.comp_abstract);
-    }
 
     if(session->local.comp && session->local.comp->init) {
         if(session->local.comp->init(session, 1,
-                                     &session->local.comp_abstract)) {
+                                     &session->local.comp_abstract))
             return LIBSSH2_ERROR_KEX_FAILURE;
-        }
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Client to Server compression initialized"));
 
-    if(session->remote.comp && session->remote.comp->dtor) {
+    if(session->remote.comp && session->remote.comp->dtor)
         session->remote.comp->dtor(session, 0, &session->remote.comp_abstract);
-    }
 
     if(session->remote.comp && session->remote.comp->init) {
         if(session->remote.comp->init(session, 0,
-                                      &session->remote.comp_abstract)) {
+                                      &session->remote.comp_abstract))
             return LIBSSH2_ERROR_KEX_FAILURE;
-        }
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Server to Client compression initialized"));
@@ -616,9 +580,8 @@ static void kex_diffie_hellman_cleanup(
         key_state->state = ssh2_NB_state_idle;
     }
 
-    if(key_state->exchange_state.state != ssh2_NB_state_idle) {
+    if(key_state->exchange_state.state != ssh2_NB_state_idle)
         diffie_hellman_state_cleanup(session, &key_state->exchange_state);
-    }
 }
 
 /*
@@ -692,10 +655,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         /* Send KEX init */
         /* packet_type(1) + String Length(4) + leading 0(1) */
         exchange_state->e_packet_len = ssh2_bn_bytes(exchange_state->e) + 6;
-        if(ssh2_bn_bits(exchange_state->e) % 8) {
-            /* Leading 00 not needed */
-            exchange_state->e_packet_len--;
-        }
+        if(ssh2_bn_bits(exchange_state->e) % 8)
+            exchange_state->e_packet_len--;  /* Leading 00 not needed */
 
         exchange_state->e_packet =
             SSH2_ALLOC(session, exchange_state->e_packet_len);
@@ -733,9 +694,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
     if(exchange_state->state == ssh2_NB_state_created) {
         rc = ssh2_transport_send(session, exchange_state->e_packet,
                                  exchange_state->e_packet_len, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc, "Unable to send KEX init message");
             goto clean_exit;
@@ -753,9 +713,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             ssh2_deb((session, LIBSSH2_TRACE_KEX,
                       "Waiting for badly guessed KEX packet (to be ignored)"));
             burn_type = ssh2_packet_burn(session, &exchange_state->burn_state);
-            if(burn_type == LIBSSH2_ERROR_EAGAIN) {
+            if(burn_type == LIBSSH2_ERROR_EAGAIN)
                 return burn_type;
-            }
             else if(burn_type <= 0) {
                 /* Failed to receive a packet */
                 ret = burn_type;
@@ -780,9 +739,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                  &exchange_state->s_packet,
                                  &exchange_state->s_packet_len, 0, NULL,
                                  0, &exchange_state->req_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         if(rc) {
             ret = ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                            "Timed out waiting for KEX reply");
@@ -790,9 +748,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         }
 
         ret = process_host_key(session, &buf, exchange_state, NULL, 0);
-        if(ret) {
+        if(ret)
             goto clean_exit;
-        }
 
         if(ssh2_get_string(&buf, &(exchange_state->f_value),
                            &(exchange_state->f_value_len))) {
@@ -820,10 +777,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         ssh2_dh_secret(&exchange_state->x, exchange_state->k,
                        exchange_state->f, p, exchange_state->ctx);
         exchange_state->k_value_len = ssh2_bn_bytes(exchange_state->k) + 5;
-        if(ssh2_bn_bits(exchange_state->k) % 8) {
-            /* do not need leading 00 */
-            exchange_state->k_value_len--;
-        }
+        if(ssh2_bn_bits(exchange_state->k) % 8)
+            exchange_state->k_value_len--;  /* do not need leading 00 */
         exchange_state->k_value =
             SSH2_ALLOC(session, exchange_state->k_value_len);
         if(!exchange_state->k_value) {
@@ -916,10 +871,9 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                        exchange_state->h_sig_comp, 12);
         }
 
-        if(midhash) {
+        if(midhash)
             hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
                                        midhash, midhash_len);
-        }
 
         hok &= sha_algo_ctx_update(sha_algo_value, exchange_hash_ctx,
                                    exchange_state->e_packet + 1,
@@ -968,9 +922,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
         rc = ssh2_transport_send(session, &exchange_state->c, 1, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Unable to send NEWKEYS message DH-SHA");
@@ -982,9 +935,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 
     if(exchange_state->state == ssh2_NB_state_sent3) {
         ret = finish_kex(session, exchange_state, digest_len, sha_algo_value);
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 clean_exit:
@@ -1049,9 +1001,8 @@ static int kex_method_diffie_hellman_group1_sha1_key_exchange(
                                   (void *)&exchange_hash_ctx,
                                   SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
                                   NULL, 0, &key_state->exchange_state);
-    if(ret == LIBSSH2_ERROR_EAGAIN) {
+    if(ret == LIBSSH2_ERROR_EAGAIN)
         return ret;
-    }
 
 clean_exit:
     kex_diffie_hellman_cleanup(session, key_state);
@@ -1144,9 +1095,8 @@ static int kex_method_diffie_hellman_group14_key_exchange(
     ret = hashfunc(session, key_state->g, key_state->p,
                    256, sha_algo_value, exchange_hash_ctx, SSH_MSG_KEXDH_INIT,
                    SSH_MSG_KEXDH_REPLY, NULL, 0, &key_state->exchange_state);
-    if(ret == LIBSSH2_ERROR_EAGAIN) {
+    if(ret == LIBSSH2_ERROR_EAGAIN)
         return ret;
-    }
 
 clean_exit:
     kex_diffie_hellman_cleanup(session, key_state);
@@ -1258,9 +1208,8 @@ static int kex_method_diffie_hellman_group16_sha512_key_exchange(
                                   512, (void *)&exchange_hash_ctx,
                                   SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
                                   NULL, 0, &key_state->exchange_state);
-    if(ret == LIBSSH2_ERROR_EAGAIN) {
+    if(ret == LIBSSH2_ERROR_EAGAIN)
         return ret;
-    }
 
 clean_exit:
     kex_diffie_hellman_cleanup(session, key_state);
@@ -1394,9 +1343,8 @@ static int kex_method_diffie_hellman_group18_sha512_key_exchange(
                                   512, (void *)&exchange_hash_ctx,
                                   SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
                                   NULL, 0, &key_state->exchange_state);
-    if(ret == LIBSSH2_ERROR_EAGAIN) {
+    if(ret == LIBSSH2_ERROR_EAGAIN)
         return ret;
-    }
 
 clean_exit:
     kex_diffie_hellman_cleanup(session, key_state);
@@ -1432,9 +1380,8 @@ static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
     if(key_state->state == ssh2_NB_state_created) {
         rc = ssh2_transport_send(session, key_state->request,
                                  key_state->request_len, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Unable to send Group Exchange Request");
@@ -1448,9 +1395,8 @@ static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
         rc = ssh2_packet_require(session, SSH_MSG_KEX_DH_GEX_GROUP,
                                  &key_state->data, &key_state->data_len,
                                  0, NULL, 0, &key_state->req_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc, "Timeout waiting for GEX_GROUP reply");
             goto dh_gex_clean_exit;
@@ -1516,9 +1462,8 @@ static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
                                       key_state->data + 1,
                                       key_state->data_len - 1,
                                       &key_state->exchange_state);
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 dh_gex_clean_exit:
@@ -1555,9 +1500,8 @@ static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
     if(key_state->state == ssh2_NB_state_created) {
         rc = ssh2_transport_send(session, key_state->request,
                                  key_state->request_len, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Unable to send Group Exchange Request SHA256");
@@ -1571,9 +1515,8 @@ static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
         rc = ssh2_packet_require(session, SSH_MSG_KEX_DH_GEX_GROUP,
                                  &key_state->data, &key_state->data_len,
                                  0, NULL, 0, &key_state->req_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Timeout waiting for GEX_GROUP reply SHA256");
@@ -1642,9 +1585,8 @@ static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
                                       key_state->data + 1,
                                       key_state->data_len - 1,
                                       &key_state->exchange_state);
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 dh_gex_clean_exit:
@@ -1926,13 +1868,11 @@ static int kex_session_ecdh_curve_type(const char *name,
         type = SSH2_EC_CURVE_NISTP384;
     else if(!strcmp(name, "ecdh-sha2-nistp521"))
         type = SSH2_EC_CURVE_NISTP521;
-    else {
+    else
         return -1;
-    }
 
-    if(out_type) {
+    if(out_type)
         *out_type = type;
-    }
 
     return 0;
 }
@@ -1971,9 +1911,8 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
 
     key_state->state = ssh2_NB_state_idle;
 
-    if(key_state->exchange_state.state != ssh2_NB_state_idle) {
+    if(key_state->exchange_state.state != ssh2_NB_state_idle)
         ecdh_exchange_state_cleanup(session, &key_state->exchange_state);
-    }
 }
 
 /*
@@ -2011,9 +1950,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
         }
 
         ret = process_host_key(session, &buf, exchange_state, data, data_len);
-        if(ret) {
+        if(ret)
             goto clean_exit;
-        }
 
         /* server public key Q_S */
         if(ssh2_get_string(&buf, &server_public_key, &server_public_key_len)) {
@@ -2040,10 +1978,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
         }
 
         exchange_state->k_value_len = ssh2_bn_bytes(exchange_state->k) + 5;
-        if(ssh2_bn_bits(exchange_state->k) % 8) {
-            /* do not need leading 00 */
-            exchange_state->k_value_len--;
-        }
+        if(ssh2_bn_bits(exchange_state->k) % 8)
+            exchange_state->k_value_len--;  /* do not need leading 00 */
         exchange_state->k_value =
             SSH2_ALLOC(session, exchange_state->k_value_len);
         if(!exchange_state->k_value) {
@@ -2097,9 +2033,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
 
     if(exchange_state->state == ssh2_NB_state_sent) {
         rc = ssh2_transport_send(session, &exchange_state->c, 1, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc, "Unable to send NEWKEYS message ECDH");
             goto clean_exit;
@@ -2130,9 +2065,8 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
             goto clean_exit;
         }
         ret = finish_kex(session, exchange_state, digest_len, sha_algo_value);
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 clean_exit:
@@ -2154,7 +2088,6 @@ static int kex_method_ecdh_key_exchange(
     ssh2_curve_type type;
 
     if(key_state->state == ssh2_NB_state_idle) {
-
         key_state->public_key_oct = NULL;
         key_state->state = ssh2_NB_state_created;
     }
@@ -2191,9 +2124,8 @@ static int kex_method_ecdh_key_exchange(
     if(key_state->state == ssh2_NB_state_sent) {
         rc = ssh2_transport_send(session, key_state->request,
                                  key_state->request_len, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc, "Unable to send ECDH_INIT");
             goto ecdh_clean_exit;
@@ -2206,9 +2138,8 @@ static int kex_method_ecdh_key_exchange(
         rc = ssh2_packet_require(session, SSH2_MSG_KEX_ECDH_REPLY,
                                  &key_state->data, &key_state->data_len,
                                  0, NULL, 0, &key_state->req_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Timeout waiting for ECDH_REPLY reply");
@@ -2234,9 +2165,8 @@ static int kex_method_ecdh_key_exchange(
                               key_state->private_key,
                               &key_state->exchange_state);
 
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 ecdh_clean_exit:
@@ -2296,9 +2226,8 @@ static void kex_method_mlkem_nistp_cleanup(
 
     key_state->state = ssh2_NB_state_idle;
 
-    if(key_state->exchange_state.state != ssh2_NB_state_idle) {
+    if(key_state->exchange_state.state != ssh2_NB_state_idle)
         ecdh_exchange_state_cleanup(session, &key_state->exchange_state);
-    }
 }
 
 static int mlkem_nistp(LIBSSH2_SESSION *session,
@@ -2364,9 +2293,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
         }
 
         ret = process_host_key(session, &buf, exchange_state, data, data_len);
-        if(ret) {
+        if(ret)
             goto clean_exit;
-        }
 
         /* server public key Q_S */
         if(ssh2_get_string(&buf, &server_public_key, &server_public_key_len)) {
@@ -2500,9 +2428,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
 
     if(exchange_state->state == ssh2_NB_state_sent) {
         rc = ssh2_transport_send(session, &exchange_state->c, 1, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Unable to send NEWKEYS message mlkemnistp");
@@ -2515,17 +2442,15 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
     if(exchange_state->state == ssh2_NB_state_sent2) {
         ret = finish_kex(session, exchange_state,
                          (int)digest_len, sha_algo_value);
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 clean_exit:
     mlkem_nistp_exchange_state_cleanup(session, exchange_state);
 
-    if(shared_secret) {
+    if(shared_secret)
         SSH2_FREE(session, shared_secret);
-    }
 
     return ret;
 }
@@ -2605,9 +2530,8 @@ static int kex_method_mlkem_nistp_key_exchange(
     if(key_state->state == ssh2_NB_state_sent) {
         rc = ssh2_transport_send(session, key_state->request,
                                  key_state->request_len, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         if(rc) {
             ret = ssh2_err(session, rc, "Unable to send ECDH_INIT");
             goto clean_exit;
@@ -2620,9 +2544,8 @@ static int kex_method_mlkem_nistp_key_exchange(
         rc = ssh2_packet_require(session, SSH2_MSG_KEX_ECDH_REPLY,
                                  &key_state->data, &key_state->data_len,
                                  0, NULL, 0, &key_state->req_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         if(rc) {
             ret = ssh2_err(session, rc,
                            "Timeout waiting for ECDH_REPLY reply");
@@ -2641,9 +2564,8 @@ static int kex_method_mlkem_nistp_key_exchange(
                           key_state->mlkem_private_key,
                           &key_state->exchange_state);
 
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 clean_exit:
@@ -2695,9 +2617,8 @@ static void kex_method_curve25519_cleanup(
 
     key_state->state = ssh2_NB_state_idle;
 
-    if(key_state->exchange_state.state != ssh2_NB_state_idle) {
+    if(key_state->exchange_state.state != ssh2_NB_state_idle)
         curve25519_exchange_state_cleanup(session, &key_state->exchange_state);
-    }
 }
 
 /*
@@ -2734,9 +2655,8 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         }
 
         ret = process_host_key(session, &buf, exchange_state, data, data_len);
-        if(ret) {
+        if(ret)
             goto clean_exit;
-        }
 
         /* server public key Q_S */
         if(ssh2_get_string(&buf, &server_public_key, &server_public_key_len)) {
@@ -2769,10 +2689,8 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         }
 
         exchange_state->k_value_len = ssh2_bn_bytes(exchange_state->k) + 5;
-        if(ssh2_bn_bits(exchange_state->k) % 8) {
-            /* do not need leading 00 */
-            exchange_state->k_value_len--;
-        }
+        if(ssh2_bn_bits(exchange_state->k) % 8)
+            exchange_state->k_value_len--;  /* do not need leading 00 */
         exchange_state->k_value =
             SSH2_ALLOC(session, exchange_state->k_value_len);
         if(!exchange_state->k_value) {
@@ -2815,9 +2733,8 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
 
     if(exchange_state->state == ssh2_NB_state_sent) {
         rc = ssh2_transport_send(session, &exchange_state->c, 1, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Unable to send NEWKEYS message curve25519");
@@ -2829,9 +2746,8 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
         ret = finish_kex(session, exchange_state, SHA256_DIGEST_LENGTH, 256);
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 clean_exit:
@@ -2850,7 +2766,6 @@ static int kex_method_curve25519_key_exchange(
     int rc = 0;
 
     if(key_state->state == ssh2_NB_state_idle) {
-
         key_state->public_key_oct = NULL;
         key_state->state = ssh2_NB_state_created;
     }
@@ -2891,9 +2806,8 @@ static int kex_method_curve25519_key_exchange(
     if(key_state->state == ssh2_NB_state_sent) {
         rc = ssh2_transport_send(session, key_state->request,
                                  key_state->request_len, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc, "Unable to send ECDH_INIT");
             goto clean_exit;
@@ -2906,9 +2820,8 @@ static int kex_method_curve25519_key_exchange(
         rc = ssh2_packet_require(session, SSH2_MSG_KEX_ECDH_REPLY,
                                  &key_state->data, &key_state->data_len,
                                  0, NULL, 0, &key_state->req_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Timeout waiting for ECDH_REPLY reply");
@@ -2925,9 +2838,8 @@ static int kex_method_curve25519_key_exchange(
                                 key_state->curve25519_private_key,
                                 &key_state->exchange_state);
 
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 clean_exit:
@@ -2991,9 +2903,8 @@ static void kex_method_mlkem768x25519_cleanup(
 
     key_state->state = ssh2_NB_state_idle;
 
-    if(key_state->exchange_state.state != ssh2_NB_state_idle) {
+    if(key_state->exchange_state.state != ssh2_NB_state_idle)
         curve25519_exchange_state_cleanup(session, &key_state->exchange_state);
-    }
 }
 
 static int mlkem768x25519_sha256(
@@ -3027,9 +2938,8 @@ static int mlkem768x25519_sha256(
         ssh2_sha256_ctx k_ctx;
 
         ret = process_host_key(session, &buf, exchange_state, data, data_len);
-        if(ret) {
+        if(ret)
             goto clean_exit;
-        }
 
         /* server public key Q_S */
         if(ssh2_get_string(&buf, &server_public_key, &server_public_key_len)) {
@@ -3127,9 +3037,8 @@ static int mlkem768x25519_sha256(
 
     if(exchange_state->state == ssh2_NB_state_sent) {
         rc = ssh2_transport_send(session, &exchange_state->c, 1, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ret = ssh2_err(session, rc,
                            "Unable to send NEWKEYS message mlkem768x25519");
@@ -3141,9 +3050,8 @@ static int mlkem768x25519_sha256(
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
         ret = finish_kex(session, exchange_state, SHA256_DIGEST_LENGTH, 256);
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 clean_exit:
@@ -3159,7 +3067,6 @@ static int kex_method_mlkem768x25519_key_exchange(
     int rc = 0;
 
     if(key_state->state == ssh2_NB_state_idle) {
-
         key_state->public_key_oct = NULL;
         key_state->state = ssh2_NB_state_created;
     }
@@ -3204,9 +3111,8 @@ static int kex_method_mlkem768x25519_key_exchange(
     if(key_state->state == ssh2_NB_state_sent) {
         rc = ssh2_transport_send(session, key_state->request,
                                  key_state->request_len, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         if(rc) {
             ret = ssh2_err(session, rc, "Unable to send ECDH_INIT");
             goto clean_exit;
@@ -3219,9 +3125,8 @@ static int kex_method_mlkem768x25519_key_exchange(
         rc = ssh2_packet_require(session, SSH2_MSG_KEX_ECDH_REPLY,
                                  &key_state->data, &key_state->data_len, 0,
                                  NULL, 0, &key_state->req_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         if(rc) {
             ret = ssh2_err(session, rc,
                            "Timeout waiting for ECDH_REPLY reply");
@@ -3241,9 +3146,8 @@ static int kex_method_mlkem768x25519_key_exchange(
                                     key_state->mlkem_private_key,
                                     &key_state->exchange_state);
 
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
     }
 
 clean_exit:
@@ -3433,9 +3337,8 @@ static size_t kex_method_strlen(const struct common_method **method)
 {
     size_t len = 0;
 
-    if(!method || !*method) {
+    if(!method || !*method)
         return 0;
-    }
 
     while(*method && (*method)->name) {
         len += strlen((*method)->name) + 1;
@@ -3454,9 +3357,8 @@ static uint32_t kex_method_list(unsigned char *buf, uint32_t list_strlen,
     ssh2_htonu32(buf, list_strlen);
     buf += 4;
 
-    if(!method || !*method) {
+    if(!method || !*method)
         return 4;
-    }
 
     while(*method && (*method)->name) {
         uint32_t mlen = (uint32_t)strlen((*method)->name);
@@ -3528,10 +3430,9 @@ static int kexinit(LIBSSH2_SESSION *session)
                     lang_cs_len + lang_sc_len;
 
         s = data = SSH2_ALLOC(session, data_len);
-        if(!data) {
+        if(!data)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory");
-        }
 
         *(s++) = SSH_MSG_KEXINIT;
 
@@ -3635,9 +3536,8 @@ static int kexinit(LIBSSH2_SESSION *session)
                         "Unable to send KEXINIT packet to remote host");
     }
 
-    if(session->local.kexinit) {
+    if(session->local.kexinit)
         SSH2_FREE(session, session->local.kexinit);
-    }
 
     session->local.kexinit = data;
     session->local.kexinit_len = data_len;
@@ -3660,14 +3560,12 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
     unsigned char *end_haystack;
     size_t left;
 
-    if(!haystack || !needle) {
+    if(!haystack || !needle)
         return NULL;
-    }
 
     /* Haystack too short to bother trying */
-    if(haystack_len < needle_len || needle_len == 0) {
+    if(haystack_len < needle_len || needle_len == 0)
         return NULL;
-    }
 
     s = haystack;
     end_haystack = &haystack[haystack_len];
@@ -3675,9 +3573,8 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
 
     /* Needle at start of haystack */
     if(!strncmp((char *)haystack, (const char *)needle, needle_len) &&
-       (needle_len == haystack_len || haystack[needle_len] == ',')) {
+       (needle_len == haystack_len || haystack[needle_len] == ','))
         return haystack;
-    }
 
     /* Search until we run out of comas or we run out of haystack,
        whichever comes first */
@@ -3689,16 +3586,14 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
             s++;
             left--;
         }
-        else {
+        else
             return NULL;
-        }
 
         /* Needle at X position */
         if(!strncmp((char *)s, (const char *)needle, needle_len) &&
            (((s - haystack) + needle_len) == haystack_len ||
-            s[needle_len] == ',')) {
+            s[needle_len] == ','))
             return s;
-        }
     }
 
     return NULL;
@@ -3710,9 +3605,9 @@ static const struct common_method *kex_get_method_by_name(
 {
     while(*methodlist) {
         if(strlen((*methodlist)->name) == name_len &&
-           !strncmp((*methodlist)->name, name, name_len)) {
+           !strncmp((*methodlist)->name, name, name_len))
             return *methodlist;
-        }
+
         methodlist++;
     }
     return NULL;
@@ -3740,10 +3635,8 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session,
                         (char *)s, method_len,
                         (const struct common_method **)hostkeyp);
 
-                if(!method) {
-                    /* Invalid method -- Should never be reached */
-                    return -1;
-                }
+                if(!method)
+                    return -1;  /* Invalid method -- Should never be reached */
 
                 /* OK so far, but does it suit our purposes? (Encrypting
                    vs Signing) */
@@ -3804,9 +3697,8 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
     const unsigned char *strict =
         (const unsigned char *)"kex-strict-s-v00@openssh.com";
 
-    if(ssh2_kex_agree_instr(kex, kex_len, strict, 28)) {
+    if(ssh2_kex_agree_instr(kex, kex_len, strict, 28))
         session->kex_strict = 1;
-    }
 
     if(session->kex_prefs) {
         s = (unsigned char *)session->kex_prefs;
@@ -3821,10 +3713,8 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
                         (char *)s, method_len,
                         (const struct common_method **)kexp);
 
-                if(!method) {
-                    /* Invalid method -- Should never be reached */
-                    return -1;
-                }
+                if(!method)
+                    return -1;  /* Invalid method -- Should never be reached */
 
                 /* We have agreed on a key exchange method,
                  * Can we agree on a hostkey that works with this kex?
@@ -3832,12 +3722,12 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
                 if(kex_agree_hostkey(session, method->flags, hostkey,
                                      hostkey_len) == 0) {
                     session->kex = method;
-                    if(session->burn_optimistic_kexinit && kex == q) {
+                    if(session->burn_optimistic_kexinit && kex == q)
                         /* Server sent an optimistic packet, and client agrees
                          * with preference cancel burning the first KEX_INIT
                          * packet that comes in */
                         session->burn_optimistic_kexinit = 0;
-                    }
+
                     return 0;
                 }
             }
@@ -3858,12 +3748,12 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
             if(kex_agree_hostkey(session, (*kexp)->flags, hostkey,
                                  hostkey_len) == 0) {
                 session->kex = *kexp;
-                if(session->burn_optimistic_kexinit && kex == s) {
+                if(session->burn_optimistic_kexinit && kex == s)
                     /* Server sent an optimistic packet, and client agrees
                      * with preference cancel burning the first KEX_INIT
                      * packet that comes in */
                     session->burn_optimistic_kexinit = 0;
-                }
+
                 return 0;
             }
         }
@@ -3898,10 +3788,8 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
                          (char *)s, method_len,
                          (const struct common_method **)cryptp);
 
-                if(!method) {
-                    /* Invalid method -- Should never be reached */
-                    return -1;
-                }
+                if(!method)
+                    return -1;  /* Invalid method -- Should never be reached */
 
                 endpoint->crypt = method;
                 return 0;
@@ -3959,10 +3847,8 @@ static int kex_agree_mac(LIBSSH2_SESSION *session,
                         (char *)s, method_len,
                         (const struct common_method **)macp);
 
-                if(!method) {
-                    /* Invalid method -- Should never be reached */
-                    return -1;
-                }
+                if(!method)
+                    return -1;  /* Invalid method -- Should never be reached */
 
                 endpoint->mac = method;
                 return 0;
@@ -4011,10 +3897,8 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
                         (char *)s, method_len,
                         (const struct common_method **)compp);
 
-                if(!method) {
-                    /* Invalid method -- Should never be reached */
-                    return -1;
-                }
+                if(!method)
+                    return -1;  /* Invalid method -- Should never be reached */
 
                 endpoint->comp = method;
                 return 0;
@@ -4093,41 +3977,34 @@ static int kex_agree_methods(LIBSSH2_SESSION *session, unsigned char *data,
     /* If the server sent an optimistic packet, assume that it guessed wrong.
      * If the guess is determined to be right (by kex_agree_kex_hostkey)
      * This flag is reset to zero so that it is not ignored */
-    if(ssh2_check_length(&buf, 1)) {
+    if(ssh2_check_length(&buf, 1))
         session->burn_optimistic_kexinit = *(buf.dataptr++);
-    }
-    else {
+    else
         return -1;
-    }
 
     /* Next uint32 in packet is all zeros (reserved) */
 
-    if(kex_agree_kex_hostkey(session, kex, kex_len, hostkey, hostkey_len)) {
+    if(kex_agree_kex_hostkey(session, kex, kex_len, hostkey, hostkey_len))
         return -1;
-    }
 
     if(kex_agree_crypt(session, &session->local, crypt_cs, crypt_cs_len) ||
-       kex_agree_crypt(session, &session->remote, crypt_sc, crypt_sc_len)) {
+       kex_agree_crypt(session, &session->remote, crypt_sc, crypt_sc_len))
         return -1;
-    }
 
     /* This must happen after kex_agree_crypt since some MACs depend on the
        negotiated crypto method */
     if(kex_agree_mac(session, &session->local, mac_cs, mac_cs_len) ||
-       kex_agree_mac(session, &session->remote, mac_sc, mac_sc_len)) {
+       kex_agree_mac(session, &session->remote, mac_sc, mac_sc_len))
         return -1;
-    }
 
     if(kex_agree_comp(session, &session->local, comp_cs, comp_cs_len) ||
-       kex_agree_comp(session, &session->remote, comp_sc, comp_sc_len)) {
+       kex_agree_comp(session, &session->remote, comp_sc, comp_sc_len))
         return -1;
-    }
 
 #if 0
     if(kex_agree_lang(session, &session->local, lang_cs, lang_cs_len) ||
-       kex_agree_lang(session, &session->remote, lang_sc, lang_sc_len)) {
+       kex_agree_lang(session, &session->remote, lang_sc, lang_sc_len))
         return -1;
-    }
 #endif
 
     ssh2_deb((session, LIBSSH2_TRACE_KEX, "Agreed on KEX method: %s",
@@ -4169,16 +4046,14 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
         session->state |= SSH2_STATE_EXCHANGING_KEYS;
 
         if(reexchange) {
-            if(session->kex && session->kex->cleanup) {
+            if(session->kex && session->kex->cleanup)
                 session->kex->cleanup(session, &key_state->key_state_low);
-            }
 
             session->kex = NULL;
 
-            if(session->hostkey && session->hostkey->dtor) {
+            if(session->hostkey && session->hostkey->dtor)
                 session->hostkey->dtor(session,
                                        &session->server_hostkey_abstract);
-            }
             session->hostkey = NULL;
         }
 
@@ -4226,9 +4101,8 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
                 return retcode;
             }
             else if(retcode) {
-                if(session->local.kexinit) {
+                if(session->local.kexinit)
                     SSH2_FREE(session, session->local.kexinit);
-                }
                 session->local.kexinit = key_state->oldlocal;
                 session->local.kexinit_len = key_state->oldlocal_len;
                 key_state->state = ssh2_NB_state_idle;
@@ -4238,9 +4112,8 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
                 return -1;
             }
 
-            if(session->remote.kexinit) {
+            if(session->remote.kexinit)
                 SSH2_FREE(session, session->remote.kexinit);
-            }
             session->remote.kexinit = key_state->data;
             session->remote.kexinit_len = key_state->data_len;
             key_state->data = NULL;
@@ -4252,9 +4125,8 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
             key_state->state = ssh2_NB_state_sent2;
         }
     }
-    else {
+    else
         key_state->state = ssh2_NB_state_sent2;
-    }
 
     if(rc == 0 && session->kex && session->kex->exchange_keys) {
         if(key_state->state == ssh2_NB_state_sent2) {
@@ -4264,10 +4136,9 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
                 session->state &= ~SSH2_STATE_KEX_ACTIVE;
                 return retcode;
             }
-            else if(retcode) {
+            else if(retcode)
                 rc = ssh2_err(session, LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE,
                               "Unrecoverable error exchanging keys");
-            }
         }
     }
 
@@ -4364,9 +4235,8 @@ int libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
 
     s = newprefs = SSH2_ALLOC(session, prefs_len + 1);
     if(!newprefs) {
-        if(tmpprefs) {
+        if(tmpprefs)
             SSH2_FREE(session, tmpprefs);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Error allocated space for method preferences");
     }
@@ -4378,26 +4248,21 @@ int libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
 
         if(!kex_get_method_by_name(s, method_len, mlist)) {
             /* Strip out unsupported method */
-            if(p) {
+            if(p)
                 memmove(s, p + 1, strlen(s) - method_len);
-            }
             else {
-                if(s > newprefs) {
+                if(s > newprefs)
                     *(--s) = '\0';
-                }
-                else {
+                else
                     *s = '\0';
-                }
             }
         }
-        else {
+        else
             s = p ? (p + 1) : NULL;
-        }
     }
 
-    if(tmpprefs) {
+    if(tmpprefs)
         SSH2_FREE(session, tmpprefs);
-    }
 
     if(!*newprefs) {
         SSH2_FREE(session, newprefs);
@@ -4412,11 +4277,10 @@ int libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
         size_t kex_extensions_len = strlen(kex_extensions);
         size_t tmp_len = kex_extensions_len + strlen(newprefs);
         tmpprefs = SSH2_ALLOC(session, tmp_len + 1);
-        if(!tmpprefs) {
+        if(!tmpprefs)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Error allocated space for kex method"
                             " preferences");
-        }
 
         memcpy(tmpprefs, kex_extensions, kex_extensions_len);
         memcpy(tmpprefs + kex_extensions_len, newprefs, strlen(newprefs));
@@ -4426,9 +4290,8 @@ int libssh2_session_method_pref(LIBSSH2_SESSION *session, int method_type,
         newprefs = tmpprefs;
     }
 
-    if(*prefvar) {
+    if(*prefvar)
         SSH2_FREE(session, *prefvar);
-    }
     *prefvar = newprefs;
 
     return 0;
@@ -4516,19 +4379,18 @@ int libssh2_session_supported_algs(LIBSSH2_SESSION *session,
 
     /* allocate buffer */
     *algs = SSH2_ALLOC(session, ialg * sizeof(const char *));
-    if(!*algs) {
+    if(!*algs)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Memory allocation failed");
-    }
+
     /* Past this point *algs must be deallocated in case of an error! */
 
     /* copy non-NULL pointers only */
     for(i = 0, j = 0; mlist[i] && j < ialg; i++) {
-        if(!mlist[i]->name) {
+        if(!mlist[i]->name)
             /* maybe a weird situation but if it occurs, do not include NULL
                pointers */
             continue;
-        }
 
         /* note that [] has higher priority than * (dereferencing) */
         (*algs)[j++] = mlist[i]->name;

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -255,9 +255,8 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         entry->comment[commentlen] = 0; /* force a null-terminator */
         entry->comment_len = commentlen;
     }
-    else {
+    else
         entry->comment = NULL;
-    }
 
     /* add this new host to the big list of known hosts */
     ssh2_list_add(&hosts->head, &entry->node);
@@ -427,11 +426,10 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                     if(!ssh2_hmac_ctx_init(&ctx))
                         break;
 
-                    if(SHA_DIGEST_LENGTH != node->name_len) {
+                    if(SHA_DIGEST_LENGTH != node->name_len)
                         /* the name hash length must be the sha1 size or
                            we cannot match it */
                         break;
-                    }
                     if(!ssh2_hmac_sha1_init(&ctx, node->salt, node->salt_len))
                         break;
                     if(!ssh2_hmac_update(&ctx, host, strlen(host)) ||
@@ -812,22 +810,17 @@ static int hostline(LIBSSH2_KNOWNHOSTS *hosts,
     }
 
     /* Figure out host format */
-    if(hostlen < 3 || memcmp(host, "|1|", 3)) {
+    if(hostlen < 3 || memcmp(host, "|1|", 3))
         /* old style plain text: [name]([,][name])*
-
-           for the sake of simplicity, we add them as separate hosts with the
-           same key
-        */
+           for simplicity, we add them as separate hosts with the same key */
         return oldstyle_hostline(hosts, host, hostlen, key_type_name,
                                  key_type_len, key, keylen, key_type,
                                  comment, commentlen);
-    }
-    else {
+    else
         /* |1|[salt]|[hash] */
         return hashed_hostline(hosts, host, hostlen, key_type_name,
                                key_type_len, key, keylen, key_type,
                                comment, commentlen);
-    }
 }
 
 /*

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -153,16 +153,15 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     (void)e2data;
     (void)e2len;
 
-    if(ddata) {
+    if(ddata)
         rc = gcry_sexp_build(rsa, NULL,
                  "(private-key(rsa(n%b)(e%b)(d%b)(q%b)(p%b)(u%b)))",
                  nlen, ndata, elen, edata, dlen, ddata, plen, pdata,
                  qlen, qdata, coefflen, coeffdata);
-    }
-    else {
+    else
         rc = gcry_sexp_build(rsa, NULL, "(public-key(rsa(n%b)(e%b)))",
                              nlen, ndata, elen, edata);
-    }
+
     if(rc) {
         *rsa = NULL;
         return -1;
@@ -199,9 +198,8 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
         algo = "sha512";
         ret = ssh2_sha512(m, m_len, hash);
     }
-    else {
+    else
         ret = 1;
-    }
 
     if(ret) {
         ret = -1;
@@ -255,16 +253,14 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsactx,
 {
     int rc;
 
-    if(x_len) {
+    if(x_len)
         rc = gcry_sexp_build(dsactx, NULL,
                              "(private-key(dsa(p%b)(q%b)(g%b)(y%b)(x%b)))",
                              p_len, p, q_len, q, g_len, g, y_len, y, x_len, x);
-    }
-    else {
+    else
         rc = gcry_sexp_build(dsactx, NULL,
                              "(public-key(dsa(p%b)(q%b)(g%b)(y%b)))",
                              p_len, p, q_len, q, g_len, g, y_len, y);
-    }
 
     if(rc) {
         *dsactx = NULL;
@@ -305,16 +301,14 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
     unsigned int nlen, elen, dlen, plen, qlen, e1len, e2len, coefflen;
 
     fp = fopen(filename, "rb");
-    if(!fp) {
+    if(!fp)
         return -1;
-    }
 
     ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
                          passphrase, fp, &data, &datalen);
     fclose(fp);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     save_data = data;
 
@@ -422,16 +416,14 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
     unsigned int plen, qlen, glen, ylen, xlen;
 
     fp = fopen(filename, "rb");
-    if(!fp) {
+    if(!fp)
         return -1;
-    }
 
     ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
                          passphrase, fp, &data, &datalen);
     fclose(fp);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     save_data = data;
 
@@ -591,25 +583,22 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsactx,
     const char *tmp;
     size_t size;
 
-    if(hash_len != SHA_DIGEST_LENGTH) {
+    if(hash_len != SHA_DIGEST_LENGTH)
         return -1;
-    }
 
     memcpy(zhash + 1, hash, hash_len);
     zhash[0] = 0;
 
     if(gcry_sexp_build(&data, NULL, "(data (value %b))",
-                       (int)(hash_len + 1), zhash)) {
+                       (int)(hash_len + 1), zhash))
         return -1;
-    }
 
     ret = gcry_pk_sign(&sig_sexp, data, dsactx);
 
     gcry_sexp_release(data);
 
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     memset(sig, 0, 40);
 
@@ -660,12 +649,10 @@ err:
     ret = -1;
 
 out:
-    if(sig_sexp) {
+    if(sig_sexp)
         gcry_sexp_release(sig_sexp);
-    }
-    if(data) {
+    if(data)
         gcry_sexp_release(data);
-    }
     return ret;
 }
 
@@ -677,15 +664,14 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     gcry_sexp_t s_sig, s_hash;
     int rc = -1;
 
-    if(ssh2_sha1(m, m_len, hash + 1)) {
+    if(ssh2_sha1(m, m_len, hash + 1))
         return -1;
-    }
+
     hash[0] = 0;
 
     if(gcry_sexp_build(&s_hash, NULL, "(data(flags raw)(value %b))",
-                       SHA_DIGEST_LENGTH + 1, hash)) {
+                       SHA_DIGEST_LENGTH + 1, hash))
         return -1;
-    }
 
     if(gcry_sexp_build(&s_sig, NULL, "(sig-val(dsa(r %b)(s %b)))",
                        20, sig, 20, sig + 20)) {
@@ -712,9 +698,8 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
     (void)encrypt;
 
     ret = gcry_cipher_open(h, cipher, mode, 0);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     ret = gcry_cipher_setkey(*h, secret, keylen);
     if(ret) {
@@ -747,12 +732,10 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx,
     (void)algo;
     (void)firstlast;
 
-    if(encrypt) {
+    if(encrypt)
         ret = gcry_cipher_encrypt(*ctx, block, blocksize, block, blocksize);
-    }
-    else {
+    else
         ret = gcry_cipher_decrypt(*ctx, block, blocksize, block, blocksize);
-    }
     return ret;
 }
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -140,7 +140,7 @@
 #define ssh2_hmac_ctx         gcry_md_hd_t
 
 #define ssh2_crypto_init()    gcry_control(GCRYCTL_DISABLE_SECMEM)
-#define ssh2_crypto_exit()
+#define ssh2_crypto_exit()    do {} while(0)
 
 #define ssh2_rsa_ctx          struct gcry_sexp
 #define ssh2_rsa_free(rsactx) gcry_sexp_release(rsactx)

--- a/src/mac.c
+++ b/src/mac.c
@@ -92,9 +92,8 @@ static int mac_method_common_init(LIBSSH2_SESSION *session, unsigned char *key,
  */
 static int mac_method_common_dtor(LIBSSH2_SESSION *session, void **abstract)
 {
-    if(*abstract) {
+    if(*abstract)
         SSH2_FREE(session, *abstract);
-    }
     *abstract = NULL;
 
     return 0;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -291,9 +291,8 @@ ssh2_bn *ssh2_mbed_bn_init(void)
     ssh2_bn *bignum;
 
     bignum = (ssh2_bn *)mbedtls_calloc(1, sizeof(ssh2_bn));
-    if(bignum) {
+    if(bignum)
         mbedtls_mpi_init(bignum);
-    }
 
     return bignum;
 }
@@ -379,14 +378,12 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 
     ret = 0;
     if(mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(E)), edata, elen) ||
-       mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(N)), ndata, nlen)) {
+       mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(N)), ndata, nlen))
         ret = -1;
-    }
 
-    if(!ret) {
+    if(!ret)
         ctx->MBEDTLS_PRIVATE(len) =
             mbedtls_mpi_size(&(ctx->MBEDTLS_PRIVATE(N)));
-    }
 
     if(!ret && ddata) {
         if(mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(D)),
@@ -403,13 +400,11 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
                                    coeffdata, coefflen)) {
             ret = -1;
         }
-        else {
+        else
             ret = mbedtls_rsa_check_privkey(ctx);
-        }
     }
-    else if(!ret) {
+    else if(!ret)
         ret = mbedtls_rsa_check_pubkey(ctx);
-    }
 
     if(ret && ctx) {
         ssh2_rsa_free(ctx);
@@ -472,9 +467,9 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     /* mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
        private-key from memory fails if the last byte is not a null byte */
     filedata_nullterm = mbedtls_calloc(filedata_len + 1, 1);
-    if(!filedata_nullterm) {
+    if(!filedata_nullterm)
         return -1;
-    }
+
     memcpy(filedata_nullterm, filedata, filedata_len);
 
     mbedtls_pk_init(&pkey);
@@ -518,15 +513,12 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
     if(!hash)
         return -1;
 
-    if(hash_len == SHA_DIGEST_LENGTH) {
+    if(hash_len == SHA_DIGEST_LENGTH)
         md_type = MBEDTLS_MD_SHA1;
-    }
-    else if(hash_len == SHA256_DIGEST_LENGTH) {
+    else if(hash_len == SHA256_DIGEST_LENGTH)
         md_type = MBEDTLS_MD_SHA256;
-    }
-    else if(hash_len == SHA512_DIGEST_LENGTH) {
+    else if(hash_len == SHA512_DIGEST_LENGTH)
         md_type = MBEDTLS_MD_SHA512;
-    }
     else {
         free(hash);
         return -1; /* unsupported digest */
@@ -566,19 +558,16 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
 
     sig_len = mbedtls_rsa_get_len(rsactx);
     sig = SSH2_ALLOC(session, sig_len);
-    if(!sig) {
+    if(!sig)
         return -1;
-    }
+
     ret = 0;
-    if(hash_len == SHA_DIGEST_LENGTH) {
+    if(hash_len == SHA_DIGEST_LENGTH)
         md_type = MBEDTLS_MD_SHA1;
-    }
-    else if(hash_len == SHA256_DIGEST_LENGTH) {
+    else if(hash_len == SHA256_DIGEST_LENGTH)
         md_type = MBEDTLS_MD_SHA256;
-    }
-    else if(hash_len == SHA512_DIGEST_LENGTH) {
+    else if(hash_len == SHA512_DIGEST_LENGTH)
         md_type = MBEDTLS_MD_SHA512;
-    }
     else {
         ssh2_err(session, LIBSSH2_ERROR_PROTO,
                  "Unsupported hash digest length");
@@ -633,9 +622,8 @@ static unsigned char *mbed_gen_publickey_from_rsa(LIBSSH2_SESSION *session,
     len = 4 + 7 + 4 + e_bytes + 4 + n_bytes;
 
     key = SSH2_ALLOC(session, len);
-    if(!key) {
+    if(!key)
         return NULL;
-    }
 
     /* Process key encoding. */
     p = key;
@@ -682,18 +670,15 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
     /* write method */
     mthlen = 7;
     mth = SSH2_ALLOC(session, mthlen);
-    if(mth) {
+    if(mth)
         memcpy(mth, "ssh-rsa", mthlen);
-    }
-    else {
+    else
         ret = -1;
-    }
 
     rsa = mbedtls_pk_rsa(*pkey);
     key = mbed_gen_publickey_from_rsa(session, rsa, &keylen);
-    if(!key) {
+    if(!key)
         ret = -1;
-    }
 
     /* write output */
     if(ret) {
@@ -761,9 +746,9 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     /* mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
        private-key from memory fails if the last byte is not a null byte */
     privatekeydata_nullterm = mbedtls_calloc(privatekeydata_len + 1, 1);
-    if(!privatekeydata_nullterm) {
+    if(!privatekeydata_nullterm)
         return -1;
-    }
+
     memcpy(privatekeydata_nullterm, privatekeydata, privatekeydata_len);
 
     mbedtls_pk_init(&pkey);
@@ -1103,13 +1088,11 @@ static int mbed_ecdsa_curve_type_from_name(const char *name,
         type = SSH2_EC_CURVE_NISTP384;
     else if(!strcmp(name, "ecdsa-sha2-nistp521"))
         type = SSH2_EC_CURVE_NISTP521;
-    else {
+    else
         return -1;
-    }
 
-    if(out_type) {
+    if(out_type)
         *out_type = type;
-    }
 
     return 0;
 }
@@ -1179,9 +1162,8 @@ failed:
 
 cleanup:
 
-    if(decrypted) {
+    if(decrypted)
         ssh2_string_buf_free(session, decrypted);
-    }
 
     return *ctx ? 0 : -1;
 }
@@ -1285,20 +1267,17 @@ static unsigned char *mbed_mpi_write_binary(unsigned char *buf,
     unsigned char *p = buf;
     uint32_t size = (uint32_t)bytes;
 
-    if(sizeof(&p) / sizeof(p[0]) < 4) {
+    if(sizeof(&p) / sizeof(p[0]) < 4)
         goto done;
-    }
 
     p += 4;
     *p = 0;
 
-    if(size > 0) {
+    if(size > 0)
         mbedtls_mpi_write_binary(mpi, p + 1, size - 1);
-    }
 
-    if(size > 0 && !(*(p + 1) & 0x80)) {
+    if(size > 0 && !(*(p + 1) & 0x80))
         memmove(p, p + 1, --size);
-    }
 
     ssh2_htonu32(p - 4, size);
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -382,10 +382,9 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
     *datalen = 0;
     *data = SSH2_ALLOC(session, src_len);
     d = (unsigned char *)*data;
-    if(!d) {
+    if(!d)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Unable to allocate memory for base64 decoding");
-    }
 
     for(s = src; s < (src + src_len); s++) {
         v = base64_reverse_table[(unsigned char)*s];
@@ -547,10 +546,8 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
     const char *contexttext = contexts[0];
     unsigned int contextindex;
 
-    if(!(session->showmask & context)) {
-        /* no such output asked for */
-        return;
-    }
+    if(!(session->showmask & context))
+        return;  /* no such output asked for */
 
     /* Find the first matching context string for this message */
     for(contextindex = 0; contextindex < SSH2_ARRAYSIZE(contexts);
@@ -562,9 +559,8 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
     }
 
     gettimeofday(&now, NULL);
-    if(!firstsec) {
+    if(!firstsec)
         firstsec = now.tv_sec;
-    }
     now.tv_sec -= firstsec;
 
     len = snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
@@ -754,9 +750,8 @@ int ssh2_gettimeofday(struct timeval *tp, void *tzp)
 void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size)
 {
     void *p = SSH2_ALLOC(session, size);
-    if(p) {
+    if(p)
         memset(p, 0, size);
-    }
     return p;
 }
 
@@ -808,9 +803,8 @@ void ssh2_string_buf_free(LIBSSH2_SESSION *session, struct string_buf *buf)
 
 int ssh2_get_byte(struct string_buf *buf, unsigned char *out)
 {
-    if(!ssh2_check_length(buf, 1)) {
+    if(!ssh2_check_length(buf, 1))
         return -1;
-    }
 
     *out = buf->dataptr[0];
     buf->dataptr += 1;
@@ -819,9 +813,8 @@ int ssh2_get_byte(struct string_buf *buf, unsigned char *out)
 
 int ssh2_get_boolean(struct string_buf *buf, unsigned char *out)
 {
-    if(!ssh2_check_length(buf, 1)) {
+    if(!ssh2_check_length(buf, 1))
         return -1;
-    }
 
     *out = buf->dataptr[0] == 0 ? 0 : 1;
     buf->dataptr += 1;
@@ -830,9 +823,8 @@ int ssh2_get_boolean(struct string_buf *buf, unsigned char *out)
 
 int ssh2_get_u32(struct string_buf *buf, uint32_t *out)
 {
-    if(!ssh2_check_length(buf, 4)) {
+    if(!ssh2_check_length(buf, 4))
         return -1;
-    }
 
     *out = ssh2_ntohu32(buf->dataptr);
     buf->dataptr += 4;
@@ -841,9 +833,8 @@ int ssh2_get_u32(struct string_buf *buf, uint32_t *out)
 
 int ssh2_get_u64(struct string_buf *buf, libssh2_uint64_t *out)
 {
-    if(!ssh2_check_length(buf, 8)) {
+    if(!ssh2_check_length(buf, 8))
         return -1;
-    }
 
     *out = ssh2_ntohu64(buf->dataptr);
     buf->dataptr += 8;
@@ -855,9 +846,8 @@ int ssh2_match_string(struct string_buf *buf, const char *match)
     unsigned char *out;
     size_t len = 0;
     if(ssh2_get_string(buf, &out, &len) || len != strlen(match) ||
-       strncmp((char *)out, match, strlen(match))) {
+       strncmp((char *)out, match, strlen(match)))
         return -1;
-    }
     return 0;
 }
 
@@ -865,12 +855,10 @@ int ssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
                     size_t *outlen)
 {
     uint32_t data_len;
-    if(!buf || ssh2_get_u32(buf, &data_len) != 0) {
+    if(!buf || ssh2_get_u32(buf, &data_len) != 0)
         return -1;
-    }
-    if(!ssh2_check_length(buf, data_len)) {
+    if(!ssh2_check_length(buf, data_len))
         return -1;
-    }
     *outbuf = buf->dataptr;
     buf->dataptr += data_len;
 
@@ -886,22 +874,18 @@ int ssh2_copy_string(LIBSSH2_SESSION *session, struct string_buf *buf,
     size_t str_len;
     unsigned char *str;
 
-    if(ssh2_get_string(buf, &str, &str_len)) {
+    if(ssh2_get_string(buf, &str, &str_len))
         return -1;
-    }
 
     if(str_len) {
         *outbuf = SSH2_ALLOC(session, str_len);
-        if(*outbuf) {
+        if(*outbuf)
             memcpy(*outbuf, str, str_len);
-        }
-        else {
+        else
             return -1;
-        }
     }
-    else {
+    else
         *outbuf = NULL;
-    }
 
     if(outlen)
         *outlen = str_len;
@@ -916,12 +900,10 @@ int ssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf,
     uint32_t bn_len;
     unsigned char *bnptr;
 
-    if(ssh2_get_u32(buf, &data_len)) {
+    if(ssh2_get_u32(buf, &data_len))
         return -1;
-    }
-    if(!ssh2_check_length(buf, data_len)) {
+    if(!ssh2_check_length(buf, data_len))
         return -1;
-    }
 
     bn_len = data_len;
     bnptr = buf->dataptr;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -860,10 +860,9 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
     *h = EVP_CIPHER_CTX_new();
     rc = !EVP_CipherInit(*h, algo(), secret, iv, encrypt);
 #if LIBSSH2_AES_GCM
-    if(is_aesgcm) {
+    if(is_aesgcm)
         /* Sets both fixed and invocation_counter parts of IV */
         rc |= !EVP_CIPHER_CTX_ctrl(*h, EVP_CTRL_AEAD_SET_IV_FIXED, -1, iv);
-    }
 #endif /* LIBSSH2_AES_GCM */
 
     return rc;

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -221,7 +221,7 @@
 #include "crypto_config.h"
 
 void ssh2_crypto_init(void);
-#define ssh2_crypto_exit()
+#define ssh2_crypto_exit() do {} while(0)
 
 int ssh2_random(unsigned char *buf, size_t len);
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -231,8 +231,8 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
  *
  *******************************************************************/
 
-#define ssh2_crypto_init()
-#define ssh2_crypto_exit()
+#define ssh2_crypto_init()   do {} while(0)
+#define ssh2_crypto_exit()   do {} while(0)
 
 #define ssh2_sha1_ctx        Qc3_Format_ALGD0100_T
 #define ssh2_sha256_ctx      Qc3_Format_ALGD0100_T

--- a/src/packet.c
+++ b/src/packet.c
@@ -83,45 +83,37 @@ static SSH2_INLINE int packet_queue_listener(
         buf.dataptr = buf.data;
         buf.len = datalen;
 
-        if(datalen < offset + 12) { /* 3 * 4-byte */
+        if(datalen < offset + 12) /* 3 * 4-byte */
             return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                             "Unexpected packet size");
-        }
 
         buf.dataptr += offset;
 
-        if(ssh2_get_u32(&buf, &(listen_state->sender_channel))) {
+        if(ssh2_get_u32(&buf, &(listen_state->sender_channel)))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting channel");
-        }
-        if(ssh2_get_u32(&buf, &(listen_state->initial_window_size))) {
+        if(ssh2_get_u32(&buf, &(listen_state->initial_window_size)))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting window size");
-        }
-        if(ssh2_get_u32(&buf, &(listen_state->packet_size))) {
+        if(ssh2_get_u32(&buf, &(listen_state->packet_size)))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting packet");
-        }
-        if(ssh2_get_string(&buf, &(listen_state->host), &temp_len)) {
+        if(ssh2_get_string(&buf, &(listen_state->host), &temp_len))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting host");
-        }
         listen_state->host_len = (uint32_t)temp_len;
 
-        if(ssh2_get_u32(&buf, &(listen_state->port))) {
+        if(ssh2_get_u32(&buf, &(listen_state->port)))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting port");
-        }
-        if(ssh2_get_string(&buf, &(listen_state->shost), &temp_len)) {
+        if(ssh2_get_string(&buf, &(listen_state->shost), &temp_len))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting shost");
-        }
         listen_state->shost_len = (uint32_t)temp_len;
 
-        if(ssh2_get_u32(&buf, &(listen_state->sport))) {
+        if(ssh2_get_u32(&buf, &(listen_state->sport)))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting sport");
-        }
 
         ssh2_deb((session, LIBSSH2_TRACE_CONN,
                   "Remote received connection from %.*s:%u to %.*s:%u",
@@ -255,9 +247,8 @@ static SSH2_INLINE int packet_queue_listener(
 
     rc = ssh2_transport_send(session, listen_state->packet,
                              packet_len, NULL, 0);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
     else if(rc) {
         listen_state->state = ssh2_NB_state_idle;
         return ssh2_err(session, rc, "Unable to send open failure");
@@ -282,7 +273,6 @@ static SSH2_INLINE int packet_x11_open(
     int rc;
 
     if(x11open_state->state == ssh2_NB_state_idle) {
-
         size_t offset = strlen("x11") + 5;
         size_t temp_len = 0;
         unsigned char *temp_buf = NULL;
@@ -404,9 +394,8 @@ static SSH2_INLINE int packet_x11_open(
         if(x11open_state->state == ssh2_NB_state_created) {
             rc = ssh2_transport_send(session, x11open_state->packet, 17,
                                      NULL, 0);
-            if(rc == LIBSSH2_ERROR_EAGAIN) {
+            if(rc == LIBSSH2_ERROR_EAGAIN)
                 return rc;
-            }
             else if(rc) {
                 SSH2_FREE(session, x11open_state->shost);
                 x11open_state->shost = NULL;
@@ -447,9 +436,8 @@ x11_exit:
 
     rc = ssh2_transport_send(session, x11open_state->packet, packet_len,
                              NULL, 0);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
     else if(rc) {
         x11open_state->state = ssh2_NB_state_idle;
         return ssh2_err(session, rc, "Unable to send open failure");
@@ -479,26 +467,22 @@ static SSH2_INLINE int packet_authagent_open(
     buf.dataptr = buf.data;
     buf.len = datalen;
 
-    if(datalen < offset + 12) { /* 27-byte header + 3 * 4-byte */
+    if(datalen < offset + 12) /* 27-byte header + 3 * 4-byte */
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Unexpected packet size");
-    }
 
     buf.dataptr += offset;
 
     if(authagent_state->state == ssh2_NB_state_idle) {
-        if(ssh2_get_u32(&buf, &(authagent_state->sender_channel))) {
+        if(ssh2_get_u32(&buf, &(authagent_state->sender_channel)))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting channel");
-        }
-        if(ssh2_get_u32(&buf, &(authagent_state->initial_window_size))) {
+        if(ssh2_get_u32(&buf, &(authagent_state->initial_window_size)))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting window size");
-        }
-        if(ssh2_get_u32(&buf, &(authagent_state->packet_size))) {
+        if(ssh2_get_u32(&buf, &(authagent_state->packet_size)))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting packet");
-        }
 
         ssh2_deb((session, LIBSSH2_TRACE_CONN,
                   "Auth Agent Connection Received on channel %u",
@@ -567,9 +551,8 @@ static SSH2_INLINE int packet_authagent_open(
         if(authagent_state->state == ssh2_NB_state_created) {
             rc = ssh2_transport_send(session, authagent_state->packet, 17,
                                      NULL, 0);
-            if(rc == LIBSSH2_ERROR_EAGAIN) {
+            if(rc == LIBSSH2_ERROR_EAGAIN)
                 return rc;
-            }
             else if(rc) {
                 authagent_state->state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -607,9 +590,8 @@ authagent_exit:
 
     rc = ssh2_transport_send(session, authagent_state->packet, packet_len,
                              NULL, 0);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
     else if(rc) {
         authagent_state->state = ssh2_NB_state_idle;
         return ssh2_err(session, rc, "Unable to send open failure");
@@ -764,11 +746,10 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                 ssh2_get_string(&buf, &message, &message_len);
                 ssh2_get_string(&buf, &language, &language_len);
 
-                if(session->ssh_msg_disconnect) {
+                if(session->ssh_msg_disconnect)
                     SSH2_DISCONNECT(session, reason, (const char *)message,
                                     message_len, (const char *)language,
                                     language_len);
-                }
 
                 ssh2_deb((session, LIBSSH2_TRACE_TRANS,
                           "Disconnect(%u): %.*s(%.*s)", reason,
@@ -788,9 +769,8 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
 
         case SSH_MSG_IGNORE:
             if(datalen >= 2) {
-                if(session->ssh_msg_ignore) {
+                if(session->ssh_msg_ignore)
                     SSH2_IGNORE(session, (char *)data + 1, datalen - 1);
-                }
             }
             else if(session->ssh_msg_ignore) {
                 SSH2_IGNORE(session, "", 0);
@@ -821,11 +801,10 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                     ssh2_get_string(&buf, &language, &language_len);
                 }
 
-                if(session->ssh_msg_debug) {
+                if(session->ssh_msg_debug)
                     SSH2_DEBUG(session, always_display, (const char *)message,
                                message_len, (const char *)language,
                                language_len);
-                }
             }
 
             ssh2_deb((session, LIBSSH2_TRACE_TRANS, "Debug Packet: %.*s",
@@ -852,10 +831,9 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                 buf.dataptr += 1; /* advance past type */
 
                 if(ssh2_get_u32(&buf, &nr_extensions) != 0 ||
-                   nr_extensions >= 1024) {
+                   nr_extensions >= 1024)
                     rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                   "Invalid extension info received");
-                }
 
                 while(rc == 0 && nr_extensions > 0) {
 
@@ -871,18 +849,16 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                     if(ssh2_get_string(&buf, &value, &value_len))
                         break;
 
-                    if(name && value) {
+                    if(name && value)
                         ssh2_deb((session, LIBSSH2_TRACE_KEX,
                                   "Server to Client extension %.*s: %.*s",
                                   (int)name_len, name, (int)value_len, value));
-                    }
 
                     if(name && name_len == 15 &&
                        !memcmp(name, "server-sig-algs", 15)) {
-                        if(session->server_sign_algorithms) {
+                        if(session->server_sign_algorithms)
                             SSH2_FREE(session,
                                       session->server_sign_algorithms);
-                        }
 
                         session->server_sign_algorithms =
                             SSH2_ALLOC(session, value_len + 1);
@@ -892,10 +868,9 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
                                    value, value_len);
                             session->server_sign_algorithms[value_len] = '\0';
                         }
-                        else {
+                        else
                             rc = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                           "memory for server sign algo");
-                        }
                     }
                 }
             }
@@ -1149,10 +1124,9 @@ ssh2_packet_add_jump_point1:
                     if(channelp) {
 
                         uint32_t status = 0;
-                        if(ssh2_get_u32(&buf, &status)) {
+                        if(ssh2_get_u32(&buf, &status))
                             rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                           "exit-signal status error");
-                        }
 
                         channelp->exit_status = (int)status;
 
@@ -1176,15 +1150,13 @@ ssh2_packet_add_jump_point1:
                         /* signal name (without SIG prefix) */
                         unsigned char *sig_name = NULL;
                         size_t sig_len = 0;
-                        if(ssh2_get_string(&buf, &sig_name, &sig_len)) {
+                        if(ssh2_get_string(&buf, &sig_name, &sig_len))
                             rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                           "signal name protocol error");
-                        }
 
-                        if(sig_len > UINT32_MAX - 1) {
+                        if(sig_len > UINT32_MAX - 1)
                             rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                           "signal name out of bounds");
-                        }
                         else if(sig_len > 0) {
                             channelp->exit_signal =
                                 SSH2_ALLOC(session, sig_len + 1);
@@ -1201,14 +1173,12 @@ ssh2_packet_add_jump_point1:
                                           channelp->local.id,
                                           channelp->remote.id));
                             }
-                            else {
+                            else
                                 rc = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                               "exit signal alloc error");
-                            }
                         }
-                        else {
+                        else
                             channelp->exit_signal = NULL;
-                        }
                     }
                 }
 
@@ -1329,10 +1299,9 @@ ssh2_packet_add_jump_authagent:
                 channelp =
                     ssh2_channel_locate(session, ssh2_ntohu32(data + 1));
                 if(channelp) {
-                    if(bytestoadd > UINT32_MAX - channelp->local.window_size) {
+                    if(bytestoadd > UINT32_MAX - channelp->local.window_size)
                         rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                       "Window adjust out of bounds");
-                    }
                     else {
                         channelp->local.window_size += bytestoadd;
 
@@ -1474,9 +1443,8 @@ int ssh2_packet_askv(LIBSSH2_SESSION *session,
     for(i = 0; i < packet_types_len; i++) {
         if(ssh2_packet_ask(session, packet_types[i], data,
                            data_len, match_ofs,
-                           match_buf, match_len) == 0) {
+                           match_buf, match_len) == 0)
             return 0;
-        }
     }
 
     return -1;
@@ -1500,10 +1468,8 @@ int ssh2_packet_require(LIBSSH2_SESSION *session,
     if(state->start == 0) {
         if(ssh2_packet_ask(session, packet_type, data, data_len,
                            match_ofs, match_buf,
-                           match_len) == 0) {
-            /* A packet was available in the packet brigade */
-            return 0;
-        }
+                           match_len) == 0)
+            return 0;  /* A packet was available in the packet brigade */
 
         state->start = time(NULL);
     }
@@ -1557,9 +1523,8 @@ int ssh2_packet_burn(LIBSSH2_SESSION *session, ssh2_NB_states *state)
     int ret;
 
     if(*state == ssh2_NB_state_idle) {
-        for(i = 1; i < 255; i++) {
+        for(i = 1; i < 255; i++)
             all_packets[i - 1] = i;
-        }
         all_packets[254] = 0;
 
         if(ssh2_packet_askv(session, all_packets, &data, &data_len, 0,
@@ -1577,17 +1542,14 @@ int ssh2_packet_burn(LIBSSH2_SESSION *session, ssh2_NB_states *state)
 
     while(session->socket_state == SSH2_SOCKET_CONNECTED) {
         ret = ssh2_transport_read(session);
-        if(ret == LIBSSH2_ERROR_EAGAIN) {
+        if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
-        }
         else if(ret < 0) {
             *state = ssh2_NB_state_idle;
             return ret;
         }
-        else if(ret == 0) {
-            /* FIXME: this might busyloop */
-            continue;
-        }
+        else if(ret == 0)
+            continue;  /* FIXME: this might busyloop */
 
         /* Be lazy, let packet_ask pull it out of the brigade */
         if(ssh2_packet_ask(session, (unsigned char)ret, &data, &data_len,
@@ -1622,9 +1584,8 @@ int ssh2_packet_requirev(LIBSSH2_SESSION *session,
         return 0;
     }
 
-    if(state->start == 0) {
+    if(state->start == 0)
         state->start = time(NULL);
-    }
 
     while(session->socket_state != SSH2_SOCKET_DISCONNECTED) {
         int ret = ssh2_transport_read(session);
@@ -1640,9 +1601,8 @@ int ssh2_packet_requirev(LIBSSH2_SESSION *session,
                 state->start = 0;
                 return LIBSSH2_ERROR_TIMEOUT;
             }
-            else if(ret == LIBSSH2_ERROR_EAGAIN) {
+            else if(ret == LIBSSH2_ERROR_EAGAIN)
                 return ret;
-            }
         }
 
         if(strchr((const char *)packet_types, ret)) {

--- a/src/pem.c
+++ b/src/pem.c
@@ -44,25 +44,21 @@ static int readline(char *line, int line_size, FILE *fp)
 {
     size_t len;
 
-    if(!line) {
+    if(!line)
         return -1;
-    }
-    if(!fgets(line, line_size, fp)) {
+    if(!fgets(line, line_size, fp))
         return -1;
+
+    if(*line) {
+        len = strlen(line);
+        if(len > 0 && line[len - 1] == '\n')
+            line[len - 1] = '\0';
     }
 
     if(*line) {
         len = strlen(line);
-        if(len > 0 && line[len - 1] == '\n') {
+        if(len > 0 && line[len - 1] == '\r')
             line[len - 1] = '\0';
-        }
-    }
-
-    if(*line) {
-        len = strlen(line);
-        if(len > 0 && line[len - 1] == '\r') {
-            line[len - 1] = '\0';
-        }
     }
 
     return 0;
@@ -78,9 +74,8 @@ static int readline_memory(char *line, size_t line_size,
 
     for(len = 0; off + len < filedata_len && len < line_size - 1; len++) {
         if(filedata[off + len] == '\n' ||
-           filedata[off + len] == '\r') {
+           filedata[off + len] == '\r')
             break;
-        }
     }
 
     if(len) {
@@ -163,9 +158,8 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
                                 data, datalen);
 
 out:
-    if(filedata) {
+    if(filedata)
         SSH2_FREE(session, filedata);
-    }
     return ret;
 }
 
@@ -187,14 +181,12 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
     do {
         *line = '\0';
 
-        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
+        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off))
             return -1;
-        }
     } while(strcmp(line, headerbegin));
 
-    if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
+    if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off))
         return -1;
-    }
 
     if(passphrase &&
        !memcmp(line, crypt_annotation, strlen(crypt_annotation))) {
@@ -267,9 +259,8 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         }
     } while(strcmp(line, headerend));
 
-    if(!b64data) {
+    if(!b64data)
         return -1;
-    }
 
     if(ssh2_base64_decode(session, (char **)data, datalen,
                           b64data, b64datalen)) {
@@ -327,9 +318,8 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(free_secret) {
+        if(free_secret)
             ssh2_explicit_zero((char *)secret, sizeof(secret));
-        }
 
         /* Do the actual decryption */
         if((*datalen % blocksize) != 0) {
@@ -528,9 +518,8 @@ static int openssh_pem_parse_data(LIBSSH2_SESSION *session,
         /* !checksrc! disable EQUALSNULL 1 */
         while((cur_method = *all_methods++) != NULL) {
             if(*cur_method->name && !memcmp(ciphername, cur_method->name,
-                                            strlen(cur_method->name))) {
+                                            strlen(cur_method->name)))
                 method = cur_method;
-            }
         }
 
         /* None of the available crypt methods were able to decrypt the key */
@@ -740,14 +729,12 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
     do {
         *line = '\0';
 
-        if(readline(line, LINE_SIZE, fp)) {
+        if(readline(line, LINE_SIZE, fp))
             return -1;
-        }
     } while(strcmp(line, OPENSSH_PRIVKEY_HEADER));
 
-    if(readline(line, LINE_SIZE, fp)) {
+    if(readline(line, LINE_SIZE, fp))
         return -1;
-    }
 
     do {
         if(*line) {
@@ -775,9 +762,8 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
         }
     } while(strcmp(line, OPENSSH_PRIVKEY_FOOTER));
 
-    if(!b64data) {
+    if(!b64data)
         return -1;
-    }
 
     ret = openssh_pem_parse_data(session, passphrase,
                                  b64data, b64datalen, decrypted_buf);
@@ -816,9 +802,8 @@ int ssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                             "Error parsing PEM: OpenSSH header not found");
 
-        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
+        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off))
             return -1;
-        }
     } while(strcmp(line, OPENSSH_PRIVKEY_HEADER));
 
     *line = '\0';
@@ -875,33 +860,28 @@ static int read_asn1_length(const unsigned char *data,
     unsigned int lenlen;
     int nextpos;
 
-    if(datalen < 1) {
+    if(datalen < 1)
         return -1;
-    }
     *len = data[0];
 
     if(*len >= 0x80) {
         lenlen = *len & 0x7F;
-        if(1 + lenlen > datalen) {
+        if(1 + lenlen > datalen)
             return -1;
-        }
         *len = data[1];
         if(lenlen > 1) {
             *len <<= 8;
-            if(2 + lenlen > datalen) {
+            if(2 + lenlen > datalen)
                 return -1;
-            }
             *len |= data[2];
         }
     }
-    else {
+    else
         lenlen = 0;
-    }
 
     nextpos = 1 + lenlen;
-    if(lenlen > 2 || 1 + lenlen + *len > datalen) {
+    if(lenlen > 2 || 1 + lenlen + *len > datalen)
         return -1;
-    }
 
     return nextpos;
 }
@@ -911,21 +891,18 @@ int ssh2_pem_decode_sequence(unsigned char **data, size_t *datalen)
     size_t len;
     int lenlen;
 
-    if(*datalen < 1) {
+    if(*datalen < 1)
         return -1;
-    }
 
-    if((*data)[0] != '\x30') {
+    if((*data)[0] != '\x30')
         return -1;
-    }
 
     (*data)++;
     (*datalen)--;
 
     lenlen = read_asn1_length(*data, *datalen, &len);
-    if(lenlen < 0 || lenlen + len != *datalen) {
+    if(lenlen < 0 || lenlen + len != *datalen)
         return -1;
-    }
 
     *data += lenlen;
     *datalen -= lenlen;
@@ -939,21 +916,18 @@ int ssh2_pem_decode_integer(unsigned char **data, size_t *datalen,
     size_t len;
     int lenlen;
 
-    if(*datalen < 1) {
+    if(*datalen < 1)
         return -1;
-    }
 
-    if((*data)[0] != '\x02') {
+    if((*data)[0] != '\x02')
         return -1;
-    }
 
     (*data)++;
     (*datalen)--;
 
     lenlen = read_asn1_length(*data, *datalen, &len);
-    if(lenlen < 0 || lenlen + len > *datalen) {
+    if(lenlen < 0 || lenlen + len > *datalen)
         return -1;
-    }
 
     *data += lenlen;
     *datalen -= lenlen;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -103,16 +103,13 @@ static void publickey_status_error(const LIBSSH2_PUBLICKEY *pkey,
     const char *msg;
 
     /* GENERAL_FAILURE got remapped between version 1 and 2 */
-    if(status == 6 && pkey && pkey->version == 1) {
+    if(status == 6 && pkey && pkey->version == 1)
         status = 7;
-    }
 
-    if(status > SSH2_PUBLICKEY_STATUS_CODE_MAX) {
+    if(status > SSH2_PUBLICKEY_STATUS_CODE_MAX)
         msg = "unknown";
-    }
-    else {
+    else
         msg = publickey_status_codes[status].name;
-    }
 
     ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL, msg);
 }
@@ -132,20 +129,17 @@ static int publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
 
     if(pkey->receive_state == ssh2_NB_state_idle) {
         rc = ssh2_channel_read(channel, 0, (char *)buffer, 4);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
-        }
-        else if(rc != 4) {
+        else if(rc != 4)
             return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                             "Invalid response from publickey subsystem");
-        }
 
         pkey->receive_packet_len = ssh2_ntohu32(buffer);
         pkey->receive_packet = SSH2_ALLOC(session, pkey->receive_packet_len);
-        if(!pkey->receive_packet) {
+        if(!pkey->receive_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate publickey response buffer");
-        }
 
         pkey->receive_state = ssh2_NB_state_sent;
     }
@@ -153,9 +147,8 @@ static int publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
     if(pkey->receive_state == ssh2_NB_state_sent) {
         rc = ssh2_channel_read(channel, 0, (char *)pkey->receive_packet,
                                pkey->receive_packet_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
-        }
         else if(rc != (ssize_t)pkey->receive_packet_len) {
             SSH2_FREE(session, pkey->receive_packet);
             pkey->receive_packet = NULL;
@@ -186,17 +179,13 @@ static int publickey_response_id(unsigned char **pdata, size_t data_len)
     unsigned char *data = *pdata;
     const struct publickey_code_list *codes = publickey_response_codes;
 
-    if(data_len < 4) {
-        /* Malformed response */
-        return -1;
-    }
+    if(data_len < 4)
+        return -1;  /* Malformed response */
     response_len = ssh2_ntohu32(data);
     data += 4;
     data_len -= 4;
-    if(data_len < response_len) {
-        /* Malformed response */
-        return -1;
-    }
+    if(data_len < response_len)
+        return -1;  /* Malformed response */
 
     while(codes->name) {
         if((unsigned long)codes->name_len == response_len &&
@@ -222,19 +211,16 @@ static int publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
 
     for(;;) {
         int rc = publickey_packet_receive(pkey, &data, &data_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
-        else if(rc) {
+        else if(rc)
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_TIMEOUT,
                             "Timeout waiting for response from "
                             "publickey subsystem");
-        }
 
-        if(data_len < 4) {
+        if(data_len < 4)
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Publickey response too small");
-        }
 
         s = data;
         response = publickey_response_id(&s, data_len);
@@ -244,10 +230,9 @@ static int publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
             /* Error, or processing complete */
             unsigned long status = 0;
 
-            if(data_len < 8) {
+            if(data_len < 8)
                 return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                                 "Publickey response too small");
-            }
 
             status = ssh2_ntohu32(s);
 
@@ -261,10 +246,9 @@ static int publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
         }
         default:
             SSH2_FREE(session, data);
-            if(response < 0) {
+            if(response < 0)
                 return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                                 "Invalid publickey subsystem response");
-            }
             /* Unknown/Unexpected */
             ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                      "Unexpected publickey subsystem response");
@@ -590,18 +574,16 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
         }
         else {
             packet_len += 5; /* overwrite(1) + attribute_count(4) */
-            for(i = 0; i < num_attrs; i++) {
+            for(i = 0; i < num_attrs; i++)
                 packet_len += 9 + attrs[i].name_len + attrs[i].value_len;
                 /* name_len(4) + value_len(4) + mandatory(1) */
-            }
         }
 
         pkey->add_packet = SSH2_ALLOC(session, packet_len);
-        if(!pkey->add_packet) {
+        if(!pkey->add_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for "
                             "publickey \"add\" packet");
-        }
 
         pkey->add_s = pkey->add_packet;
         ssh2_htonu32(pkey->add_s, (uint32_t)(packet_len - 4));
@@ -666,9 +648,8 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
         ssize_t nwritten;
         nwritten = ssh2_channel_write(channel, 0, pkey->add_packet,
                                       (pkey->add_s - pkey->add_packet));
-        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+        if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
-        }
         else if((pkey->add_s - pkey->add_packet) != nwritten) {
             SSH2_FREE(session, pkey->add_packet);
             pkey->add_packet = NULL;
@@ -682,9 +663,8 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
     }
 
     rc = publickey_response_success(pkey);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
 
     pkey->add_state = ssh2_NB_state_idle;
 
@@ -718,11 +698,10 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
         pkey->remove_packet = NULL;
 
         pkey->remove_packet = SSH2_ALLOC(session, packet_len);
-        if(!pkey->remove_packet) {
+        if(!pkey->remove_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for "
                             "publickey \"remove\" packet");
-        }
 
         pkey->remove_s = pkey->remove_packet;
         ssh2_htonu32(pkey->remove_s, (uint32_t)(packet_len - 4));
@@ -751,9 +730,8 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
         ssize_t nwritten;
         nwritten = ssh2_channel_write(channel, 0, pkey->remove_packet,
                                       (pkey->remove_s - pkey->remove_packet));
-        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+        if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
-        }
         else if((pkey->remove_s - pkey->remove_packet) != nwritten) {
             SSH2_FREE(session, pkey->remove_packet);
             pkey->remove_packet = NULL;
@@ -768,9 +746,8 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
     }
 
     rc = publickey_response_success(pkey);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
 
     pkey->remove_state = ssh2_NB_state_idle;
 
@@ -821,9 +798,8 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                                       pkey->listFetch_buffer,
                                       (pkey->listFetch_s -
                                        pkey->listFetch_buffer));
-        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+        if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
-        }
         else if((pkey->listFetch_s - pkey->listFetch_buffer) != nwritten) {
             pkey->listFetch_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -836,9 +812,8 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
     for(;;) {
         rc = publickey_packet_receive(pkey, &pkey->listFetch_data,
                                       &pkey->listFetch_data_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc) {
             ssh2_err(session, LIBSSH2_ERROR_SOCKET_TIMEOUT,
                      "Timeout waiting for response from publickey subsystem");
@@ -1135,9 +1110,8 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                         list[keys].attrs[i].mandatory = 0;
                     }
                 }
-                else {
+                else
                     list[keys].attrs = NULL;
-                }
             }
             /* To be FREEd in libssh2_publickey_list_free() */
             list[keys].packet = pkey->listFetch_data;
@@ -1161,9 +1135,8 @@ err_exit:
         SSH2_FREE(session, pkey->listFetch_data);
         pkey->listFetch_data = NULL;
     }
-    if(list) {
+    if(list)
         libssh2_publickey_list_free(pkey, list);
-    }
     pkey->listFetch_state = ssh2_NB_state_idle;
     return -1;
 }
@@ -1183,9 +1156,8 @@ void libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
     session = pkey->channel->session;
 
     while(p->packet) {
-        if(p->attrs) {
+        if(p->attrs)
             SSH2_FREE(session, p->attrs);
-        }
         SSH2_FREE(session, p->packet);
         p++;
     }

--- a/src/scp.c
+++ b/src/scp.c
@@ -321,11 +321,10 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
             memcpy(&session->scpRecv_command[cmd_len], path, path_len);
             cmd_len += path_len;
         }
-        else {
+        else
             cmd_len += shell_quotearg(path,
                                       &session->scpRecv_command[cmd_len],
                                       session->scpRecv_command_len - cmd_len);
-        }
 
         /* the command to exec should _not_ be null-terminated */
         session->scpRecv_command_len = cmd_len;
@@ -349,10 +348,9 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 session->scpRecv_command = NULL;
                 session->scpRecv_state = ssh2_NB_state_idle;
             }
-            else {
+            else
                 ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
                          "Would block starting up channel");
-            }
             return NULL;
         }
 
@@ -393,9 +391,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                      "Would block sending initial wakeup");
             return NULL;
         }
-        else if(rc != 1) {
+        else if(rc != 1)
             goto scp_recv_error;
-        }
 
         /* Parse SCP response */
         session->scpRecv_response_len = 0;
@@ -570,9 +567,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                              "Would block waiting to send SCP ACK");
                     return NULL;
                 }
-                else if(rc != 1) {
+                else if(rc != 1)
                     goto scp_recv_error;
-                }
 
                 ssh2_deb((session, LIBSSH2_TRACE_SCP,
                           "mtime = %ld, atime = %ld",
@@ -724,9 +720,9 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                              "Would block sending SCP ACK");
                     return NULL;
                 }
-                else if(rc != 1) {
+                else if(rc != 1)
                     goto scp_recv_error;
-                }
+
                 ssh2_deb((session, LIBSSH2_TRACE_SCP, "mode = 0%lo size = %ld",
                           (unsigned long)session->scpRecv_mode,
                           (long)session->scpRecv_size));
@@ -870,10 +866,9 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
             memcpy(&session->scpSend_command[cmd_len], path, path_len);
             cmd_len += path_len;
         }
-        else {
+        else
             cmd_len += shell_quotearg(path, &session->scpSend_command[cmd_len],
                                       session->scpSend_command_len - cmd_len);
-        }
 
         /* the command to exec should _not_ be null-terminated */
         session->scpSend_command_len = cmd_len;
@@ -897,10 +892,9 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
                 session->scpSend_command = NULL;
                 session->scpSend_state = ssh2_NB_state_idle;
             }
-            else {
+            else
                 ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
                          "Would block starting up channel");
-            }
             return NULL;
         }
 
@@ -1012,11 +1006,8 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
             session->scpSend_state = ssh2_NB_state_sent4;
         }
     }
-    else {
-        if(session->scpSend_state == ssh2_NB_state_sent2) {
-            session->scpSend_state = ssh2_NB_state_sent4;
-        }
-    }
+    else if(session->scpSend_state == ssh2_NB_state_sent2)
+        session->scpSend_state = ssh2_NB_state_sent4;
 
     if(session->scpSend_state == ssh2_NB_state_sent4) {
         /* Send mode, size, and basename */
@@ -1105,10 +1096,9 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
 scp_send_empty_channel:
     /* the code only jumps here as a result of a zero read from channel_read()
        so we check EOF status to avoid getting stuck in a loop */
-    if(libssh2_channel_eof(session->scpSend_channel)) {
+    if(libssh2_channel_eof(session->scpSend_channel))
         ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                  "Unexpected channel close");
-    }
     else
         return session->scpSend_channel;
     /* fall-through */

--- a/src/session.c
+++ b/src/session.c
@@ -104,9 +104,8 @@ static int banner_receive(LIBSSH2_SESSION *session)
 
         session->banner_TxRx_state = ssh2_NB_state_created;
     }
-    else {
+    else
         banner_len = session->banner_TxRx_total_send;
-    }
 
     while(banner_len < sizeof(session->banner_TxRx_banner) &&
           (banner_len == 0 ||
@@ -146,9 +145,8 @@ static int banner_receive(LIBSSH2_SESSION *session)
             return LIBSSH2_ERROR_SOCKET_DISCONNECT;
         }
 
-        if((c == '\r' || c == '\n') && banner_len == 0) {
+        if((c == '\r' || c == '\n') && banner_len == 0)
             continue;
-        }
 
         if(c == '\0') {
             /* NULLs are not allowed in SSH banners */
@@ -177,10 +175,10 @@ static int banner_receive(LIBSSH2_SESSION *session)
         SSH2_FREE(session, session->remote.banner);
 
     session->remote.banner = SSH2_ALLOC(session, banner_len + 1);
-    if(!session->remote.banner) {
+    if(!session->remote.banner)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Error allocating space for remote banner");
-    }
+
     memcpy(session->remote.banner, session->banner_TxRx_banner, banner_len);
     session->remote.banner[banner_len] = '\0';
     ssh2_deb((session, LIBSSH2_TRACE_TRANS, "Received Banner: %s",
@@ -307,15 +305,13 @@ static int get_socket_nonblocking(libssh2_socket_t sockfd)
 {                                 /* operate on this */
 #ifdef HAVE_O_NONBLOCK  /* most recent unix versions */
     int flags = fcntl(sockfd, F_GETFL, 0);
-    if(flags == -1) {
+    if(flags == -1)
         return 1;  /* Assume blocking on error */
-    }
     return (flags & O_NONBLOCK);
 #elif defined(HAVE_SO_NONBLOCK)  /* BeOS */
     long b;
-    if(getsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b))) {
+    if(getsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b)))
         return 1;  /* Assume blocking on error */
-    }
     return (int)b;
 #elif defined(SO_STATE) && defined(__VMS)  /* VMS TCP/IP Services */
     size_t sockstat = 0;
@@ -323,21 +319,18 @@ static int get_socket_nonblocking(libssh2_socket_t sockfd)
     size_t size = sizeof(int);
     callstat = getsockopt(sockfd, SOL_SOCKET, SO_STATE,
                           (char *)&sockstat, &size);
-    if(callstat == -1) {
+    if(callstat == -1)
         return 0;
-    }
-    if((sockstat & SS_NBIO) != 0) {
+    if((sockstat & SS_NBIO) != 0)
         return 1;
-    }
     return 0;
 #elif defined(_WIN32)
     unsigned int option_value;
     socklen_t option_len = sizeof(option_value);
 
     if(getsockopt(sockfd, SOL_SOCKET, SO_ERROR,
-                  (void *)&option_value, &option_len)) {
+                  (void *)&option_value, &option_len))
         return 1;  /* Assume blocking on error */
-    }
     return (int)option_value;
 #else
     (void)sockfd;
@@ -361,10 +354,9 @@ int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
         return 0;
 
     session->local.banner = SSH2_ALLOC(session, banner_len + 3);
-    if(!session->local.banner) {
+    if(!session->local.banner)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Unable to allocate memory for local banner");
-    }
 
     memcpy(session->local.banner, banner, banner_len);
 
@@ -406,15 +398,12 @@ LIBSSH2_SESSION *libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
     LIBSSH2_REALLOC_FUNC(*local_realloc) = ssh2_default_realloc;
     LIBSSH2_SESSION *session;
 
-    if(my_alloc) {
+    if(my_alloc)
         local_alloc = my_alloc;
-    }
-    if(my_free) {
+    if(my_free)
         local_free = my_free;
-    }
-    if(my_realloc) {
+    if(my_realloc)
         local_realloc = my_realloc;
-    }
 
     session = local_alloc(sizeof(LIBSSH2_SESSION), &abstract);
     if(session) {
@@ -585,16 +574,15 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
        (seconds_to_next == 0 || ms_to_next > session->api_timeout)) {
         time_t now = time(NULL);
         elapsed_ms = (long)(1000 * difftime(now, start_time));
-        if(elapsed_ms > session->api_timeout) {
+        if(elapsed_ms > session->api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");
-        }
+
         ms_to_next = (session->api_timeout - elapsed_ms);
         has_timeout = 1;
     }
-    else if(ms_to_next > 0) {
+    else if(ms_to_next > 0)
         has_timeout = 1;
-    }
     else
         has_timeout = 0;
 
@@ -659,10 +647,10 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
                     has_timeout ? &tv : NULL);
     }
 #endif
-    if(rc == 0) {
+    if(rc == 0)
         return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                         "Timed out waiting on socket");
-    }
+
     if(rc < 0) {
         /* Profiling tools that use SIGPROF can cause EINTR responses.
            poll() / select() do not set any descriptor states on EINTR,
@@ -690,11 +678,10 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
     if(session->startup_state == ssh2_NB_state_idle) {
         ssh2_deb((session, LIBSSH2_TRACE_TRANS,
                   "session_startup for socket %ld", (long)sock));
-        if(LIBSSH2_INVALID_SOCKET == sock) {
-            /* Did we forget something? */
+        if(LIBSSH2_INVALID_SOCKET == sock)  /* Did we forget something? */
             return ssh2_err(session, LIBSSH2_ERROR_BAD_SOCKET,
                             "Bad socket provided");
-        }
+
         session->socket_fd = sock;
 
         session->socket_prev_blockstate =
@@ -703,11 +690,10 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
         if(session->socket_prev_blockstate) {
             /* If in blocking state change to non-blocking */
             rc = session_nonblock(session->socket_fd, 1);
-            if(rc) {
+            if(rc)
                 return ssh2_err(session, rc,
                                 "Failed changing socket's "
                                 "blocking state to non-blocking");
-            }
         }
 
         session->startup_state = ssh2_NB_state_created;
@@ -717,9 +703,9 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
         rc = banner_send(session);
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        else if(rc) {
+        else if(rc)
             return ssh2_err(session, rc, "Failed sending banner");
-        }
+
         session->startup_state = ssh2_NB_state_sent;
         session->banner_TxRx_state = ssh2_NB_state_idle;
     }
@@ -764,10 +750,9 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
                                  sizeof("ssh-userauth") + 5 - 1, NULL, 0);
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        else if(rc) {
+        else if(rc)
             return ssh2_err(session, rc,
                             "Unable to ask for ssh-userauth service");
-        }
 
         session->startup_state = ssh2_NB_state_sent4;
     }
@@ -883,187 +868,138 @@ static int session_free(LIBSSH2_SESSION *session)
         session->free_state = ssh2_NB_state_sent1;
     }
 
-    if(session->kex && session->kex->cleanup) {
+    if(session->kex && session->kex->cleanup)
         session->kex->cleanup(session,
                               &session->startup_key_state.key_state_low);
-    }
 
     /* hostkey */
-    if(session->hostkey && session->hostkey->dtor) {
+    if(session->hostkey && session->hostkey->dtor)
         session->hostkey->dtor(session, &session->server_hostkey_abstract);
-    }
 
     if(session->state & SSH2_STATE_NEWKEYS) {
 
         /* Client to Server */
         /* crypt */
-        if(session->local.crypt && session->local.crypt->dtor) {
+        if(session->local.crypt && session->local.crypt->dtor)
             session->local.crypt->dtor(session,
                                        &session->local.crypt_abstract);
-        }
         /* comp */
-        if(session->local.comp && session->local.comp->dtor) {
+        if(session->local.comp && session->local.comp->dtor)
             session->local.comp->dtor(session, 1,
                                       &session->local.comp_abstract);
-        }
         /* mac */
-        if(session->local.mac && session->local.mac->dtor) {
+        if(session->local.mac && session->local.mac->dtor)
             session->local.mac->dtor(session, &session->local.mac_abstract);
-        }
 
         /* Server to Client */
         /* crypt */
-        if(session->remote.crypt && session->remote.crypt->dtor) {
+        if(session->remote.crypt && session->remote.crypt->dtor)
             session->remote.crypt->dtor(session,
                                         &session->remote.crypt_abstract);
-        }
         /* comp */
-        if(session->remote.comp && session->remote.comp->dtor) {
+        if(session->remote.comp && session->remote.comp->dtor)
             session->remote.comp->dtor(session, 0,
                                        &session->remote.comp_abstract);
-        }
         /* mac */
-        if(session->remote.mac && session->remote.mac->dtor) {
+        if(session->remote.mac && session->remote.mac->dtor)
             session->remote.mac->dtor(session, &session->remote.mac_abstract);
-        }
 
         /* session_id */
-        if(session->session_id) {
+        if(session->session_id)
             SSH2_FREE(session, session->session_id);
-        }
     }
 
     /* Free banner(s) */
-    if(session->remote.banner) {
+    if(session->remote.banner)
         SSH2_FREE(session, session->remote.banner);
-    }
-    if(session->local.banner) {
+    if(session->local.banner)
         SSH2_FREE(session, session->local.banner);
-    }
 
     /* Free preference(s) */
-    if(session->kex_prefs) {
+    if(session->kex_prefs)
         SSH2_FREE(session, session->kex_prefs);
-    }
-    if(session->hostkey_prefs) {
+    if(session->hostkey_prefs)
         SSH2_FREE(session, session->hostkey_prefs);
-    }
 
-    if(session->local.kexinit) {
+    if(session->local.kexinit)
         SSH2_FREE(session, session->local.kexinit);
-    }
-    if(session->local.crypt_prefs) {
+    if(session->local.crypt_prefs)
         SSH2_FREE(session, session->local.crypt_prefs);
-    }
-    if(session->local.mac_prefs) {
+    if(session->local.mac_prefs)
         SSH2_FREE(session, session->local.mac_prefs);
-    }
-    if(session->local.comp_prefs) {
+    if(session->local.comp_prefs)
         SSH2_FREE(session, session->local.comp_prefs);
-    }
-    if(session->local.lang_prefs) {
+    if(session->local.lang_prefs)
         SSH2_FREE(session, session->local.lang_prefs);
-    }
 
-    if(session->remote.kexinit) {
+    if(session->remote.kexinit)
         SSH2_FREE(session, session->remote.kexinit);
-    }
-    if(session->remote.crypt_prefs) {
+    if(session->remote.crypt_prefs)
         SSH2_FREE(session, session->remote.crypt_prefs);
-    }
-    if(session->remote.mac_prefs) {
+    if(session->remote.mac_prefs)
         SSH2_FREE(session, session->remote.mac_prefs);
-    }
-    if(session->remote.comp_prefs) {
+    if(session->remote.comp_prefs)
         SSH2_FREE(session, session->remote.comp_prefs);
-    }
-    if(session->remote.lang_prefs) {
+    if(session->remote.lang_prefs)
         SSH2_FREE(session, session->remote.lang_prefs);
-    }
-    if(session->server_sign_algorithms) {
+    if(session->server_sign_algorithms)
         SSH2_FREE(session, session->server_sign_algorithms);
-    }
-    if(session->sign_algo_prefs) {
+    if(session->sign_algo_prefs)
         SSH2_FREE(session, session->sign_algo_prefs);
-    }
 
     /*
      * Make sure all memory used in the state variables are free
      */
-    if(session->kexinit_data) {
+    if(session->kexinit_data)
         SSH2_FREE(session, session->kexinit_data);
-    }
-    if(session->startup_data) {
+    if(session->startup_data)
         SSH2_FREE(session, session->startup_data);
-    }
-    if(session->userauth_list_data) {
+    if(session->userauth_list_data)
         SSH2_FREE(session, session->userauth_list_data);
-    }
-    if(session->userauth_banner) {
+    if(session->userauth_banner)
         SSH2_FREE(session, session->userauth_banner);
-    }
-    if(session->userauth_pswd_data) {
+    if(session->userauth_pswd_data)
         SSH2_FREE(session, session->userauth_pswd_data);
-    }
-    if(session->userauth_pswd_newpw) {
+    if(session->userauth_pswd_newpw)
         SSH2_FREE(session, session->userauth_pswd_newpw);
-    }
-    if(session->userauth_host_packet) {
+    if(session->userauth_host_packet)
         SSH2_FREE(session, session->userauth_host_packet);
-    }
-    if(session->userauth_host_method) {
+    if(session->userauth_host_method)
         SSH2_FREE(session, session->userauth_host_method);
-    }
-    if(session->userauth_host_data) {
+    if(session->userauth_host_data)
         SSH2_FREE(session, session->userauth_host_data);
-    }
-    if(session->userauth_pblc_data) {
+    if(session->userauth_pblc_data)
         SSH2_FREE(session, session->userauth_pblc_data);
-    }
-    if(session->userauth_pblc_packet) {
+    if(session->userauth_pblc_packet)
         SSH2_FREE(session, session->userauth_pblc_packet);
-    }
-    if(session->userauth_pblc_method) {
+    if(session->userauth_pblc_method)
         SSH2_FREE(session, session->userauth_pblc_method);
-    }
-    if(session->userauth_kybd_data) {
+    if(session->userauth_kybd_data)
         SSH2_FREE(session, session->userauth_kybd_data);
-    }
-    if(session->userauth_kybd_packet) {
+    if(session->userauth_kybd_packet)
         SSH2_FREE(session, session->userauth_kybd_packet);
-    }
-    if(session->userauth_kybd_auth_instruction) {
+    if(session->userauth_kybd_auth_instruction)
         SSH2_FREE(session, session->userauth_kybd_auth_instruction);
-    }
-    if(session->open_packet) {
+    if(session->open_packet)
         SSH2_FREE(session, session->open_packet);
-    }
-    if(session->open_data) {
+    if(session->open_data)
         SSH2_FREE(session, session->open_data);
-    }
-    if(session->direct_message) {
+    if(session->direct_message)
         SSH2_FREE(session, session->direct_message);
-    }
-    if(session->fwdLstn_packet) {
+    if(session->fwdLstn_packet)
         SSH2_FREE(session, session->fwdLstn_packet);
-    }
-    if(session->pkeyInit_data) {
+    if(session->pkeyInit_data)
         SSH2_FREE(session, session->pkeyInit_data);
-    }
-    if(session->scpRecv_command) {
+    if(session->scpRecv_command)
         SSH2_FREE(session, session->scpRecv_command);
-    }
-    if(session->scpSend_command) {
+    if(session->scpSend_command)
         SSH2_FREE(session, session->scpSend_command);
-    }
-    if(session->sftpInit_sftp) {
+    if(session->sftpInit_sftp)
         SSH2_FREE(session, session->sftpInit_sftp);
-    }
 
     /* Free payload buffer */
-    if(session->packet.total_num) {
+    if(session->packet.total_num)
         SSH2_FREE(session, session->packet.payload);
-    }
 
     /* Cleanup all remaining packets */
     /* !checksrc! disable EQUALSNULL 1 */
@@ -1085,21 +1021,17 @@ static int session_free(LIBSSH2_SESSION *session)
     if(session->socket_prev_blockstate) {
         /* if the socket was previously blocking, put it back so */
         rc = session_nonblock(session->socket_fd, 0);
-        if(rc) {
+        if(rc)
             ssh2_deb((session, LIBSSH2_TRACE_TRANS,
                       "unable to reset socket's blocking state"));
-        }
     }
 
-    if(session->server_hostkey) {
+    if(session->server_hostkey)
         SSH2_FREE(session, session->server_hostkey);
-    }
 
     /* error string */
-    if(session->err_msg &&
-       ((session->err_flags & SSH2_ERR_FLAG_DUP) != 0)) {
+    if(session->err_msg && ((session->err_flags & SSH2_ERR_FLAG_DUP) != 0))
         SSH2_FREE(session, (char *)SSH2_UNCONST(session->err_msg));
-    }
 
     SSH2_FREE(session, session);
 
@@ -1270,17 +1202,14 @@ int libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
         if(errmsg) {
             if(want_buf) {
                 *errmsg = SSH2_ALLOC(session, 1);
-                if(*errmsg) {
+                if(*errmsg)
                     **errmsg = 0;
-                }
             }
-            else {
+            else
                 *errmsg = (char *)SSH2_UNCONST("");
-            }
         }
-        if(errmsg_len) {
+        if(errmsg_len)
             *errmsg_len = 0;
-        }
         return 0;
     }
 
@@ -1301,9 +1230,8 @@ int libssh2_session_last_error(LIBSSH2_SESSION *session, char **errmsg,
             *errmsg = (char *)SSH2_UNCONST(error);
     }
 
-    if(errmsg_len) {
+    if(errmsg_len)
         *errmsg_len = (int)msglen;
-    }
 
     return session->err_code;
 }
@@ -1408,9 +1336,9 @@ long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
  */
 void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
 {
-    if(timeout <= 0) {
+    if(timeout <= 0)
         timeout = SSH2_DEFAULT_READ_TIMEOUT;
-    }
+
     session->packet_read_timeout = timeout;
 }
 
@@ -1441,10 +1369,9 @@ int libssh2_poll_channel_read(LIBSSH2_CHANNEL *channel, int extended)
     packet = ssh2_list_first(&session->packets);
 
     while(packet) {
-        if(packet->data_len < 5) {
+        if(packet->data_len < 5)
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Packet too small");
-        }
 
         if(channel->local.id == ssh2_ntohu32(packet->data + 1)) {
             if(extended == 1 &&
@@ -1682,9 +1609,8 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                     break;
                 }
             }
-            if(fds[i].revents) {
+            if(fds[i].revents)
                 active_fds++;
-            }
         }
 
         if(active_fds) {
@@ -1709,9 +1635,8 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                 case LIBSSH2_POLLFD_SOCKET:
                     fds[i].revents = sockets[i].revents;
                     sockets[i].revents = 0; /* Be nice in case we loop again */
-                    if(fds[i].revents) {
+                    if(fds[i].revents)
                         active_fds++;
-                    }
                     break;
                 case LIBSSH2_POLLFD_CHANNEL:
                     if(sockets[i].events & POLLIN) {
@@ -1768,15 +1693,12 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
-                    if(FD_ISSET(fds[i].fd.socket, &rfds)) {
+                    if(FD_ISSET(fds[i].fd.socket, &rfds))
                         fds[i].revents |= LIBSSH2_POLLFD_POLLIN;
-                    }
-                    if(FD_ISSET(fds[i].fd.socket, &wfds)) {
+                    if(FD_ISSET(fds[i].fd.socket, &wfds))
                         fds[i].revents |= LIBSSH2_POLLFD_POLLOUT;
-                    }
-                    if(fds[i].revents) {
+                    if(fds[i].revents)
                         active_fds++;
-                    }
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/session.c
+++ b/src/session.c
@@ -160,9 +160,8 @@ static int banner_receive(LIBSSH2_SESSION *session)
 
     while(banner_len &&
           (session->banner_TxRx_banner[banner_len - 1] == '\n' ||
-           session->banner_TxRx_banner[banner_len - 1] == '\r')) {
+           session->banner_TxRx_banner[banner_len - 1] == '\r'))
         banner_len--;
-    }
 
     /* From this point on, we are done here */
     session->banner_TxRx_state = ssh2_NB_state_idle;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -169,9 +169,8 @@ static int sftp_packet_add(LIBSSH2_SFTP *sftp,
     struct sftp_packet *packet;
     uint32_t request_id;
 
-    if(data_len < 5) {
+    if(data_len < 5)
         return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
-    }
 
     ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Received packet type %u (len %lu)",
               (unsigned int)data[0], (unsigned long)data_len));
@@ -237,10 +236,9 @@ static int sftp_packet_add(LIBSSH2_SFTP *sftp,
     }
 
     packet = SSH2_ALLOC(session, sizeof(struct sftp_packet));
-    if(!packet) {
+    if(!packet)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Unable to allocate datablock for SFTP packet");
-    }
 
     packet->data = data;
     packet->data_len = data_len;
@@ -394,9 +392,8 @@ window_adjust:
             SSH2_FREE(session, packet);
             return (int)rc;
         }
-        else {
+        else
             return packet_type;
-        }
     }
     /* NOT REACHED */
 }
@@ -486,9 +483,8 @@ static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
     LIBSSH2_SESSION *session = sftp->channel->session;
     int rc;
 
-    if(!data || !data_len || required_size == 0) {
+    if(!data || !data_len || required_size == 0)
         return LIBSSH2_ERROR_BAD_USE;
-    }
 
     ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Requiring packet %u id %u",
               (unsigned int)packet_type, request_id));
@@ -498,9 +494,8 @@ static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
         ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Got %u",
                   (unsigned int)packet_type));
 
-        if(*data_len < required_size) {
+        if(*data_len < required_size)
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-        }
 
         return LIBSSH2_ERROR_NONE;
     }
@@ -516,9 +511,8 @@ static int sftp_packet_require(LIBSSH2_SFTP *sftp, unsigned char packet_type,
             ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Got %u",
                       (unsigned int)packet_type));
 
-            if(*data_len < required_size) {
+            if(*data_len < required_size)
                 return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-            }
 
             return LIBSSH2_ERROR_NONE;
         }
@@ -540,9 +534,8 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
     int i;
     int rc;
 
-    if(!data || !data_len || required_size == 0) {
+    if(!data || !data_len || required_size == 0)
         return LIBSSH2_ERROR_BAD_USE;
-    }
 
     /* If no timeout is active, start a new one */
     if(sftp->requirev_start == 0)
@@ -558,9 +551,8 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
                  */
                 sftp->requirev_start = 0;
 
-                if(*data_len < required_size) {
+                if(*data_len < required_size)
                     return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-                }
 
                 return LIBSSH2_ERROR_NONE;
             }
@@ -581,9 +573,8 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
                 sftp->requirev_start = 0;
                 return LIBSSH2_ERROR_TIMEOUT;
             }
-            else if(rc == LIBSSH2_ERROR_EAGAIN) {
+            else if(rc == LIBSSH2_ERROR_EAGAIN)
                 return rc;
-            }
         }
     }
 
@@ -629,18 +620,16 @@ static ssize_t sftp_attr2bin(unsigned char *p,
 
     ssh2_store_u32(&s, (uint32_t)(attrs->flags & flag_mask));
 
-    if(attrs->flags & LIBSSH2_SFTP_ATTR_SIZE) {
+    if(attrs->flags & LIBSSH2_SFTP_ATTR_SIZE)
         ssh2_store_u64(&s, attrs->filesize);
-    }
 
     if(attrs->flags & LIBSSH2_SFTP_ATTR_UIDGID) {
         ssh2_store_u32(&s, (uint32_t)attrs->uid);
         ssh2_store_u32(&s, (uint32_t)attrs->gid);
     }
 
-    if(attrs->flags & LIBSSH2_SFTP_ATTR_PERMISSIONS) {
+    if(attrs->flags & LIBSSH2_SFTP_ATTR_PERMISSIONS)
         ssh2_store_u32(&s, (uint32_t)attrs->permissions);
-    }
 
     if(attrs->flags & LIBSSH2_SFTP_ATTR_ACMODTIME) {
         ssh2_store_u32(&s, (uint32_t)attrs->atime);
@@ -659,33 +648,30 @@ static ssize_t sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs,
     buf.dataptr = buf.data;
     buf.len = data_len;
 
-    if(ssh2_get_u32(&buf, &flags)) {
+    if(ssh2_get_u32(&buf, &flags))
         return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-    }
+
     attrs->flags = flags;
 
     if(attrs->flags & LIBSSH2_SFTP_ATTR_SIZE) {
-        if(ssh2_get_u64(&buf, &(attrs->filesize))) {
+        if(ssh2_get_u64(&buf, &(attrs->filesize)))
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-        }
     }
 
     if(attrs->flags & LIBSSH2_SFTP_ATTR_UIDGID) {
         uint32_t uid = 0;
         uint32_t gid = 0;
         if(ssh2_get_u32(&buf, &uid) ||
-           ssh2_get_u32(&buf, &gid)) {
+           ssh2_get_u32(&buf, &gid))
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-        }
         attrs->uid = uid;
         attrs->gid = gid;
     }
 
     if(attrs->flags & LIBSSH2_SFTP_ATTR_PERMISSIONS) {
         uint32_t permissions;
-        if(ssh2_get_u32(&buf, &permissions)) {
+        if(ssh2_get_u32(&buf, &permissions))
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-        }
         attrs->permissions = permissions;
     }
 
@@ -693,9 +679,8 @@ static ssize_t sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs,
         uint32_t atime;
         uint32_t mtime;
         if(ssh2_get_u32(&buf, &atime) ||
-           ssh2_get_u32(&buf, &mtime)) {
+           ssh2_get_u32(&buf, &mtime))
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-        }
         attrs->atime = atime;
         attrs->mtime = mtime;
     }
@@ -709,15 +694,13 @@ static ssize_t sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs,
         size_t edata_len;
         unsigned char *edata;
 
-        if(ssh2_get_u32(&buf, &extended_count)) {
+        if(ssh2_get_u32(&buf, &extended_count))
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-        }
 
         for(i = 0; i < extended_count; ++i) {
             if(ssh2_get_string(&buf, &etype, &etype_len) ||
-               ssh2_get_string(&buf, &edata, &edata_len)) {
+               ssh2_get_string(&buf, &edata, &edata_len))
                 return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-            }
         }
     }
 
@@ -741,14 +724,12 @@ LIBSSH2_CHANNEL_CLOSE_FUNC(sftp_dtor)
     (void)channel;
 
     /* Free the partial packet storage for sftp_packet_read */
-    if(sftp->partial_packet) {
+    if(sftp->partial_packet)
         SSH2_FREE(session, sftp->partial_packet);
-    }
 
     /* Free the packet storage for ssh2_sftp_packet_readdir() */
-    if(sftp->readdir_packet) {
+    if(sftp->readdir_packet)
         SSH2_FREE(session, sftp->readdir_packet);
-    }
 
     SSH2_FREE(session, sftp);
 }
@@ -793,10 +774,9 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
                               LIBSSH2_CHANNEL_WINDOW_DEFAULT,
                               LIBSSH2_CHANNEL_PACKET_DEFAULT, NULL, 0);
         if(!session->sftpInit_channel) {
-            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN) {
+            if(libssh2_session_last_errno(session) == LIBSSH2_ERROR_EAGAIN)
                 ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
                          "Would block starting up channel");
-            }
             else {
                 ssh2_err(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
                          "Unable to startup channel");
@@ -910,9 +890,8 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         return NULL;
     }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                  "Invalid SSH_FXP_VERSION response");
         goto sftp_init_error;
@@ -1146,9 +1125,8 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
 
         sftp->last_errno = LIBSSH2_FX_OK;
 
-        if(attrs_in) {
+        if(attrs_in)
             memcpy(&attrs, attrs_in, sizeof(LIBSSH2_SFTP_ATTRIBUTES));
-        }
 
         sftp->open_packet_len = packet_len;
 
@@ -1228,9 +1206,8 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
             return NULL;
         }
         else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-            if(data_len > 0) {
+            if(data_len > 0)
                 SSH2_FREE(session, data);
-            }
             ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                      "Response too small");
             return NULL;
@@ -1272,9 +1249,8 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
                     return NULL;
                 }
                 else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-                    if(data_len > 0) {
+                    if(data_len > 0)
                         SSH2_FREE(session, data);
-                    }
                     ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                              "Too small FXP_HANDLE");
                     return NULL;
@@ -1446,9 +1422,8 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
             return copy;
         }
 
-        if(filep->eof) {
+        if(filep->eof)
             return 0;
-        }
         else {
             /* We allow a number of bytes being requested at any given time
                without having been acked - until we reach EOF. */
@@ -1579,12 +1554,10 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                     /* We still have data left to send for this chunk.
                      * If there is at least one completely sent chunk,
                      * we can get out of this loop and start reading.  */
-                    if(chunk != ssh2_list_first(&handle->packet_list)) {
+                    if(chunk != ssh2_list_first(&handle->packet_list))
                         break;
-                    }
-                    else {
+                    else
                         continue;
-                    }
                 }
             }
 
@@ -1613,28 +1586,23 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
             if(chunk->lefttosend) {
                 /* if the chunk still has data left to send, we should not wait
                    for an ACK for it yet */
-                if(bytes_in_buffer > 0) {
+                if(bytes_in_buffer > 0)
                     return bytes_in_buffer;
-                }
-                else {
-                    /* we should never reach this point */
+                else  /* we should never reach this point */
                     return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                     "sftp_read() internal error");
-                }
             }
 
             rc = sftp_packet_requirev(sftp, 2, read_responses,
                                       chunk->request_id, &data, &data_len, 9);
-            if(rc == LIBSSH2_ERROR_EAGAIN && bytes_in_buffer) {
+            if(rc == LIBSSH2_ERROR_EAGAIN && bytes_in_buffer)
                 /* do not return EAGAIN if we have already
                  * written data into the buffer */
                 return bytes_in_buffer;
-            }
 
             if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-                if(data_len > 0) {
+                if(data_len > 0)
                     SSH2_FREE(session, data);
-                }
                 return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                 "Response too small");
             }
@@ -1673,7 +1641,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                 }
 
             case SSH_FXP_DATA:
-                if(chunk->offset != filep->offset) {
+                if(chunk->offset != filep->offset)
                     /* This could happen if the server returns less bytes than
                        requested, which should not happen for normal files.
                        See:
@@ -1681,27 +1649,24 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                      */
                     return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                     "Read Packet At Unexpected Offset");
-                }
 
                 rc32 = ssh2_ntohu32(data + 5);
                 if(rc32 > (data_len - 9))
                     return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                     "SFTP Protocol badness");
 
-                if(rc32 > chunk->len) {
+                if(rc32 > chunk->len)
                     /* A chunk larger than we requested was returned to us.
                        This is a protocol violation and we do not know how to
                        deal with it. Bail out! */
                     return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                     "FXP_READ response too big");
-                }
 
-                if(rc32 != chunk->len) {
+                if(rc32 != chunk->len)
                     /* a short read does not imply end of file, but we must
                        adjust the offset_sent since it was advanced with a
                        full chunk->len before */
                     filep->offset_sent -= (chunk->len - rc32);
-                }
 
                 if((bytes_in_buffer + rc32) > buffer_size) {
                     /* figure out the overlap amount */
@@ -1738,12 +1703,10 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                 /* check if we have space left in the buffer
                  * and either continue to the next chunk or stop
                  */
-                if(bytes_in_buffer < buffer_size) {
+                if(bytes_in_buffer < buffer_size)
                     chunk = next;
-                }
-                else {
+                else
                     chunk = NULL;
-                }
 
                 break;
             default:
@@ -1929,9 +1892,8 @@ end:
                   "Reading entries from directory handle"));
         retcode = ssh2_channel_write(channel, 0, sftp->readdir_packet,
                                      packet_len);
-        if(retcode == LIBSSH2_ERROR_EAGAIN) {
+        if(retcode == LIBSSH2_ERROR_EAGAIN)
             return retcode;
-        }
         else if((ssize_t)packet_len != retcode) {
             SSH2_FREE(session, sftp->readdir_packet);
             sftp->readdir_packet = NULL;
@@ -1952,9 +1914,8 @@ end:
     if(retcode == LIBSSH2_ERROR_EAGAIN)
         return retcode;
     else if(retcode == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "Status message too short");
     }
@@ -2184,9 +2145,8 @@ static ssize_t sftp_write(LIBSSH2_SFTP_HANDLE *handle, const char *buffer,
             rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
                                      chunk->request_id, &data, &data_len, 9);
             if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-                if(data_len > 0) {
+                if(data_len > 0)
                     SSH2_FREE(session, data);
-                }
                 return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                                 "FXP write packet too short");
             }
@@ -2294,11 +2254,10 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
 
         ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Issuing fsync command"));
         s = packet = SSH2_ALLOC(session, packet_len);
-        if(!packet) {
+        if(!packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_EXTENDED "
                             "packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
         *(s++) = SSH_FXP_EXTENDED;
@@ -2309,9 +2268,8 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
 
         sftp->fsync_state = ssh2_NB_state_created;
     }
-    else {
+    else
         packet = sftp->fsync_packet;
-    }
 
     if(sftp->fsync_state == ssh2_NB_state_created) {
         rc = ssh2_channel_write(channel, 0, packet, packet_len);
@@ -2334,13 +2292,11 @@ static int sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
 
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
                              sftp->fsync_request_id, &data, &data_len, 9);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return (int)rc;
-    }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP fsync packet too short");
     }
@@ -2400,11 +2356,10 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
         ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Issuing %s command",
                   setstat ? "set-stat" : "stat"));
         s = sftp->fstat_packet = SSH2_ALLOC(session, packet_len);
-        if(!sftp->fstat_packet) {
+        if(!sftp->fstat_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for "
                             "FSTAT/FSETSTAT packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
         *(s++) = setstat ? SSH_FXP_FSETSTAT : SSH_FXP_FSTAT;
@@ -2412,18 +2367,16 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
         ssh2_store_u32(&s, sftp->fstat_request_id);
         ssh2_store_str(&s, handle->handle, handle->handle_len);
 
-        if(setstat) {
+        if(setstat)
             s += sftp_attr2bin(s, attrs);
-        }
 
         sftp->fstat_state = ssh2_NB_state_created;
     }
 
     if(sftp->fstat_state == ssh2_NB_state_created) {
         rc = ssh2_channel_write(channel, 0, sftp->fstat_packet, packet_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
-        }
         else if((ssize_t)packet_len != rc) {
             SSH2_FREE(session, sftp->fstat_packet);
             sftp->fstat_packet = NULL;
@@ -2443,9 +2396,8 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
     if(rc == LIBSSH2_ERROR_EAGAIN)
         return (int)rc;
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP fstat packet too short");
     }
@@ -2462,9 +2414,8 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
 
         retcode = ssh2_ntohu32(data + 5);
         SSH2_FREE(session, data);
-        if(retcode == LIBSSH2_FX_OK) {
+        if(retcode == LIBSSH2_FX_OK)
             return 0;
-        }
         else {
             sftp->last_errno = retcode;
             return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
@@ -2637,9 +2588,8 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
         ssize_t nwritten;
         nwritten =
             ssh2_channel_write(channel, 0, handle->close_packet, packet_len);
-        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+        if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
-        }
         else if((ssize_t)packet_len != nwritten) {
             SSH2_FREE(session, handle->close_packet);
             handle->close_packet = NULL;
@@ -2658,29 +2608,25 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
         rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
                                  handle->close_request_id, &data,
                                  &data_len, 9);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
-        }
         else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-            if(data_len > 0) {
+            if(data_len > 0)
                 SSH2_FREE(session, data);
-            }
             data = NULL;
             ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                      "Packet too short in FXP_CLOSE command");
         }
-        else if(rc) {
+        else if(rc)
             ssh2_err(session, rc, "Error waiting for status message");
-        }
 
         handle->close_state = ssh2_NB_state_sent1;
     }
 
-    if(!data) {
+    if(!data)
         /* if it reaches this point with data unset, something unwanted
            happened for which we should have set an error code */
         assert(rc);
-    }
     else {
         uint32_t retcode = ssh2_ntohu32(data + 5);
         SSH2_FREE(session, data);
@@ -2746,10 +2692,9 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + filename_len(4) */
     packet_len = 13;
 
-    if(packet_len + (uint32_t)filename_len < packet_len) {
+    if(packet_len + (uint32_t)filename_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large sftp_unlink");
-    }
     packet_len += (uint32_t)filename_len;
 
     if(sftp->unlink_state == ssh2_NB_state_idle) {
@@ -2757,10 +2702,9 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
 
         ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Unlinking %s", filename));
         s = sftp->unlink_packet = SSH2_ALLOC(session, packet_len);
-        if(!sftp->unlink_packet) {
+        if(!sftp->unlink_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_REMOVE packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
         *(s++) = SSH_FXP_REMOVE;
@@ -2774,9 +2718,8 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
         ssize_t nwritten;
         nwritten =
             ssh2_channel_write(channel, 0, sftp->unlink_packet, packet_len);
-        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+        if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
-        }
         else if((ssize_t)packet_len != nwritten) {
             SSH2_FREE(session, sftp->unlink_packet);
             sftp->unlink_packet = NULL;
@@ -2793,13 +2736,11 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
                              sftp->unlink_request_id, &data,
                              &data_len, 9);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP unlink packet too short");
     }
@@ -2813,9 +2754,8 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
     retcode = ssh2_ntohu32(data + 5);
     SSH2_FREE(session, data);
 
-    if(retcode == LIBSSH2_FX_OK) {
+    if(retcode == LIBSSH2_FX_OK)
         return 0;
-    }
     else {
         sftp->last_errno = retcode;
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
@@ -2858,33 +2798,29 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
        source_filename_len(4) + dest_filename_len(4) + flags(4){SFTP5+) */
     packet_len = 17 + (sftp->version >= 5 ? 4 : 0);
 
-    if(packet_len + (uint32_t)source_filename_len < packet_len) {
+    if(packet_len + (uint32_t)source_filename_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large sftp_rename");
-    }
     packet_len += (uint32_t)source_filename_len;
 
-    if(packet_len + (uint32_t)dest_filename_len < packet_len) {
+    if(packet_len + (uint32_t)dest_filename_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large (2) sftp_rename");
-    }
     packet_len += dest_filename_len;
 
     if(sftp->rename_state == ssh2_NB_state_idle) {
         sftp->last_errno = LIBSSH2_FX_OK;
 
-        if(sftp->version < 2) {
+        if(sftp->version < 2)
             return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                             "Server does not support RENAME");
-        }
 
         ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Renaming %s to %s",
                   source_filename, dest_filename));
         sftp->rename_s = sftp->rename_packet = SSH2_ALLOC(session, packet_len);
-        if(!sftp->rename_packet) {
+        if(!sftp->rename_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_RENAME packet");
-        }
 
         ssh2_store_u32(&sftp->rename_s, packet_len - 4);
         *(sftp->rename_s++) = SSH_FXP_RENAME;
@@ -2902,9 +2838,8 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
     if(sftp->rename_state == ssh2_NB_state_created) {
         rc = ssh2_channel_write(channel, 0, sftp->rename_packet,
                                 sftp->rename_s - sftp->rename_packet);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
-        }
         else if((ssize_t)packet_len != rc) {
             SSH2_FREE(session, sftp->rename_packet);
             sftp->rename_packet = NULL;
@@ -2920,13 +2855,11 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
 
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
                              sftp->rename_request_id, &data, &data_len, 9);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return (int)rc;
-    }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP rename packet too short");
     }
@@ -3000,10 +2933,9 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
     ssize_t rc;
     uint32_t retcode;
 
-    if(sftp->posix_rename_version != 1) {
+    if(sftp->posix_rename_version != 1)
         return ssh2_err(session, LIBSSH2_FX_OP_UNSUPPORTED,
                         "Server does not support posix-rename@openssh.com");
-    }
 
     /* 45 = packet_len(4) + packet_type(1) + request_id(4) +
        string_len(4) + strlen("posix-rename@openssh.com")(24) +
@@ -3012,27 +2944,24 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
 
     packet_len = 45;
 
-    if(packet_len + (uint32_t)source_filename_len < packet_len) {
+    if(packet_len + (uint32_t)source_filename_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large posix-rename@openssh.com");
-    }
     packet_len += (uint32_t)source_filename_len;
 
-    if(packet_len + (uint32_t)dest_filename_len < packet_len) {
+    if(packet_len + (uint32_t)dest_filename_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large (2) posix-rename@openssh.com");
-    }
     packet_len += (uint32_t)dest_filename_len;
 
     if(sftp->posix_rename_state == ssh2_NB_state_idle) {
         ssh2_deb((session, LIBSSH2_TRACE_SFTP,
                   "Issuing posix_rename command"));
         s = packet = SSH2_ALLOC(session, packet_len);
-        if(!packet) {
+        if(!packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_EXTENDED "
                             "packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
         *(s++) = SSH_FXP_EXTENDED;
@@ -3044,9 +2973,8 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
 
         sftp->posix_rename_state = ssh2_NB_state_created;
     }
-    else {
+    else
         packet = sftp->posix_rename_packet;
-    }
 
     if(sftp->posix_rename_state == ssh2_NB_state_created) {
         rc = ssh2_channel_write(channel, 0, packet, packet_len);
@@ -3070,13 +2998,11 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
                              sftp->posix_rename_request_id,
                              &data, &data_len, 9);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return (int)rc;
-    }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP posix_rename packet too short");
     }
@@ -3141,10 +3067,9 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
     /* 20 = strlen ("fstatvfs@openssh.com") */
     packet_len = 20 + 17;
 
-    if(packet_len + (uint32_t)handle->handle_len < packet_len) {
+    if(packet_len + (uint32_t)handle->handle_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large sftp_fstatvfs");
-    }
     packet_len += (uint32_t)handle->handle_len;
 
     if(sftp->fstatvfs_state == ssh2_NB_state_idle) {
@@ -3153,11 +3078,10 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
         ssh2_deb((session, LIBSSH2_TRACE_SFTP,
                   "Getting file system statistics"));
         s = packet = SSH2_ALLOC(session, packet_len);
-        if(!packet) {
+        if(!packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_EXTENDED "
                             "packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
         *(s++) = SSH_FXP_EXTENDED;
@@ -3168,9 +3092,8 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
 
         sftp->fstatvfs_state = ssh2_NB_state_created;
     }
-    else {
+    else
         packet = sftp->fstatvfs_packet;
-    }
 
     if(sftp->fstatvfs_state == ssh2_NB_state_created) {
         rc = ssh2_channel_write(channel, 0, packet, packet_len);
@@ -3193,13 +3116,11 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
 
     rc = sftp_packet_requirev(sftp, 2, responses, sftp->fstatvfs_request_id,
                               &data, &data_len, 9);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return (int)rc;
-    }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP fstatvfs packet too short");
     }
@@ -3286,10 +3207,9 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
     /* 19 = strlen ("statvfs@openssh.com") */
     packet_len = 19 + 17;
 
-    if(packet_len + (uint32_t)path_len < packet_len) {
+    if(packet_len + (uint32_t)path_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large sftp_statvfs");
-    }
     packet_len += (uint32_t)path_len;
 
     if(sftp->statvfs_state == ssh2_NB_state_idle) {
@@ -3298,11 +3218,10 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
         ssh2_deb((session, LIBSSH2_TRACE_SFTP,
                   "Getting file system statistics of %s", path));
         s = packet = SSH2_ALLOC(session, packet_len);
-        if(!packet) {
+        if(!packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_EXTENDED "
                             "packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
         *(s++) = SSH_FXP_EXTENDED;
@@ -3313,9 +3232,8 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
 
         sftp->statvfs_state = ssh2_NB_state_created;
     }
-    else {
+    else
         packet = sftp->statvfs_packet;
-    }
 
     if(sftp->statvfs_state == ssh2_NB_state_created) {
         rc = ssh2_channel_write(channel, 0, packet, packet_len);
@@ -3338,13 +3256,11 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
 
     rc = sftp_packet_requirev(sftp, 2, responses, sftp->statvfs_request_id,
                               &data, &data_len, 9);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return (int)rc;
-    }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP fstat packet too short");
     }
@@ -3435,10 +3351,9 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
     packet_len = 13 + sftp_attrsize(attrs.flags);
 
-    if(packet_len + (uint32_t)path_len < packet_len) {
+    if(packet_len + (uint32_t)path_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large sftp_mkdir");
-    }
     packet_len += (uint32_t)path_len;
 
     if(sftp->mkdir_state == ssh2_NB_state_idle) {
@@ -3448,10 +3363,9 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
                   "Creating directory %s with mode 0%lo",
                   path, (unsigned long)mode));
         s = packet = SSH2_ALLOC(session, packet_len);
-        if(!packet) {
+        if(!packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_MKDIR packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
         *(s++) = SSH_FXP_MKDIR;
@@ -3463,9 +3377,8 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
 
         sftp->mkdir_state = ssh2_NB_state_created;
     }
-    else {
+    else
         packet = sftp->mkdir_packet;
-    }
 
     if(sftp->mkdir_state == ssh2_NB_state_created) {
         ssize_t nwritten;
@@ -3487,13 +3400,11 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
 
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS, sftp->mkdir_request_id,
                              &data, &data_len, 9);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP mkdir packet too short");
     }
@@ -3547,10 +3458,9 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
     unsigned char *s, *data = NULL;
     int rc;
 
-    if(packet_len + (uint32_t)path_len < packet_len) {
+    if(packet_len + (uint32_t)path_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large sftp_rmdir");
-    }
     packet_len += (uint32_t)path_len;
 
     if(sftp->rmdir_state == ssh2_NB_state_idle) {
@@ -3559,10 +3469,9 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
         ssh2_deb((session, LIBSSH2_TRACE_SFTP, "Removing directory: %s",
                   path));
         s = sftp->rmdir_packet = SSH2_ALLOC(session, packet_len);
-        if(!sftp->rmdir_packet) {
+        if(!sftp->rmdir_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_RMDIR packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
         *(s++) = SSH_FXP_RMDIR;
@@ -3577,9 +3486,8 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
         ssize_t nwritten;
         nwritten = ssh2_channel_write(channel, 0, sftp->rmdir_packet,
                                       packet_len);
-        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+        if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
-        }
         else if((ssize_t)packet_len != nwritten) {
             SSH2_FREE(session, sftp->rmdir_packet);
             sftp->rmdir_packet = NULL;
@@ -3595,13 +3503,11 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
 
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS,
                              sftp->rmdir_request_id, &data, &data_len, 9);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
-    }
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP rmdir packet too short");
     }
@@ -3615,9 +3521,8 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
     retcode = ssh2_ntohu32(data + 5);
     SSH2_FREE(session, data);
 
-    if(retcode == LIBSSH2_FX_OK) {
+    if(retcode == LIBSSH2_FX_OK)
         return 0;
-    }
     else {
         sftp->last_errno = retcode;
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
@@ -3658,10 +3563,9 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
     };
     int rc;
 
-    if(packet_len + (uint32_t)path_len < packet_len) {
+    if(packet_len + (uint32_t)path_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large sftp_stat");
-    }
     packet_len += (uint32_t)path_len;
 
     if(sftp->stat_state == ssh2_NB_state_idle) {
@@ -3672,10 +3576,9 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
                   (stat_type == LIBSSH2_SFTP_LSTAT ? "LStatting" : "Statting"),
                   path));
         s = sftp->stat_packet = SSH2_ALLOC(session, packet_len);
-        if(!sftp->stat_packet) {
+        if(!sftp->stat_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for FXP_*STAT packet");
-        }
 
         ssh2_store_u32(&s, packet_len - 4);
 
@@ -3706,9 +3609,8 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
         ssize_t nwritten;
         nwritten = ssh2_channel_write(channel, 0,
                                       sftp->stat_packet, packet_len);
-        if(nwritten == LIBSSH2_ERROR_EAGAIN) {
+        if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
-        }
         else if((ssize_t)packet_len != nwritten) {
             SSH2_FREE(session, sftp->stat_packet);
             sftp->stat_packet = NULL;
@@ -3727,9 +3629,8 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
     if(rc == LIBSSH2_ERROR_EAGAIN)
         return rc;
     else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP stat packet too short");
     }
@@ -3808,38 +3709,32 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
     packet_len = 13;
 
-    if(packet_len + (uint32_t)path_len < packet_len) {
+    if(packet_len + (uint32_t)path_len < packet_len)
         return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                         "Input too large sftp_symlink");
-    }
     packet_len += (uint32_t)path_len;
 
     if(link_type == LIBSSH2_SFTP_SYMLINK) {
-
         if((target_len + 4) < target_len ||
-           (packet_len + 4 + target_len) < packet_len) {
+           (packet_len + 4 + target_len) < packet_len)
             return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                             "Input too large (2) sftp_symlink");
-        }
-        else {
+        else
             packet_len += (4 + target_len);
-        }
     }
 
     if(sftp->symlink_state == ssh2_NB_state_idle) {
         sftp->last_errno = LIBSSH2_FX_OK;
 
-        if(sftp->version < 3 && link_type != LIBSSH2_SFTP_REALPATH) {
+        if(sftp->version < 3 && link_type != LIBSSH2_SFTP_REALPATH)
             return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                             "Server does not support SYMLINK or READLINK");
-        }
 
         s = sftp->symlink_packet = SSH2_ALLOC(session, packet_len);
-        if(!sftp->symlink_packet) {
+        if(!sftp->symlink_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for "
                             "SYMLINK/READLINK/REALPATH packet");
-        }
 
         ssh2_deb((session, LIBSSH2_TRACE_SFTP, "%s %s on %s",
                   (link_type ==
@@ -3897,9 +3792,8 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
     if(retcode == LIBSSH2_ERROR_EAGAIN)
         return retcode;
     else if(retcode == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-        if(data_len > 0) {
+        if(data_len > 0)
             SSH2_FREE(session, data);
-        }
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "SFTP symlink packet too short");
     }
@@ -3959,9 +3853,8 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
             target[lk_len] = '\0';
             retcode = (int)lk_len;
         }
-        else {
+        else
             retcode = LIBSSH2_ERROR_BUFFER_TOO_SMALL;
-        }
     }
     else {
         SSH2_FREE(session, data);

--- a/src/transport.c
+++ b/src/transport.c
@@ -62,10 +62,8 @@ static void debugdump(LIBSSH2_SESSION *session,
     size_t used;
     static const char *hex_chars = "0123456789ABCDEF";
 
-    if(!(session->showmask & LIBSSH2_TRACE_TRANS)) {
-        /* not asked for, bail out */
-        return;
-    }
+    if(!(session->showmask & LIBSSH2_TRACE_TRANS))
+        return;  /* not asked for, bail out */
 
     used = snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
                     desc, (unsigned long)size);
@@ -188,9 +186,8 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
     memset(macbuf, '\0', sizeof(macbuf));
 
     if(!encrypted || (!CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET) &&
-                      !CRYPT_FLAG_R(session, INTEGRATED_MAC))) {
+                      !CRYPT_FLAG_R(session, INTEGRATED_MAC)))
         remote_mac = session->remote.mac;
-    }
 
     if(session->fullpacket_state == ssh2_NB_state_idle) {
         session->fullpacket_macstate = SSH2_MAC_CONFIRMED;
@@ -201,23 +198,19 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
             /* Calculate MAC hash */
             int etm = remote_mac->etm;
             size_t mac_len = remote_mac->mac_len;
-            if(etm) {
-                /* store hash here */
+            if(etm)  /* store hash here */
                 remote_mac->hash(session, macbuf,
                                  session->remote.seqno,
                                  p->payload, p->total_num - mac_len,
                                  NULL, 0,
                                  &session->remote.mac_abstract);
-            }
-            else {
-                /* store hash here */
+            else  /* store hash here */
                 remote_mac->hash(session, macbuf,
                                  session->remote.seqno,
                                  p->init, 5,
                                  p->payload,
                                  session->fullpacket_payload_len,
                                  &session->remote.mac_abstract);
-            }
 
             /* Compare the calculated hash with the MAC we read from
              * the network. The read one is at the end of the payload
@@ -244,16 +237,14 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
 
                 rc = decrypt(session, p->payload + 4,
                              first_block, blocksize, FIRST_BLOCK);
-                if(rc) {
+                if(rc)
                     return rc;
-                }
 
                 /* we need buffer for decrypt */
                 decrypt_size = p->total_num - mac_len - 4;
                 decrypt_buffer = SSH2_ALLOC(session, decrypt_size);
-                if(!decrypt_buffer) {
+                if(!decrypt_buffer)
                     return LIBSSH2_ERROR_ALLOC;
-                }
 
                 /* grab padding length and copy anything else
                    into target buffer */
@@ -264,9 +255,8 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
                     return LIBSSH2_ERROR_PROTO;
                 }
 
-                if(blocksize > 1) {
+                if(blocksize > 1)
                     memcpy(decrypt_buffer, first_block + 1, blocksize - 1);
-                }
 
                 /* decrypt all other blocks packet */
                 if(blocksize < decrypt_size) {
@@ -284,10 +274,9 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
                 p->payload = decrypt_buffer;
             }
         }
-        else if(encrypted && CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
+        else if(encrypted && CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET))
             /* etm trim off padding byte from payload */
             memmove(p->payload, &p->payload[1], p->packet_length - 1);
-        }
 
         session->remote.seqno++;
 
@@ -347,9 +336,8 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
     session->fullpacket_state = ssh2_NB_state_idle;
 
     if(session->kex_strict &&
-       session->fullpacket_packet_type == SSH_MSG_NEWKEYS) {
+       session->fullpacket_packet_type == SSH_MSG_NEWKEYS)
         session->remote.seqno = 0;
-    }
 
     return session->fullpacket_packet_type;
 }
@@ -428,13 +416,11 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
 
     do {
         int etm;
-        if(session->socket_state == SSH2_SOCKET_DISCONNECTED) {
+        if(session->socket_state == SSH2_SOCKET_DISCONNECTED)
             return LIBSSH2_ERROR_SOCKET_DISCONNECT;
-        }
 
-        if(session->state & SSH2_STATE_NEWKEYS) {
+        if(session->state & SSH2_STATE_NEWKEYS)
             blocksize = session->remote.crypt->blocksize;
-        }
         else {
             encrypted = 0;      /* not encrypted */
             blocksize = 5;      /* not strictly true, but we can use 5 here to
@@ -442,12 +428,10 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
         }
 
         if(encrypted) {
-            if(CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
+            if(CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET))
                 auth_len = session->remote.crypt->auth_len;
-            }
-            else {
+            else
                 remote_mac = session->remote.mac;
-            }
         }
 
         etm = encrypted && remote_mac ? remote_mac->etm : 0;
@@ -479,10 +463,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 p->readidx = 0;
                 p->writeidx = remainbuf;
             }
-            else {
-                /* nothing to move, zero the indexes */
+            else /* nothing to move, zero the indexes */
                 p->readidx = p->writeidx = 0;
-            }
 
             /* now read a big chunk from the network into the temp buffer */
             nread = SSH2_RECV(session, &p->buf[remainbuf],
@@ -577,9 +559,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                     /* first decrypted block */
                     rc = decrypt(session, &p->buf[p->readidx],
                                  block, blocksize, FIRST_BLOCK);
-                    if(rc != LIBSSH2_ERROR_NONE) {
+                    if(rc != LIBSSH2_ERROR_NONE)
                         return rc;
-                    }
                     /* Save the first 5 bytes of the decrypted package, to be
                        used in the hash calculation later down.
                        This is ignored in the INTEGRATED_MAC case. */
@@ -601,12 +582,10 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
             }
 
             if(!encrypted || !CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
-                if(p->packet_length < 1) {
+                if(p->packet_length < 1)
                     return LIBSSH2_ERROR_DECRYPT;
-                }
-                else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD) {
+                else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD)
                     return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
-                }
 
                 if(etm) {
                     /* do not know what padding is until we decrypt the full
@@ -624,9 +603,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                        immediately following) until after the entire packet is
                        authenticated, so this is safe. */
                     p->padding_length = block[4];
-                    if(p->padding_length > p->packet_length - 1) {
+                    if(p->padding_length > p->packet_length - 1)
                         return LIBSSH2_ERROR_DECRYPT;
-                    }
 
                     /* total_num is the number of bytes following the initial
                        (5 bytes) packet length and padding length fields */
@@ -645,12 +623,10 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 total_num = 4;
 
                 p->packet_length = ssh2_ntohu32(block);
-                if(p->packet_length < 1) {
+                if(p->packet_length < 1)
                     return LIBSSH2_ERROR_DECRYPT;
-                }
-                else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD) {
+                else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD)
                     return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
-                }
 
                 /* total_num may include size field, however due to existing
                  * logic it needs to be removed after the entire packet is read
@@ -672,16 +648,14 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
              * or less (including length, padding length, payload,
              * padding, and MAC.)."
              */
-            if(total_num > LIBSSH2_PACKET_MAXPAYLOAD || total_num == 0) {
+            if(total_num > LIBSSH2_PACKET_MAXPAYLOAD || total_num == 0)
                 return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
-            }
 
             /* Get a packet handle put data into. We get one to
                hold all data, including padding and MAC. */
             p->payload = SSH2_ALLOC(session, total_num);
-            if(!p->payload) {
+            if(!p->payload)
                 return LIBSSH2_ERROR_ALLOC;
-            }
             p->total_num = total_num;
             /* init write pointer to start of payload buffer */
             p->wptr = p->payload;
@@ -725,11 +699,10 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
            package */
         remainpack = p->total_num - p->data_num;
 
-        if(numbytes > remainpack) {
+        if(numbytes > remainpack)
             /* if we have more data in the buffer than what is going into this
                particular packet, we limit this round to this packet only */
             numbytes = remainpack;
-        }
 
         if(encrypted && CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
             if(numbytes < remainpack) {
@@ -788,10 +761,9 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 firstlast = MIDDLE_BLOCK;
             }
         }
-        else {
-            /* unencrypted data should not be decrypted at all */
+        else /* unencrypted data should not be decrypted at all */
             numdecrypt = 0;
-        }
+
         assert(numdecrypt >= 0);
 
         /* if there are bytes to decrypt, do that */
@@ -823,9 +795,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                    decrypted */
                 p->padding_length = p->wptr[0];
 
-                if(p->padding_length > p->packet_length - 1) {
+                if(p->padding_length > p->packet_length - 1)
                     return LIBSSH2_ERROR_DECRYPT;
-                }
             }
             else {
                 rc = decrypt(session, &p->buf[p->readidx], p->wptr, numdecrypt,
@@ -852,9 +823,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
            copy them as-is to the target buffer */
         if(numbytes > 0) {
 
-            if((size_t)numbytes <= (p->total_num - (p->wptr - p->payload))) {
+            if((size_t)numbytes <= (p->total_num - (p->wptr - p->payload)))
                 memcpy(p->wptr, &p->buf[p->readidx], numbytes);
-            }
             else {
                 if(p->payload)
                     SSH2_FREE(session, p->payload);
@@ -1051,12 +1021,10 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
     encrypted = (session->state & SSH2_STATE_NEWKEYS) ? 1 : 0;
 
     if(encrypted && session->local.crypt &&
-       CRYPT_FLAG_L(session, REQUIRES_FULL_PACKET)) {
+       CRYPT_FLAG_L(session, REQUIRES_FULL_PACKET))
         auth_len = session->local.crypt->auth_len;
-    }
-    else {
+    else
         local_mac = session->local.mac;
-    }
 
     etm = encrypted && local_mac ? local_mac->etm : 0;
 
@@ -1136,9 +1104,8 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
     /* if the padding becomes too small we add another blocksize worth
        of it (taken from the original libssh2 where it did not have any
        real explanation) */
-    if(padding_length < 4) {
+    if(padding_length < 4)
         padding_length += blocksize;
-    }
 #ifdef LIBSSH2_RANDOM_PADDING
     /* FIXME: we can add padding here, but that also makes the packets
        bigger etc */
@@ -1165,10 +1132,9 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
     p->outbuf[4] = (unsigned char)padding_length;
 
     /* fill the padding area with random junk */
-    if(ssh2_random(p->outbuf + 5 + data_len, padding_length)) {
+    if(ssh2_random(p->outbuf + 5 + data_len, padding_length))
         return ssh2_err(session, LIBSSH2_ERROR_RANDGEN,
                         "Unable to get random bytes for packet padding");
-    }
 
     if(encrypted) {
         size_t i;
@@ -1194,9 +1160,8 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
                                            p->outbuf,
                                            packet_length,
                                            &session->local.crypt_abstract,
-                                           0)) {
+                                           0))
                 return LIBSSH2_ERROR_ENCRYPT;
-            }
         }
         else {
             /* Encrypt the whole packet data, one block size at a time.
@@ -1269,9 +1234,8 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
 
     session->local.seqno++;
 
-    if(session->kex_strict && data[0] == SSH_MSG_NEWKEYS) {
+    if(session->kex_strict && data[0] == SSH_MSG_NEWKEYS)
         session->local.seqno = 0;
-    }
 
     ret = SSH2_SEND(session, p->outbuf, total_length,
                     SSH2_SOCKET_SEND_FLAGS(session));

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -99,9 +99,8 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
 
         session->userauth_list_data_len = username_len + 27;
 
-        if(session->userauth_list_data) {
+        if(session->userauth_list_data)
             SSH2_FREE(session, session->userauth_list_data);
-        }
 
         s = session->userauth_list_data =
             SSH2_ALLOC(session, session->userauth_list_data_len);
@@ -176,9 +175,8 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
                 return NULL;
             }
 
-            if(session->userauth_banner) {
+            if(session->userauth_banner)
                 SSH2_FREE(session, session->userauth_banner);
-            }
 
             session->userauth_banner = SSH2_ALLOC(session, banner_len + 1);
             if(!session->userauth_banner) {
@@ -275,10 +273,9 @@ int libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
     if(!session)
         return LIBSSH2_ERROR_MISSING_USERAUTH_BANNER;
 
-    if(!session->userauth_banner) {
+    if(!session->userauth_banner)
         return ssh2_err(session, LIBSSH2_ERROR_MISSING_USERAUTH_BANNER,
                         "Missing userauth banner");
-    }
 
     if(banner)
         *banner = session->userauth_banner;
@@ -323,10 +320,9 @@ static int userauth_password(LIBSSH2_SESSION *session,
          * 40 = packet_type(1) + username_len(4) + service_len(4) +
          * service(14)"ssh-connection" + method_len(4) + method(8)"password" +
          * chgpwdbool(1) + password_len(4) */
-        if(username_len > UINT32_MAX - 40) {
+        if(username_len > UINT32_MAX - 40)
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                             "username_len out of bounds");
-        }
 
         session->userauth_pswd_data_len = username_len + 40;
 
@@ -337,11 +333,10 @@ static int userauth_password(LIBSSH2_SESSION *session,
            struct */
         s = session->userauth_pswd_data =
             SSH2_ALLOC(session, session->userauth_pswd_data_len);
-        if(!session->userauth_pswd_data) {
+        if(!session->userauth_pswd_data)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for "
                             "userauth-password request");
-        }
 
         *(s++) = SSH_MSG_USERAUTH_REQUEST;
         ssh2_store_str(&s, username, username_len);
@@ -361,10 +356,9 @@ static int userauth_password(LIBSSH2_SESSION *session,
         rc = ssh2_transport_send(session, session->userauth_pswd_data,
                                  session->userauth_pswd_data_len,
                                  password, password_len);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
                             "Would block writing password request");
-        }
 
         /* now free the sent packet */
         SSH2_FREE(session, session->userauth_pswd_data);
@@ -456,12 +450,11 @@ password_response:
                                          &session->userauth_pswd_newpw,
                                          &session->userauth_pswd_newpw_len,
                                          &session->abstract);
-                        if(!session->userauth_pswd_newpw) {
+                        if(!session->userauth_pswd_newpw)
                             return ssh2_err(session,
                                             LIBSSH2_ERROR_PASSWORD_EXPIRED,
                                             "Password expired, and "
                                             "callback failed");
-                        }
 
                         /* basic data_len + newpw_len(4) */
                         if(username_len <= UINT32_MAX - password_len - 44) {
@@ -506,10 +499,9 @@ password_response:
                                             (const unsigned char *)
                                             session->userauth_pswd_newpw,
                                             session->userauth_pswd_newpw_len);
-                        if(rc == LIBSSH2_ERROR_EAGAIN) {
+                        if(rc == LIBSSH2_ERROR_EAGAIN)
                             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
                                             "Would block waiting");
-                        }
 
                         /* free the allocated packets again */
                         SSH2_FREE(session, session->userauth_pswd_data);
@@ -517,11 +509,10 @@ password_response:
                         SSH2_FREE(session, session->userauth_pswd_newpw);
                         session->userauth_pswd_newpw = NULL;
 
-                        if(rc) {
+                        if(rc)
                             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                                             "Unable to send userauth "
                                             "password-change request");
-                        }
 
                         /*
                          * Ugliest use of goto ever.  Blame it on the
@@ -579,16 +570,14 @@ static int memory_read_publickey(LIBSSH2_SESSION *session,
     size_t pubkey_len = pubkeyfiledata_len;
     size_t tmp_len;
 
-    if(pubkeyfiledata_len <= 1) {
+    if(pubkeyfiledata_len <= 1)
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Invalid data in public key file");
-    }
 
     pubkey = SSH2_ALLOC(session, pubkeyfiledata_len);
-    if(!pubkey) {
+    if(!pubkey)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Unable to allocate memory for public key data");
-    }
 
     memcpy(pubkey, pubkeyfiledata, pubkeyfiledata_len);
 
@@ -614,10 +603,9 @@ static int memory_read_publickey(LIBSSH2_SESSION *session,
     sp1++;
 
     sp2 = memchr(sp1, ' ', pubkey_len - (sp1 - pubkey));
-    if(!sp2) {
+    if(!sp2)
         /* Assume that the id string is missing, but that it is okay */
         sp2 = pubkey + pubkey_len;
-    }
 
     if(ssh2_base64_decode(session, (char **)&tmp, &tmp_len, (const char *)sp1,
                           sp2 - sp1)) {
@@ -664,13 +652,13 @@ static int file_read_publickey(LIBSSH2_SESSION *session,
               pubkeyfile));
     /* Read Public Key */
     fd = fopen(pubkeyfile, "rb");
-    if(!fd) {
+    if(!fd)
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Unable to open public key file");
-    }
-    while(!feof(fd) && fread(&c, 1, 1, fd) == 1 && c != '\r' && c != '\n') {
+
+    while(!feof(fd) && fread(&c, 1, 1, fd) == 1 && c != '\r' && c != '\n')
         pubkey_len++;
-    }
+
     fseek(fd, 0L, SEEK_SET);
 
     if(pubkey_len <= 1) {
@@ -695,9 +683,8 @@ static int file_read_publickey(LIBSSH2_SESSION *session,
     /*
      * Remove trailing whitespace
      */
-    while(pubkey_len && isspace(pubkey[pubkey_len - 1])) {
+    while(pubkey_len && isspace(pubkey[pubkey_len - 1]))
         pubkey_len--;
-    }
 
     if(!pubkey_len) {
         SSH2_FREE(session, pubkey);
@@ -716,10 +703,9 @@ static int file_read_publickey(LIBSSH2_SESSION *session,
 
     sp_len = sp1 > pubkey ? (sp1 - pubkey) : 0;
     sp2 = memchr(sp1, ' ', pubkey_len - sp_len);
-    if(!sp2) {
+    if(!sp2)
         /* Assume that the id string is missing, but that it is okay */
         sp2 = pubkey + pubkey_len;
-    }
 
     if(ssh2_base64_decode(session, (char **)&tmp, &tmp_len, (const char *)sp1,
                           sp2 - sp1)) {
@@ -763,10 +749,9 @@ static int memory_read_privatekey(LIBSSH2_SESSION *session,
         }
         hostkey_methods_avail++;
     }
-    if(!*hostkey_method) {
+    if(!*hostkey_method)
         return ssh2_err(session, LIBSSH2_ERROR_METHOD_NONE,
                         "No handler for specified private key");
-    }
 
     if((*hostkey_method)->initPEMFromMemory(session, privkeyfiledata,
                                             privkeyfiledata_len,
@@ -806,10 +791,9 @@ static int file_read_privatekey(LIBSSH2_SESSION *session,
         }
         hostkey_methods_avail++;
     }
-    if(!*hostkey_method) {
+    if(!*hostkey_method)
         return ssh2_err(session, LIBSSH2_ERROR_METHOD_NONE,
                         "No handler for specified private key");
-    }
 
     if((*hostkey_method)->initPEM(session, privkeyfile,
                                   (const unsigned char *)passphrase,
@@ -861,15 +845,13 @@ static int sign_frommemory(LIBSSH2_SESSION *session,
 
     if(privkeyobj->signv(session, sig, sig_len, 1, &datavec,
                          &hostkey_abstract)) {
-        if(privkeyobj->dtor) {
+        if(privkeyobj->dtor)
             privkeyobj->dtor(session, &hostkey_abstract);
-        }
         return -1;
     }
 
-    if(privkeyobj->dtor) {
+    if(privkeyobj->dtor)
         privkeyobj->dtor(session, &hostkey_abstract);
-    }
     return 0;
 }
 
@@ -901,15 +883,13 @@ static int sign_fromfile(LIBSSH2_SESSION *session,
 
     if(privkeyobj->signv(session, sig, sig_len, 1, &datavec,
                          &hostkey_abstract)) {
-        if(privkeyobj->dtor) {
+        if(privkeyobj->dtor)
             privkeyobj->dtor(session, &hostkey_abstract);
-        }
         return -1;
     }
 
-    if(privkeyobj->dtor) {
+    if(privkeyobj->dtor)
         privkeyobj->dtor(session, &hostkey_abstract);
-    }
     return 0;
 }
 
@@ -922,9 +902,8 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
     LIBSSH2_PRIVKEY_SK *sk_info = (LIBSSH2_PRIVKEY_SK *)(*abstract);
     LIBSSH2_SK_SIG_INFO sig_info = { 0 };
 
-    if(sk_info->handle_len <= 0) {
+    if(sk_info->handle_len <= 0)
         return LIBSSH2_ERROR_DECRYPT;
-    }
 
     rc = sk_info->sign_callback(session,
                                 &sig_info,
@@ -1003,9 +982,8 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
 
         SSH2_FREE(session, sig_info.sig_r);
 
-        if(sig_info.sig_s) {
+        if(sig_info.sig_s)
             SSH2_FREE(session, sig_info.sig_s);
-        }
     }
     else {
         ssh2_deb((session, LIBSSH2_ERROR_DECRYPT,
@@ -1147,15 +1125,13 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
             session->userauth_host_method = NULL;
             SSH2_FREE(session, session->userauth_host_packet);
             session->userauth_host_packet = NULL;
-            if(privkeyobj->dtor) {
+            if(privkeyobj->dtor)
                 privkeyobj->dtor(session, &abstract);
-            }
             return -1;
         }
 
-        if(privkeyobj && privkeyobj->dtor) {
+        if(privkeyobj && privkeyobj->dtor)
             privkeyobj->dtor(session, &abstract);
-        }
 
         if(sig_len > pubkeydata_len) {
             unsigned char *newpacket;
@@ -1203,9 +1179,8 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                  session->userauth_host_s -
                                  session->userauth_host_packet,
                                  NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
-        }
         else if(rc) {
             SSH2_FREE(session, session->userauth_host_packet);
             session->userauth_host_packet = NULL;
@@ -1231,15 +1206,13 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                   &data_len, 0, NULL, 0,
                                   &session->
                                   userauth_host_packet_requirev_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
-        }
 
         session->userauth_host_state = ssh2_NB_state_idle;
-        if(rc || data_len < 1) {
+        if(rc || data_len < 1)
             return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                             "Auth failed");
-        }
 
         if(session->userauth_host_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
             ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1289,30 +1262,26 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
 size_t plain_method(char *method, size_t method_len)
 {
     if(!strncmp("ssh-rsa-cert-v01@openssh.com",
-                method, method_len)) {
+                method, method_len))
         return 7;
-    }
 
     if(!strncmp("rsa-sha2-256-cert-v01@openssh.com",
                 method, method_len) ||
        !strncmp("rsa-sha2-512-cert-v01@openssh.com",
-                method, method_len)) {
+                method, method_len))
         return 12;
-    }
 
     if(!strncmp("ecdsa-sha2-nistp256-cert-v01@openssh.com",
                 method, method_len) ||
        !strncmp("ecdsa-sha2-nistp384-cert-v01@openssh.com",
                 method, method_len) ||
        !strncmp("ecdsa-sha2-nistp521-cert-v01@openssh.com",
-                method, method_len)) {
+                method, method_len))
         return 19;
-    }
 
     if(!strncmp("ssh-ed25519-cert-v01@openssh.com",
-                method, method_len)) {
+                method, method_len))
         return 11;
-    }
 
     if(!strncmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com",
                 method, method_len)) {
@@ -1359,9 +1328,9 @@ static int is_version_less_than_78(const char *version)
         return 0; /* Not a valid number */
 
     if((major >= 1 && major <= 6) ||
-       (major == 7 && minor >= 0 && minor <= 7)) {
+       (major == 7 && minor >= 0 && minor <= 7))
         return 1; /* Version is in the specified range */
-    }
+
     return 0;
 }
 
@@ -1400,10 +1369,9 @@ static int key_sign_algorithm(LIBSSH2_SESSION *session,
     const char *supported_algs =
         ssh2_supported_key_sign_algs(session, *key_method, *key_method_len);
 
-    if(!supported_algs || !session->server_sign_algorithms) {
+    if(!supported_algs || !session->server_sign_algorithms)
         /* no upgrading key algorithm supported, do nothing */
         return LIBSSH2_ERROR_NONE;
-    }
 
     /* Set "SSH_BUG_SIGTYPE" flag when the remote server version is OpenSSH 7.7
        or lower and when the RSA key in question is a certificate to ignore
@@ -1594,11 +1562,11 @@ retry_auth:
 
             session->userauth_pblc_method =
                 SSH2_ALLOC(session, session->userauth_pblc_method_len);
-            if(!session->userauth_pblc_method) {
+            if(!session->userauth_pblc_method)
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Unable to allocate memory "
                                 "for public key data");
-            }
+
             memcpy(session->userauth_pblc_method, pubkeydata + 4,
                    session->userauth_pblc_method_len);
         }
@@ -1616,11 +1584,10 @@ retry_auth:
         }
 
         if(session->userauth_pblc_method_len &&
-           session->userauth_pblc_method) {
+           session->userauth_pblc_method)
             ssh2_deb((session, LIBSSH2_TRACE_KEX, "Signing using %.*s",
                       (int)session->userauth_pblc_method_len,
                       session->userauth_pblc_method));
-        }
 
         /*
          * 45 = packet_type(1) + username_len(4) + servicename_len(4) +
@@ -1696,9 +1663,8 @@ retry_auth:
                                   NULL, 0,
                                   &session->
                                   userauth_pblc_packet_requirev_state);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
-        }
         else if(rc || session->userauth_pblc_data_len < 1) {
             SSH2_FREE(session, session->userauth_pblc_packet);
             session->userauth_pblc_packet = NULL;
@@ -1756,11 +1722,10 @@ retry_auth:
         s = buf = SSH2_ALLOC(session,
                              4 + session->session_id_len +
                              session->userauth_pblc_packet_len);
-        if(!buf) {
+        if(!buf)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for "
                             "userauth-publickey signed data");
-        }
 
         ssh2_store_str(&s, (const char *)session->session_id,
                        session->session_id_len);
@@ -1771,9 +1736,8 @@ retry_auth:
 
         rc = sign_callback(session, &sig, &sig_len, buf, s - buf, abstract);
         SSH2_FREE(session, buf);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
-        }
         else if(rc == LIBSSH2_ERROR_ALGO_UNSUPPORTED && auth_attempts == 1) {
             /* try again with the default key algo */
             SSH2_FREE(session, session->userauth_pblc_method);
@@ -1794,10 +1758,9 @@ retry_auth:
                             "Callback returned error");
         }
 
-        if(!sig) {
+        if(!sig)
             return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                             "Callback did not return signature");
-        }
 
         /*
          * If this function was restarted, pubkeydata_len might still be 0
@@ -1872,9 +1835,8 @@ retry_auth:
                                  session->userauth_pblc_s -
                                  session->userauth_pblc_packet,
                                  NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
-        }
         else if(rc) {
             SSH2_FREE(session, session->userauth_pblc_packet);
             session->userauth_pblc_packet = NULL;
@@ -1895,10 +1857,9 @@ retry_auth:
                               &session->userauth_pblc_data,
                               &session->userauth_pblc_data_len, 0, NULL, 0,
                               &session->userauth_pblc_packet_requirev_state);
-    if(rc == LIBSSH2_ERROR_EAGAIN) {
+    if(rc == LIBSSH2_ERROR_EAGAIN)
         return ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
                         "Would block waiting for publickey USERAUTH response");
-    }
     else if(rc || session->userauth_pblc_data_len < 1) {
         session->userauth_pblc_state = ssh2_NB_state_idle;
         return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
@@ -2140,9 +2101,8 @@ static int userauth_keyboard_interactive(
         memset(&session->userauth_kybd_packet_requirev_state, 0,
                sizeof(session->userauth_kybd_packet_requirev_state));
 
-        if(username_len > MAX_INPUT_LEN) {
+        if(username_len > MAX_INPUT_LEN)
             return ssh2_err(session, LIBSSH2_ERROR_INVAL, "Username too long");
-        }
 
         session->userauth_kybd_packet_len =
             1                   /* byte    SSH_MSG_USERAUTH_REQUEST */
@@ -2157,11 +2117,10 @@ static int userauth_keyboard_interactive(
 
         session->userauth_kybd_data = s =
             SSH2_ALLOC(session, session->userauth_kybd_packet_len);
-        if(!s) {
+        if(!s)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                             "Unable to allocate memory for "
                             "keyboard-interactive authentication");
-        }
 
         *s++ = SSH_MSG_USERAUTH_REQUEST;
 
@@ -2189,9 +2148,8 @@ static int userauth_keyboard_interactive(
     if(session->userauth_kybd_state == ssh2_NB_state_created) {
         rc = ssh2_transport_send(session, session->userauth_kybd_data,
                                  session->userauth_kybd_packet_len, NULL, 0);
-        if(rc == LIBSSH2_ERROR_EAGAIN) {
+        if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
-        }
         else if(rc) {
             SSH2_FREE(session, session->userauth_kybd_data);
             session->userauth_kybd_data = NULL;
@@ -2213,9 +2171,8 @@ static int userauth_keyboard_interactive(
                                       0, NULL, 0,
                                       &session->
                                       userauth_kybd_packet_requirev_state);
-            if(rc == LIBSSH2_ERROR_EAGAIN) {
+            if(rc == LIBSSH2_ERROR_EAGAIN)
                 return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
-            }
             else if(rc || session->userauth_kybd_data_len < 1) {
                 session->userauth_kybd_state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
@@ -2244,10 +2201,8 @@ static int userauth_keyboard_interactive(
             }
 
             /* server requested PAM-like conversation */
-            if(userauth_keyboard_interactive_decode_info_request(session)
-               < 0) {
+            if(userauth_keyboard_interactive_decode_info_request(session) < 0)
                 goto cleanup;
-            }
 
             response_callback((const char *)session->userauth_kybd_auth_name,
                               (int)session->userauth_kybd_auth_name_len,
@@ -2300,10 +2255,9 @@ static int userauth_keyboard_interactive(
             s++;
             ssh2_store_u32(&s, session->userauth_kybd_num_prompts);
 
-            for(i = 0; i < session->userauth_kybd_num_prompts; i++) {
+            for(i = 0; i < session->userauth_kybd_num_prompts; i++)
                 ssh2_store_str(&s, session->userauth_kybd_responses[i].text,
                                session->userauth_kybd_responses[i].length);
-            }
 
             session->userauth_kybd_state = ssh2_NB_state_sent1;
         }
@@ -2430,10 +2384,9 @@ int libssh2_userauth_publickey_sk(
                                      &(sk_info.key_handle),
                                      &(sk_info.handle_len),
                                      privatekeydata, privatekeydata_len,
-                                     passphrase)) {
+                                     passphrase))
             return ssh2_err(session, LIBSSH2_ERROR_FILE,
                             "Unable to extract public key from private key.");
-        }
         else if(publickeydata_len == 0 || !publickeydata) {
             session->userauth_pblc_method = tmp_method;
             session->userauth_pblc_method_len = tmp_method_len;
@@ -2445,9 +2398,8 @@ int libssh2_userauth_publickey_sk(
             const char *ecdsa = "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
             const char *ed25519 = "sk-ssh-ed25519-cert-v01@openssh.com";
 
-            if(tmp_method) {
+            if(tmp_method)
                 SSH2_FREE(session, tmp_method);
-            }
 
             if(!strncmp((const char *)publickeydata, ecdsa, strlen(ecdsa))) {
                 session->userauth_pblc_method_len = strlen(ecdsa);
@@ -2485,19 +2437,17 @@ int libssh2_userauth_publickey_sk(
                                      pubkeydata, pubkeydata_len,
                                      libssh2_sign_sk, &sign_abstract);
 
-        while(rc == LIBSSH2_ERROR_EAGAIN) {
+        while(rc == LIBSSH2_ERROR_EAGAIN)
             rc = ssh2_userauth_publickey(session, username, username_len,
                                          pubkeydata, pubkeydata_len,
                                          libssh2_sign_sk, &sign_abstract);
-        }
     }
 
     if(tmp_publickeydata)
         SSH2_FREE(session, tmp_publickeydata);
 
-    if(sk_info.application) {
+    if(sk_info.application)
         SSH2_FREE(session, SSH2_UNCONST(sk_info.application));
-    }
 
     return rc;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -120,9 +120,9 @@ static void wcng_safe_free(void *buf, size_t len)
 static void wcng_memcpy_with_be_padding(unsigned char *dest, ULONG dest_len,
                                         unsigned char *src, ULONG src_len)
 {
-    if(dest_len > src_len) {
+    if(dest_len > src_len)
         memset(dest, 0, dest_len - src_len);
-    }
+
     memcpy((dest + dest_len) - src_len, src, src_len);
 }
 
@@ -167,9 +167,8 @@ static int wcng_bn_resize(ssh2_bn *bn, ULONG length)
     if(length == bn->length)
         return 0;
 
-    if(bn->bignum && bn->length > 0 && length < bn->length) {
+    if(bn->bignum && bn->length > 0 && length < bn->length)
         ssh2_explicit_zero(bn->bignum + length, bn->length - length);
-    }
 
     bignum = realloc(bn->bignum, length);
     if(!bignum)
@@ -273,9 +272,8 @@ static int wcng_bn_mod_exp(ssh2_bn *r, ssh2_bn *a, ssh2_bn *p, ssh2_bn *m)
 
                     wcng_safe_free(bignum, length);
 
-                    if(BCRYPT_SUCCESS(ret)) {
+                    if(BCRYPT_SUCCESS(ret))
                         wcng_bn_resize(r, offset);
-                    }
                 }
                 else
                     ret = (NTSTATUS)STATUS_NO_MEMORY;
@@ -364,9 +362,8 @@ int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin)
             bn->bignum = bignum;
             bn->length = length;
         }
-        else {
+        else
             return -1;
-        }
     }
 
     return 0;
@@ -477,84 +474,69 @@ void ssh2_crypto_init(void)
 
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgRNG,
                                       BCRYPT_RNG_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgRNG = NULL;
-    }
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHashMD5,
                                       BCRYPT_MD5_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHashMD5 = NULL;
-    }
 #endif
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHashSHA1,
                                       BCRYPT_SHA1_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHashSHA1 = NULL;
-    }
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHashSHA256,
                                       BCRYPT_SHA256_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHashSHA256 = NULL;
-    }
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHashSHA384,
                                       BCRYPT_SHA384_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHashSHA384 = NULL;
-    }
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHashSHA512,
                                       BCRYPT_SHA512_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHashSHA512 = NULL;
-    }
-
 #if LIBSSH2_MD5
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHmacMD5,
                                       BCRYPT_MD5_ALGORITHM, NULL,
                                       BCRYPT_ALG_HANDLE_HMAC_FLAG);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHmacMD5 = NULL;
-    }
 #endif
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHmacSHA1,
                                       BCRYPT_SHA1_ALGORITHM, NULL,
                                       BCRYPT_ALG_HANDLE_HMAC_FLAG);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHmacSHA1 = NULL;
-    }
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHmacSHA256,
                                       BCRYPT_SHA256_ALGORITHM, NULL,
                                       BCRYPT_ALG_HANDLE_HMAC_FLAG);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHmacSHA256 = NULL;
-    }
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHmacSHA384,
                                       BCRYPT_SHA384_ALGORITHM, NULL,
                                       BCRYPT_ALG_HANDLE_HMAC_FLAG);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHmacSHA384 = NULL;
-    }
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgHmacSHA512,
                                       BCRYPT_SHA512_ALGORITHM, NULL,
                                       BCRYPT_ALG_HANDLE_HMAC_FLAG);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgHmacSHA512 = NULL;
-    }
 
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgRSA,
                                       BCRYPT_RSA_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgRSA = NULL;
-    }
 #if LIBSSH2_DSA
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgDSA,
                                       BCRYPT_DSA_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgDSA = NULL;
-    }
 #endif
-
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgAES_CBC,
                                       BCRYPT_AES_ALGORITHM, NULL, 0);
     if(BCRYPT_SUCCESS(ret)) {
@@ -564,9 +546,8 @@ void ssh2_crypto_init(void)
                                 sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
         if(!BCRYPT_SUCCESS(ret)) {
             ret = BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgAES_CBC, 0);
-            if(BCRYPT_SUCCESS(ret)) {
+            if(BCRYPT_SUCCESS(ret))
                 ssh2_wcng.hAlgAES_CBC = NULL;
-            }
         }
     }
 
@@ -579,9 +560,8 @@ void ssh2_crypto_init(void)
                                 sizeof(BCRYPT_CHAIN_MODE_ECB), 0);
         if(!BCRYPT_SUCCESS(ret)) {
             ret = BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgAES_ECB, 0);
-            if(BCRYPT_SUCCESS(ret)) {
+            if(BCRYPT_SUCCESS(ret))
                 ssh2_wcng.hAlgAES_ECB = NULL;
-            }
         }
     }
 #if LIBSSH2_RC4
@@ -594,9 +574,8 @@ void ssh2_crypto_init(void)
                                 sizeof(BCRYPT_CHAIN_MODE_NA), 0);
         if(!BCRYPT_SUCCESS(ret)) {
             ret = BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgRC4_NA, 0);
-            if(BCRYPT_SUCCESS(ret)) {
+            if(BCRYPT_SUCCESS(ret))
                 ssh2_wcng.hAlgRC4_NA = NULL;
-            }
         }
     }
 #endif
@@ -610,17 +589,15 @@ void ssh2_crypto_init(void)
                                 sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
         if(!BCRYPT_SUCCESS(ret)) {
             ret = BCryptCloseAlgorithmProvider(ssh2_wcng.hAlg3DES_CBC, 0);
-            if(BCRYPT_SUCCESS(ret)) {
+            if(BCRYPT_SUCCESS(ret))
                 ssh2_wcng.hAlg3DES_CBC = NULL;
-            }
         }
     }
 #endif
     ret = BCryptOpenAlgorithmProvider(&ssh2_wcng.hAlgDH,
                                       BCRYPT_DH_ALGORITHM, NULL, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         ssh2_wcng.hAlgDH = NULL;
-    }
 
 #if LIBSSH2_ECDSA
     for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
@@ -632,18 +609,16 @@ void ssh2_crypto_init(void)
             wcng_ecdsa_algs[curve].provider[WCNG_ECC_KEYTYPE_ECDSA],
             NULL,
             0);
-        if(BCRYPT_SUCCESS(ret)) {
+        if(BCRYPT_SUCCESS(ret))
             ssh2_wcng.hAlgECDSA[curve] = alg_handle_ecdsa;
-        }
 
         ret = BCryptOpenAlgorithmProvider(
             &alg_handle_ecdh,
             wcng_ecdsa_algs[curve].provider[WCNG_ECC_KEYTYPE_ECDH],
             NULL,
             0);
-        if(BCRYPT_SUCCESS(ret)) {
+        if(BCRYPT_SUCCESS(ret))
             ssh2_wcng.hAlgECDH[curve] = alg_handle_ecdh;
-        }
     }
 #endif
 }
@@ -715,9 +690,8 @@ int ssh2_random(unsigned char *buf, size_t len)
 {
     int ret;
 
-    if(len > ULONG_MAX) {
+    if(len > ULONG_MAX)
         return -1;
-    }
 
     ret = BCryptGenRandom(ssh2_wcng.hAlgRNG, buf, (ULONG)len, 0);
 
@@ -741,22 +715,19 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
                             (unsigned char *)&dwHash,
                             sizeof(dwHash),
                             &cbData, 0);
-    if(!BCRYPT_SUCCESS(ret) || dwHash != hashlen) {
+    if(!BCRYPT_SUCCESS(ret) || dwHash != hashlen)
         return -1;
-    }
 
     ret = BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH,
                             (unsigned char *)&dwHashObject,
                             sizeof(dwHashObject),
                             &cbData, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         return -1;
-    }
 
     pbHashObject = malloc(dwHashObject);
-    if(!pbHashObject) {
+    if(!pbHashObject)
         return -1;
-    }
 
     ret = BCryptCreateHash(hAlg, &hHash,
                            pbHashObject, dwHashObject,
@@ -922,15 +893,13 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
         hAlgHash = ssh2_wcng.hAlgHashSHA512;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA512_ALGORITHM;
     }
-    else {
+    else
         return -1;
-    }
 
     datalen = m_len;
     data = malloc(datalen);
-    if(!data) {
+    if(!data)
         return -1;
-    }
 
     hash = malloc(hashlen);
     if(!hash) {
@@ -954,9 +923,8 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
         return -1;
     }
 
-    if(flags & BCRYPT_PAD_PKCS1) {
+    if(flags & BCRYPT_PAD_PKCS1)
         pPaddingInfo = &paddingInfoPKCS1;
-    }
     else
         pPaddingInfo = NULL;
 
@@ -983,9 +951,8 @@ static int wcng_load_pem(LIBSSH2_SESSION *session,
     int ret;
 
     fp = fopen(filename, "rb");
-    if(!fp) {
+    if(!fp)
         return -1;
-    }
 
     ret = ssh2_pem_parse(session, headerbegin, headerend,
                          passphrase,
@@ -1008,21 +975,19 @@ static int wcng_load_private(LIBSSH2_SESSION *session,
     int ret = -1;
 
 #if LIBSSH2_RSA
-    if(ret && tryLoadRSA) {
+    if(ret && tryLoadRSA)
         ret = wcng_load_pem(session, filename, passphrase,
                             PEM_RSA_HEADER, PEM_RSA_FOOTER,
                             &data, &datalen);
-    }
 #else
    (void)tryLoadRSA;
 #endif
 
 #if LIBSSH2_DSA
-    if(ret && tryLoadDSA) {
+    if(ret && tryLoadDSA)
         ret = wcng_load_pem(session, filename, passphrase,
                             PEM_DSA_HEADER, PEM_DSA_FOOTER,
                             &data, &datalen);
-    }
 #else
    (void)tryLoadDSA;
 #endif
@@ -1048,23 +1013,21 @@ static int wcng_load_private_memory(LIBSSH2_SESSION *session,
     int ret = -1;
 
 #if LIBSSH2_RSA
-    if(ret && tryLoadRSA) {
+    if(ret && tryLoadRSA)
         ret = ssh2_pem_parse_memory(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
                                     passphrase,
                                     privatekeydata, privatekeydata_len,
                                     &data, &datalen);
-    }
 #else
    (void)tryLoadRSA;
 #endif
 
 #if LIBSSH2_DSA
-    if(ret && tryLoadDSA) {
+    if(ret && tryLoadDSA)
         ret = ssh2_pem_parse_memory(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
                                     passphrase,
                                     privatekeydata, privatekeydata_len,
                                     &data, &datalen);
-    }
 #else
     (void)tryLoadDSA;
 #endif
@@ -1089,14 +1052,12 @@ static int wcng_asn_decode(unsigned char *pbEncoded, DWORD cbEncoded,
                               lpszStructType,
                               pbEncoded, cbEncoded, 0, NULL,
                               NULL, &cbDecoded);
-    if(!ret) {
+    if(!ret)
         return -1;
-    }
 
     pbDecoded = malloc(cbDecoded);
-    if(!pbDecoded) {
+    if(!pbDecoded)
         return -1;
-    }
 
     ret = CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
                               lpszStructType,
@@ -1121,9 +1082,8 @@ static int wcng_bn_ltob(unsigned char *pbInput,
     unsigned char *pbOutput;
     DWORD cbOutput, index, offset, length;
 
-    if(cbInput < 1) {
+    if(cbInput < 1)
         return 0;
-    }
 
     offset = 0;
     length = cbInput - 1;
@@ -1134,14 +1094,12 @@ static int wcng_bn_ltob(unsigned char *pbInput,
     }
 
     pbOutput = malloc(cbOutput);
-    if(!pbOutput) {
+    if(!pbOutput)
         return -1;
-    }
 
     pbOutput[0] = 0;
-    for(index = 0; (index + offset) < cbOutput && index < cbInput; index++) {
+    for(index = 0; (index + offset) < cbOutput && index < cbInput; index++)
         pbOutput[index + offset] = pbInput[length - index];
-    }
 
     *ppbOutput = pbOutput;
     *pcbOutput = cbOutput;
@@ -1225,9 +1183,8 @@ static int wcng_asn_decode_bns(unsigned char *pbEncoded,
                 ret = -1;
             }
         }
-        else {
+        else
             ret = -1;
-        }
 
         wcng_safe_free(pbDecoded, cbDecoded);
     }
@@ -1290,9 +1247,8 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     }
 
     rsakey = malloc(keylen);
-    if(!rsakey) {
+    if(!rsakey)
         return -1;
-    }
 
     memset(rsakey, 0, keylen);
 
@@ -1409,9 +1365,8 @@ static int wcng_rsa_new_private_parse(ssh2_rsa_ctx **rsa,
 
     wcng_safe_free(pbEncoded, cbEncoded);
 
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgRSA, NULL, LEGACY_RSAPRIVATE_BLOB,
                               &hKey, pbStructInfo, cbStructInfo, 0);
@@ -1445,9 +1400,8 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
 
     ret = wcng_load_private(session, filename, passphrase,
                             &pbEncoded, &cbEncoded, 1, 0);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return wcng_rsa_new_private_parse(rsa, session, pbEncoded, cbEncoded);
 }
@@ -1463,9 +1417,8 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 
     ret = wcng_load_private_memory(session, filedata, filedata_len,
                                    passphrase, &pbEncoded, &cbEncoded, 1, 0);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return wcng_rsa_new_private_parse(rsa, session, pbEncoded, cbEncoded);
 }
@@ -1523,9 +1476,8 @@ static int wcng_rsa_sha_sign(LIBSSH2_SESSION *session,
 
     datalen = (ULONG)hash_len;
     data = malloc(datalen);
-    if(!data) {
+    if(!data)
         return -1;
-    }
     memcpy(data, hash, datalen);
 
     ret = BCryptSignHash(rsa->hKey, &paddingInfo,
@@ -1542,9 +1494,8 @@ static int wcng_rsa_sha_sign(LIBSSH2_SESSION *session,
                 *signature_len = siglen;
                 *signature = sig;
             }
-            else {
+            else
                 SSH2_FREE(session, sig);
-            }
         }
         else
             ret = (NTSTATUS)STATUS_NO_MEMORY;
@@ -1616,9 +1567,8 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         keylen += 20;
 
     dsakey = malloc(keylen);
-    if(!dsakey) {
+    if(!dsakey)
         return -1;
-    }
 
     memset(dsakey, 0, keylen);
 
@@ -1709,21 +1659,18 @@ static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
 
     wcng_safe_free(pbEncoded, cbEncoded);
 
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
-    if(length == 6) {
+    if(length == 6)
         ret = ssh2_dsa_new(dsa,
                            rpbDecoded[1], rcbDecoded[1],
                            rpbDecoded[2], rcbDecoded[2],
                            rpbDecoded[3], rcbDecoded[3],
                            rpbDecoded[4], rcbDecoded[4],
                            rpbDecoded[5], rcbDecoded[5]);
-    }
-    else {
+    else
         ret = -1;
-    }
 
     for(index = 0; index < length; index++) {
         wcng_safe_free(rpbDecoded[index], rcbDecoded[index]);
@@ -1748,9 +1695,8 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
 
     ret = wcng_load_private(session, filename, passphrase,
                             &pbEncoded, &cbEncoded, 0, 1);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return wcng_dsa_new_private_parse(dsa, session, pbEncoded, cbEncoded);
 }
@@ -1766,9 +1712,8 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
 
     ret = wcng_load_private_memory(session, filedata, filedata_len,
                                    passphrase, &pbEncoded, &cbEncoded, 0, 1);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return wcng_dsa_new_private_parse(dsa, session, pbEncoded, cbEncoded);
 }
@@ -1791,9 +1736,8 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
 
     datalen = (ULONG)hash_len;
     data = malloc(datalen);
-    if(!data) {
+    if(!data)
         return -1;
-    }
 
     memcpy(data, hash, datalen);
 
@@ -1806,9 +1750,8 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
             if(sig) {
                 ret = BCryptSignHash(dsa->hKey, NULL, data, datalen,
                                      sig, siglen, &cbData, 0);
-                if(BCRYPT_SUCCESS(ret)) {
+                if(BCRYPT_SUCCESS(ret))
                     memcpy(sig_fixed, sig, siglen);
-                }
 
                 wcng_safe_free(sig, siglen);
             }
@@ -1854,14 +1797,12 @@ static int wcng_ecdsa_decode_uncompressed_point(
 {
     unsigned int curve;
 
-    if(!point) {
+    if(!point)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     /* Verify that the point uses uncompressed format */
-    if(encoded_point_len == 0 || encoded_point[0] != 4) {
+    if(encoded_point_len == 0 || encoded_point[0] != 4)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
         if(wcng_ecdsa_algs[curve].point_length ==
@@ -1902,9 +1843,8 @@ static int wcng_p1363signature_from_point(IN const unsigned char *r,
     size_t s_trimmed_len;
 
     /* Validate parameters */
-    if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs)) {
+    if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs))
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *signature = NULL;
     *signature_length = (size_t)wcng_ecdsa_algs[curve].point_length * 2;
@@ -1926,15 +1866,13 @@ static int wcng_p1363signature_from_point(IN const unsigned char *r,
 
     /* Validate r and s fits into signature */
     if(r_trimmed_len > *signature_length / 2 ||
-       s_trimmed_len > *signature_length / 2) {
+       s_trimmed_len > *signature_length / 2)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     /* Concatenate into zero-filled buffer and zero-pad if necessary */
     *signature = calloc(1, *signature_length);
-    if(!*signature) {
+    if(!*signature)
         return LIBSSH2_ERROR_ALLOC;
-    }
 
     memcpy(*signature + (*signature_length / 2) - r_trimmed_len,
            r_trimmed, r_trimmed_len);
@@ -1958,22 +1896,19 @@ static int wcng_publickey_from_point(IN wcng_ecc_keytype keytype,
     size_t ecc_blob_len;
 
     /* Validate parameters */
-    if(!key) {
+    if(!key)
         return LIBSSH2_ERROR_INVAL;
-    }
 
-    if(point->x_len != point->y_len) {
+    if(point->x_len != point->y_len)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *key = NULL;
 
     /* Initialize a blob to import */
     ecc_blob_len = sizeof(BCRYPT_ECCKEY_BLOB) + point->x_len + point->y_len;
     ecc_blob = malloc(ecc_blob_len);
-    if(!ecc_blob) {
+    if(!ecc_blob)
         return LIBSSH2_ERROR_ALLOC;
-    }
 
     ecc_blob->cbKey = point->x_len;
     ecc_blob->dwMagic =
@@ -2022,13 +1957,11 @@ static int wcng_privatekey_from_point(IN wcng_ecc_keytype keytype,
     size_t ecc_blob_len;
 
     /* Validate parameters */
-    if(!key) {
+    if(!key)
         return LIBSSH2_ERROR_INVAL;
-    }
 
-    if(q->x_len != q->y_len) {
+    if(q->x_len != q->y_len)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *key = NULL;
 
@@ -2036,9 +1969,8 @@ static int wcng_privatekey_from_point(IN wcng_ecc_keytype keytype,
     ecc_blob_len =
         sizeof(BCRYPT_ECCPRIVATE_BLOB) + q->x_len + q->y_len + d_len;
     ecc_blob = malloc(ecc_blob_len);
-    if(!ecc_blob) {
+    if(!ecc_blob)
         return LIBSSH2_ERROR_ALLOC;
-    }
 
     ecc_blob->cbKey = q->x_len;
     ecc_blob->dwMagic =
@@ -2092,13 +2024,11 @@ static int wcng_uncompressed_point_from_publickey(
     PUCHAR point_y;
 
     /* Validate parameters */
-    if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs)) {
+    if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs))
         return LIBSSH2_ERROR_INVAL;
-    }
 
-    if(!encoded_point || !encoded_point_len) {
+    if(!encoded_point || !encoded_point_len)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *encoded_point = NULL;
     *encoded_point_len = 0;
@@ -2161,9 +2091,8 @@ static int wcng_uncompressed_point_from_publickey(
     memcpy((*encoded_point) + 1 + ecc_blob->cbKey, point_y, ecc_blob->cbKey);
 
 cleanup:
-    if(ecc_blob) {
+    if(ecc_blob)
         SSH2_FREE(session, ecc_blob);
-    }
 
     return result;
 }
@@ -2174,9 +2103,8 @@ cleanup:
  */
 void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx)
 {
-    if(!ctx) {
+    if(!ctx)
         return;
-    }
 
     (void)BCryptDestroyKey(ctx->handle);
     free(ctx);
@@ -2198,17 +2126,14 @@ int ssh2_ecdsa_create_key(IN LIBSSH2_SESSION *session,
     BCRYPT_KEY_HANDLE key_handle = NULL;
 
     /* Validate parameters */
-    if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs)) {
+    if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs))
         return LIBSSH2_ERROR_INVAL;
-    }
 
-    if(!ssh2_wcng.hAlgECDH[curve]) {
+    if(!ssh2_wcng.hAlgECDH[curve])
         return LIBSSH2_ERROR_INVAL;
-    }
 
-    if(!privatekey || !encoded_publickey || !encoded_publickey_len) {
+    if(!privatekey || !encoded_publickey || !encoded_publickey_len)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *privatekey = NULL;
     *encoded_publickey = NULL;
@@ -2239,10 +2164,9 @@ int ssh2_ecdsa_create_key(IN LIBSSH2_SESSION *session,
         key_handle,
         encoded_publickey,
         encoded_publickey_len);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                           "Exporting ECDH key pair failed");
-    }
 
     *privatekey = malloc(sizeof(struct wcng_ecdsa_ctx));
     if(!*privatekey) {
@@ -2254,13 +2178,11 @@ int ssh2_ecdsa_create_key(IN LIBSSH2_SESSION *session,
     (*privatekey)->handle = key_handle;
 
 cleanup:
-    if(result != LIBSSH2_ERROR_NONE && key_handle) {
+    if(result != LIBSSH2_ERROR_NONE && key_handle)
         (void)BCryptDestroyKey(key_handle);
-    }
 
-    if(result != LIBSSH2_ERROR_NONE && *privatekey) {
+    if(result != LIBSSH2_ERROR_NONE && *privatekey)
         free(*privatekey);
-    }
 
     return result;
 }
@@ -2280,13 +2202,11 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     struct ecdsa_point publickey;
 
     /* Validate parameters */
-    if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs)) {
+    if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs))
         return LIBSSH2_ERROR_INVAL;
-    }
 
-    if(!key) {
+    if(!key)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *key = NULL;
 
@@ -2294,17 +2214,15 @@ int ssh2_ecdsa_curve_name_with_octal_new(
         publickey_encoded,
         publickey_encoded_len,
         &publickey);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     result = wcng_publickey_from_point(
         WCNG_ECC_KEYTYPE_ECDSA,
         &publickey,
         &publickey_handle);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     *key = malloc(sizeof(struct wcng_ecdsa_ctx));
     if(!*key) {
@@ -2338,9 +2256,8 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **secret,
     struct ecdsa_point server_publickey;
 
     /* Validate parameters */
-    if(!secret) {
+    if(!secret)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *secret = NULL;
 
@@ -2349,17 +2266,15 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **secret,
         server_publickey_encoded,
         server_publickey_encoded_len,
         &server_publickey);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         return result;
-    }
 
     result = wcng_publickey_from_point(
         WCNG_ECC_KEYTYPE_ECDH,
         &server_publickey,
         &publickey_handle);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         return result;
-    }
 
     /* Establish the shared secret between ourselves and the peer */
     status = BCryptSecretAgreement(
@@ -2431,9 +2346,8 @@ cleanup:
         *secret = NULL;
     }
 
-    if(result != LIBSSH2_ERROR_NONE && agreed_secret_handle) {
+    if(result != LIBSSH2_ERROR_NONE && agreed_secret_handle)
         BCryptDestroySecret(agreed_secret_handle);
-    }
 
     return result;
 }
@@ -2444,9 +2358,8 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
     unsigned int curve;
 
     /* Validate parameters */
-    if(!name || !out_curve) {
+    if(!name || !out_curve)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
         if(!strcmp(name, wcng_ecdsa_algs[curve].name)) {
@@ -2484,9 +2397,8 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *key,
         ssh2_ecdsa_get_curve_type(key),
         &signature_p1363,
         &signature_p1363_len);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     /* Create hash over m */
     switch(ssh2_ecdsa_get_curve_type(key)) {
@@ -2511,9 +2423,8 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *key,
 
     hash = malloc(hash_len);
     result = ssh2_wcng_hash(m, (ULONG)m_len, hash_alg, hash, hash_len);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     /* Verify signature over hash */
     status = BCryptVerifySignature(
@@ -2537,13 +2448,11 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *key,
     result = LIBSSH2_ERROR_NONE;
 
 cleanup:
-    if(hash) {
+    if(hash)
         free(hash);
-    }
 
-    if(signature_p1363) {
+    if(signature_p1363)
         free(signature_p1363);
-    }
 
     return result;
 }
@@ -2563,17 +2472,15 @@ int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **key,
     size_t datalen = 0;
 
     /* Validate parameters */
-    if(!key || !session || !filename) {
+    if(!key || !session || !filename)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *key = NULL;
 
-    if(passphrase && strlen((const char *)passphrase) > 0) {
+    if(passphrase && strlen((const char *)passphrase) > 0)
         return ssh2_err(session, LIBSSH2_ERROR_INVAL,
                         "Passphrase-protected ECDSA private key "
                         "files are unsupported");
-    }
 
     file_handle = fopen(filename, "rb");
     if(!file_handle) {
@@ -2589,25 +2496,21 @@ int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **key,
         file_handle,
         &data,
         &datalen);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     result = ssh2_ecdsa_new_private_frommemory(key, session,
                                                (const char *)data, datalen,
                                                passphrase);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
 cleanup:
-    if(file_handle) {
+    if(file_handle)
         fclose(file_handle);
-    }
 
-    if(data) {
+    if(data)
         SSH2_FREE(session, data);
-    }
 
     return result;
 }
@@ -2644,14 +2547,12 @@ static int wcng_parse_ecdsa_privatekey(OUT struct wcng_ecdsa_ctx **key,
 
     /* Read the 2 checkints and check that they match */
     result = ssh2_get_u32(&data_buffer, &check1);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     result = ssh2_get_u32(&data_buffer, &check2);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     if(check1 != check2) {
         result = LIBSSH2_ERROR_FILE;
@@ -2664,40 +2565,34 @@ static int wcng_parse_ecdsa_privatekey(OUT struct wcng_ecdsa_ctx **key,
     /* Read the key type */
     result = ssh2_get_string(&data_buffer,
                              (unsigned char **)&keytype, &keytype_len);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     result = wcng_ecdsa_curve_type_from_name(keytype, &curve_type);
-    if(result < 0) {
+    if(result < 0)
         goto cleanup;
-    }
 
     /* Read the curve */
     result = ssh2_get_string(&data_buffer, &ignore, &ignore_len);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     /* Read Q */
     result = ssh2_get_string(&data_buffer, &publickey, &publickey_len);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     result = wcng_ecdsa_decode_uncompressed_point(
         publickey,
         publickey_len,
         &q);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     /* Read d */
     result = ssh2_get_bignum_bytes(&data_buffer, &d, &d_len);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     /* Ignore the rest (comment, etc) */
 
@@ -2708,9 +2603,8 @@ static int wcng_parse_ecdsa_privatekey(OUT struct wcng_ecdsa_ctx **key,
         d,
         d_len,
         &key_handle);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     *key = malloc(sizeof(struct wcng_ecdsa_ctx));
     if(!*key) {
@@ -2724,9 +2618,8 @@ static int wcng_parse_ecdsa_privatekey(OUT struct wcng_ecdsa_ctx **key,
     result = LIBSSH2_ERROR_NONE;
 
 cleanup:
-    if(result != LIBSSH2_ERROR_NONE && key_handle) {
+    if(result != LIBSSH2_ERROR_NONE && key_handle)
         (void)BCryptDestroyKey(key_handle);
-    }
 
     return result;
 }
@@ -2751,17 +2644,15 @@ int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **key,
     size_t privatekey_len;
 
     /* Validate parameters */
-    if(!key || !session || !data) {
+    if(!key || !session || !data)
         return LIBSSH2_ERROR_INVAL;
-    }
 
     *key = NULL;
 
-    if(passphrase && strlen((const char *)passphrase) > 0) {
+    if(passphrase && strlen((const char *)passphrase) > 0)
         return ssh2_err(session, LIBSSH2_ERROR_INVAL,
                         "Passphrase-protected ECDSA private key "
                         "files are unsupported");
-    }
 
     /* Read OPENSSH_PRIVKEY_AUTH_MAGIC */
     if(data_len < sizeof(OPENSSH_PRIVKEY_AUTH_MAGIC) ||
@@ -2778,27 +2669,23 @@ int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **key,
 
     /* Read ciphername, should be 'none' as we do not support passphrases */
     result = ssh2_match_string(&data_buffer, "none");
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     /* Read kdfname, should be 'none' as we do not support passphrases */
     result = ssh2_match_string(&data_buffer, "none");
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     /* Read kdfoptions, should be empty */
     result = ssh2_match_string(&data_buffer, "");
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     /* Read number of keys N */
     result = ssh2_get_u32(&data_buffer, &key_count);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     if(key_count == 0) {
         result = LIBSSH2_ERROR_FILE;
@@ -2811,23 +2698,20 @@ int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **key,
         size_t publickey_len;
 
         result = ssh2_get_string(&data_buffer, &publickey, &publickey_len);
-        if(result != LIBSSH2_ERROR_NONE) {
+        if(result != LIBSSH2_ERROR_NONE)
             goto cleanup;
-        }
     }
 
     /* Read first private key */
     result = ssh2_get_string(&data_buffer, &privatekey, &privatekey_len);
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
-    }
 
     result = wcng_parse_ecdsa_privatekey(key, privatekey, privatekey_len);
 
 cleanup:
-    if(result != LIBSSH2_ERROR_NONE) {
+    if(result != LIBSSH2_ERROR_NONE)
         return ssh2_err(session, result, "The key is malformed");
-    }
 
     return result;
 }
@@ -2933,13 +2817,10 @@ cleanup:
         *signature_len = 0;
     }
 
-    if(cng_signature) {
+    if(cng_signature)
         free(cng_signature);
-    }
-
-    if(hash_buffer) {
+    if(hash_buffer)
         free(hash_buffer);
-    }
 
     return result;
 }
@@ -2994,19 +2875,16 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
 
     wcng_safe_free(pbEncoded, cbEncoded);
 
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     if(length == 9) { /* private RSA key */
         mthlen = 7;
         mth = SSH2_ALLOC(session, mthlen);
-        if(mth) {
+        if(mth)
             memcpy(mth, "ssh-rsa", mthlen);
-        }
-        else {
+        else
             ret = -1;
-        }
 
         keylen = 4 + mthlen + 4 + rcbDecoded[2] + 4 + rcbDecoded[1];
         key = SSH2_ALLOC(session, keylen);
@@ -3021,19 +2899,16 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
                                 rpbDecoded[1],
                                 rcbDecoded[1]);
         }
-        else {
+        else
             ret = -1;
-        }
     }
     else if(length == 6) { /* private DSA key */
         mthlen = 7;
         mth = SSH2_ALLOC(session, mthlen);
-        if(mth) {
+        if(mth)
             memcpy(mth, "ssh-dss", mthlen);
-        }
-        else {
+        else
             ret = -1;
-        }
 
         keylen = 4 + mthlen + 4 + rcbDecoded[1] + 4 + rcbDecoded[2]
                             + 4 + rcbDecoded[3] + 4 + rcbDecoded[4];
@@ -3057,13 +2932,11 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
                                 rpbDecoded[4],
                                 rcbDecoded[4]);
         }
-        else {
+        else
             ret = -1;
-        }
     }
-    else {
+    else
         ret = -1;
-    }
 
     for(index = 0; index < length; index++) {
         wcng_safe_free(rpbDecoded[index], rcbDecoded[index]);
@@ -3105,9 +2978,8 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     ret = wcng_load_private(session, privatekey,
                             (const unsigned char *)passphrase,
                             &pbEncoded, &cbEncoded, 1, 1);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return wcng_pub_priv_keyfile_parse(session, method, method_len,
                                        pubkeydata, pubkeydata_len,
@@ -3131,9 +3003,8 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                    privatekeydata_len,
                                    (const unsigned char *)passphrase,
                                    &pbEncoded, &cbEncoded, 1, 1);
-    if(ret) {
+    if(ret)
         return -1;
-    }
 
     return wcng_pub_priv_keyfile_parse(session, method, method_len,
                                        pubkeydata, pubkeydata_len,
@@ -3192,22 +3063,19 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
                             (unsigned char *)&dwKeyObject,
                             sizeof(dwKeyObject),
                             &cbData, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         return -1;
-    }
 
     ret = BCryptGetProperty(*algo.phAlg, BCRYPT_BLOCK_LENGTH,
                             (unsigned char *)&dwBlockLength,
                             sizeof(dwBlockLength),
                             &cbData, 0);
-    if(!BCRYPT_SUCCESS(ret)) {
+    if(!BCRYPT_SUCCESS(ret))
         return -1;
-    }
 
     pbKeyObject = malloc(dwKeyObject);
-    if(!pbKeyObject) {
+    if(!pbKeyObject)
         return -1;
-    }
 
     keylen = (ULONG)sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) + algo.dwKeyLength;
     header = malloc(keylen);
@@ -3300,34 +3168,30 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
     cbInput = (ULONG)blocksize;
 
-    if(algo.ctrMode) {
+    if(algo.ctrMode)
         pbInput = ctx->pbCtr;
-    }
-    else {
+    else
         pbInput = block;
-    }
 
-    if(encrypt || algo.ctrMode) {
+    if(encrypt || algo.ctrMode)
         ret = BCryptEncrypt(ctx->hKey, pbInput, cbInput, NULL,
                             ctx->pbIV, ctx->dwIV, NULL, 0, &cbOutput, 0);
-    }
-    else {
+    else
         ret = BCryptDecrypt(ctx->hKey, pbInput, cbInput, NULL,
                             ctx->pbIV, ctx->dwIV, NULL, 0, &cbOutput, 0);
-    }
+
     if(BCRYPT_SUCCESS(ret)) {
         pbOutput = malloc(cbOutput);
         if(pbOutput) {
-            if(encrypt || algo.ctrMode) {
+            if(encrypt || algo.ctrMode)
                 ret = BCryptEncrypt(ctx->hKey, pbInput, cbInput, NULL,
                                     ctx->pbIV, ctx->dwIV,
                                     pbOutput, cbOutput, &cbOutput, 0);
-            }
-            else {
+            else
                 ret = BCryptDecrypt(ctx->hKey, pbInput, cbInput, NULL,
                                     ctx->pbIV, ctx->dwIV,
                                     pbOutput, cbOutput, &cbOutput, 0);
-            }
+
             if(BCRYPT_SUCCESS(ret)) {
                 if(algo.ctrMode) {
                     /* CTR mode intentionally XORs in place:
@@ -3336,9 +3200,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                     ssh2_xor_data(block, block, pbOutput, blocksize);
                     wcng_aes_ctr_increment(ctx->pbCtr, ctx->dwCtrLength);
                 }
-                else {
+                else
                     memcpy(block, pbOutput, cbOutput);
-                }
             }
 
             wcng_safe_free(pbOutput, cbOutput);
@@ -3434,15 +3297,13 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
         status = BCryptGenerateKeyPair(ssh2_wcng.hAlgDH,
                                        &dhctx->dh_handle,
                                        key_length_bytes * 8, 0);
-        if(!BCRYPT_SUCCESS(status)) {
+        if(!BCRYPT_SUCCESS(status))
             return -1;
-        }
 
         dh_params_len = (ULONG)sizeof(*dh_params) + 2 * key_length_bytes;
         dh_params = malloc(dh_params_len);
-        if(!dh_params) {
+        if(!dh_params)
             return -1;
-        }
 
         /* Populate DH parameters blob; after the header follows the `p`
          * value and the `g` value. */
@@ -3458,63 +3319,55 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
 
         status = BCryptSetProperty(dhctx->dh_handle, BCRYPT_DH_PARAMETERS,
                                    (PUCHAR)dh_params, dh_params_len, 0);
-        if(hasAlgDHwithKDF == -1) {
+        if(hasAlgDHwithKDF == -1)
             /* We know that the raw KDF is not supported, so discard this. */
             free(dh_params);
-        }
-        else {
+        else
             /* Pass ownership to dhctx; these parameters are freed when
              * the context is destroyed. We need to keep the parameters more
              * easily available so that we have access to the `g` value when
              * ssh2_wcng_dh_secret() is called later. */
             dhctx->dh_params = dh_params;
-        }
+
         dh_params = NULL;
 
-        if(!BCRYPT_SUCCESS(status)) {
+        if(!BCRYPT_SUCCESS(status))
             return -1;
-        }
 
         status = BCryptFinalizeKeyPair(dhctx->dh_handle, 0);
-        if(!BCRYPT_SUCCESS(status)) {
+        if(!BCRYPT_SUCCESS(status))
             return -1;
-        }
 
         key_length_bytes = 0;
-        if(hasAlgDHwithKDF == 1) {
+        if(hasAlgDHwithKDF == 1)
             /* Now we need to extract the public portion of the key so that we
              * set it in the `pub` bignum to satisfy our caller.
              * First measure up the size of the required buffer. */
             key_type = BCRYPT_DH_PUBLIC_BLOB;
-        }
-        else {
+        else
             /* We also need to extract the private portion of the key to
              * set it in the `*dhctx' bignum if the raw KDF is not supported.
              * First measure up the size of the required buffer. */
             key_type = BCRYPT_DH_PRIVATE_BLOB;
-        }
+
         status = BCryptExportKey(dhctx->dh_handle, NULL, key_type,
                                  NULL, 0, &key_length_bytes, 0);
-        if(!BCRYPT_SUCCESS(status)) {
+        if(!BCRYPT_SUCCESS(status))
             return -1;
-        }
 
         dh_key_blob = malloc(key_length_bytes);
-        if(!dh_key_blob) {
+        if(!dh_key_blob)
             return -1;
-        }
 
         status = BCryptExportKey(dhctx->dh_handle, NULL, key_type,
                                  (PUCHAR)dh_key_blob, key_length_bytes,
                                  &key_length_bytes, 0);
         if(!BCRYPT_SUCCESS(status)) {
-            if(hasAlgDHwithKDF == 1) {
+            if(hasAlgDHwithKDF == 1)
                 /* We have no private data, because raw KDF is supported */
                 free(dh_key_blob);
-            }
-            else { /* we may have potentially private data, use secure free */
+            else /* we may have potentially private data, use secure free */
                 wcng_safe_free(dh_key_blob, key_length_bytes);
-            }
             return -1;
         }
 
@@ -3528,13 +3381,11 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
          * followed by the Modulus, Generator and Public data. Those components
          * each have equal size, specified by dh_key_blob->cbKey. */
         if(wcng_bn_resize(pub, dh_key_blob->cbKey)) {
-            if(hasAlgDHwithKDF == 1) {
+            if(hasAlgDHwithKDF == 1)
                 /* We have no private data, because raw KDF is supported */
                 free(dh_key_blob);
-            }
-            else { /* we may have potentially private data, use secure free */
+            else /* we may have potentially private data, use secure free */
                 wcng_safe_free(dh_key_blob, key_length_bytes);
-            }
             return -1;
         }
 
@@ -3616,9 +3467,9 @@ int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
             unsigned char *src;
 
             public_blob = malloc(public_blob_len);
-            if(!public_blob) {
+            if(!public_blob)
                 return -1;
-            }
+
             public_blob->dwMagic = BCRYPT_DH_PUBLIC_MAGIC;
             public_blob->cbKey = key_length_bytes;
 
@@ -3643,26 +3494,23 @@ int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
         status = BCryptImportKeyPair(ssh2_wcng.hAlgDH, NULL,
                                      BCRYPT_DH_PUBLIC_BLOB, &peer_public,
                                      (PUCHAR)public_blob, public_blob_len, 0);
-        if(!BCRYPT_SUCCESS(status)) {
+        if(!BCRYPT_SUCCESS(status))
             goto out;
-        }
 
         /* Set up a handle that we can use to establish the shared secret
          * between ourselves (our saved dh_handle) and the peer. */
         status = BCryptSecretAgreement(dhctx->dh_handle, peer_public,
                                        &agreement, 0);
-        if(!BCRYPT_SUCCESS(status)) {
+        if(!BCRYPT_SUCCESS(status))
             goto out;
-        }
 
         /* Compute the size of the buffer that is needed to hold the derived
          * shared secret. */
         status = BCryptDeriveKey(agreement, BCRYPT_KDF_RAW_SECRET, NULL, NULL,
                                  0, &secret_len_bytes, 0);
         if(!BCRYPT_SUCCESS(status)) {
-            if(status == STATUS_NOT_SUPPORTED) {
+            if(status == STATUS_NOT_SUPPORTED)
                 ssh2_wcng.hasAlgDHwithKDF = -1;
-            }
             goto out;
         }
 
@@ -3678,9 +3526,8 @@ int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                                  secret->bignum, secret_len_bytes,
                                  &secret_len_bytes, 0);
         if(!BCRYPT_SUCCESS(status)) {
-            if(status == STATUS_NOT_SUPPORTED) {
+            if(status == STATUS_NOT_SUPPORTED)
                 ssh2_wcng.hasAlgDHwithKDF = -1;
-            }
             goto out;
         }
 
@@ -3693,18 +3540,16 @@ int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
         ssh2_wcng.hasAlgDHwithKDF = 1;
 
 out:
-        if(peer_public) {
+        if(peer_public)
             BCryptDestroyKey(peer_public);
-        }
-        if(agreement) {
+        if(agreement)
             BCryptDestroySecret(agreement);
-        }
 
         free(public_blob);
 
-        if(status == STATUS_NOT_SUPPORTED && ssh2_wcng.hasAlgDHwithKDF == -1) {
+        if(status == STATUS_NOT_SUPPORTED && ssh2_wcng.hasAlgDHwithKDF == -1)
             goto fallback; /* fallback to RSA-based implementation */
-        }
+
         return BCRYPT_SUCCESS(status) ? 0 : -1;
     }
 

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -94,9 +94,8 @@ static int run_command_varg(char **output, const char *command, va_list args)
     int ret;
     size_t buf_len;
 
-    if(output) {
+    if(output)
         *output = NULL;
-    }
 
     /* Format the command string */
 #if defined(__GNUC__) || defined(__clang__)
@@ -133,23 +132,20 @@ static int run_command_varg(char **output, const char *command, va_list args)
     buf[0] = 0;
     buf_len = 0;
     while(buf_len < (sizeof(buf) - 1) &&
-          fgets(&buf[buf_len], (int)(sizeof(buf) - buf_len), pipe)) {
+          fgets(&buf[buf_len], (int)(sizeof(buf) - buf_len), pipe))
         buf_len = strlen(buf);
-    }
 
     ret = pclose(pipe);
-    if(ret) {
+    if(ret)
         fprintf(stderr, "Error running command '%s' (exit %d): %s\n",
                 command, ret, buf);
-    }
 
     if(output) {
         /* command output may contain a trailing newline, so we trim
          * whitespace here */
         size_t end = strlen(buf);
-        while(end > 0 && isspace((int)buf[end - 1])) {
+        while(end > 0 && isspace((int)buf[end - 1]))
             buf[end - 1] = '\0';
-        }
 
         *output = libssh2_strdup(buf);
     }
@@ -186,18 +182,16 @@ static int build_openssh_server_docker_image(void)
             if(ret == 0) {
                 ret = run_command(NULL, "docker tag %s libssh2/openssh_server",
                                   container_image_name);
-                if(ret == 0) {
+                if(ret == 0)
                     return ret;
-                }
             }
         }
         return run_command(NULL,
                            "docker build --quiet -t libssh2/openssh_server %s",
                            srcdir_path("openssh_server"));
     }
-    else {
+    else
         return 0;
-    }
 }
 
 static const char *openssh_server_port(void)
@@ -209,12 +203,11 @@ static int start_openssh_server(char **container_id_out)
 {
     if(have_docker) {
         const char *container_host_port = openssh_server_port();
-        if(container_host_port) {
+        if(container_host_port)
             return run_command(container_id_out,
                                "docker run --rm -d -p %s:22 "
                                "libssh2/openssh_server",
                                container_host_port);
-        }
 
         return run_command(container_id_out,
                            "docker run --rm -d -p 22 "
@@ -228,12 +221,10 @@ static int start_openssh_server(char **container_id_out)
 
 static int stop_openssh_server(char *container_id)
 {
-    if(have_docker) {
+    if(have_docker)
         return run_command(NULL, "docker stop %s", container_id);
-    }
-    else {
+    else
         return 0;
-    }
 }
 
 static const char *docker_machine_name(void)
@@ -251,10 +242,8 @@ static int is_running_inside_a_container(void)
     char line[1024];
     int found = 0;
     f = fopen(cgroup_filename, "r");
-    if(!f) {
-        /* Do not go further, we are not in a container */
-        return 0;
-    }
+    if(!f)
+        return 0;  /* Do not go further, we are not in a container */
     while(fgets(line, sizeof(line), f)) {
         if(strstr(line, "docker")) {
             found = 1;
@@ -288,9 +277,8 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
         for(;;) {
             int ret = run_command(ip_address_out, "docker-machine ip %s",
                                   active_docker_machine);
-            if(ret == 0) {
+            if(ret == 0)
                 return 0;
-            }
             else if(attempt_no > 5) {
                 fprintf(
                     stderr,
@@ -306,21 +294,19 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
         }
     }
     else {
-        if(is_running_inside_a_container()) {
+        if(is_running_inside_a_container())
             return run_command(ip_address_out,
                                "docker inspect --format "
                                "\"{{ .NetworkSettings.IPAddress }}\""
                                " %s",
                                container_id);
-        }
-        else {
+        else
             return run_command(ip_address_out,
                                "docker inspect --format "
                                "\"{{ index (index (index "
                                ".NetworkSettings.Ports "
                                "\\\"22/tcp\\\") 0) \\\"HostIp\\\" }}\" %s",
                                container_id);
-        }
     }
 }
 
@@ -330,13 +316,12 @@ static int port_from_container(char *container_id, char **port_out)
         *port_out = libssh2_strdup("22");
         return 0;
     }
-    else {
+    else
         return run_command(port_out,
                            "docker inspect --format "
                            "\"{{ index (index (index .NetworkSettings.Ports "
                            "\\\"22/tcp\\\") 0) \\\"HostPort\\\" }}\" %s",
                            container_id);
-    }
 }
 
 static void close_socket_to_container(libssh2_socket_t sock)
@@ -380,14 +365,12 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     else {
         const char *env;
         env = getenv("OPENSSH_SERVER_HOST");
-        if(!env) {
+        if(!env)
             env = "127.0.0.1";
-        }
         ip_address = libssh2_strdup(env);
         env = openssh_server_port();
-        if(!env) {
+        if(!env)
             env = "4711";
-        }
         port_string = libssh2_strdup(env);
     }
 
@@ -461,9 +444,8 @@ int start_openssh_fixture(void)
     have_docker = !getenv("OPENSSH_NO_DOCKER");
 
     ret = build_openssh_server_docker_image();
-    if(!ret) {
+    if(!ret)
         return start_openssh_server(&running_container_id);
-    }
     else {
         fprintf(stderr, "Failed to build docker image\n");
         return ret;
@@ -477,9 +459,8 @@ void stop_openssh_fixture(void)
         free(running_container_id);
         running_container_id = NULL;
     }
-    else if(have_docker) {
+    else if(have_docker)
         fprintf(stderr, "Cannot stop container - none started\n");
-    }
 
 #ifdef _WIN32
     WSACleanup();

--- a/tests/ossfuzz/ssh2_client_fuzzer.cc
+++ b/tests/ossfuzz/ssh2_client_fuzzer.cc
@@ -56,16 +56,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     /* Create a session and start the handshake using the fuzz data
        passed in. */
     session = libssh2_session_init();
-    if(session) {
+    if(session)
         libssh2_session_set_blocking(session, 1);
-    }
-    else {
+    else
         goto EXIT_LABEL;
-    }
 
-    if(libssh2_session_handshake(session, socket_fds[0])) {
+    if(libssh2_session_handshake(session, socket_fds[0]))
         goto EXIT_LABEL;
-    }
 
     /* If we get here the handshake actually completed. */
     handshake_completed = 1;
@@ -73,11 +70,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 EXIT_LABEL:
 
     if(session) {
-        if(handshake_completed) {
+        if(handshake_completed)
             libssh2_session_disconnect(session,
                                        "Normal Shutdown, "
                                        "Thank you for playing");
-        }
 
         libssh2_session_free(session);
     }

--- a/tests/ossfuzz/standaloneengine.cc
+++ b/tests/ossfuzz/standaloneengine.cc
@@ -51,22 +51,20 @@ int main(int argc, char **argv)
                 free(buffer);
                 buffer = NULL;
             }
-            else {
+            else
                 fprintf(stderr,
                         "[%s] Failed to allocate %zu bytes \n",
                         argv[ii],
                         buffer_len);
-            }
 
             /* Close the file as it is no longer needed. */
             fclose(infile);
             infile = NULL;
         }
-        else {
+        else
             /* Failed to open the file.
                Maybe wrong name or wrong permissions? */
             fprintf(stderr, "[%s] Open failed. \n", argv[ii]);
-        }
 
         printf("\n");
     }

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -53,16 +53,14 @@ int main(void)
     do {
         int skipped, rc;
         LIBSSH2_SESSION *session = start_session_fixture(&skipped, &rc);
-        if(session) {
+        if(session)
             exit_code = (test(session) == 0) ? 0 : 1;
-        }
         else if(skipped) {
             fprintf(stderr, "Test skipped.\n");
             exit_code = 0;
         }
-        else {
+        else
             exit_code = 1;
-        }
         stop_session_fixture();
         if(exit_code == 0 ||
 #ifdef LIBSSH2_WINCNG

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -58,9 +58,8 @@ static int connect_to_server(void)
 {
     int rc;
     connected_socket = open_socket_to_openssh_server();
-    if(connected_socket == LIBSSH2_INVALID_SOCKET) {
+    if(connected_socket == LIBSSH2_INVALID_SOCKET)
         return LIBSSH2_ERROR_SOCKET_NONE;
-    }
 
     rc = libssh2_session_handshake(connected_session, connected_socket);
     if(rc) {
@@ -145,9 +144,9 @@ LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err)
     }
 
     rc = start_openssh_fixture();
-    if(rc) {
+    if(rc)
         return NULL;
-    }
+
     rc = libssh2_init(0);
     if(rc) {
         fprintf(stderr, "libssh2_init failed (%d)\n", rc);
@@ -201,9 +200,8 @@ LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err)
         return NULL;
     }
 
-    if(getenv("FIXTURE_TRACE_ALL_CONNECT")) {
+    if(getenv("FIXTURE_TRACE_ALL_CONNECT"))
         libssh2_trace(connected_session, 0);
-    }
 
     return connected_session;
 }
@@ -216,9 +214,8 @@ void print_last_session_error(const char *function)
             libssh2_session_last_error(connected_session, &message, NULL, 0);
         fprintf(stderr, "%s failed (%d): %s\n", function, rc, message);
     }
-    else {
+    else
         fprintf(stderr, "No session\n");
-    }
 }
 
 static void srcdir_path_free(void);
@@ -230,9 +227,8 @@ void stop_session_fixture(void)
         libssh2_session_free(connected_session);
         connected_session = NULL;
     }
-    else {
+    else
         fprintf(stderr, "Cannot stop session - none started\n");
-    }
 
     close_socket_to_openssh_server(connected_socket);
     connected_socket = LIBSSH2_INVALID_SOCKET;
@@ -313,10 +309,9 @@ static void kbd_callback(const char *name, int name_len,
 
     fprintf(stdout, "Kb-int name: %.*s\n", name_len, name);
     fprintf(stdout, "Kb-int instruction: %.*s\n", instruct_len, instruct);
-    for(i = 0; i < num_prompts; ++i) {
+    for(i = 0; i < num_prompts; ++i)
         fprintf(stdout, "Kb-int prompt %d: %.*s\n", i,
                 (int)prompts[i].length, prompts[i].text);
-    }
 
     if(num_prompts == 1) {
         responses[0].text = libssh2_strdup(kbd_password);
@@ -527,13 +522,12 @@ int test_auth_pubkey(LIBSSH2_SESSION *session, int flags,
 
         free(buffer);
     }
-    else {
+    else
         rc = libssh2_userauth_publickey_fromfile_ex(session, username,
                                                 (unsigned int)strlen(username),
                                                     srcdir_path(fn_pub),
                                                     srcdir_path(fn_priv),
                                                     password);
-    }
 
     if((flags & TEST_AUTH_SHOULDFAIL) != 0) {
         if(rc == 0) {

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -76,8 +76,7 @@ static char const *skip_crypt[] = {
     /* Due to a bug with mbedTLS support, these crypt methods fail.
        Until that bug is fixed, do not run them there to avoid this
        known issue causing red tests.
-       See: https://github.com/libssh2/libssh2/issues/793
-     */
+       See: https://github.com/libssh2/libssh2/issues/793 */
     "3des-cbc",
     "aes128-cbc",
     "aes192-cbc",
@@ -86,17 +85,14 @@ static char const *skip_crypt[] = {
     "aes256-gcm@openssh.com",
     "rijndael-cbc@lysator.liu.se",
 #endif
-
 #if !LIBSSH2_3DES
     "3des-cbc",
 #endif
-
 #if !LIBSSH2_AES_GCM
     /* Support for AES-GCM hasn't been added to these back-ends yet */
     "aes128-gcm@openssh.com",
     "aes256-gcm@openssh.com",
 #endif
-
     NULL
 };
 
@@ -478,13 +474,12 @@ int test_auth_pubkey(LIBSSH2_SESSION *session, int flags,
     /* Ignore our hard-wired Dockerfile user when not running under Docker */
     if(!openssh_fixture_have_docker() && !strcmp(username, "libssh2")) {
         username = getenv("USER");
-        if(!username) {
+        if(!username)
 #ifdef _WIN32
             username = getenv("USERNAME");
 #else
             username = getenv("LOGNAME");
 #endif
-        }
     }
 
     if(!username) {

--- a/tests/test_hostkey.c
+++ b/tests/test_hostkey.c
@@ -34,21 +34,18 @@ int test(LIBSSH2_SESSION *session)
         return 1;
     }
 
-    if(type == LIBSSH2_HOSTKEY_TYPE_ED25519) {
+    if(type == LIBSSH2_HOSTKEY_TYPE_ED25519)
         rc = ssh2_base64_decode(session, &expected_hostkey, &expected_len,
                                 EXPECTED_ED25519_HOSTKEY,
                                 strlen(EXPECTED_ED25519_HOSTKEY));
-    }
-    else if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA_256) {
+    else if(type == LIBSSH2_HOSTKEY_TYPE_ECDSA_256)
         rc = ssh2_base64_decode(session, &expected_hostkey, &expected_len,
                                 EXPECTED_ECDSA_HOSTKEY,
                                 strlen(EXPECTED_ECDSA_HOSTKEY));
-    }
-    else if(type == LIBSSH2_HOSTKEY_TYPE_RSA) {
+    else if(type == LIBSSH2_HOSTKEY_TYPE_RSA)
         rc = ssh2_base64_decode(session, &expected_hostkey, &expected_len,
                                 EXPECTED_RSA_HOSTKEY,
                                 strlen(EXPECTED_RSA_HOSTKEY));
-    }
     else {
         fprintf(stderr, "Unexpected type of hostkey: %d\n", type);
         return 1;

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -58,9 +58,8 @@ static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
     char *p = buffer;
     char *end = buffer + buffer_len;
 
-    for(i = 0; i < hash_len && (end - p) >= 3; ++i) {
+    for(i = 0; i < hash_len && (end - p) >= 3; ++i)
         p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
-    }
 }
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -152,17 +152,15 @@ int main(int argc, char *argv[])
 #endif
         do {
             rc = libssh2_session_handshake(session, sock);
-            if(rc == 0) {
+            if(rc == 0)
                 break;
-            }
             fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
             if(
 #ifdef LIBSSH2_WINCNG
                rc != LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE ||
 #endif
-               ++retry > retries) {
+               ++retry > retries)
                 break;
-            }
             fprintf(stderr, "Retrying... %d / %d\n", retry, retries);
         } while(1);
     }
@@ -176,9 +174,8 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++) {
+    for(i = 0; i < 20; i++)
         fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
-    }
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */
@@ -186,15 +183,12 @@ int main(int argc, char *argv[])
                                          (unsigned int)strlen(username));
     if(userauthlist) {
         fprintf(stderr, "Authentication methods: %s\n", userauthlist);
-        if(strstr(userauthlist, "password")) {
+        if(strstr(userauthlist, "password"))
             auth_pw |= 1;
-        }
-        if(strstr(userauthlist, "keyboard-interactive")) {
+        if(strstr(userauthlist, "keyboard-interactive"))
             auth_pw |= 2;
-        }
-        if(strstr(userauthlist, "publickey")) {
+        if(strstr(userauthlist, "publickey"))
             auth_pw |= 4;
-        }
 
         if(auth_pw & 4) {
             /* Authenticate by public key */
@@ -204,9 +198,8 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Authentication by public key failed.\n");
                 goto shutdown;
             }
-            else {
+            else
                 fprintf(stderr, "Authentication by public key succeeded.\n");
-            }
         }
         else {
             fprintf(stderr, "No supported authentication methods found.\n");


### PR DESCRIPTION
Follow-up to b171deefdebe62eb8e583e2a98c9ab450d36dd80 #2077
Follow-up to 28824712fea2843cfac1097bdaf81fb48ce483ac #2004

---

Double-checked by comparing binary objects before and after this
patch with libgcrypt, libressl4, openssl3, mbedtls3 on macOS and
wincng (with ECDSA) via cross-mingw-w64. All with debug logging
and zlib enabled.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
