### PR TITLE
publickey: cap packet size in `publickey_packet_receive()`

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -136,6 +136,10 @@ static int publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
                             "Invalid response from publickey subsystem");
 
         pkey->receive_packet_len = ssh2_ntohu32(buffer);
+        if(pkey->receive_packet_len > LIBSSH2_PACKET_MAXPAYLOAD) {
+            return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                            "Too large publickey packet");
+        }
         pkey->receive_packet = SSH2_ALLOC(session, pkey->receive_packet_len);
         if(!pkey->receive_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,


### PR DESCRIPTION
Reported-by: manus-use on GitHub

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
