### PR TITLE
tests: tidy up `srcdir_path()` more

### DIFF
--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -265,9 +265,9 @@ const char *srcdir_path(const char *file)
         abort();
     }
 
-    buflen = srclen + 1 /* / */ + filelen + 1 /* \0 */;
+    buflen = srclen + 1 + filelen + 1;  /* srcdir + / + file + nul */
 
-    filepath[curpath] = calloc(1, buflen);
+    filepath[curpath] = malloc(buflen);
     if(!filepath[curpath]) {
         fprintf(stderr, "srcdir_path: failed allocating buffer.\n");
         abort();

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -245,7 +245,7 @@ static size_t curpath;
 const char *srcdir_path(const char *file)
 {
     const char *srcdir = getenv("srcdir");
-    int len;
+    size_t buflen, srclen, filelen;
 
     if(!srcdir || !*srcdir)
         return file;
@@ -257,19 +257,23 @@ const char *srcdir_path(const char *file)
         abort();
     }
 
-    len = ssh2_snprintf(NULL, 0, "%s/%s", srcdir, file);
-    if(len <= 2) {
-        fprintf(stderr, "srcdir_path: failed determining size.\n");
+    srclen = strlen(srcdir);
+    filelen = strlen(file);
+
+    if(srclen > 8192 || filelen > 8192) {
+        fprintf(stderr, "srcdir_path: input names too large.\n");
         abort();
     }
 
-    filepath[curpath] = calloc(1, (size_t)len + 1);
+    buflen = srclen + 1 /* / */ + filelen + 1 /* \0 */;
+
+    filepath[curpath] = calloc(1, buflen);
     if(!filepath[curpath]) {
         fprintf(stderr, "srcdir_path: failed allocating buffer.\n");
         abort();
     }
 
-    ssh2_snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", srcdir, file);
+    ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
 
     return filepath[curpath++];
 }

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -239,47 +239,39 @@ void stop_session_fixture(void)
 static char *filepath[32];
 static size_t curpath;
 
-/* Return a static string that contains a file path relative to the srcdir
-   variable, if found. */
-char *srcdir_path(const char *file)
+/* If 'srcdir' env is set, return '$srcdir/<file>' in a dynamic buffer
+   (released automatically on exit), otherwise return the input pointer
+   unchanged. */
+const char *srcdir_path(const char *file)
 {
-    if(file) {
-        char *p;
-        int len;
+    const char *srcdir = getenv("srcdir");
+    int len;
 
-        if(curpath >= SSH2_ARRAYSIZE(filepath)) {
-            fprintf(stderr, "srcdir_path ran out of filepath slots.\n");
-            return NULL;
-        }
-        assert(curpath < SSH2_ARRAYSIZE(filepath));
+    if(!srcdir || !*srcdir)
+        return file;
+    if(!file)
+        return NULL;
 
-        p = getenv("srcdir");
-        if(p) {
-            len = ssh2_snprintf(NULL, 0, "%s/%s", p, file);
-            if(len <= 2)
-                return NULL;
-
-            filepath[curpath] = calloc(1, (size_t)len + 1);
-            if(!filepath[curpath])
-                return NULL;
-
-            ssh2_snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p,
-                          file);
-        }
-        else {
-            len = ssh2_snprintf(NULL, 0, "%s", file);
-            if(len <= 0)
-                return NULL;
-
-            filepath[curpath] = calloc(1, (size_t)len + 1);
-            if(!filepath[curpath])
-                return NULL;
-
-            ssh2_snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
-        }
-        return filepath[curpath++];
+    if(curpath >= SSH2_ARRAYSIZE(filepath)) {
+        fprintf(stderr, "srcdir_path: ran out of filepath slots.\n");
+        abort();
     }
-    return NULL;
+
+    len = ssh2_snprintf(NULL, 0, "%s/%s", srcdir, file);
+    if(len <= 2) {
+        fprintf(stderr, "srcdir_path: failed determining size.\n");
+        abort();
+    }
+
+    filepath[curpath] = calloc(1, (size_t)len + 1);
+    if(!filepath[curpath]) {
+        fprintf(stderr, "srcdir_path: failed allocating buffer.\n");
+        abort();
+    }
+
+    ssh2_snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", srcdir, file);
+
+    return filepath[curpath++];
 }
 
 static void srcdir_path_free(void)

--- a/tests/session_fixture.h
+++ b/tests/session_fixture.h
@@ -47,7 +47,7 @@
 LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err);
 void stop_session_fixture(void);
 void print_last_session_error(const char *function);
-char *srcdir_path(const char *file);
+const char *srcdir_path(const char *file);
 
 #define TEST_AUTH_SHOULDFAIL  1
 #define TEST_AUTH_FROMMEM     2


### PR DESCRIPTION
- if `srcdir` is unset or empty return the received filename as-is.
- replace `assert()` with an always-enabled check, error messages and
  `abort()` on fail. To make it work in debug build and not return
  `NULL` to the caller.
- determine buffer length manuall, to not rely on `snprintf()`.
- limit input sizes.
- switch from `calloc()` to `malloc()` to avoid GCC false positive
  `-Wformat-truncation`.
  Ref: https://github.com/libssh2/libssh2/actions/runs/27912044754/job/82590731447#step:24:45
- restore lost `const` to return value.
- constify `getenv()` result pointer.
- rename `p` to `srcdir`.
- flatten.

If this still falls short in some ways, it's still an option to revert 
to static buffers.

Follow-up to aae3776a4fcf7c8994b3b7f1e5b57b005e1efe3c #2089
Follow-up to 12427f4fb8e789adcee4a6e30974932883915e88 #1415

---

https://github.com/libssh2/libssh2/pull/2102/files?w=1
