### PR TITLE
publickey: fix potential multiplication overflow in 32-bit `libssh2_publickey_list_fetch()`

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1048,15 +1048,14 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                 }
 
                 if(list[keys].num_attrs) {
-                    size_t num_attrs = list[keys].num_attrs;
-                    if(num_attrs > 1024) {
+                    if(list[keys].num_attrs > 1024) {
                         ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                  "Too many publickey attributes");
                         goto err_exit;
                     }
                     list[keys].attrs =
                         SSH2_ALLOC(session,
-                                   num_attrs *
+                                   list[keys].num_attrs *
                                        sizeof(libssh2_publickey_attribute));
                     if(!list[keys].attrs) {
                         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
@@ -1064,7 +1063,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                                  "publickey attributes");
                         goto err_exit;
                     }
-                    for(i = 0; i < num_attrs; i++) {
+                    for(i = 0; i < list[keys].num_attrs; i++) {
                         if(pkey->listFetch_s + 4 <=
                            pkey->listFetch_data + pkey->listFetch_data_len) {
                             list[keys].attrs[i].name_len =

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1057,7 +1057,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                     }
                     list[keys].attrs =
                         SSH2_ALLOC(session,
-                                   list[keys].num_attrs *
+                                   num_attrs *
                                        sizeof(libssh2_publickey_attribute));
                     if(!list[keys].attrs) {
                         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
@@ -1065,7 +1065,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                                  "publickey attributes");
                         goto err_exit;
                     }
-                    for(i = 0; i < list[keys].num_attrs; i++) {
+                    for(i = 0; i < num_attrs; i++) {
                         if(pkey->listFetch_s + 4 <=
                            pkey->listFetch_data + pkey->listFetch_data_len) {
                             list[keys].attrs[i].name_len =

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1048,6 +1048,12 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                 }
 
                 if(list[keys].num_attrs) {
+                    if(list[keys].num_attrs >
+                           SIZE_MAX / sizeof(libssh2_publickey_attribute)) {
+                        ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
+                                 "Too many publickey attributes");
+                        goto err_exit;
+                    }
                     list[keys].attrs =
                         SSH2_ALLOC(session,
                                    list[keys].num_attrs *

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1049,8 +1049,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
 
                 if(list[keys].num_attrs) {
                     size_t num_attrs = list[keys].num_attrs;
-                    if(num_attrs >
-                           SIZE_MAX / sizeof(libssh2_publickey_attribute)) {
+                    if(num_attrs > 1024) {
                         ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                  "Too many publickey attributes");
                         goto err_exit;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1050,7 +1050,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                 if(list[keys].num_attrs) {
                     if(list[keys].num_attrs >
                            SIZE_MAX / sizeof(libssh2_publickey_attribute)) {
-                        ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
+                        ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                  "Too many publickey attributes");
                         goto err_exit;
                     }

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1048,7 +1048,8 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                 }
 
                 if(list[keys].num_attrs) {
-                    if(list[keys].num_attrs >
+                    size_t num_attrs = list[keys].num_attrs;
+                    if(num_attrs >
                            SIZE_MAX / sizeof(libssh2_publickey_attribute)) {
                         ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                  "Too many publickey attributes");


### PR DESCRIPTION
Cap list size at 1024 elements.

Reported-and-initial-patch-by: Mateusz Gierblinski
Reported-and-initial-patch-by: Behzod Abdullayev
Reported-by: Sharique Raza

Follow-up to e15f5d97a04cc676ce117dd324fef85b046207a9
