### PR TITLE
mbedtls: switch to PSA Crypto API for hash/digests and drbg

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -67,7 +67,7 @@ int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen);
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data);
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -67,7 +67,7 @@ int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen);
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen);
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -434,7 +434,7 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                     if(!ssh2_hmac_sha1_init(&ctx, node->salt, node->salt_len))
                         break;
                     if(!ssh2_hmac_update(&ctx, host, strlen(host)) ||
-                       !ssh2_hmac_final(&ctx, hash, SHA_DIGEST_LENGTH)) {
+                       !ssh2_hmac_final(&ctx, hash, SSH2_SHA1_DIG_LEN)) {
                         ssh2_hmac_cleanup(&ctx);
                         break;
                     }

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -434,7 +434,7 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                     if(!ssh2_hmac_sha1_init(&ctx, node->salt, node->salt_len))
                         break;
                     if(!ssh2_hmac_update(&ctx, host, strlen(host)) ||
-                       !ssh2_hmac_final(&ctx, hash)) {
+                       !ssh2_hmac_final(&ctx, hash, SHA_DIGEST_LENGTH)) {
                         ssh2_hmac_cleanup(&ctx);
                         break;
                     }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -121,11 +121,12 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     unsigned char *res = gcry_md_read(*ctx, 0);
+    (void)keylen;
 
     if(!res)
         return 0;
 
-    memcpy(key, res, keylen);
+    memcpy(key, res, gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx)));
 
     return 1;
 }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -118,15 +118,15 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
     return 1;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
     unsigned char *res = gcry_md_read(*ctx, 0);
-    (void)keylen;
+    (void)maclen;
 
     if(!res)
         return 0;
 
-    memcpy(key, res, gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx)));
+    memcpy(mac, res, gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx)));
 
     return 1;
 }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -118,14 +118,14 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
     return 1;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     unsigned char *res = gcry_md_read(*ctx, 0);
 
     if(!res)
         return 0;
 
-    memcpy(data, res, gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx)));
+    memcpy(key, res, keylen);
 
     return 1;
 }

--- a/src/mac.c
+++ b/src/mac.c
@@ -125,7 +125,7 @@ static int mac_method_hmac_sha2_512_hash(LIBSSH2_SESSION *session,
     if(res && addtl && addtl_len)
         res = ssh2_hmac_update(&ctx, addtl, addtl_len);
     if(res)
-        res = ssh2_hmac_final(&ctx, buf);
+        res = ssh2_hmac_final(&ctx, buf, SSH2_SHA512_DIG_LEN);
     ssh2_hmac_cleanup(&ctx);
 
     return !res;
@@ -179,7 +179,7 @@ static int mac_method_hmac_sha2_256_hash(LIBSSH2_SESSION *session,
     if(res && addtl && addtl_len)
         res = ssh2_hmac_update(&ctx, addtl, addtl_len);
     if(res)
-        res = ssh2_hmac_final(&ctx, buf);
+        res = ssh2_hmac_final(&ctx, buf, SSH2_SHA256_DIG_LEN);
     ssh2_hmac_cleanup(&ctx);
 
     return !res;
@@ -232,7 +232,7 @@ static int mac_method_hmac_sha1_hash(LIBSSH2_SESSION *session,
     if(res && addtl && addtl_len)
         res = ssh2_hmac_update(&ctx, addtl, addtl_len);
     if(res)
-        res = ssh2_hmac_final(&ctx, buf);
+        res = ssh2_hmac_final(&ctx, buf, SSH2_SHA1_DIG_LEN);
     ssh2_hmac_cleanup(&ctx);
 
     return !res;
@@ -314,7 +314,7 @@ static int mac_method_hmac_md5_hash(LIBSSH2_SESSION *session,
     if(res && addtl && addtl_len)
         res = ssh2_hmac_update(&ctx, addtl, addtl_len);
     if(res)
-        res = ssh2_hmac_final(&ctx, buf);
+        res = ssh2_hmac_final(&ctx, buf, SSH2_MD5_DIG_LEN);
     ssh2_hmac_cleanup(&ctx);
 
     return !res;
@@ -387,7 +387,7 @@ static int mac_method_hmac_ripemd160_hash(LIBSSH2_SESSION *session,
     if(res && addtl && addtl_len)
         res = ssh2_hmac_update(&ctx, addtl, addtl_len);
     if(res)
-        res = ssh2_hmac_final(&ctx, buf);
+        res = ssh2_hmac_final(&ctx, buf, SSH2_RIPEMD160_DIG_LEN);
     ssh2_hmac_cleanup(&ctx);
 
     return !res;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -190,14 +190,14 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg)
 {
     memset(ctx, 0, sizeof(*ctx));
-    return psa_hash_setup(ctx, alg) == PSA_SUCCESS ? 1 : 0;
+    return psa_hash_setup(ctx, alg) == PSA_SUCCESS;
 }
 
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
                          unsigned char *hash, size_t len)
 {
     size_t actual_len;
-    return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS ? 1 : 0;
+    return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS;
 }
 
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
@@ -271,14 +271,14 @@ int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 {
-    return psa_mac_update(&ctx->mac, data, datalen) == PSA_SUCCESS ? 1 : 0;
+    return psa_mac_update(&ctx->mac, data, datalen) == PSA_SUCCESS;
 }
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
     size_t actual_len;
     return psa_mac_sign_finish(&ctx->mac, mac, maclen,
-                               &actual_len) == PSA_SUCCESS ? 1 : 0;
+                               &actual_len) == PSA_SUCCESS;
 }
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -274,10 +274,10 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
     return psa_mac_update(&ctx->mac, data, datalen) == PSA_SUCCESS ? 1 : 0;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
     size_t actual_len;
-    return psa_mac_sign_finish(&ctx->mac, key, keylen,
+    return psa_mac_sign_finish(&ctx->mac, mac, maclen,
                                &actual_len) == PSA_SUCCESS ? 1 : 0;
 }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -61,8 +61,12 @@ static mbedtls_ctr_drbg_context mbed_ctr_drbg;
 void ssh2_crypto_init(void)
 {
 #if MBEDTLS_VERSION_NUMBER < 0x04000000
-    int ret;
+    int ret = 0;
+#endif
 
+    (void)psa_crypto_init();
+
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
     mbedtls_entropy_init(&mbed_entropy);
     mbedtls_ctr_drbg_init(&mbed_ctr_drbg);
 
@@ -76,6 +80,8 @@ void ssh2_crypto_init(void)
 
 void ssh2_crypto_exit(void)
 {
+    mbedtls_psa_crypto_free();
+
 #if MBEDTLS_VERSION_NUMBER < 0x04000000
     mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
     mbedtls_entropy_free(&mbed_entropy);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -177,45 +177,27 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return ret == 0 ? 0 : -1;
 }
 
-int ssh2_mbed_hash_init(psa_hash_operation_t *ctx,
-                        psa_algorithm_t md_type,
-                        const unsigned char *key, size_t keylen)
+int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg)
 {
-    const mbedtls_md_info_t *md_info;
-    int ret, hmac;
-
-    hmac = key ? 1 : 0;
-
-    mbedtls_md_init(ctx);
-    ret = mbedtls_md_setup(ctx, md_info, hmac);
-    if(!ret) {
-        if(hmac)
-            ret = mbedtls_md_hmac_starts(ctx, key, keylen);
-        else
-            ret = mbedtls_md_starts(ctx);
-    }
-
-    return ret == 0 ? 1 : 0;
+    memset(ctx, 0, sizeof(*ctx));
+    return psa_hash_setup(ctx, alg) == PSA_SUCCESS ? 1 : 0;
 }
 
-int ssh2_mbed_hash_final(psa_hash_operation_t *ctx, unsigned char *hash)
+int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
+                         unsigned char *hash, size_t len)
 {
     size_t actual_length;
-    psa_status_t status;
-
-    status = psa_hash_finish(ctx, hash, ..., &actual_length);
-
-    return ret == PSA_SUCCESS ? 1 : 0;
- }
+    return psa_hash_finish(ctx, hash, len, &actual_length) == PSA_SUCCESS ? 1 : 0;
+}
 
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   psa_algorithm_t md_type, unsigned char *hash)
+                   psa_algorithm_t alg, unsigned char *hash)
 {
     size_t actual_length;
     psa_status_t status;
 
     status = psa_hash_compute(alg, data, datalen,
-                              hash, sha256len, &actual_length);
+                              hash, PSA_HASH_LENGTH(alg), &actual_length);
 
     return status == PSA_SUCCESS ? 0 : -1;
 }
@@ -229,30 +211,30 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 #if LIBSSH2_MD5
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, MBEDTLS_MD_MD5, key, keylen);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_MD5, key, keylen);
 }
 #endif
 
 #if LIBSSH2_HMAC_RIPEMD
 int ssh2_hmac_ripemd160_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, MBEDTLS_MD_RIPEMD160, key, keylen);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_RIPEMD160, key, keylen);
 }
 #endif
 
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, MBEDTLS_MD_SHA1, key, keylen);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_1, key, keylen);
 }
 
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, MBEDTLS_MD_SHA256, key, keylen);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_256, key, keylen);
 }
 
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, MBEDTLS_MD_SHA512, key, keylen);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_512, key, keylen);
 }
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -177,7 +177,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return ret == 0 ? 0 : -1;
 }
 
-int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,
+int ssh2_mbed_hash_init(psa_hash_operation_t *ctx,
                         mbedtls_md_type_t md_type,
                         const unsigned char *key, size_t keylen)
 {
@@ -202,7 +202,7 @@ int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,
     return ret == 0 ? 1 : 0;
 }
 
-int ssh2_mbed_hash_final(mbedtls_md_context_t *ctx, unsigned char *hash)
+int ssh2_mbed_hash_final(psa_hash_operation_t *ctx, unsigned char *hash)
 {
     int ret;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -233,7 +233,9 @@ static int mbed_hmac_init(ssh2_hmac_ctx *ctx, psa_algorithm_t alg,
 
     ctx->mac = psa_mac_operation_init();
     if(psa_mac_sign_setup(&ctx->mac, ctx->key_id, alg_hmac) != PSA_SUCCESS) {
+        (void)psa_mac_abort(&ctx->mac);
         psa_destroy_key(ctx->key_id);
+        ctx->key_id = 0;
         return 0;
     }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -187,8 +187,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return ret == 0 ? 0 : -1;
 }
 
-int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg,
-                        const unsigned char *key, size_t keylen)
+int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg)
 {
     memset(ctx, 0, sizeof(*ctx));
     return psa_hash_setup(ctx, alg) == PSA_SUCCESS ? 1 : 0;
@@ -219,33 +218,40 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
     return 1;
 }
 
+static int mbed_hmac_init(psa_hash_operation_t *ctx, psa_algorithm_t alg,
+                          const unsigned char *key, size_t keylen)
+{
+    memset(ctx, 0, sizeof(*ctx));
+    return psa_hash_setup(ctx, alg) == PSA_SUCCESS ? 1 : 0;
+}
+
 #if LIBSSH2_MD5
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_MD5, key, keylen);
+    return mbed_hmac_init(ctx, PSA_ALG_MD5, key, keylen);
 }
 #endif
 
 #if LIBSSH2_HMAC_RIPEMD
 int ssh2_hmac_ripemd160_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_RIPEMD160, key, keylen);
+    return mbed_hmac_init(ctx, PSA_ALG_RIPEMD160, key, keylen);
 }
 #endif
 
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_1, key, keylen);
+    return mbed_hmac_init(ctx, PSA_ALG_SHA_1, key, keylen);
 }
 
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_256, key, keylen);
+    return mbed_hmac_init(ctx, PSA_ALG_SHA_256, key, keylen);
 }
 
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_512, key, keylen);
+    return mbed_hmac_init(ctx, PSA_ALG_SHA_512, key, keylen);
 }
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -256,10 +256,11 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
     return psa_hash_update(ctx, data, datalen) == PSA_SUCCESS ? 1 : 0;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     size_t actual_length;
-    return psa_hash_finish(ctx, data, 0, &actual_length) == PSA_SUCCESS ? 1 : 0;
+    return psa_hash_finish(ctx, key, keylen,
+                           &actual_length) == PSA_SUCCESS ? 1 : 0;
 }
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -190,18 +190,18 @@ int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg)
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
                          unsigned char *hash, size_t len)
 {
-    size_t actual_length;
-    return psa_hash_finish(ctx, hash, len, &actual_length) == PSA_SUCCESS ? 1 : 0;
+    size_t actual_len;
+    return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS ? 1 : 0;
 }
 
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
                    psa_algorithm_t alg, unsigned char *hash)
 {
-    size_t actual_length;
+    size_t actual_len;
     psa_status_t status;
 
     status = psa_hash_compute(alg, data, datalen,
-                              hash, PSA_HASH_LENGTH(alg), &actual_length);
+                              hash, PSA_HASH_LENGTH(alg), &actual_len);
 
     return status == PSA_SUCCESS ? 0 : -1;
 }
@@ -258,9 +258,9 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    size_t actual_length;
+    size_t actual_len;
     return psa_hash_finish(ctx, key, keylen,
-                           &actual_length) == PSA_SUCCESS ? 1 : 0;
+                           &actual_len) == PSA_SUCCESS ? 1 : 0;
 }
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -283,7 +283,7 @@ int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 {
-     psa_destroy_key(ctx->key_id);
+    psa_destroy_key(ctx->key_id);
 }
 
 /*******************************************************************/

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -187,7 +187,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return ret == 0 ? 0 : -1;
 }
 
-int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg)
+int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg,
+                        const unsigned char *key, size_t keylen)
 {
     memset(ctx, 0, sizeof(*ctx));
     return psa_hash_setup(ctx, alg) == PSA_SUCCESS ? 1 : 0;
@@ -221,40 +222,30 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 #if LIBSSH2_MD5
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    (void)key;
-    (void)keylen;
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_MD5);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_MD5, key, keylen);
 }
 #endif
 
 #if LIBSSH2_HMAC_RIPEMD
 int ssh2_hmac_ripemd160_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    (void)key;
-    (void)keylen;
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_RIPEMD160);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_RIPEMD160, key, keylen);
 }
 #endif
 
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    (void)key;
-    (void)keylen;
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_1);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_1, key, keylen);
 }
 
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    (void)key;
-    (void)keylen;
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_256);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_256, key, keylen);
 }
 
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    (void)key;
-    (void)keylen;
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_512);
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_512, key, keylen);
 }
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -233,9 +233,7 @@ static int mbed_hmac_init(ssh2_hmac_ctx *ctx, psa_algorithm_t alg,
 
     ctx->mac = psa_mac_operation_init();
     if(psa_mac_sign_setup(&ctx->mac, ctx->key_id, alg_hmac) != PSA_SUCCESS) {
-        (void)psa_mac_abort(&ctx->mac);
-        psa_destroy_key(ctx->key_id);
-        ctx->key_id = 0;
+        ssh2_hmac_cleanup(ctx);
         return 0;
     }
 
@@ -285,7 +283,9 @@ int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 {
+    (void)psa_mac_abort(&ctx->mac);
     psa_destroy_key(ctx->key_id);
+    ctx->key_id = PSA_KEY_ID_NULL;
 }
 
 /*******************************************************************/

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -223,18 +223,17 @@ static int mbed_hmac_init(ssh2_hmac_ctx *ctx, psa_algorithm_t alg,
 {
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg_hmac = PSA_ALG_HMAC(alg);
-    psa_key_id_t key_id;
 
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH);
     psa_set_key_algorithm(&attributes, alg_hmac);
     psa_set_key_type(&attributes, PSA_KEY_TYPE_HMAC);
 
-    if(psa_import_key(&attributes, key, keylen, &key_id) != PSA_SUCCESS)
+    if(psa_import_key(&attributes, key, keylen, &ctx->key_id) != PSA_SUCCESS)
         return 0;
 
-    *ctx = psa_mac_operation_init();
-    if(psa_mac_sign_setup(ctx, key_id, alg_hmac) != PSA_SUCCESS) {
-        psa_destroy_key(key_id);
+    ctx->mac = psa_mac_operation_init();
+    if(psa_mac_sign_setup(&ctx->mac, ctx->key_id, alg_hmac) != PSA_SUCCESS) {
+        psa_destroy_key(ctx->key_id);
         return -1;
     }
 
@@ -272,19 +271,19 @@ int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 {
-    return psa_mac_update(ctx, data, datalen) == PSA_SUCCESS ? 1 : 0;
+    return psa_mac_update(&ctx->mac, data, datalen) == PSA_SUCCESS ? 1 : 0;
 }
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     size_t actual_len;
-    return psa_mac_sign_finish(ctx, key, keylen,
+    return psa_mac_sign_finish(&ctx->mac, key, keylen,
                                &actual_len) == PSA_SUCCESS ? 1 : 0;
 }
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 {
-    (void)ctx;
+     psa_destroy_key(ctx->key_id);
 }
 
 /*******************************************************************/

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -184,10 +184,6 @@ int ssh2_mbed_hash_init(psa_hash_operation_t *ctx,
     const mbedtls_md_info_t *md_info;
     int ret, hmac;
 
-    md_info = mbedtls_md_info_from_type(md_type);
-    if(!md_info)
-        return 0;
-
     hmac = key ? 1 : 0;
 
     mbedtls_md_init(ctx);
@@ -204,27 +200,24 @@ int ssh2_mbed_hash_init(psa_hash_operation_t *ctx,
 
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx, unsigned char *hash)
 {
-    int ret;
+    size_t actual_length;
+    psa_status_t status;
 
-    ret = mbedtls_md_finish(ctx, hash);
-    mbedtls_md_free(ctx);
+    status = psa_hash_finish(ctx, hash, ..., &actual_length);
 
-    return ret == 0 ? 1 : 0;
-}
+    return ret == PSA_SUCCESS ? 1 : 0;
+ }
 
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
                    psa_algorithm_t md_type, unsigned char *hash)
 {
-    const mbedtls_md_info_t *md_info;
-    int ret;
+    size_t actual_length;
+    psa_status_t status;
 
-    md_info = mbedtls_md_info_from_type(md_type);
-    if(!md_info)
-        return 0;
+    status = psa_hash_compute(alg, data, datalen,
+                              hash, sha256len, &actual_length);
 
-    ret = mbedtls_md(md_info, data, datalen, hash);
-
-    return ret == 0 ? 0 : -1;
+    return status == PSA_SUCCESS ? 0 : -1;
 }
 
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -253,21 +253,18 @@ int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 {
-    int ret = mbedtls_md_hmac_update(ctx, data, datalen);
-
-    return ret == 0 ? 1 : 0;
+    return psa_hash_update(ctx, data, datalen) == PSA_SUCCESS ? 1 : 0;
 }
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data)
 {
-    int ret = mbedtls_md_hmac_finish(ctx, data);
-
-    return ret == 0 ? 1 : 0;
+    size_t actual_length;
+    return psa_hash_finish(ctx, data, 0, &actual_length) == PSA_SUCCESS ? 1 : 0;
 }
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 {
-    mbedtls_md_free(ctx);
+    (void)ctx;
 }
 
 /*******************************************************************/

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -215,30 +215,40 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 #if LIBSSH2_MD5
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_MD5, key, keylen);
+    (void)key;
+    (void)keylen;
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_MD5);
 }
 #endif
 
 #if LIBSSH2_HMAC_RIPEMD
 int ssh2_hmac_ripemd160_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_RIPEMD160, key, keylen);
+    (void)key;
+    (void)keylen;
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_RIPEMD160);
 }
 #endif
 
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_1, key, keylen);
+    (void)key;
+    (void)keylen;
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_1);
 }
 
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_256, key, keylen);
+    (void)key;
+    (void)keylen;
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_256);
 }
 
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_512, key, keylen);
+    (void)key;
+    (void)keylen;
+    return ssh2_mbed_hash_init(ctx, PSA_ALG_SHA_512);
 }
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -490,7 +490,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *m, size_t m_len)
 {
     int ret;
-    psa_algorithm_t md_type;
+    mbedtls_md_type_t md_type;
     unsigned char *hash;
 
     if(sig_len < mbedtls_rsa_get_len(rsactx))
@@ -500,17 +500,22 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
     if(!hash)
         return -1;
 
-    if(hash_len == SSH2_SHA1_DIG_LEN)
+    if(hash_len == SSH2_SHA1_DIG_LEN) {
+        ret = ssh2_mbed_hash(m, m_len, PSA_ALG_SHA_1, hash);
         md_type = MBEDTLS_MD_SHA1;
-    else if(hash_len == SSH2_SHA256_DIG_LEN)
+    }
+    else if(hash_len == SSH2_SHA256_DIG_LEN) {
+        ret = ssh2_mbed_hash(m, m_len, PSA_ALG_SHA_256, hash);
         md_type = MBEDTLS_MD_SHA256;
-    else if(hash_len == SSH2_SHA512_DIG_LEN)
+    }
+    else if(hash_len == SSH2_SHA512_DIG_LEN) {
+        ret = ssh2_mbed_hash(m, m_len, PSA_ALG_SHA_512, hash);
         md_type = MBEDTLS_MD_SHA512;
+    }
     else {
         free(hash);
         return -1; /* unsupported digest */
     }
-    ret = ssh2_mbed_hash(m, m_len, md_type, hash);
 
     if(ret) {
         free(hash);
@@ -541,7 +546,7 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
     int ret;
     unsigned char *sig;
     size_t sig_len;
-    psa_algorithm_t md_type;
+    mbedtls_md_type_t md_type;
 
     sig_len = mbedtls_rsa_get_len(rsactx);
     sig = SSH2_ALLOC(session, sig_len);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -215,6 +215,7 @@ int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 {
     ctx->mac = psa_mac_operation_init();
+    ctx->key_id = PSA_KEY_ID_NULL;
     return 1;
 }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -48,8 +48,10 @@
  * mbedTLS backend: Global context handles
  */
 
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
 static mbedtls_entropy_context mbed_entropy;
 static mbedtls_ctr_drbg_context mbed_ctr_drbg;
+#endif
 
 /*******************************************************************/
 /*
@@ -58,6 +60,7 @@ static mbedtls_ctr_drbg_context mbed_ctr_drbg;
 
 void ssh2_crypto_init(void)
 {
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
     int ret;
 
     mbedtls_entropy_init(&mbed_entropy);
@@ -68,19 +71,20 @@ void ssh2_crypto_init(void)
                                 &mbed_entropy, NULL, 0);
     if(ret)
         mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
+#endif
 }
 
 void ssh2_crypto_exit(void)
 {
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
     mbedtls_ctr_drbg_free(&mbed_ctr_drbg);
     mbedtls_entropy_free(&mbed_entropy);
+#endif
 }
 
 int ssh2_random(unsigned char *buf, size_t len)
 {
-    int ret;
-    ret = mbedtls_ctr_drbg_random(&mbed_ctr_drbg, buf, len);
-    return ret == 0 ? 0 : -1;
+    return psa_generate_random(buf, len) == PSA_SUCCESS ? 0 : -1;
 }
 
 static void mbed_safe_free(void *buf, size_t len)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -178,7 +178,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 }
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx,
-                        mbedtls_md_type_t md_type,
+                        psa_algorithm_t md_type,
                         const unsigned char *key, size_t keylen)
 {
     const mbedtls_md_info_t *md_info;
@@ -213,7 +213,7 @@ int ssh2_mbed_hash_final(psa_hash_operation_t *ctx, unsigned char *hash)
 }
 
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   mbedtls_md_type_t md_type, unsigned char *hash)
+                   psa_algorithm_t md_type, unsigned char *hash)
 {
     const mbedtls_md_info_t *md_info;
     int ret;
@@ -503,7 +503,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *m, size_t m_len)
 {
     int ret;
-    mbedtls_md_type_t md_type;
+    psa_algorithm_t md_type;
     unsigned char *hash;
 
     if(sig_len < mbedtls_rsa_get_len(rsactx))
@@ -554,7 +554,7 @@ int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
     int ret;
     unsigned char *sig;
     size_t sig_len;
-    mbedtls_md_type_t md_type;
+    psa_algorithm_t md_type;
 
     sig_len = mbedtls_rsa_get_len(rsactx);
     sig = SSH2_ALLOC(session, sig_len);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -234,10 +234,10 @@ static int mbed_hmac_init(ssh2_hmac_ctx *ctx, psa_algorithm_t alg,
     ctx->mac = psa_mac_operation_init();
     if(psa_mac_sign_setup(&ctx->mac, ctx->key_id, alg_hmac) != PSA_SUCCESS) {
         psa_destroy_key(ctx->key_id);
-        return -1;
+        return 0;
     }
 
-    return 0;
+    return 1;
 }
 
 #if LIBSSH2_MD5

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -218,11 +218,27 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
     return 1;
 }
 
-static int mbed_hmac_init(psa_hash_operation_t *ctx, psa_algorithm_t alg,
+static int mbed_hmac_init(ssh2_hmac_ctx *ctx, psa_algorithm_t alg,
                           const unsigned char *key, size_t keylen)
 {
-    memset(ctx, 0, sizeof(*ctx));
-    return psa_hash_setup(ctx, alg) == PSA_SUCCESS ? 1 : 0;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_algorithm_t alg_hmac = PSA_ALG_HMAC(alg);
+    psa_key_id_t key_id;
+
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH);
+    psa_set_key_algorithm(&attributes, alg_hmac);
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_HMAC);
+
+    if(psa_import_key(&attributes, key, keylen, &key_id) != PSA_SUCCESS)
+        return 0;
+
+    *ctx = psa_mac_operation_init();
+    if(psa_mac_sign_setup(ctx, key_id, alg_hmac) != PSA_SUCCESS) {
+        psa_destroy_key(key_id);
+        return -1;
+    }
+
+    return 0;
 }
 
 #if LIBSSH2_MD5
@@ -256,14 +272,14 @@ int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 {
-    return psa_hash_update(ctx, data, datalen) == PSA_SUCCESS ? 1 : 0;
+    return psa_mac_update(ctx, data, datalen) == PSA_SUCCESS ? 1 : 0;
 }
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     size_t actual_len;
-    return psa_hash_finish(ctx, key, keylen,
-                           &actual_len) == PSA_SUCCESS ? 1 : 0;
+    return psa_mac_sign_finish(ctx, key, keylen,
+                               &actual_len) == PSA_SUCCESS ? 1 : 0;
 }
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -189,7 +189,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    *ctx = psa_hash_operation_init();
     return psa_hash_setup(ctx, alg) == PSA_SUCCESS;
 }
 
@@ -214,7 +214,7 @@ int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
 
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    ctx->mac = psa_mac_operation_init();
     return 1;
 }
 
@@ -231,7 +231,6 @@ static int mbed_hmac_init(ssh2_hmac_ctx *ctx, psa_algorithm_t alg,
     if(psa_import_key(&attributes, key, keylen, &ctx->key_id) != PSA_SUCCESS)
         return 0;
 
-    ctx->mac = psa_mac_operation_init();
     if(psa_mac_sign_setup(&ctx->mac, ctx->key_id, alg_hmac) != PSA_SUCCESS) {
         ssh2_hmac_cleanup(ctx);
         return 0;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -224,7 +224,7 @@ static int mbed_hmac_init(ssh2_hmac_ctx *ctx, psa_algorithm_t alg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg_hmac = PSA_ALG_HMAC(alg);
 
-    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH);
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE);
     psa_set_key_algorithm(&attributes, alg_hmac);
     psa_set_key_type(&attributes, PSA_KEY_TYPE_HMAC);
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -202,11 +202,11 @@ int ssh2_random(unsigned char *buf, size_t len);
 #endif
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx,
-                        mbedtls_md_type_t md_type,
+                        psa_algorithm_t md_type,
                         const unsigned char *key, size_t keylen);
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx, unsigned char *hash);
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   mbedtls_md_type_t md_type, unsigned char *hash);
+                   psa_algorithm_t md_type, unsigned char *hash);
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -64,6 +64,9 @@
 #if MBEDTLS_VERSION_NUMBER < 0x03010000
 #  error "mbedTLS 3.1.0 or greater required"
 #endif
+#if MBEDTLS_VERSION_NUMBER < 0x04000000 && !defined(MBEDTLS_CTR_DRBG_C)
+#  error "MBEDTLS_CTR_DRBG_C is required for mbedTLS 3.x."
+#endif
 
 /* Define which features are supported. */
 #if defined(PSA_WANT_ALG_MD5) && PSA_WANT_ALG_MD5

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -75,7 +75,11 @@
 #define LIBSSH2_MD5 0
 #endif
 
+#if defined(PSA_WANT_ALG_RIPEMD160) && PSA_WANT_ALG_RIPEMD160
 #define LIBSSH2_HMAC_RIPEMD 1
+#else
+#define LIBSSH2_HMAC_RIPEMD 0
+#endif
 #define LIBSSH2_HMAC_SHA256 1
 #define LIBSSH2_HMAC_SHA512 1
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -66,7 +66,11 @@
 #endif
 
 /* Define which features are supported. */
+#if defined(PSA_WANT_ALG_MD5) && PSA_WANT_ALG_MD5
 #define LIBSSH2_MD5 1
+#else
+#define LIBSSH2_MD5 0
+#endif
 
 #define LIBSSH2_HMAC_RIPEMD 1
 #define LIBSSH2_HMAC_SHA256 1

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -119,14 +119,14 @@ int ssh2_random(unsigned char *buf, size_t len);
  * mbedTLS backend: HMAC functions
  */
 
-#define ssh2_hmac_ctx mbedtls_md_context_t
+#define ssh2_hmac_ctx psa_hash_operation_t
 
 /*******************************************************************/
 /*
  * mbedTLS backend: SHA1 functions
  */
 
-#define ssh2_sha1_ctx mbedtls_md_context_t
+#define ssh2_sha1_ctx psa_hash_operation_t
 
 #define ssh2_sha1_init(pctx) \
     ssh2_mbed_hash_init(pctx, MBEDTLS_MD_SHA1, NULL, 0)
@@ -142,7 +142,7 @@ int ssh2_random(unsigned char *buf, size_t len);
  * mbedTLS backend: SHA256 functions
  */
 
-#define ssh2_sha256_ctx mbedtls_md_context_t
+#define ssh2_sha256_ctx psa_hash_operation_t
 
 #define ssh2_sha256_init(pctx) \
     ssh2_mbed_hash_init(pctx, MBEDTLS_MD_SHA256, NULL, 0)
@@ -158,7 +158,7 @@ int ssh2_random(unsigned char *buf, size_t len);
  * mbedTLS backend: SHA384 functions
  */
 
-#define ssh2_sha384_ctx mbedtls_md_context_t
+#define ssh2_sha384_ctx psa_hash_operation_t
 
 #define ssh2_sha384_init(pctx) \
     ssh2_mbed_hash_init(pctx, MBEDTLS_MD_SHA384, NULL, 0)
@@ -174,7 +174,7 @@ int ssh2_random(unsigned char *buf, size_t len);
  * mbedTLS backend: SHA512 functions
  */
 
-#define ssh2_sha512_ctx mbedtls_md_context_t
+#define ssh2_sha512_ctx psa_hash_operation_t
 
 #define ssh2_sha512_init(pctx) \
     ssh2_mbed_hash_init(pctx, MBEDTLS_MD_SHA512, NULL, 0)
@@ -191,7 +191,7 @@ int ssh2_random(unsigned char *buf, size_t len);
  */
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_ctx mbedtls_md_context_t
+#define ssh2_md5_ctx psa_hash_operation_t
 
 #define ssh2_md5_init(pctx) \
     ssh2_mbed_hash_init(pctx, MBEDTLS_MD_MD5, NULL, 0)
@@ -201,10 +201,10 @@ int ssh2_random(unsigned char *buf, size_t len);
     ssh2_mbed_hash_final(&(ctx), hash)
 #endif
 
-int ssh2_mbed_hash_init(mbedtls_md_context_t *ctx,
+int ssh2_mbed_hash_init(psa_hash_operation_t *ctx,
                         mbedtls_md_type_t md_type,
                         const unsigned char *key, size_t keylen);
-int ssh2_mbed_hash_final(mbedtls_md_context_t *ctx, unsigned char *hash);
+int ssh2_mbed_hash_final(psa_hash_operation_t *ctx, unsigned char *hash);
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
                    mbedtls_md_type_t md_type, unsigned char *hash);
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -44,6 +44,7 @@
 #include <mbedtls/version.h>
 #include <mbedtls/platform.h>
 #include <mbedtls/md.h>
+#if MBEDTLS_VERSION_NUMBER < 0x04000000
 #include <mbedtls/rsa.h>
 #include <mbedtls/bignum.h>
 #include <mbedtls/cipher.h>
@@ -55,6 +56,7 @@
 #endif
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
+#endif
 #include <mbedtls/pk.h>
 #include <mbedtls/error.h>
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -136,7 +136,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha1_ctx psa_hash_operation_t
 
 #define ssh2_sha1_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1, NULL, 0)
 #define ssh2_sha1_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -153,7 +153,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha256_ctx psa_hash_operation_t
 
 #define ssh2_sha256_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256, NULL, 0)
 #define ssh2_sha256_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -170,7 +170,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha384_ctx psa_hash_operation_t
 
 #define ssh2_sha384_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384, NULL, 0)
 #define ssh2_sha384_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -187,7 +187,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha512_ctx psa_hash_operation_t
 
 #define ssh2_sha512_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512, NULL, 0)
 #define ssh2_sha512_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -205,7 +205,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_md5_ctx psa_hash_operation_t
 
 #define ssh2_md5_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_MD5)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_MD5, NULL, 0)
 #define ssh2_md5_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -213,7 +213,8 @@ int ssh2_random(unsigned char *buf, size_t len);
     ssh2_mbed_hash_final(&(ctx), hash, MD5_DIGEST_LENGTH)
 #endif
 
-int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
+int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg,
+                        const unsigned char *key, size_t keylen);
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
                          unsigned char *hash, size_t len);
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -143,8 +143,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha1_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
 #define ssh2_sha1_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
-                      datalen) == PSA_SUCCESS) ? 1 : 0)
+    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha1_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, SHA_DIGEST_LENGTH)
 #define ssh2_sha1(data, datalen, hash) \
@@ -160,8 +159,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha256_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
 #define ssh2_sha256_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
-                      datalen) == PSA_SUCCESS) ? 1 : 0)
+    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha256_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, SHA256_DIGEST_LENGTH)
 #define ssh2_sha256(data, datalen, hash) \
@@ -177,8 +175,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha384_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
 #define ssh2_sha384_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
-                      datalen) == PSA_SUCCESS) ? 1 : 0)
+    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha384_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, SHA384_DIGEST_LENGTH)
 #define ssh2_sha384(data, datalen, hash) \
@@ -194,8 +191,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha512_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
 #define ssh2_sha512_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
-                      datalen) == PSA_SUCCESS) ? 1 : 0)
+    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha512_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, SHA512_DIGEST_LENGTH)
 #define ssh2_sha512(data, datalen, hash) \
@@ -212,8 +208,7 @@ struct mbed_hash_ctx {
 #define ssh2_md5_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_MD5)
 #define ssh2_md5_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
-                      datalen) == PSA_SUCCESS) ? 1 : 0)
+    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_md5_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, MD5_DIGEST_LENGTH)
 #endif

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -138,8 +138,8 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha1_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
 #define ssh2_sha1_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), \
-                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
+    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
+                      datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_sha1_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, SHA_DIGEST_LENGTH)
 #define ssh2_sha1(data, datalen, hash) \
@@ -155,8 +155,8 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha256_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
 #define ssh2_sha256_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), \
-                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
+    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
+                      datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_sha256_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, SHA256_DIGEST_LENGTH)
 #define ssh2_sha256(data, datalen, hash) \
@@ -172,8 +172,8 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha384_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
 #define ssh2_sha384_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), \
-                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
+    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
+                      datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_sha384_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, SHA384_DIGEST_LENGTH)
 #define ssh2_sha384(data, datalen, hash) \
@@ -189,8 +189,8 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha512_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
 #define ssh2_sha512_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), \
-                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
+    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
+                      datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_sha512_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, SHA512_DIGEST_LENGTH)
 #define ssh2_sha512(data, datalen, hash) \
@@ -207,8 +207,8 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_md5_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_MD5)
 #define ssh2_md5_update(ctx, data, datalen) \
-    ((psa_hash_update(&(ctx), \
-                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
+    ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
+                      datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_md5_final(ctx, hash) \
     ssh2_mbed_hash_final(&(ctx), hash, MD5_DIGEST_LENGTH)
 #endif

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -132,14 +132,15 @@ int ssh2_random(unsigned char *buf, size_t len);
 
 #define ssh2_sha1_ctx psa_hash_operation_t
 
-#define ssh2_sha1_init(pctx) \
-    ssh2_mbed_hash_init(pctx, MBEDTLS_MD_SHA1, NULL, 0)
+#define ssh2_sha1_init(ctx) \
+    ssh2_mbed_hash_init(&(ctx), PSA_ALG_SHA_1)
 #define ssh2_sha1_update(ctx, data, datalen) \
-    (mbedtls_md_update(&(ctx), (const unsigned char *)(data), datalen) == 0)
+    ((psa_hash_update(&(ctx), \
+                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_sha1_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash)
+    ssh2_mbed_hash_final(&(ctx), hash, SHA_DIGEST_LENGTH)
 #define ssh2_sha1(data, datalen, hash) \
-    ssh2_mbed_hash(data, datalen, MBEDTLS_MD_SHA1, hash)
+    ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_1, hash)
 
 /*******************************************************************/
 /*
@@ -149,13 +150,14 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha256_ctx psa_hash_operation_t
 
 #define ssh2_sha256_init(pctx) \
-    ssh2_mbed_hash_init(pctx, MBEDTLS_MD_SHA256, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
 #define ssh2_sha256_update(ctx, data, datalen) \
-    (mbedtls_md_update(&(ctx), (const unsigned char *)(data), datalen) == 0)
+    ((psa_hash_update(&(ctx), \
+                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_sha256_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash)
+    ssh2_mbed_hash_final(&(ctx), hash, SHA256_DIGEST_LENGTH)
 #define ssh2_sha256(data, datalen, hash) \
-    ssh2_mbed_hash(data, datalen, MBEDTLS_MD_SHA256, hash)
+    ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_256, hash)
 
 /*******************************************************************/
 /*
@@ -165,13 +167,14 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha384_ctx psa_hash_operation_t
 
 #define ssh2_sha384_init(pctx) \
-    ssh2_mbed_hash_init(pctx, MBEDTLS_MD_SHA384, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
 #define ssh2_sha384_update(ctx, data, datalen) \
-    (mbedtls_md_update(&(ctx), (const unsigned char *)(data), datalen) == 0)
+    ((psa_hash_update(&(ctx), \
+                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_sha384_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash)
+    ssh2_mbed_hash_final(&(ctx), hash, SHA384_DIGEST_LENGTH)
 #define ssh2_sha384(data, datalen, hash) \
-    ssh2_mbed_hash(data, datalen, MBEDTLS_MD_SHA384, hash)
+    ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_384, hash)
 
 /*******************************************************************/
 /*
@@ -181,13 +184,14 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha512_ctx psa_hash_operation_t
 
 #define ssh2_sha512_init(pctx) \
-    ssh2_mbed_hash_init(pctx, MBEDTLS_MD_SHA512, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
 #define ssh2_sha512_update(ctx, data, datalen) \
-    (mbedtls_md_update(&(ctx), (const unsigned char *)(data), datalen) == 0)
+    ((psa_hash_update(&(ctx), \
+                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_sha512_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash)
+    ssh2_mbed_hash_final(&(ctx), hash, SHA512_DIGEST_LENGTH)
 #define ssh2_sha512(data, datalen, hash) \
-    ssh2_mbed_hash(data, datalen, MBEDTLS_MD_SHA512, hash)
+    ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_512, hash)
 
 /*******************************************************************/
 /*
@@ -198,19 +202,19 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_md5_ctx psa_hash_operation_t
 
 #define ssh2_md5_init(pctx) \
-    ssh2_mbed_hash_init(pctx, MBEDTLS_MD_MD5, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_MD5)
 #define ssh2_md5_update(ctx, data, datalen) \
-    (mbedtls_md_update(&(ctx), (const unsigned char *)(data), datalen) == 0)
+    ((psa_hash_update(&(ctx), \
+                      (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)
 #define ssh2_md5_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash)
+    ssh2_mbed_hash_final(&(ctx), hash, MD5_DIGEST_LENGTH)
 #endif
 
-int ssh2_mbed_hash_init(psa_hash_operation_t *ctx,
-                        psa_algorithm_t md_type,
-                        const unsigned char *key, size_t keylen);
-int ssh2_mbed_hash_final(psa_hash_operation_t *ctx, unsigned char *hash);
+int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
+int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
+                         unsigned char *hash, size_t len);
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   psa_algorithm_t md_type, unsigned char *hash);
+                   psa_algorithm_t alg, unsigned char *hash);
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -149,7 +149,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha1_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha1_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SHA_DIGEST_LENGTH)
+    ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA1_DIG_LEN)
 #define ssh2_sha1(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_1, hash)
 
@@ -165,7 +165,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha256_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha256_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SHA256_DIGEST_LENGTH)
+    ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA256_DIG_LEN)
 #define ssh2_sha256(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_256, hash)
 
@@ -181,7 +181,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha384_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha384_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SHA384_DIGEST_LENGTH)
+    ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA384_DIG_LEN)
 #define ssh2_sha384(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_384, hash)
 
@@ -197,7 +197,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha512_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha512_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SHA512_DIGEST_LENGTH)
+    ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA512_DIG_LEN)
 #define ssh2_sha512(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_512, hash)
 
@@ -214,7 +214,7 @@ struct mbed_hash_ctx {
 #define ssh2_md5_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_md5_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, MD5_DIGEST_LENGTH)
+    ssh2_mbed_hash_final(&(ctx), hash, SSH2_MD5_DIG_LEN)
 #endif
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -126,7 +126,7 @@ int ssh2_random(unsigned char *buf, size_t len);
  * mbedTLS backend: HMAC functions
  */
 
-#define ssh2_hmac_ctx psa_hash_operation_t
+#define ssh2_hmac_ctx psa_mac_operation_t
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -126,7 +126,12 @@ int ssh2_random(unsigned char *buf, size_t len);
  * mbedTLS backend: HMAC functions
  */
 
-#define ssh2_hmac_ctx psa_mac_operation_t
+struct mbed_hash_ctx {
+    psa_mac_operation_t mac;
+    psa_key_id_t key_id;
+};
+
+#define ssh2_hmac_ctx struct mbed_hash_ctx
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -126,7 +126,7 @@ int ssh2_random(unsigned char *buf, size_t len);
  * mbedTLS backend: HMAC functions
  */
 
-#define ssh2_hmac_ctx struct psa_hash_operation_s
+#define ssh2_hmac_ctx psa_hash_operation_t
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -126,7 +126,7 @@ int ssh2_random(unsigned char *buf, size_t len);
  * mbedTLS backend: HMAC functions
  */
 
-#define ssh2_hmac_ctx psa_hash_operation_t
+#define ssh2_hmac_ctx struct psa_hash_operation_s
 
 /*******************************************************************/
 /*
@@ -135,8 +135,8 @@ int ssh2_random(unsigned char *buf, size_t len);
 
 #define ssh2_sha1_ctx psa_hash_operation_t
 
-#define ssh2_sha1_init(ctx) \
-    ssh2_mbed_hash_init(&(ctx), PSA_ALG_SHA_1)
+#define ssh2_sha1_init(pctx) \
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
 #define ssh2_sha1_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), \
                       (const uint8_t *)data, datalen) == PSA_SUCCESS) ? 1 : 0)

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -43,7 +43,8 @@
 
 #include <mbedtls/version.h>
 #include <mbedtls/platform.h>
-#include <mbedtls/md.h>
+#include <psa/crypto_config.h>
+#include <psa/crypto.h>
 #if MBEDTLS_VERSION_NUMBER < 0x04000000
 #include <mbedtls/rsa.h>
 #include <mbedtls/bignum.h>

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -136,7 +136,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha1_ctx psa_hash_operation_t
 
 #define ssh2_sha1_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
 #define ssh2_sha1_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -153,7 +153,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha256_ctx psa_hash_operation_t
 
 #define ssh2_sha256_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
 #define ssh2_sha256_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -170,7 +170,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha384_ctx psa_hash_operation_t
 
 #define ssh2_sha384_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
 #define ssh2_sha384_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -187,7 +187,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_sha512_ctx psa_hash_operation_t
 
 #define ssh2_sha512_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
 #define ssh2_sha512_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -205,7 +205,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_md5_ctx psa_hash_operation_t
 
 #define ssh2_md5_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_MD5, NULL, 0)
+    ssh2_mbed_hash_init(pctx, PSA_ALG_MD5)
 #define ssh2_md5_update(ctx, data, datalen) \
     ((psa_hash_update(&(ctx), (const uint8_t *)(data), \
                       datalen) == PSA_SUCCESS) ? 1 : 0)
@@ -213,8 +213,7 @@ int ssh2_random(unsigned char *buf, size_t len);
     ssh2_mbed_hash_final(&(ctx), hash, MD5_DIGEST_LENGTH)
 #endif
 
-int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg,
-                        const unsigned char *key, size_t keylen);
+int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
                          unsigned char *hash, size_t len);
 int ssh2_mbed_hash(const unsigned char *data, size_t datalen,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -144,13 +144,13 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 #endif
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
-    (void)keylen;
+    (void)maclen;
 #ifdef USE_OPENSSL_3
-    return EVP_MAC_final(*ctx, key, NULL, MAX_MACSIZE);
+    return EVP_MAC_final(*ctx, mac, NULL, MAX_MACSIZE);
 #else
-    return HMAC_Final(*ctx, key, NULL);
+    return HMAC_Final(*ctx, mac, NULL);
 #endif
 }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -144,12 +144,13 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 #endif
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
+    (void)keylen;
 #ifdef USE_OPENSSL_3
-    return EVP_MAC_final(*ctx, data, NULL, MAX_MACSIZE);
+    return EVP_MAC_final(*ctx, key, NULL, MAX_MACSIZE);
 #else
-    return HMAC_Final(*ctx, data, NULL);
+    return HMAC_Final(*ctx, key, NULL);
 #endif
 }
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1045,16 +1045,17 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *out)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     char data;
     Qus_EC_t errcode;
+    (void)keylen;
 
     ctx->hash.Final_Op_Flag = Qc3_Final;
     set_EC_length(errcode, sizeof(errcode));
     Qc3CalculateHMAC((char *)data, &zero, Qc3_Data, (char *)&ctx->hash,
                      Qc3_Alg_Token, ctx->key.Key_Context_Token, Qc3_Key_Token,
-                     anycsp, NULL, (char *)out, (char *)&errcode);
+                     anycsp, NULL, (char *)key, (char *)&errcode);
     return errcode.Bytes_Available ? 0 : 1;
 }
 
@@ -1453,7 +1454,7 @@ static int pbkdf2(LIBSSH2_SESSION *session, char **dk,
         ni = htonl(i);
         if(!ssh2_hmac_update(&hctx, pkcs5->salt, pkcs5->saltlen) ||
            !ssh2_hmac_update(&hctx, &ni, sizeof(ni)) ||
-           !ssh2_hmac_final(&hctx, mac)) {
+           !ssh2_hmac_final(&hctx, mac, pkcs5->hashlen)) {
             SSH2_FREE(session, buf);
             *dk = NULL;
             ssh2_os400qc3_crypto_dtor(&hctx);
@@ -1462,7 +1463,7 @@ static int pbkdf2(LIBSSH2_SESSION *session, char **dk,
         memcpy(buf, mac, pkcs5->hashlen);
         for(j = 1; j < pkcs5->itercount; j++) {
             if(!ssh2_hmac_update(&hctx, mac, pkcs5->hashlen) ||
-               !ssh2_hmac_final(&hctx, mac)) {
+               !ssh2_hmac_final(&hctx, mac, pkcs5->hashlen)) {
                 SSH2_FREE(session, buf);
                 *dk = NULL;
                 ssh2_os400qc3_crypto_dtor(&hctx);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1045,17 +1045,17 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
     char data;
     Qus_EC_t errcode;
-    (void)keylen;
+    (void)maclen;
 
     ctx->hash.Final_Op_Flag = Qc3_Final;
     set_EC_length(errcode, sizeof(errcode));
     Qc3CalculateHMAC((char *)data, &zero, Qc3_Data, (char *)&ctx->hash,
                      Qc3_Alg_Token, ctx->key.Key_Context_Token, Qc3_Key_Token,
-                     anycsp, NULL, (char *)key, (char *)&errcode);
+                     anycsp, NULL, (char *)mac, (char *)&errcode);
     return errcode.Bytes_Available ? 0 : 1;
 }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -838,10 +838,10 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
     return ret == 0 ? 1 : 0;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
-    int ret = BCryptFinishHash(ctx->hHash, key, ctx->cbHash, 0);
-    (void)keylen;
+    int ret = BCryptFinishHash(ctx->hHash, mac, ctx->cbHash, 0);
+    (void)maclen;
 
     return BCRYPT_SUCCESS(ret) ? 1 : 0;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -838,9 +838,10 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
     return ret == 0 ? 1 : 0;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *data)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    int ret = BCryptFinishHash(ctx->hHash, data, ctx->cbHash, 0);
+    int ret = BCryptFinishHash(ctx->hHash, key, ctx->cbHash, 0);
+    (void)keylen;
 
     return BCRYPT_SUCCESS(ret) ? 1 : 0;
 }


### PR DESCRIPTION
The new API is compatible with supported mbedTLS 3 version, while it
also supports mbedTLS 4.

Also:
- pass the mac return buffer size to `ssh2_hmac_final()`, because
  the PSA Crypto API needs it.

Refs:
https://arm-software.github.io/psa-api/crypto/1.1/api/ops/hashes.html
https://arm-software.github.io/psa-api/crypto/1.1/api/ops/macs.html
https://arm-software.github.io/psa-api/crypto/1.1/api/keys/management.html
https://arm-software.github.io/psa-api/crypto/1.1/api/keys/policy.html

---

- [x] rebase on #2131
