### PR TITLE
session: fix `-Wformat-overflow` with gcc-16

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1129,8 +1129,9 @@ static int session_disconnect(LIBSSH2_SESSION *session, int reason,
 
     if(session->disconnect_state == ssh2_NB_state_idle) {
         ssh2_deb((session, LIBSSH2_TRACE_TRANS,
-                  "Disconnecting: reason=%d, desc=%s, lang=%s",
-                  reason, description, lang));
+                  "Disconnecting: reason=%d, desc=%s, lang=%s", reason,
+                  description ? description : "(null)",
+                  lang ? lang : "(null)"));
         if(description)
             descr_len = strlen(description);
 


### PR DESCRIPTION
Seen on macOS, with GCC 16.1.0:
```
In function 'session_disconnect',
src/session.c:1132:19: error: '%s' directive argument is null [-Werror=format-overflow=]
 1132 |                   "Disconnecting: reason=%d, desc=%s, lang=%s",
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/session.c: In function 'libssh2_session_disconnect_ex':
src/session.c:1132:60: note: format string is defined here
 1132 |                   "Disconnecting: reason=%d, desc=%s, lang=%s",
      |                                                            ^~
src/session.c:1132:19: error: '%s' directive argument is null [-Werror=format-overflow=]
 1132 |                   "Disconnecting: reason=%d, desc=%s, lang=%s",
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/session.c: In function 'libssh2_session_disconnect_ex':
src/session.c:1132:51: note: format string is defined here
 1132 |                   "Disconnecting: reason=%d, desc=%s, lang=%s",
      |                                                   ^~
```

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
