### PR TITLE
src: rename and tidy up digest length macros

### DIFF
--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -81,7 +81,7 @@ Releases the HMAC computation context at ctx.
 3.1) SHA-1
 Must always be implemented.
 
-SHA_DIGEST_LENGTH
+SSH2_SHA1_DIG_LEN
 #define to 20, the SHA-1 digest length.
 
 ssh2_sha1_ctx
@@ -118,7 +118,7 @@ Returns 1 for success and 0 for failure.
 3.2) SHA-256
 Must always be implemented.
 
-SHA256_DIGEST_LENGTH
+SSH2_SHA256_DIG_LEN
 #define to 32, the SHA-256 digest length.
 
 ssh2_sha256_ctx
@@ -137,7 +137,7 @@ this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
 int ssh2_sha256_final(ssh2_sha256_ctx ctx,
-                      unsigned char output[SHA256_DIGEST_LENGTH]);
+                      unsigned char output[SSH2_SHA256_DIG_LEN]);
 Gets the computed SHA-256 signature from context ctx into the output buffer.
 Release the context.
 Note: if the ctx parameter is modified by the underlying code,
@@ -146,7 +146,7 @@ Must return 1 for success and 0 for failure.
 
 int ssh2_sha256(const unsigned char *message,
                 size_t len,
-                unsigned char output[SHA256_DIGEST_LENGTH]);
+                unsigned char output[SSH2_SHA256_DIG_LEN]);
 Computes the SHA-256 signature over the given message of length len and
 store the result into the output buffer.
 Return 1 if error, else 0.
@@ -166,7 +166,7 @@ Returns 1 for success and 0 for failure.
 3.3) SHA-384
 Mandatory if ECDSA is implemented. Can be omitted otherwise.
 
-SHA384_DIGEST_LENGTH
+SSH2_SHA384_DIG_LEN
 #define to 48, the SHA-384 digest length.
 
 ssh2_sha384_ctx
@@ -185,7 +185,7 @@ this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
 int ssh2_sha384_final(ssh2_sha384_ctx ctx,
-                      unsigned char output[SHA384_DIGEST_LENGTH]);
+                      unsigned char output[SSH2_SHA384_DIG_LEN]);
 Gets the computed SHA-384 signature from context ctx into the output buffer.
 Release the context.
 Note: if the ctx parameter is modified by the underlying code,
@@ -194,7 +194,7 @@ Must return 1 for success and 0 for failure.
 
 int ssh2_sha384(const unsigned char *message,
                 size_t len,
-                unsigned char output[SHA384_DIGEST_LENGTH]);
+                unsigned char output[SSH2_SHA384_DIG_LEN]);
 Computes the SHA-384 signature over the given message of length len and
 store the result into the output buffer.
 Return 1 if error, else 0.
@@ -202,7 +202,7 @@ Return 1 if error, else 0.
 3.4) SHA-512
 Must always be implemented.
 
-SHA512_DIGEST_LENGTH
+SSH2_SHA512_DIG_LEN
 #define to 64, the SHA-512 digest length.
 
 ssh2_sha512_ctx
@@ -221,7 +221,7 @@ this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
 int ssh2_sha512_final(ssh2_sha512_ctx ctx,
-                      unsigned char output[SHA512_DIGEST_LENGTH]);
+                      unsigned char output[SSH2_SHA512_DIG_LEN]);
 Gets the computed SHA-512 signature from context ctx into the output buffer.
 Release the context.
 Note: if the ctx parameter is modified by the underlying code,
@@ -230,7 +230,7 @@ Must return 1 for success and 0 for failure.
 
 int ssh2_sha512(const unsigned char *message,
                 size_t len,
-                unsigned char output[SHA512_DIGEST_LENGTH]);
+                unsigned char output[SSH2_SHA512_DIG_LEN]);
 Computes the SHA-512 signature over the given message of length len and
 store the result into the output buffer.
 Return 1 if error, else 0.
@@ -252,7 +252,7 @@ LIBSSH2_MD5
 #define to 1 if the crypto library supports MD5, else 0.
 If defined as 0, the rest of this section can be omitted.
 
-MD5_DIGEST_LENGTH
+SSH2_MD5_DIG_LEN
 #define to 16, the MD5 digest length.
 
 ssh2_md5_ctx
@@ -272,7 +272,7 @@ this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
 int ssh2_md5_final(ssh2_md5_ctx ctx,
-                   unsigned char output[MD5_DIGEST_LENGTH]);
+                   unsigned char output[SSH2_MD5_DIG_LEN]);
 Gets the computed MD5 signature from context ctx into the output buffer.
 Release the context.
 Note: if the ctx parameter is modified by the underlying code,

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -62,7 +62,7 @@ static void bcrypt_hash(uint8_t *sha2pass, uint8_t *sha2salt, uint8_t *out)
     uint32_t cdata[BCRYPT_BLOCKS];
     int i;
     uint16_t j;
-    uint16_t shalen = SHA512_DIGEST_LENGTH;
+    uint16_t shalen = SSH2_SHA512_DIG_LEN;
 
     /* key expansion */
     Blowfish_initstate(&state);
@@ -97,8 +97,8 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
                         const uint8_t *salt, size_t saltlen,
                         uint8_t *key, size_t keylen, unsigned int rounds)
 {
-    uint8_t sha2pass[SHA512_DIGEST_LENGTH];
-    uint8_t sha2salt[SHA512_DIGEST_LENGTH];
+    uint8_t sha2pass[SSH2_SHA512_DIG_LEN];
+    uint8_t sha2salt[SSH2_SHA512_DIG_LEN];
     uint8_t out[BCRYPT_HASHSIZE];
     uint8_t tmpout[BCRYPT_HASHSIZE];
     uint8_t *countsalt;

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -73,7 +73,7 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_DIG_LEN                16
 #endif
-#define SSH2_SHA_DIG_LEN                20
+#define SSH2_SHA1_DIG_LEN               20
 #define SSH2_SHA256_DIG_LEN             32
 #define SSH2_SHA384_DIG_LEN             48
 #define SSH2_SHA512_DIG_LEN             64

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -73,6 +73,9 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_DIG_LEN                16
 #endif
+#if LIBSSH2_HMAC_RIPEMD
+#define SSH2_RIPEMD160_DIG_LEN          20
+#endif
 #define SSH2_SHA1_DIG_LEN               20
 #define SSH2_SHA256_DIG_LEN             32
 #define SSH2_SHA384_DIG_LEN             48

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -71,12 +71,12 @@ int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data);
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define MD5_DIGEST_LENGTH               16
+#define SSH2_MD5_DIG_LEN                16
 #endif
-#define SHA_DIGEST_LENGTH               20
-#define SHA256_DIGEST_LENGTH            32
-#define SHA384_DIGEST_LENGTH            48
-#define SHA512_DIGEST_LENGTH            64
+#define SSH2_SHA_DIG_LEN                20
+#define SSH2_SHA256_DIG_LEN             32
+#define SSH2_SHA384_DIG_LEN             48
+#define SSH2_SHA512_DIG_LEN             64
 
 #define SSH2_ED25519_KEY_LEN            32
 #define SSH2_ED25519_PRIVATE_KEY_LEN    64

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -70,6 +70,14 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen);
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data);
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 
+#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
+#define MD5_DIGEST_LENGTH 16
+#endif
+#define SHA_DIGEST_LENGTH    20
+#define SHA256_DIGEST_LENGTH 32
+#define SHA384_DIGEST_LENGTH 48
+#define SHA512_DIGEST_LENGTH 64
+
 #define SSH2_ED25519_KEY_LEN            32
 #define SSH2_ED25519_PRIVATE_KEY_LEN    64
 #define SSH2_ED25519_SIG_LEN            64

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -71,12 +71,12 @@ int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data);
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define MD5_DIGEST_LENGTH 16
+#define MD5_DIGEST_LENGTH               16
 #endif
-#define SHA_DIGEST_LENGTH    20
-#define SHA256_DIGEST_LENGTH 32
-#define SHA384_DIGEST_LENGTH 48
-#define SHA512_DIGEST_LENGTH 64
+#define SHA_DIGEST_LENGTH               20
+#define SHA256_DIGEST_LENGTH            32
+#define SHA384_DIGEST_LENGTH            48
+#define SHA512_DIGEST_LENGTH            64
 
 #define SSH2_ED25519_KEY_LEN            32
 #define SSH2_ED25519_PRIVATE_KEY_LEN    64

--- a/src/crypto_config.h
+++ b/src/crypto_config.h
@@ -79,13 +79,3 @@
 #undef LIBSSH2_3DES
 #define LIBSSH2_3DES 0
 #endif
-
-/* shared macro definitions */
-
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define MD5_DIGEST_LENGTH 16
-#endif
-#define SHA_DIGEST_LENGTH    20
-#define SHA256_DIGEST_LENGTH 32
-#define SHA384_DIGEST_LENGTH 48
-#define SHA512_DIGEST_LENGTH 64

--- a/src/crypto_config.h
+++ b/src/crypto_config.h
@@ -79,3 +79,13 @@
 #undef LIBSSH2_3DES
 #define LIBSSH2_3DES 0
 #endif
+
+/* shared macro definitions */
+
+#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
+#define MD5_DIGEST_LENGTH 16
+#endif
+#define SHA_DIGEST_LENGTH    20
+#define SHA256_DIGEST_LENGTH 32
+#define SHA384_DIGEST_LENGTH 48
+#define SHA512_DIGEST_LENGTH 64

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -220,7 +220,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
 #else
     int ret;
     int i;
-    unsigned char hash[SHA_DIGEST_LENGTH];
+    unsigned char hash[SSH2_SHA_DIG_LEN];
     ssh2_sha1_ctx ctx;
 
     if(!ssh2_sha1_init(&ctx))
@@ -232,7 +232,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha1_final(ctx, hash))
         return -1;
 
-    ret = ssh2_rsa_sha1_sign(session, rsactx, hash, SHA_DIGEST_LENGTH,
+    ret = ssh2_rsa_sha1_sign(session, rsactx, hash, SSH2_SHA_DIG_LEN,
                              signature, signature_len);
     if(ret)
         return -1;
@@ -264,7 +264,7 @@ static int hostkey_method_ssh_rsa_sha2_256_sig_verify(
 
     sig += 20;
     sig_len -= 20;
-    return ssh2_rsa_sha2_verify(rsactx, SHA256_DIGEST_LENGTH, sig, sig_len,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA256_DIG_LEN, sig, sig_len,
                                 m, m_len);
 }
 
@@ -286,7 +286,7 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
 #else
     int ret;
     int i;
-    unsigned char hash[SHA256_DIGEST_LENGTH];
+    unsigned char hash[SSH2_SHA256_DIG_LEN];
     ssh2_sha256_ctx ctx;
 
     if(!ssh2_sha256_init(&ctx))
@@ -298,7 +298,7 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha256_final(ctx, hash))
         return -1;
 
-    ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SHA256_DIGEST_LENGTH,
+    ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SSH2_SHA256_DIG_LEN,
                              signature, signature_len);
     if(ret)
         return -1;
@@ -327,7 +327,7 @@ static int hostkey_method_ssh_rsa_sha2_512_sig_verify(
 
     sig += 20;
     sig_len -= 20;
-    return ssh2_rsa_sha2_verify(rsactx, SHA512_DIGEST_LENGTH, sig,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA512_DIG_LEN, sig,
                                 sig_len, m, m_len);
 }
 
@@ -349,7 +349,7 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
 #else
     int ret;
     int i;
-    unsigned char hash[SHA512_DIGEST_LENGTH];
+    unsigned char hash[SSH2_SHA512_DIG_LEN];
     ssh2_sha512_ctx ctx;
 
     if(!ssh2_sha512_init(&ctx))
@@ -361,7 +361,7 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha512_final(ctx, hash))
         return -1;
 
-    ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SHA512_DIGEST_LENGTH,
+    ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SSH2_SHA512_DIG_LEN,
                              signature, signature_len);
     if(ret)
         return -1;
@@ -392,7 +392,7 @@ static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
 
 static const struct hostkey_method hostkey_method_ssh_rsa = {
     "ssh-rsa",
-    SHA_DIGEST_LENGTH,
+    SSH2_SHA_DIG_LEN,
     hostkey_method_ssh_rsa_init,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -408,7 +408,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa = {
 
 static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256 = {
     "rsa-sha2-256",
-    SHA256_DIGEST_LENGTH,
+    SSH2_SHA256_DIG_LEN,
     hostkey_method_ssh_rsa_init,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -420,7 +420,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256 = {
 
 static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512 = {
     "rsa-sha2-512",
-    SHA512_DIGEST_LENGTH,
+    SSH2_SHA512_DIG_LEN,
     hostkey_method_ssh_rsa_init,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -436,7 +436,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512 = {
 
 static const struct hostkey_method hostkey_method_ssh_rsa_cert = {
     "ssh-rsa-cert-v01@openssh.com",
-    SHA_DIGEST_LENGTH,
+    SSH2_SHA_DIG_LEN,
     NULL,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -452,7 +452,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_cert = {
 
 static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256_cert = {
     "rsa-sha2-256-cert-v01@openssh.com",
-    SHA256_DIGEST_LENGTH,
+    SSH2_SHA256_DIG_LEN,
     NULL,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -464,7 +464,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256_cert = {
 
 static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512_cert = {
     "rsa-sha2-512-cert-v01@openssh.com",
-    SHA512_DIGEST_LENGTH,
+    SSH2_SHA512_DIG_LEN,
     NULL,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -631,7 +631,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
                                         void **abstract)
 {
     ssh2_dsa_ctx *dsactx = (ssh2_dsa_ctx *)(*abstract);
-    unsigned char hash[SHA_DIGEST_LENGTH];
+    unsigned char hash[SSH2_SHA_DIG_LEN];
     ssh2_sha1_ctx ctx;
     int i;
 
@@ -641,11 +641,11 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    *signature = SSH2_CALLOC(session, 2 * SHA_DIGEST_LENGTH);
+    *signature = SSH2_CALLOC(session, 2 * SSH2_SHA_DIG_LEN);
     if(!*signature)
         return -1;
 
-    *signature_len = 2 * SHA_DIGEST_LENGTH;
+    *signature_len = 2 * SSH2_SHA_DIG_LEN;
 
     for(i = 0; i < veccount; i++) {
         if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
@@ -654,7 +654,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha1_final(ctx, hash))
         return -1;
 
-    if(ssh2_dsa_sha1_sign(dsactx, hash, SHA_DIGEST_LENGTH, *signature)) {
+    if(ssh2_dsa_sha1_sign(dsactx, hash, SSH2_SHA_DIG_LEN, *signature)) {
         SSH2_FREE(session, *signature);
         return -1;
     }
@@ -680,7 +680,7 @@ static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
 
 static const struct hostkey_method hostkey_method_ssh_dss = {
     "ssh-dss",
-    SHA_DIGEST_LENGTH,
+    SSH2_SHA_DIG_LEN,
     hostkey_method_ssh_dss_init,
     hostkey_method_ssh_dss_initPEM,
     hostkey_method_ssh_dss_initPEMFromMemory,
@@ -940,7 +940,7 @@ static int hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
 
 static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256 = {
     "ecdsa-sha2-nistp256",
-    SHA256_DIGEST_LENGTH,
+    SSH2_SHA256_DIG_LEN,
     hostkey_method_ssh_ecdsa_init,
     hostkey_method_ssh_ecdsa_initPEM,
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
@@ -952,7 +952,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256 = {
 
 static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp384 = {
     "ecdsa-sha2-nistp384",
-    SHA384_DIGEST_LENGTH,
+    SSH2_SHA384_DIG_LEN,
     hostkey_method_ssh_ecdsa_init,
     hostkey_method_ssh_ecdsa_initPEM,
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
@@ -964,7 +964,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp384 = {
 
 static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521 = {
     "ecdsa-sha2-nistp521",
-    SHA512_DIGEST_LENGTH,
+    SSH2_SHA512_DIG_LEN,
     hostkey_method_ssh_ecdsa_init,
     hostkey_method_ssh_ecdsa_initPEM,
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
@@ -976,7 +976,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521 = {
 
 static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256_cert = {
     "ecdsa-sha2-nistp256-cert-v01@openssh.com",
-    SHA256_DIGEST_LENGTH,
+    SSH2_SHA256_DIG_LEN,
     NULL,
     hostkey_method_ssh_ecdsa_initPEM,
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
@@ -988,7 +988,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256_cert = {
 
 static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp384_cert = {
     "ecdsa-sha2-nistp384-cert-v01@openssh.com",
-    SHA384_DIGEST_LENGTH,
+    SSH2_SHA384_DIG_LEN,
     NULL,
     hostkey_method_ssh_ecdsa_initPEM,
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
@@ -1000,7 +1000,7 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp384_cert = {
 
 static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521_cert = {
     "ecdsa-sha2-nistp521-cert-v01@openssh.com",
-    SHA512_DIGEST_LENGTH,
+    SSH2_SHA512_DIG_LEN,
     NULL,
     hostkey_method_ssh_ecdsa_initPEM,
     hostkey_method_ssh_ecdsa_initPEMFromMemory,
@@ -1241,7 +1241,7 @@ static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
 
 static const struct hostkey_method hostkey_method_ssh_ed25519 = {
     "ssh-ed25519",
-    SHA256_DIGEST_LENGTH,
+    SSH2_SHA256_DIG_LEN,
     hostkey_method_ssh_ed25519_init,
     hostkey_method_ssh_ed25519_initPEM,
     hostkey_method_ssh_ed25519_initPEMFromMemory,
@@ -1253,7 +1253,7 @@ static const struct hostkey_method hostkey_method_ssh_ed25519 = {
 
 static const struct hostkey_method hostkey_method_ssh_ed25519_cert = {
     "ssh-ed25519-cert-v01@openssh.com",
-    SHA256_DIGEST_LENGTH,
+    SSH2_SHA256_DIG_LEN,
     hostkey_method_ssh_ed25519_init_cert,
     hostkey_method_ssh_ed25519_initPEM,
     hostkey_method_ssh_ed25519_initPEMFromMemory,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -220,7 +220,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
 #else
     int ret;
     int i;
-    unsigned char hash[SSH2_SHA_DIG_LEN];
+    unsigned char hash[SSH2_SHA1_DIG_LEN];
     ssh2_sha1_ctx ctx;
 
     if(!ssh2_sha1_init(&ctx))
@@ -232,7 +232,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha1_final(ctx, hash))
         return -1;
 
-    ret = ssh2_rsa_sha1_sign(session, rsactx, hash, SSH2_SHA_DIG_LEN,
+    ret = ssh2_rsa_sha1_sign(session, rsactx, hash, SSH2_SHA1_DIG_LEN,
                              signature, signature_len);
     if(ret)
         return -1;
@@ -392,7 +392,7 @@ static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
 
 static const struct hostkey_method hostkey_method_ssh_rsa = {
     "ssh-rsa",
-    SSH2_SHA_DIG_LEN,
+    SSH2_SHA1_DIG_LEN,
     hostkey_method_ssh_rsa_init,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -436,7 +436,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512 = {
 
 static const struct hostkey_method hostkey_method_ssh_rsa_cert = {
     "ssh-rsa-cert-v01@openssh.com",
-    SSH2_SHA_DIG_LEN,
+    SSH2_SHA1_DIG_LEN,
     NULL,
     hostkey_method_ssh_rsa_initPEM,
     hostkey_method_ssh_rsa_initPEMFromMemory,
@@ -631,7 +631,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
                                         void **abstract)
 {
     ssh2_dsa_ctx *dsactx = (ssh2_dsa_ctx *)(*abstract);
-    unsigned char hash[SSH2_SHA_DIG_LEN];
+    unsigned char hash[SSH2_SHA1_DIG_LEN];
     ssh2_sha1_ctx ctx;
     int i;
 
@@ -641,11 +641,11 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    *signature = SSH2_CALLOC(session, 2 * SSH2_SHA_DIG_LEN);
+    *signature = SSH2_CALLOC(session, 2 * SSH2_SHA1_DIG_LEN);
     if(!*signature)
         return -1;
 
-    *signature_len = 2 * SSH2_SHA_DIG_LEN;
+    *signature_len = 2 * SSH2_SHA1_DIG_LEN;
 
     for(i = 0; i < veccount; i++) {
         if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
@@ -654,7 +654,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha1_final(ctx, hash))
         return -1;
 
-    if(ssh2_dsa_sha1_sign(dsactx, hash, SSH2_SHA_DIG_LEN, *signature)) {
+    if(ssh2_dsa_sha1_sign(dsactx, hash, SSH2_SHA1_DIG_LEN, *signature)) {
         SSH2_FREE(session, *signature);
         return -1;
     }
@@ -680,7 +680,7 @@ static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
 
 static const struct hostkey_method hostkey_method_ssh_dss = {
     "ssh-dss",
-    SSH2_SHA_DIG_LEN,
+    SSH2_SHA1_DIG_LEN,
     hostkey_method_ssh_dss_init,
     hostkey_method_ssh_dss_initPEM,
     hostkey_method_ssh_dss_initPEMFromMemory,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -868,7 +868,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
 
 #define HOSTKEY_METHOD_EC_SIGNV_HASH(digest_type)                     \
     do {                                                              \
-        unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];         \
+        unsigned char hash[SSH2_SHA##digest_type##_DIG_LEN];          \
         ssh2_sha##digest_type##_ctx ctx;                              \
         int i;                                                        \
         if(!ssh2_sha##digest_type##_init(&ctx)) {                     \
@@ -891,7 +891,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
             break;                                                    \
         }                                                             \
         ret = ssh2_ecdsa_sign(session, ec_ctx, hash,                  \
-                              SHA##digest_type##_DIGEST_LENGTH,       \
+                              SSH2_SHA##digest_type##_DIG_LEN,        \
                               signature, signature_len);              \
     } while(0)
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -46,11 +46,6 @@
 
 #include <assert.h>
 
-/* define SSH2_SHA1_DIG_LEN for the macro below */
-#ifndef SSH2_SHA1_DIG_LEN
-#define SSH2_SHA1_DIG_LEN SSH2_SHA_DIG_LEN
-#endif
-
 /* TODO: Switch this to an inline and handle alloc() failures */
 /* Helper macro called from
    kex_method_diffie_hellman_group1_sha1_key_exchange */

--- a/src/kex.c
+++ b/src/kex.c
@@ -62,7 +62,7 @@
         if(!(value)) {                                                        \
             (value) = SSH2_ALLOC(session,                                     \
                                  (reqlen) +                                   \
-                                 SHA##digest_type##_DIGEST_LENGTH);           \
+                                 SSH2_SHA##digest_type##_DIG_LEN);            \
         }                                                                     \
         if(value)                                                             \
             while(len < (size_t)(reqlen)) {                                   \
@@ -72,7 +72,7 @@
                                            exchange_state->k_value_len) ||    \
                    !ssh2_sha##digest_type##_update(hash,                      \
                                          exchange_state->h_sig_comp,          \
-                                         SHA##digest_type##_DIGEST_LENGTH)) { \
+                                         SSH2_SHA##digest_type##_DIG_LEN)) {  \
                     SSH2_FREE(session, value);                                \
                     (value) = NULL;                                           \
                     break;                                                    \
@@ -99,7 +99,7 @@
                     (value) = NULL;                                           \
                     break;                                                    \
                 }                                                             \
-                len += SHA##digest_type##_DIGEST_LENGTH;                      \
+                len += SSH2_SHA##digest_type##_DIG_LEN;                       \
             }                                                                 \
     } while(0)
 
@@ -1725,7 +1725,7 @@ static int kex_session_hybrid_curve_type(const char *name,
         if(session->hostkey->sig_verify(session, exchange_state->h_sig,       \
                                         exchange_state->h_sig_len,            \
                                         exchange_state->h_sig_comp,           \
-                                        SHA##digest_type##_DIGEST_LENGTH,     \
+                                        SSH2_SHA##digest_type##_DIG_LEN,      \
                                         &session->server_hostkey_abstract)) { \
             rc = -1;                                                          \
         }                                                                     \
@@ -1843,7 +1843,7 @@ static int kex_session_hybrid_curve_type(const char *name,
         if(session->hostkey->sig_verify(session, exchange_state->h_sig,       \
                                         exchange_state->h_sig_len,            \
                                         exchange_state->h_sig_comp,           \
-                                        SHA##digest_type##_DIGEST_LENGTH,     \
+                                        SSH2_SHA##digest_type##_DIG_LEN,      \
                                         &session->server_hostkey_abstract)) { \
             rc = -1;                                                          \
         }                                                                     \

--- a/src/kex.c
+++ b/src/kex.c
@@ -46,9 +46,9 @@
 
 #include <assert.h>
 
-/* define SHA1_DIGEST_LENGTH for the macro below */
-#ifndef SHA1_DIGEST_LENGTH
-#define SHA1_DIGEST_LENGTH SHA_DIGEST_LENGTH
+/* define SSH2_SHA1_DIG_LEN for the macro below */
+#ifndef SSH2_SHA1_DIG_LEN
+#define SSH2_SHA1_DIG_LEN SSH2_SHA_DIG_LEN
 #endif
 
 /* TODO: Switch this to an inline and handle alloc() failures */
@@ -251,10 +251,10 @@ static int process_host_key(LIBSSH2_SESSION *session,
     }
 #ifdef LIBSSH2DEBUG
     {
-        char fingerprint[MD5_DIGEST_LENGTH * 3 + 1];
+        char fingerprint[SSH2_MD5_DIG_LEN * 3 + 1];
         char *fprint = fingerprint;
         int i;
-        for(i = 0; i < MD5_DIGEST_LENGTH; i++, fprint += 3)
+        for(i = 0; i < SSH2_MD5_DIG_LEN; i++, fprint += 3)
             ssh2_snprintf(fprint, 4, "%02x:", session->server_hostkey_md5[i]);
         *(--fprint) = '\0';
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Server's MD5 Fingerprint: %s",
@@ -276,10 +276,10 @@ static int process_host_key(LIBSSH2_SESSION *session,
     }
 #ifdef LIBSSH2DEBUG
     {
-        char fingerprint[SHA1_DIGEST_LENGTH * 3 + 1];
+        char fingerprint[SSH2_SHA1_DIG_LEN * 3 + 1];
         char *fprint = fingerprint;
         int i;
-        for(i = 0; i < SHA1_DIGEST_LENGTH; i++, fprint += 3)
+        for(i = 0; i < SSH2_SHA1_DIG_LEN; i++, fprint += 3)
             ssh2_snprintf(fprint, 4, "%02x:", session->server_hostkey_sha1[i]);
         *(--fprint) = '\0';
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Server's SHA1 Fingerprint: %s",
@@ -304,7 +304,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
         char *base64Fingerprint = NULL;
         ssh2_base64_encode(session,
                            (const char *)session->server_hostkey_sha256,
-                           SHA256_DIGEST_LENGTH, &base64Fingerprint);
+                           SSH2_SHA256_DIG_LEN, &base64Fingerprint);
         if(base64Fingerprint) {
             ssh2_deb((session, LIBSSH2_TRACE_KEX,
                       "Server's SHA256 Fingerprint: %s", base64Fingerprint));
@@ -607,13 +607,13 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
     int digest_len = 0;
 
     if(sha_algo_value == 512)
-        digest_len = SHA512_DIGEST_LENGTH;
+        digest_len = SSH2_SHA512_DIG_LEN;
     else if(sha_algo_value == 384)
-        digest_len = SHA384_DIGEST_LENGTH;
+        digest_len = SSH2_SHA384_DIG_LEN;
     else if(sha_algo_value == 256)
-        digest_len = SHA256_DIGEST_LENGTH;
+        digest_len = SSH2_SHA256_DIG_LEN;
     else if(sha_algo_value == 1)
-        digest_len = SHA1_DIGEST_LENGTH;
+        digest_len = SSH2_SHA1_DIG_LEN;
     else {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                        "SHA algo value is unimplemented");
@@ -2048,15 +2048,15 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
         int sha_algo_value = 0;
 
         if(type == SSH2_EC_CURVE_NISTP256) {
-            digest_len = SHA256_DIGEST_LENGTH;
+            digest_len = SSH2_SHA256_DIG_LEN;
             sha_algo_value = 256;
         }
         else if(type == SSH2_EC_CURVE_NISTP384) {
-            digest_len = SHA384_DIGEST_LENGTH;
+            digest_len = SSH2_SHA384_DIG_LEN;
             sha_algo_value = 384;
         }
         else if(type == SSH2_EC_CURVE_NISTP521) {
-            digest_len = SHA512_DIGEST_LENGTH;
+            digest_len = SSH2_SHA512_DIG_LEN;
             sha_algo_value = 512;
         }
         else {
@@ -2253,14 +2253,14 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
 
     switch(type) {
     case SSH2_EC_CURVE_NISTP256:
-        digest_len = SHA256_DIGEST_LENGTH;
+        digest_len = SSH2_SHA256_DIG_LEN;
         ml_kem_cipher_len = SSH2_MLKEM_768_CIPHERTEXT;
         ml_kem_size = 768;
         public_pq_key_len = SSH2_MLKEM_768_PUBLIC_KEY_LEN;
         sha_algo_value = 256;
         break;
     case SSH2_EC_CURVE_NISTP384:
-        digest_len = SHA384_DIGEST_LENGTH;
+        digest_len = SSH2_SHA384_DIG_LEN;
         ml_kem_cipher_len = SSH2_MLKEM_1024_CIPHERTEXT;
         ml_kem_size = 1024;
         public_pq_key_len = SSH2_MLKEM_1024_PUBLIC_KEY_LEN;
@@ -2745,7 +2745,7 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
     }
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
-        ret = finish_kex(session, exchange_state, SHA256_DIGEST_LENGTH, 256);
+        ret = finish_kex(session, exchange_state, SSH2_SHA256_DIG_LEN, 256);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
     }
@@ -2964,7 +2964,7 @@ static int mlkem768x25519_sha256(
             goto clean_exit;
         }
 
-        exchange_state->k_value_len = SHA256_DIGEST_LENGTH + 4;
+        exchange_state->k_value_len = SSH2_SHA256_DIG_LEN + 4;
 
         exchange_state->k_value =
             SSH2_ALLOC(session, exchange_state->k_value_len);
@@ -2973,7 +2973,7 @@ static int mlkem768x25519_sha256(
                            "Unable to allocate buffer for K");
             goto clean_exit;
         }
-        ssh2_htonu32(exchange_state->k_value, SHA256_DIGEST_LENGTH);
+        ssh2_htonu32(exchange_state->k_value, SSH2_SHA256_DIG_LEN);
 
         /* Compute the ML-KEM shared secret */
         rc = ssh2_mlkem_get_sk(shared_secret, 768,
@@ -3049,7 +3049,7 @@ static int mlkem768x25519_sha256(
     }
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
-        ret = finish_kex(session, exchange_state, SHA256_DIGEST_LENGTH, 256);
+        ret = finish_kex(session, exchange_state, SSH2_SHA256_DIG_LEN, 256);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
     }

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -422,12 +422,12 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                        plain input to produce a hash to compare with the
                        stored hash.
                     */
-                    unsigned char hash[SSH2_SHA_DIG_LEN];
+                    unsigned char hash[SSH2_SHA1_DIG_LEN];
                     ssh2_hmac_ctx ctx;
                     if(!ssh2_hmac_ctx_init(&ctx))
                         break;
 
-                    if(SSH2_SHA_DIG_LEN != node->name_len)
+                    if(SSH2_SHA1_DIG_LEN != node->name_len)
                         /* the name hash length must be the sha1 size or
                            we cannot match it */
                         break;
@@ -440,7 +440,7 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                     }
                     ssh2_hmac_cleanup(&ctx);
 
-                    if(!memcmp(hash, node->name, SSH2_SHA_DIG_LEN))
+                    if(!memcmp(hash, node->name, SSH2_SHA1_DIG_LEN))
                         /* this is a node we are interested in */
                         match = 1;
                 }

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -422,12 +422,12 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                        plain input to produce a hash to compare with the
                        stored hash.
                     */
-                    unsigned char hash[SHA_DIGEST_LENGTH];
+                    unsigned char hash[SSH2_SHA_DIG_LEN];
                     ssh2_hmac_ctx ctx;
                     if(!ssh2_hmac_ctx_init(&ctx))
                         break;
 
-                    if(SHA_DIGEST_LENGTH != node->name_len)
+                    if(SSH2_SHA_DIG_LEN != node->name_len)
                         /* the name hash length must be the sha1 size or
                            we cannot match it */
                         break;
@@ -440,7 +440,7 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                     }
                     ssh2_hmac_cleanup(&ctx);
 
-                    if(!memcmp(hash, node->name, SHA_DIGEST_LENGTH))
+                    if(!memcmp(hash, node->name, SSH2_SHA_DIG_LEN))
                         /* this is a node we are interested in */
                         match = 1;
                 }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -186,15 +186,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
     if(!hash)
         return -1;
 
-    if(hash_len == SHA_DIGEST_LENGTH) {
+    if(hash_len == SSH2_SHA_DIG_LEN) {
         algo = "sha1";
         ret = ssh2_sha1(m, m_len, hash);
     }
-    else if(hash_len == SHA256_DIGEST_LENGTH) {
+    else if(hash_len == SSH2_SHA256_DIG_LEN) {
         algo = "sha256";
         ret = ssh2_sha256(m, m_len, hash);
     }
-    else if(hash_len == SHA512_DIGEST_LENGTH) {
+    else if(hash_len == SSH2_SHA512_DIG_LEN) {
         algo = "sha512";
         ret = ssh2_sha512(m, m_len, hash);
     }
@@ -237,7 +237,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH, sig, sig_len, m,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA_DIG_LEN, sig, sig_len, m,
                                     m_len);
 }
 #endif
@@ -504,11 +504,11 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
     unsigned char *out_sig;
     int ret = -1;
 
-    if(hash_len == SHA_DIGEST_LENGTH)
+    if(hash_len == SSH2_SHA_DIG_LEN)
         algo = "sha1";
-    else if(hash_len == SHA256_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA256_DIG_LEN)
         algo = "sha256";
-    else if(hash_len == SHA512_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA512_DIG_LEN)
         algo = "sha512";
     else {
         ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -576,14 +576,14 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsactx,
                        const unsigned char *hash,
                        size_t hash_len, unsigned char *sig)
 {
-    unsigned char zhash[SHA_DIGEST_LENGTH + 1];
+    unsigned char zhash[SSH2_SHA_DIG_LEN + 1];
     gcry_sexp_t sig_sexp;
     gcry_sexp_t data;
     int ret;
     const char *tmp;
     size_t size;
 
-    if(hash_len != SHA_DIGEST_LENGTH)
+    if(hash_len != SSH2_SHA_DIG_LEN)
         return -1;
 
     memcpy(zhash + 1, hash, hash_len);
@@ -660,7 +660,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len)
 {
-    unsigned char hash[SHA_DIGEST_LENGTH + 1];
+    unsigned char hash[SSH2_SHA_DIG_LEN + 1];
     gcry_sexp_t s_sig, s_hash;
     int rc = -1;
 
@@ -670,7 +670,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     hash[0] = 0;
 
     if(gcry_sexp_build(&s_hash, NULL, "(data(flags raw)(value %b))",
-                       SHA_DIGEST_LENGTH + 1, hash))
+                       SSH2_SHA_DIG_LEN + 1, hash))
         return -1;
 
     if(gcry_sexp_build(&s_sig, NULL, "(sig-val(dsa(r %b)(s %b)))",

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -186,7 +186,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
     if(!hash)
         return -1;
 
-    if(hash_len == SSH2_SHA_DIG_LEN) {
+    if(hash_len == SSH2_SHA1_DIG_LEN) {
         algo = "sha1";
         ret = ssh2_sha1(m, m_len, hash);
     }
@@ -237,8 +237,8 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA_DIG_LEN, sig, sig_len, m,
-                                    m_len);
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA1_DIG_LEN, sig, sig_len, m,
+                                m_len);
 }
 #endif
 #endif
@@ -504,7 +504,7 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
     unsigned char *out_sig;
     int ret = -1;
 
-    if(hash_len == SSH2_SHA_DIG_LEN)
+    if(hash_len == SSH2_SHA1_DIG_LEN)
         algo = "sha1";
     else if(hash_len == SSH2_SHA256_DIG_LEN)
         algo = "sha256";
@@ -576,14 +576,14 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsactx,
                        const unsigned char *hash,
                        size_t hash_len, unsigned char *sig)
 {
-    unsigned char zhash[SSH2_SHA_DIG_LEN + 1];
+    unsigned char zhash[SSH2_SHA1_DIG_LEN + 1];
     gcry_sexp_t sig_sexp;
     gcry_sexp_t data;
     int ret;
     const char *tmp;
     size_t size;
 
-    if(hash_len != SSH2_SHA_DIG_LEN)
+    if(hash_len != SSH2_SHA1_DIG_LEN)
         return -1;
 
     memcpy(zhash + 1, hash, hash_len);
@@ -660,7 +660,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len)
 {
-    unsigned char hash[SSH2_SHA_DIG_LEN + 1];
+    unsigned char hash[SSH2_SHA1_DIG_LEN + 1];
     gcry_sexp_t s_sig, s_hash;
     int rc = -1;
 
@@ -670,7 +670,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     hash[0] = 0;
 
     if(gcry_sexp_build(&s_hash, NULL, "(data(flags raw)(value %b))",
-                       SSH2_SHA_DIG_LEN + 1, hash))
+                       SSH2_SHA1_DIG_LEN + 1, hash))
         return -1;
 
     if(gcry_sexp_build(&s_sig, NULL, "(sig-val(dsa(r %b)(s %b)))",

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -69,14 +69,6 @@
 
 #include "crypto_config.h"
 
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define MD5_DIGEST_LENGTH 16
-#endif
-#define SHA_DIGEST_LENGTH    20
-#define SHA256_DIGEST_LENGTH 32
-#define SHA384_DIGEST_LENGTH 48
-#define SHA512_DIGEST_LENGTH 64
-
 #define ssh2_random(buf, len) (gcry_randomize(buf, len, GCRY_STRONG_RANDOM), 0)
 
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -80,7 +80,7 @@
 #define ssh2_sha1_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha1_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA_DIG_LEN), \
+    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA1_DIG_LEN), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha1(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA1, out, message, len), 0)

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -80,7 +80,7 @@
 #define ssh2_sha1_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha1_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SHA_DIGEST_LENGTH), \
+    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA_DIG_LEN), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha1(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA1, out, message, len), 0)
@@ -91,7 +91,7 @@
 #define ssh2_sha256_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha256_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SHA256_DIGEST_LENGTH), \
+    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA256_DIG_LEN), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha256(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA256, out, message, len), 0)
@@ -102,7 +102,7 @@
 #define ssh2_sha384_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha384_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SHA384_DIGEST_LENGTH), \
+    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA384_DIG_LEN), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha384(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA384, out, message, len), 0)
@@ -113,7 +113,7 @@
 #define ssh2_sha512_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha512_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SHA512_DIGEST_LENGTH), \
+    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA512_DIG_LEN), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha512(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA512, out, message, len), 0)
@@ -125,7 +125,7 @@
 #define ssh2_md5_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_md5_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), MD5_DIGEST_LENGTH), \
+    (memcpy(out, gcry_md_read(ctx, 0), SSH2_MD5_DIG_LEN), \
      gcry_md_close(ctx), 1)
 #endif
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -748,7 +748,7 @@ struct _LIBSSH2_SESSION {
     unsigned char server_hostkey_md5[SSH2_MD5_DIG_LEN];
     int server_hostkey_md5_valid;
 #endif /* !LIBSSH2_MD5 */
-    unsigned char server_hostkey_sha1[SSH2_SHA_DIG_LEN];
+    unsigned char server_hostkey_sha1[SSH2_SHA1_DIG_LEN];
     int server_hostkey_sha1_valid;
 
     unsigned char server_hostkey_sha256[SSH2_SHA256_DIG_LEN];

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -238,7 +238,7 @@ struct iovec {
  * padding length, payload, padding, and MAC.)."
  */
 #define MAX_SSH_PACKET_LEN 35000
-#define MAX_SHA_DIGEST_LEN SHA512_DIGEST_LENGTH
+#define MAX_SHA_DIGEST_LEN SSH2_SHA512_DIG_LEN
 
 #define SSH2_ALLOC(session, count) \
     session->alloc(count, &(session)->abstract)
@@ -745,13 +745,13 @@ struct _LIBSSH2_SESSION {
     unsigned char *server_hostkey;
     uint32_t server_hostkey_len;
 #if LIBSSH2_MD5
-    unsigned char server_hostkey_md5[MD5_DIGEST_LENGTH];
+    unsigned char server_hostkey_md5[SSH2_MD5_DIG_LEN];
     int server_hostkey_md5_valid;
 #endif /* !LIBSSH2_MD5 */
-    unsigned char server_hostkey_sha1[SHA_DIGEST_LENGTH];
+    unsigned char server_hostkey_sha1[SSH2_SHA_DIG_LEN];
     int server_hostkey_sha1_valid;
 
-    unsigned char server_hostkey_sha256[SHA256_DIGEST_LENGTH];
+    unsigned char server_hostkey_sha256[SSH2_SHA256_DIG_LEN];
     int server_hostkey_sha256_valid;
 
     /* public key algorithms accepted as comma separated list */

--- a/src/mac.c
+++ b/src/mac.c
@@ -268,7 +268,7 @@ static int mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
                                         const unsigned char *addtl,
                                         size_t addtl_len, void **abstract)
 {
-    unsigned char temp[SSH2_SHA_DIG_LEN];
+    unsigned char temp[SSH2_SHA1_DIG_LEN];
 
     if(mac_method_hmac_sha1_hash(session, temp, seqno, packet, packet_len,
                                  addtl, addtl_len, abstract))

--- a/src/mac.c
+++ b/src/mac.c
@@ -268,7 +268,7 @@ static int mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
                                         const unsigned char *addtl,
                                         size_t addtl_len, void **abstract)
 {
-    unsigned char temp[SHA_DIGEST_LENGTH];
+    unsigned char temp[SSH2_SHA_DIG_LEN];
 
     if(mac_method_hmac_sha1_hash(session, temp, seqno, packet, packet_len,
                                  addtl, addtl_len, abstract))
@@ -340,7 +340,7 @@ static int mac_method_hmac_md5_96_hash(LIBSSH2_SESSION *session,
                                        const unsigned char *addtl,
                                        size_t addtl_len, void **abstract)
 {
-    unsigned char temp[MD5_DIGEST_LENGTH];
+    unsigned char temp[SSH2_MD5_DIG_LEN];
 
     if(mac_method_hmac_md5_hash(session, temp, seqno, packet, packet_len,
                                 addtl, addtl_len, abstract))

--- a/src/mac.c
+++ b/src/mac.c
@@ -119,7 +119,7 @@ static int mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION *session,
 
     if(!ssh2_hmac_ctx_init(&ctx))
         return 1;
-    res = ssh2_hmac_sha512_init(&ctx, *abstract, 64) &&
+    res = ssh2_hmac_sha512_init(&ctx, *abstract, SSH2_SHA512_DIG_LEN) &&
           ssh2_hmac_update(&ctx, seqno_buf, 4) &&
           ssh2_hmac_update(&ctx, packet, packet_len);
     if(res && addtl && addtl_len)
@@ -134,7 +134,7 @@ static int mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION *session,
 static const struct mac_method mac_method_hmac_sha2_512 = {
     "hmac-sha2-512",
     64,
-    64,
+    SSH2_SHA512_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_sha2_512_hash,
     mac_method_common_dtor,
@@ -144,7 +144,7 @@ static const struct mac_method mac_method_hmac_sha2_512 = {
 static const struct mac_method mac_method_hmac_sha2_512_etm = {
     "hmac-sha2-512-etm@openssh.com",
     64,
-    64,
+    SSH2_SHA512_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_sha2_512_hash,
     mac_method_common_dtor,
@@ -173,7 +173,7 @@ static int mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION *session,
 
     if(!ssh2_hmac_ctx_init(&ctx))
         return 1;
-    res = ssh2_hmac_sha256_init(&ctx, *abstract, 32) &&
+    res = ssh2_hmac_sha256_init(&ctx, *abstract, SSH2_SHA256_DIG_LEN) &&
           ssh2_hmac_update(&ctx, seqno_buf, 4) &&
           ssh2_hmac_update(&ctx, packet, packet_len);
     if(res && addtl && addtl_len)
@@ -188,7 +188,7 @@ static int mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION *session,
 static const struct mac_method mac_method_hmac_sha2_256 = {
     "hmac-sha2-256",
     32,
-    32,
+    SSH2_SHA256_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_sha2_256_hash,
     mac_method_common_dtor,
@@ -198,7 +198,7 @@ static const struct mac_method mac_method_hmac_sha2_256 = {
 static const struct mac_method mac_method_hmac_sha2_256_etm = {
     "hmac-sha2-256-etm@openssh.com",
     32,
-    32,
+    SSH2_SHA256_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_sha2_256_hash,
     mac_method_common_dtor,
@@ -226,7 +226,7 @@ static int mac_method_hmac_sha1_hash(LIBSSH2_SESSION *session,
 
     if(!ssh2_hmac_ctx_init(&ctx))
         return 1;
-    res = ssh2_hmac_sha1_init(&ctx, *abstract, 20) &&
+    res = ssh2_hmac_sha1_init(&ctx, *abstract, SSH2_SHA1_DIG_LEN) &&
           ssh2_hmac_update(&ctx, seqno_buf, 4) &&
           ssh2_hmac_update(&ctx, packet, packet_len);
     if(res && addtl && addtl_len)
@@ -241,7 +241,7 @@ static int mac_method_hmac_sha1_hash(LIBSSH2_SESSION *session,
 static const struct mac_method mac_method_hmac_sha1 = {
     "hmac-sha1",
     20,
-    20,
+    SSH2_SHA1_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_sha1_hash,
     mac_method_common_dtor,
@@ -251,7 +251,7 @@ static const struct mac_method mac_method_hmac_sha1 = {
 static const struct mac_method mac_method_hmac_sha1_etm = {
     "hmac-sha1-etm@openssh.com",
     20,
-    20,
+    SSH2_SHA1_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_sha1_hash,
     mac_method_common_dtor,
@@ -281,7 +281,7 @@ static int mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
 static const struct mac_method mac_method_hmac_sha1_96 = {
     "hmac-sha1-96",
     12,
-    20,
+    SSH2_SHA1_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_sha1_96_hash,
     mac_method_common_dtor,
@@ -308,7 +308,7 @@ static int mac_method_hmac_md5_hash(LIBSSH2_SESSION *session,
 
     if(!ssh2_hmac_ctx_init(&ctx))
         return 1;
-    res = ssh2_hmac_md5_init(&ctx, *abstract, 16) &&
+    res = ssh2_hmac_md5_init(&ctx, *abstract, SSH2_MD5_DIG_LEN) &&
           ssh2_hmac_update(&ctx, seqno_buf, 4) &&
           ssh2_hmac_update(&ctx, packet, packet_len);
     if(res && addtl && addtl_len)
@@ -323,7 +323,7 @@ static int mac_method_hmac_md5_hash(LIBSSH2_SESSION *session,
 static const struct mac_method mac_method_hmac_md5 = {
     "hmac-md5",
     16,
-    16,
+    SSH2_MD5_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_md5_hash,
     mac_method_common_dtor,

--- a/src/mac.c
+++ b/src/mac.c
@@ -381,7 +381,7 @@ static int mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION *session,
 
     if(!ssh2_hmac_ctx_init(&ctx))
         return 1;
-    res = ssh2_hmac_ripemd160_init(&ctx, *abstract, 20) &&
+    res = ssh2_hmac_ripemd160_init(&ctx, *abstract, SSH2_RIPEMD160_DIG_LEN) &&
           ssh2_hmac_update(&ctx, seqno_buf, 4) &&
           ssh2_hmac_update(&ctx, packet, packet_len);
     if(res && addtl && addtl_len)
@@ -396,7 +396,7 @@ static int mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION *session,
 static const struct mac_method mac_method_hmac_ripemd160 = {
     "hmac-ripemd160",
     20,
-    20,
+    SSH2_RIPEMD160_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_ripemd160_hash,
     mac_method_common_dtor,
@@ -406,7 +406,7 @@ static const struct mac_method mac_method_hmac_ripemd160 = {
 static const struct mac_method mac_method_hmac_ripemd160_openssh_com = {
     "hmac-ripemd160@openssh.com",
     20,
-    20,
+    SSH2_RIPEMD160_DIG_LEN,
     mac_method_common_init,
     mac_method_hmac_ripemd160_hash,
     mac_method_common_dtor,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -513,7 +513,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
     if(!hash)
         return -1;
 
-    if(hash_len == SSH2_SHA_DIG_LEN)
+    if(hash_len == SSH2_SHA1_DIG_LEN)
         md_type = MBEDTLS_MD_SHA1;
     else if(hash_len == SSH2_SHA256_DIG_LEN)
         md_type = MBEDTLS_MD_SHA256;
@@ -542,7 +542,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA_DIG_LEN,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA1_DIG_LEN,
                                 sig, sig_len, m, m_len);
 }
 
@@ -562,7 +562,7 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
         return -1;
 
     ret = 0;
-    if(hash_len == SSH2_SHA_DIG_LEN)
+    if(hash_len == SSH2_SHA1_DIG_LEN)
         md_type = MBEDTLS_MD_SHA1;
     else if(hash_len == SSH2_SHA256_DIG_LEN)
         md_type = MBEDTLS_MD_SHA256;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -975,11 +975,11 @@ cleanup:
 
 #define SSH2_MBED_ECDSA_VERIFY(digest_type)                                   \
     do {                                                                      \
-        unsigned char hsh[SHA##digest_type##_DIGEST_LENGTH];                  \
+        unsigned char hsh[SSH2_SHA##digest_type##_DIG_LEN];                   \
                                                                               \
         if(ssh2_sha##digest_type(m, m_len, hsh) == 0) {                       \
             rc = mbedtls_ecdsa_verify(&ec_ctx->MBEDTLS_PRIVATE(grp), hsh,     \
-                                      SHA##digest_type##_DIGEST_LENGTH,       \
+                                      SSH2_SHA##digest_type##_DIG_LEN,        \
                                       &ec_ctx->MBEDTLS_PRIVATE(Q), &pr, &ps); \
         }                                                                     \
     } while(0)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -513,11 +513,11 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
     if(!hash)
         return -1;
 
-    if(hash_len == SHA_DIGEST_LENGTH)
+    if(hash_len == SSH2_SHA_DIG_LEN)
         md_type = MBEDTLS_MD_SHA1;
-    else if(hash_len == SHA256_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA256_DIG_LEN)
         md_type = MBEDTLS_MD_SHA256;
-    else if(hash_len == SHA512_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA512_DIG_LEN)
         md_type = MBEDTLS_MD_SHA512;
     else {
         free(hash);
@@ -542,7 +542,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA_DIG_LEN,
                                 sig, sig_len, m, m_len);
 }
 
@@ -562,11 +562,11 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
         return -1;
 
     ret = 0;
-    if(hash_len == SHA_DIGEST_LENGTH)
+    if(hash_len == SSH2_SHA_DIG_LEN)
         md_type = MBEDTLS_MD_SHA1;
-    else if(hash_len == SHA256_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA256_DIG_LEN)
         md_type = MBEDTLS_MD_SHA256;
-    else if(hash_len == SHA512_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA512_DIG_LEN)
         md_type = MBEDTLS_MD_SHA512;
     else {
         ssh2_err(session, LIBSSH2_ERROR_PROTO,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -99,14 +99,6 @@
 
 #include "crypto_config.h"
 
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define MD5_DIGEST_LENGTH 16
-#endif
-#define SHA_DIGEST_LENGTH    20
-#define SHA256_DIGEST_LENGTH 32
-#define SHA384_DIGEST_LENGTH 48
-#define SHA512_DIGEST_LENGTH 64
-
 /*******************************************************************/
 /*
  * mbedTLS backend: Generic functions

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -372,7 +372,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
     if(!hash)
         return -1;
 
-    if(hash_len == SSH2_SHA_DIG_LEN) {
+    if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
         ret = ssh2_ossl_sha1(m, m_len, hash);
     }
@@ -430,7 +430,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA_DIG_LEN, sig, sig_len, m,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA1_DIG_LEN, sig, sig_len, m,
                                 m_len);
 }
 #endif
@@ -576,7 +576,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     int der_len = 0;
 #endif
 
-    unsigned char hash[SSH2_SHA_DIG_LEN];
+    unsigned char hash[SSH2_SHA1_DIG_LEN];
     DSA_SIG *dsasig;
     BIGNUM *r;
     BIGNUM *s;
@@ -597,7 +597,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     if(ctx && !ssh2_ossl_sha1(m, m_len, hash)) {
         /* ssh2_ossl_sha1() succeeded */
         if(EVP_PKEY_verify_init(ctx) > 0)
-            ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA_DIG_LEN);
+            ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
     }
 
     if(ctx)
@@ -608,7 +608,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
 #else
     if(!ssh2_ossl_sha1(m, m_len, hash))
         /* ssh2_ossl_sha1() succeeded */
-        ret = DSA_do_verify(hash, SSH2_SHA_DIG_LEN, dsasig, dsactx);
+        ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsactx);
 #endif
 
     DSA_SIG_free(dsasig);
@@ -2549,7 +2549,7 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session, ssh2_rsa_ctx *rsactx,
         return -1;
 
 #ifdef USE_OPENSSL_3
-    if(hash_len == SSH2_SHA_DIG_LEN)
+    if(hash_len == SSH2_SHA1_DIG_LEN)
         md = EVP_sha1();
     else if(hash_len == SSH2_SHA256_DIG_LEN)
         md = EVP_sha256();
@@ -2572,7 +2572,7 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session, ssh2_rsa_ctx *rsactx,
             EVP_PKEY_CTX_free(ctx);
     }
 #else
-    if(hash_len == SSH2_SHA_DIG_LEN)
+    if(hash_len == SSH2_SHA1_DIG_LEN)
         ret = RSA_sign(NID_sha1,
                        hash, (unsigned int)hash_len, sig, &sig_len, rsactx);
     else if(hash_len == SSH2_SHA256_DIG_LEN)
@@ -2645,7 +2645,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsactx,
 #else
     (void)hash_len;
 
-    sig = DSA_do_sign(hash, SSH2_SHA_DIG_LEN, dsactx);
+    sig = DSA_do_sign(hash, SSH2_SHA1_DIG_LEN, dsactx);
 #endif
 
     if(!sig)
@@ -2654,20 +2654,20 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsactx,
     DSA_SIG_get0(sig, &r, &s);
 
     r_len = BN_num_bytes(r);
-    if(r_len < 1 || r_len > SSH2_SHA_DIG_LEN) {
+    if(r_len < 1 || r_len > SSH2_SHA1_DIG_LEN) {
         DSA_SIG_free(sig);
         return -1;
     }
     s_len = BN_num_bytes(s);
-    if(s_len < 1 || s_len > SSH2_SHA_DIG_LEN) {
+    if(s_len < 1 || s_len > SSH2_SHA1_DIG_LEN) {
         DSA_SIG_free(sig);
         return -1;
     }
 
-    memset(signature, 0, SSH2_SHA_DIG_LEN * 2);
+    memset(signature, 0, SSH2_SHA1_DIG_LEN * 2);
 
-    BN_bn2bin(r, signature + (SSH2_SHA_DIG_LEN - r_len));
-    BN_bn2bin(s, signature + SSH2_SHA_DIG_LEN + (SSH2_SHA_DIG_LEN - s_len));
+    BN_bn2bin(r, signature + (SSH2_SHA1_DIG_LEN - r_len));
+    BN_bn2bin(s, signature + SSH2_SHA1_DIG_LEN + (SSH2_SHA1_DIG_LEN - s_len));
 
     DSA_SIG_free(sig);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -372,15 +372,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
     if(!hash)
         return -1;
 
-    if(hash_len == SHA_DIGEST_LENGTH) {
+    if(hash_len == SSH2_SHA_DIG_LEN) {
         nid_type = NID_sha1;
         ret = ssh2_ossl_sha1(m, m_len, hash);
     }
-    else if(hash_len == SHA256_DIGEST_LENGTH) {
+    else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
         ret = ssh2_ossl_sha256(m, m_len, hash);
     }
-    else if(hash_len == SHA512_DIGEST_LENGTH) {
+    else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
         ret = ssh2_ossl_sha512(m, m_len, hash);
     }
@@ -430,7 +430,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH, sig, sig_len, m,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA_DIG_LEN, sig, sig_len, m,
                                 m_len);
 }
 #endif
@@ -576,7 +576,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     int der_len = 0;
 #endif
 
-    unsigned char hash[SHA_DIGEST_LENGTH];
+    unsigned char hash[SSH2_SHA_DIG_LEN];
     DSA_SIG *dsasig;
     BIGNUM *r;
     BIGNUM *s;
@@ -597,7 +597,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     if(ctx && !ssh2_ossl_sha1(m, m_len, hash)) {
         /* ssh2_ossl_sha1() succeeded */
         if(EVP_PKEY_verify_init(ctx) > 0)
-            ret = EVP_PKEY_verify(ctx, der, der_len, hash, SHA_DIGEST_LENGTH);
+            ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA_DIG_LEN);
     }
 
     if(ctx)
@@ -608,7 +608,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
 #else
     if(!ssh2_ossl_sha1(m, m_len, hash))
         /* ssh2_ossl_sha1() succeeded */
-        ret = DSA_do_verify(hash, SHA_DIGEST_LENGTH, dsasig, dsactx);
+        ret = DSA_do_verify(hash, SSH2_SHA_DIG_LEN, dsasig, dsactx);
 #endif
 
     DSA_SIG_free(dsasig);
@@ -2549,11 +2549,11 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session, ssh2_rsa_ctx *rsactx,
         return -1;
 
 #ifdef USE_OPENSSL_3
-    if(hash_len == SHA_DIGEST_LENGTH)
+    if(hash_len == SSH2_SHA_DIG_LEN)
         md = EVP_sha1();
-    else if(hash_len == SHA256_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA256_DIG_LEN)
         md = EVP_sha256();
-    else if(hash_len == SHA512_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA512_DIG_LEN)
         md = EVP_sha512();
     else
         ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -2572,13 +2572,13 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session, ssh2_rsa_ctx *rsactx,
             EVP_PKEY_CTX_free(ctx);
     }
 #else
-    if(hash_len == SHA_DIGEST_LENGTH)
+    if(hash_len == SSH2_SHA_DIG_LEN)
         ret = RSA_sign(NID_sha1,
                        hash, (unsigned int)hash_len, sig, &sig_len, rsactx);
-    else if(hash_len == SHA256_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA256_DIG_LEN)
         ret = RSA_sign(NID_sha256,
                        hash, (unsigned int)hash_len, sig, &sig_len, rsactx);
-    else if(hash_len == SHA512_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA512_DIG_LEN)
         ret = RSA_sign(NID_sha512,
                        hash, (unsigned int)hash_len, sig, &sig_len, rsactx);
     else {
@@ -2645,7 +2645,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsactx,
 #else
     (void)hash_len;
 
-    sig = DSA_do_sign(hash, SHA_DIGEST_LENGTH, dsactx);
+    sig = DSA_do_sign(hash, SSH2_SHA_DIG_LEN, dsactx);
 #endif
 
     if(!sig)
@@ -2654,20 +2654,20 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsactx,
     DSA_SIG_get0(sig, &r, &s);
 
     r_len = BN_num_bytes(r);
-    if(r_len < 1 || r_len > SHA_DIGEST_LENGTH) {
+    if(r_len < 1 || r_len > SSH2_SHA_DIG_LEN) {
         DSA_SIG_free(sig);
         return -1;
     }
     s_len = BN_num_bytes(s);
-    if(s_len < 1 || s_len > SHA_DIGEST_LENGTH) {
+    if(s_len < 1 || s_len > SSH2_SHA_DIG_LEN) {
         DSA_SIG_free(sig);
         return -1;
     }
 
-    memset(signature, 0, SHA_DIGEST_LENGTH * 2);
+    memset(signature, 0, SSH2_SHA_DIG_LEN * 2);
 
-    BN_bn2bin(r, signature + (SHA_DIGEST_LENGTH - r_len));
-    BN_bn2bin(s, signature + SHA_DIGEST_LENGTH + (SHA_DIGEST_LENGTH - s_len));
+    BN_bn2bin(r, signature + (SSH2_SHA_DIG_LEN - r_len));
+    BN_bn2bin(s, signature + SSH2_SHA_DIG_LEN + (SSH2_SHA_DIG_LEN - s_len));
 
     DSA_SIG_free(sig);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -763,25 +763,25 @@ int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
 }
 
 #ifdef USE_OPENSSL_3
-#define SSH2_OSSL_ECDSA_VERIFY(digest_type)                              \
-    do {                                                                 \
-        unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];            \
-        if(ssh2_sha##digest_type(m, m_len, hash) == 0) {                 \
-            ret = EVP_PKEY_verify_init(ctx);                             \
-            if(ret > 0) {                                                \
-                ret = EVP_PKEY_verify(ctx, der, der_len, hash,           \
-                                      SHA##digest_type##_DIGEST_LENGTH); \
-            }                                                            \
-        }                                                                \
+#define SSH2_OSSL_ECDSA_VERIFY(digest_type)                             \
+    do {                                                                \
+        unsigned char hash[SSH2_SHA##digest_type##_DIG_LEN];            \
+        if(ssh2_sha##digest_type(m, m_len, hash) == 0) {                \
+            ret = EVP_PKEY_verify_init(ctx);                            \
+            if(ret > 0) {                                               \
+                ret = EVP_PKEY_verify(ctx, der, der_len, hash,          \
+                                      SSH2_SHA##digest_type##_DIG_LEN); \
+            }                                                           \
+        }                                                               \
     } while(0)
 #else
-#define SSH2_OSSL_ECDSA_VERIFY(digest_type)                               \
-    do {                                                                  \
-        unsigned char hash[SHA##digest_type##_DIGEST_LENGTH];             \
-        if(ssh2_sha##digest_type(m, m_len, hash) == 0) {                  \
-            ret = ECDSA_do_verify(hash, SHA##digest_type##_DIGEST_LENGTH, \
-                                  ecdsa_sig, ec_key);                     \
-        }                                                                 \
+#define SSH2_OSSL_ECDSA_VERIFY(digest_type)                              \
+    do {                                                                 \
+        unsigned char hash[SSH2_SHA##digest_type##_DIG_LEN];             \
+        if(ssh2_sha##digest_type(m, m_len, hash) == 0) {                 \
+            ret = ECDSA_do_verify(hash, SSH2_SHA##digest_type##_DIG_LEN, \
+                                  ecdsa_sig, ec_key);                    \
+        }                                                                \
     } while(0)
 #endif
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -173,7 +173,7 @@ static int parse_pbkdf2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
                         struct pkcs5algo *algo, struct asn1Element *param);
 static const struct pkcs5algo PBKDF2 = {
     OID_id_PBKDF2,  parse_pbkdf2,   0,  0,  '\0',   '\0',   '\0',
-    SSH2_SHA_DIG_LEN,  Qc3_SHA1,   SSH2_SHA_DIG_LEN,  8,  8,  0
+    SSH2_SHA1_DIG_LEN,  Qc3_SHA1,   SSH2_SHA1_DIG_LEN,  8,  8,  0
 };
 
 /* id-hmacWithSHA1 OID: 1.2.840.113549.2.7 */
@@ -186,7 +186,7 @@ static int parse_hmacWithSHA1(LIBSSH2_SESSION *session,
                               struct asn1Element *param);
 static const struct pkcs5algo hmacWithSHA1 = {
     OID_id_hmacWithSHA1,    parse_hmacWithSHA1, 0,  0,  '\0',   '\0',   '\0',
-    SSH2_SHA_DIG_LEN,  Qc3_SHA1,   SSH2_SHA_DIG_LEN,  8,  8,  0
+    SSH2_SHA1_DIG_LEN,  Qc3_SHA1,   SSH2_SHA1_DIG_LEN,  8,  8,  0
 };
 
 /* desCBC OID: 1.3.14.3.2.7 */
@@ -249,7 +249,7 @@ static const unsigned char OID_pbeWithSHA1AndDES_CBC[] = {
 };
 static const struct pkcs5algo pbeWithSHA1AndDES_CBC = {
     OID_pbeWithSHA1AndDES_CBC,   parse_pbes1,    Qc3_DES,    8,  Qc3_CBC,
-    Qc3_Pad_Counter,    '\0',   8,  Qc3_SHA1,   SSH2_SHA_DIG_LEN,  8,  0,  0
+    Qc3_Pad_Counter,    '\0',   8,  Qc3_SHA1,   SSH2_SHA1_DIG_LEN,  8,  0,  0
 };
 
 /* pbeWithSHA1AndRC2-CBC OID: 1.2.840.113549.1.5.11 */
@@ -258,7 +258,7 @@ static const unsigned char OID_pbeWithSHA1AndRC2_CBC[] = {
 };
 static const struct pkcs5algo pbeWithSHA1AndRC2_CBC = {
     OID_pbeWithSHA1AndRC2_CBC,   parse_pbes1,    Qc3_RC2,    8,  Qc3_CBC,
-    Qc3_Pad_Counter,    '\0',   0,  Qc3_SHA1,   SSH2_SHA_DIG_LEN,  8,  0, 64
+    Qc3_Pad_Counter,    '\0',   0,  Qc3_SHA1,   SSH2_SHA1_DIG_LEN,  8,  0, 64
 };
 
 /* rc5-CBC-PAD OID: 1.2.840.113549.3.9: RC5 not implemented in Qc3. */
@@ -1015,7 +1015,7 @@ int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return os400qc3_hmac_init(ctx, Qc3_SHA1, SSH2_SHA_DIG_LEN,
+    return os400qc3_hmac_init(ctx, Qc3_SHA1, SSH2_SHA1_DIG_LEN,
                               key, keylen);
 }
 
@@ -2363,7 +2363,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
     algd.Public_Key_Alg = Qc3_RSA;
     algd.PKA_Block_Format = Qc3_PKCS1_01;
     switch(hash_len) {
-    case SSH2_SHA_DIG_LEN:
+    case SSH2_SHA1_DIG_LEN:
         algd.Signing_Hash_Alg = Qc3_SHA1;
         break;
     case SSH2_SHA256_DIG_LEN:
@@ -2388,7 +2388,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA_DIG_LEN,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA1_DIG_LEN,
                                 sig, sig_len, m, m_len);
 }
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -173,7 +173,7 @@ static int parse_pbkdf2(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
                         struct pkcs5algo *algo, struct asn1Element *param);
 static const struct pkcs5algo PBKDF2 = {
     OID_id_PBKDF2,  parse_pbkdf2,   0,  0,  '\0',   '\0',   '\0',
-    SHA_DIGEST_LENGTH,  Qc3_SHA1,   SHA_DIGEST_LENGTH,  8,  8,  0
+    SSH2_SHA_DIG_LEN,  Qc3_SHA1,   SSH2_SHA_DIG_LEN,  8,  8,  0
 };
 
 /* id-hmacWithSHA1 OID: 1.2.840.113549.2.7 */
@@ -186,7 +186,7 @@ static int parse_hmacWithSHA1(LIBSSH2_SESSION *session,
                               struct asn1Element *param);
 static const struct pkcs5algo hmacWithSHA1 = {
     OID_id_hmacWithSHA1,    parse_hmacWithSHA1, 0,  0,  '\0',   '\0',   '\0',
-    SHA_DIGEST_LENGTH,  Qc3_SHA1,   SHA_DIGEST_LENGTH,  8,  8,  0
+    SSH2_SHA_DIG_LEN,  Qc3_SHA1,   SSH2_SHA_DIG_LEN,  8,  8,  0
 };
 
 /* desCBC OID: 1.3.14.3.2.7 */
@@ -230,7 +230,7 @@ static const unsigned char OID_pbeWithMD5AndDES_CBC[] = {
 };
 static const struct pkcs5algo pbeWithMD5AndDES_CBC = {
     OID_pbeWithMD5AndDES_CBC,   parse_pbes1,    Qc3_DES,    8,  Qc3_CBC,
-    Qc3_Pad_Counter,    '\0',   8,  Qc3_MD5,    MD5_DIGEST_LENGTH,  8,  0,  0
+    Qc3_Pad_Counter,    '\0',   8,  Qc3_MD5,    SSH2_MD5_DIG_LEN,  8,  0,  0
 };
 
 /* pbeWithMD5AndRC2-CBC OID: 1.2.840.113549.1.5.6 */
@@ -239,7 +239,7 @@ static const unsigned char OID_pbeWithMD5AndRC2_CBC[] = {
 };
 static const struct pkcs5algo pbeWithMD5AndRC2_CBC = {
     OID_pbeWithMD5AndRC2_CBC,   parse_pbes1,    Qc3_RC2,    8,  Qc3_CBC,
-    Qc3_Pad_Counter,    '\0',   0,  Qc3_MD5,    MD5_DIGEST_LENGTH,  8,  0, 64
+    Qc3_Pad_Counter,    '\0',   0,  Qc3_MD5,    SSH2_MD5_DIG_LEN,  8,  0, 64
 };
 #endif
 
@@ -249,7 +249,7 @@ static const unsigned char OID_pbeWithSHA1AndDES_CBC[] = {
 };
 static const struct pkcs5algo pbeWithSHA1AndDES_CBC = {
     OID_pbeWithSHA1AndDES_CBC,   parse_pbes1,    Qc3_DES,    8,  Qc3_CBC,
-    Qc3_Pad_Counter,    '\0',   8,  Qc3_SHA1,   SHA_DIGEST_LENGTH,  8,  0,  0
+    Qc3_Pad_Counter,    '\0',   8,  Qc3_SHA1,   SSH2_SHA_DIG_LEN,  8,  0,  0
 };
 
 /* pbeWithSHA1AndRC2-CBC OID: 1.2.840.113549.1.5.11 */
@@ -258,7 +258,7 @@ static const unsigned char OID_pbeWithSHA1AndRC2_CBC[] = {
 };
 static const struct pkcs5algo pbeWithSHA1AndRC2_CBC = {
     OID_pbeWithSHA1AndRC2_CBC,   parse_pbes1,    Qc3_RC2,    8,  Qc3_CBC,
-    Qc3_Pad_Counter,    '\0',   0,  Qc3_SHA1,   SHA_DIGEST_LENGTH,  8,  0, 64
+    Qc3_Pad_Counter,    '\0',   0,  Qc3_SHA1,   SSH2_SHA_DIG_LEN,  8,  0, 64
 };
 
 /* rc5-CBC-PAD OID: 1.2.840.113549.3.9: RC5 not implemented in Qc3. */
@@ -1008,26 +1008,26 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
                        void *key, size_t keylen)
 {
-    return os400qc3_hmac_init(ctx, Qc3_MD5, MD5_DIGEST_LENGTH,
+    return os400qc3_hmac_init(ctx, Qc3_MD5, SSH2_MD5_DIG_LEN,
                               key, keylen);
 }
 #endif
 
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return os400qc3_hmac_init(ctx, Qc3_SHA1, SHA_DIGEST_LENGTH,
+    return os400qc3_hmac_init(ctx, Qc3_SHA1, SSH2_SHA_DIG_LEN,
                               key, keylen);
 }
 
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return os400qc3_hmac_init(ctx, Qc3_SHA256, SHA256_DIGEST_LENGTH,
+    return os400qc3_hmac_init(ctx, Qc3_SHA256, SSH2_SHA256_DIG_LEN,
                               key, keylen);
 }
 
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return os400qc3_hmac_init(ctx, Qc3_SHA512, SHA512_DIGEST_LENGTH,
+    return os400qc3_hmac_init(ctx, Qc3_SHA512, SSH2_SHA512_DIG_LEN,
                               key, keylen);
 }
 
@@ -2363,13 +2363,13 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
     algd.Public_Key_Alg = Qc3_RSA;
     algd.PKA_Block_Format = Qc3_PKCS1_01;
     switch(hash_len) {
-    case SHA_DIGEST_LENGTH:
+    case SSH2_SHA_DIG_LEN:
         algd.Signing_Hash_Alg = Qc3_SHA1;
         break;
-    case SHA256_DIGEST_LENGTH:
+    case SSH2_SHA256_DIG_LEN:
         algd.Signing_Hash_Alg = Qc3_SHA256;
         break;
-    case SHA512_DIGEST_LENGTH:
+    case SSH2_SHA512_DIG_LEN:
         algd.Signing_Hash_Alg = Qc3_SHA512;
         break;
     default:
@@ -2388,7 +2388,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsactx, SHA_DIGEST_LENGTH,
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA_DIG_LEN,
                                 sig, sig_len, m, m_len);
 }
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -190,11 +190,6 @@
 
 #include "crypto_config.h"
 
-#define SHA_DIGEST_LENGTH    20
-#define SHA256_DIGEST_LENGTH 32
-#define SHA384_DIGEST_LENGTH 48
-#define SHA512_DIGEST_LENGTH 64
-
 /*******************************************************************
  *
  * OS/400 QC3 crypto-library backend: global handles structures.
@@ -258,7 +253,6 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_sha512(d, l, out)        ssh2_os400qc3_hash(d, l, out, Qc3_SHA512)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define MD5_DIGEST_LENGTH             16
 #define ssh2_md5_ctx                  Qc3_Format_ALGD0100_T
 #define ssh2_md5_init(x)              ssh2_os400qc3_hash_init(x, Qc3_MD5)
 #define ssh2_md5_update(ctx, d, l)    ssh2_os400qc3_hash_update(&(ctx), d, l)

--- a/src/pem.c
+++ b/src/pem.c
@@ -282,7 +282,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         size_t padding = 0;
         int blocksize = method->blocksize;
         void *abstract;
-        unsigned char secret[2 * MD5_DIGEST_LENGTH];
+        unsigned char secret[2 * SSH2_MD5_DIG_LEN];
         ssh2_md5_ctx fingerprint_ctx;
 
         /* Perform key derivation (PBKDF1/MD5) */
@@ -294,15 +294,15 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
             ret = -1;
             goto out;
         }
-        if(method->secret_len > MD5_DIGEST_LENGTH) {
+        if(method->secret_len > SSH2_MD5_DIG_LEN) {
             if(!ssh2_md5_init(&fingerprint_ctx) ||
                !ssh2_md5_update(fingerprint_ctx, secret,
-                                MD5_DIGEST_LENGTH) ||
+                                SSH2_MD5_DIG_LEN) ||
                !ssh2_md5_update(fingerprint_ctx, passphrase,
                                 strlen((const char *)passphrase)) ||
                !ssh2_md5_update(fingerprint_ctx, iv, 8) ||
                !ssh2_md5_final(fingerprint_ctx,
-                               secret + MD5_DIGEST_LENGTH)) {
+                               secret + SSH2_MD5_DIG_LEN)) {
                 ret = -1;
                 goto out;
             }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -801,7 +801,7 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacMD5,
-                                  MD5_DIGEST_LENGTH, key, (ULONG)keylen);
+                                  SSH2_MD5_DIG_LEN, key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -810,7 +810,7 @@ int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA1,
-                                  SHA_DIGEST_LENGTH, key, (ULONG)keylen);
+                                  SSH2_SHA_DIG_LEN, key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -818,7 +818,7 @@ int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA256,
-                                  SHA256_DIGEST_LENGTH, key, (ULONG)keylen);
+                                  SSH2_SHA256_DIG_LEN, key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -826,7 +826,7 @@ int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA512,
-                                  SHA512_DIGEST_LENGTH, key, (ULONG)keylen);
+                                  SSH2_SHA512_DIG_LEN, key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -876,19 +876,19 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
     ULONG datalen;
     int ret;
 
-    if(hashlen == SHA_DIGEST_LENGTH) {
+    if(hashlen == SSH2_SHA_DIG_LEN) {
         hAlgHash = ssh2_wcng.hAlgHashSHA1;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA1_ALGORITHM;
     }
-    else if(hashlen == SHA256_DIGEST_LENGTH) {
+    else if(hashlen == SSH2_SHA256_DIG_LEN) {
         hAlgHash = ssh2_wcng.hAlgHashSHA256;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA256_ALGORITHM;
     }
-    else if(hashlen == SHA384_DIGEST_LENGTH) {
+    else if(hashlen == SSH2_SHA384_DIG_LEN) {
         hAlgHash = ssh2_wcng.hAlgHashSHA384;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA384_ALGORITHM;
     }
-    else if(hashlen == SHA512_DIGEST_LENGTH) {
+    else if(hashlen == SSH2_SHA512_DIG_LEN) {
         hAlgHash = ssh2_wcng.hAlgHashSHA512;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA512_ALGORITHM;
     }
@@ -1427,7 +1427,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return wcng_key_sha_verify(rsactx, SHA_DIGEST_LENGTH,
+    return wcng_key_sha_verify(rsactx, SSH2_SHA_DIG_LEN,
                                sig, (ULONG)sig_len,
                                m, (ULONG)m_len,
                                BCRYPT_PAD_PKCS1);
@@ -1459,13 +1459,13 @@ static int wcng_rsa_sha_sign(LIBSSH2_SESSION *session,
     ULONG cbData, datalen, siglen;
     NTSTATUS ret;
 
-    if(hash_len == SHA_DIGEST_LENGTH)
+    if(hash_len == SSH2_SHA_DIG_LEN)
         paddingInfo.pszAlgId = BCRYPT_SHA1_ALGORITHM;
-    else if(hash_len == SHA256_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA256_DIG_LEN)
         paddingInfo.pszAlgId = BCRYPT_SHA256_ALGORITHM;
-    else if(hash_len == SHA384_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA384_DIG_LEN)
         paddingInfo.pszAlgId = BCRYPT_SHA384_ALGORITHM;
-    else if(hash_len == SHA512_DIGEST_LENGTH)
+    else if(hash_len == SSH2_SHA512_DIG_LEN)
         paddingInfo.pszAlgId = BCRYPT_SHA512_ALGORITHM;
     else {
         ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -1721,7 +1721,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
                          const unsigned char *sig_fixed,
                          const unsigned char *m, size_t m_len)
 {
-    return wcng_key_sha_verify(dsa, SHA_DIGEST_LENGTH, sig_fixed,
+    return wcng_key_sha_verify(dsa, SSH2_SHA_DIG_LEN, sig_fixed,
                                40, m, (ULONG)m_len, 0);
 }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -810,7 +810,7 @@ int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA1,
-                                  SSH2_SHA_DIG_LEN, key, (ULONG)keylen);
+                                  SSH2_SHA1_DIG_LEN, key, (ULONG)keylen);
 
     return ret == 0 ? 1 : 0;
 }
@@ -876,7 +876,7 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
     ULONG datalen;
     int ret;
 
-    if(hashlen == SSH2_SHA_DIG_LEN) {
+    if(hashlen == SSH2_SHA1_DIG_LEN) {
         hAlgHash = ssh2_wcng.hAlgHashSHA1;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA1_ALGORITHM;
     }
@@ -1427,7 +1427,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return wcng_key_sha_verify(rsactx, SSH2_SHA_DIG_LEN,
+    return wcng_key_sha_verify(rsactx, SSH2_SHA1_DIG_LEN,
                                sig, (ULONG)sig_len,
                                m, (ULONG)m_len,
                                BCRYPT_PAD_PKCS1);
@@ -1459,7 +1459,7 @@ static int wcng_rsa_sha_sign(LIBSSH2_SESSION *session,
     ULONG cbData, datalen, siglen;
     NTSTATUS ret;
 
-    if(hash_len == SSH2_SHA_DIG_LEN)
+    if(hash_len == SSH2_SHA1_DIG_LEN)
         paddingInfo.pszAlgId = BCRYPT_SHA1_ALGORITHM;
     else if(hash_len == SSH2_SHA256_DIG_LEN)
         paddingInfo.pszAlgId = BCRYPT_SHA256_ALGORITHM;
@@ -1721,7 +1721,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
                          const unsigned char *sig_fixed,
                          const unsigned char *m, size_t m_len)
 {
-    return wcng_key_sha_verify(dsa, SSH2_SHA_DIG_LEN, sig_fixed,
+    return wcng_key_sha_verify(dsa, SSH2_SHA1_DIG_LEN, sig_fixed,
                                40, m, (ULONG)m_len, 0);
 }
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -164,56 +164,56 @@ struct wcng_hash_ctx {
 #define ssh2_sha1_ctx struct wcng_hash_ctx
 #define ssh2_sha1_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA1, \
-                         SHA_DIGEST_LENGTH, NULL, 0) == 0)
+                         SSH2_SHA_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha1_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha1_final(ctx, hash) \
     (ssh2_wcng_hash_final(&(ctx), hash) == 0)
 #define ssh2_sha1(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA1, \
-                   hash, SHA_DIGEST_LENGTH)
+                   hash, SSH2_SHA_DIG_LEN)
 
 #define ssh2_sha256_ctx struct wcng_hash_ctx
 #define ssh2_sha256_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA256, \
-                         SHA256_DIGEST_LENGTH, NULL, 0) == 0)
+                         SSH2_SHA256_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha256_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha256_final(ctx, hash) \
     (ssh2_wcng_hash_final(&(ctx), hash) == 0)
 #define ssh2_sha256(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA256, \
-                   hash, SHA256_DIGEST_LENGTH)
+                   hash, SSH2_SHA256_DIG_LEN)
 
 #define ssh2_sha384_ctx struct wcng_hash_ctx
 #define ssh2_sha384_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA384, \
-                         SHA384_DIGEST_LENGTH, NULL, 0) == 0)
+                         SSH2_SHA384_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha384_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha384_final(ctx, hash) \
     (ssh2_wcng_hash_final(&(ctx), hash) == 0)
 #define ssh2_sha384(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA384, \
-                   hash, SHA384_DIGEST_LENGTH)
+                   hash, SSH2_SHA384_DIG_LEN)
 
 #define ssh2_sha512_ctx struct wcng_hash_ctx
 #define ssh2_sha512_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA512, \
-                         SHA512_DIGEST_LENGTH, NULL, 0) == 0)
+                         SSH2_SHA512_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha512_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha512_final(ctx, hash) \
     (ssh2_wcng_hash_final(&(ctx), hash) == 0)
 #define ssh2_sha512(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA512, \
-                   hash, SHA512_DIGEST_LENGTH)
+                   hash, SSH2_SHA512_DIG_LEN)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_ctx struct wcng_hash_ctx
 #define ssh2_md5_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashMD5, \
-                         MD5_DIGEST_LENGTH, NULL, 0) == 0)
+                         SSH2_MD5_DIG_LEN, NULL, 0) == 0)
 #define ssh2_md5_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_md5_final(ctx, hash) \

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -164,14 +164,14 @@ struct wcng_hash_ctx {
 #define ssh2_sha1_ctx struct wcng_hash_ctx
 #define ssh2_sha1_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA1, \
-                         SSH2_SHA_DIG_LEN, NULL, 0) == 0)
+                         SSH2_SHA1_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha1_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha1_final(ctx, hash) \
     (ssh2_wcng_hash_final(&(ctx), hash) == 0)
 #define ssh2_sha1(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA1, \
-                   hash, SSH2_SHA_DIG_LEN)
+                   hash, SSH2_SHA1_DIG_LEN)
 
 #define ssh2_sha256_ctx struct wcng_hash_ctx
 #define ssh2_sha256_init(ctx) \

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -94,14 +94,6 @@
 
 #include "crypto_config.h"
 
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define MD5_DIGEST_LENGTH 16
-#endif
-#define SHA_DIGEST_LENGTH    20
-#define SHA256_DIGEST_LENGTH 32
-#define SHA384_DIGEST_LENGTH 48
-#define SHA512_DIGEST_LENGTH 64
-
 /*******************************************************************/
 /*
  * Windows CNG backend: Global context handles


### PR DESCRIPTION
To allow definining them globally, and avoid reusing macros names
originally defined by OpenSSL.

- rename `<name>_DIGEST_LENGTH` to `SSH2_<name>_DIG_LEN`.
  To move to the libssh2 namespace.
- rename `SSH2_SHA_DIG_LEN` to `SSH2_SHA1_DIG_LEN`,
  and drop no longer necessary local trick from kex.c.
- deduplicate definitions into `crypto.h`.
- add `SSH2_RIPEMD160_DIG_LEN` and use it.
- mac: replace magic numbers with these macros, where missing.

---

https://github.com/libssh2/libssh2/pull/2131/files?w=1
