### PR TITLE
GHA: fix and re-enable Libgcrypt tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
 
   build_linux:
     name: 'linux'
-    runs-on: ${{ matrix.compiler == 'clang-tidy' && 'ubuntu-26.04' || (matrix.image || 'ubuntu-latest') }}
+    runs-on: ${{ (matrix.compiler == 'clang-tidy' && matrix.crypto != 'Libgcrypt') && 'ubuntu-26.04' || (matrix.image || 'ubuntu-latest') }}
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,14 +617,20 @@ jobs:
           fi
 
       - name: 'tests'
-        if: ${{ !matrix.target && matrix.crypto != 'Libgcrypt' }}
+        if: ${{ !matrix.target }}
         timeout-minutes: 10
         run: |
           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
             export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures
           fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
-            export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
+            export OPENSSH_SERVER_IMAGE
+            if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ]; then
+              # use debian:bookworm for diffie-hellman-group* KEXs
+              OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:98199e448a94451491c4
+            else
+              OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
+            fi
             [ -d "$HOME"/usr ] && export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/usr/lib"
             cd bld && ctest -VV --output-on-failure
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,9 +573,8 @@ jobs:
               options+=' -DCMAKE_C_STANDARD=90'
               cflags+=' -D_DEFAULT_SOURCE'  # for glibc ISO mode, in tests: popen(), pclose(), in examples: fileno(), tcsetattr()
             fi
-            if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ]; then
-              #options+=' -DRUN_SSHD_TESTS=OFF'  # they crash on Ubuntu 26.04
-              options+=' -DENABLE_DEBUG_LOGGING=ON'
+            if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ] && [ "${MATRIX_COMPILER}" = 'clang-tidy' ]; then
+              options+=' -DRUN_SSHD_TESTS=OFF'  # fails on due to lack of support for modern algos offered by sshd on Ubuntu 26.04 used with clang-tidy
             fi
             if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
               options+=' -DENABLE_DEBUG_LOGGING=ON'
@@ -625,9 +624,6 @@ jobs:
         timeout-minutes: 10
         run: |
           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
-            export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures
-          fi
-          if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ]; then
             export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures
           fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,7 +574,8 @@ jobs:
               cflags+=' -D_DEFAULT_SOURCE'  # for glibc ISO mode, in tests: popen(), pclose(), in examples: fileno(), tcsetattr()
             fi
             if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ]; then
-              options+=' -DRUN_SSHD_TESTS=OFF'  # they crash on Ubuntu 26.04
+              #options+=' -DRUN_SSHD_TESTS=OFF'  # they crash on Ubuntu 26.04
+              options+=' -DENABLE_DEBUG_LOGGING=ON'
             fi
             if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
               options+=' -DENABLE_DEBUG_LOGGING=ON'
@@ -624,6 +625,9 @@ jobs:
         timeout-minutes: 10
         run: |
           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
+            export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures
+          fi
+          if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ]; then
             export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures
           fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
 
   build_linux:
     name: 'linux'
-    runs-on: ${{ (matrix.compiler == 'clang-tidy' && matrix.crypto != 'Libgcrypt') && 'ubuntu-26.04' || (matrix.image || 'ubuntu-latest') }}
+    runs-on: ${{ matrix.compiler == 'clang-tidy' && 'ubuntu-26.04' || (matrix.image || 'ubuntu-latest') }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -572,6 +572,9 @@ jobs:
             if [[ "${MATRIX_CRYPTO}" =~ ^(OpenSSL|Libgcrypt|mbedTLS|wolfSSL)$ && "${MATRIX_COMPILER}" != 'clang-tidy' && "${MATRIX_ZLIB}" = 'ON' ]]; then
               options+=' -DCMAKE_C_STANDARD=90'
               cflags+=' -D_DEFAULT_SOURCE'  # for glibc ISO mode, in tests: popen(), pclose(), in examples: fileno(), tcsetattr()
+            fi
+            if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ]; then
+              options+=' -DRUN_SSHD_TESTS=OFF'  # they crash on Ubuntu 26.04
             fi
             if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
               options+=' -DENABLE_DEBUG_LOGGING=ON'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
 
   build_linux:
     name: 'linux'
-    runs-on: ${{ matrix.compiler == 'clang-tidy' && 'ubuntu-26.04' || (matrix.image || 'ubuntu-latest') }}
+    runs-on: ${{ matrix.compiler == 'clang-tidy' && 'ubuntu-26.04' || (matrix.image || (matrix.crypto == 'Libgcrypt' && 'ubuntu-24.04' || 'ubuntu-latest')) }}
     timeout-minutes: 10
     strategy:
       fail-fast: false


### PR DESCRIPTION
Use the last known good test container build, with debian:bookworm, for
Libgcrypt tests.

Also:
- disable running non-containerized sshd tests in the clang-tidy job,
  because it uses the latest Ubuntu (26.04) which, as debian-trixie,
  comes with a modern OpenSSH server that's incompatible with libssh2's
  Libgcrypt backend:
  ```
  26: [libssh2] 0.055233 Failure Event: -5 - Unable to exchange encryption keys
  26: libssh2_session_handshake failed (-5): Unable to exchange encryption keys
  26: not ok 2 - sshd-test_auth_pubkey_ok_ed25519
  26/44 Test #26: test_sshd .................................***Failed    0.58 sec
  # sshd executable: '/usr/sbin/sshd' (OpenSSH_10.2p1 Ubuntu)
  # sshd log: '/tmp/tmp.QdEw2bfbFE'
  # ssh executable: '/usr/bin/ssh' (OpenSSH_10.2p1 Ubuntu-2ubuntu3.2, OpenSSL 3.5.5 27 Jan 2026)
  # ssh log: '/tmp/tmp.TDLIzPY6zV'
  1..2
  ```
  Ref: https://github.com/libssh2/libssh2/actions/runs/28610019322/job/84839842924?pr=2174#step:25:18669
- run Libgcrypt jobs on ubuntu-24.04 (was: ubuntu-latest) to ensure it
  continues working after ubuntu-latest is bumped.

Ref: https://github.com/libssh2/libssh2/pkgs/container/ci_tests_openssh_server/409796170?tag=98199e448a94451491c4
Ref: https://github.com/libssh2/libssh2/discussions/2049
Follow-up to 51f6259d181e644fcbf55247fb84b34120446e19 #1720

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
