### PR TITLE
tests: revert `srcdir_path()` to static buffers

### DIFF
--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -214,8 +214,6 @@ void print_last_session_error(const char *function)
         fprintf(stderr, "No session\n");
 }
 
-static void srcdir_path_free(void);
-
 void stop_session_fixture(void)
 {
     if(connected_session) {
@@ -231,21 +229,19 @@ void stop_session_fixture(void)
 
     libssh2_exit();
 
-    srcdir_path_free();
-
     stop_openssh_fixture();
 }
 
-static char *filepath[32];
-static size_t curpath;
-
-/* If 'srcdir' env is set, return '$srcdir/<file>' in a dynamic buffer
-   (released automatically on exit), otherwise return the input pointer
+/* If 'srcdir' env is set, return '$srcdir/<file>' in a static buffer
+   (to avoid dynamic memory allocations), otherwise return the input pointer
    unchanged. */
 const char *srcdir_path(const char *file)
 {
+    static char filepath[32][256];
+    static size_t curpath;
+
     const char *srcdir = getenv("srcdir");
-    size_t buflen, srclen, filelen;
+    int len;
 
     if(!srcdir || !*srcdir)
         return file;
@@ -257,35 +253,15 @@ const char *srcdir_path(const char *file)
         abort();
     }
 
-    srclen = strlen(srcdir);
-    filelen = strlen(file);
-
-    if(srclen > 8192 || filelen > 8192) {
-        fprintf(stderr, "srcdir_path: input names too large.\n");
+    len = ssh2_snprintf(filepath[curpath], sizeof(filepath[0]), "%s/%s",
+                        srcdir, file);
+    if(len < 0 || (size_t)len >= sizeof(filepath[0])) {
+        fprintf(stderr, "srcdir_path: path too long. srcdir='%s', fn='%s'\n",
+                srcdir, file);
         abort();
     }
-
-    buflen = srclen + 1 + filelen + 1;  /* srcdir + / + file + nul */
-
-    filepath[curpath] = malloc(buflen);
-    if(!filepath[curpath]) {
-        fprintf(stderr, "srcdir_path: failed allocating buffer.\n");
-        abort();
-    }
-
-    ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
 
     return filepath[curpath++];
-}
-
-static void srcdir_path_free(void)
-{
-    size_t i;
-    for(i = 0; i < curpath; ++i) {
-        free(filepath[i]);
-        filepath[i] = NULL;
-    }
-    curpath = 0;
 }
 
 static const char *kbd_password;


### PR DESCRIPTION
This time without using `MAXPATHLEN`, which is missing from GNU Hurd.
Nor using other constants, but fixed 256 bytes on all platforms.

Dynamic allocations almost looked good after good summer day of hair
pulling, until I ran gcc-16, gcc-15, gcc-14 locally, in unity mode,
where all 3 fell over with `-Wformat-truncate` false positives. This
isn't worth all this amount of hassle.

(It also fails in CI. What confused me is the last push only triggered
AppVeyor CI and it went green. What a mess.)

Ref: https://darnassus.sceen.net/~hurd-web/faq/foo_max/
Follow-up to 4cecccd604842f3cff947a4a9c84a106eda36d5b #2102
Follow-up to aae3776a4fcf7c8994b3b7f1e5b57b005e1efe3c #2089
Follow-up to 12427f4fb8e789adcee4a6e30974932883915e88 #1415

Fixing:
gcc-13 (in CI):
https://github.com/libssh2/libssh2/actions/runs/27913275531/job/82594004458
```
tests/session_fixture.c: In function ‘srcdir_path’:
tests/session_fixture.c:276:50: error: ‘%s’ directive output may be truncated writing likely 1 or more bytes into a region of size between 0 and 1 [-Werror=format-truncation=]
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |                                                  ^~
tests/session_fixture.c:276:46: note: assuming directive output of 1 byte
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |                                              ^~~~~~~
In file included from tests/session_fixture.h:45,
                 from tests/runner.h:44,
                 from tests/runner.c:40,
                 from bld/tests/CMakeFiles/runner.dir/Unity/unity_0_c.c:4:
src/libssh2_priv.h:151:23: note: ‘snprintf’ output 2 or more bytes (assuming 4) into a destination of size 2
  151 | #define ssh2_snprintf snprintf
tests/session_fixture.c:276:5: note: in expansion of macro ‘ssh2_snprintf’
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |     ^~~~~~~~~~~~~
```

gcc-14, gcc-15:
```
tests/session_fixture.c: In function 'srcdir_path':
tests/session_fixture.c:276:46: error: '%s' directive output may be truncated writing likely 1 or more bytes into a region of size between 0 and 1 [-Werror=format-truncation=]
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |                                              ^~~~~~~
tests/session_fixture.c:276:5: note: in expansion of macro 'ssh2_snprintf'
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |     ^~~~~~~~~~~~~
In file included from bld/tests/CMakeFiles/runner.dir/Unity/unity_0_c.c:7:
tests/session_fixture.c:276:50: note: format string is defined here
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |                                                  ^~
tests/session_fixture.c:276:46: note: assuming directive output of 1 byte
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |                                              ^~~~~~~
tests/session_fixture.c:276:5: note: in expansion of macro 'ssh2_snprintf'
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |     ^~~~~~~~~~~~~
src/libssh2_priv.h:151:23: note: '__builtin_snprintf' output 2 or more bytes (assuming 4) into a destination of size 2
  151 | #define ssh2_snprintf snprintf
      |                       ^~~~~~~~
tests/session_fixture.c:276:5: note: in expansion of macro 'ssh2_snprintf'
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |     ^~~~~~~~~~~~~
```

gcc-16:
```
tests/session_fixture.c: In function 'srcdir_path':
tests/session_fixture.c:276:46: error: '%s' directive output may be truncated writing up to 8192 bytes into a region of size 2 [-Werror=format-truncation=]
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |                                              ^~~~~~~
tests/session_fixture.c:276:5: note: in expansion of macro 'ssh2_snprintf'
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |     ^~~~~~~~~~~~~
In file included from bld/tests/CMakeFiles/runner.dir/Unity/unity_0_c.c:7:
tests/session_fixture.c:276:47: note: format string is defined here
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |                                               ^~
src/libssh2_priv.h:151:23: note: '__builtin_snprintf' output between 2 and 16386 bytes into a destination of size 2
  151 | #define ssh2_snprintf snprintf
      |                       ^~~~~~~~
tests/session_fixture.c:276:5: note: in expansion of macro 'ssh2_snprintf'
  276 |     ssh2_snprintf(filepath[curpath], buflen, "%s/%s", srcdir, file);
      |     ^~~~~~~~~~~~~
```

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
