### PR TITLE
GHA: replace OpenSSL 1.1 with 4.0 in macOS jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1053,10 +1053,10 @@ jobs:
             install: openssl@4
             configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl@4
             cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
-          - name: 'OpenSSL 3.5'
-            install: openssl@3.5
-            configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl@3.5
-            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3.5
+          - name: 'OpenSSL 3'
+            install: openssl@3
+            configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl@3
+            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3
           - name: 'wolfSSL'
             install: wolfssl
             configure: --with-crypto=wolfssl --with-libwolfssl-prefix=/opt/homebrew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1049,14 +1049,14 @@ jobs:
             install: mbedtls@3
             configure: --with-crypto=mbedtls --with-libmbedcrypto-prefix=/opt/homebrew
             cmake: -DCRYPTO_BACKEND=mbedTLS
-          - name: 'OpenSSL 3'
-            install: openssl
-            configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl
-            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl
-          - name: 'OpenSSL 1.1'
-            install: openssl@1.1
-            configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl@1.1
-            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@1.1
+          - name: 'OpenSSL 4'
+            install: openssl@4
+            configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl@4
+            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
+          - name: 'OpenSSL 3.5'
+            install: openssl@3.5
+            configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl@3.5
+            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3.5
           - name: 'wolfSSL'
             install: wolfssl
             configure: --with-crypto=wolfssl --with-libwolfssl-prefix=/opt/homebrew


### PR DESCRIPTION
Homebrew no longer offers the OpenSSL 1.1 package, and CI sometimes
fails with an error saying that. Other runs/retries using the same
runner image revision (macOS 26.4 20260527.539) are able to find the
preinstalled 1.1.1w, and using it without error.

Since the package is no longer present in the repository, I assume this
flaky failure becomes a permanent soon:
https://github.com/Homebrew/homebrew-core/tree/825330b61dc10901d179fc6e589d564742eb2705/Formula/o

Thus, to fix the flaky CI and prepare for the above, drop 1.1, replace 
it with 4.0.

Fixing flaky:
```
Warning: No available formula with the name "openssl@1.1".
Did you mean openssl@3.5, openssl@3.0, openssl@4 or openssl@3?
```
Ref: https://github.com/libssh2/libssh2/actions/runs/28063084190/job/83081490329?pr=2122#step:2:13
Ref: https://github.com/libssh2/libssh2/actions/runs/28064895381/job/83086937400
