### PR TITLE
wincng: do not require passing digest size on hash init

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -752,7 +752,7 @@ int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
 {
     int ret;
 
-    ret = BCryptFinishHash(ctx->hHash, hash, hashlen, 0);
+    ret = BCryptFinishHash(ctx->hHash, hash, (ULONG)hashlen, 0);
 
     BCryptDestroyHash(ctx->hHash);
     ctx->hHash = NULL;
@@ -830,7 +830,7 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
-    int ret = BCryptFinishHash(ctx->hHash, mac, maclen, 0);
+    int ret = BCryptFinishHash(ctx->hHash, mac, (ULONG)maclen, 0);
 
     return BCRYPT_SUCCESS(ret) ? 1 : 0;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -707,15 +707,8 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
 {
     BCRYPT_HASH_HANDLE hHash;
     unsigned char *pbHashObject;
-    ULONG dwHashObject, dwHash, cbData;
+    ULONG dwHashObject, cbData;
     int ret;
-
-    ret = BCryptGetProperty(hAlg, BCRYPT_HASH_LENGTH,
-                            (unsigned char *)&dwHash,
-                            sizeof(dwHash),
-                            &cbData, 0);
-    if(!BCRYPT_SUCCESS(ret))
-        return -1;
 
     ret = BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH,
                             (unsigned char *)&dwHashObject,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -703,7 +703,7 @@ int ssh2_random(unsigned char *buf, size_t len)
  */
 
 int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
-                        ULONG hashlen, unsigned char *key, ULONG keylen)
+                        unsigned char *key, ULONG keylen)
 {
     BCRYPT_HASH_HANDLE hHash;
     unsigned char *pbHashObject;
@@ -714,7 +714,7 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
                             (unsigned char *)&dwHash,
                             sizeof(dwHash),
                             &cbData, 0);
-    if(!BCRYPT_SUCCESS(ret) || dwHash != hashlen)
+    if(!BCRYPT_SUCCESS(ret))
         return -1;
 
     ret = BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH,
@@ -780,7 +780,7 @@ static int wcng_hash(const unsigned char *data, ULONG datalen,
     struct wcng_hash_ctx ctx;
     int ret;
 
-    ret = ssh2_wcng_hash_init(&ctx, hAlg, hashlen, NULL, 0);
+    ret = ssh2_wcng_hash_init(&ctx, hAlg, NULL, 0);
     if(!ret) {
         ret = ssh2_wcng_hash_update(&ctx, data, datalen);
         ret |= ssh2_wcng_hash_final(&ctx, hash, hashlen);
@@ -804,8 +804,7 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacMD5,
-                                  SSH2_MD5_DIG_LEN, key, (ULONG)keylen);
-
+                                  key, (ULONG)keylen);
     return ret == 0 ? 1 : 0;
 }
 #endif
@@ -813,24 +812,21 @@ int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA1,
-                                  SSH2_SHA1_DIG_LEN, key, (ULONG)keylen);
-
+                                  key, (ULONG)keylen);
     return ret == 0 ? 1 : 0;
 }
 
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA256,
-                                  SSH2_SHA256_DIG_LEN, key, (ULONG)keylen);
-
+                                  key, (ULONG)keylen);
     return ret == 0 ? 1 : 0;
 }
 
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
     int ret = ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA512,
-                                  SSH2_SHA512_DIG_LEN, key, (ULONG)keylen);
-
+                                  key, (ULONG)keylen);
     return ret == 0 ? 1 : 0;
 }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -759,9 +759,8 @@ int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
                          size_t hashlen)
 {
     int ret;
-    (void)hashlen;  /* TODO: use this */
 
-    ret = BCryptFinishHash(ctx->hHash, hash, ctx->cbHash, 0);
+    ret = BCryptFinishHash(ctx->hHash, hash, hashlen, 0);
 
     BCryptDestroyHash(ctx->hHash);
     ctx->hHash = NULL;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -739,7 +739,6 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
     ctx->hHash = hHash;
     ctx->pbHashObject = pbHashObject;
     ctx->dwHashObject = dwHashObject;
-    ctx->cbHash = dwHash;
 
     return 0;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -838,8 +838,7 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
-    int ret = BCryptFinishHash(ctx->hHash, mac, ctx->cbHash, 0);
-    (void)maclen;
+    int ret = BCryptFinishHash(ctx->hHash, mac, maclen, 0);
 
     return BCRYPT_SUCCESS(ret) ? 1 : 0;
 }

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -164,32 +164,28 @@ struct wcng_hash_ctx {
 #define ssh2_hash_ctx struct wcng_hash_ctx
 
 #define ssh2_sha1_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA1, \
-                         SSH2_SHA1_DIG_LEN, NULL, 0) == 0)
+    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA1, NULL, 0) == 0)
 #define ssh2_sha1_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha1_final(ctx, hash, hashlen) \
     (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
 
 #define ssh2_sha256_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA256, \
-                         SSH2_SHA256_DIG_LEN, NULL, 0) == 0)
+    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA256, NULL, 0) == 0)
 #define ssh2_sha256_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha256_final(ctx, hash, hashlen) \
     (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
 
 #define ssh2_sha384_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA384, \
-                         SSH2_SHA384_DIG_LEN, NULL, 0) == 0)
+    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA384, NULL, 0) == 0)
 #define ssh2_sha384_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha384_final(ctx, hash, hashlen) \
     (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
 
 #define ssh2_sha512_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA512, \
-                         SSH2_SHA512_DIG_LEN, NULL, 0) == 0)
+    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA512, NULL, 0) == 0)
 #define ssh2_sha512_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_sha512_final(ctx, hash, hashlen) \
@@ -197,8 +193,7 @@ struct wcng_hash_ctx {
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashMD5, \
-                         SSH2_MD5_DIG_LEN, NULL, 0) == 0)
+    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashMD5, NULL, 0) == 0)
 #define ssh2_md5_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_md5_final(ctx, hash, hashlen) \
@@ -206,7 +201,7 @@ struct wcng_hash_ctx {
 #endif
 
 int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
-                        ULONG hashlen, unsigned char *key, ULONG keylen);
+                        unsigned char *key, ULONG keylen);
 int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
                           const void *data, ULONG datalen);
 int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -154,7 +154,6 @@ struct wcng_hash_ctx {
     BCRYPT_HASH_HANDLE hHash;
     unsigned char *pbHashObject;
     ULONG dwHashObject;
-    ULONG cbHash;
 };
 
 /*


### PR DESCRIPTION
Also:
- use actual digest buffer size passed on hash final instead.
- use actual mac buffer size on hmac final, replacing the digest size
  stored on init.
- drop digest size from local hash struct, it's no longer used.
- drop detecting digest size in `ssh2_wcng_hash_init()`, it's no longer
  used.
