### PR TITLE
openssh_fixture: fix `ssh2_snprintf()` result check

### DIFF
--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -118,7 +118,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
     }
 
     ret = ssh2_snprintf(buf, sizeof(buf), redirect_stderr, command_buf);
-    if(ret < 0 || ret >= BUFSIZ) {
+    if(ret < 0 || (size_t)ret >= sizeof(buf)) {
         fprintf(stderr, "Unable to rewrite command (%s)\n", command);
         return -1;
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -106,7 +106,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-    if(ret < 0 || ret >= BUFSIZ) {
+    if(ret < 0 || ret >= sizeof(command_buf)) {
         fprintf(stderr, "Unable to format command (%s)\n", command);
         return -1;
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -118,7 +118,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
     }
 
     ret = ssh2_snprintf(buf, sizeof(buf), redirect_stderr, command_buf);
-    if(ret < 0 || (size_t)ret >= sizeof(buf)) {
+    if(ret < 0 || ret >= sizeof(buf)) {
         fprintf(stderr, "Unable to rewrite command (%s)\n", command);
         return -1;
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -106,7 +106,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-    if(ret < 0 || ret >= sizeof(command_buf)) {
+    if(ret < 0 || (size_t)ret >= sizeof(command_buf)) {
         fprintf(stderr, "Unable to format command (%s)\n", command);
         return -1;
     }
@@ -118,7 +118,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
     }
 
     ret = ssh2_snprintf(buf, sizeof(buf), redirect_stderr, command_buf);
-    if(ret < 0 || ret >= sizeof(buf)) {
+    if(ret < 0 || (size_t)ret >= sizeof(buf)) {
         fprintf(stderr, "Unable to rewrite command (%s)\n", command);
         return -1;
     }


### PR DESCRIPTION
Also replace the other `BUFSIZ` with `sizeof()` for robustness.

Reported by GitHub Code Quality

Follow-up to ac13b70a89a16490ff69e0d92bffa818a59e3ed5 #489

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
