### PR TITLE
libgcrypt: improve `ssh2_md5_final()`

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -44,11 +44,14 @@
 
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len)
 {
-    (void)len;
-    memcpy(hash, gcry_md_read(ctx, 0),
-           gcry_md_get_algo_dlen(gcry_md_get_algo(ctx)));
+    int ret = 0;
+    unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(ctx));
+    if(len >= digest_len) {
+        memcpy(hash, gcry_md_read(ctx, 0), digest_len);
+        ret = 1;
+    }
     gcry_md_close(ctx);
-    return 1;
+    return ret;
 }
 
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -42,6 +42,19 @@
 
 #ifdef LIBSSH2_LIBGCRYPT
 
+int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len)
+{
+    unsigned char *res = gcry_md_read(ctx, 0);
+    (void)len;
+
+    if(!res)
+        return 0;
+
+    memcpy(hash, res, gcry_md_get_algo_dlen(gcry_md_get_algo(ctx)));
+    gcry_md_close(ctx);
+    return 1;
+}
+
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 {
     *ctx = NULL;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -44,13 +44,9 @@
 
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len)
 {
-    unsigned char *res = gcry_md_read(ctx, 0);
     (void)len;
-
-    if(!res)
-        return 0;
-
-    memcpy(hash, res, gcry_md_get_algo_dlen(gcry_md_get_algo(ctx)));
+    memcpy(hash, gcry_md_read(ctx, 0),
+           gcry_md_get_algo_dlen(gcry_md_get_algo(ctx)));
     gcry_md_close(ctx);
     return 1;
 }

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -81,28 +81,28 @@
 #define ssh2_sha1_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha1_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
+    ssh2_lgcr_hash_final(ctx, out, len)
 
 #define ssh2_sha256_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA256, 0))
 #define ssh2_sha256_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha256_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
+    ssh2_lgcr_hash_final(ctx, out, len)
 
 #define ssh2_sha384_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA384, 0))
 #define ssh2_sha384_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha384_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
+    ssh2_lgcr_hash_final(ctx, out, len)
 
 #define ssh2_sha512_init(ctx) \
     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA512, 0))
 #define ssh2_sha512_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_sha512_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
+    ssh2_lgcr_hash_final(ctx, out, len)
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define ssh2_md5_init(ctx) \
@@ -110,8 +110,10 @@
 #define ssh2_md5_update(ctx, data, len) \
     (gcry_md_write(ctx, data, len), 1)
 #define ssh2_md5_final(ctx, out, len) \
-    (memcpy(out, gcry_md_read(ctx, 0), len), gcry_md_close(ctx), 1)
+    ssh2_lgcr_hash_final(ctx, out, len)
 #endif
+
+int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len);
 
 #define ssh2_hmac_ctx         gcry_md_hd_t
 


### PR DESCRIPTION
Fix to not overread the libgcrypt digest buffer when passing an output
buffer larger than that.

After recent changes `ssh2_hash_final()` function may receive the size
of the digest target buffer, not necessarily the actual size of the
digest.

Also return an error if the output buffer cannot fit the digest.

Bug: https://github.com/libssh2/libssh2/pull/2171#discussion_r3509935294
