### PR TITLE
wincng: fix to bail out on ECDH key export fail

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2153,9 +2153,11 @@ int ssh2_ecdsa_create_key(IN LIBSSH2_SESSION *session,
         key_handle,
         out_public_key_octal,
         out_public_key_octal_len);
-    if(result != LIBSSH2_ERROR_NONE)
+    if(result != LIBSSH2_ERROR_NONE) {
         result = ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                           "Exporting ECDH key pair failed");
+        goto cleanup;
+    }
 
     *out_private_key = malloc(sizeof(struct wcng_ecdsa_ctx));
     if(!*out_private_key) {


### PR DESCRIPTION
"When `wcng_uncompressed_point_from_publickey` fails, `result` is set to
an error code but execution falls through into the `malloc` / struct
initialization block instead of jumping to `cleanup`. This causes
`*out_private_key` to be allocated and populated even in the error path.
At `cleanup`, the key handle is destroyed via `BCryptDestroyKey` and
`*out_private_key` is freed, but the pointer is not set to NULL, leaving
the caller with a dangling pointer. A `goto cleanup` should follow the
`ssh2_err` call."

Reported by GitHub Code Quality

Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315