### PR TITLE
publickey: fix leaks when `publickey_response_success()` received <8 bytes

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -236,9 +236,11 @@ static int publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
             /* Error, or processing complete */
             unsigned long status = 0;
 
-            if(data_len < 8)
+            if(data_len < 8) {
+                SSH2_FREE(session, data);
                 return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                                 "Publickey response too small");
+            }
 
             status = ssh2_ntohu32(s);
 

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -222,9 +222,11 @@ static int publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
                             "Timeout waiting for response from "
                             "publickey subsystem");
 
-        if(data_len < 4)
+        if(data_len < 4) {
+            SSH2_FREE(session, data);
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Publickey response too small");
+        }
 
         s = data;
         response = publickey_response_id(&s, data_len);


### PR DESCRIPTION
Ref: https://github.com/libssh2/libssh2/pull/2143#discussion_r3495598103
