### PR TITLE
openssl: de-duplicate low-level hash functions

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -374,15 +374,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
-        ret = ssh2_ossl_hash(m, m_len, hash, "sha1");
+        ret = ssh2_ossl_hash(m, m_len, hash, EVP_sha1());
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
-        ret = ssh2_ossl_hash(m, m_len, hash, "sha256");
+        ret = ssh2_ossl_hash(m, m_len, hash, EVP_sha256());
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
-        ret = ssh2_ossl_hash(m, m_len, hash, "sha512");
+        ret = ssh2_ossl_hash(m, m_len, hash, EVP_sha512());
     }
     else {
         nid_type = 0;
@@ -594,7 +594,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     ctx = EVP_PKEY_CTX_new(dsactx, NULL);
     der_len = i2d_DSA_SIG(dsasig, &der);
 
-    if(ctx && !ssh2_ossl_hash(m, m_len, hash, "sha1")) {
+    if(ctx && !ssh2_ossl_hash(m, m_len, hash, EVP_sha1())) {
         /* ssh2_ossl_hash() succeeded */
         if(EVP_PKEY_verify_init(ctx) > 0)
             ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
@@ -606,7 +606,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     if(der)
         OPENSSL_clear_free(der, der_len);
 #else
-    if(!ssh2_ossl_hash(m, m_len, hash, "sha1"))
+    if(!ssh2_ossl_hash(m, m_len, hash, EVP_sha1()))
         /* ssh2_ossl_hash() succeeded */
         ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsactx);
 #endif
@@ -2771,14 +2771,14 @@ clean_exit:
 }
 #endif /* LIBSSH2_ECDSA */
 
-int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const char *digest)
+int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
 {
     *ctx = EVP_MD_CTX_new();
 
     if(!*ctx)
         return 0;
 
-    if(EVP_DigestInit(*ctx, EVP_get_digestbyname(digest)))
+    if(EVP_DigestInit_ex(*ctx, digest, NULL))
         return 1;
 
     EVP_MD_CTX_free(*ctx);
@@ -2801,14 +2801,14 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out)
 }
 
 int ssh2_ossl_hash(const unsigned char *message, size_t len,
-                   unsigned char *out, const char *digest)
+                   unsigned char *out, const EVP_MD *digest)
 {
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
     if(!ctx)
         return 1; /* error */
 
-    if(EVP_DigestInit(ctx, EVP_get_digestbyname(digest))) {
+    if(EVP_DigestInit_ex(ctx, digest, NULL)) {
         EVP_DigestUpdate(ctx, message, len);
         EVP_DigestFinal(ctx, out, NULL);
         EVP_MD_CTX_free(ctx);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -374,15 +374,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
-        ret = ssh2_ossl_sha1(m, m_len, hash);
+        ret = ssh2_ossl_hash(m, m_len, hash, "sha1");
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
-        ret = ssh2_ossl_sha256(m, m_len, hash);
+        ret = ssh2_ossl_hash(m, m_len, hash, "sha256");
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
-        ret = ssh2_ossl_sha512(m, m_len, hash);
+        ret = ssh2_ossl_hash(m, m_len, hash, "sha512");
     }
     else {
         nid_type = 0;
@@ -2771,7 +2771,7 @@ clean_exit:
 }
 #endif /* LIBSSH2_ECDSA */
 
-int ssh2_ossl_hash_init(ssh2_hash_ctx *ctx, const char *digest)
+int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const char *digest)
 {
     *ctx = EVP_MD_CTX_new();
 
@@ -2787,12 +2787,12 @@ int ssh2_ossl_hash_init(ssh2_hash_ctx *ctx, const char *digest)
     return 0;
 }
 
-int ssh2_ossl_hash_update(ssh2_sha1_ctx *ctx, const void *data, size_t len)
+int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len)
 {
     return EVP_DigestUpdate(*ctx, data, len);
 }
 
-int ssh2_ossl_hash_final(ssh2_sha1_ctx *ctx, unsigned char *out)
+int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out)
 {
     int ret = EVP_DigestFinal(*ctx, out, NULL);
     EVP_MD_CTX_free(*ctx);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2794,7 +2794,7 @@ int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len)
 
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out)
 {
-    int ret = EVP_DigestFinal(*ctx, out, NULL);
+    int ret = EVP_DigestFinal_ex(*ctx, out, NULL);
     EVP_MD_CTX_free(*ctx);
     *ctx = NULL;
     return ret;
@@ -2810,7 +2810,7 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 
     if(EVP_DigestInit_ex(ctx, digest, NULL)) {
         EVP_DigestUpdate(ctx, message, len);
-        EVP_DigestFinal(ctx, out, NULL);
+        EVP_DigestFinal_ex(ctx, out, NULL);
         EVP_MD_CTX_free(ctx);
         return 0; /* success */
     }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2796,6 +2796,7 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out)
 {
     int ret = EVP_DigestFinal(*ctx, out, NULL);
     EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
     return ret;
 }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -594,8 +594,8 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     ctx = EVP_PKEY_CTX_new(dsactx, NULL);
     der_len = i2d_DSA_SIG(dsasig, &der);
 
-    if(ctx && !ssh2_ossl_sha1(m, m_len, hash)) {
-        /* ssh2_ossl_sha1() succeeded */
+    if(ctx && !ssh2_ossl_hash(m, m_len, hash, "sha1")) {
+        /* ssh2_ossl_hash() succeeded */
         if(EVP_PKEY_verify_init(ctx) > 0)
             ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
     }
@@ -606,8 +606,8 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     if(der)
         OPENSSL_clear_free(der, der_len);
 #else
-    if(!ssh2_ossl_sha1(m, m_len, hash))
-        /* ssh2_ossl_sha1() succeeded */
+    if(!ssh2_ossl_hash(m, m_len, hash, "sha1"))
+        /* ssh2_ossl_hash() succeeded */
         ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsactx);
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2771,14 +2771,14 @@ clean_exit:
 }
 #endif /* LIBSSH2_ECDSA */
 
-int ssh2_ossl_sha1_init(ssh2_sha1_ctx *ctx)
+int ssh2_ossl_hash_init(ssh2_hash_ctx *ctx, const char *digest)
 {
     *ctx = EVP_MD_CTX_new();
 
     if(!*ctx)
         return 0;
 
-    if(EVP_DigestInit(*ctx, EVP_get_digestbyname("sha1")))
+    if(EVP_DigestInit(*ctx, EVP_get_digestbyname(digest)))
         return 1;
 
     EVP_MD_CTX_free(*ctx);
@@ -2787,27 +2787,27 @@ int ssh2_ossl_sha1_init(ssh2_sha1_ctx *ctx)
     return 0;
 }
 
-int ssh2_ossl_sha1_update(ssh2_sha1_ctx *ctx, const void *data, size_t len)
+int ssh2_ossl_hash_update(ssh2_sha1_ctx *ctx, const void *data, size_t len)
 {
     return EVP_DigestUpdate(*ctx, data, len);
 }
 
-int ssh2_ossl_sha1_final(ssh2_sha1_ctx *ctx, unsigned char *out)
+int ssh2_ossl_hash_final(ssh2_sha1_ctx *ctx, unsigned char *out)
 {
     int ret = EVP_DigestFinal(*ctx, out, NULL);
     EVP_MD_CTX_free(*ctx);
     return ret;
 }
 
-int ssh2_ossl_sha1(const unsigned char *message, size_t len,
-                   unsigned char *out)
+int ssh2_ossl_hash(const unsigned char *message, size_t len,
+                   unsigned char *out, const char *digest)
 {
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
     if(!ctx)
         return 1; /* error */
 
-    if(EVP_DigestInit(ctx, EVP_get_digestbyname("sha1"))) {
+    if(EVP_DigestInit(ctx, EVP_get_digestbyname(digest))) {
         EVP_DigestUpdate(ctx, message, len);
         EVP_DigestFinal(ctx, out, NULL);
         EVP_MD_CTX_free(ctx);
@@ -2816,187 +2816,6 @@ int ssh2_ossl_sha1(const unsigned char *message, size_t len,
     EVP_MD_CTX_free(ctx);
     return 1; /* error */
 }
-
-int ssh2_ossl_sha256_init(ssh2_sha256_ctx *ctx)
-{
-    *ctx = EVP_MD_CTX_new();
-
-    if(!*ctx)
-        return 0;
-
-    if(EVP_DigestInit(*ctx, EVP_get_digestbyname("sha256")))
-        return 1;
-
-    EVP_MD_CTX_free(*ctx);
-    *ctx = NULL;
-
-    return 0;
-}
-
-int ssh2_ossl_sha256_update(ssh2_sha256_ctx *ctx, const void *data, size_t len)
-{
-    return EVP_DigestUpdate(*ctx, data, len);
-}
-
-int ssh2_ossl_sha256_final(ssh2_sha256_ctx *ctx, unsigned char *out)
-{
-    int ret = EVP_DigestFinal(*ctx, out, NULL);
-    EVP_MD_CTX_free(*ctx);
-    return ret;
-}
-
-int ssh2_ossl_sha256(const unsigned char *message, size_t len,
-                     unsigned char *out)
-{
-    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-
-    if(!ctx)
-        return 1; /* error */
-
-    if(EVP_DigestInit(ctx, EVP_get_digestbyname("sha256"))) {
-        EVP_DigestUpdate(ctx, message, len);
-        EVP_DigestFinal(ctx, out, NULL);
-        EVP_MD_CTX_free(ctx);
-        return 0; /* success */
-    }
-    EVP_MD_CTX_free(ctx);
-    return 1; /* error */
-}
-
-int ssh2_ossl_sha384_init(ssh2_sha384_ctx *ctx)
-{
-    *ctx = EVP_MD_CTX_new();
-
-    if(!*ctx)
-        return 0;
-
-    if(EVP_DigestInit(*ctx, EVP_get_digestbyname("sha384")))
-        return 1;
-
-    EVP_MD_CTX_free(*ctx);
-    *ctx = NULL;
-
-    return 0;
-}
-
-int ssh2_ossl_sha384_update(ssh2_sha384_ctx *ctx, const void *data, size_t len)
-{
-    return EVP_DigestUpdate(*ctx, data, len);
-}
-
-int ssh2_ossl_sha384_final(ssh2_sha384_ctx *ctx, unsigned char *out)
-{
-    int ret = EVP_DigestFinal(*ctx, out, NULL);
-    EVP_MD_CTX_free(*ctx);
-    return ret;
-}
-
-int ssh2_ossl_sha384(const unsigned char *message, size_t len,
-                     unsigned char *out)
-{
-    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-
-    if(!ctx)
-        return 1; /* error */
-
-    if(EVP_DigestInit(ctx, EVP_get_digestbyname("sha384"))) {
-        EVP_DigestUpdate(ctx, message, len);
-        EVP_DigestFinal(ctx, out, NULL);
-        EVP_MD_CTX_free(ctx);
-        return 0; /* success */
-    }
-    EVP_MD_CTX_free(ctx);
-    return 1; /* error */
-}
-
-int ssh2_ossl_sha512_init(ssh2_sha512_ctx *ctx)
-{
-    *ctx = EVP_MD_CTX_new();
-
-    if(!*ctx)
-        return 0;
-
-    if(EVP_DigestInit(*ctx, EVP_get_digestbyname("sha512")))
-        return 1;
-
-    EVP_MD_CTX_free(*ctx);
-    *ctx = NULL;
-
-    return 0;
-}
-
-int ssh2_ossl_sha512_update(ssh2_sha512_ctx *ctx, const void *data, size_t len)
-{
-    return EVP_DigestUpdate(*ctx, data, len);
-}
-
-int ssh2_ossl_sha512_final(ssh2_sha512_ctx *ctx, unsigned char *out)
-{
-    int ret = EVP_DigestFinal(*ctx, out, NULL);
-    EVP_MD_CTX_free(*ctx);
-    return ret;
-}
-
-int ssh2_ossl_sha512(const unsigned char *message, size_t len,
-                     unsigned char *out)
-{
-    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-
-    if(!ctx)
-        return 1; /* error */
-
-    if(EVP_DigestInit(ctx, EVP_get_digestbyname("sha512"))) {
-        EVP_DigestUpdate(ctx, message, len);
-        EVP_DigestFinal(ctx, out, NULL);
-        EVP_MD_CTX_free(ctx);
-        return 0; /* success */
-    }
-    EVP_MD_CTX_free(ctx);
-    return 1; /* error */
-}
-
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-int ssh2_ossl_md5_init(ssh2_md5_ctx *ctx)
-{
-    /* MD5 digest is not supported in OpenSSL FIPS mode
-     * Trying to init it results in a latent OpenSSL error:
-     * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"
-     * Thus, return 0 in FIPS mode
-     */
-#if !defined(USE_OPENSSL_3) && \
-    !defined(LIBRESSL_VERSION_NUMBER) && \
-    !defined(LIBSSH2_WOLFSSL)
-
-    if(FIPS_mode())
-        return 0;
-#endif
-
-    *ctx = EVP_MD_CTX_new();
-
-    if(!*ctx)
-        return 0;
-
-    if(EVP_DigestInit(*ctx, EVP_get_digestbyname("md5")))
-        return 1;
-
-    EVP_MD_CTX_free(*ctx);
-    *ctx = NULL;
-
-    return 0;
-}
-
-int ssh2_ossl_md5_update(ssh2_md5_ctx *ctx, const void *data, size_t len)
-{
-    return EVP_DigestUpdate(*ctx, data, len);
-}
-
-int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out)
-{
-    int ret = EVP_DigestFinal(*ctx, out, NULL);
-    EVP_MD_CTX_free(*ctx);
-    return ret;
-}
-#endif
 
 #if LIBSSH2_ECDSA
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -228,40 +228,40 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 /* returns 0 in case of failure */
-int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const char *digest);
+int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest);
 int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len);
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out);
 /* returns 1 in case of failure */
 int ssh2_ossl_hash(const unsigned char *message, size_t len,
-                   unsigned char *out, const char *digest);
+                   unsigned char *out, const EVP_MD *digest);
 
 #define ssh2_sha1_ctx               EVP_MD_CTX *
-#define ssh2_sha1_init(x)           ssh2_ossl_hash_init(x, "sha1")
+#define ssh2_sha1_init(x)           ssh2_ossl_hash_init(x, EVP_sha1())
 #define ssh2_sha1_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha1_final(ctx, out)   ssh2_ossl_hash_final(&(ctx), out)
-#define ssh2_sha1(x, y, z)          ssh2_ossl_hash(x, y, z, "sha1")
+#define ssh2_sha1(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha1())
 
 #define ssh2_sha256_ctx             EVP_MD_CTX *
-#define ssh2_sha256_init(x)         ssh2_ossl_hash_init(x, "sha256")
+#define ssh2_sha256_init(x)         ssh2_ossl_hash_init(x, EVP_sha256())
 #define ssh2_sha256_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha256_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
-#define ssh2_sha256(x, y, z)        ssh2_ossl_hash(x, y, z, "sha256")
+#define ssh2_sha256(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha256())
 
 #define ssh2_sha384_ctx             EVP_MD_CTX *
-#define ssh2_sha384_init(x)         ssh2_ossl_hash_init(x, "sha384")
+#define ssh2_sha384_init(x)         ssh2_ossl_hash_init(x, EVP_sha384())
 #define ssh2_sha384_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha384_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
-#define ssh2_sha384(x, y, z)        ssh2_ossl_hash(x, y, z, "sha384")
+#define ssh2_sha384(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha384())
 
 #define ssh2_sha512_ctx             EVP_MD_CTX *
-#define ssh2_sha512_init(x)         ssh2_ossl_hash_init(x, "sha512")
+#define ssh2_sha512_init(x)         ssh2_ossl_hash_init(x, EVP_sha512())
 #define ssh2_sha512_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha512_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
-#define ssh2_sha512(x, y, z)        ssh2_ossl_hash(x, y, z, "sha512")
+#define ssh2_sha512(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha512())
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_ctx                EVP_MD_CTX *
@@ -274,9 +274,9 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
     !defined(LIBRESSL_VERSION_NUMBER) && \
     !defined(LIBSSH2_WOLFSSL)
 #define ssh2_md5_init(x) \  /* OpenSSL 1.1.1 */
-    (FIPS_mode() ? (*(x) = NULL, 0) : ssh2_ossl_hash_init(x, "md5"))
+    (FIPS_mode() ? (*(x) = NULL, 0) : ssh2_ossl_hash_init(x, EVP_md5()))
 #else
-#define ssh2_md5_init(x)            ssh2_ossl_hash_init(x, "md5")
+#define ssh2_md5_init(x)            ssh2_ossl_hash_init(x, EVP_md5())
 #endif
 #define ssh2_md5_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -273,7 +273,8 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 #if !defined(USE_OPENSSL_3) && \
     !defined(LIBRESSL_VERSION_NUMBER) && \
     !defined(LIBSSH2_WOLFSSL)
-#define ssh2_md5_init(x) \  /* OpenSSL 1.1.1 */
+/* OpenSSL 1.1.1 */
+#define ssh2_md5_init(x) \
     (FIPS_mode() ? (*(x) = NULL, 0) : ssh2_ossl_hash_init(x, EVP_md5()))
 #else
 #define ssh2_md5_init(x)            ssh2_ossl_hash_init(x, EVP_md5())

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -228,13 +228,11 @@ int ssh2_random(unsigned char *buf, size_t len);
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 /* returns 0 in case of failure */
-int ssh2_ossl_hash_init(ssh2_hash_ctx *ctx, const char *digest);
-int ssh2_ossl_hash_update(ssh2_hash_ctx *ctx, const void *data, size_t len);
-int ssh2_ossl_hash_final(ssh2_hash_ctx *ctx, unsigned char *out);
+int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const char *digest);
+int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len);
+int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out);
 int ssh2_ossl_hash(const unsigned char *message, size_t len,
                    unsigned char *out, const char *digest);
-
-#define ssh2_hash_ctx               EVP_MD_CTX *
 
 #define ssh2_sha1_ctx               EVP_MD_CTX *
 #define ssh2_sha1_init(x)           ssh2_ossl_hash_init(x, "sha1")

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -231,6 +231,7 @@ int ssh2_random(unsigned char *buf, size_t len);
 int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const char *digest);
 int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len);
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out);
+/* returns 1 in case of failure */
 int ssh2_ossl_hash(const unsigned char *message, size_t len,
                    unsigned char *out, const char *digest);
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -227,75 +227,61 @@ int ssh2_random(unsigned char *buf, size_t len);
 
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
-#define ssh2_sha1_ctx EVP_MD_CTX *
-
 /* returns 0 in case of failure */
-int ssh2_ossl_sha1_init(ssh2_sha1_ctx *ctx);
-int ssh2_ossl_sha1_update(ssh2_sha1_ctx *ctx, const void *data, size_t len);
-int ssh2_ossl_sha1_final(ssh2_sha1_ctx *ctx, unsigned char *out);
-int ssh2_ossl_sha1(const unsigned char *message, size_t len,
-                   unsigned char *out);
-#define ssh2_sha1_init(x)                ssh2_ossl_sha1_init(x)
+int ssh2_ossl_hash_init(ssh2_hash_ctx *ctx, const char *digest);
+int ssh2_ossl_hash_update(ssh2_hash_ctx *ctx, const void *data, size_t len);
+int ssh2_ossl_hash_final(ssh2_hash_ctx *ctx, unsigned char *out);
+int ssh2_ossl_hash(const unsigned char *message, size_t len,
+                   unsigned char *out, const char *digest);
+
+#define ssh2_hash_ctx               EVP_MD_CTX *
+
+#define ssh2_sha1_ctx               EVP_MD_CTX *
+#define ssh2_sha1_init(x)           ssh2_ossl_hash_init(x, "sha1")
 #define ssh2_sha1_update(ctx, data, len) \
-    ssh2_ossl_sha1_update(&(ctx), data, len)
-#define ssh2_sha1_final(ctx, out)        ssh2_ossl_sha1_final(&(ctx), out)
-#define ssh2_sha1(x, y, z)               ssh2_ossl_sha1(x, y, z)
+    ssh2_ossl_hash_update(&(ctx), data, len)
+#define ssh2_sha1_final(ctx, out)   ssh2_ossl_hash_final(&(ctx), out)
+#define ssh2_sha1(x, y, z)          ssh2_ossl_hash(x, y, z, "sha1")
 
-#define ssh2_sha256_ctx EVP_MD_CTX *
-
-/* returns 0 in case of failure */
-int ssh2_ossl_sha256_init(ssh2_sha256_ctx *ctx);
-int ssh2_ossl_sha256_update(ssh2_sha256_ctx *ctx, const void *data,
-                            size_t len);
-int ssh2_ossl_sha256_final(ssh2_sha256_ctx *ctx, unsigned char *out);
-int ssh2_ossl_sha256(const unsigned char *message, size_t len,
-                     unsigned char *out);
-#define ssh2_sha256_init(x) ssh2_ossl_sha256_init(x)
+#define ssh2_sha256_ctx             EVP_MD_CTX *
+#define ssh2_sha256_init(x)         ssh2_ossl_hash_init(x, "sha256")
 #define ssh2_sha256_update(ctx, data, len) \
-    ssh2_ossl_sha256_update(&(ctx), data, len)
-#define ssh2_sha256_final(ctx, out) ssh2_ossl_sha256_final(&(ctx), out)
-#define ssh2_sha256(x, y, z)        ssh2_ossl_sha256(x, y, z)
+    ssh2_ossl_hash_update(&(ctx), data, len)
+#define ssh2_sha256_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
+#define ssh2_sha256(x, y, z)        ssh2_ossl_hash(x, y, z, "sha256")
 
-#define ssh2_sha384_ctx EVP_MD_CTX *
-
-/* returns 0 in case of failure */
-int ssh2_ossl_sha384_init(ssh2_sha384_ctx *ctx);
-int ssh2_ossl_sha384_update(ssh2_sha384_ctx *ctx, const void *data,
-                            size_t len);
-int ssh2_ossl_sha384_final(ssh2_sha384_ctx *ctx, unsigned char *out);
-int ssh2_ossl_sha384(const unsigned char *message, size_t len,
-                     unsigned char *out);
-#define ssh2_sha384_init(x) ssh2_ossl_sha384_init(x)
+#define ssh2_sha384_ctx             EVP_MD_CTX *
+#define ssh2_sha384_init(x)         ssh2_ossl_hash_init(x, "sha384")
 #define ssh2_sha384_update(ctx, data, len) \
-    ssh2_ossl_sha384_update(&(ctx), data, len)
-#define ssh2_sha384_final(ctx, out) ssh2_ossl_sha384_final(&(ctx), out)
-#define ssh2_sha384(x, y, z)        ssh2_ossl_sha384(x, y, z)
+    ssh2_ossl_hash_update(&(ctx), data, len)
+#define ssh2_sha384_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
+#define ssh2_sha384(x, y, z)        ssh2_ossl_hash(x, y, z, "sha384")
 
-#define ssh2_sha512_ctx EVP_MD_CTX *
-
-/* returns 0 in case of failure */
-int ssh2_ossl_sha512_init(ssh2_sha512_ctx *ctx);
-int ssh2_ossl_sha512_update(ssh2_sha512_ctx *ctx, const void *data,
-                            size_t len);
-int ssh2_ossl_sha512_final(ssh2_sha512_ctx *ctx, unsigned char *out);
-int ssh2_ossl_sha512(const unsigned char *message, size_t len,
-                     unsigned char *out);
-#define ssh2_sha512_init(x) ssh2_ossl_sha512_init(x)
+#define ssh2_sha512_ctx             EVP_MD_CTX *
+#define ssh2_sha512_init(x)         ssh2_ossl_hash_init(x, "sha512")
 #define ssh2_sha512_update(ctx, data, len) \
-    ssh2_ossl_sha512_update(&(ctx), data, len)
-#define ssh2_sha512_final(ctx, out) ssh2_ossl_sha512_final(&(ctx), out)
-#define ssh2_sha512(x, y, z)        ssh2_ossl_sha512(x, y, z)
+    ssh2_ossl_hash_update(&(ctx), data, len)
+#define ssh2_sha512_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
+#define ssh2_sha512(x, y, z)        ssh2_ossl_hash(x, y, z, "sha512")
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_ctx EVP_MD_CTX *
-
-/* returns 0 in case of failure */
-int ssh2_ossl_md5_init(ssh2_md5_ctx *ctx);
-int ssh2_ossl_md5_update(ssh2_md5_ctx *ctx, const void *data, size_t len);
-int ssh2_ossl_md5_final(ssh2_md5_ctx *ctx, unsigned char *out);
-#define ssh2_md5_init(x)                ssh2_ossl_md5_init(x)
-#define ssh2_md5_update(ctx, data, len) ssh2_ossl_md5_update(&(ctx), data, len)
-#define ssh2_md5_final(ctx, out)        ssh2_ossl_md5_final(&(ctx), out)
+#define ssh2_md5_ctx                EVP_MD_CTX *
+/* MD5 digest is not supported in OpenSSL FIPS mode
+ * Trying to init it results in a latent OpenSSL error:
+ * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"
+ * Thus, return 0 in FIPS mode
+ */
+#if !defined(USE_OPENSSL_3) && \
+    !defined(LIBRESSL_VERSION_NUMBER) && \
+    !defined(LIBSSH2_WOLFSSL)
+#define ssh2_md5_init(x) \
+    (FIPS_mode() ? 0 : ssh2_ossl_hash_init(x, "md5"))  /* OpenSSL 1.1.1 */
+#else
+#define ssh2_md5_init(x)            ssh2_ossl_hash_init(x, "md5")
+#endif
+#define ssh2_md5_update(ctx, data, len) \
+    ssh2_ossl_hash_update(&(ctx), data, len)
+#define ssh2_md5_final(ctx, out)    ssh2_ossl_hash_final(&(ctx), out)
 #endif /* LIBSSH2_MD5 || LIBSSH2_MD5_PEM */
 
 #ifdef USE_OPENSSL_3

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -273,8 +273,8 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 #if !defined(USE_OPENSSL_3) && \
     !defined(LIBRESSL_VERSION_NUMBER) && \
     !defined(LIBSSH2_WOLFSSL)
-#define ssh2_md5_init(x) \
-    (FIPS_mode() ? 0 : ssh2_ossl_hash_init(x, "md5"))  /* OpenSSL 1.1.1 */
+#define ssh2_md5_init(x) \  /* OpenSSL 1.1.1 */
+    (FIPS_mode() ? (*(x) = NULL, 0) : ssh2_ossl_hash_init(x, "md5"))
 #else
 #define ssh2_md5_init(x)            ssh2_ossl_hash_init(x, "md5")
 #endif


### PR DESCRIPTION
Also:
- replace `EVP_DigestInit()` with `EVP_DigestInit_ex()` to
  prefer the modern inferface, that accepts a digest handle instead of
  a string.

- replace `EVP_DigestFinal()` with `EVP_DigestFinal_ex()`,
  To avoid an unnecessary internal call to `EVP_MD_CTX_reset()`, done by
  the former. The context is freed right after these calls.

- fix `ssh2_ossl_hash_final()` to clear the context pointer after
  freeing.
  Bug: https://github.com/libssh2/libssh2/pull/2134#discussion_r3492390686

- initialize MD5 object to NULL in OpenSSL 1.1.1 FIPS mode.
  Bug: https://github.com/libssh2/libssh2/pull/2134#discussion_r3492994473

---

https://github.com/libssh2/libssh2/pull/2134/files?w=1
