### PR TITLE
crypto: unify hash context types into one

### DIFF
--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -78,20 +78,20 @@ Releases the HMAC computation context at ctx.
 
 3) Hash algorithms.
 
+ssh2_hash_ctx
+Type of a hash computation context. Generally a struct.
+
 3.1) SHA-1
 Must always be implemented.
 
 SSH2_SHA1_DIG_LEN
 #define to 20, the SHA-1 digest length.
 
-ssh2_sha1_ctx
-Type of an SHA-1 computation context. Generally a struct.
-
-int ssh2_sha1_init(ssh2_sha1_ctx *x);
+int ssh2_sha1_init(ssh2_hash_ctx *x);
 Initializes the SHA-1 computation context at x.
 Returns 1 for success and 0 for failure
 
-int ssh2_sha1_update(ssh2_sha1_ctx ctx,
+int ssh2_sha1_update(ssh2_hash_ctx ctx,
                      const unsigned char *data,
                      size_t len);
 Continue computation of SHA-1 on len bytes at data using context ctx.
@@ -99,7 +99,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
-int ssh2_sha1_final(ssh2_sha1_ctx ctx,
+int ssh2_sha1_final(ssh2_hash_ctx ctx,
                     unsigned char output[SHA_DIGEST_LEN]);
 Get the computed SHA-1 signature from context ctx and store it into the
 output buffer.
@@ -121,14 +121,11 @@ Must always be implemented.
 SSH2_SHA256_DIG_LEN
 #define to 32, the SHA-256 digest length.
 
-ssh2_sha256_ctx
-Type of an SHA-256 computation context. Generally a struct.
-
-int ssh2_sha256_init(ssh2_sha256_ctx *x);
+int ssh2_sha256_init(ssh2_hash_ctx *x);
 Initializes the SHA-256 computation context at x.
 Returns 1 for success and 0 for failure
 
-int ssh2_sha256_update(ssh2_sha256_ctx ctx,
+int ssh2_sha256_update(ssh2_hash_ctx ctx,
                        const unsigned char *data,
                        size_t len);
 Continue computation of SHA-256 on len bytes at data using context ctx.
@@ -136,7 +133,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
-int ssh2_sha256_final(ssh2_sha256_ctx ctx,
+int ssh2_sha256_final(ssh2_hash_ctx ctx,
                       unsigned char output[SSH2_SHA256_DIG_LEN]);
 Gets the computed SHA-256 signature from context ctx into the output buffer.
 Release the context.
@@ -169,14 +166,11 @@ Mandatory if ECDSA is implemented. Can be omitted otherwise.
 SSH2_SHA384_DIG_LEN
 #define to 48, the SHA-384 digest length.
 
-ssh2_sha384_ctx
-Type of an SHA-384 computation context. Generally a struct.
-
-int ssh2_sha384_init(ssh2_sha384_ctx *x);
+int ssh2_sha384_init(ssh2_hash_ctx *x);
 Initializes the SHA-384 computation context at x.
 Returns 1 for success and 0 for failure
 
-int ssh2_sha384_update(ssh2_sha384_ctx ctx,
+int ssh2_sha384_update(ssh2_hash_ctx ctx,
                        const unsigned char *data,
                        size_t len);
 Continue computation of SHA-384 on len bytes at data using context ctx.
@@ -184,7 +178,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
-int ssh2_sha384_final(ssh2_sha384_ctx ctx,
+int ssh2_sha384_final(ssh2_hash_ctx ctx,
                       unsigned char output[SSH2_SHA384_DIG_LEN]);
 Gets the computed SHA-384 signature from context ctx into the output buffer.
 Release the context.
@@ -205,14 +199,11 @@ Must always be implemented.
 SSH2_SHA512_DIG_LEN
 #define to 64, the SHA-512 digest length.
 
-ssh2_sha512_ctx
-Type of an SHA-512 computation context. Generally a struct.
-
-int ssh2_sha512_init(ssh2_sha512_ctx *x);
+int ssh2_sha512_init(ssh2_hash_ctx *x);
 Initializes the SHA-512 computation context at x.
 Returns 1 for success and 0 for failure
 
-int ssh2_sha512_update(ssh2_sha512_ctx ctx,
+int ssh2_sha512_update(ssh2_hash_ctx ctx,
                        const unsigned char *data,
                        size_t len);
 Continue computation of SHA-512 on len bytes at data using context ctx.
@@ -220,7 +211,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
-int ssh2_sha512_final(ssh2_sha512_ctx ctx,
+int ssh2_sha512_final(ssh2_hash_ctx ctx,
                       unsigned char output[SSH2_SHA512_DIG_LEN]);
 Gets the computed SHA-512 signature from context ctx into the output buffer.
 Release the context.
@@ -255,14 +246,11 @@ If defined as 0, the rest of this section can be omitted.
 SSH2_MD5_DIG_LEN
 #define to 16, the MD5 digest length.
 
-ssh2_md5_ctx
-Type of an MD5 computation context. Generally a struct.
-
-int ssh2_md5_init(ssh2_md5_ctx *x);
+int ssh2_md5_init(ssh2_hash_ctx *x);
 Initializes the MD5 computation context at x.
 Returns 1 for success and 0 for failure
 
-int ssh2_md5_update(ssh2_md5_ctx ctx,
+int ssh2_md5_update(ssh2_hash_ctx ctx,
                     const unsigned char *data,
                     size_t len);
 Continues computation of MD5 on len bytes at data using context ctx.
@@ -271,7 +259,7 @@ Note: if the ctx parameter is modified by the underlying code,
 this procedure must be implemented as a macro to map ctx --> &ctx.
 Must return 1 for success and 0 for failure.
 
-int ssh2_md5_final(ssh2_md5_ctx ctx,
+int ssh2_md5_final(ssh2_hash_ctx ctx,
                    unsigned char output[SSH2_MD5_DIG_LEN]);
 Gets the computed MD5 signature from context ctx into the output buffer.
 Release the context.

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -105,7 +105,7 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
     size_t i, j, amt, stride;
     uint32_t count;
     size_t origkeylen = keylen;
-    ssh2_sha512_ctx ctx;
+    ssh2_hash_ctx ctx;
 
     /* nothing crazy */
     if(rounds < 1)

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -221,7 +221,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     int ret;
     int i;
     unsigned char hash[SSH2_SHA1_DIG_LEN];
-    ssh2_sha1_ctx ctx;
+    ssh2_hash_ctx ctx;
 
     if(!ssh2_sha1_init(&ctx))
         return -1;
@@ -287,7 +287,7 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
     int ret;
     int i;
     unsigned char hash[SSH2_SHA256_DIG_LEN];
-    ssh2_sha256_ctx ctx;
+    ssh2_hash_ctx ctx;
 
     if(!ssh2_sha256_init(&ctx))
         return -1;
@@ -350,7 +350,7 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     int ret;
     int i;
     unsigned char hash[SSH2_SHA512_DIG_LEN];
-    ssh2_sha512_ctx ctx;
+    ssh2_hash_ctx ctx;
 
     if(!ssh2_sha512_init(&ctx))
         return -1;
@@ -632,7 +632,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
 {
     ssh2_dsa_ctx *dsactx = (ssh2_dsa_ctx *)(*abstract);
     unsigned char hash[SSH2_SHA1_DIG_LEN];
-    ssh2_sha1_ctx ctx;
+    ssh2_hash_ctx ctx;
     int i;
 
     if(!ssh2_sha1_init(&ctx)) {
@@ -869,7 +869,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
 #define HOSTKEY_METHOD_EC_SIGNV_HASH(digest_type)                     \
     do {                                                              \
         unsigned char hash[SSH2_SHA##digest_type##_DIG_LEN];          \
-        ssh2_sha##digest_type##_ctx ctx;                              \
+        ssh2_hash_ctx ctx;                                            \
         int i;                                                        \
         if(!ssh2_sha##digest_type##_init(&ctx)) {                     \
             ret = -1;                                                 \

--- a/src/kex.c
+++ b/src/kex.c
@@ -52,7 +52,7 @@
 
 #define KEX_METHOD_SHA_VALUE_HASH(digest_type, value, reqlen, version)        \
     do {                                                                      \
-        ssh2_sha##digest_type##_ctx hash;                                     \
+        ssh2_hash_ctx hash;                                                   \
         size_t len = 0;                                                       \
         if(!(value)) {                                                        \
             (value) = SSH2_ALLOC(session,                                     \
@@ -108,13 +108,13 @@
 static int sha_algo_ctx_init(int sha_algo, void *ctx)
 {
     if(sha_algo == 512)
-        return ssh2_sha512_init((ssh2_sha512_ctx *)ctx);
+        return ssh2_sha512_init((ssh2_hash_ctx *)ctx);
     else if(sha_algo == 384)
-        return ssh2_sha384_init((ssh2_sha384_ctx *)ctx);
+        return ssh2_sha384_init((ssh2_hash_ctx *)ctx);
     else if(sha_algo == 256)
-        return ssh2_sha256_init((ssh2_sha256_ctx *)ctx);
+        return ssh2_sha256_init((ssh2_hash_ctx *)ctx);
     else if(sha_algo == 1)
-        return ssh2_sha1_init((ssh2_sha1_ctx *)ctx);
+        return ssh2_sha1_init((ssh2_hash_ctx *)ctx);
 #ifdef LIBSSH2DEBUG
     else
         assert(0);
@@ -125,22 +125,16 @@ static int sha_algo_ctx_init(int sha_algo, void *ctx)
 static int sha_algo_ctx_update(int sha_algo, void *ctx,
                                const void *data, size_t len)
 {
-    if(sha_algo == 512) {
-        ssh2_sha512_ctx *_ctx = (ssh2_sha512_ctx *)ctx;
+    ssh2_hash_ctx *_ctx = (ssh2_hash_ctx *)ctx;
+
+    if(sha_algo == 512)
         return ssh2_sha512_update(*_ctx, data, len);
-    }
-    else if(sha_algo == 384) {
-        ssh2_sha384_ctx *_ctx = (ssh2_sha384_ctx *)ctx;
+    else if(sha_algo == 384)
         return ssh2_sha384_update(*_ctx, data, len);
-    }
-    else if(sha_algo == 256) {
-        ssh2_sha256_ctx *_ctx = (ssh2_sha256_ctx *)ctx;
+    else if(sha_algo == 256)
         return ssh2_sha256_update(*_ctx, data, len);
-    }
-    else if(sha_algo == 1) {
-        ssh2_sha1_ctx *_ctx = (ssh2_sha1_ctx *)ctx;
+    else if(sha_algo == 1)
         return ssh2_sha1_update(*_ctx, data, len);
-    }
 #ifdef LIBSSH2DEBUG
     else
         assert(0);
@@ -150,22 +144,16 @@ static int sha_algo_ctx_update(int sha_algo, void *ctx,
 
 static int sha_algo_ctx_final(int sha_algo, void *ctx, void *hash)
 {
-    if(sha_algo == 512) {
-        ssh2_sha512_ctx *_ctx = (ssh2_sha512_ctx *)ctx;
+    ssh2_hash_ctx *_ctx = (ssh2_hash_ctx *)ctx;
+
+    if(sha_algo == 512)
         return ssh2_sha512_final(*_ctx, hash);
-    }
-    else if(sha_algo == 384) {
-        ssh2_sha384_ctx *_ctx = (ssh2_sha384_ctx *)ctx;
+    else if(sha_algo == 384)
         return ssh2_sha384_final(*_ctx, hash);
-    }
-    else if(sha_algo == 256) {
-        ssh2_sha256_ctx *_ctx = (ssh2_sha256_ctx *)ctx;
+    else if(sha_algo == 256)
         return ssh2_sha256_final(*_ctx, hash);
-    }
-    else if(sha_algo == 1) {
-        ssh2_sha1_ctx *_ctx = (ssh2_sha1_ctx *)ctx;
+    else if(sha_algo == 1)
         return ssh2_sha1_final(*_ctx, hash);
-    }
 #ifdef LIBSSH2DEBUG
     else
         assert(0);
@@ -234,7 +222,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_MD5
     {
-        ssh2_md5_ctx fingerprint_ctx;
+        ssh2_hash_ctx fingerprint_ctx;
 
         if(ssh2_md5_init(&fingerprint_ctx) &&
            ssh2_md5_update(fingerprint_ctx, session->server_hostkey,
@@ -259,7 +247,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
 #endif /* !LIBSSH2_MD5 */
 
     {
-        ssh2_sha1_ctx fingerprint_ctx;
+        ssh2_hash_ctx fingerprint_ctx;
 
         if(ssh2_sha1_init(&fingerprint_ctx) &&
            ssh2_sha1_update(fingerprint_ctx, session->server_hostkey,
@@ -283,7 +271,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
 #endif /* LIBSSH2DEBUG */
 
     {
-        ssh2_sha256_ctx fingerprint_ctx;
+        ssh2_hash_ctx fingerprint_ctx;
 
         if(ssh2_sha256_init(&fingerprint_ctx) &&
            ssh2_sha256_update(fingerprint_ctx, session->server_hostkey,
@@ -970,7 +958,7 @@ static int kex_method_diffie_hellman_group1_sha1_key_exchange(
     };
 
     int ret;
-    ssh2_sha1_ctx exchange_hash_ctx;
+    ssh2_hash_ctx exchange_hash_ctx;
 
     if(key_state->state == ssh2_NB_state_idle) {
         /* g == 2 */
@@ -1109,7 +1097,7 @@ clean_exit:
 static int kex_method_diffie_hellman_group14_sha1_key_exchange(
     LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
-    ssh2_sha1_ctx ctx;
+    ssh2_hash_ctx ctx;
     return kex_method_diffie_hellman_group14_key_exchange(
         session, key_state, 1, &ctx, diffie_hellman_sha_algo);
 }
@@ -1120,7 +1108,7 @@ static int kex_method_diffie_hellman_group14_sha1_key_exchange(
 static int kex_method_diffie_hellman_group14_sha256_key_exchange(
     LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
-    ssh2_sha256_ctx ctx;
+    ssh2_hash_ctx ctx;
     return kex_method_diffie_hellman_group14_key_exchange(
         session, key_state, 256, &ctx, diffie_hellman_sha_algo);
 }
@@ -1177,7 +1165,7 @@ static int kex_method_diffie_hellman_group16_sha512_key_exchange(
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     };
     int ret;
-    ssh2_sha512_ctx exchange_hash_ctx;
+    ssh2_hash_ctx exchange_hash_ctx;
 
     if(key_state->state == ssh2_NB_state_idle) {
         key_state->p = ssh2_bn_init_from_bin(); /* SSH2 defined value
@@ -1311,7 +1299,7 @@ static int kex_method_diffie_hellman_group18_sha512_key_exchange(
         0xFF, 0xFF, 0xFF, 0xFF
     };
     int ret;
-    ssh2_sha512_ctx exchange_hash_ctx;
+    ssh2_hash_ctx exchange_hash_ctx;
 
     if(key_state->state == ssh2_NB_state_idle) {
         key_state->p = ssh2_bn_init_from_bin(); /* SSH2 defined value
@@ -1408,7 +1396,7 @@ static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
         size_t p_len, g_len;
         unsigned char *p, *g;
         struct string_buf buf;
-        ssh2_sha1_ctx exchange_hash_ctx;
+        ssh2_hash_ctx exchange_hash_ctx;
         int bits;
 
         if(key_state->data_len < 9) {
@@ -1529,7 +1517,7 @@ static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
         unsigned char *p, *g;
         size_t p_len, g_len;
         struct string_buf buf;
-        ssh2_sha256_ctx exchange_hash_ctx;
+        ssh2_hash_ctx exchange_hash_ctx;
         int bits;
 
         if(key_state->data_len < 9) {
@@ -1637,7 +1625,7 @@ static int kex_session_hybrid_curve_type(const char *name,
  */
 #define KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY(digest_type)                     \
     do {                                                                      \
-        ssh2_sha##digest_type##_ctx ctx;                                      \
+        ssh2_hash_ctx ctx;                                                    \
         int hok;                                                              \
         if(!ssh2_sha##digest_type##_init(&ctx)) {                             \
             rc = -1;                                                          \
@@ -1752,7 +1740,7 @@ static int kex_session_hybrid_curve_type(const char *name,
  */
 #define KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY(digest_type)                 \
     do {                                                                      \
-        ssh2_sha##digest_type##_ctx ctx;                                      \
+        ssh2_hash_ctx ctx;                                                    \
         int hok;                                                              \
         if(!ssh2_sha##digest_type##_init(&ctx)) {                             \
             rc = -1;                                                          \
@@ -2366,7 +2354,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
         /* verify hash */
         switch(type) {
         case SSH2_EC_CURVE_NISTP256: {
-            ssh2_sha256_ctx k_ctx;
+            ssh2_hash_ctx k_ctx;
             if(!ssh2_sha256_init(&k_ctx)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                                "kex: failed to initialize hash");
@@ -2388,7 +2376,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
             break;
         }
         case SSH2_EC_CURVE_NISTP384: {
-            ssh2_sha384_ctx k_ctx;
+            ssh2_hash_ctx k_ctx;
             if(!ssh2_sha384_init(&k_ctx)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                                "kex: failed to initialize hash");
@@ -2934,7 +2922,7 @@ static int mlkem768x25519_sha256(
                                     SSH2_ED25519_KEY_LEN];
         size_t server_public_key_len;
         struct string_buf buf;
-        ssh2_sha256_ctx k_ctx;
+        ssh2_hash_ctx k_ctx;
 
         ret = process_host_key(session, &buf, exchange_state, data, data_len);
         if(ret)

--- a/src/kex.c
+++ b/src/kex.c
@@ -52,14 +52,13 @@
 
 #define KEX_METHOD_SHA_VALUE_HASH(digest_type, value, reqlen, version)        \
     do {                                                                      \
-        ssh2_hash_ctx hash;                                                   \
-        size_t len = 0;                                                       \
-        if(!(value)) {                                                        \
+        if(!(value))                                                          \
             (value) = SSH2_ALLOC(session,                                     \
                                  (reqlen) +                                   \
                                  SSH2_SHA##digest_type##_DIG_LEN);            \
-        }                                                                     \
-        if(value)                                                             \
+        if(value) {                                                           \
+            ssh2_hash_ctx hash;                                               \
+            size_t len = 0;                                                   \
             while(len < (size_t)(reqlen)) {                                   \
                 if(!ssh2_sha##digest_type##_init(&hash) ||                    \
                    !ssh2_sha##digest_type##_update(hash,                      \
@@ -96,6 +95,7 @@
                 }                                                             \
                 len += SSH2_SHA##digest_type##_DIG_LEN;                       \
             }                                                                 \
+        }                                                                     \
     } while(0)
 
 /*

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -73,7 +73,8 @@
 
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
-#define ssh2_sha1_ctx gcry_md_hd_t
+#define ssh2_hash_ctx gcry_md_hd_t
+
 /* returns 0 in case of failure */
 #define ssh2_sha1_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA1, 0))
@@ -85,7 +86,6 @@
 #define ssh2_sha1(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA1, out, message, len), 0)
 
-#define ssh2_sha256_ctx gcry_md_hd_t
 #define ssh2_sha256_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA256, 0))
 #define ssh2_sha256_update(ctx, data, len) \
@@ -96,7 +96,6 @@
 #define ssh2_sha256(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA256, out, message, len), 0)
 
-#define ssh2_sha384_ctx gcry_md_hd_t
 #define ssh2_sha384_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA384, 0))
 #define ssh2_sha384_update(ctx, data, len) \
@@ -107,7 +106,6 @@
 #define ssh2_sha384(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA384, out, message, len), 0)
 
-#define ssh2_sha512_ctx gcry_md_hd_t
 #define ssh2_sha512_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA512, 0))
 #define ssh2_sha512_update(ctx, data, len) \
@@ -119,7 +117,6 @@
     (gcry_md_hash_buffer(GCRY_MD_SHA512, out, message, len), 0)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_ctx gcry_md_hd_t
 #define ssh2_md5_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_MD5, 0))
 #define ssh2_md5_update(ctx, data, len) \

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -139,10 +139,10 @@ struct mbed_hash_ctx {
 
 /*******************************************************************/
 /*
- * mbedTLS backend: SHA1 functions
+ * mbedTLS backend: hash functions
  */
 
-#define ssh2_sha1_ctx psa_hash_operation_t
+#define ssh2_hash_ctx psa_hash_operation_t
 
 #define ssh2_sha1_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
@@ -153,13 +153,6 @@ struct mbed_hash_ctx {
 #define ssh2_sha1(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_1, hash)
 
-/*******************************************************************/
-/*
- * mbedTLS backend: SHA256 functions
- */
-
-#define ssh2_sha256_ctx psa_hash_operation_t
-
 #define ssh2_sha256_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
 #define ssh2_sha256_update(ctx, data, datalen) \
@@ -168,13 +161,6 @@ struct mbed_hash_ctx {
     ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA256_DIG_LEN)
 #define ssh2_sha256(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_256, hash)
-
-/*******************************************************************/
-/*
- * mbedTLS backend: SHA384 functions
- */
-
-#define ssh2_sha384_ctx psa_hash_operation_t
 
 #define ssh2_sha384_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
@@ -185,13 +171,6 @@ struct mbed_hash_ctx {
 #define ssh2_sha384(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_384, hash)
 
-/*******************************************************************/
-/*
- * mbedTLS backend: SHA512 functions
- */
-
-#define ssh2_sha512_ctx psa_hash_operation_t
-
 #define ssh2_sha512_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
 #define ssh2_sha512_update(ctx, data, datalen) \
@@ -201,14 +180,7 @@ struct mbed_hash_ctx {
 #define ssh2_sha512(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_512, hash)
 
-/*******************************************************************/
-/*
- * mbedTLS backend: MD5 functions
- */
-
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_ctx psa_hash_operation_t
-
 #define ssh2_md5_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_MD5)
 #define ssh2_md5_update(ctx, data, datalen) \

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -235,28 +235,26 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out);
 int ssh2_ossl_hash(const unsigned char *message, size_t len,
                    unsigned char *out, const EVP_MD *digest);
 
-#define ssh2_sha1_ctx               EVP_MD_CTX *
+#define ssh2_hash_ctx               EVP_MD_CTX *
+
 #define ssh2_sha1_init(x)           ssh2_ossl_hash_init(x, EVP_sha1())
 #define ssh2_sha1_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha1_final(ctx, out)   ssh2_ossl_hash_final(&(ctx), out)
 #define ssh2_sha1(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha1())
 
-#define ssh2_sha256_ctx             EVP_MD_CTX *
 #define ssh2_sha256_init(x)         ssh2_ossl_hash_init(x, EVP_sha256())
 #define ssh2_sha256_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha256_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
 #define ssh2_sha256(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha256())
 
-#define ssh2_sha384_ctx             EVP_MD_CTX *
 #define ssh2_sha384_init(x)         ssh2_ossl_hash_init(x, EVP_sha384())
 #define ssh2_sha384_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha384_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
 #define ssh2_sha384(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha384())
 
-#define ssh2_sha512_ctx             EVP_MD_CTX *
 #define ssh2_sha512_init(x)         ssh2_ossl_hash_init(x, EVP_sha512())
 #define ssh2_sha512_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
@@ -264,7 +262,6 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 #define ssh2_sha512(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha512())
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_ctx                EVP_MD_CTX *
 /* MD5 digest is not supported in OpenSSL FIPS mode
  * Trying to init it results in a latent OpenSSL error:
  * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -229,10 +229,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_crypto_init()   do {} while(0)
 #define ssh2_crypto_exit()   do {} while(0)
 
-#define ssh2_sha1_ctx        Qc3_Format_ALGD0100_T
-#define ssh2_sha256_ctx      Qc3_Format_ALGD0100_T
-#define ssh2_sha384_ctx      Qc3_Format_ALGD0100_T
-#define ssh2_sha512_ctx      Qc3_Format_ALGD0100_T
+#define ssh2_hash_ctx        Qc3_Format_ALGD0100_T
 #define ssh2_hmac_ctx        struct os400qc3_crypto_ctx
 #define ssh2_cipher_ctx      struct os400qc3_crypto_ctx
 
@@ -253,7 +250,6 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_sha512(d, l, out)        ssh2_os400qc3_hash(d, l, out, Qc3_SHA512)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_ctx                  Qc3_Format_ALGD0100_T
 #define ssh2_md5_init(x)              ssh2_os400qc3_hash_init(x, Qc3_MD5)
 #define ssh2_md5_update(ctx, d, l)    ssh2_os400qc3_hash_update(&(ctx), d, l)
 #define ssh2_md5_final(ctx, out)      ssh2_os400qc3_hash_final(&(ctx), out)

--- a/src/pem.c
+++ b/src/pem.c
@@ -281,7 +281,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         int blocksize = method->blocksize;
         void *abstract;
         unsigned char secret[2 * SSH2_MD5_DIG_LEN];
-        ssh2_md5_ctx fingerprint_ctx;
+        ssh2_hash_ctx fingerprint_ctx;
 
         /* Perform key derivation (PBKDF1/MD5) */
         if(!ssh2_md5_init(&fingerprint_ctx) ||

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -161,7 +161,8 @@ struct wcng_hash_ctx {
  * Windows CNG backend: Hash functions
  */
 
-#define ssh2_sha1_ctx struct wcng_hash_ctx
+#define ssh2_hash_ctx struct wcng_hash_ctx
+
 #define ssh2_sha1_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA1, \
                          SSH2_SHA1_DIG_LEN, NULL, 0) == 0)
@@ -173,7 +174,6 @@ struct wcng_hash_ctx {
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA1, \
                    hash, SSH2_SHA1_DIG_LEN)
 
-#define ssh2_sha256_ctx struct wcng_hash_ctx
 #define ssh2_sha256_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA256, \
                          SSH2_SHA256_DIG_LEN, NULL, 0) == 0)
@@ -185,7 +185,6 @@ struct wcng_hash_ctx {
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA256, \
                    hash, SSH2_SHA256_DIG_LEN)
 
-#define ssh2_sha384_ctx struct wcng_hash_ctx
 #define ssh2_sha384_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA384, \
                          SSH2_SHA384_DIG_LEN, NULL, 0) == 0)
@@ -197,7 +196,6 @@ struct wcng_hash_ctx {
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA384, \
                    hash, SSH2_SHA384_DIG_LEN)
 
-#define ssh2_sha512_ctx struct wcng_hash_ctx
 #define ssh2_sha512_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA512, \
                          SSH2_SHA512_DIG_LEN, NULL, 0) == 0)
@@ -210,7 +208,6 @@ struct wcng_hash_ctx {
                    hash, SSH2_SHA512_DIG_LEN)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_ctx struct wcng_hash_ctx
 #define ssh2_md5_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashMD5, \
                          SSH2_MD5_DIG_LEN, NULL, 0) == 0)


### PR DESCRIPTION
Prior to this patch all per-hash context types in all crypto backends 
mapped to the same type per backend. Simplify by replacing per-hash type
with a single type. Aligning this with the hash primitives that were
previously unified everywhere.

If there ever arises a need to support a new crypto backend that only
supports separate types, it can be done by adding a holder type with 
unions for example. The general direction of crypto backends though is
to unify hash functions. All currently supported backends do.

Also: scope variables in `KEX_METHOD_SHA_VALUE_HASH()`, fix `{}` nit.
