### PR TITLE
openssl: pass actual mac buffer size to `EVP_MAC_final()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -146,10 +146,10 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
-    (void)maclen;
 #ifdef USE_OPENSSL_3
     return EVP_MAC_final(*ctx, mac, NULL, maclen);
 #else
+    (void)maclen;
     return HMAC_Final(*ctx, mac, NULL);
 #endif
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -148,7 +148,7 @@ int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
     (void)maclen;
 #ifdef USE_OPENSSL_3
-    return EVP_MAC_final(*ctx, mac, NULL, MAX_MACSIZE);
+    return EVP_MAC_final(*ctx, mac, NULL, maclen);
 #else
     return HMAC_Final(*ctx, mac, NULL);
 #endif


### PR DESCRIPTION
Follow-up to e3905e55d9df6fd7cc4acb865c189b7357ab6b85 #2132

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
