### PR TITLE
example/ssh2: replace GCC silencer pragma with a simpler workaround

### DIFF
--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -199,8 +199,8 @@ int main(int argc, char *argv[])
             char const *h = getenv("HOME");
             if(!h || !*h)
                 h = ".";
-            fn1sz = strlen(h) + strlen(pubkey) + 3;
-            fn2sz = strlen(h) + strlen(privkey) + 3;
+            fn1sz = strlen(h) + strlen(pubkey) + 4;
+            fn2sz = strlen(h) + strlen(privkey) + 4;
             fn1 = malloc(fn1sz);
             fn2 = malloc(fn2sz);
             if(!fn1 || !fn2) {

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -199,6 +199,8 @@ int main(int argc, char *argv[])
             char const *h = getenv("HOME");
             if(!h || !*h)
                 h = ".";
+            /* Silence GCC -Wformat-truncation false positives by allocating
+               2 extra bytes for each buffer. */
             fn1sz = strlen(h) + strlen(pubkey) + 4;
             fn2sz = strlen(h) + strlen(privkey) + 4;
             fn1 = malloc(fn1sz);

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -199,8 +199,8 @@ int main(int argc, char *argv[])
             char const *h = getenv("HOME");
             if(!h || !*h)
                 h = ".";
-            fn1sz = strlen(h) + strlen(pubkey) + 2;
-            fn2sz = strlen(h) + strlen(privkey) + 2;
+            fn1sz = strlen(h) + strlen(pubkey) + 3;
+            fn2sz = strlen(h) + strlen(privkey) + 3;
             fn1 = malloc(fn1sz);
             fn2 = malloc(fn2sz);
             if(!fn1 || !fn2) {
@@ -210,18 +210,10 @@ int main(int argc, char *argv[])
                 goto shutdown;
             }
             /* Avoid false positives */
-#if defined(__GNUC__) && __GNUC__ >= 7
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wformat-truncation=1"
-#endif
             /* Using asprintf() here would be much cleaner,
                but less portable */
             snprintf(fn1, fn1sz, "%s/%s", h, pubkey);
             snprintf(fn2, fn2sz, "%s/%s", h, privkey);
-#if defined(__GNUC__) && __GNUC__ >= 7
-#pragma GCC diagnostic pop
-#endif
-
             if(libssh2_userauth_publickey_fromfile(session, username,
                                                    fn1, fn2,
                                                    password)) {

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -201,8 +201,8 @@ int main(int argc, char *argv[])
                 h = ".";
             /* Silence GCC -Wformat-truncation false positives by allocating
                2 extra bytes for each buffer. */
-            fn1sz = strlen(h) + strlen(pubkey) + 4;
-            fn2sz = strlen(h) + strlen(privkey) + 4;
+            fn1sz = strlen(h) + strlen(pubkey) + 2 + 2;
+            fn2sz = strlen(h) + strlen(privkey) + 2 + 2;
             fn1 = malloc(fn1sz);
             fn2 = malloc(fn2sz);
             if(!fn1 || !fn2) {


### PR DESCRIPTION
As of gcc-16, this still causes a false positive:
```
example/ssh2.c: In function 'main':
example/ssh2.c:215:34: error: '__builtin_snprintf' output may be truncated before the last format character [-Werror=format-truncation=]
  215 |             snprintf(fn1, fn1sz, "%s/%s", h, pubkey);
      |                                  ^~~~~~~
example/ssh2.c:215:40: note: format string is defined here
  215 |             snprintf(fn1, fn1sz, "%s/%s", h, pubkey);
      |                                        ^
example/ssh2.c:215:13: note: '__builtin_snprintf' output 17 or more bytes (assuming 18) into a destination of size 17
  215 |             snprintf(fn1, fn1sz, "%s/%s", h, pubkey);
      |             ^~~~~~~~
example/ssh2.c:216:34: error: '__builtin_snprintf' output may be truncated before the last format character [-Werror=format-truncation=]
  216 |             snprintf(fn2, fn2sz, "%s/%s", h, privkey);
      |                                  ^~~~~~~
example/ssh2.c:216:40: note: format string is defined here
  216 |             snprintf(fn2, fn2sz, "%s/%s", h, privkey);
      |                                        ^
example/ssh2.c:216:13: note: '__builtin_snprintf' output 13 or more bytes (assuming 14) into a destination of size 13
  216 |             snprintf(fn2, fn2sz, "%s/%s", h, privkey);
      |             ^~~~~~~~                                           
```

By bumping the allocated buffers by one byte, the above disappears, but
remains in gcc-13. Fix by bumping buffer by one more byte.
```
example/ssh2.c: In function ‘main’:
example/ssh2.c:228:40: error: ‘snprintf’ output may be truncated before the last format character [-Werror=format-truncation=]
  228 |             snprintf(fn1, fn1sz, "%s/%s", h, pubkey);
      |                                        ^
example/ssh2.c:228:13: note: ‘snprintf’ output 3 or more bytes (assuming 4) into a destination of size 3
  228 |             snprintf(fn1, fn1sz, "%s/%s", h, pubkey);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
example/ssh2.c:229:40: error: ‘snprintf’ output may be truncated before the last format character [-Werror=format-truncation=]
  229 |             snprintf(fn2, fn2sz, "%s/%s", h, privkey);
      |                                        ^
example/ssh2.c:229:13: note: ‘snprintf’ output 3 or more bytes (assuming 4) into a destination of size 3
  229 |             snprintf(fn2, fn2sz, "%s/%s", h, privkey);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Ref: https://github.com/libssh2/libssh2/actions/runs/27890978881/job/82534253967#step:24:67
