### PR TITLE
cmake: fix to really disable picky warning for clang-tidy combined with gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,8 +182,6 @@ if(NOT LIBSSH2_DISABLE_INSTALL)
     DESTINATION ${CMAKE_INSTALL_DOCDIR})
 endif()
 
-include(PickyWarnings)
-
 set(LIBSSH2_LIBS_SOCKET "")
 set(LIBSSH2_LIBS "")
 
@@ -291,6 +289,8 @@ if(LIBSSH2_CLANG_TIDY)
     list(APPEND CMAKE_C_CLANG_TIDY ${_tidy_flags_list})
   endif()
 endif()
+
+include(PickyWarnings)
 
 # Auto-detection
 


### PR DESCRIPTION
Follow-up to 6e47049cff4f8d2a0067a0909ab9df3954a5a92f #1844

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
