### PR TITLE
channel: fix refund bytes for DATA packets in `ssh2_channel_flush()`

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1613,7 +1613,14 @@ int ssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
                               channel->local.id, channel->remote.id));
 
                     /* It is one of the streams we wanted to flush */
-                    channel->flush_refund_bytes += packet->data_len - 13;
+                    if(packet_type == SSH_MSG_CHANNEL_EXTENDED_DATA)
+                        /* 13-byte header =
+                           type(1) + channel(4) + streamid(4) + datalen(4) */
+                        channel->flush_refund_bytes += packet->data_len - 13;
+                    else /* SSH_MSG_CHANNEL_DATA */
+                        /* 9-byte header =
+                           type(1) + channel(4) + datalen(4) */
+                        channel->flush_refund_bytes += packet->data_len - 9;
                     channel->flush_flush_bytes += bytes_to_flush;
 
                     SSH2_FREE(channel->session, packet->data);

--- a/src/channel.c
+++ b/src/channel.c
@@ -1613,14 +1613,7 @@ int ssh2_channel_flush(LIBSSH2_CHANNEL *channel, int streamid)
                               channel->local.id, channel->remote.id));
 
                     /* It is one of the streams we wanted to flush */
-                    if(packet_type == SSH_MSG_CHANNEL_EXTENDED_DATA)
-                        /* 13-byte header =
-                           type(1) + channel(4) + streamid(4) + datalen(4) */
-                        channel->flush_refund_bytes += packet->data_len - 13;
-                    else /* SSH_MSG_CHANNEL_DATA */
-                        /* 9-byte header =
-                           type(1) + channel(4) + datalen(4) */
-                        channel->flush_refund_bytes += packet->data_len - 9;
+                    channel->flush_refund_bytes += bytes_to_flush;
                     channel->flush_flush_bytes += bytes_to_flush;
 
                     SSH2_FREE(channel->session, packet->data);


### PR DESCRIPTION
Reported-by: afldl on github
Fixes #2020
Follow-up to 4b8db8c1ab3fb21618bca72a671fdf2a5d1ac122

---

https://github.com/libssh2/libssh2/pull/2158/files?w=1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
