### PR TITLE
wincng: fix potential NULL deref in `wcng_uncompressed_point_from_publickey()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2112,23 +2112,27 @@ static int wcng_uncompressed_point_from_publickey(
         NULL,
         0, &ecc_blob_len,
         0);
-    if(BCRYPT_SUCCESS(status) && ecc_blob_len > 0) {
-        ecc_blob = SSH2_ALLOC(session, ecc_blob_len);
-        if(!ecc_blob) {
-            result = LIBSSH2_ERROR_ALLOC;
-            goto cleanup;
-        }
-
-        status = BCryptExportKey(key,
-            NULL,
-            BCRYPT_ECCPUBLIC_BLOB,
-            (PUCHAR)ecc_blob,
-            ecc_blob_len, &ecc_blob_len,
-            0);
-    }
-    else {
+    if(!BCRYPT_SUCCESS(status) || ecc_blob_len == 0) {
         result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
-                          "Decoding the ECC public key failed");
+                          "Failed preparing to decode the ECC public key");
+        goto cleanup;
+    }
+
+    ecc_blob = SSH2_ALLOC(session, ecc_blob_len);
+    if(!ecc_blob) {
+        result = LIBSSH2_ERROR_ALLOC;
+        goto cleanup;
+    }
+
+    status = BCryptExportKey(key,
+        NULL,
+        BCRYPT_ECCPUBLIC_BLOB,
+        (PUCHAR)ecc_blob,
+        ecc_blob_len, &ecc_blob_len,
+        0);
+    if(!BCRYPT_SUCCESS(status)) {
+        result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
+                          "Failed decoding the ECC public key");
         goto cleanup;
     }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2114,7 +2114,7 @@ static int wcng_uncompressed_point_from_publickey(
         0);
     if(!BCRYPT_SUCCESS(status) || ecc_blob_len == 0) {
         result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
-                          "Failed preparing to decode the ECC public key");
+                          "Preparing to decode the ECC public key failed");
         goto cleanup;
     }
 
@@ -2132,7 +2132,7 @@ static int wcng_uncompressed_point_from_publickey(
         0);
     if(!BCRYPT_SUCCESS(status)) {
         result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
-                          "Failed decoding the ECC public key");
+                          "Decoding the ECC public key failed");
         goto cleanup;
     }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2126,8 +2126,7 @@ static int wcng_uncompressed_point_from_publickey(
             ecc_blob_len, &ecc_blob_len,
             0);
     }
-
-    if(!BCRYPT_SUCCESS(status)) {
+    else {
         result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                           "Decoding the ECC public key failed");
         goto cleanup;


### PR DESCRIPTION
Seen with GNU 15.2.0 CMake Release build:
```
src/wincng.c:2137:42: error: potential null pointer dereference [-Werror=null-dereference]
 2137 |     point_y = (PUCHAR)ecc_blob + ecc_blob->cbKey + sizeof(BCRYPT_ECCKEY_BLOB);
      |                                  ~~~~~~~~^~~~~~~
```

---

https://github.com/libssh2/libssh2/pull/2095/files?w=1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
