### PR TITLE
wincng: on deinit, only close ECDSA/ECDH algos if set

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -677,8 +677,10 @@ void ssh2_crypto_exit(void)
 
 #if LIBSSH2_ECDSA
     for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
-        (void)BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgECDSA[curve], 0);
-        (void)BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgECDH[curve], 0);
+        if(ssh2_wcng.hAlgECDSA[curve])
+            (void)BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgECDSA[curve], 0);
+        if(ssh2_wcng.hAlgECDH[curve])
+            (void)BCryptCloseAlgorithmProvider(ssh2_wcng.hAlgECDH[curve], 0);
     }
 #endif
 


### PR DESCRIPTION
To sync with rest of algos.

Reported by GitHub Code Quality

Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315

---

https://github.com/libssh2/libssh2/pull/2189/files?w=1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
