### PR TITLE
test_ssh2: fix to free channel on `libssh2_channel_shell()` fail

### DIFF
--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
     char *userauthlist;
     int rc;
     LIBSSH2_SESSION *session = NULL;
-    LIBSSH2_CHANNEL *channel;
+    LIBSSH2_CHANNEL *channel = NULL;
     unsigned int counter;
 
 #ifdef _WIN32
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
      */
     if(libssh2_channel_request_pty(channel, "vanilla")) {
         fprintf(stderr, "Failed requesting pty\n");
-        goto skip_shell;
+        goto shutdown;  /* skip shell */
     }
 
     /* Open a SHELL on that pty */
@@ -236,12 +236,10 @@ int main(int argc, char *argv[])
 
     rc = 0;
 
-skip_shell:
+shutdown:
 
     if(channel)
         libssh2_channel_free(channel);
-
-shutdown:
 
     if(session) {
         libssh2_session_disconnect(session, "Normal Shutdown");


### PR DESCRIPTION
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
