### PR TITLE
GHA: disable `VCPKG_APPLOCAL_DEPS` to avoid flaky CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1004,6 +1004,7 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake \
             -DCMAKE_GENERATOR_PLATFORM=${archgen} \
             -DVCPKG_TARGET_TRIPLET="${MATRIX_ARCH}-${MATRIX_PLAT}" \
+            -DVCPKG_APPLOCAL_DEPS=OFF \
             -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
             -DCMAKE_UNITY_BUILD="${MATRIX_UNITY}" \
             -DENABLE_WERROR=ON \


### PR DESCRIPTION
During last week MSVC GHA jobs started failing on occasion. Log clues.
are "deploying dependencies", "The process cannot access the file
because it is being used by another process.", and "C:\vcpkg\vcpkg.exe
z-applocal". Turns out the latter command has been introduced recently.
Then two weeks ago vcpkg's cmake script switched to it by default for 
the `VCPKG_APPLOCAL_DEPS` option. This option is enabled by default.
It's vcpkg's implementation of the DLL copying feature, which I just
dropped from libssh2 (suspecting it as a root cause for these failures).

Fix by disabling this option, since libssh2 CI jobs don't need it.

Examples, with shared libssh2:
combined with WINCNG:
Before: https://github.com/libssh2/libssh2/actions/runs/27901568257/job/82562736781 (229 steps)
After: https://github.com/libssh2/libssh2/actions/runs/27924142060/job/82623203836 (179 steps)
combined with OpenSSL:
Before: https://github.com/libssh2/libssh2/actions/runs/27902733625/job/82565870012 (229 steps)
After: https://github.com/libssh2/libssh2/actions/runs/27924142060/job/82623203795 (179 steps)

Fixing:
```
  D:/a/libssh2/libssh2/bld/tests/Release/test_read.exe: message: deploying dependencies
  The process cannot access the file because it is being used by another process.
  sftp_RW_nonblock.vcxproj -> D:\a\libssh2\libssh2\bld\example\Release\sftp_RW_nonblock.exe
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: The command "setlocal [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: C:\vcpkg\vcpkg.exe z-applocal --target-binary=D:/a/libssh2/libssh2/bld/tests/Release/test_auth_pubkey_ok_ecdsa_signed.exe --installed-bin-dir=C:/vcpkg/installed/x64-windows/bin [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: if %errorlevel% neq 0 goto :cmEnd [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: :cmEnd [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: :cmErrorLevel [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: exit /b %1 [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: :cmDone [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: if %errorlevel% neq 0 goto :VCEnd [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: :VCEnd" exited with code 32. [D:\a\libssh2\libssh2\bld\tests\test_auth_pubkey_ok_ecdsa_signed.vcxproj]
```
Ref: https://github.com/libssh2/libssh2/actions/runs/27922679181/job/82619051657?pr=2113

Refs:
https://github.com/libssh2/libssh2/pull/2078/commits/1e5e2923f71a6624ee9ca46bba7fa8d33611e80e
https://devblogs.microsoft.com/cppblog/whats-new-in-vcpkg-apr-2026/
https://github.com/microsoft/vcpkg/blame/a0b1c8d3a477c1cb4813d8e127a56961707ca42b/scripts/buildsystems/vcpkg.cmake#L48-L50
https://github.com/microsoft/vcpkg/blob/a0b1c8d3a477c1cb4813d8e127a56961707ca42b/scripts/buildsystems/vcpkg.cmake#L622
https://github.com/microsoft/vcpkg/commit/b8ab03c3c560acae6fa7fdc228957cad7134d2fe
https://github.com/microsoft/vcpkg/pull/52315

Bug: https://github.com/libssh2/libssh2/pull/2101#issuecomment-4763841047
Follow-up to 3b730f2ef158ead8e277ed6f51430ab8903feae8 #2101
