### PR TITLE
channel: fix state machine in `ssh2_channel_extended_data()`

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1874,7 +1874,7 @@ int ssh2_channel_extended_data(LIBSSH2_CHANNEL *channel, int ignore_mode)
         channel->extData2_state = ssh2_NB_state_created;
     }
 
-    if(channel->extData2_state == ssh2_NB_state_idle) {
+    if(channel->extData2_state == ssh2_NB_state_created) {
         if(ignore_mode == LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE) {
             int rc = ssh2_channel_flush(channel,
                                         LIBSSH2_CHANNEL_FLUSH_EXTENDED_DATA);


### PR DESCRIPTION
The worker function permanently ignored
`ignore_mode == LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE`, and never called
`ssh2_channel_flush()` via this codepath.

"The state check at line 1876 should be `ssh2_NB_state_created` instead
of `ssh2_NB_state_idle`. The state is set to `created` on line 1873, so
checking for `idle` means the flush operation will never execute. This
appears to be a logic error in the state machine."

Reported by GitHub Code Quality
