### PR TITLE
build: stop redefining system symbol `snprintf`

### DIFF
--- a/example/.checksrc
+++ b/example/.checksrc
@@ -8,4 +8,5 @@ allowfunc fstat
 allowfunc printf
 allowfunc recv
 allowfunc send
+allowfunc snprintf
 allowfunc strdup

--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -20,7 +20,6 @@ my @options = (
     "-afree",
     "-amalloc",
     "-arealloc",
-    "-asnprintf",
     "-asocket",
     "-berrno",
 );

--- a/src/agent.c
+++ b/src/agent.c
@@ -653,8 +653,8 @@ static int agent_transact_pageant(LIBSSH2_AGENT *agent,
         return ssh2_err(agent->session, LIBSSH2_ERROR_AGENT_PROTOCOL,
                         "found no pageant");
 
-    snprintf(mapname, sizeof(mapname),
-             "PageantRequest%08x", (unsigned)GetCurrentThreadId());
+    ssh2_snprintf(mapname, sizeof(mapname),
+                  "PageantRequest%08x", (unsigned)GetCurrentThreadId());
     filemap = CreateFileMappingA(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
                                  0, PAGEANT_MAX_MSGLEN, mapname);
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -1329,8 +1329,8 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
         }
         else {
             int i;
-            /* note: the snprintf() loop always writes 3 bytes so the
-               last one writes the trailing zero after the
+            /* note: the ssh2_snprintf() loop always writes 3 bytes so
+               the last one writes the trailing zero after the
                LIBSSH2_X11_RANDOM_COOKIE_LEN border in s, but s has extra
                4 bytes of size (for screen_number) */
             unsigned char buffer[LIBSSH2_X11_RANDOM_COOKIE_LEN / 2];
@@ -1341,7 +1341,7 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
                                 "for x11-req cookie");
 
             for(i = 0; i < (LIBSSH2_X11_RANDOM_COOKIE_LEN / 2); i++)
-                snprintf((char *)&s[i * 2], 3, "%02X", buffer[i]);
+                ssh2_snprintf((char *)&s[i * 2], 3, "%02X", buffer[i]);
         }
         s += cookie_len;
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -255,7 +255,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
         char *fprint = fingerprint;
         int i;
         for(i = 0; i < MD5_DIGEST_LENGTH; i++, fprint += 3)
-            snprintf(fprint, 4, "%02x:", session->server_hostkey_md5[i]);
+            ssh2_snprintf(fprint, 4, "%02x:", session->server_hostkey_md5[i]);
         *(--fprint) = '\0';
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Server's MD5 Fingerprint: %s",
                   fingerprint));
@@ -280,7 +280,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
         char *fprint = fingerprint;
         int i;
         for(i = 0; i < SHA1_DIGEST_LENGTH; i++, fprint += 3)
-            snprintf(fprint, 4, "%02x:", session->server_hostkey_sha1[i]);
+            ssh2_snprintf(fprint, 4, "%02x:", session->server_hostkey_sha1[i]);
         *(--fprint) = '\0';
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Server's SHA1 Fingerprint: %s",
                   fingerprint));

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -375,7 +375,8 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
     /* if a port number is given, check for a '[host]:port' first before the
        plain 'host' */
     if(port >= 0) {
-        int len = snprintf(hostbuff, sizeof(hostbuff), "[%s]:%d", hostp, port);
+        int len = ssh2_snprintf(hostbuff, sizeof(hostbuff), "[%s]:%d",
+                                hostp, port);
         if(len < 0 || len >= (int)sizeof(hostbuff)) {
             ssh2_err(hosts->session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                      "Known-host write buffer too small");
@@ -1076,17 +1077,18 @@ static int knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
 
         if(required_size <= buflen) {
             if(node->comment && key_type_len)
-                snprintf(buf, buflen, "|1|%s|%s %s %s %s\n", saltalloc,
-                         namealloc, key_type_name, node->key, node->comment);
+                ssh2_snprintf(buf, buflen, "|1|%s|%s %s %s %s\n", saltalloc,
+                              namealloc, key_type_name, node->key,
+                              node->comment);
             else if(node->comment)
-                snprintf(buf, buflen, "|1|%s|%s %s %s\n", saltalloc, namealloc,
-                         node->key, node->comment);
+                ssh2_snprintf(buf, buflen, "|1|%s|%s %s %s\n", saltalloc,
+                              namealloc, node->key, node->comment);
             else if(key_type_len)
-                snprintf(buf, buflen, "|1|%s|%s %s %s\n", saltalloc, namealloc,
-                         key_type_name, node->key);
+                ssh2_snprintf(buf, buflen, "|1|%s|%s %s %s\n", saltalloc,
+                              namealloc, key_type_name, node->key);
             else
-                snprintf(buf, buflen, "|1|%s|%s %s\n", saltalloc, namealloc,
-                         node->key);
+                ssh2_snprintf(buf, buflen, "|1|%s|%s %s\n", saltalloc,
+                              namealloc, node->key);
         }
 
         SSH2_FREE(hosts->session, namealloc);
@@ -1098,16 +1100,16 @@ static int knownhost_writeline(LIBSSH2_KNOWNHOSTS *hosts,
 
         if(required_size <= buflen) {
             if(node->comment && key_type_len)
-                snprintf(buf, buflen, "%s %s %s %s\n", node->name,
-                         key_type_name, node->key, node->comment);
+                ssh2_snprintf(buf, buflen, "%s %s %s %s\n", node->name,
+                              key_type_name, node->key, node->comment);
             else if(node->comment)
-                snprintf(buf, buflen, "%s %s %s\n", node->name, node->key,
-                         node->comment);
+                ssh2_snprintf(buf, buflen, "%s %s %s\n", node->name, node->key,
+                              node->comment);
             else if(key_type_len)
-                snprintf(buf, buflen, "%s %s %s\n", node->name, key_type_name,
-                         node->key);
+                ssh2_snprintf(buf, buflen, "%s %s %s\n", node->name,
+                              key_type_name, node->key);
             else
-                snprintf(buf, buflen, "%s %s\n", node->name, node->key);
+                ssh2_snprintf(buf, buflen, "%s %s\n", node->name, node->key);
         }
     }
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -147,10 +147,9 @@
 #endif
 
 /* Use local implementation when not available */
-#ifndef HAVE_SNPRINTF
-#undef snprintf
-#define snprintf ssh2_snprintf
-#define LIBSSH2_SNPRINTF
+#ifdef HAVE_SNPRINTF
+#define ssh2_snprintf snprintf
+#else
 int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
     SSH2_PRINTF(3, 4);
 #endif

--- a/src/misc.c
+++ b/src/misc.c
@@ -58,7 +58,7 @@
 
 /* snprintf not in Visual Studio CRT and _snprintf dangerously incompatible.
    We provide a safe wrapper if snprintf not found */
-#ifdef LIBSSH2_SNPRINTF
+#ifndef HAVE_SNPRINTF
 #include <stdarg.h>
 
 /* Want safe, 'n += snprintf(b + n ...)' like function. If cp_max_len is 1 then

--- a/src/misc.c
+++ b/src/misc.c
@@ -563,8 +563,8 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         firstsec = now.tv_sec;
     now.tv_sec -= firstsec;
 
-    len = snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
-                   (int)now.tv_sec, (int)now.tv_usec, contexttext);
+    len = ssh2_snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
+                        (int)now.tv_sec, (int)now.tv_usec, contexttext);
 
     if(len >= buflen)
         msglen = buflen - 1;

--- a/src/scp.c
+++ b/src/scp.c
@@ -307,8 +307,9 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
             return NULL;
         }
 
-        snprintf((char *)session->scpRecv_command,
-                 session->scpRecv_command_len, "scp -%sf ", sb ? "p" : "");
+        ssh2_snprintf((char *)session->scpRecv_command,
+                      session->scpRecv_command_len,
+                      "scp -%sf ", sb ? "p" : "");
 
         cmd_len = strlen((char *)session->scpRecv_command);
 
@@ -851,9 +852,9 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
             return NULL;
         }
 
-        snprintf((char *)session->scpSend_command,
-                 session->scpSend_command_len,
-                 "scp -%st ", (mtime || atime) ? "p" : "");
+        ssh2_snprintf((char *)session->scpSend_command,
+                      session->scpSend_command_len,
+                      "scp -%st ", (mtime || atime) ? "p" : "");
 
         cmd_len = strlen((char *)session->scpSend_command);
 
@@ -951,9 +952,9 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
         if(mtime || atime) {
             /* Send mtime and atime to be used for file */
             session->scpSend_response_len =
-                snprintf((char *)session->scpSend_response,
-                         SSH2_SCP_RESPONSE_BUFLEN, "T%ld 0 %ld 0\n",
-                         (long)mtime, (long)atime);
+                ssh2_snprintf((char *)session->scpSend_response,
+                              SSH2_SCP_RESPONSE_BUFLEN, "T%ld 0 %ld 0\n",
+                              (long)mtime, (long)atime);
             ssh2_deb((session, LIBSSH2_TRACE_SCP, "Sent %s",
                       session->scpSend_response));
         }
@@ -1018,10 +1019,10 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
             base = path;
 
         session->scpSend_response_len =
-            snprintf((char *)session->scpSend_response,
-                     SSH2_SCP_RESPONSE_BUFLEN,
-                     "C0%o %" SSH2_INT64_T_FORMAT " %s\n",
-                     (unsigned int)mode, size, base);
+            ssh2_snprintf((char *)session->scpSend_response,
+                          SSH2_SCP_RESPONSE_BUFLEN,
+                          "C0%o %" SSH2_INT64_T_FORMAT " %s\n",
+                          (unsigned int)mode, size, base);
         ssh2_deb((session, LIBSSH2_TRACE_SCP, "Sent %s",
                   session->scpSend_response));
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -65,8 +65,8 @@ static void debugdump(LIBSSH2_SESSION *session,
     if(!(session->showmask & LIBSSH2_TRACE_TRANS))
         return;  /* not asked for, bail out */
 
-    used = snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
-                    desc, (unsigned long)size);
+    used = ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
+                         desc, (unsigned long)size);
     if(session->tracehandler)
         (session->tracehandler)(session, session->tracehandler_context,
                                 buffer, used);
@@ -76,7 +76,8 @@ static void debugdump(LIBSSH2_SESSION *session,
 
     for(i = 0; i < size; i += width) {
 
-        used = snprintf(buffer, sizeof(buffer), "%04lx: ", (unsigned long)i);
+        used = ssh2_snprintf(buffer, sizeof(buffer), "%04lx: ",
+                             (unsigned long)i);
 
         /* hex not disabled, show it */
         for(c = 0; c < width; c++) {

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -117,7 +117,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
         return -1;
     }
 
-    ret = snprintf(buf, sizeof(buf), redirect_stderr, command_buf);
+    ret = ssh2_snprintf(buf, sizeof(buf), redirect_stderr, command_buf);
     if(ret < 0 || ret >= BUFSIZ) {
         fprintf(stderr, "Unable to rewrite command (%s)\n", command);
         return -1;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -255,7 +255,7 @@ char *srcdir_path(const char *file)
 
         p = getenv("srcdir");
         if(p) {
-            len = snprintf(NULL, 0, "%s/%s", p, file);
+            len = ssh2_snprintf(NULL, 0, "%s/%s", p, file);
             if(len <= 2)
                 return NULL;
 
@@ -263,10 +263,11 @@ char *srcdir_path(const char *file)
             if(!filepath[curpath])
                 return NULL;
 
-            snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p, file);
+            ssh2_snprintf(filepath[curpath], (size_t)len + 1, "%s/%s", p,
+                          file);
         }
         else {
-            len = snprintf(NULL, 0, "%s", file);
+            len = ssh2_snprintf(NULL, 0, "%s", file);
             if(len <= 0)
                 return NULL;
 
@@ -274,7 +275,7 @@ char *srcdir_path(const char *file)
             if(!filepath[curpath])
                 return NULL;
 
-            snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
+            ssh2_snprintf(filepath[curpath], (size_t)len + 1, "%s", file);
         }
         return filepath[curpath++];
     }

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -62,7 +62,8 @@ static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
         *p = 0;
 
         for(i = 0; i < hash_len && (end - p) >= 3; ++i, p += 2)
-            snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
+            ssh2_snprintf(p, (size_t)(end - p), "%02X",
+                          (unsigned char)hash[i]);
     }
 }
 

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -86,9 +86,9 @@ int test(LIBSSH2_SESSION *session)
     }
 
     /* command to transfer the desired amount of data */
-    snprintf(remote_command, sizeof(remote_command),
-             "dd if=/dev/zero bs=%lu count=%lu status=none",
-             xfer_bs, xfer_count);
+    ssh2_snprintf(remote_command, sizeof(remote_command),
+                  "dd if=/dev/zero bs=%lu count=%lu status=none",
+                  xfer_bs, xfer_count);
 
     /* Send the command to transfer data */
     if(libssh2_channel_exec(channel, remote_command)) {


### PR DESCRIPTION
Introduce and use the local name `ssh2_snprintf()` instead, and map it
to system `snprintf()` when safe, otherwise directly  call the local
implementation already using this name.

Also: adjust checksrc rules.
