### PR TITLE
misc: null-terminate `ssh2_snprintf()` output in pre-VS2015 builds

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -56,14 +56,14 @@
 #define SSH2_SEND_LOW  send
 #endif
 
-/* snprintf not in Visual Studio CRT and _snprintf dangerously incompatible.
-   We provide a safe wrapper if snprintf not found */
+/* snprintf is not in <VS2015 CRT and _snprintf dangerously incompatible.
+   We provide a safe wrapper for these environments */
 #ifndef HAVE_SNPRINTF
 #include <stdarg.h>
 
 /* Want safe, 'n += snprintf(b + n ...)' like function. Returns number of chars
  * placed in cp excluding the trailing null char. For cp_max_len > 0 the return
- * value is always < cp_max_len; for cp_max_len <= 0 the return value is 0 (and
+ * value is always < cp_max_len; for cp_max_len == 0 the return value is 0 (and
  * no chars are written to cp). Always null-terminate the output. */
 int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
 {

--- a/src/misc.c
+++ b/src/misc.c
@@ -61,11 +61,10 @@
 #ifndef HAVE_SNPRINTF
 #include <stdarg.h>
 
-/* Want safe, 'n += snprintf(b + n ...)' like function. If cp_max_len is 1 then
- * assume cp is pointing to a null char and do nothing. Returns number of chars
+/* Want safe, 'n += snprintf(b + n ...)' like function. Returns number of chars
  * placed in cp excluding the trailing null char. For cp_max_len > 0 the return
  * value is always < cp_max_len; for cp_max_len <= 0 the return value is 0 (and
- * no chars are written to cp). */
+ * no chars are written to cp). Always null-terminate the output. */
 int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
 {
     va_list args;
@@ -73,13 +72,15 @@ int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
     if(!cp_max_len)
         return 0;
     if(cp_max_len == 1) {
-        cp[0] = 0;
+        if(cp)
+            cp[0] = 0;
         return 0;
     }
     va_start(args, fmt);
     /* !checksrc! disable BANNEDFUNC 1 */
     n = vsnprintf(cp, cp_max_len, fmt, args);
-    cp[cp_max_len - 1] = 0;
+    if(cp)
+        cp[cp_max_len - 1] = 0;
     va_end(args);
     return (n < (int)cp_max_len) ? n : (int)(cp_max_len - 1);
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -56,7 +56,7 @@
 #define SSH2_SEND_LOW  send
 #endif
 
-/* snprintf is not in <VS2015 CRT and _snprintf dangerously incompatible.
+/* snprintf is not in pre-VS2015 CRTs and _snprintf dangerously incompatible.
    We provide a safe wrapper for these environments */
 #ifndef HAVE_SNPRINTF
 #include <stdarg.h>

--- a/src/misc.c
+++ b/src/misc.c
@@ -70,12 +70,16 @@ int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
 {
     va_list args;
     int n;
-
-    if(cp_max_len < 2)
+    if(!cp_max_len)
         return 0;
+    if(cp_max_len == 1) {
+        cp[0] = 0;
+        return 0;
+    }
     va_start(args, fmt);
     /* !checksrc! disable BANNEDFUNC 1 */
     n = vsnprintf(cp, cp_max_len, fmt, args);
+    cp[cp_max_len - 1] = 0;
     va_end(args);
     return (n < (int)cp_max_len) ? n : (int)(cp_max_len - 1);
 }


### PR DESCRIPTION
Prior to Visual Studio 2015 CRT `vsnprintf()` did not guarantee to
null-terminate the output buffer. Do it in local code to fix that,
and align `ssh2_snprintf()` with VS2015+ and other platforms with a
C99-compliant implementation.

Refs:
https://github.com/curl/curl/commit/64f28b8f8859fc80816f7db3b5c4b6f2fd84bd27
https://github.com/curl/curl/pull/20765
https://learn.microsoft.com/cpp/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l
https://pubs.opengroup.org/onlinepubs/9699919799/functions/snprintf.html
https://linux.die.net/man/3/snprintf

Follow-up to 4cdf785cd313c3272d04c2ef7458a35d44533d8b #812
Follow-up to 6bf898336889b5151503f882e1f76eecd480a191
