### PR TITLE
openssh_fixture: trim all right-padding whitespace from external command results

### DIFF
--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -144,8 +144,10 @@ static int run_command_varg(char **output, const char *command, va_list args)
         /* command output may contain a trailing newline, so we trim
          * whitespace here */
         size_t end = strlen(buf);
-        if(end > 0 && isspace((int)buf[end - 1]))
+        while(end > 0 && isspace((int)buf[end - 1])) {
             buf[end - 1] = '\0';
+            --end;
+        }
 
         *output = libssh2_strdup(buf);
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -144,7 +144,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
         /* command output may contain a trailing newline, so we trim
          * whitespace here */
         size_t end = strlen(buf);
-        while(end > 0 && isspace((int)buf[end - 1]))
+        if(end > 0 && isspace((int)buf[end - 1]))
             buf[end - 1] = '\0';
 
         *output = libssh2_strdup(buf);


### PR DESCRIPTION
Prior to this patch only the rightmost one was deleted.

Reported by GitHub Code Quality
Follow-up to cf80f2f4b5255cc85a04ee43b27a29c678c1edb1

---

Do we want to trim all ending whitespace here? or perhaps
the CR byte from a CRLF ending? [QUESTION, mine]

"The variable 'end' is decremented by setting `buf[end - 1] = '\0'` but
'end' itself is never decremented in the loop, causing an infinite loop.
After setting the null terminator, decrement 'end' with `--end;` to
properly advance through the buffer."

```c
while(end > 0 && isspace((int)buf[end - 1])) {
    buf[end - 1] = '\0';
    --end;
}
```
