### PR TITLE
openssl: map `ssh2_hash_update()` to OpenSSL API directly

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -87,11 +87,6 @@ int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
     return 0;
 }
 
-int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len)
-{
-    return EVP_DigestUpdate(*ctx, data, len);
-}
-
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
 {
     int ret = EVP_DigestFinal_ex(*ctx, out, NULL);

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -229,7 +229,6 @@ int ssh2_random(unsigned char *buf, size_t len);
 
 /* returns 0 in case of failure */
 int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest);
-int ssh2_ossl_hash_update(EVP_MD_CTX **ctx, const void *data, size_t len);
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 
 #define ssh2_hash_ctx                 EVP_MD_CTX *
@@ -244,7 +243,7 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 #endif
 
 #define ssh2_hash_init(pctx, alg)     ssh2_ossl_hash_init(pctx, alg)
-#define ssh2_hash_update(ctx, d, l)   ssh2_ossl_hash_update(&(ctx), d, l)
+#define ssh2_hash_update(ctx, d, l)   EVP_DigestUpdate(ctx, d, l)
 #define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)
 
 #ifdef USE_OPENSSL_3


### PR DESCRIPTION
Replacing the local wrapper.

Cherry-picked from #2171

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
