### PR TITLE
wincng: drop floating point math

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -184,7 +184,7 @@ static int wcng_bn_random(ssh2_bn *rnd, int bits, int top, int bottom)
     unsigned char *bignum;
     ULONG length;
 
-    if(!rnd)
+    if(!rnd || bits <= 0)
         return -1;
 
     length = (ULONG)((bits + 7) / 8);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -62,7 +62,6 @@
 #include <wincrypt.h>  /* for CryptDecodeObjectEx() */
 #endif
 #include <bcrypt.h>
-#include <math.h>
 
 #include <stdlib.h>
 
@@ -188,7 +187,7 @@ static int wcng_bn_random(ssh2_bn *rnd, int bits, int top, int bottom)
     if(!rnd)
         return -1;
 
-    length = (ULONG)(ceil(((double)bits) / 8.0) * sizeof(unsigned char));
+    length = (ULONG)((bits + 7) / 8);
     if(wcng_bn_resize(rnd, length))
         return -1;
 
@@ -303,7 +302,7 @@ int ssh2_wcng_bn_set_word(ssh2_bn *bn, ULONG word)
         bits++;
     bits++;
 
-    length = (ULONG)(ceil(((double)bits) / 8.0) * sizeof(unsigned char));
+    length = (bits + 7) / 8;
     if(wcng_bn_resize(bn, length))
         return -1;
 
@@ -349,7 +348,7 @@ int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin)
     memcpy(bn->bignum, bin, len);
 
     bits = ssh2_wcng_bn_bits(bn);
-    length = (ULONG)(ceil(((double)bits) / 8.0) * sizeof(unsigned char));
+    length = (bits + 7) / 8;
 
     offset = bn->length - length;
     if(offset > 0) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -187,7 +187,7 @@ static int wcng_bn_random(ssh2_bn *rnd, int bits, int top, int bottom)
     if(!rnd || bits <= 0)
         return -1;
 
-    length = (ULONG)((bits + 7) / 8);
+    length = ((ULONG)bits + 7) / 8;
     if(wcng_bn_resize(rnd, length))
         return -1;
 


### PR DESCRIPTION
For number of bits to bytes conversions.

Also: requires positive number of bits in `wcng_bn_random()`. To match
mbedtls sibling code and avoid UB.

Suggested by GitHub Code Quality

---

"The use of floating-point arithmetic with `ceil` and division by 8.0 is
unnecessarily complex for converting bits to bytes. Consider using
integer arithmetic: `length = (ULONG)((bits + 7) / 8)` for better
performance and clarity."

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
