### PR TITLE
kex: propagate errors from `kex_method_ec_sha_hash_create_verify()`

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -1559,10 +1559,12 @@ static int kex_method_ec_sha_hash_create_verify(
     ssh2_hash_alg hash_alg, size_t digest_len)
 {
     ssh2_hash_ctx ctx;
+    int err;
     int hok;
 
     if(!ssh2_hash_init(&ctx, hash_alg))
-        return -1;
+        return ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
+                        "Unable to initialize hash context");
 
     hok = 1;
     if(session->local.banner) {
@@ -1623,15 +1625,22 @@ static int kex_method_ec_sha_hash_create_verify(
 
     if(!hok || !ssh2_hash_final(ctx, exchange_state->h_sig_comp,
                                 sizeof(exchange_state->h_sig_comp)))
-        return -1;
+        return ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
+                        "kex: failed to calculate hash");
 
-    if(session->hostkey->sig_verify(session,
-                                    exchange_state->h_sig,
-                                    exchange_state->h_sig_len,
-                                    exchange_state->h_sig_comp,
-                                    digest_len,
-                                    &session->server_hostkey_abstract))
-        return -1;
+    err = session->hostkey->sig_verify(session,
+                                       exchange_state->h_sig,
+                                       exchange_state->h_sig_len,
+                                       exchange_state->h_sig_comp,
+                                       digest_len,
+                                       &session->server_hostkey_abstract);
+    if(err) {
+        ssh2_deb((session, LIBSSH2_TRACE_KEX,
+                  "Failed hostkey sig_verify(): %s: %d",
+                  session->hostkey->name, err));
+        return ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_SIGN,
+                        "Unable to verify hostkey signature EC");
+    }
 
     return 0;
 }

--- a/src/kex.c
+++ b/src/kex.c
@@ -1805,21 +1805,21 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
         /* verify hash */
         switch(type) {
         case SSH2_EC_CURVE_NISTP256:
-            rc = kex_method_ec_sha_hash_create_verify(session, exchange_state,
+            ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                      public_key, public_key_len, NULL, 0,
                      server_public_key, server_public_key_len,
                      SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
                      "Unable to verify hostkey signature ECDH");
             break;
         case SSH2_EC_CURVE_NISTP384:
-            rc = kex_method_ec_sha_hash_create_verify(session, exchange_state,
+            ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                      public_key, public_key_len, NULL, 0,
                      server_public_key, server_public_key_len,
                      SSH2_SHA384_ALG, SSH2_SHA384_DIG_LEN,
                      "Unable to verify hostkey signature ECDH");
             break;
         case SSH2_EC_CURVE_NISTP521:
-            rc = kex_method_ec_sha_hash_create_verify(session, exchange_state,
+            ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                      public_key, public_key_len, NULL, 0,
                      server_public_key, server_public_key_len,
                      SSH2_SHA512_ALG, SSH2_SHA512_DIG_LEN,
@@ -1827,7 +1827,7 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
             break;
         }
 
-        if(rc)
+        if(ret)
             goto clean_exit;
 
         exchange_state->c = SSH_MSG_NEWKEYS;
@@ -2189,7 +2189,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                                "kex: failed to calculate hash");
                 goto clean_exit;
             }
-            rc = kex_method_ec_sha_hash_create_verify(session,
+            ret = kex_method_ec_sha_hash_create_verify(session,
                      exchange_state,
                      public_t_key, public_t_key_len,
                      public_pq_key, public_pq_key_len,
@@ -2218,7 +2218,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                                "kex: failed to calculate hash");
                 goto clean_exit;
             }
-            rc = kex_method_ec_sha_hash_create_verify(session,
+            ret = kex_method_ec_sha_hash_create_verify(session,
                      exchange_state,
                      public_t_key, public_t_key_len,
                      public_pq_key, public_pq_key_len,
@@ -2230,10 +2230,9 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
         default:
             ret = ssh2_err(session, -1,
                            "Unexpected KEX hybrid nistp curve type");
-            goto clean_exit;
         }
 
-        if(rc)
+        if(ret)
             goto clean_exit;
 
         exchange_state->c = SSH_MSG_NEWKEYS;
@@ -2532,12 +2531,12 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         }
 
         /* verify hash */
-        rc = kex_method_ec_sha_hash_create_verify(session, exchange_state,
+        ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                  public_key, public_key_len, NULL, 0,
                  server_public_key, server_public_key_len,
                  SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
                  "Unable to verify hostkey signature curve25519");
-        if(rc)
+        if(ret)
             goto clean_exit;
 
         exchange_state->c = SSH_MSG_NEWKEYS;
@@ -2836,14 +2835,14 @@ static int mlkem768x25519_sha256(
         }
 
         /* verify hash */
-        rc = kex_method_ec_sha_hash_create_verify(session,
+        ret = kex_method_ec_sha_hash_create_verify(session,
                  exchange_state,
                  public_t_key, public_t_key_len,
                  public_pq_key, public_pq_key_len,
                  server_public_key, server_public_key_len,
                  SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
                  "Unable to verify hostkey signature mlkem768x25519");
-        if(rc)
+        if(ret)
             goto clean_exit;
 
         exchange_state->c = SSH_MSG_NEWKEYS;

--- a/src/kex.c
+++ b/src/kex.c
@@ -741,7 +741,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
 
         if(!ssh2_hash_init(ctx, hash_alg)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
-                           "Unable to initialize hash context");
+                           "Unable to initialize hash context DH-SHA");
             goto clean_exit;
         }
         hok = 1;
@@ -809,7 +809,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
         if(!hok || !ssh2_hash_final(*ctx, exchange_state->h_sig_comp,
                                     sizeof(exchange_state->h_sig_comp))) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
-                           "kex: failed to calculate hash");
+                           "Failed to calculate hash DH-SHA");
             goto clean_exit;
         }
 
@@ -1556,7 +1556,7 @@ static int kex_method_ec_sha_hash_create_verify(
     unsigned char *public_key, size_t public_key_len,
     unsigned char *public_pq_key, size_t public_pq_key_len,
     unsigned char *server_public_key, size_t server_public_key_len,
-    ssh2_hash_alg hash_alg, size_t digest_len)
+    ssh2_hash_alg hash_alg, size_t digest_len, const char *signerr)
 {
     ssh2_hash_ctx ctx;
     int err;
@@ -1564,7 +1564,7 @@ static int kex_method_ec_sha_hash_create_verify(
 
     if(!ssh2_hash_init(&ctx, hash_alg))
         return ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
-                        "Unable to initialize hash context");
+                        "Unable to initialize hash context EC/ED");
 
     hok = 1;
     if(session->local.banner) {
@@ -1626,7 +1626,7 @@ static int kex_method_ec_sha_hash_create_verify(
     if(!hok || !ssh2_hash_final(ctx, exchange_state->h_sig_comp,
                                 sizeof(exchange_state->h_sig_comp)))
         return ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
-                        "kex: failed to calculate hash");
+                        "Failed to calculate hash EC/ED");
 
     err = session->hostkey->sig_verify(session,
                                        exchange_state->h_sig,
@@ -1638,11 +1638,10 @@ static int kex_method_ec_sha_hash_create_verify(
         ssh2_deb((session, LIBSSH2_TRACE_KEX,
                   "Failed hostkey sig_verify(): %s: %d",
                   session->hostkey->name, err));
-        return ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_SIGN,
-                        "Unable to verify hostkey signature EC");
+        return ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_SIGN, signerr);
     }
 
-    return 0;
+    return LIBSSH2_ERROR_NONE;
 }
 #endif /* LIBSSH2_ECDSA || LIBSSH2_ED25519 */
 
@@ -1809,27 +1808,27 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
             rc = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                      public_key, public_key_len, NULL, 0,
                      server_public_key, server_public_key_len,
-                     SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN);
+                     SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
+                     "Unable to verify hostkey signature ECDH");
             break;
         case SSH2_EC_CURVE_NISTP384:
             rc = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                      public_key, public_key_len, NULL, 0,
                      server_public_key, server_public_key_len,
-                     SSH2_SHA384_ALG, SSH2_SHA384_DIG_LEN);
+                     SSH2_SHA384_ALG, SSH2_SHA384_DIG_LEN,
+                     "Unable to verify hostkey signature ECDH");
             break;
         case SSH2_EC_CURVE_NISTP521:
             rc = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                      public_key, public_key_len, NULL, 0,
                      server_public_key, server_public_key_len,
-                     SSH2_SHA512_ALG, SSH2_SHA512_DIG_LEN);
+                     SSH2_SHA512_ALG, SSH2_SHA512_DIG_LEN,
+                     "Unable to verify hostkey signature ECDH");
             break;
         }
 
-        if(rc) {
-            ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_SIGN,
-                           "Unable to verify hostkey signature ECDH");
+        if(rc)
             goto clean_exit;
-        }
 
         exchange_state->c = SSH_MSG_NEWKEYS;
         exchange_state->state = ssh2_NB_state_sent;
@@ -2195,7 +2194,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                      public_t_key, public_t_key_len,
                      public_pq_key, public_pq_key_len,
                      server_public_key, server_public_key_len,
-                     SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN);
+                     SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
+                     "Unable to verify hostkey signature mlkemnistp");
             break;
         }
         case SSH2_EC_CURVE_NISTP384: {
@@ -2223,7 +2223,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                      public_t_key, public_t_key_len,
                      public_pq_key, public_pq_key_len,
                      server_public_key, server_public_key_len,
-                     SSH2_SHA384_ALG, SSH2_SHA384_DIG_LEN);
+                     SSH2_SHA384_ALG, SSH2_SHA384_DIG_LEN,
+                     "Unable to verify hostkey signature mlkemnistp");
             break;
         }
         default:
@@ -2232,11 +2233,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        if(rc) {
-            ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_SIGN,
-                           "Unable to verify hostkey signature mlkemnistp");
+        if(rc)
             goto clean_exit;
-        }
 
         exchange_state->c = SSH_MSG_NEWKEYS;
         exchange_state->state = ssh2_NB_state_sent;
@@ -2537,12 +2535,10 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
         rc = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                  public_key, public_key_len, NULL, 0,
                  server_public_key, server_public_key_len,
-                 SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN);
-        if(rc) {
-            ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_SIGN,
-                           "Unable to verify hostkey signature curve25519");
+                 SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
+                 "Unable to verify hostkey signature curve25519");
+        if(rc)
             goto clean_exit;
-        }
 
         exchange_state->c = SSH_MSG_NEWKEYS;
         exchange_state->state = ssh2_NB_state_sent;
@@ -2845,13 +2841,10 @@ static int mlkem768x25519_sha256(
                  public_t_key, public_t_key_len,
                  public_pq_key, public_pq_key_len,
                  server_public_key, server_public_key_len,
-                 SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN);
-        if(rc) {
-            ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_SIGN,
-                           "Unable to verify hostkey signature "
-                           "mlkem768x25519");
+                 SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
+                 "Unable to verify hostkey signature mlkem768x25519");
+        if(rc)
             goto clean_exit;
-        }
 
         exchange_state->c = SSH_MSG_NEWKEYS;
         exchange_state->state = ssh2_NB_state_sent;


### PR DESCRIPTION
Also:
- emit errors on low-level hash failures.
- move final `LIBSSH2_ERROR_HASH_INIT` error to this low-level worker.
- make error messages distinct, where missing.

To sync with sister code in `diffie_hellman_sha_algo()`.

Follow-up to 7fd8b99fee44a345cf98de70a1a84f54410a9c4b #2186
Follow-up to f2b416053b936c580305286ad0c2eec325d2e1d5 #2184
Cherry-picked from #2171

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
