### PR TITLE
test_hostkey_hash: silence `-Wformat-truncation` in `calculate_digest()`

### DIFF
--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -58,7 +58,7 @@ static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
     char *p = buffer;
     char *end = buffer + buffer_len;
 
-    for(i = 0; i < hash_len && p < end - 3; ++i) {
+    for(i = 0; i < hash_len && p < end - 2; ++i) {
         p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
     }
 }

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -58,7 +58,7 @@ static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
     char *p = buffer;
     char *end = buffer + buffer_len;
 
-    for(i = 0; i < hash_len && p < end; ++i) {
+    for(i = 0; i < hash_len && p < end - 3; ++i) {
         p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
     }
 }


### PR DESCRIPTION
Seen with GNU 15.2.0 CMake Release build for Windows:
```
tests/test_hostkey_hash.c:62:14: error: '%02X' directive output truncated writing 2 bytes into a region of size 1 [-Werror=format-truncation=]
   62 |         p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
