### PR TITLE
crypto: make the caller pass the digest buffer size

### DIFF
--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -126,7 +126,7 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
     /* collapse password */
     if(!ssh2_sha512_init(&ctx) ||
        !ssh2_sha512_update(ctx, pass, passlen) ||
-       !ssh2_sha512_final(ctx, sha2pass)) {
+       !ssh2_sha512_final(ctx, sha2pass, sizeof(sha2pass))) {
         free(countsalt);
         return -1;
     }
@@ -141,7 +141,7 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
         /* first round, salt is salt */
         if(!ssh2_sha512_init(&ctx) ||
            !ssh2_sha512_update(ctx, countsalt, saltlen + 4) ||
-           !ssh2_sha512_final(ctx, sha2salt)) {
+           !ssh2_sha512_final(ctx, sha2salt, sizeof(sha2salt))) {
             ssh2_explicit_zero(out, sizeof(out));
             free(countsalt);
             return -1;
@@ -154,7 +154,7 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
             /* subsequent rounds, salt is previous output */
             if(!ssh2_sha512_init(&ctx) ||
                !ssh2_sha512_update(ctx, tmpout, sizeof(tmpout)) ||
-               !ssh2_sha512_final(ctx, sha2salt)) {
+               !ssh2_sha512_final(ctx, sha2salt, sizeof(sha2salt))) {
                 ssh2_explicit_zero(out, sizeof(out));
                 free(countsalt);
                 return -1;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -229,7 +229,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
         if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
     }
-    if(!ssh2_sha1_final(ctx, hash))
+    if(!ssh2_sha1_final(ctx, hash, sizeof(hash)))
         return -1;
 
     ret = ssh2_rsa_sha1_sign(session, rsactx, hash, SSH2_SHA1_DIG_LEN,
@@ -295,7 +295,7 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
         if(!ssh2_sha256_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
     }
-    if(!ssh2_sha256_final(ctx, hash))
+    if(!ssh2_sha256_final(ctx, hash, sizeof(hash)))
         return -1;
 
     ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SSH2_SHA256_DIG_LEN,
@@ -358,7 +358,7 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
         if(!ssh2_sha512_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
     }
-    if(!ssh2_sha512_final(ctx, hash))
+    if(!ssh2_sha512_final(ctx, hash, sizeof(hash)))
         return -1;
 
     ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SSH2_SHA512_DIG_LEN,
@@ -651,7 +651,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
         if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
     }
-    if(!ssh2_sha1_final(ctx, hash))
+    if(!ssh2_sha1_final(ctx, hash, sizeof(hash)))
         return -1;
 
     if(ssh2_dsa_sha1_sign(dsactx, hash, SSH2_SHA1_DIG_LEN, *signature)) {
@@ -886,7 +886,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
         if(ret == -1) {                                               \
             break;                                                    \
         }                                                             \
-        if(!ssh2_sha##digest_type##_final(ctx, hash)) {               \
+        if(!ssh2_sha##digest_type##_final(ctx, hash, sizeof(hash))) { \
             ret = -1;                                                 \
             break;                                                    \
         }                                                             \

--- a/src/kex.c
+++ b/src/kex.c
@@ -88,7 +88,8 @@
                         break;                                                \
                     }                                                         \
                 }                                                             \
-                if(!ssh2_sha##digest_type##_final(hash, (value) + len)) {     \
+                if(!ssh2_sha##digest_type##_final(hash, (value) + len,        \
+                                          SSH2_SHA##digest_type##_DIG_LEN)) { \
                     SSH2_FREE(session, value);                                \
                     (value) = NULL;                                           \
                     break;                                                    \
@@ -142,18 +143,19 @@ static int sha_algo_ctx_update(int sha_algo, void *ctx,
     return 0;
 }
 
-static int sha_algo_ctx_final(int sha_algo, void *ctx, void *hash)
+static int sha_algo_ctx_final(int sha_algo, void *ctx,
+                              void *hash, size_t hashlen)
 {
     ssh2_hash_ctx *_ctx = (ssh2_hash_ctx *)ctx;
 
     if(sha_algo == 512)
-        return ssh2_sha512_final(*_ctx, hash);
+        return ssh2_sha512_final(*_ctx, hash, hashlen);
     else if(sha_algo == 384)
-        return ssh2_sha384_final(*_ctx, hash);
+        return ssh2_sha384_final(*_ctx, hash, hashlen);
     else if(sha_algo == 256)
-        return ssh2_sha256_final(*_ctx, hash);
+        return ssh2_sha256_final(*_ctx, hash, hashlen);
     else if(sha_algo == 1)
-        return ssh2_sha1_final(*_ctx, hash);
+        return ssh2_sha1_final(*_ctx, hash, hashlen);
 #ifdef LIBSSH2DEBUG
     else
         assert(0);
@@ -227,7 +229,8 @@ static int process_host_key(LIBSSH2_SESSION *session,
         if(ssh2_md5_init(&fingerprint_ctx) &&
            ssh2_md5_update(fingerprint_ctx, session->server_hostkey,
                            session->server_hostkey_len) &&
-           ssh2_md5_final(fingerprint_ctx, session->server_hostkey_md5))
+           ssh2_md5_final(fingerprint_ctx, session->server_hostkey_md5,
+                          sizeof(session->server_hostkey_md5)))
             session->server_hostkey_md5_valid = TRUE;
         else
             session->server_hostkey_md5_valid = FALSE;
@@ -252,7 +255,8 @@ static int process_host_key(LIBSSH2_SESSION *session,
         if(ssh2_sha1_init(&fingerprint_ctx) &&
            ssh2_sha1_update(fingerprint_ctx, session->server_hostkey,
                             session->server_hostkey_len) &&
-           ssh2_sha1_final(fingerprint_ctx, session->server_hostkey_sha1))
+           ssh2_sha1_final(fingerprint_ctx, session->server_hostkey_sha1,
+                           sizeof(session->server_hostkey_sha1)))
             session->server_hostkey_sha1_valid = TRUE;
         else
             session->server_hostkey_sha1_valid = FALSE;
@@ -276,8 +280,8 @@ static int process_host_key(LIBSSH2_SESSION *session,
         if(ssh2_sha256_init(&fingerprint_ctx) &&
            ssh2_sha256_update(fingerprint_ctx, session->server_hostkey,
                               session->server_hostkey_len) &&
-           ssh2_sha256_final(fingerprint_ctx,
-                             session->server_hostkey_sha256))
+           ssh2_sha256_final(fingerprint_ctx, session->server_hostkey_sha256,
+                             sizeof(session->server_hostkey_sha256)))
             session->server_hostkey_sha256_valid = TRUE;
         else
             session->server_hostkey_sha256_valid = FALSE;
@@ -1704,7 +1708,8 @@ static int kex_session_hybrid_curve_type(const char *name,
                                               exchange_state->k_value_len);   \
                                                                               \
         if(!hok ||                                                            \
-           !ssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp)) { \
+           !ssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp,    \
+                                       sizeof(exchange_state->h_sig_comp))) { \
             rc = -1;                                                          \
             break;                                                            \
         }                                                                     \
@@ -1822,7 +1827,8 @@ static int kex_session_hybrid_curve_type(const char *name,
                                               exchange_state->k_value_len);   \
                                                                               \
         if(!hok ||                                                            \
-           !ssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp)) { \
+           !ssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp,    \
+                                       sizeof(exchange_state->h_sig_comp))) { \
             rc = -1;                                                          \
             break;                                                            \
         }                                                                     \
@@ -2367,7 +2373,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                 goto clean_exit;
             }
 
-            if(!ssh2_sha256_final(k_ctx, exchange_state->k_value + 4)) {
+            if(!ssh2_sha256_final(k_ctx,
+                                  exchange_state->k_value + 4, digest_len)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                                "kex: failed to calculate hash");
                 goto clean_exit;
@@ -2389,7 +2396,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                 goto clean_exit;
             }
 
-            if(!ssh2_sha384_final(k_ctx, exchange_state->k_value + 4)) {
+            if(!ssh2_sha384_final(k_ctx,
+                                  exchange_state->k_value + 4, digest_len)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                                "kex: failed to calculate hash");
                 goto clean_exit;
@@ -3002,7 +3010,9 @@ static int mlkem768x25519_sha256(
             goto clean_exit;
         }
 
-        if(!ssh2_sha256_final(k_ctx, exchange_state->k_value + 4)) {
+        if(!ssh2_sha256_final(k_ctx,
+                              exchange_state->k_value + 4,
+                              SSH2_SHA256_DIG_LEN)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
             goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -883,7 +883,8 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
                                    exchange_state->k_value_len);
 
         if(!hok || !sha_algo_ctx_final(sha_algo_value, exchange_hash_ctx,
-                                       exchange_state->h_sig_comp)) {
+                                       exchange_state->h_sig_comp,
+                                       sizeof(exchange_state->h_sig_comp))) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
             goto clean_exit;

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -80,8 +80,8 @@
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA1, 0))
 #define ssh2_sha1_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
-#define ssh2_sha1_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA1_DIG_LEN), \
+#define ssh2_sha1_final(ctx, out, len) \
+    (memcpy(out, gcry_md_read(ctx, 0), len), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha1(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA1, out, message, len), 0)
@@ -90,8 +90,8 @@
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA256, 0))
 #define ssh2_sha256_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
-#define ssh2_sha256_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA256_DIG_LEN), \
+#define ssh2_sha256_final(ctx, out, len) \
+    (memcpy(out, gcry_md_read(ctx, 0), len), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha256(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA256, out, message, len), 0)
@@ -100,8 +100,8 @@
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA384, 0))
 #define ssh2_sha384_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
-#define ssh2_sha384_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA384_DIG_LEN), \
+#define ssh2_sha384_final(ctx, out, len) \
+    (memcpy(out, gcry_md_read(ctx, 0), len), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha384(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA384, out, message, len), 0)
@@ -110,8 +110,8 @@
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA512, 0))
 #define ssh2_sha512_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
-#define ssh2_sha512_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SSH2_SHA512_DIG_LEN), \
+#define ssh2_sha512_final(ctx, out, len) \
+    (memcpy(out, gcry_md_read(ctx, 0), len), \
      gcry_md_close(ctx), 1)
 #define ssh2_sha512(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA512, out, message, len), 0)
@@ -121,8 +121,8 @@
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_MD5, 0))
 #define ssh2_md5_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
-#define ssh2_md5_final(ctx, out) \
-    (memcpy(out, gcry_md_read(ctx, 0), SSH2_MD5_DIG_LEN), \
+#define ssh2_md5_final(ctx, out, len) \
+    (memcpy(out, gcry_md_read(ctx, 0), len), \
      gcry_md_close(ctx), 1)
 #endif
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -81,8 +81,7 @@
 #define ssh2_sha1_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha1_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), \
-     gcry_md_close(ctx), 1)
+    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
 #define ssh2_sha1(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA1, out, message, len), 0)
 
@@ -91,8 +90,7 @@
 #define ssh2_sha256_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha256_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), \
-     gcry_md_close(ctx), 1)
+    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
 #define ssh2_sha256(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA256, out, message, len), 0)
 
@@ -101,8 +99,7 @@
 #define ssh2_sha384_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha384_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), \
-     gcry_md_close(ctx), 1)
+    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
 #define ssh2_sha384(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA384, out, message, len), 0)
 
@@ -111,8 +108,7 @@
 #define ssh2_sha512_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha512_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), \
-     gcry_md_close(ctx), 1)
+    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
 #define ssh2_sha512(message, len, out) \
     (gcry_md_hash_buffer(GCRY_MD_SHA512, out, message, len), 0)
 
@@ -122,8 +118,7 @@
 #define ssh2_md5_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_md5_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), \
-     gcry_md_close(ctx), 1)
+    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
 #endif
 
 #define ssh2_hmac_ctx         gcry_md_hd_t

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -148,8 +148,8 @@ struct mbed_hash_ctx {
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
 #define ssh2_sha1_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_sha1_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA1_DIG_LEN)
+#define ssh2_sha1_final(ctx, hash, hashlen) \
+    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
 #define ssh2_sha1(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_1, hash)
 
@@ -157,8 +157,8 @@ struct mbed_hash_ctx {
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
 #define ssh2_sha256_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_sha256_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA256_DIG_LEN)
+#define ssh2_sha256_final(ctx, hash, hashlen) \
+    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
 #define ssh2_sha256(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_256, hash)
 
@@ -166,8 +166,8 @@ struct mbed_hash_ctx {
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
 #define ssh2_sha384_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_sha384_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA384_DIG_LEN)
+#define ssh2_sha384_final(ctx, hash, hashlen) \
+    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
 #define ssh2_sha384(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_384, hash)
 
@@ -175,8 +175,8 @@ struct mbed_hash_ctx {
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
 #define ssh2_sha512_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_sha512_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SSH2_SHA512_DIG_LEN)
+#define ssh2_sha512_final(ctx, hash, hashlen) \
+    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
 #define ssh2_sha512(data, datalen, hash) \
     ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_512, hash)
 
@@ -185,8 +185,8 @@ struct mbed_hash_ctx {
     ssh2_mbed_hash_init(pctx, PSA_ALG_MD5)
 #define ssh2_md5_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_md5_final(ctx, hash) \
-    ssh2_mbed_hash_final(&(ctx), hash, SSH2_MD5_DIG_LEN)
+#define ssh2_md5_final(ctx, hash, hashlen) \
+    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
 #endif
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2793,9 +2793,10 @@ int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len)
     return EVP_DigestUpdate(*ctx, data, len);
 }
 
-int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out)
+int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
 {
     int ret = EVP_DigestFinal_ex(*ctx, out, NULL);
+    (void)outlen;
     EVP_MD_CTX_free(*ctx);
     *ctx = NULL;
     return ret;

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -274,11 +274,11 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 #define ssh2_md5_init(x) \
     (FIPS_mode() ? (*(x) = NULL, 0) : ssh2_ossl_hash_init(x, EVP_md5()))
 #else
-#define ssh2_md5_init(x)            ssh2_ossl_hash_init(x, EVP_md5())
+#define ssh2_md5_init(x)              ssh2_ossl_hash_init(x, EVP_md5())
 #endif
 #define ssh2_md5_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
-#define ssh2_md5_final(ctx, out)    ssh2_ossl_hash_final(&(ctx), out)
+#define ssh2_md5_final(ctx, h, hl)    ssh2_ossl_hash_final(&(ctx), h, hl)
 #endif /* LIBSSH2_MD5 || LIBSSH2_MD5_PEM */
 
 #ifdef USE_OPENSSL_3

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -230,36 +230,36 @@ int ssh2_random(unsigned char *buf, size_t len);
 /* returns 0 in case of failure */
 int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest);
 int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len);
-int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out);
+int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 /* returns 1 in case of failure */
 int ssh2_ossl_hash(const unsigned char *message, size_t len,
                    unsigned char *out, const EVP_MD *digest);
 
-#define ssh2_hash_ctx               EVP_MD_CTX *
+#define ssh2_hash_ctx                 EVP_MD_CTX *
 
-#define ssh2_sha1_init(x)           ssh2_ossl_hash_init(x, EVP_sha1())
+#define ssh2_sha1_init(x)             ssh2_ossl_hash_init(x, EVP_sha1())
 #define ssh2_sha1_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
-#define ssh2_sha1_final(ctx, out)   ssh2_ossl_hash_final(&(ctx), out)
-#define ssh2_sha1(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha1())
+#define ssh2_sha1_final(ctx, h, hl)   ssh2_ossl_hash_final(&(ctx), h, hl)
+#define ssh2_sha1(x, y, z)            ssh2_ossl_hash(x, y, z, EVP_sha1())
 
-#define ssh2_sha256_init(x)         ssh2_ossl_hash_init(x, EVP_sha256())
+#define ssh2_sha256_init(x)           ssh2_ossl_hash_init(x, EVP_sha256())
 #define ssh2_sha256_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
-#define ssh2_sha256_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
-#define ssh2_sha256(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha256())
+#define ssh2_sha256_final(ctx, h, hl) ssh2_ossl_hash_final(&(ctx), h, hl)
+#define ssh2_sha256(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha256())
 
-#define ssh2_sha384_init(x)         ssh2_ossl_hash_init(x, EVP_sha384())
+#define ssh2_sha384_init(x)           ssh2_ossl_hash_init(x, EVP_sha384())
 #define ssh2_sha384_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
-#define ssh2_sha384_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
-#define ssh2_sha384(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha384())
+#define ssh2_sha384_final(ctx, h, hl) ssh2_ossl_hash_final(&(ctx), h, hl)
+#define ssh2_sha384(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha384())
 
-#define ssh2_sha512_init(x)         ssh2_ossl_hash_init(x, EVP_sha512())
+#define ssh2_sha512_init(x)           ssh2_ossl_hash_init(x, EVP_sha512())
 #define ssh2_sha512_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
-#define ssh2_sha512_final(ctx, out) ssh2_ossl_hash_final(&(ctx), out)
-#define ssh2_sha512(x, y, z)        ssh2_ossl_hash(x, y, z, EVP_sha512())
+#define ssh2_sha512_final(ctx, h, hl) ssh2_ossl_hash_final(&(ctx), h, hl)
+#define ssh2_sha512(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha512())
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 /* MD5 digest is not supported in OpenSSL FIPS mode

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -945,10 +945,12 @@ int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx, unsigned char *out)
+int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx,
+                             unsigned char *out, size_t outlen)
 {
     char data;
     Qus_EC_t errcode;
+    (void)outlen;
 
     ctx->Final_Op_Flag = Qc3_Final;
     set_EC_length(errcode, sizeof(errcode));

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -235,24 +235,24 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 
 #define ssh2_sha1_init(x)             ssh2_os400qc3_hash_init(x, Qc3_SHA1)
 #define ssh2_sha1_update(ctx, d, l)   ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_sha1_final(ctx, out)     ssh2_os400qc3_hash_final(&(ctx), out)
+#define ssh2_sha1_final(ctx, h, hl)   ssh2_os400qc3_hash_final(&(ctx), h, hl)
 #define ssh2_sha256_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA256)
 #define ssh2_sha256_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_sha256_final(ctx, out)   ssh2_os400qc3_hash_final(&(ctx), out)
-#define ssh2_sha256(d, l, out)        ssh2_os400qc3_hash(d, l, out, Qc3_SHA256)
+#define ssh2_sha256_final(ctx, h, hl) ssh2_os400qc3_hash_final(&(ctx), h, hl)
+#define ssh2_sha256(d, l, h)          ssh2_os400qc3_hash(d, l, h, Qc3_SHA256)
 #define ssh2_sha384_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA384)
 #define ssh2_sha384_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_sha384_final(ctx, out)   ssh2_os400qc3_hash_final(&(ctx), out)
-#define ssh2_sha384(d, l, out)        ssh2_os400qc3_hash(d, l, out, Qc3_SHA384)
+#define ssh2_sha384_final(ctx, h, hl) ssh2_os400qc3_hash_final(&(ctx), h, hl)
+#define ssh2_sha384(d, l, h)          ssh2_os400qc3_hash(d, l, h, Qc3_SHA384)
 #define ssh2_sha512_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA512)
 #define ssh2_sha512_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_sha512_final(ctx, out)   ssh2_os400qc3_hash_final(&(ctx), out)
-#define ssh2_sha512(d, l, out)        ssh2_os400qc3_hash(d, l, out, Qc3_SHA512)
+#define ssh2_sha512_final(ctx, h, hl) ssh2_os400qc3_hash_final(&(ctx), h, hl)
+#define ssh2_sha512(d, l, h)          ssh2_os400qc3_hash(d, l, h, Qc3_SHA512)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_init(x)              ssh2_os400qc3_hash_init(x, Qc3_MD5)
 #define ssh2_md5_update(ctx, d, l)    ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_md5_final(ctx, out)      ssh2_os400qc3_hash_final(&(ctx), out)
+#define ssh2_md5_final(ctx, h, hl)    ssh2_os400qc3_hash_final(&(ctx), h, hl)
 #endif
 
 int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algo);

--- a/src/pem.c
+++ b/src/pem.c
@@ -288,7 +288,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
            !ssh2_md5_update(fingerprint_ctx, passphrase,
                             strlen((const char *)passphrase)) ||
            !ssh2_md5_update(fingerprint_ctx, iv, 8) ||
-           !ssh2_md5_final(fingerprint_ctx, secret)) {
+           !ssh2_md5_final(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN)) {
             ret = -1;
             goto out;
         }
@@ -300,7 +300,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
                                 strlen((const char *)passphrase)) ||
                !ssh2_md5_update(fingerprint_ctx, iv, 8) ||
                !ssh2_md5_final(fingerprint_ctx,
-                               secret + SSH2_MD5_DIG_LEN)) {
+                               secret + SSH2_MD5_DIG_LEN, SSH2_MD5_DIG_LEN)) {
                 ret = -1;
                 goto out;
             }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -755,9 +755,11 @@ int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash)
+int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
+                         ULONG hashlen)
 {
     int ret;
+    (void)hashlen;  /* TODO: use this */
 
     ret = BCryptFinishHash(ctx->hHash, hash, ctx->cbHash, 0);
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -782,7 +782,7 @@ int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
     ret = ssh2_wcng_hash_init(&ctx, hAlg, hashlen, NULL, 0);
     if(!ret) {
         ret = ssh2_wcng_hash_update(&ctx, data, datalen);
-        ret |= ssh2_wcng_hash_final(&ctx, hash);
+        ret |= ssh2_wcng_hash_final(&ctx, hash, hashlen);
     }
 
     return ret;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -756,7 +756,7 @@ int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
 }
 
 int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
-                         ULONG hashlen)
+                         size_t hashlen)
 {
     int ret;
     (void)hashlen;  /* TODO: use this */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -168,8 +168,8 @@ struct wcng_hash_ctx {
                          SSH2_SHA1_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha1_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_sha1_final(ctx, hash) \
-    (ssh2_wcng_hash_final(&(ctx), hash) == 0)
+#define ssh2_sha1_final(ctx, hash, hashlen) \
+    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
 #define ssh2_sha1(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA1, \
                    hash, SSH2_SHA1_DIG_LEN)
@@ -179,8 +179,8 @@ struct wcng_hash_ctx {
                          SSH2_SHA256_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha256_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_sha256_final(ctx, hash) \
-    (ssh2_wcng_hash_final(&(ctx), hash) == 0)
+#define ssh2_sha256_final(ctx, hash, hashlen) \
+    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
 #define ssh2_sha256(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA256, \
                    hash, SSH2_SHA256_DIG_LEN)
@@ -190,8 +190,8 @@ struct wcng_hash_ctx {
                          SSH2_SHA384_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha384_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_sha384_final(ctx, hash) \
-    (ssh2_wcng_hash_final(&(ctx), hash) == 0)
+#define ssh2_sha384_final(ctx, hash, hashlen) \
+    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
 #define ssh2_sha384(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA384, \
                    hash, SSH2_SHA384_DIG_LEN)
@@ -201,8 +201,8 @@ struct wcng_hash_ctx {
                          SSH2_SHA512_DIG_LEN, NULL, 0) == 0)
 #define ssh2_sha512_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_sha512_final(ctx, hash) \
-    (ssh2_wcng_hash_final(&(ctx), hash) == 0)
+#define ssh2_sha512_final(ctx, hash, hashlen) \
+    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
 #define ssh2_sha512(data, datalen, hash) \
     ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA512, \
                    hash, SSH2_SHA512_DIG_LEN)
@@ -213,15 +213,16 @@ struct wcng_hash_ctx {
                          SSH2_MD5_DIG_LEN, NULL, 0) == 0)
 #define ssh2_md5_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_md5_final(ctx, hash) \
-    (ssh2_wcng_hash_final(&(ctx), hash) == 0)
+#define ssh2_md5_final(ctx, hash, hashlen) \
+    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
 #endif
 
 int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
                         ULONG hashlen, unsigned char *key, ULONG keylen);
 int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
                           const void *data, ULONG datalen);
-int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash);
+int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
+                         ULONG hashlen);
 int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
                    BCRYPT_ALG_HANDLE hAlg, unsigned char *hash, ULONG hashlen);
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -222,7 +222,7 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
 int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
                           const void *data, ULONG datalen);
 int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
-                         ULONG hashlen);
+                         size_t hashlen);
 int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
                    BCRYPT_ALG_HANDLE hAlg, unsigned char *hash, ULONG hashlen);
 


### PR DESCRIPTION
Instead of the macros/functions assuming the digest length based on hash
type.

Some backend do support checking for this. For those which don't, this
patch allows to verify manually. WinCNG currently uses a trick where the
size is passed on init, and reuses this on final. This patch may allow
to avoid that (in a future commit.)
