### PR TITLE
tidy-up: comments

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -329,12 +329,12 @@ int main(int argc, char *argv[])
 shutdown:
 
     if(forwardsock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(forwardsock, 2);
+        shutdown(forwardsock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(forwardsock);
     }
 
     if(listensock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(listensock, 2);
+        shutdown(listensock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(listensock);
     }
 
@@ -347,7 +347,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/scp.c
+++ b/example/scp.c
@@ -172,7 +172,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -289,7 +289,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -211,7 +211,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -295,7 +295,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -277,7 +277,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -354,7 +354,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -220,7 +220,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -165,7 +165,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -164,7 +164,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -293,7 +293,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -205,7 +205,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -281,7 +281,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -292,7 +292,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -272,7 +272,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -223,7 +223,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -324,7 +324,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -230,7 +230,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -290,7 +290,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -372,7 +372,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -301,7 +301,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -293,7 +293,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -325,7 +325,7 @@ int main(int argc, char *argv[])
 shutdown:
 
     if(forwardsock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(forwardsock, 2);
+        shutdown(forwardsock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(forwardsock);
     }
 
@@ -341,7 +341,7 @@ shutdown:
     }
 
     if(sock != LIBSSH2_INVALID_SOCKET) {
-        shutdown(sock, 2);
+        shutdown(sock, 2 /* SHUT_RDWR */);
         LIBSSH2_SOCKET_CLOSE(sock);
     }
 

--- a/src/chacha.h
+++ b/src/chacha.h
@@ -21,11 +21,13 @@ struct chacha_ctx {
     u32 input[16];
 };
 
+#if 0
 #define CHACHA_MINKEYLEN    16
 #define CHACHA_NONCELEN     8
 #define CHACHA_CTRLEN       8
 #define CHACHA_STATELEN     (CHACHA_NONCELEN + CHACHA_CTRLEN)
 #define CHACHA_BLOCKLEN     64
+#endif
 
 void chacha_keysetup(struct chacha_ctx *x, const u8 *k, u32 kbits);
 void chacha_ivsetup(struct chacha_ctx *x, const u8 *iv, const u8 *counter);

--- a/src/kex.c
+++ b/src/kex.c
@@ -2364,7 +2364,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        /*/ verify hash */
+        /* verify hash */
         switch(type) {
         case SSH2_EC_CURVE_NISTP256: {
             ssh2_sha256_ctx k_ctx;
@@ -2718,7 +2718,7 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
             }
         }
 
-        /*/ verify hash */
+        /* verify hash */
         KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(256);
 
         if(rc) {
@@ -3021,7 +3021,7 @@ static int mlkem768x25519_sha256(
             goto clean_exit;
         }
 
-        /*/ verify hash */
+        /* verify hash */
         KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY(256);
 
         if(rc) {

--- a/src/misc.c
+++ b/src/misc.c
@@ -62,9 +62,9 @@
 #include <stdarg.h>
 
 /* Want safe, 'n += snprintf(b + n ...)' like function. Returns number of chars
- * placed in cp excluding the null-terminator. For cp_max_len > 0 the return
- * value is always < cp_max_len; for cp_max_len == 0 the return value is 0 (and
- * no chars are written to cp). Always null-terminate the output. */
+   placed in cp excluding the null-terminator. For cp_max_len > 0 the return
+   value is always < cp_max_len; for cp_max_len == 0 the return value is 0 (and
+   no chars are written to cp). Always null-terminate the output. */
 int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
 {
     va_list args;
@@ -426,16 +426,14 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
 }
 
 /* ---- Base64 Encoding/Decoding Table --- */
+
 static const char table64[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 /*
- * ssh2_base64_encode()
- *
  * Returns the length of the newly created base64 string. The third argument
  * is a pointer to an allocated area holding the base64 data. If something
  * went wrong, 0 is returned.
- *
  */
 size_t ssh2_base64_encode(LIBSSH2_SESSION *session,
                           const char *inp, size_t insize, char **outptr)
@@ -504,6 +502,7 @@ size_t ssh2_base64_encode(LIBSSH2_SESSION *session,
 
     return strlen(base64data); /* return the length of the new data */
 }
+
 /* ---- End of Base64 Encoding ---- */
 
 void libssh2_free(LIBSSH2_SESSION *session, void *ptr)
@@ -931,7 +930,6 @@ int ssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf,
 /* Given the current location in buf, ssh2_check_length() ensures
    callers can read the next len number of bytes out of the buffer
    before reading the buffer content */
-
 int ssh2_check_length(struct string_buf *buf, size_t requested_len)
 {
     unsigned char *endp = &buf->data[buf->len];

--- a/src/misc.c
+++ b/src/misc.c
@@ -62,7 +62,7 @@
 #include <stdarg.h>
 
 /* Want safe, 'n += snprintf(b + n ...)' like function. Returns number of chars
- * placed in cp excluding the trailing null char. For cp_max_len > 0 the return
+ * placed in cp excluding the null-terminator. For cp_max_len > 0 the return
  * value is always < cp_max_len; for cp_max_len == 0 the return value is 0 (and
  * no chars are written to cp). Always null-terminate the output. */
 int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)


### PR DESCRIPTION
- chacha: comment out unused macros.
- example: add `SHUT_RDWR` comments to match test code.
- kex: delete stray characters.
- misc: use 'null-terminator'.
- misc: nits.
