### PR TITLE
example: check `write()` and `fgets()` results to silence `-Wunused-result`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckIncludeFiles)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,6 @@ message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(CMAKE_BUILD_TYPE "RelWithDebInfo")
-
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckIncludeFiles)

--- a/example/scp.c
+++ b/example/scp.c
@@ -152,8 +152,12 @@ int main(int argc, char *argv[])
             amount = (int)(fileinfo.st_size - got);
 
         nread = libssh2_channel_read(channel, mem, (size_t)amount);
-        if(nread > 0)
-            write(1, mem, (size_t)nread);
+        if(nread > 0) {
+            ssize_t nwritten = write(1, mem, (size_t)nread);
+            if(nwritten != nread)
+                fprintf(stderr, "write failed: %ld vs %ld\n",
+                        (long)nread, (long)nwritten);
+        }
         else if(nread < 0) {
             fprintf(stderr, "libssh2_channel_read() failed: %ld\n",
                     (long)nread);

--- a/example/scp.c
+++ b/example/scp.c
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
         if(nread > 0) {
             ssize_t nwritten = write(1, mem, (size_t)nread);
             if(nwritten != nread)
-                fprintf(stderr, "write failed: %ld vs %ld\n",
+                fprintf(stderr, "write failed: %ld != %ld\n",
                         (long)nread, (long)nwritten);
         }
         else if(nread < 0) {

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -253,7 +253,7 @@ int main(int argc, char *argv[])
             if(nread > 0) {
                 ssize_t nwritten = write(1, mem, (size_t)nread);
                 if(nwritten != nread)
-                    fprintf(stderr, "write failed: %ld vs %ld\n",
+                    fprintf(stderr, "write failed: %ld != %ld\n",
                             (long)nread, (long)nwritten);
                 got += nread;
                 total += nread;

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -251,7 +251,10 @@ int main(int argc, char *argv[])
             /* loop until we block */
             nread = libssh2_channel_read(channel, mem, (size_t)amount);
             if(nread > 0) {
-                write(1, mem, (size_t)nread);
+                ssize_t nwritten = write(1, mem, (size_t)nread);
+                if(nwritten != nread)
+                    fprintf(stderr, "write failed: %ld vs %ld\n",
+                            (long)nread, (long)nwritten);
                 got += nread;
                 total += nread;
             }

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -260,8 +260,12 @@ int main(int argc, char *argv[])
         /* loop until we fail */
         fprintf(stderr, "libssh2_sftp_read().\n");
         nread = libssh2_sftp_read(sftp_handle, mem, sizeof(mem));
-        if(nread > 0)
-            write(1, mem, (size_t)nread);
+        if(nread > 0) {
+            ssize_t nwritten = write(1, mem, (size_t)nread);
+            if(nwritten != nread)
+                fprintf(stderr, "write failed: %ld vs %ld\n",
+                        (long)nread, (long)nwritten);
+        }
         else
             break;
     } while(1);

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -70,7 +70,8 @@ static void kbd_callback(const char *name, int name_len,
         fprintf(stderr, "'\n");
 
         fprintf(stderr, "Please type response: ");
-        fgets(buf, sizeof(buf), stdin);
+        if(!fgets(buf, sizeof(buf), stdin))
+            fprintf(stderr, "fgets() failed.\n");
         n = strlen(buf);
         while(n > 0 && strchr("\r\n", buf[n - 1]))
             n--;

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
         if(nread > 0) {
             ssize_t nwritten = write(1, mem, (size_t)nread);
             if(nwritten != nread)
-                fprintf(stderr, "write failed: %ld vs %ld\n",
+                fprintf(stderr, "write failed: %ld != %ld\n",
                         (long)nread, (long)nwritten);
         }
         else

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -242,7 +242,7 @@ int main(int argc, char *argv[])
                 /* write to stderr */
                 ssize_t nwritten = write(2, mem, (size_t)nread);
                 if(nwritten != nread)
-                    fprintf(stderr, "write failed: %ld vs %ld\n",
+                    fprintf(stderr, "write failed: %ld != %ld\n",
                             (long)nread, (long)nwritten);
                 /* write to temporary storage area */
                 fwrite(mem, (size_t)nread, 1, tempstorage);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -240,7 +240,10 @@ int main(int argc, char *argv[])
 
             if(nread > 0) {
                 /* write to stderr */
-                write(2, mem, (size_t)nread);
+                ssize_t nwritten = write(2, mem, (size_t)nread);
+                if(nwritten != nread)
+                    fprintf(stderr, "write failed: %ld vs %ld\n",
+                            (long)nread, (long)nwritten);
                 /* write to temporary storage area */
                 fwrite(mem, (size_t)nread, 1, tempstorage);
             }

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
             total += nread;
             nwritten = write(1, mem, (size_t)nread);
             if(nwritten != nread)
-                fprintf(stderr, "write failed: %ld vs %ld\n",
+                fprintf(stderr, "write failed: %ld != %ld\n",
                         (long)nread, (long)nwritten);
         }
         else

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -262,8 +262,12 @@ int main(int argc, char *argv[])
             waitsocket(sock, session); /* now we wait */
         }
         if(nread > 0) {
+            ssize_t nwritten;
             total += nread;
-            write(1, mem, (size_t)nread);
+            nwritten = write(1, mem, (size_t)nread);
+            if(nwritten != nread)
+                fprintf(stderr, "write failed: %ld vs %ld\n",
+                        (long)nread, (long)nwritten);
         }
         else
             break;

--- a/example/x11.c
+++ b/example/x11.c
@@ -223,8 +223,12 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, libssh2_socket_t sock)
     rc = libssh2_poll(fds, nfds, 0);
     if(rc > 0) {
         nread = libssh2_channel_read(channel, buf, bufsize);
-        if(nread > 0)
-            write(sock, buf, (size_t)nread);
+        if(nread > 0) {
+            ssize_t nwritten = write(sock, buf, (size_t)nread);
+            if(nwritten != nread)
+                fprintf(stderr, "write failed: %ld vs %ld\n",
+                        (long)nread, (long)nwritten);
+        }
     }
 
     rc = select((int)(sock + 1), &set, NULL, NULL, &timeval_out);

--- a/example/x11.c
+++ b/example/x11.c
@@ -226,7 +226,7 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, libssh2_socket_t sock)
         if(nread > 0) {
             ssize_t nwritten = write(sock, buf, (size_t)nread);
             if(nwritten != nread)
-                fprintf(stderr, "write failed: %ld vs %ld\n",
+                fprintf(stderr, "write failed: %ld != %ld\n",
                         (long)nread, (long)nwritten);
         }
     }


### PR DESCRIPTION
Seen when building in cmake Release config on Linux:
```
example/scp_nonblock.c:254:17: error: ignoring return value
of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  254 |                 write(1, mem, (size_t)nread);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Ref: https://github.com/libssh2/libssh2/actions/runs/28063084190/job/83084069984

```
example/sftp.c:73:9: error: ignoring return value of ‘fgets’ declared
with attribute ‘warn_unused_result’ [-Wunused-result]
   73 |         fgets(buf, sizeof(buf), stdin);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Ref: https://github.com/libssh2/libssh2/actions/runs/28064008314/job/83084278796
