### PR TITLE
crypto: unify hash macros

### DIFF
--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -125,8 +125,8 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
 
     /* collapse password */
     if(!ssh2_sha512_init(&ctx) ||
-       !ssh2_sha512_update(ctx, pass, passlen) ||
-       !ssh2_sha512_final(ctx, sha2pass, sizeof(sha2pass))) {
+       !ssh2_hash_update(ctx, pass, passlen) ||
+       !ssh2_hash_final(ctx, sha2pass, sizeof(sha2pass))) {
         free(countsalt);
         return -1;
     }
@@ -140,8 +140,8 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
 
         /* first round, salt is salt */
         if(!ssh2_sha512_init(&ctx) ||
-           !ssh2_sha512_update(ctx, countsalt, saltlen + 4) ||
-           !ssh2_sha512_final(ctx, sha2salt, sizeof(sha2salt))) {
+           !ssh2_hash_update(ctx, countsalt, saltlen + 4) ||
+           !ssh2_hash_final(ctx, sha2salt, sizeof(sha2salt))) {
             ssh2_explicit_zero(out, sizeof(out));
             free(countsalt);
             return -1;
@@ -153,8 +153,8 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
         for(i = 1; i < rounds; i++) {
             /* subsequent rounds, salt is previous output */
             if(!ssh2_sha512_init(&ctx) ||
-               !ssh2_sha512_update(ctx, tmpout, sizeof(tmpout)) ||
-               !ssh2_sha512_final(ctx, sha2salt, sizeof(sha2salt))) {
+               !ssh2_hash_update(ctx, tmpout, sizeof(tmpout)) ||
+               !ssh2_hash_final(ctx, sha2salt, sizeof(sha2salt))) {
                 ssh2_explicit_zero(out, sizeof(out));
                 free(countsalt);
                 return -1;

--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -124,7 +124,7 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
     memcpy(countsalt, salt, saltlen);
 
     /* collapse password */
-    if(!ssh2_sha512_init(&ctx) ||
+    if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG) ||
        !ssh2_hash_update(ctx, pass, passlen) ||
        !ssh2_hash_final(ctx, sha2pass, sizeof(sha2pass))) {
         free(countsalt);
@@ -139,7 +139,7 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
         countsalt[saltlen + 3] = count & 0xff;
 
         /* first round, salt is salt */
-        if(!ssh2_sha512_init(&ctx) ||
+        if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG) ||
            !ssh2_hash_update(ctx, countsalt, saltlen + 4) ||
            !ssh2_hash_final(ctx, sha2salt, sizeof(sha2salt))) {
             ssh2_explicit_zero(out, sizeof(out));
@@ -152,7 +152,7 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
 
         for(i = 1; i < rounds; i++) {
             /* subsequent rounds, salt is previous output */
-            if(!ssh2_sha512_init(&ctx) ||
+            if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG) ||
                !ssh2_hash_update(ctx, tmpout, sizeof(tmpout)) ||
                !ssh2_hash_final(ctx, sha2salt, sizeof(sha2salt))) {
                 ssh2_explicit_zero(out, sizeof(out));

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -223,7 +223,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA1_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_sha1_init(&ctx))
+    if(!ssh2_hash_init(&ctx, SSH2_SHA1_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
@@ -289,7 +289,7 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA256_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_sha256_init(&ctx))
+    if(!ssh2_hash_init(&ctx, SSH2_SHA256_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
@@ -352,7 +352,7 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA512_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_sha512_init(&ctx))
+    if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
@@ -635,7 +635,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
     ssh2_hash_ctx ctx;
     int i;
 
-    if(!ssh2_sha1_init(&ctx)) {
+    if(!ssh2_hash_init(&ctx, SSH2_SHA1_ALG)) {
         *signature = NULL;
         *signature_len = 0;
         return -1;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -871,7 +871,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
         unsigned char hash[SSH2_SHA##digest_type##_DIG_LEN];          \
         ssh2_hash_ctx ctx;                                            \
         int i;                                                        \
-        if(!ssh2_sha##digest_type##_init(&ctx)) {                     \
+        if(!ssh2_hash_init(&ctx, SSH2_SHA##digest_type##_ALG)) {      \
             ret = -1;                                                 \
             break;                                                    \
         }                                                             \

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -226,10 +226,10 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha1_init(&ctx))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
     }
-    if(!ssh2_sha1_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;
 
     ret = ssh2_rsa_sha1_sign(session, rsactx, hash, SSH2_SHA1_DIG_LEN,
@@ -292,10 +292,10 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha256_init(&ctx))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_sha256_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
     }
-    if(!ssh2_sha256_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;
 
     ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SSH2_SHA256_DIG_LEN,
@@ -355,10 +355,10 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     if(!ssh2_sha512_init(&ctx))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_sha512_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
     }
-    if(!ssh2_sha512_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;
 
     ret = ssh2_rsa_sha2_sign(session, rsactx, hash, SSH2_SHA512_DIG_LEN,
@@ -648,10 +648,10 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
     *signature_len = 2 * SSH2_SHA1_DIG_LEN;
 
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_sha1_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
             return -1;
     }
-    if(!ssh2_sha1_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;
 
     if(ssh2_dsa_sha1_sign(dsactx, hash, SSH2_SHA1_DIG_LEN, *signature)) {
@@ -876,9 +876,8 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
             break;                                                    \
         }                                                             \
         for(i = 0; i < veccount; i++) {                               \
-            if(!ssh2_sha##digest_type##_update(ctx,                   \
-                                               datavec[i].iov_base,   \
-                                               datavec[i].iov_len)) { \
+            if(!ssh2_hash_update(ctx, datavec[i].iov_base,            \
+                                      datavec[i].iov_len)) {          \
                 ret = -1;                                             \
                 break;                                                \
             }                                                         \
@@ -886,7 +885,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
         if(ret == -1) {                                               \
             break;                                                    \
         }                                                             \
-        if(!ssh2_sha##digest_type##_final(ctx, hash, sizeof(hash))) { \
+        if(!ssh2_hash_final(ctx, hash, sizeof(hash))) {               \
             ret = -1;                                                 \
             break;                                                    \
         }                                                             \

--- a/src/kex.c
+++ b/src/kex.c
@@ -60,7 +60,7 @@
             ssh2_hash_ctx hash;                                               \
             size_t len = 0;                                                   \
             while(len < (size_t)(reqlen)) {                                   \
-                if(!ssh2_sha##digest_type##_init(&hash) ||                    \
+                if(!ssh2_hash_init(&hash, SSH2_SHA##digest_type##_ALG) ||     \
                    !ssh2_hash_update(hash,                      \
                                            exchange_state->k_value,           \
                                            exchange_state->k_value_len) ||    \
@@ -1632,7 +1632,7 @@ static int kex_session_hybrid_curve_type(const char *name,
     do {                                                                      \
         ssh2_hash_ctx ctx;                                                    \
         int hok;                                                              \
-        if(!ssh2_sha##digest_type##_init(&ctx)) {                             \
+        if(!ssh2_hash_init(&ctx, SSH2_SHA##digest_type##_ALG)) {              \
             rc = -1;                                                          \
             break;                                                            \
         }                                                                     \
@@ -1748,7 +1748,7 @@ static int kex_session_hybrid_curve_type(const char *name,
     do {                                                                      \
         ssh2_hash_ctx ctx;                                                    \
         int hok;                                                              \
-        if(!ssh2_sha##digest_type##_init(&ctx)) {                             \
+        if(!ssh2_hash_init(&ctx, SSH2_SHA##digest_type##_ALG)) {              \
             rc = -1;                                                          \
             break;                                                            \
         }                                                                     \

--- a/src/kex.c
+++ b/src/kex.c
@@ -109,13 +109,13 @@
 static int sha_algo_ctx_init(int sha_algo, void *ctx)
 {
     if(sha_algo == 512)
-        return ssh2_sha512_init((ssh2_hash_ctx *)ctx);
+        return ssh2_hash_init((ssh2_hash_ctx *)ctx, SSH2_SHA512_ALG);
     else if(sha_algo == 384)
-        return ssh2_sha384_init((ssh2_hash_ctx *)ctx);
+        return ssh2_hash_init((ssh2_hash_ctx *)ctx, SSH2_SHA384_ALG);
     else if(sha_algo == 256)
-        return ssh2_sha256_init((ssh2_hash_ctx *)ctx);
+        return ssh2_hash_init((ssh2_hash_ctx *)ctx, SSH2_SHA256_ALG);
     else if(sha_algo == 1)
-        return ssh2_sha1_init((ssh2_hash_ctx *)ctx);
+        return ssh2_hash_init((ssh2_hash_ctx *)ctx, SSH2_SHA1_ALG);
 #ifdef LIBSSH2DEBUG
     else
         assert(0);
@@ -252,7 +252,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
     {
         ssh2_hash_ctx fingerprint_ctx;
 
-        if(ssh2_sha1_init(&fingerprint_ctx) &&
+        if(ssh2_hash_init(&fingerprint_ctx, SSH2_SHA1_ALG) &&
            ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
                             session->server_hostkey_len) &&
            ssh2_hash_final(fingerprint_ctx, session->server_hostkey_sha1,
@@ -277,7 +277,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
     {
         ssh2_hash_ctx fingerprint_ctx;
 
-        if(ssh2_sha256_init(&fingerprint_ctx) &&
+        if(ssh2_hash_init(&fingerprint_ctx, SSH2_SHA256_ALG) &&
            ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
                               session->server_hostkey_len) &&
            ssh2_hash_final(fingerprint_ctx, session->server_hostkey_sha256,
@@ -2362,7 +2362,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
         switch(type) {
         case SSH2_EC_CURVE_NISTP256: {
             ssh2_hash_ctx k_ctx;
-            if(!ssh2_sha256_init(&k_ctx)) {
+            if(!ssh2_hash_init(&k_ctx, SSH2_SHA256_ALG)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                                "kex: failed to initialize hash");
                 goto clean_exit;
@@ -2385,7 +2385,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
         }
         case SSH2_EC_CURVE_NISTP384: {
             ssh2_hash_ctx k_ctx;
-            if(!ssh2_sha384_init(&k_ctx)) {
+            if(!ssh2_hash_init(&k_ctx, SSH2_SHA384_ALG)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                                "kex: failed to initialize hash");
                 goto clean_exit;
@@ -2997,7 +2997,7 @@ static int mlkem768x25519_sha256(
             goto clean_exit;
         }
 
-        if(!ssh2_sha256_init(&k_ctx)) {
+        if(!ssh2_hash_init(&k_ctx, SSH2_SHA256_ALG)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                            "kex: failed to initialize hash");
             goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -226,7 +226,7 @@ static int process_host_key(LIBSSH2_SESSION *session,
     {
         ssh2_hash_ctx fingerprint_ctx;
 
-        if(ssh2_md5_init(&fingerprint_ctx) &&
+        if(ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) &&
            ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
                            session->server_hostkey_len) &&
            ssh2_hash_final(fingerprint_ctx, session->server_hostkey_md5,

--- a/src/kex.c
+++ b/src/kex.c
@@ -61,35 +61,32 @@
             size_t len = 0;                                                   \
             while(len < (size_t)(reqlen)) {                                   \
                 if(!ssh2_hash_init(&hash, SSH2_SHA##digest_type##_ALG) ||     \
-                   !ssh2_hash_update(hash,                      \
-                                           exchange_state->k_value,           \
+                   !ssh2_hash_update(hash, exchange_state->k_value,           \
                                            exchange_state->k_value_len) ||    \
-                   !ssh2_hash_update(hash,                      \
-                                         exchange_state->h_sig_comp,          \
-                                         SSH2_SHA##digest_type##_DIG_LEN)) {  \
+                   !ssh2_hash_update(hash, exchange_state->h_sig_comp,        \
+                                          SSH2_SHA##digest_type##_DIG_LEN)) { \
                     SSH2_FREE(session, value);                                \
                     (value) = NULL;                                           \
                     break;                                                    \
                 }                                                             \
                 if(len > 0) {                                                 \
-                    if(!ssh2_hash_update(hash, value, len)) {   \
+                    if(!ssh2_hash_update(hash, value, len)) {                 \
                         SSH2_FREE(session, value);                            \
                         (value) = NULL;                                       \
                         break;                                                \
                     }                                                         \
                 }                                                             \
                 else {                                                        \
-                    if(!ssh2_hash_update(hash, version, 1) ||   \
-                       !ssh2_hash_update(hash,                  \
-                                                  session->session_id,        \
-                                                  session->session_id_len)) { \
+                    if(!ssh2_hash_update(hash, version, 1) ||                 \
+                       !ssh2_hash_update(hash, session->session_id,           \
+                                               session->session_id_len)) {    \
                         SSH2_FREE(session, value);                            \
                         (value) = NULL;                                       \
                         break;                                                \
                     }                                                         \
                 }                                                             \
-                if(!ssh2_hash_final(hash, (value) + len,        \
-                                          SSH2_SHA##digest_type##_DIG_LEN)) { \
+                if(!ssh2_hash_final(hash, (value) + len,                      \
+                                    SSH2_SHA##digest_type##_DIG_LEN)) {       \
                     SSH2_FREE(session, value);                                \
                     (value) = NULL;                                           \
                     break;                                                    \
@@ -228,9 +225,9 @@ static int process_host_key(LIBSSH2_SESSION *session,
 
         if(ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) &&
            ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
-                           session->server_hostkey_len) &&
+                            session->server_hostkey_len) &&
            ssh2_hash_final(fingerprint_ctx, session->server_hostkey_md5,
-                          sizeof(session->server_hostkey_md5)))
+                           sizeof(session->server_hostkey_md5)))
             session->server_hostkey_md5_valid = TRUE;
         else
             session->server_hostkey_md5_valid = FALSE;
@@ -279,9 +276,9 @@ static int process_host_key(LIBSSH2_SESSION *session,
 
         if(ssh2_hash_init(&fingerprint_ctx, SSH2_SHA256_ALG) &&
            ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
-                              session->server_hostkey_len) &&
+                            session->server_hostkey_len) &&
            ssh2_hash_final(fingerprint_ctx, session->server_hostkey_sha256,
-                             sizeof(session->server_hostkey_sha256)))
+                           sizeof(session->server_hostkey_sha256)))
             session->server_hostkey_sha256_valid = TRUE;
         else
             session->server_hostkey_sha256_valid = FALSE;
@@ -1640,77 +1637,60 @@ static int kex_session_hybrid_curve_type(const char *name,
         if(session->local.banner) {                                           \
             ssh2_htonu32(exchange_state->h_sig_comp,                          \
                      (uint32_t)(strlen((char *)session->local.banner) - 2));  \
-            hok &= ssh2_hash_update(ctx,                        \
-                                              exchange_state->h_sig_comp, 4); \
-            hok &= ssh2_hash_update(ctx,                        \
-                                  (char *)session->local.banner,              \
+            hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);      \
+            hok &= ssh2_hash_update(ctx, (char *)session->local.banner,       \
                                   strlen((char *)session->local.banner) - 2); \
         }                                                                     \
         else {                                                                \
             ssh2_htonu32(exchange_state->h_sig_comp,                          \
                          sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);             \
-            hok &= ssh2_hash_update(ctx,                        \
-                                              exchange_state->h_sig_comp, 4); \
-            hok &= ssh2_hash_update(ctx,                        \
-                                     LIBSSH2_SSH_DEFAULT_BANNER,              \
-                                     sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1); \
+            hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);      \
+            hok &= ssh2_hash_update(ctx, LIBSSH2_SSH_DEFAULT_BANNER,          \
+                                  sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);    \
         }                                                                     \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)strlen((char *)session->remote.banner));       \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                     session->remote.banner,                  \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, session->remote.banner,                  \
                                      strlen((char *)session->remote.banner)); \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)session->local.kexinit_len);                   \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              session->local.kexinit,         \
-                                              session->local.kexinit_len);    \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, session->local.kexinit,                  \
+                                     session->local.kexinit_len);             \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)session->remote.kexinit_len);                  \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              session->remote.kexinit,        \
-                                              session->remote.kexinit_len);   \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, session->remote.kexinit,                 \
+                                     session->remote.kexinit_len);            \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      session->server_hostkey_len);                            \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              session->server_hostkey,        \
-                                              session->server_hostkey_len);   \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, session->server_hostkey,                 \
+                                     session->server_hostkey_len);            \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)public_key_len);                               \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              public_key,                     \
-                                              public_key_len);                \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, public_key,                              \
+                                     public_key_len);                         \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)server_public_key_len);                        \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              server_public_key,              \
-                                              server_public_key_len);         \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, server_public_key,                       \
+                                     server_public_key_len);                  \
                                                                               \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->k_value,        \
-                                              exchange_state->k_value_len);   \
+        hok &= ssh2_hash_update(ctx, exchange_state->k_value,                 \
+                                     exchange_state->k_value_len);            \
                                                                               \
         if(!hok ||                                                            \
-           !ssh2_hash_final(ctx, exchange_state->h_sig_comp,    \
-                                       sizeof(exchange_state->h_sig_comp))) { \
+           !ssh2_hash_final(ctx, exchange_state->h_sig_comp,                  \
+                                 sizeof(exchange_state->h_sig_comp))) {       \
             rc = -1;                                                          \
             break;                                                            \
         }                                                                     \
@@ -1756,80 +1736,62 @@ static int kex_session_hybrid_curve_type(const char *name,
         if(session->local.banner) {                                           \
             ssh2_htonu32(exchange_state->h_sig_comp,                          \
                      (uint32_t)(strlen((char *)session->local.banner) - 2));  \
-            hok &= ssh2_hash_update(ctx,                        \
-                                              exchange_state->h_sig_comp, 4); \
-            hok &= ssh2_hash_update(ctx,                        \
-                                  (char *)session->local.banner,              \
+            hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);      \
+            hok &= ssh2_hash_update(ctx, (char *)session->local.banner,       \
                                   strlen((char *)session->local.banner) - 2); \
         }                                                                     \
         else {                                                                \
             ssh2_htonu32(exchange_state->h_sig_comp,                          \
                          sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);             \
-            hok &= ssh2_hash_update(ctx,                        \
-                                              exchange_state->h_sig_comp, 4); \
-            hok &= ssh2_hash_update(ctx,                        \
-                                     LIBSSH2_SSH_DEFAULT_BANNER,              \
-                                     sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1); \
+            hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);      \
+            hok &= ssh2_hash_update(ctx, LIBSSH2_SSH_DEFAULT_BANNER,          \
+                                  sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);    \
         }                                                                     \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)strlen((char *)session->remote.banner));       \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                     session->remote.banner,                  \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, session->remote.banner,                  \
                                      strlen((char *)session->remote.banner)); \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)session->local.kexinit_len);                   \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              session->local.kexinit,         \
-                                              session->local.kexinit_len);    \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, session->local.kexinit,                  \
+                                     session->local.kexinit_len);             \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)session->remote.kexinit_len);                  \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              session->remote.kexinit,        \
-                                              session->remote.kexinit_len);   \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, session->remote.kexinit,                 \
+                                     session->remote.kexinit_len);            \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      session->server_hostkey_len);                            \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              session->server_hostkey,        \
-                                              session->server_hostkey_len);   \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, session->server_hostkey,                 \
+                                     session->server_hostkey_len);            \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)(public_pq_key_len + public_t_key_len));       \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              public_pq_key,                  \
-                                              public_pq_key_len);             \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              public_t_key,                   \
-                                              public_t_key_len);              \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, public_pq_key,                           \
+                                     public_pq_key_len);                      \
+        hok &= ssh2_hash_update(ctx, public_t_key,                            \
+                                     public_t_key_len);                       \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)server_public_key_len);                        \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              server_public_key,              \
-                                              server_public_key_len);         \
+        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);          \
+        hok &= ssh2_hash_update(ctx, server_public_key,                       \
+                                     server_public_key_len);                  \
                                                                               \
-        hok &= ssh2_hash_update(ctx,                            \
-                                              exchange_state->k_value,        \
-                                              exchange_state->k_value_len);   \
+        hok &= ssh2_hash_update(ctx, exchange_state->k_value,                 \
+                                     exchange_state->k_value_len);            \
                                                                               \
         if(!hok ||                                                            \
-           !ssh2_hash_final(ctx, exchange_state->h_sig_comp,    \
-                                       sizeof(exchange_state->h_sig_comp))) { \
+           !ssh2_hash_final(ctx, exchange_state->h_sig_comp,                  \
+                            sizeof(exchange_state->h_sig_comp))) {            \
             rc = -1;                                                          \
             break;                                                            \
         }                                                                     \
@@ -2375,7 +2337,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
             }
 
             if(!ssh2_hash_final(k_ctx,
-                                  exchange_state->k_value + 4, digest_len)) {
+                                exchange_state->k_value + 4, digest_len)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                                "kex: failed to calculate hash");
                 goto clean_exit;
@@ -2398,7 +2360,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
             }
 
             if(!ssh2_hash_final(k_ctx,
-                                  exchange_state->k_value + 4, digest_len)) {
+                                exchange_state->k_value + 4, digest_len)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                                "kex: failed to calculate hash");
                 goto clean_exit;
@@ -3004,16 +2966,15 @@ static int mlkem768x25519_sha256(
         }
 
         if(!ssh2_hash_update(k_ctx, shared_secret,
-                               SSH2_MLKEM_SHARED_SECRET_LEN +
-                                   SSH2_ED25519_KEY_LEN)) {
+                             SSH2_MLKEM_SHARED_SECRET_LEN +
+                                 SSH2_ED25519_KEY_LEN)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
             goto clean_exit;
         }
 
-        if(!ssh2_hash_final(k_ctx,
-                              exchange_state->k_value + 4,
-                              SSH2_SHA256_DIG_LEN)) {
+        if(!ssh2_hash_final(k_ctx, exchange_state->k_value + 4,
+                            SSH2_SHA256_DIG_LEN)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
             goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -61,10 +61,10 @@
             size_t len = 0;                                                   \
             while(len < (size_t)(reqlen)) {                                   \
                 if(!ssh2_sha##digest_type##_init(&hash) ||                    \
-                   !ssh2_sha##digest_type##_update(hash,                      \
+                   !ssh2_hash_update(hash,                      \
                                            exchange_state->k_value,           \
                                            exchange_state->k_value_len) ||    \
-                   !ssh2_sha##digest_type##_update(hash,                      \
+                   !ssh2_hash_update(hash,                      \
                                          exchange_state->h_sig_comp,          \
                                          SSH2_SHA##digest_type##_DIG_LEN)) {  \
                     SSH2_FREE(session, value);                                \
@@ -72,15 +72,15 @@
                     break;                                                    \
                 }                                                             \
                 if(len > 0) {                                                 \
-                    if(!ssh2_sha##digest_type##_update(hash, value, len)) {   \
+                    if(!ssh2_hash_update(hash, value, len)) {   \
                         SSH2_FREE(session, value);                            \
                         (value) = NULL;                                       \
                         break;                                                \
                     }                                                         \
                 }                                                             \
                 else {                                                        \
-                    if(!ssh2_sha##digest_type##_update(hash, version, 1) ||   \
-                       !ssh2_sha##digest_type##_update(hash,                  \
+                    if(!ssh2_hash_update(hash, version, 1) ||   \
+                       !ssh2_hash_update(hash,                  \
                                                   session->session_id,        \
                                                   session->session_id_len)) { \
                         SSH2_FREE(session, value);                            \
@@ -88,7 +88,7 @@
                         break;                                                \
                     }                                                         \
                 }                                                             \
-                if(!ssh2_sha##digest_type##_final(hash, (value) + len,        \
+                if(!ssh2_hash_final(hash, (value) + len,        \
                                           SSH2_SHA##digest_type##_DIG_LEN)) { \
                     SSH2_FREE(session, value);                                \
                     (value) = NULL;                                           \
@@ -129,13 +129,13 @@ static int sha_algo_ctx_update(int sha_algo, void *ctx,
     ssh2_hash_ctx *_ctx = (ssh2_hash_ctx *)ctx;
 
     if(sha_algo == 512)
-        return ssh2_sha512_update(*_ctx, data, len);
+        return ssh2_hash_update(*_ctx, data, len);
     else if(sha_algo == 384)
-        return ssh2_sha384_update(*_ctx, data, len);
+        return ssh2_hash_update(*_ctx, data, len);
     else if(sha_algo == 256)
-        return ssh2_sha256_update(*_ctx, data, len);
+        return ssh2_hash_update(*_ctx, data, len);
     else if(sha_algo == 1)
-        return ssh2_sha1_update(*_ctx, data, len);
+        return ssh2_hash_update(*_ctx, data, len);
 #ifdef LIBSSH2DEBUG
     else
         assert(0);
@@ -149,13 +149,13 @@ static int sha_algo_ctx_final(int sha_algo, void *ctx,
     ssh2_hash_ctx *_ctx = (ssh2_hash_ctx *)ctx;
 
     if(sha_algo == 512)
-        return ssh2_sha512_final(*_ctx, hash, hashlen);
+        return ssh2_hash_final(*_ctx, hash, hashlen);
     else if(sha_algo == 384)
-        return ssh2_sha384_final(*_ctx, hash, hashlen);
+        return ssh2_hash_final(*_ctx, hash, hashlen);
     else if(sha_algo == 256)
-        return ssh2_sha256_final(*_ctx, hash, hashlen);
+        return ssh2_hash_final(*_ctx, hash, hashlen);
     else if(sha_algo == 1)
-        return ssh2_sha1_final(*_ctx, hash, hashlen);
+        return ssh2_hash_final(*_ctx, hash, hashlen);
 #ifdef LIBSSH2DEBUG
     else
         assert(0);
@@ -227,9 +227,9 @@ static int process_host_key(LIBSSH2_SESSION *session,
         ssh2_hash_ctx fingerprint_ctx;
 
         if(ssh2_md5_init(&fingerprint_ctx) &&
-           ssh2_md5_update(fingerprint_ctx, session->server_hostkey,
+           ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
                            session->server_hostkey_len) &&
-           ssh2_md5_final(fingerprint_ctx, session->server_hostkey_md5,
+           ssh2_hash_final(fingerprint_ctx, session->server_hostkey_md5,
                           sizeof(session->server_hostkey_md5)))
             session->server_hostkey_md5_valid = TRUE;
         else
@@ -253,9 +253,9 @@ static int process_host_key(LIBSSH2_SESSION *session,
         ssh2_hash_ctx fingerprint_ctx;
 
         if(ssh2_sha1_init(&fingerprint_ctx) &&
-           ssh2_sha1_update(fingerprint_ctx, session->server_hostkey,
+           ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
                             session->server_hostkey_len) &&
-           ssh2_sha1_final(fingerprint_ctx, session->server_hostkey_sha1,
+           ssh2_hash_final(fingerprint_ctx, session->server_hostkey_sha1,
                            sizeof(session->server_hostkey_sha1)))
             session->server_hostkey_sha1_valid = TRUE;
         else
@@ -278,9 +278,9 @@ static int process_host_key(LIBSSH2_SESSION *session,
         ssh2_hash_ctx fingerprint_ctx;
 
         if(ssh2_sha256_init(&fingerprint_ctx) &&
-           ssh2_sha256_update(fingerprint_ctx, session->server_hostkey,
+           ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
                               session->server_hostkey_len) &&
-           ssh2_sha256_final(fingerprint_ctx, session->server_hostkey_sha256,
+           ssh2_hash_final(fingerprint_ctx, session->server_hostkey_sha256,
                              sizeof(session->server_hostkey_sha256)))
             session->server_hostkey_sha256_valid = TRUE;
         else
@@ -1640,76 +1640,76 @@ static int kex_session_hybrid_curve_type(const char *name,
         if(session->local.banner) {                                           \
             ssh2_htonu32(exchange_state->h_sig_comp,                          \
                      (uint32_t)(strlen((char *)session->local.banner) - 2));  \
-            hok &= ssh2_sha##digest_type##_update(ctx,                        \
+            hok &= ssh2_hash_update(ctx,                        \
                                               exchange_state->h_sig_comp, 4); \
-            hok &= ssh2_sha##digest_type##_update(ctx,                        \
+            hok &= ssh2_hash_update(ctx,                        \
                                   (char *)session->local.banner,              \
                                   strlen((char *)session->local.banner) - 2); \
         }                                                                     \
         else {                                                                \
             ssh2_htonu32(exchange_state->h_sig_comp,                          \
                          sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);             \
-            hok &= ssh2_sha##digest_type##_update(ctx,                        \
+            hok &= ssh2_hash_update(ctx,                        \
                                               exchange_state->h_sig_comp, 4); \
-            hok &= ssh2_sha##digest_type##_update(ctx,                        \
+            hok &= ssh2_hash_update(ctx,                        \
                                      LIBSSH2_SSH_DEFAULT_BANNER,              \
                                      sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1); \
         }                                                                     \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)strlen((char *)session->remote.banner));       \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                      session->remote.banner,                  \
                                      strlen((char *)session->remote.banner)); \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)session->local.kexinit_len);                   \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               session->local.kexinit,         \
                                               session->local.kexinit_len);    \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)session->remote.kexinit_len);                  \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               session->remote.kexinit,        \
                                               session->remote.kexinit_len);   \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      session->server_hostkey_len);                            \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               session->server_hostkey,        \
                                               session->server_hostkey_len);   \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)public_key_len);                               \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               public_key,                     \
                                               public_key_len);                \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)server_public_key_len);                        \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               server_public_key,              \
                                               server_public_key_len);         \
                                                                               \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->k_value,        \
                                               exchange_state->k_value_len);   \
                                                                               \
         if(!hok ||                                                            \
-           !ssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp,    \
+           !ssh2_hash_final(ctx, exchange_state->h_sig_comp,    \
                                        sizeof(exchange_state->h_sig_comp))) { \
             rc = -1;                                                          \
             break;                                                            \
@@ -1756,79 +1756,79 @@ static int kex_session_hybrid_curve_type(const char *name,
         if(session->local.banner) {                                           \
             ssh2_htonu32(exchange_state->h_sig_comp,                          \
                      (uint32_t)(strlen((char *)session->local.banner) - 2));  \
-            hok &= ssh2_sha##digest_type##_update(ctx,                        \
+            hok &= ssh2_hash_update(ctx,                        \
                                               exchange_state->h_sig_comp, 4); \
-            hok &= ssh2_sha##digest_type##_update(ctx,                        \
+            hok &= ssh2_hash_update(ctx,                        \
                                   (char *)session->local.banner,              \
                                   strlen((char *)session->local.banner) - 2); \
         }                                                                     \
         else {                                                                \
             ssh2_htonu32(exchange_state->h_sig_comp,                          \
                          sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);             \
-            hok &= ssh2_sha##digest_type##_update(ctx,                        \
+            hok &= ssh2_hash_update(ctx,                        \
                                               exchange_state->h_sig_comp, 4); \
-            hok &= ssh2_sha##digest_type##_update(ctx,                        \
+            hok &= ssh2_hash_update(ctx,                        \
                                      LIBSSH2_SSH_DEFAULT_BANNER,              \
                                      sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1); \
         }                                                                     \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)strlen((char *)session->remote.banner));       \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                      session->remote.banner,                  \
                                      strlen((char *)session->remote.banner)); \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)session->local.kexinit_len);                   \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               session->local.kexinit,         \
                                               session->local.kexinit_len);    \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)session->remote.kexinit_len);                  \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               session->remote.kexinit,        \
                                               session->remote.kexinit_len);   \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      session->server_hostkey_len);                            \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               session->server_hostkey,        \
                                               session->server_hostkey_len);   \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)(public_pq_key_len + public_t_key_len));       \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               public_pq_key,                  \
                                               public_pq_key_len);             \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               public_t_key,                   \
                                               public_t_key_len);              \
                                                                               \
         ssh2_htonu32(exchange_state->h_sig_comp,                              \
                      (uint32_t)server_public_key_len);                        \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->h_sig_comp, 4); \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               server_public_key,              \
                                               server_public_key_len);         \
                                                                               \
-        hok &= ssh2_sha##digest_type##_update(ctx,                            \
+        hok &= ssh2_hash_update(ctx,                            \
                                               exchange_state->k_value,        \
                                               exchange_state->k_value_len);   \
                                                                               \
         if(!hok ||                                                            \
-           !ssh2_sha##digest_type##_final(ctx, exchange_state->h_sig_comp,    \
+           !ssh2_hash_final(ctx, exchange_state->h_sig_comp,    \
                                        sizeof(exchange_state->h_sig_comp))) { \
             rc = -1;                                                          \
             break;                                                            \
@@ -2368,13 +2368,13 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                 goto clean_exit;
             }
 
-            if(!ssh2_sha256_update(k_ctx, shared_secret, shared_secret_len)) {
+            if(!ssh2_hash_update(k_ctx, shared_secret, shared_secret_len)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                                "kex: failed to calculate hash");
                 goto clean_exit;
             }
 
-            if(!ssh2_sha256_final(k_ctx,
+            if(!ssh2_hash_final(k_ctx,
                                   exchange_state->k_value + 4, digest_len)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                                "kex: failed to calculate hash");
@@ -2391,13 +2391,13 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                 goto clean_exit;
             }
 
-            if(!ssh2_sha384_update(k_ctx, shared_secret, shared_secret_len)) {
+            if(!ssh2_hash_update(k_ctx, shared_secret, shared_secret_len)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                                "kex: failed to calculate hash");
                 goto clean_exit;
             }
 
-            if(!ssh2_sha384_final(k_ctx,
+            if(!ssh2_hash_final(k_ctx,
                                   exchange_state->k_value + 4, digest_len)) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                                "kex: failed to calculate hash");
@@ -3003,7 +3003,7 @@ static int mlkem768x25519_sha256(
             goto clean_exit;
         }
 
-        if(!ssh2_sha256_update(k_ctx, shared_secret,
+        if(!ssh2_hash_update(k_ctx, shared_secret,
                                SSH2_MLKEM_SHARED_SECRET_LEN +
                                    SSH2_ED25519_KEY_LEN)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
@@ -3011,7 +3011,7 @@ static int mlkem768x25519_sha256(
             goto clean_exit;
         }
 
-        if(!ssh2_sha256_final(k_ctx,
+        if(!ssh2_hash_final(k_ctx,
                               exchange_state->k_value + 4,
                               SSH2_SHA256_DIG_LEN)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -74,6 +74,7 @@
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
 #define ssh2_hash_ctx gcry_md_hd_t
+#define ssh2_hash_alg int
 
 #define SSH2_SHA1_ALG   GCRY_MD_SHA1
 #define SSH2_SHA256_ALG GCRY_MD_SHA256

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -75,6 +75,20 @@
 
 #define ssh2_hash_ctx gcry_md_hd_t
 
+#define SSH2_SHA1_ALG   GCRY_MD_SHA1
+#define SSH2_SHA256_ALG GCRY_MD_SHA256
+#define SSH2_SHA384_ALG GCRY_MD_SHA384
+#define SSH2_SHA512_ALG GCRY_MD_SHA512
+#define SSH2_MD5_ALG    GCRY_MD_MD5
+
+/* returns 0 in case of failure */
+#define ssh2_hash_init(ctx, id) \
+    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, id, 0))
+#define ssh2_hash_update(ctx, data, len) \
+    (gcry_md_write(ctx, data, len), 1)
+#define ssh2_hash_final(ctx, out, len) \
+    ssh2_lgcr_hash_final(ctx, out, len)
+
 /* returns 0 in case of failure */
 #define ssh2_sha1_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA1, 0))

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -84,12 +84,12 @@
 #endif
 
 /* returns 0 in case of failure */
-#define ssh2_hash_init(ctx, alg) \
-    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, alg, 0))
-#define ssh2_hash_update(ctx, data, len) \
-    (gcry_md_write(ctx, data, len), 1)
-#define ssh2_hash_final(ctx, out, len) \
-    ssh2_lgcr_hash_final(ctx, out, len)
+#define ssh2_hash_init(pctx, alg) \
+    (gcry_md_open(pctx, alg, 0) == GPG_ERR_NO_ERROR)
+#define ssh2_hash_update(ctx, d, l) \
+    (gcry_md_write(ctx, d, l), 1)
+#define ssh2_hash_final(ctx, h, l) \
+    ssh2_lgcr_hash_final(ctx, h, l)
 
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len);
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -84,8 +84,8 @@
 #endif
 
 /* returns 0 in case of failure */
-#define ssh2_hash_init(ctx, id) \
-    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, id, 0))
+#define ssh2_hash_init(ctx, alg) \
+    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, alg, 0))
 #define ssh2_hash_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_hash_final(ctx, out, len) \

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -79,7 +79,9 @@
 #define SSH2_SHA256_ALG GCRY_MD_SHA256
 #define SSH2_SHA384_ALG GCRY_MD_SHA384
 #define SSH2_SHA512_ALG GCRY_MD_SHA512
+#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_ALG    GCRY_MD_MD5
+#endif
 
 /* returns 0 in case of failure */
 #define ssh2_hash_init(ctx, id) \
@@ -88,44 +90,6 @@
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_hash_final(ctx, out, len) \
     ssh2_lgcr_hash_final(ctx, out, len)
-
-/* returns 0 in case of failure */
-#define ssh2_sha1_init(ctx) \
-    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA1, 0))
-#define ssh2_sha1_update(ctx, data, len) \
-    (gcry_md_write(ctx, data, len), 1)
-#define ssh2_sha1_final(ctx, out, len) \
-    ssh2_lgcr_hash_final(ctx, out, len)
-
-#define ssh2_sha256_init(ctx) \
-    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA256, 0))
-#define ssh2_sha256_update(ctx, data, len) \
-    (gcry_md_write(ctx, data, len), 1)
-#define ssh2_sha256_final(ctx, out, len) \
-    ssh2_lgcr_hash_final(ctx, out, len)
-
-#define ssh2_sha384_init(ctx) \
-    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA384, 0))
-#define ssh2_sha384_update(ctx, data, len) \
-    (gcry_md_write(ctx, data, len), 1)
-#define ssh2_sha384_final(ctx, out, len) \
-    ssh2_lgcr_hash_final(ctx, out, len)
-
-#define ssh2_sha512_init(ctx) \
-    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA512, 0))
-#define ssh2_sha512_update(ctx, data, len) \
-    (gcry_md_write(ctx, data, len), 1)
-#define ssh2_sha512_final(ctx, out, len) \
-    ssh2_lgcr_hash_final(ctx, out, len)
-
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_init(ctx) \
-    (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_MD5, 0))
-#define ssh2_md5_update(ctx, data, len) \
-    (gcry_md_write(ctx, data, len), 1)
-#define ssh2_md5_final(ctx, out, len) \
-    ssh2_lgcr_hash_final(ctx, out, len)
-#endif
 
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len);
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -143,6 +143,7 @@ struct mbed_hash_ctx {
  */
 
 #define ssh2_hash_ctx psa_hash_operation_t
+#define ssh2_hash_alg psa_algorithm_t
 
 #define SSH2_SHA1_ALG   PSA_ALG_SHA_1
 #define SSH2_SHA256_ALG PSA_ALG_SHA_256

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -148,7 +148,9 @@ struct mbed_hash_ctx {
 #define SSH2_SHA256_ALG PSA_ALG_SHA_256
 #define SSH2_SHA384_ALG PSA_ALG_SHA_384
 #define SSH2_SHA512_ALG PSA_ALG_SHA_512
+#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_ALG    PSA_ALG_MD5
+#endif
 
 #define ssh2_hash_init(pctx, id) \
     ssh2_mbed_hash_init(pctx, id)
@@ -156,43 +158,6 @@ struct mbed_hash_ctx {
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_hash_final(ctx, hash, hashlen) \
     ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-
-#define ssh2_sha1_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
-#define ssh2_sha1_update(ctx, data, datalen) \
-    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_sha1_final(ctx, hash, hashlen) \
-    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-
-#define ssh2_sha256_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_256)
-#define ssh2_sha256_update(ctx, data, datalen) \
-    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_sha256_final(ctx, hash, hashlen) \
-    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-
-#define ssh2_sha384_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_384)
-#define ssh2_sha384_update(ctx, data, datalen) \
-    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_sha384_final(ctx, hash, hashlen) \
-    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-
-#define ssh2_sha512_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_512)
-#define ssh2_sha512_update(ctx, data, datalen) \
-    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_sha512_final(ctx, hash, hashlen) \
-    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_init(pctx) \
-    ssh2_mbed_hash_init(pctx, PSA_ALG_MD5)
-#define ssh2_md5_update(ctx, data, datalen) \
-    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_md5_final(ctx, hash, hashlen) \
-    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
-#endif
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -154,10 +154,10 @@ struct mbed_hash_ctx {
 
 #define ssh2_hash_init(pctx, alg) \
     ssh2_mbed_hash_init(pctx, alg)
-#define ssh2_hash_update(ctx, data, datalen) \
-    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
-#define ssh2_hash_final(ctx, hash, hashlen) \
-    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
+#define ssh2_hash_update(ctx, d, l) \
+    (psa_hash_update(&(ctx), (const uint8_t *)(d), l) == PSA_SUCCESS)
+#define ssh2_hash_final(ctx, h, l) \
+    ssh2_mbed_hash_final(&(ctx), h, l)
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -144,6 +144,19 @@ struct mbed_hash_ctx {
 
 #define ssh2_hash_ctx psa_hash_operation_t
 
+#define SSH2_SHA1_ALG   PSA_ALG_SHA_1
+#define SSH2_SHA256_ALG PSA_ALG_SHA_256
+#define SSH2_SHA384_ALG PSA_ALG_SHA_384
+#define SSH2_SHA512_ALG PSA_ALG_SHA_512
+#define SSH2_MD5_ALG    PSA_ALG_MD5
+
+#define ssh2_hash_init(pctx, id) \
+    ssh2_mbed_hash_init(pctx, id)
+#define ssh2_hash_update(ctx, data, datalen) \
+    (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
+#define ssh2_hash_final(ctx, hash, hashlen) \
+    ssh2_mbed_hash_final(&(ctx), hash, hashlen)
+
 #define ssh2_sha1_init(pctx) \
     ssh2_mbed_hash_init(pctx, PSA_ALG_SHA_1)
 #define ssh2_sha1_update(ctx, data, datalen) \

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -152,8 +152,8 @@ struct mbed_hash_ctx {
 #define SSH2_MD5_ALG    PSA_ALG_MD5
 #endif
 
-#define ssh2_hash_init(pctx, id) \
-    ssh2_mbed_hash_init(pctx, id)
+#define ssh2_hash_init(pctx, alg) \
+    ssh2_mbed_hash_init(pctx, alg)
 #define ssh2_hash_update(ctx, data, datalen) \
     (psa_hash_update(&(ctx), (const uint8_t *)(data), datalen) == PSA_SUCCESS)
 #define ssh2_hash_final(ctx, hash, hashlen) \

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -58,6 +58,21 @@ void ssh2_crypto_init(void)
 
 int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
 {
+#if !defined(USE_OPENSSL_3) && \
+    !defined(LIBRESSL_VERSION_NUMBER) && \
+    !defined(LIBSSH2_WOLFSSL)
+    /* OpenSSL 1.1.1
+     * MD5 digest is not supported in OpenSSL FIPS mode
+     * Trying to init it results in a latent OpenSSL error:
+     * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"
+     * Thus, return 0 in FIPS mode
+     */
+    if(digest == EVP_md5() && FIPS_mode()) {
+        *ctx = NULL;
+        return 0;
+    }
+#endif
+
     *ctx = EVP_MD_CTX_new();
 
     if(!*ctx)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -233,6 +233,7 @@ int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len);
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 
 #define ssh2_hash_ctx                 EVP_MD_CTX *
+#define ssh2_hash_alg                 const EVP_MD *
 
 #define SSH2_SHA1_ALG   EVP_sha1()
 #define SSH2_SHA256_ALG EVP_sha256()

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -245,7 +245,7 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 #define SSH2_MD5_ALG    EVP_md5()
 #endif
 
-#define ssh2_hash_init(x, id)         ssh2_ossl_hash_init(x, id)
+#define ssh2_hash_init(x, alg)        ssh2_ossl_hash_init(x, alg)
 #define ssh2_hash_update(ctx, d, l)   ssh2_ossl_hash_update(&(ctx), d, l)
 #define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -245,7 +245,7 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 #define SSH2_MD5_ALG    EVP_md5()
 #endif
 
-#define ssh2_hash_init(x, alg)        ssh2_ossl_hash_init(x, alg)
+#define ssh2_hash_init(pctx, alg)     ssh2_ossl_hash_init(pctx, alg)
 #define ssh2_hash_update(ctx, d, l)   ssh2_ossl_hash_update(&(ctx), d, l)
 #define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -237,6 +237,16 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 
 #define ssh2_hash_ctx                 EVP_MD_CTX *
 
+#define SSH2_SHA1_ALG   EVP_sha1()
+#define SSH2_SHA256_ALG EVP_sha256()
+#define SSH2_SHA384_ALG EVP_sha384()
+#define SSH2_SHA512_ALG EVP_sha512()
+#define SSH2_MD5_ALG    EVP_md5()
+
+#define ssh2_hash_init(x, id)         ssh2_ossl_hash_init(x, id)
+#define ssh2_hash_update(ctx, d, l)   ssh2_ossl_hash_update(&(ctx), d, l)
+#define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)
+
 #define ssh2_sha1_init(x)             ssh2_ossl_hash_init(x, EVP_sha1())
 #define ssh2_sha1_update(ctx, d, l)   ssh2_ossl_hash_update(&(ctx), d, l)
 #define ssh2_sha1_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -241,43 +241,13 @@ int ssh2_ossl_hash(const unsigned char *message, size_t len,
 #define SSH2_SHA256_ALG EVP_sha256()
 #define SSH2_SHA384_ALG EVP_sha384()
 #define SSH2_SHA512_ALG EVP_sha512()
+#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_ALG    EVP_md5()
+#endif
 
 #define ssh2_hash_init(x, id)         ssh2_ossl_hash_init(x, id)
 #define ssh2_hash_update(ctx, d, l)   ssh2_ossl_hash_update(&(ctx), d, l)
 #define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)
-
-#define ssh2_sha1_init(x)             ssh2_ossl_hash_init(x, EVP_sha1())
-#define ssh2_sha1_update(ctx, d, l)   ssh2_ossl_hash_update(&(ctx), d, l)
-#define ssh2_sha1_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)
-#define ssh2_sha256_init(x)           ssh2_ossl_hash_init(x, EVP_sha256())
-#define ssh2_sha256_update(ctx, d, l) ssh2_ossl_hash_update(&(ctx), d, l)
-#define ssh2_sha256_final(ctx, h, l)  ssh2_ossl_hash_final(&(ctx), h, l)
-#define ssh2_sha384_init(x)           ssh2_ossl_hash_init(x, EVP_sha384())
-#define ssh2_sha384_update(ctx, d, l) ssh2_ossl_hash_update(&(ctx), d, l)
-#define ssh2_sha384_final(ctx, h, l)  ssh2_ossl_hash_final(&(ctx), h, l)
-#define ssh2_sha512_init(x)           ssh2_ossl_hash_init(x, EVP_sha512())
-#define ssh2_sha512_update(ctx, d, l) ssh2_ossl_hash_update(&(ctx), d, l)
-#define ssh2_sha512_final(ctx, h, l)  ssh2_ossl_hash_final(&(ctx), h, l)
-
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-/* MD5 digest is not supported in OpenSSL FIPS mode
- * Trying to init it results in a latent OpenSSL error:
- * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"
- * Thus, return 0 in FIPS mode
- */
-#if !defined(USE_OPENSSL_3) && \
-    !defined(LIBRESSL_VERSION_NUMBER) && \
-    !defined(LIBSSH2_WOLFSSL)
-/* OpenSSL 1.1.1 */
-#define ssh2_md5_init(x) \
-    (FIPS_mode() ? (*(x) = NULL, 0) : ssh2_ossl_hash_init(x, EVP_md5()))
-#else
-#define ssh2_md5_init(x)              ssh2_ossl_hash_init(x, EVP_md5())
-#endif
-#define ssh2_md5_update(ctx, d, l)    ssh2_ossl_hash_update(&(ctx), d, l)
-#define ssh2_md5_final(ctx, h, l)     ssh2_ossl_hash_final(&(ctx), h, l)
-#endif /* LIBSSH2_MD5 || LIBSSH2_MD5_PEM */
 
 #ifdef USE_OPENSSL_3
 #define ssh2_hmac_ctx EVP_MAC_CTX *

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -231,9 +231,6 @@ int ssh2_random(unsigned char *buf, size_t len);
 int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest);
 int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len);
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
-/* returns 1 in case of failure */
-int ssh2_ossl_hash(const unsigned char *message, size_t len,
-                   unsigned char *out, const EVP_MD *digest);
 
 #define ssh2_hash_ctx                 EVP_MD_CTX *
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -241,7 +241,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define SSH2_MD5_ALG    Qc3_MD5
 #endif
 
-#define ssh2_hash_init(x, id)        ssh2_os400qc3_hash_init(x, id)
+#define ssh2_hash_init(x, alg)       ssh2_os400qc3_hash_init(x, alg)
 #define ssh2_hash_update(ctx, d, l)  ssh2_os400qc3_hash_update(&(ctx), d, l)
 #define ssh2_hash_final(ctx, h, l)   ssh2_os400qc3_hash_final(&(ctx), h, l)
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -230,6 +230,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_crypto_exit()   do {} while(0)
 
 #define ssh2_hash_ctx        Qc3_Format_ALGD0100_T
+#define ssh2_hash_alg        unsigned int
 #define ssh2_hmac_ctx        struct os400qc3_crypto_ctx
 #define ssh2_cipher_ctx      struct os400qc3_crypto_ctx
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -233,6 +233,16 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_hmac_ctx        struct os400qc3_crypto_ctx
 #define ssh2_cipher_ctx      struct os400qc3_crypto_ctx
 
+#define SSH2_SHA1_ALG   Qc3_SHA1
+#define SSH2_SHA256_ALG Qc3_SHA256
+#define SSH2_SHA384_ALG Qc3_SHA384
+#define SSH2_SHA512_ALG Qc3_SHA512
+#define SSH2_MD5_ALG    Qc3_MD5
+
+#define ssh2_hash_init(x, id)         ssh2_os400qc3_hash_init(x, id)
+#define ssh2_hash_update(ctx, d, l)   ssh2_os400qc3_hash_update(&(ctx), d, l)
+#define ssh2_hash_final(ctx, h, l)    ssh2_os400qc3_hash_final(&(ctx), h, l)
+
 #define ssh2_sha1_init(x)             ssh2_os400qc3_hash_init(x, Qc3_SHA1)
 #define ssh2_sha1_update(ctx, d, l)   ssh2_os400qc3_hash_update(&(ctx), d, l)
 #define ssh2_sha1_final(ctx, h, l)    ssh2_os400qc3_hash_final(&(ctx), h, l)

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -237,29 +237,13 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define SSH2_SHA256_ALG Qc3_SHA256
 #define SSH2_SHA384_ALG Qc3_SHA384
 #define SSH2_SHA512_ALG Qc3_SHA512
-#define SSH2_MD5_ALG    Qc3_MD5
-
-#define ssh2_hash_init(x, id)         ssh2_os400qc3_hash_init(x, id)
-#define ssh2_hash_update(ctx, d, l)   ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_hash_final(ctx, h, l)    ssh2_os400qc3_hash_final(&(ctx), h, l)
-
-#define ssh2_sha1_init(x)             ssh2_os400qc3_hash_init(x, Qc3_SHA1)
-#define ssh2_sha1_update(ctx, d, l)   ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_sha1_final(ctx, h, l)    ssh2_os400qc3_hash_final(&(ctx), h, l)
-#define ssh2_sha256_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA256)
-#define ssh2_sha256_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_sha256_final(ctx, h, l)  ssh2_os400qc3_hash_final(&(ctx), h, l)
-#define ssh2_sha384_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA384)
-#define ssh2_sha384_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_sha384_final(ctx, h, l)  ssh2_os400qc3_hash_final(&(ctx), h, l)
-#define ssh2_sha512_init(x)           ssh2_os400qc3_hash_init(x, Qc3_SHA512)
-#define ssh2_sha512_update(ctx, d, l) ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_sha512_final(ctx, h, l)  ssh2_os400qc3_hash_final(&(ctx), h, l)
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_init(x)              ssh2_os400qc3_hash_init(x, Qc3_MD5)
-#define ssh2_md5_update(ctx, d, l)    ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_md5_final(ctx, h, l)     ssh2_os400qc3_hash_final(&(ctx), h, l)
+#define SSH2_MD5_ALG    Qc3_MD5
 #endif
+
+#define ssh2_hash_init(x, id)        ssh2_os400qc3_hash_init(x, id)
+#define ssh2_hash_update(ctx, d, l)  ssh2_os400qc3_hash_update(&(ctx), d, l)
+#define ssh2_hash_final(ctx, h, l)   ssh2_os400qc3_hash_final(&(ctx), h, l)
 
 int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algo);
 int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -241,7 +241,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define SSH2_MD5_ALG    Qc3_MD5
 #endif
 
-#define ssh2_hash_init(x, alg)       ssh2_os400qc3_hash_init(x, alg)
+#define ssh2_hash_init(pctx, alg)    ssh2_os400qc3_hash_init(pctx, alg)
 #define ssh2_hash_update(ctx, d, l)  ssh2_os400qc3_hash_update(&(ctx), d, l)
 #define ssh2_hash_final(ctx, h, l)   ssh2_os400qc3_hash_final(&(ctx), h, l)
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -286,7 +286,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         /* Perform key derivation (PBKDF1/MD5) */
         if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) ||
            !ssh2_hash_update(fingerprint_ctx, passphrase,
-                            strlen((const char *)passphrase)) ||
+                             strlen((const char *)passphrase)) ||
            !ssh2_hash_update(fingerprint_ctx, iv, 8) ||
            !ssh2_hash_final(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN)) {
             ret = -1;
@@ -294,13 +294,12 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         }
         if(method->secret_len > SSH2_MD5_DIG_LEN) {
             if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) ||
-               !ssh2_hash_update(fingerprint_ctx, secret,
-                                SSH2_MD5_DIG_LEN) ||
+               !ssh2_hash_update(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN) ||
                !ssh2_hash_update(fingerprint_ctx, passphrase,
-                                strlen((const char *)passphrase)) ||
+                                 strlen((const char *)passphrase)) ||
                !ssh2_hash_update(fingerprint_ctx, iv, 8) ||
                !ssh2_hash_final(fingerprint_ctx,
-                               secret + SSH2_MD5_DIG_LEN, SSH2_MD5_DIG_LEN)) {
+                                secret + SSH2_MD5_DIG_LEN, SSH2_MD5_DIG_LEN)) {
                 ret = -1;
                 goto out;
             }

--- a/src/pem.c
+++ b/src/pem.c
@@ -285,21 +285,21 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
 
         /* Perform key derivation (PBKDF1/MD5) */
         if(!ssh2_md5_init(&fingerprint_ctx) ||
-           !ssh2_md5_update(fingerprint_ctx, passphrase,
+           !ssh2_hash_update(fingerprint_ctx, passphrase,
                             strlen((const char *)passphrase)) ||
-           !ssh2_md5_update(fingerprint_ctx, iv, 8) ||
-           !ssh2_md5_final(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN)) {
+           !ssh2_hash_update(fingerprint_ctx, iv, 8) ||
+           !ssh2_hash_final(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN)) {
             ret = -1;
             goto out;
         }
         if(method->secret_len > SSH2_MD5_DIG_LEN) {
             if(!ssh2_md5_init(&fingerprint_ctx) ||
-               !ssh2_md5_update(fingerprint_ctx, secret,
+               !ssh2_hash_update(fingerprint_ctx, secret,
                                 SSH2_MD5_DIG_LEN) ||
-               !ssh2_md5_update(fingerprint_ctx, passphrase,
+               !ssh2_hash_update(fingerprint_ctx, passphrase,
                                 strlen((const char *)passphrase)) ||
-               !ssh2_md5_update(fingerprint_ctx, iv, 8) ||
-               !ssh2_md5_final(fingerprint_ctx,
+               !ssh2_hash_update(fingerprint_ctx, iv, 8) ||
+               !ssh2_hash_final(fingerprint_ctx,
                                secret + SSH2_MD5_DIG_LEN, SSH2_MD5_DIG_LEN)) {
                 ret = -1;
                 goto out;

--- a/src/pem.c
+++ b/src/pem.c
@@ -284,7 +284,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         ssh2_hash_ctx fingerprint_ctx;
 
         /* Perform key derivation (PBKDF1/MD5) */
-        if(!ssh2_md5_init(&fingerprint_ctx) ||
+        if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) ||
            !ssh2_hash_update(fingerprint_ctx, passphrase,
                             strlen((const char *)passphrase)) ||
            !ssh2_hash_update(fingerprint_ctx, iv, 8) ||
@@ -293,7 +293,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
             goto out;
         }
         if(method->secret_len > SSH2_MD5_DIG_LEN) {
-            if(!ssh2_md5_init(&fingerprint_ctx) ||
+            if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) ||
                !ssh2_hash_update(fingerprint_ctx, secret,
                                 SSH2_MD5_DIG_LEN) ||
                !ssh2_hash_update(fingerprint_ctx, passphrase,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -162,6 +162,7 @@ struct wcng_hash_ctx {
  */
 
 #define ssh2_hash_ctx struct wcng_hash_ctx
+#define ssh2_hash_alg BCRYPT_ALG_HANDLE
 
 #define SSH2_SHA1_ALG   ssh2_wcng.hAlgHashSHA1
 #define SSH2_SHA256_ALG ssh2_wcng.hAlgHashSHA256

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -163,6 +163,19 @@ struct wcng_hash_ctx {
 
 #define ssh2_hash_ctx struct wcng_hash_ctx
 
+#define SSH2_SHA1_ALG   ssh2_wcng.hAlgHashSHA1
+#define SSH2_SHA256_ALG ssh2_wcng.hAlgHashSHA256
+#define SSH2_SHA384_ALG ssh2_wcng.hAlgHashSHA384
+#define SSH2_SHA512_ALG ssh2_wcng.hAlgHashSHA512
+#define SSH2_MD5_ALG    ssh2_wcng.hAlgHashMD5
+
+#define ssh2_hash_init(ctx, id) \
+    (ssh2_wcng_hash_init(ctx, id, NULL, 0) == 0)
+#define ssh2_hash_update(ctx, data, datalen) \
+    (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
+#define ssh2_hash_final(ctx, hash, hashlen) \
+    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
+
 #define ssh2_sha1_init(ctx) \
     (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA1, NULL, 0) == 0)
 #define ssh2_sha1_update(ctx, data, datalen) \

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -172,8 +172,8 @@ struct wcng_hash_ctx {
 #endif
 
 /* FIXME: sync worker return values with ssh2_hash_* expectations */
-#define ssh2_hash_init(ctx, id) \
-    (ssh2_wcng_hash_init(ctx, id, NULL, 0) == 0)
+#define ssh2_hash_init(ctx, alg) \
+    (ssh2_wcng_hash_init(ctx, alg, NULL, 0) == 0)
 #define ssh2_hash_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_hash_final(ctx, hash, hashlen) \

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -172,12 +172,12 @@ struct wcng_hash_ctx {
 #endif
 
 /* FIXME: sync worker return values with ssh2_hash_* expectations */
-#define ssh2_hash_init(ctx, alg) \
-    (ssh2_wcng_hash_init(ctx, alg, NULL, 0) == 0)
-#define ssh2_hash_update(ctx, data, datalen) \
-    (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_hash_final(ctx, hash, hashlen) \
-    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
+#define ssh2_hash_init(pctx, alg) \
+    (ssh2_wcng_hash_init(pctx, alg, NULL, 0) == 0)
+#define ssh2_hash_update(ctx, d, l) \
+    (ssh2_wcng_hash_update(&(ctx), d, (ULONG)(l)) == 0)
+#define ssh2_hash_final(ctx, h, l) \
+    (ssh2_wcng_hash_final(&(ctx), h, l) == 0)
 
 int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
                         unsigned char *key, ULONG keylen);

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -167,51 +167,17 @@ struct wcng_hash_ctx {
 #define SSH2_SHA256_ALG ssh2_wcng.hAlgHashSHA256
 #define SSH2_SHA384_ALG ssh2_wcng.hAlgHashSHA384
 #define SSH2_SHA512_ALG ssh2_wcng.hAlgHashSHA512
+#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_ALG    ssh2_wcng.hAlgHashMD5
+#endif
 
+/* FIXME: sync worker return values with ssh2_hash_* expectations */
 #define ssh2_hash_init(ctx, id) \
     (ssh2_wcng_hash_init(ctx, id, NULL, 0) == 0)
 #define ssh2_hash_update(ctx, data, datalen) \
     (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
 #define ssh2_hash_final(ctx, hash, hashlen) \
     (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-
-#define ssh2_sha1_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA1, NULL, 0) == 0)
-#define ssh2_sha1_update(ctx, data, datalen) \
-    (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_sha1_final(ctx, hash, hashlen) \
-    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-
-#define ssh2_sha256_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA256, NULL, 0) == 0)
-#define ssh2_sha256_update(ctx, data, datalen) \
-    (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_sha256_final(ctx, hash, hashlen) \
-    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-
-#define ssh2_sha384_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA384, NULL, 0) == 0)
-#define ssh2_sha384_update(ctx, data, datalen) \
-    (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_sha384_final(ctx, hash, hashlen) \
-    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-
-#define ssh2_sha512_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashSHA512, NULL, 0) == 0)
-#define ssh2_sha512_update(ctx, data, datalen) \
-    (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_sha512_final(ctx, hash, hashlen) \
-    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-
-#if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define ssh2_md5_init(ctx) \
-    (ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHashMD5, NULL, 0) == 0)
-#define ssh2_md5_update(ctx, data, datalen) \
-    (ssh2_wcng_hash_update(&(ctx), data, (ULONG)(datalen)) == 0)
-#define ssh2_md5_final(ctx, hash, hashlen) \
-    (ssh2_wcng_hash_final(&(ctx), hash, hashlen) == 0)
-#endif
 
 int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
                         unsigned char *key, ULONG keylen);


### PR DESCRIPTION
Replace per-hash-algo macros with a unified set, named
`ssh2_hash_{initupdate,final}()`. The init macro expects the algorithm
(`SSH2_*_ALG`). Update and final functions are the same for all. This 
layout allows more flexibility for callers, because the only two things
changing between hash algos is an init argument and the digest buffer
size. Also add a generic type to hold the ALG macros: `ssh2_hash_alg`.

This gives room to many streamlining, which will be done in a series of
follow-up patches (originally tested together in this PR): factor out
and merge large helper macros, hash dispatchers, replace hash selectors 
with ALG macros, and some more.

Also:
- openssl: replicate MD5 FIPS logic for OpenSSL 1.1.1 in the hash init
  function. (It isn't super ideal, but since both 1.1.1 and MD5 are on
  their way out, I deem it fine.)

Follow-up to 542567d19dadd6fcd5914cde947f5b7db1defcea #2169
Follow-up to b72f144177c6e476ed47464b3900688f9c2f2cc6 #2166
Follow-up to bae63c334990ab42510c4c0742124c080b746926 #2165
Follow-up to 409cbad69bf9cc71c069e628b005e714bf9b456c #2163

---

Moved to separate PRs:

After this change, simplify code accordingly:
- kex: drop local dispatcher functions re-implementing this effect
  with runtime branching.
- factor out large helper macros solving the dispatching via
  the preprocessor prior to this patch. Also reducing binary size and
  making the source code easier to maintain.
  - kex: `KEX_METHOD_HYBRID_SHA_HASH_CREATE_VERIFY()`
  - kex: `KEX_METHOD_EC_SHA_HASH_CREATE_VERIFY()`
  - kex: `KEX_METHOD_SHA_VALUE_HASH()`
  - hostkey: `HOSTKEY_METHOD_EC_SIGNV_HASH()`
- kex: merge EC and EC+PQ `kex_method_*_hash_create_verify()` functions
  into one.

There is more code that can be streamlined after this, where the hash
type is passed around as an integer (number of sha bits) and branches
off to select ALG and size. Also a helper to translate ALG to size may
simplify. Also the thin wrapper macros may be dropped for most backends.
`void *` can also be replaced with `ssh2_hash_ctx` type in some places.
Subjects to future PRs.

- [ ] split into multiple PRs.
