### PR TITLE
crypto: `ssh2_dh_key_pair()` reject `group_order <= 0`, where missing

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -823,8 +823,12 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                      ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
     (void)bnctx;
+
+    if(group_order < 0)
+        return -1;
+
     /* Generate x and e */
-    gcry_mpi_randomize(*dhctx, group_order * 8 - 1, GCRY_VERY_STRONG_RANDOM);
+    gcry_mpi_randomize(*dhctx, (group_order * 8) - 1, GCRY_VERY_STRONG_RANDOM);
     gcry_mpi_powm(pub, g, *dhctx, p);
     return 0;
 }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -824,7 +824,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
 {
     (void)bnctx;
 
-    if(group_order < 0)
+    if(group_order <= 0)
         return -1;
 
     /* Generate x and e */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -835,6 +835,10 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                      ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
     (void)bnctx;
+
+    if(group_order < 0)
+        return -1;
+
     /* Generate x and e */
     mbed_bn_random(*dhctx, (group_order * 8) - 1, 0, -1);
     mbedtls_mpi_exp_mod(pub, g, *dhctx, p, NULL);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -836,7 +836,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
 {
     (void)bnctx;
 
-    if(group_order < 0)
+    if(group_order <= 0)
         return -1;
 
     /* Generate x and e */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4369,8 +4369,11 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                      ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
+    if(group_order < 0)
+        return -1;
+
     /* Generate x and e */
-    BN_rand(*dhctx, group_order * 8 - 1, 0, -1);
+    BN_rand(*dhctx, (group_order * 8) - 1, 0, -1);
     BN_mod_exp(pub, g, *dhctx, p, bnctx);
     return 0;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4369,7 +4369,7 @@ void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                      ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx)
 {
-    if(group_order < 0)
+    if(group_order <= 0)
         return -1;
 
     /* Generate x and e */

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1263,7 +1263,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
 
     (void)bnctx;
 
-    if(group_order < 0)
+    if(group_order <= 0)
         return -1;
 
     /* Build the PKCS#3 structure. */

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1261,8 +1261,10 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     int pubkeylen;
     Qus_EC_t errcode;
 
-    (void)group_order;
     (void)bnctx;
+
+    if(group_order < 0)
+        return -1;
 
     /* Build the PKCS#3 structure. */
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3278,7 +3278,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
 
     (void)bnctx;
 
-    if(group_order < 0)
+    if(group_order <= 0)
         return -1;
 
     while(ssh2_wcng.hAlgDH && hasAlgDHwithKDF != -1) {


### PR DESCRIPTION
As already done in WinCNG, but for negative only.

Follow-up to 5a96f494ee0b00282afb2db2e091246fc5e1774a #879

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
