### PR TITLE
wincng: validate argument to prevent passing NULL to `strcmp()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2441,7 +2441,7 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
     unsigned int curve;
 
     /* Validate parameters */
-    if(!out_curve) {
+    if(!name || !out_curve) {
         return LIBSSH2_ERROR_INVAL;
     }
 


### PR DESCRIPTION
Can't happen with current code.

Seen with GNU 15.2.0 CMake Release build:
```
src/wincng.c:2448:13: error: argument 1 null where non-null expected [-Werror=nonnull]
 2448 |         if(!strcmp(name, wcng_ecdsa_algs[curve].name)) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
