### PR TITLE
test_hostkey_hash: fix `-Wformat-truncation` with gcc-16

### DIFF
--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -58,7 +58,7 @@ static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
     char *p = buffer;
     char *end = buffer + buffer_len;
 
-    for(i = 0; i < hash_len && p < end - 2; ++i) {
+    for(i = 0; i < hash_len && (end - p) >= 3; ++i) {
         p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
     }
 }


### PR DESCRIPTION
Seen with GNU 16.1.0 CMake Release build for Windows:
```
In function 'calculate_digest',
    inlined from 'test' at tests/test_hostkey_hash.c:189:9:
tests/test_hostkey_hash.c:62:14: error: '%02X' directive output truncated writing 2 bytes into a region of size 1 [-Werror=format-truncation=]
   62 |         p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
      |              ^~~~~~~~
tests/test_hostkey_hash.c:62:14: note: directive argument in the range [0, 255]
tests/test_hostkey_hash.c:62:14: note: '__builtin___snprintf_chk' output 3 bytes into a destination of size 1
   62 |         p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
      |              ^~~~~~~~
[...]
```

Follow-up to 837ce2f1230de8c2821918f8b470cca50e9d4fd6 #2096

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
