### PR TITLE
publickey: fix potential OOB read in `publickey_response_success()`

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -236,7 +236,7 @@ static int publickey_response_success(LIBSSH2_PUBLICKEY *pkey)
             /* Error, or processing complete */
             unsigned long status = 0;
 
-            if(data_len < 8) {
+            if(data_len < (size_t)(s - data) + 4) {
                 SSH2_FREE(session, data);
                 return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                                 "Publickey response too small");


### PR DESCRIPTION
"The size check for reading the 4-byte status field is incorrect:
`data_len < 8` doesn't account for the variable-length response name
that `publickey_response_id()` advances `s` past. A truncated packet
like `[len=6]["status"]` (10 bytes total) will pass the current check
but still cause an out-of-bounds read in `ssh2_ntohu32(s)`. The check
should ensure there are at least 4 bytes remaining at `s`."

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2144#discussion_r3495678198
