### PR TITLE
pem.c: Fix incorrect line clearing

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -231,8 +231,6 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         }
     }
 
-    *line = '\0';
-
     do {
         if(*line) {
             char *tmp;


### PR DESCRIPTION
Remove line clearing null termination that was introduced as a regression from #1746. Fixes #2130.

Credit: [Michael](https://github.com/R6502)