### PR TITLE
crypto: simplify/prune single-shot hash functions and macros

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -166,16 +166,19 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
         return -1;
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
+        gcry_md_hash_buffer(GCRY_MD_SHA1, hash, m, m_len);
         algo = "sha1";
-        ret = ssh2_sha1(m, m_len, hash);
+        ret = 0;
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
+        gcry_md_hash_buffer(GCRY_MD_SHA256, hash, m, m_len);
         algo = "sha256";
-        ret = ssh2_sha256(m, m_len, hash);
+        ret = 0;
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
+        gcry_md_hash_buffer(GCRY_MD_SHA512, hash, m, m_len);
         algo = "sha512";
-        ret = ssh2_sha512(m, m_len, hash);
+        ret = 0;
     }
     else
         ret = 1;
@@ -643,8 +646,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     gcry_sexp_t s_sig, s_hash;
     int rc = -1;
 
-    if(ssh2_sha1(m, m_len, hash + 1))
-        return -1;
+    gcry_md_hash_buffer(GCRY_MD_SHA1, hash + 1, m, m_len);
 
     hash[0] = 0;
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -82,8 +82,6 @@
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha1_final(ctx, out, len) \
     (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
-#define ssh2_sha1(message, len, out) \
-    (gcry_md_hash_buffer(GCRY_MD_SHA1, out, message, len), 0)
 
 #define ssh2_sha256_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA256, 0))
@@ -91,8 +89,6 @@
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha256_final(ctx, out, len) \
     (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
-#define ssh2_sha256(message, len, out) \
-    (gcry_md_hash_buffer(GCRY_MD_SHA256, out, message, len), 0)
 
 #define ssh2_sha384_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA384, 0))
@@ -100,8 +96,6 @@
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha384_final(ctx, out, len) \
     (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
-#define ssh2_sha384(message, len, out) \
-    (gcry_md_hash_buffer(GCRY_MD_SHA384, out, message, len), 0)
 
 #define ssh2_sha512_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA512, 0))
@@ -109,8 +103,6 @@
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha512_final(ctx, out, len) \
     (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
-#define ssh2_sha512(message, len, out) \
-    (gcry_md_hash_buffer(GCRY_MD_SHA512, out, message, len), 0)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_init(ctx) \

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -196,13 +196,12 @@ int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
 }
 
 static int mbed_hash(const unsigned char *data, size_t datalen,
-                     psa_algorithm_t alg, unsigned char *hash)
+                     psa_algorithm_t alg, unsigned char *hash, size_t hashlen)
 {
     size_t actual_len;
     psa_status_t status;
 
-    status = psa_hash_compute(alg, data, datalen,
-                              hash, PSA_HASH_LENGTH(alg), &actual_len);
+    status = psa_hash_compute(alg, data, datalen, hash, hashlen, &actual_len);
 
     return status == PSA_SUCCESS ? 0 : -1;
 }
@@ -509,15 +508,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
         return -1;
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
-        ret = mbed_hash(m, m_len, PSA_ALG_SHA_1, hash);
+        ret = mbed_hash(m, m_len, PSA_ALG_SHA_1, hash, hash_len);
         md_type = MBEDTLS_MD_SHA1;
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
-        ret = mbed_hash(m, m_len, PSA_ALG_SHA_256, hash);
+        ret = mbed_hash(m, m_len, PSA_ALG_SHA_256, hash, hash_len);
         md_type = MBEDTLS_MD_SHA256;
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
-        ret = mbed_hash(m, m_len, PSA_ALG_SHA_512, hash);
+        ret = mbed_hash(m, m_len, PSA_ALG_SHA_512, hash, hash_len);
         md_type = MBEDTLS_MD_SHA512;
     }
     else {

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -195,17 +195,6 @@ int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
     return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS;
 }
 
-static int mbed_hash(const unsigned char *data, size_t datalen,
-                     psa_algorithm_t alg, unsigned char *hash, size_t hashlen)
-{
-    size_t actual_len;
-    psa_status_t status;
-
-    status = psa_hash_compute(alg, data, datalen, hash, hashlen, &actual_len);
-
-    return status == PSA_SUCCESS ? 0 : -1;
-}
-
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 {
     ctx->mac = psa_mac_operation_init();
@@ -497,6 +486,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
                          const unsigned char *m, size_t m_len)
 {
     int ret;
+    size_t actual_len;
     mbedtls_md_type_t md_type;
     unsigned char *hash;
 
@@ -508,15 +498,18 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
         return -1;
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
-        ret = mbed_hash(m, m_len, PSA_ALG_SHA_1, hash, hash_len);
+        ret = psa_hash_compute(PSA_ALG_SHA_1, m, m_len, hash, hash_len,
+                               &actual_len) == PSA_SUCCESS ? 0 : -1;
         md_type = MBEDTLS_MD_SHA1;
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
-        ret = mbed_hash(m, m_len, PSA_ALG_SHA_256, hash, hash_len);
+        ret = psa_hash_compute(PSA_ALG_SHA_256, m, m_len, hash, hash_len,
+                               &actual_len) == PSA_SUCCESS ? 0 : -1;
         md_type = MBEDTLS_MD_SHA256;
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
-        ret = mbed_hash(m, m_len, PSA_ALG_SHA_512, hash, hash_len);
+        ret = psa_hash_compute(PSA_ALG_SHA_512, m, m_len, hash, hash_len,
+                               &actual_len) == PSA_SUCCESS ? 0 : -1;
         md_type = MBEDTLS_MD_SHA512;
     }
     else {

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -195,8 +195,8 @@ int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
     return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS;
 }
 
-int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   psa_algorithm_t alg, unsigned char *hash)
+static int mbed_hash(const unsigned char *data, size_t datalen,
+                     psa_algorithm_t alg, unsigned char *hash)
 {
     size_t actual_len;
     psa_status_t status;
@@ -509,15 +509,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx,
         return -1;
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
-        ret = ssh2_mbed_hash(m, m_len, PSA_ALG_SHA_1, hash);
+        ret = mbed_hash(m, m_len, PSA_ALG_SHA_1, hash);
         md_type = MBEDTLS_MD_SHA1;
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
-        ret = ssh2_mbed_hash(m, m_len, PSA_ALG_SHA_256, hash);
+        ret = mbed_hash(m, m_len, PSA_ALG_SHA_256, hash);
         md_type = MBEDTLS_MD_SHA256;
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
-        ret = ssh2_mbed_hash(m, m_len, PSA_ALG_SHA_512, hash);
+        ret = mbed_hash(m, m_len, PSA_ALG_SHA_512, hash);
         md_type = MBEDTLS_MD_SHA512;
     }
     else {

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -982,6 +982,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
                       const unsigned char *m, size_t m_len)
 {
     mbedtls_mpi pr, ps;
+    size_t actual_len;
     int rc = -1;
 
     mbedtls_mpi_init(&pr);
@@ -996,7 +997,8 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     switch(ssh2_ecdsa_get_curve_type(ec_ctx)) {
     case SSH2_EC_CURVE_NISTP256: {
         unsigned char hsh[SSH2_SHA256_DIG_LEN];
-        if(mbed_hash(m, m_len, PSA_ALG_SHA_256, hsh, sizeof(hsh)) == 0)
+        if(psa_hash_compute(PSA_ALG_SHA_256, m, m_len, hsh, sizeof(hsh),
+                            &actual_len) == PSA_SUCCESS)
             rc = mbedtls_ecdsa_verify(&ec_ctx->MBEDTLS_PRIVATE(grp),
                                       hsh, sizeof(hsh),
                                       &ec_ctx->MBEDTLS_PRIVATE(Q), &pr, &ps);
@@ -1004,7 +1006,8 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     case SSH2_EC_CURVE_NISTP384: {
         unsigned char hsh[SSH2_SHA384_DIG_LEN];
-        if(mbed_hash(m, m_len, PSA_ALG_SHA_384, hsh, sizeof(hsh)) == 0)
+        if(psa_hash_compute(PSA_ALG_SHA_384, m, m_len, hsh, sizeof(hsh),
+                            &actual_len) == PSA_SUCCESS)
             rc = mbedtls_ecdsa_verify(&ec_ctx->MBEDTLS_PRIVATE(grp),
                                       hsh, sizeof(hsh),
                                       &ec_ctx->MBEDTLS_PRIVATE(Q), &pr, &ps);
@@ -1012,7 +1015,8 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     case SSH2_EC_CURVE_NISTP521: {
         unsigned char hsh[SSH2_SHA512_DIG_LEN];
-        if(mbed_hash(m, m_len, PSA_ALG_SHA_512, hsh, sizeof(hsh)) == 0)
+        if(psa_hash_compute(PSA_ALG_SHA_512, m, m_len, hsh, sizeof(hsh),
+                            &actual_len) == PSA_SUCCESS)
             rc = mbedtls_ecdsa_verify(&ec_ctx->MBEDTLS_PRIVATE(grp),
                                       hsh, sizeof(hsh),
                                       &ec_ctx->MBEDTLS_PRIVATE(Q), &pr, &ps);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -973,17 +973,6 @@ cleanup:
     return rc;
 }
 
-#define SSH2_MBED_ECDSA_VERIFY(digest_type)                                   \
-    do {                                                                      \
-        unsigned char hsh[SSH2_SHA##digest_type##_DIG_LEN];                   \
-                                                                              \
-        if(ssh2_sha##digest_type(m, m_len, hsh) == 0) {                       \
-            rc = mbedtls_ecdsa_verify(&ec_ctx->MBEDTLS_PRIVATE(grp), hsh,     \
-                                      SSH2_SHA##digest_type##_DIG_LEN,        \
-                                      &ec_ctx->MBEDTLS_PRIVATE(Q), &pr, &ps); \
-        }                                                                     \
-    } while(0)
-
 /*
  * Verifies the ECDSA signature of a hashed message
  */
@@ -1005,15 +994,30 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
         goto cleanup;
 
     switch(ssh2_ecdsa_get_curve_type(ec_ctx)) {
-    case SSH2_EC_CURVE_NISTP256:
-        SSH2_MBED_ECDSA_VERIFY(256);
+    case SSH2_EC_CURVE_NISTP256: {
+        unsigned char hsh[SSH2_SHA256_DIG_LEN];
+        if(mbed_hash(m, m_len, PSA_ALG_SHA_256, hsh, sizeof(hsh)) == 0)
+            rc = mbedtls_ecdsa_verify(&ec_ctx->MBEDTLS_PRIVATE(grp),
+                                      hsh, sizeof(hsh),
+                                      &ec_ctx->MBEDTLS_PRIVATE(Q), &pr, &ps);
         break;
-    case SSH2_EC_CURVE_NISTP384:
-        SSH2_MBED_ECDSA_VERIFY(384);
+    }
+    case SSH2_EC_CURVE_NISTP384: {
+        unsigned char hsh[SSH2_SHA384_DIG_LEN];
+        if(mbed_hash(m, m_len, PSA_ALG_SHA_384, hsh, sizeof(hsh)) == 0)
+            rc = mbedtls_ecdsa_verify(&ec_ctx->MBEDTLS_PRIVATE(grp),
+                                      hsh, sizeof(hsh),
+                                      &ec_ctx->MBEDTLS_PRIVATE(Q), &pr, &ps);
         break;
-    case SSH2_EC_CURVE_NISTP521:
-        SSH2_MBED_ECDSA_VERIFY(512);
+    }
+    case SSH2_EC_CURVE_NISTP521: {
+        unsigned char hsh[SSH2_SHA512_DIG_LEN];
+        if(mbed_hash(m, m_len, PSA_ALG_SHA_512, hsh, sizeof(hsh)) == 0)
+            rc = mbedtls_ecdsa_verify(&ec_ctx->MBEDTLS_PRIVATE(grp),
+                                      hsh, sizeof(hsh),
+                                      &ec_ctx->MBEDTLS_PRIVATE(Q), &pr, &ps);
         break;
+    }
     default:
         rc = -1;
     }

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -150,8 +150,6 @@ struct mbed_hash_ctx {
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha1_final(ctx, hash, hashlen) \
     ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-#define ssh2_sha1(data, datalen, hash) \
-    ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_1, hash)
 
 #define ssh2_sha256_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
@@ -159,8 +157,6 @@ struct mbed_hash_ctx {
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha256_final(ctx, hash, hashlen) \
     ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-#define ssh2_sha256(data, datalen, hash) \
-    ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_256, hash)
 
 #define ssh2_sha384_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
@@ -168,8 +164,6 @@ struct mbed_hash_ctx {
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha384_final(ctx, hash, hashlen) \
     ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-#define ssh2_sha384(data, datalen, hash) \
-    ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_384, hash)
 
 #define ssh2_sha512_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
@@ -177,8 +171,6 @@ struct mbed_hash_ctx {
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_sha512_final(ctx, hash, hashlen) \
     ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-#define ssh2_sha512(data, datalen, hash) \
-    ssh2_mbed_hash(data, datalen, PSA_ALG_SHA_512, hash)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_init(pctx) \
@@ -192,8 +184,6 @@ struct mbed_hash_ctx {
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
                          unsigned char *hash, size_t len);
-int ssh2_mbed_hash(const unsigned char *data, size_t datalen,
-                   psa_algorithm_t alg, unsigned char *hash);
 
 /*******************************************************************/
 /*

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -46,6 +46,53 @@
 #include <stdlib.h>
 #include <assert.h>
 
+int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
+{
+    *ctx = EVP_MD_CTX_new();
+
+    if(!*ctx)
+        return 0;
+
+    if(EVP_DigestInit_ex(*ctx, digest, NULL))
+        return 1;
+
+    EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
+
+    return 0;
+}
+
+int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len)
+{
+    return EVP_DigestUpdate(*ctx, data, len);
+}
+
+int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
+{
+    int ret = EVP_DigestFinal_ex(*ctx, out, NULL);
+    (void)outlen;
+    EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
+    return ret;
+}
+
+int ssh2_ossl_hash(const unsigned char *message, size_t len,
+                   unsigned char *out, const EVP_MD *digest)
+{
+    int ret = 1; /* error */
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+
+    if(ctx) {
+        if(EVP_DigestInit_ex(ctx, digest, NULL) &&
+           EVP_DigestUpdate(ctx, message, len) &&
+           EVP_DigestFinal_ex(ctx, out, NULL))
+            ret = 0; /* success */
+        EVP_MD_CTX_free(ctx);
+    }
+
+    return ret;
+}
+
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 {
 #ifdef USE_OPENSSL_3
@@ -2771,53 +2818,6 @@ clean_exit:
     return rc;
 }
 #endif /* LIBSSH2_ECDSA */
-
-int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
-{
-    *ctx = EVP_MD_CTX_new();
-
-    if(!*ctx)
-        return 0;
-
-    if(EVP_DigestInit_ex(*ctx, digest, NULL))
-        return 1;
-
-    EVP_MD_CTX_free(*ctx);
-    *ctx = NULL;
-
-    return 0;
-}
-
-int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len)
-{
-    return EVP_DigestUpdate(*ctx, data, len);
-}
-
-int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
-{
-    int ret = EVP_DigestFinal_ex(*ctx, out, NULL);
-    (void)outlen;
-    EVP_MD_CTX_free(*ctx);
-    *ctx = NULL;
-    return ret;
-}
-
-int ssh2_ossl_hash(const unsigned char *message, size_t len,
-                   unsigned char *out, const EVP_MD *digest)
-{
-    int ret = 1; /* error */
-    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-
-    if(ctx) {
-        if(EVP_DigestInit_ex(ctx, digest, NULL) &&
-           EVP_DigestUpdate(ctx, message, len) &&
-           EVP_DigestFinal_ex(ctx, out, NULL))
-            ret = 0; /* success */
-        EVP_MD_CTX_free(ctx);
-    }
-
-    return ret;
-}
 
 #if LIBSSH2_ECDSA
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2825,9 +2825,6 @@ clean_exit:
 
     return rc;
 }
-#endif /* LIBSSH2_ECDSA */
-
-#if LIBSSH2_ECDSA
 
 static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
                                     unsigned char **method, size_t *method_len,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -76,8 +76,8 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
     return ret;
 }
 
-int ssh2_ossl_hash(const unsigned char *message, size_t len,
-                   unsigned char *out, const EVP_MD *digest)
+static int ossl_hash(const unsigned char *message, size_t len,
+                     unsigned char *out, const EVP_MD *digest)
 {
     int ret = 1; /* error */
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
@@ -422,15 +422,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
-        ret = ssh2_ossl_hash(m, m_len, hash, EVP_sha1());
+        ret = ossl_hash(m, m_len, hash, EVP_sha1());
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
-        ret = ssh2_ossl_hash(m, m_len, hash, EVP_sha256());
+        ret = ossl_hash(m, m_len, hash, EVP_sha256());
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
-        ret = ssh2_ossl_hash(m, m_len, hash, EVP_sha512());
+        ret = ossl_hash(m, m_len, hash, EVP_sha512());
     }
     else {
         nid_type = 0;
@@ -642,8 +642,8 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     ctx = EVP_PKEY_CTX_new(dsactx, NULL);
     der_len = i2d_DSA_SIG(dsasig, &der);
 
-    if(ctx && !ssh2_ossl_hash(m, m_len, hash, EVP_sha1())) {
-        /* ssh2_ossl_hash() succeeded */
+    if(ctx && !ossl_hash(m, m_len, hash, EVP_sha1())) {
+        /* ossl_hash() succeeded */
         if(EVP_PKEY_verify_init(ctx) > 0)
             ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
     }
@@ -654,8 +654,8 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     if(der)
         OPENSSL_clear_free(der, der_len);
 #else
-    if(!ssh2_ossl_hash(m, m_len, hash, EVP_sha1()))
-        /* ssh2_ossl_hash() succeeded */
+    if(!ossl_hash(m, m_len, hash, EVP_sha1()))
+        /* ossl_hash() succeeded */
         ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsactx);
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -810,29 +810,6 @@ int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
     return (ret == 1) ? 0 : -1;
 }
 
-#ifdef USE_OPENSSL_3
-#define SSH2_OSSL_ECDSA_VERIFY(digest_type)                             \
-    do {                                                                \
-        unsigned char hash[SSH2_SHA##digest_type##_DIG_LEN];            \
-        if(ssh2_sha##digest_type(m, m_len, hash) == 0) {                \
-            ret = EVP_PKEY_verify_init(ctx);                            \
-            if(ret > 0) {                                               \
-                ret = EVP_PKEY_verify(ctx, der, der_len, hash,          \
-                                      SSH2_SHA##digest_type##_DIG_LEN); \
-            }                                                           \
-        }                                                               \
-    } while(0)
-#else
-#define SSH2_OSSL_ECDSA_VERIFY(digest_type)                              \
-    do {                                                                 \
-        unsigned char hash[SSH2_SHA##digest_type##_DIG_LEN];             \
-        if(ssh2_sha##digest_type(m, m_len, hash) == 0) {                 \
-            ret = ECDSA_do_verify(hash, SSH2_SHA##digest_type##_DIG_LEN, \
-                                  ecdsa_sig, ec_key);                    \
-        }                                                                \
-    } while(0)
-#endif
-
 int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
                       const unsigned char *r, size_t r_len,
                       const unsigned char *s, size_t s_len,
@@ -869,16 +846,31 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
         ret = -1;
         goto cleanup;
     }
-#endif
 
-    if(type == SSH2_EC_CURVE_NISTP256)
-        SSH2_OSSL_ECDSA_VERIFY(256);
-    else if(type == SSH2_EC_CURVE_NISTP384)
-        SSH2_OSSL_ECDSA_VERIFY(384);
-    else if(type == SSH2_EC_CURVE_NISTP521)
-        SSH2_OSSL_ECDSA_VERIFY(512);
-
-#ifdef USE_OPENSSL_3
+    if(type == SSH2_EC_CURVE_NISTP256) {
+        unsigned char hash[SSH2_SHA256_DIG_LEN];
+        if(ossl_hash(m, m_len, hash, EVP_sha256()) == 0) {
+            ret = EVP_PKEY_verify_init(ctx);
+            if(ret > 0)
+                ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
+        }
+    }
+    else if(type == SSH2_EC_CURVE_NISTP384) {
+        unsigned char hash[SSH2_SHA384_DIG_LEN];
+        if(ossl_hash(m, m_len, hash, EVP_sha384()) == 0) {
+            ret = EVP_PKEY_verify_init(ctx);
+            if(ret > 0)
+                ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
+        }
+    }
+    else if(type == SSH2_EC_CURVE_NISTP521) {
+        unsigned char hash[SSH2_SHA512_DIG_LEN];
+        if(ossl_hash(m, m_len, hash, EVP_sha512()) == 0) {
+            ret = EVP_PKEY_verify_init(ctx);
+            if(ret > 0)
+                ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
+        }
+    }
 cleanup:
 
     if(ctx)
@@ -886,6 +878,22 @@ cleanup:
 
     if(der)
         OPENSSL_free(der);
+#else
+    if(type == SSH2_EC_CURVE_NISTP256) {
+        unsigned char hash[SSH2_SHA256_DIG_LEN];
+        if(ossl_hash(m, m_len, hash, EVP_sha256()) == 0)
+            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
+    }
+    else if(type == SSH2_EC_CURVE_NISTP384) {
+        unsigned char hash[SSH2_SHA384_DIG_LEN];
+        if(ossl_hash(m, m_len, hash, EVP_sha384()) == 0)
+            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
+    }
+    else if(type == SSH2_EC_CURVE_NISTP521) {
+        unsigned char hash[SSH2_SHA512_DIG_LEN];
+        if(ossl_hash(m, m_len, hash, EVP_sha512()) == 0)
+            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
+    }
 #endif
 
     if(ecdsa_sig)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -241,25 +241,21 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 #define ssh2_sha1_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha1_final(ctx, h, hl)   ssh2_ossl_hash_final(&(ctx), h, hl)
-#define ssh2_sha1(x, y, z)            ssh2_ossl_hash(x, y, z, EVP_sha1())
 
 #define ssh2_sha256_init(x)           ssh2_ossl_hash_init(x, EVP_sha256())
 #define ssh2_sha256_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha256_final(ctx, h, hl) ssh2_ossl_hash_final(&(ctx), h, hl)
-#define ssh2_sha256(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha256())
 
 #define ssh2_sha384_init(x)           ssh2_ossl_hash_init(x, EVP_sha384())
 #define ssh2_sha384_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha384_final(ctx, h, hl) ssh2_ossl_hash_final(&(ctx), h, hl)
-#define ssh2_sha384(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha384())
 
 #define ssh2_sha512_init(x)           ssh2_ossl_hash_init(x, EVP_sha512())
 #define ssh2_sha512_update(ctx, data, len) \
     ssh2_ossl_hash_update(&(ctx), data, len)
 #define ssh2_sha512_final(ctx, h, hl) ssh2_ossl_hash_final(&(ctx), h, hl)
-#define ssh2_sha512(x, y, z)          ssh2_ossl_hash(x, y, z, EVP_sha512())
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 /* MD5 digest is not supported in OpenSSL FIPS mode

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -961,19 +961,6 @@ int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx,
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_os400qc3_hash(const unsigned char *message, unsigned long len,
-                       unsigned char *out, unsigned int algo)
-{
-    Qc3_Format_ALGD0100_T ctx;
-
-    if(!ssh2_os400qc3_hash_init(&ctx, algo) ||
-       !ssh2_os400qc3_hash_update(&ctx, message, len) ||
-       !ssh2_os400qc3_hash_final(&ctx, out))
-        return 1;
-
-    return 0;
-}
-
 static int os400qc3_hmac_init(struct os400qc3_crypto_ctx *ctx,
                               int algo, size_t minkeylen,
                               void *key, int keylen)

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -256,9 +256,6 @@ int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algo);
 int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,
                               const unsigned char *data, int len);
 int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx, unsigned char *out);
-int ssh2_os400qc3_hash(const unsigned char *message,
-                       unsigned long len, unsigned char *out,
-                       unsigned int algo);
 
 /* Bignum */
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -239,15 +239,12 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_sha256_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA256)
 #define ssh2_sha256_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
 #define ssh2_sha256_final(ctx, h, hl) ssh2_os400qc3_hash_final(&(ctx), h, hl)
-#define ssh2_sha256(d, l, h)          ssh2_os400qc3_hash(d, l, h, Qc3_SHA256)
 #define ssh2_sha384_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA384)
 #define ssh2_sha384_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
 #define ssh2_sha384_final(ctx, h, hl) ssh2_os400qc3_hash_final(&(ctx), h, hl)
-#define ssh2_sha384(d, l, h)          ssh2_os400qc3_hash(d, l, h, Qc3_SHA384)
 #define ssh2_sha512_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA512)
 #define ssh2_sha512_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
 #define ssh2_sha512_final(ctx, h, hl) ssh2_os400qc3_hash_final(&(ctx), h, hl)
-#define ssh2_sha512(d, l, h)          ssh2_os400qc3_hash(d, l, h, Qc3_SHA512)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_init(x)              ssh2_os400qc3_hash_init(x, Qc3_MD5)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -773,8 +773,9 @@ int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
-                   BCRYPT_ALG_HANDLE hAlg, unsigned char *hash, ULONG hashlen)
+static int wcng_hash(const unsigned char *data, ULONG datalen,
+                     BCRYPT_ALG_HANDLE hAlg,
+                     unsigned char *hash, ULONG hashlen)
 {
     struct wcng_hash_ctx ctx;
     int ret;
@@ -910,7 +911,7 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
     }
     memcpy(data, m, datalen);
 
-    ret = ssh2_wcng_hash(data, datalen, hAlgHash, hash, hashlen);
+    ret = wcng_hash(data, datalen, hAlgHash, hash, hashlen);
     wcng_safe_free(data, datalen);
 
     if(ret) {
@@ -2424,7 +2425,7 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *key,
     }
 
     hash = malloc(hash_len);
-    result = ssh2_wcng_hash(m, (ULONG)m_len, hash_alg, hash, hash_len);
+    result = wcng_hash(m, (ULONG)m_len, hash_alg, hash, hash_len);
     if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -170,9 +170,6 @@ struct wcng_hash_ctx {
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha1_final(ctx, hash, hashlen) \
     (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-#define ssh2_sha1(data, datalen, hash) \
-    ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA1, \
-                   hash, SSH2_SHA1_DIG_LEN)
 
 #define ssh2_sha256_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA256, \
@@ -181,9 +178,6 @@ struct wcng_hash_ctx {
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha256_final(ctx, hash, hashlen) \
     (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-#define ssh2_sha256(data, datalen, hash) \
-    ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA256, \
-                   hash, SSH2_SHA256_DIG_LEN)
 
 #define ssh2_sha384_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA384, \
@@ -192,9 +186,6 @@ struct wcng_hash_ctx {
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha384_final(ctx, hash, hashlen) \
     (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-#define ssh2_sha384(data, datalen, hash) \
-    ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA384, \
-                   hash, SSH2_SHA384_DIG_LEN)
 
 #define ssh2_sha512_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA512, \
@@ -203,9 +194,6 @@ struct wcng_hash_ctx {
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha512_final(ctx, hash, hashlen) \
     (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-#define ssh2_sha512(data, datalen, hash) \
-    ssh2_wcng_hash(data, datalen, ssh2_wcng.hAlgHashSHA512, \
-                   hash, SSH2_SHA512_DIG_LEN)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_init(ctx) \


### PR DESCRIPTION
- drop global single-shot macros, they were unused in global code.

- make local single-shot functions static, drop ssh2 namespace.

- mbedtls: replace local single-shot hash wrapper with direct PSA API
  calls. Also pass digest buffer sizes.

- mbedlts: unwrap local macro `SSH2_MBED_ECDSA_VERIFY()` to improve
  readability and avoid fragile macro trick. (Cost: +7 lines)

- openssl: unwrap local macro `SSH2_OSSL_ECDSA_VERIFY()` to improve
  readability and avoid fragile macro trick. (Cost: +10 lines)

- libgcrypt: drop interim single-shot macros in favor of direct API
  calls.
