### PR TITLE
wincng: fix NULL deref on OOM in `ssh2_ecdsa_verify()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2410,6 +2410,10 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
     }
 
     hash = malloc(hash_len);
+    if(!hash) {
+        result = LIBSSH2_ERROR_ALLOC;
+        goto cleanup;
+    }
     if(!wcng_hash(m, (ULONG)m_len, hash_alg, hash, hash_len))
         goto cleanup;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2414,8 +2414,10 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
     }
-    if(!wcng_hash(m, (ULONG)m_len, hash_alg, hash, hash_len))
+    if(!wcng_hash(m, (ULONG)m_len, hash_alg, hash, hash_len)) {
+        result = LIBSSH2_ERROR_PUBLICKEY_PROTOCOL;
         goto cleanup;
+    }
 
     /* Verify signature over hash */
     status = BCryptVerifySignature(


### PR DESCRIPTION
Also return an error code on `wcng_hash()` fail.

Reported by GitHub Code Quality and Copilot

Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
