### PR TITLE
test_ssh2, examples: avoid crash on NULL fingerprint

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -153,8 +153,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -153,8 +153,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */

--- a/example/scp.c
+++ b/example/scp.c
@@ -113,8 +113,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/scp.c
+++ b/example/scp.c
@@ -113,8 +113,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -186,8 +186,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -186,8 +186,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -135,8 +135,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -135,8 +135,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -188,8 +188,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -188,8 +188,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -173,8 +173,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -173,8 +173,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -165,8 +165,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -165,8 +165,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     tempstorage = fopen(storage, "wb");

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -133,8 +133,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -133,8 +133,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -114,8 +114,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -114,8 +114,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -114,8 +114,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -114,8 +114,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -187,8 +187,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -187,8 +187,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -132,8 +132,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -132,8 +132,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -181,8 +181,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -181,8 +181,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -182,8 +182,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -182,8 +182,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -142,8 +142,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -142,8 +142,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -126,8 +126,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     if(auth_pw) {

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -126,8 +126,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -145,8 +145,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -145,8 +145,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -105,8 +105,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -105,8 +105,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -177,8 +177,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -177,8 +177,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -151,8 +151,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -151,8 +151,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -174,8 +174,10 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    if(!fingerprint)
+    if(!fingerprint) {
         fprintf(stderr, "(null)");
+        goto shutdown;
+    }
     else
         for(i = 0; i < 20; i++)
             fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -174,8 +174,11 @@ int main(int argc, char *argv[])
      */
     fingerprint = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
     fprintf(stderr, "Fingerprint: ");
-    for(i = 0; i < 20; i++)
-        fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
+    if(!fingerprint)
+        fprintf(stderr, "(null)");
+    else
+        for(i = 0; i < 20; i++)
+            fprintf(stderr, "%02X ", (unsigned char)fingerprint[i]);
     fprintf(stderr, "\n");
 
     /* check what authentication methods are available */


### PR DESCRIPTION
Also bail out right away to avoid other issues down the line.

Seen in CI when Libgcrypt could not negotiate keys with modern sshd
server on Ubuntu 26.04:
```
26: 1..2
26: Failure establishing SSH session: -5
26: Fingerprint: /home/runner/tests/test_sshd.test: line 151:  8233 Segmentation fault
         (core dumped) ${LIBSSH2_TEST_EXE_RUNNER:-} "${test}"
26: not ok 1 - sshd-test_ssh2
26: libssh2_session_handshake failed (-5): Unable to exchange encryption keys
```
Ref: https://github.com/libssh2/libssh2/actions/runs/28582866680/job/84747161004?pr=2174

Ref: #2174

---

IIRC this was also reported by GH Code Quality or Copilot earlier somewhere.
