### PR TITLE
crypto: drop intermediate macros for `ssh2_dh_key_pair()`/`ssh2_dh_secret()`

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -353,10 +353,10 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
 void ssh2_dh_init(ssh2_dh_ctx *dhctx);
 void ssh2_dh_dtor(ssh2_dh_ctx *dhctx);
-int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
-                     ssh2_bn *g, ssh2_bn *p, int group_order);
-int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                   ssh2_bn *f, ssh2_bn *p);
+int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
+                     ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx);
+int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                   ssh2_bn *p, ssh2_bn_ctx *bnctx);
 
 #if LIBSSH2_RSA
 #define PEM_RSA_HEADER "-----BEGIN RSA PRIVATE KEY-----"

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -352,11 +352,11 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
                                          size_t key_method_len);
 
 void ssh2_dh_init(ssh2_dh_ctx *dhctx);
-void ssh2_dh_dtor(ssh2_dh_ctx *dhctx);
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                      ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx);
 int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                    ssh2_bn *p, ssh2_bn_ctx *bnctx);
+void ssh2_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #if LIBSSH2_RSA
 #define PEM_RSA_HEADER "-----BEGIN RSA PRIVATE KEY-----"

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -353,6 +353,10 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
 void ssh2_dh_init(ssh2_dh_ctx *dhctx);
 void ssh2_dh_dtor(ssh2_dh_ctx *dhctx);
+int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
+                     ssh2_bn *g, ssh2_bn *p, int group_order);
+int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
+                   ssh2_bn *f, ssh2_bn *p);
 
 #if LIBSSH2_RSA
 #define PEM_RSA_HEADER "-----BEGIN RSA PRIVATE KEY-----"

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -819,8 +819,8 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = gcry_mpi_new(0);                   /* Random from client */
 }
 
-int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                          ssh2_bn *p, int group_order)
+int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
+                     ssh2_bn *p, int group_order)
 {
     /* Generate x and e */
     gcry_mpi_randomize(*dhctx, group_order * 8 - 1, GCRY_VERY_STRONG_RANDOM);
@@ -828,8 +828,8 @@ int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     return 0;
 }
 
-int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                        ssh2_bn *p)
+int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                   ssh2_bn *p)
 {
     /* Compute the shared secret */
     gcry_mpi_powm(secret, f, *dhctx, p);

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -820,8 +820,9 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 }
 
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                     ssh2_bn *p, int group_order)
+                     ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
+    (void)bnctx;
     /* Generate x and e */
     gcry_mpi_randomize(*dhctx, group_order * 8 - 1, GCRY_VERY_STRONG_RANDOM);
     gcry_mpi_powm(pub, g, *dhctx, p);
@@ -829,8 +830,9 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
 }
 
 int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                   ssh2_bn *p)
+                   ssh2_bn *p, ssh2_bn_ctx *bnctx)
 {
+    (void)bnctx;
     /* Compute the shared secret */
     gcry_mpi_powm(secret, f, *dhctx, p);
     return 0;

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -188,14 +188,5 @@
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx struct gcry_mpi *
-#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
-    ssh2_lgcr_dh_key_pair(dhctx, pub, g, p, group_order)
-#define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
-    ssh2_lgcr_dh_secret(dhctx, secret, f, p)
-
-int ssh2_lgcr_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                          ssh2_bn *p, int group_order);
-int ssh2_lgcr_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                        ssh2_bn *p);
 
 #endif /* LIBSSH2_LIBGCRYPT_H */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -832,8 +832,9 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 }
 
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                     ssh2_bn *p, int group_order)
+                     ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
+    (void)bnctx;
     /* Generate x and e */
     mbed_bn_random(*dhctx, (group_order * 8) - 1, 0, -1);
     mbedtls_mpi_exp_mod(pub, g, *dhctx, p, NULL);
@@ -841,8 +842,9 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
 }
 
 int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                   ssh2_bn *p)
+                   ssh2_bn *p, ssh2_bn_ctx *bnctx)
 {
+    (void)bnctx;
     /* Compute the shared secret */
     mbedtls_mpi_exp_mod(secret, f, *dhctx, p, NULL);
     return 0;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -831,8 +831,8 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = ssh2_mbed_bn_init(); /* Random from client */
 }
 
-int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                          ssh2_bn *p, int group_order)
+int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
+                     ssh2_bn *p, int group_order)
 {
     /* Generate x and e */
     mbed_bn_random(*dhctx, (group_order * 8) - 1, 0, -1);
@@ -840,8 +840,8 @@ int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     return 0;
 }
 
-int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                        ssh2_bn *p)
+int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                   ssh2_bn *p)
 {
     /* Compute the shared secret */
     mbedtls_mpi_exp_mod(secret, f, *dhctx, p, NULL);

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -329,14 +329,5 @@ void ssh2_mbed_bn_free(ssh2_bn *bn);
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx mbedtls_mpi *
-#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
-    ssh2_mbed_dh_key_pair(dhctx, pub, g, p, group_order)
-#define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
-    ssh2_mbed_dh_secret(dhctx, secret, f, p)
-
-int ssh2_mbed_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                          ssh2_bn *p, int group_order);
-int ssh2_mbed_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                        ssh2_bn *p);
 
 #endif /* LIBSSH2_MBEDTLS_H */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4366,8 +4366,8 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     *dhctx = BN_new(); /* Random from client */
 }
 
-int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                          ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
+int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
+                     ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
     /* Generate x and e */
     BN_rand(*dhctx, group_order * 8 - 1, 0, -1);
@@ -4375,8 +4375,8 @@ int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     return 0;
 }
 
-int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                        ssh2_bn *p, ssh2_bn_ctx *bnctx)
+int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                   ssh2_bn *p, ssh2_bn_ctx *bnctx)
 {
     /* Compute the shared secret */
     BN_mod_exp(secret, f, *dhctx, p, bnctx);

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -377,14 +377,5 @@ int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val);
 #define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #define ssh2_dh_ctx BIGNUM *
-#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
-    ssh2_ossl_dh_key_pair(dhctx, pub, g, p, group_order, bnctx)
-#define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
-    ssh2_ossl_dh_secret(dhctx, secret, f, p, bnctx)
-
-int ssh2_ossl_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                          ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx);
-int ssh2_ossl_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                        ssh2_bn *p, ssh2_bn_ctx *bnctx);
 
 #endif /* LIBSSH2_OPENSSL_H */

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1247,8 +1247,8 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     memset((char *)dhctx, 0, sizeof(*dhctx));
 }
 
-int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
-                              ssh2_bn *g, ssh2_bn *p, int group_order)
+int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
+                     ssh2_bn *g, ssh2_bn *p, int group_order)
 {
     struct asn1Element *prime;
     struct asn1Element *base;
@@ -1294,8 +1294,8 @@ int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
     return ssh2_bn_from_bin(pub, pubkeylen, (unsigned char *)pubkey);
 }
 
-int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                            ssh2_bn *f, ssh2_bn *p)
+int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
+                   ssh2_bn *f, ssh2_bn *p)
 {
     char *pubkey;
     int pubkeysize;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1247,8 +1247,8 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
     memset((char *)dhctx, 0, sizeof(*dhctx));
 }
 
-int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
-                     ssh2_bn *g, ssh2_bn *p, int group_order)
+int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
+                     ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
     struct asn1Element *prime;
     struct asn1Element *base;
@@ -1262,6 +1262,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
     Qus_EC_t errcode;
 
     (void)group_order;
+    (void)bnctx;
 
     /* Build the PKCS#3 structure. */
 
@@ -1294,8 +1295,8 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
     return ssh2_bn_from_bin(pub, pubkeylen, (unsigned char *)pubkey);
 }
 
-int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                   ssh2_bn *f, ssh2_bn *p)
+int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                   ssh2_bn *p, ssh2_bn_ctx *bnctx)
 {
     char *pubkey;
     int pubkeysize;
@@ -1303,6 +1304,8 @@ int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
     int secretbufsize;
     int secretbuflen;
     Qus_EC_t errcode;
+
+    (void)bnctx;
 
     pubkeysize = (ssh2_bn_bits(f) + 7) >> 3;
     pubkey = alloca(pubkeysize);

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -328,15 +328,6 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
 #define SSH2_DH_MAX_MODULUS_BITS 2048
 
 #define ssh2_dh_ctx struct os400qc3_dh_ctx
-#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
-    ssh2_os400qc3_dh_key_pair(dhctx, pub, g, p, group_order)
-#define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
-    ssh2_os400qc3_dh_secret(dhctx, secret, f, p)
-
-int ssh2_os400qc3_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub,
-                              ssh2_bn *g, ssh2_bn *p, int group_order);
-int ssh2_os400qc3_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret,
-                            ssh2_bn *f, ssh2_bn *p);
 
 /*******************************************************************
  *

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3271,8 +3271,8 @@ static int wcng_round_down(int number, int multiple)
  * `group_order'. Can use the given big number context `bnctx' if needed.  The
  * private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
  * the public key is returned in `pub'. 0 is returned upon success, else -1. */
-int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                          ssh2_bn *p, int group_order)
+int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
+                     ssh2_bn *p, int group_order)
 {
     const int hasAlgDHwithKDF = ssh2_wcng.hasAlgDHwithKDF;
 
@@ -3326,7 +3326,7 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
             /* Pass ownership to dhctx; these parameters are freed when
              * the context is destroyed. We need to keep the parameters more
              * easily available so that we have access to the `g` value when
-             * ssh2_wcng_dh_secret() is called later. */
+             * ssh2_dh_secret() is called later. */
             dhctx->dh_params = dh_params;
 
         dh_params = NULL;
@@ -3445,8 +3445,8 @@ int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
  * `*dhctx', the public key `f' from the other party and the same prime `p'
  * used at context creation. The result is stored in `secret'.  0 is returned
  * upon success, else -1.  */
-int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                        ssh2_bn *p)
+int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
+                   ssh2_bn *p)
 {
     if(ssh2_wcng.hAlgDH && ssh2_wcng.hasAlgDHwithKDF != -1 &&
        dhctx->dh_handle && dhctx->dh_params && f) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3272,9 +3272,11 @@ static int wcng_round_down(int number, int multiple)
  * private key is stored as opaque in the Diffie-Hellman context `*dhctx' and
  * the public key is returned in `pub'. 0 is returned upon success, else -1. */
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                     ssh2_bn *p, int group_order)
+                     ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
     const int hasAlgDHwithKDF = ssh2_wcng.hasAlgDHwithKDF;
+
+    (void)bnctx;
 
     if(group_order < 0)
         return -1;
@@ -3446,8 +3448,10 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
  * used at context creation. The result is stored in `secret'.  0 is returned
  * upon success, else -1.  */
 int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                   ssh2_bn *p)
+                   ssh2_bn *p, ssh2_bn_ctx *bnctx)
 {
+    (void)bnctx;
+
     if(ssh2_wcng.hAlgDH && ssh2_wcng.hasAlgDHwithKDF != -1 &&
        dhctx->dh_handle && dhctx->dh_params && f) {
         BCRYPT_KEY_HANDLE peer_public = NULL;

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -400,14 +400,5 @@ struct wcng_dh_ctx {
 };
 
 #define ssh2_dh_ctx struct wcng_dh_ctx
-#define ssh2_dh_key_pair(dhctx, pub, g, p, group_order, bnctx) \
-    ssh2_wcng_dh_key_pair(dhctx, pub, g, p, group_order)
-#define ssh2_dh_secret(dhctx, secret, f, p, bnctx) \
-    ssh2_wcng_dh_secret(dhctx, secret, f, p)
-
-int ssh2_wcng_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
-                          ssh2_bn *p, int group_order);
-int ssh2_wcng_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
-                        ssh2_bn *p);
 
 #endif /* LIBSSH2_WINCNG_H */


### PR DESCRIPTION
Follow-up to c75c7a8b805f321a51e1515f7b0eff713f0ee3f9 #1971
