### PR TITLE
version: add `libssh2_build_options()`

### DIFF
--- a/docs/Makefile.inc
+++ b/docs/Makefile.inc
@@ -16,6 +16,7 @@ man_MANS = \
   libssh2_agent_userauth.3 \
   libssh2_banner_set.3 \
   libssh2_base64_decode.3 \
+  libssh2_build_options.3 \
   libssh2_channel_close.3 \
   libssh2_channel_direct_streamlocal_ex.3 \
   libssh2_channel_direct_tcpip.3 \

--- a/docs/libssh2_build_options.md
+++ b/docs/libssh2_build_options.md
@@ -28,8 +28,9 @@ enabled/disabled statuses.
 
 # RETURN VALUE
 
-A read-only string with the build options. Each supported option followed by
-either `on` or `off` reflecting its status.
+A read-only, space-separated list of key:value pairs describing build options.
+Most options use `on` or `off`; `crypto` reports the selected crypto backend
+name.
 
 # EXAMPLE
 

--- a/docs/libssh2_build_options.md
+++ b/docs/libssh2_build_options.md
@@ -1,0 +1,42 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_version
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_crypto_engine(3)
+  - libssh2_version(3)
+---
+
+# NAME
+
+libssh2_build_options - return build-time options
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+const char *libssh2_build_options(void);
+~~~
+
+# DESCRIPTION
+
+Return the full list of options available at build time, along with their
+enabled/disabled statuses.
+
+# RETURN VALUE
+
+A read-only string with the build options. Each supported option followed by
+either `on` or `off` reflecting its status.
+
+# EXAMPLE
+
+~~~c
+printf("libssh2 build options: %s", libssh2_build_options());
+~~~
+
+# AVAILABILITY
+
+Added in libssh2 1.12.0

--- a/docs/libssh2_build_options.md
+++ b/docs/libssh2_build_options.md
@@ -29,8 +29,9 @@ enabled/disabled statuses.
 # RETURN VALUE
 
 A read-only, space-separated list of key:value pairs describing build options.
-Most options use `on` or `off`; `crypto` reports the selected crypto backend
-name.
+Options use `on` or `off`, except `crypto` which may report these values:
+`AWS-LC`, `BoringSSL`, `Libgcrypt`, `LibreSSL`, `mbedTLS`, `OpenSSL`,
+`OpenSSL/1.1.1`, `OS400QC3`, `WinCNG`, `wolfSSL`.
 
 # EXAMPLE
 

--- a/docs/libssh2_build_options.md
+++ b/docs/libssh2_build_options.md
@@ -1,7 +1,7 @@
 ---
 c: Copyright (C) The libssh2 project and its contributors.
 SPDX-License-Identifier: BSD-3-Clause
-Title: libssh2_version
+Title: libssh2_build_options
 Section: 3
 Source: libssh2
 See-also:

--- a/docs/libssh2_crypto_engine.md
+++ b/docs/libssh2_crypto_engine.md
@@ -5,6 +5,8 @@ Title: libssh2_crypto_engine
 Section: 3
 Source: libssh2
 See-also:
+  - libssh2_build_options(3)
+  - libssh2_version(3)
 ---
 
 # NAME

--- a/docs/libssh2_version.md
+++ b/docs/libssh2_version.md
@@ -6,7 +6,7 @@ Section: 3
 Source: libssh2
 See-also:
   - libssh2_build_options(3)
-  - libssh2_version(3)
+  - libssh2_crypto_engine(3)
 ---
 
 # NAME

--- a/docs/libssh2_version.md
+++ b/docs/libssh2_version.md
@@ -5,6 +5,8 @@ Title: libssh2_version
 Section: 3
 Source: libssh2
 See-also:
+  - libssh2_build_options(3)
+  - libssh2_version(3)
 ---
 
 # NAME

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1060,6 +1060,7 @@ typedef enum {
 } libssh2_crypto_engine_t;
 
 LIBSSH2_API libssh2_crypto_engine_t libssh2_crypto_engine(void);
+LIBSSH2_API const char *libssh2_build_options(void);
 
 #define HAVE_LIBSSH2_KNOWNHOST_API 0x010101 /* since 1.1.1 */
 #define HAVE_LIBSSH2_VERSION_API   0x010100 /* libssh2_version since 1.1 */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -42,6 +42,7 @@
  */
 
 #define SSH2_CRYPTO_ENGINE libssh2_gcrypt
+#define SSH2_CRYPTO_ENGINE_NAME "Libgrcypt"
 
 #include <gcrypt.h>
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -42,7 +42,7 @@
  */
 
 #define SSH2_CRYPTO_ENGINE libssh2_gcrypt
-#define SSH2_CRYPTO_ENGINE_NAME "Libgrcypt"
+#define SSH2_CRYPTO_ENGINE_NAME "Libgcrypt"
 
 #include <gcrypt.h>
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -40,6 +40,7 @@
  */
 
 #define SSH2_CRYPTO_ENGINE libssh2_mbedtls
+#define SSH2_CRYPTO_ENGINE_NAME "mbedTLS"
 
 #include <mbedtls/version.h>
 #include <mbedtls/platform.h>

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -114,16 +114,26 @@
 #endif /* LIBSSH2_WOLFSSL */
 
 #ifdef LIBSSH2_WOLFSSL
+#  define SSH2_CRYPTO_ENGINE_NAME "wolfSSL"
 #  if LIBWOLFSSL_VERSION_HEX < 0x05004000
 #    error "wolfSSL 5.4.0 or greater required"
 #  endif
 #elif defined(LIBRESSL_VERSION_NUMBER)
+#  define SSH2_CRYPTO_ENGINE_NAME "LibreSSL"
 #  if LIBRESSL_VERSION_NUMBER < 0x3070000fL
 #    error "LibreSSL 3.7.0 or greater required"
 #  endif
 #else /* AWS-LC/BoringSSL advertise themselves as 0x1010107f */
 #  if OPENSSL_VERSION_NUMBER < 0x10101000L
 #    error "OpenSSL 1.1.1 or greater required"
+#  elif defined(OPENSSL_IS_AWSLC)
+#    define SSH2_CRYPTO_ENGINE_NAME "AWS-LC"
+#  elif defined(OPENSSL_IS_BORINGSSL)
+#    define SSH2_CRYPTO_ENGINE_NAME "BoringSSL"
+#  elif !defined(USE_OPENSSL_3)
+#    define SSH2_CRYPTO_ENGINE_NAME "OpenSSL1.1.1"
+#  else
+#    define SSH2_CRYPTO_ENGINE_NAME "OpenSSL"
 #  endif
 #endif
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -131,7 +131,7 @@
 #  elif defined(OPENSSL_IS_BORINGSSL)
 #    define SSH2_CRYPTO_ENGINE_NAME "BoringSSL"
 #  elif !defined(USE_OPENSSL_3)
-#    define SSH2_CRYPTO_ENGINE_NAME "OpenSSL1.1.1"
+#    define SSH2_CRYPTO_ENGINE_NAME "OpenSSL/1.1.1"
 #  else
 #    define SSH2_CRYPTO_ENGINE_NAME "OpenSSL"
 #  endif

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -41,6 +41,7 @@
  */
 
 #define SSH2_CRYPTO_ENGINE libssh2_os400qc3
+#define SSH2_CRYPTO_ENGINE_NAME "OS400QC3"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/version.c
+++ b/src/version.c
@@ -52,6 +52,9 @@ libssh2_crypto_engine_t libssh2_crypto_engine(void)
 }
 
 static const char *ssh2_build_options =
+    "crypto:"
+    SSH2_CRYPTO_ENGINE_NAME
+    " "
     "MD5:"
 #if LIBSSH2_MD5
     "on"

--- a/src/version.c
+++ b/src/version.c
@@ -180,6 +180,15 @@ static const char *ssh2_build_options =
 #else
     "off"
 #endif
+#ifdef LIBSSH2_WOLFSSL
+    " "
+    "debug-wolfSSL:"
+#ifdef DEBUG_WOLFSSL
+    "on"
+#else
+    "off"
+#endif
+#endif /* LIBSSH2_WOLFSSL */
     ;
 
 const char *libssh2_build_options(void)

--- a/src/version.c
+++ b/src/version.c
@@ -132,6 +132,13 @@ static const char *ssh2_build_options =
     "off"
 #endif
     " "
+    "AES-GCM:"
+#if LIBSSH2_AES_GCM
+    "on"
+#else
+    "off"
+#endif
+    " "
     "BLOWFISH:"
 #if LIBSSH2_BLOWFISH
     "on"

--- a/src/version.c
+++ b/src/version.c
@@ -118,6 +118,13 @@ static const char *ssh2_build_options =
     "off"
 #endif
     " "
+    "AES-GCM:"
+#if LIBSSH2_AES_GCM
+    "on"
+#else
+    "off"
+#endif
+    " "
     "AES-CTR:"
 #if LIBSSH2_AES_CTR
     "on"
@@ -127,13 +134,6 @@ static const char *ssh2_build_options =
     " "
     "AES-CBC:"
 #if LIBSSH2_AES_CBC
-    "on"
-#else
-    "off"
-#endif
-    " "
-    "AES-GCM:"
-#if LIBSSH2_AES_GCM
     "on"
 #else
     "off"

--- a/src/version.c
+++ b/src/version.c
@@ -50,3 +50,129 @@ libssh2_crypto_engine_t libssh2_crypto_engine(void)
 {
     return SSH2_CRYPTO_ENGINE;
 }
+
+static const char *ssh2_build_options =
+    "MD5:"
+#if LIBSSH2_MD5
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "MD5-PEM:"
+#if LIBSSH2_MD5_PEM
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "RIPEMD160:"
+#if LIBSSH2_HMAC_RIPEMD
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "DSA:"
+#if LIBSSH2_DSA
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "RSA:"
+#if LIBSSH2_RSA
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "RSA-SHA1:"
+#if LIBSSH2_RSA_SHA1
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "ECDSA:"
+#if LIBSSH2_ECDSA
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "ED25519:"
+#if LIBSSH2_ED25519
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "ML-KEM:"
+#if LIBSSH2_MLKEM
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "AES-CTR:"
+#if LIBSSH2_AES_CTR
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "AES-CBC:"
+#if LIBSSH2_AES_CBC
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "BLOWFISH:"
+#if LIBSSH2_BLOWFISH
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "RC4:"
+#if LIBSSH2_RC4
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "CAST:"
+#if LIBSSH2_CAST
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "3DES:"
+#if LIBSSH2_3DES
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "zlib:"
+#ifdef LIBSSH2_HAVE_ZLIB
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "debug-logging:"
+#ifdef LIBSSH2DEBUG
+    "on"
+#else
+    "off"
+#endif
+    ;
+
+const char *libssh2_build_options(void)
+{
+    return ssh2_build_options;
+}

--- a/src/version.c
+++ b/src/version.c
@@ -164,6 +164,13 @@ static const char *ssh2_build_options =
     "off"
 #endif
     " "
+    "clear-memory:"
+#ifndef LIBSSH2_NO_CLEAR_MEMORY
+    "on"
+#else
+    "off"
+#endif
+    " "
     "debug-logging:"
 #ifdef LIBSSH2DEBUG
     "on"

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -41,6 +41,7 @@
  */
 
 #define SSH2_CRYPTO_ENGINE libssh2_wincng
+#define SSH2_CRYPTO_ENGINE_NAME "WinCNG"
 
 /* required for cross-compilation against the w64 mingw-runtime package */
 #if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -8,34 +8,12 @@
 
 int main(int argc, char **argv)
 {
-    const char *crypto_str;
-
     (void)argc;
-
-    switch(libssh2_crypto_engine()) {
-    case libssh2_gcrypt:
-        crypto_str = "libgcrypt";
-        break;
-    case libssh2_mbedtls:
-        crypto_str = "mbedTLS";
-        break;
-    case libssh2_openssl:
-        crypto_str = "openssl compatible";
-        break;
-    case libssh2_os400qc3:
-        crypto_str = "OS400QC3";
-        break;
-    case libssh2_wincng:
-        crypto_str = "WinCNG";
-        break;
-    default:
-        crypto_str = "(unrecognized)";
-    }
 
     puts("libssh2 test:");
     puts(argv[0]);
     puts(libssh2_version(0));
-    puts(crypto_str);
+    puts(libssh2_build_options());
     puts("---");
 
     return 0;


### PR DESCRIPTION
Returning for example (without newlines):
```
crypto:LibreSSL MD5:off MD5-PEM:off RIPEMD160:off DSA:off
RSA:on RSA-SHA1:on ECDSA:on ED25519:on ML-KEM:off
AES-CTR:on AES-CBC:on BLOWFISH:off RC4:off CAST:off
3DES:off zlib:on clear-memory:on debug-logging:on
```

To allow library users to find out these details, and add a searchable
static string to binaries with this information.

Possible values for `crypto`: `AWS-LC`, `BoringSSL`, `Libgcrypt`,
`LibreSSL`, `mbedTLS`, `OpenSSL`, `OpenSSL/1.1.1`, `OS400QC3`, `WinCNG`,
`wolfSSL`.

Also:
- replace manual translation of crypto engine enum to name in CMake
  integration test snippet with the new API.

Fixes #2161

---

- [x] perhaps also include the crypto engine, e.g. as `crypto:<engine-name>`?
