### PR TITLE
publickey: fix potential arbitrary free in `libssh2_publickey_list_fetch()`

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -905,6 +905,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                     goto err_exit;
                 }
                 list = newlist;
+                memset(&list[keys], 0, sizeof(list[keys]));
             }
             if(pkey->version == 1) {
                 unsigned long comment_len;


### PR DESCRIPTION
Due to uninitialized list entry.

Reported-and-patch-by: Behzod Abdullayev
Reported-by: Sharique Raza

Follow-up to e15f5d97a04cc676ce117dd324fef85b046207a9
