### PR TITLE
wincng: do more bounds check in `wcng_uncompressed_point_from_publickey()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2138,7 +2138,7 @@ static int wcng_uncompressed_point_from_publickey(
 
     if(ecc_blob_len < sizeof(BCRYPT_ECCKEY_BLOB) + (ecc_blob->cbKey * 2)) {
         result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
-                          "Preparing to decode the ECC public key failed");
+                          "Decoded ECC public key buffer too small");
         goto cleanup;
     }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2112,7 +2112,7 @@ static int wcng_uncompressed_point_from_publickey(
         NULL,
         0, &ecc_blob_len,
         0);
-    if(!BCRYPT_SUCCESS(status) || ecc_blob_len == 0) {
+    if(!BCRYPT_SUCCESS(status) || ecc_blob_len < sizeof(BCRYPT_ECCKEY_BLOB)) {
         result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                           "Preparing to decode the ECC public key failed");
         goto cleanup;
@@ -2137,7 +2137,7 @@ static int wcng_uncompressed_point_from_publickey(
     }
 
     point_x = (PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB);
-    point_y = (PUCHAR)ecc_blob + ecc_blob->cbKey + sizeof(BCRYPT_ECCKEY_BLOB);
+    point_y = (PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB) + ecc_blob->cbKey;
 
     /*
      * Create uncompressed point, which needs to look like the following:

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2136,6 +2136,12 @@ static int wcng_uncompressed_point_from_publickey(
         goto cleanup;
     }
 
+    if(ecc_blob_len < sizeof(BCRYPT_ECCKEY_BLOB) + (ecc_blob->cbKey * 2)) {
+        result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
+                          "Preparing to decode the ECC public key failed");
+        goto cleanup;
+    }
+
     point_x = (PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB);
     point_y = (PUCHAR)ecc_blob + sizeof(BCRYPT_ECCKEY_BLOB) + ecc_blob->cbKey;
 


### PR DESCRIPTION
- verify the buffer is at least `BCRYPT_ECCKEY_BLOB` struct sized before
  reading it.
- verify if the returned buffer fits the extra two keys before reading
  them.

Also: improve readability of a nearby line.

Ref: https://learn.microsoft.com/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_ecckey_blob
Bug: https://github.com/libssh2/libssh2/pull/2095#discussion_r3447646859
Ref: 8eb4953c49ed5414cbe5e9b5c4fc73c64d36900f #2095
