### PR TITLE
wincng: make `ssh2_wcng_hash_update()` length `size_t` (was: `ULONG`)

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -745,10 +745,10 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
 }
 
 int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
-                          const void *data, ULONG datalen)
+                          const void *data, size_t datalen)
 {
-    int ret = BCryptHashData(ctx->hHash, SSH2_UNCONST(data), datalen, 0);
-
+    int ret = BCryptHashData(ctx->hHash,
+                             SSH2_UNCONST(data), (ULONG)datalen, 0);
     return BCRYPT_SUCCESS(ret);
 }
 
@@ -827,7 +827,7 @@ int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 {
-    return ssh2_wcng_hash_update(ctx, data, (ULONG)datalen);
+    return ssh2_wcng_hash_update(ctx, data, datalen);
 }
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -747,9 +747,9 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
 int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
                           const void *data, size_t datalen)
 {
-    int ret = BCryptHashData(ctx->hHash,
-                             SSH2_UNCONST(data), (ULONG)datalen, 0);
-    return BCRYPT_SUCCESS(ret);
+    return datalen <= ULONG_MAX &&
+        BCRYPT_SUCCESS(BCryptHashData(ctx->hHash,
+                                      SSH2_UNCONST(data), (ULONG)datalen, 0));
 }
 
 int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -173,17 +173,14 @@ struct wcng_hash_ctx {
 #endif
 
 /* returns 0 in case of failure */
-#define ssh2_hash_init(pctx, alg) \
-    ssh2_wcng_hash_init(pctx, alg, NULL, 0)
-#define ssh2_hash_update(ctx, d, l) \
-    ssh2_wcng_hash_update(&(ctx), d, (ULONG)(l))
-#define ssh2_hash_final(ctx, h, l) \
-    ssh2_wcng_hash_final(&(ctx), h, l)
+#define ssh2_hash_init(pctx, alg)   ssh2_wcng_hash_init(pctx, alg, NULL, 0)
+#define ssh2_hash_update(ctx, d, l) ssh2_wcng_hash_update(&(ctx), d, l)
+#define ssh2_hash_final(ctx, h, l)  ssh2_wcng_hash_final(&(ctx), h, l)
 
 int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
                         unsigned char *key, ULONG keylen);
 int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
-                          const void *data, ULONG datalen);
+                          const void *data, size_t datalen);
 int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
                          size_t hashlen);
 int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,


### PR DESCRIPTION
Cherry-picked from #2171

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
