### PR TITLE
test_hostkey_hash: tidy up `calculate_digest()`

### DIFF
--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -54,12 +54,16 @@ static const size_t SHA256_HASH_SIZE = 32;
 static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
                              size_t buffer_len)
 {
-    size_t i;
-    char *p = buffer;
-    char *end = buffer + buffer_len;
+    if(buffer && buffer_len) {
+        size_t i;
+        char *p = buffer;
+        char *end = buffer + buffer_len;
 
-    for(i = 0; i < hash_len && (end - p) >= 3; ++i)
-        p += snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
+        *p = 0;
+
+        for(i = 0; i < hash_len && (end - p) >= 3; ++i, p += 2)
+            snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
+    }
 }
 
 int test(LIBSSH2_SESSION *session)


### PR DESCRIPTION
To pacify code analyzers by not using the return value of `snprintf()`
to advance the output pointer.

Also:
- check output buffer arguments.
- clear output buffer if too small for conversion.

Ref: https://github.com/libssh2/libssh2/pull/2103#discussion_r3448610423
Follow-up to 36d38812d028b3c44b657fda90089e255c1d3b5c #2099
Follow-up to 837ce2f1230de8c2821918f8b470cca50e9d4fd6 #2096

---

https://github.com/libssh2/libssh2/pull/2104/files?w=1
