### PR TITLE
chacha: silence `-Wuninitialized` with gcc-16+

### DIFF
--- a/src/chacha.c
+++ b/src/chacha.c
@@ -81,6 +81,10 @@ void chacha_ivsetup(struct chacha_ctx *x, const u8 *iv, const u8 *counter)
     x->input[15] = U8TO32_LITTLE(iv + 4);
 }
 
+#if defined(__GNUC__) && __GNUC__ >= 16
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
 void chacha_encrypt_bytes(struct chacha_ctx *x, const u8 *m, u8 *c,
                           size_t bytes)
 {
@@ -215,3 +219,6 @@ void chacha_encrypt_bytes(struct chacha_ctx *x, const u8 *m, u8 *c,
         m += 64;
     }
 }
+#if defined(__GNUC__) && __GNUC__ >= 16
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Seems like a legit warning, but the operations made on uninitialized 
values appear to be discarded and not affecting output.
                                                               
The code also matches the upstream copy in openssh, where I found no
issues reported, and there were no fixes applied.

Therefore this patch silences the warning with a local `#pragma`.

Seen with GCC 16.1.0 `-O3`:
```
src/chacha.c: In function 'chacha_encrypt_bytes.part.0.constprop':
src/chacha.c:27:28: error: 'tmp' is used uninitialized [-Werror=uninitialized]
   27 |      ((u32)((p)[2]) << 16) | \
      |                            ^
src/chacha.c:39:27: note: in definition of macro 'XOR'
   39 | #define XOR(v, w) ((v) ^ (w))
      |                           ^
src/chacha.c:165:22: note: in expansion of macro 'U8TO32_LITTLE'
  165 |         x1 = XOR(x1, U8TO32_LITTLE(m + 4));
      |                      ^~~~~~~~~~~~~
src/chacha.c:90:8: note: 'tmp' declared here
   90 |     u8 tmp[64];
      |        ^~~
```

Ref: https://github.com/openssh/openssh-portable/blob/0d156d385e1e9c31bd5fb3652cf620a1f51c9b19/chacha.c
