### PR TITLE
tests: fix wrong index in `srcdir_path()` cleanup

### DIFF
--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -71,21 +71,25 @@ char *srcdir_path(const char *file)
         p = getenv("srcdir");
         if(p) {
             len = snprintf(NULL, 0, "%s/%s", p, file);
-            if(len > 2) {
-                filepath[curpath] = calloc(1, (size_t)len + 1);
-                snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
-            }
-            else
+            if(len <= 2)
                 return NULL;
+
+            filepath[curpath] = calloc(1, (size_t)len + 1);
+            if(!filepath[curpath])
+                return NULL;
+
+            snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
         }
         else {
             len = snprintf(NULL, 0, "%s", file);
-            if(len > 0) {
-                filepath[curpath] = calloc(1, (size_t)len + 1);
-                snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
-            }
-            else
+            if(len <= 0)
                 return NULL;
+
+            filepath[curpath] = calloc(1, (size_t)len + 1);
+            if(!filepath[curpath])
+                return NULL;
+
+            snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
         }
         return filepath[curpath++];
     }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -97,6 +97,7 @@ static void srcdir_path_free(void)
     size_t i;
     for(i = 0; i < curpath; ++i) {
         free(filepath[i]);
+        filepath[i] = NULL;
     }
     curpath = 0;
 }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -235,9 +235,9 @@ void stop_session_fixture(void)
     close_socket_to_openssh_server(connected_socket);
     connected_socket = LIBSSH2_INVALID_SOCKET;
 
-    srcdir_path(NULL);  /* cleanup allocated filepath */
-
     libssh2_exit();
+
+    srcdir_path(NULL);  /* cleanup allocated filepath */
 
     stop_openssh_fixture();
 }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -97,7 +97,7 @@ static void srcdir_path_free(void)
 {
     size_t i;
     for(i = 0; i < curpath; ++i) {
-        free(filepath[curpath]);
+        free(filepath[i]);
     }
     curpath = 0;
 }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -51,6 +51,57 @@
 #include <stdlib.h>  /* for getenv() */
 #include <assert.h>
 
+static char *filepath[32];
+static int curpath;
+
+/* Return a static string that contains a file path relative to the srcdir
+   variable, if found. */
+char *srcdir_path(const char *file)
+{
+    if(file) {
+        char *p;
+        int len;
+
+        if(curpath >= SSH2_ARRAYSIZE(filepath)) {
+            fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
+        }
+        assert(curpath < SSH2_ARRAYSIZE(filepath));
+
+        p = getenv("srcdir");
+        if(p) {
+            len = snprintf(NULL, 0, "%s/%s", p, file);
+            if(len > 2) {
+                filepath[curpath] = calloc(1, (size_t)len + 1);
+                snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
+            }
+            else {
+                return NULL;
+            }
+        }
+        else {
+            len = snprintf(NULL, 0, "%s", file);
+            if(len > 0) {
+                filepath[curpath] = calloc(1, (size_t)len + 1);
+                snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
+            }
+            else {
+                return NULL;
+            }
+        }
+        return filepath[curpath++];
+    }
+    return NULL;
+}
+
+static void srcdir_path_free(void)
+{
+    int i;
+    for(i = 0; i < curpath; ++i) {
+        free(filepath[curpath]);
+    }
+    curpath = 0;
+}
+
 static LIBSSH2_SESSION *connected_session = NULL;
 static libssh2_socket_t connected_socket = LIBSSH2_INVALID_SOCKET;
 
@@ -237,56 +288,9 @@ void stop_session_fixture(void)
 
     libssh2_exit();
 
-    srcdir_path(NULL);  /* cleanup allocated filepath */
+    srcdir_path_free();
 
     stop_openssh_fixture();
-}
-
-/* Return a static string that contains a file path relative to the srcdir
- * variable, if found.
- */
-#define NUMPATHS 32
-char *srcdir_path(const char *file)
-{
-    static char *filepath[NUMPATHS];
-    static int curpath;
-    char *p = getenv("srcdir");
-    if(file) {
-        int len;
-        if(curpath >= NUMPATHS) {
-            fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
-        }
-        assert(curpath < NUMPATHS);
-        if(p) {
-            len = snprintf(NULL, 0, "%s/%s", p, file);
-            if(len > 2) {
-                filepath[curpath] = calloc(1, (size_t)len + 1);
-                snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
-            }
-            else {
-                return NULL;
-            }
-        }
-        else {
-            len = snprintf(NULL, 0, "%s", file);
-            if(len > 0) {
-                filepath[curpath] = calloc(1, (size_t)len + 1);
-                snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
-            }
-            else {
-                return NULL;
-            }
-        }
-        return filepath[curpath++];
-    }
-    else {
-        int i;
-        for(i = 0; i < curpath; ++i) {
-            free(filepath[i]);
-        }
-        curpath = 0;
-        return NULL;
-    }
 }
 
 static const char *kbd_password;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -75,9 +75,8 @@ char *srcdir_path(const char *file)
                 filepath[curpath] = calloc(1, (size_t)len + 1);
                 snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
             }
-            else {
+            else
                 return NULL;
-            }
         }
         else {
             len = snprintf(NULL, 0, "%s", file);
@@ -85,9 +84,8 @@ char *srcdir_path(const char *file)
                 filepath[curpath] = calloc(1, (size_t)len + 1);
                 snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
             }
-            else {
+            else
                 return NULL;
-            }
         }
         return filepath[curpath++];
     }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -52,7 +52,7 @@
 #include <assert.h>
 
 static char *filepath[32];
-static int curpath;
+static size_t curpath;
 
 /* Return a static string that contains a file path relative to the srcdir
    variable, if found. */
@@ -95,7 +95,7 @@ char *srcdir_path(const char *file)
 
 static void srcdir_path_free(void)
 {
-    int i;
+    size_t i;
     for(i = 0; i < curpath; ++i) {
         free(filepath[curpath]);
     }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -51,61 +51,6 @@
 #include <stdlib.h>  /* for getenv() */
 #include <assert.h>
 
-static char *filepath[32];
-static size_t curpath;
-
-/* Return a static string that contains a file path relative to the srcdir
-   variable, if found. */
-char *srcdir_path(const char *file)
-{
-    if(file) {
-        char *p;
-        int len;
-
-        if(curpath >= SSH2_ARRAYSIZE(filepath)) {
-            fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
-            return NULL;
-        }
-        assert(curpath < SSH2_ARRAYSIZE(filepath));
-
-        p = getenv("srcdir");
-        if(p) {
-            len = snprintf(NULL, 0, "%s/%s", p, file);
-            if(len <= 2)
-                return NULL;
-
-            filepath[curpath] = calloc(1, (size_t)len + 1);
-            if(!filepath[curpath])
-                return NULL;
-
-            snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
-        }
-        else {
-            len = snprintf(NULL, 0, "%s", file);
-            if(len <= 0)
-                return NULL;
-
-            filepath[curpath] = calloc(1, (size_t)len + 1);
-            if(!filepath[curpath])
-                return NULL;
-
-            snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
-        }
-        return filepath[curpath++];
-    }
-    return NULL;
-}
-
-static void srcdir_path_free(void)
-{
-    size_t i;
-    for(i = 0; i < curpath; ++i) {
-        free(filepath[i]);
-        filepath[i] = NULL;
-    }
-    curpath = 0;
-}
-
 static LIBSSH2_SESSION *connected_session = NULL;
 static libssh2_socket_t connected_socket = LIBSSH2_INVALID_SOCKET;
 
@@ -276,6 +221,8 @@ void print_last_session_error(const char *function)
     }
 }
 
+static void srcdir_path_free(void);
+
 void stop_session_fixture(void)
 {
     if(connected_session) {
@@ -295,6 +242,61 @@ void stop_session_fixture(void)
     srcdir_path_free();
 
     stop_openssh_fixture();
+}
+
+static char *filepath[32];
+static size_t curpath;
+
+/* Return a static string that contains a file path relative to the srcdir
+   variable, if found. */
+char *srcdir_path(const char *file)
+{
+    if(file) {
+        char *p;
+        int len;
+
+        if(curpath >= SSH2_ARRAYSIZE(filepath)) {
+            fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
+            return NULL;
+        }
+        assert(curpath < SSH2_ARRAYSIZE(filepath));
+
+        p = getenv("srcdir");
+        if(p) {
+            len = snprintf(NULL, 0, "%s/%s", p, file);
+            if(len <= 2)
+                return NULL;
+
+            filepath[curpath] = calloc(1, (size_t)len + 1);
+            if(!filepath[curpath])
+                return NULL;
+
+            snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
+        }
+        else {
+            len = snprintf(NULL, 0, "%s", file);
+            if(len <= 0)
+                return NULL;
+
+            filepath[curpath] = calloc(1, (size_t)len + 1);
+            if(!filepath[curpath])
+                return NULL;
+
+            snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
+        }
+        return filepath[curpath++];
+    }
+    return NULL;
+}
+
+static void srcdir_path_free(void)
+{
+    size_t i;
+    for(i = 0; i < curpath; ++i) {
+        free(filepath[i]);
+        filepath[i] = NULL;
+    }
+    curpath = 0;
 }
 
 static const char *kbd_password;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -64,6 +64,7 @@ char *srcdir_path(const char *file)
 
         if(curpath >= SSH2_ARRAYSIZE(filepath)) {
             fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
+            return NULL;
         }
         assert(curpath < SSH2_ARRAYSIZE(filepath));
 

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -282,7 +282,7 @@ char *srcdir_path(const char *file)
     else {
         int i;
         for(i = 0; i < curpath; ++i) {
-            free(filepath[curpath]);
+            free(filepath[i]);
         }
         curpath = 0;
         return NULL;


### PR DESCRIPTION
Causing memleak, OOB read and freeing an invalid pointer.

Also:
- fix potentially freeing the whole list when receiving `NULL` input
  path. (reported by clang-tidy, could not happen with existing tests.)
- make use of `SSH2_ARRAYSIZE()`, bump index type to `size_t`.
- avoid calling `getenv()` when unnecessary.
- clear freed slot pointers.
- avoid crash on OOM by checking `calloc()` results.
- return `NULL` if no more empty slots.
- drop single-instruction `{}` blocks.

Root issue spotted by GitHub Code Quality

Note: this is still problematic after this many changes since the many
failure mores all return `NULL` which then crash/break the actual test,
in obscure ways.

Follow-up to 12427f4fb8e789adcee4a6e30974932883915e88 #1415

---

https://github.com/libssh2/libssh2/pull/2089/files?w=1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
