### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/docs/libssh2_version.md
+++ b/docs/libssh2_version.md
@@ -16,8 +16,7 @@ libssh2_version - return the libssh2 version number
 ~~~c
 #include <libssh2.h>
 
-const char *
-libssh2_version(int required_version);
+const char *libssh2_version(int required_version);
 ~~~
 
 # DESCRIPTION

--- a/docs/libssh2_version.md
+++ b/docs/libssh2_version.md
@@ -41,7 +41,7 @@ To make sure you run with the correct libssh2 version:
 
 ~~~c
 if(!libssh2_version(LIBSSH2_VERSION_NUM)) {
-  fprintf(stderr, \&"Runtime libssh2 version too old.\&");
+  fprintf(stderr, "Runtime libssh2 version too old.");
   return -1;  /* return error */
 }
 ~~~
@@ -49,7 +49,7 @@ if(!libssh2_version(LIBSSH2_VERSION_NUM)) {
 Unconditionally get the version number:
 
 ~~~c
-printf(\&"libssh2 version: %s\&", libssh2_version(0));
+printf("libssh2 version: %s", libssh2_version(0));
 ~~~
 
 # AVAILABILITY

--- a/src/channel.c
+++ b/src/channel.c
@@ -1456,7 +1456,7 @@ int ssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
         ssh2_deb((session, LIBSSH2_TRACE_CONN,
                   "starting request(%s) on channel %u/%u, message=%s",
                   request, channel->local.id, channel->remote.id,
-                  message ? message : "<null>"));
+                  message ? message : "(null)"));
         s = channel->process_packet =
             SSH2_ALLOC(session, channel->process_packet_len);
         if(!channel->process_packet)

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -450,7 +450,7 @@ static int crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
         }
     }
 
-    return (ret == 0) ? 0 : 1;
+    return ret == 0 ? 0 : 1;
 }
 
 static int crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -286,12 +286,12 @@ int ssh2_ed25519_new_private_frommemory_sk(ssh2_ed25519_ctx **ed_ctx,
 
 #if LIBSSH2_MLKEM
 int ssh2_mlkem_new(LIBSSH2_SESSION *session,
-                   int ml_kem_size,
+                   int mlkem_size,
                    unsigned char **out_public_key,
                    unsigned char **out_private_key);
 
 int ssh2_mlkem_get_sk(unsigned char *out_shared_key,
-                      int ml_kem_size,
+                      int mlkem_size,
                       uint8_t *private_key,
                       uint8_t *server_ciphertext);
 #endif /* LIBSSH2_MLKEM */

--- a/src/kex.c
+++ b/src/kex.c
@@ -2009,10 +2009,10 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
                        struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
-    int rc, ml_kem_size;
+    int rc, mlkem_size;
     ssh2_hash_alg hash_alg;
     ssh2_curve_type type;
-    size_t digest_len, ml_kem_cipher_len, public_pq_key_len;
+    size_t digest_len, mlkem_cipher_len, public_pq_key_len;
     unsigned char *shared_secret = NULL;
 
     if(kex_session_hybrid_curve_type(session->kex->name, &type)) {
@@ -2025,15 +2025,15 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
     case SSH2_EC_CURVE_NISTP256:
         hash_alg = SSH2_SHA256_ALG;
         digest_len = SSH2_SHA256_DIG_LEN;
-        ml_kem_cipher_len = SSH2_MLKEM_768_CIPHERTEXT;
-        ml_kem_size = 768;
+        mlkem_cipher_len = SSH2_MLKEM_768_CIPHERTEXT;
+        mlkem_size = 768;
         public_pq_key_len = SSH2_MLKEM_768_PUBLIC_KEY_LEN;
         break;
     case SSH2_EC_CURVE_NISTP384:
         hash_alg = SSH2_SHA384_ALG;
         digest_len = SSH2_SHA384_DIG_LEN;
-        ml_kem_cipher_len = SSH2_MLKEM_1024_CIPHERTEXT;
-        ml_kem_size = 1024;
+        mlkem_cipher_len = SSH2_MLKEM_1024_CIPHERTEXT;
+        mlkem_size = 1024;
         public_pq_key_len = SSH2_MLKEM_1024_PUBLIC_KEY_LEN;
         break;
     default:
@@ -2073,7 +2073,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        if(server_public_key_len <= ml_kem_cipher_len) {
+        if(server_public_key_len <= mlkem_cipher_len) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Unexpected mlkemnistp server public key length");
             goto clean_exit;
@@ -2100,8 +2100,8 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
 
         /* Compute the ecdh shared secret K */
         rc = ssh2_ecdh_gen_k(&exchange_state->k, private_t_key,
-                             server_public_key + ml_kem_cipher_len,
-                             server_public_key_len - ml_kem_cipher_len);
+                             server_public_key + mlkem_cipher_len,
+                             server_public_key_len - mlkem_cipher_len);
         if(rc) {
             ret = ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
                            "Unable to create ECDH shared secret");
@@ -2119,7 +2119,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
         }
 
         /* Compute the ML-KEM shared secret */
-        rc = ssh2_mlkem_get_sk(shared_secret, ml_kem_size, private_pq_key,
+        rc = ssh2_mlkem_get_sk(shared_secret, mlkem_size, private_pq_key,
                                server_public_key);
         if(rc) {
             ret = ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
@@ -2247,7 +2247,7 @@ static int kex_method_mlkem_nistp_key_exchange(
 
     if(key_state->state == ssh2_NB_state_created) {
         ssh2_curve_type type;
-        int ml_kem_size;
+        int mlkem_size;
         size_t mlkem_public_key_len;
         size_t mlkem_private_key_len;
         unsigned char *s = NULL;
@@ -2260,12 +2260,12 @@ static int kex_method_mlkem_nistp_key_exchange(
 
         switch(type) {
         case SSH2_EC_CURVE_NISTP256:
-            ml_kem_size = 768;
+            mlkem_size = 768;
             mlkem_public_key_len = SSH2_MLKEM_768_PUBLIC_KEY_LEN;
             mlkem_private_key_len = SSH2_MLKEM_768_PRIVATE_KEY_LEN;
             break;
         case SSH2_EC_CURVE_NISTP384:
-            ml_kem_size = 1024;
+            mlkem_size = 1024;
             mlkem_public_key_len = SSH2_MLKEM_1024_PUBLIC_KEY_LEN;
             mlkem_private_key_len = SSH2_MLKEM_1024_PRIVATE_KEY_LEN;
             break;
@@ -2283,7 +2283,7 @@ static int kex_method_mlkem_nistp_key_exchange(
             goto clean_exit;
         }
 
-        rc = ssh2_mlkem_new(session, ml_kem_size,
+        rc = ssh2_mlkem_new(session, mlkem_size,
                             &key_state->mlkem_public_key,
                             &key_state->mlkem_private_key);
         if(rc) {

--- a/src/kex.c
+++ b/src/kex.c
@@ -3121,8 +3121,8 @@ struct common_method {
 
 /*
  * Calculate the length of a particular method list's resulting string
- * Includes SUM(strlen() of each individual method plus 1 (for coma)) - 1
- * (because the last coma is not used)
+ * Includes SUM(strlen() of each individual method plus 1 (for comma)) - 1
+ * (because the last comma is not used)
  * Another sign of bad coding practices gone mad. Pretend you do not see this.
  */
 static size_t kex_method_strlen(const struct common_method **method)
@@ -4145,18 +4145,16 @@ int libssh2_session_supported_algs(LIBSSH2_SESSION *session,
     if(!mlist)
         return ssh2_err(session, LIBSSH2_ERROR_INVAL, "No algorithm found");
 
-    /*
-      mlist is looped through twice. The first time to find the number od
-      supported algorithms (needed to allocate the proper size of array) and
-      the second time to actually copy the pointers.  Typically this function
-      it not called often (typically at the beginning of a session) and
-      the number of algorithms (i.e. number of iterations in one loop) are
-      not expected to become high (typically it does not exceed 20) for quite
-      a long time.
+    /* mlist is looped through twice. The first time to find the number of
+       supported algorithms (needed to allocate the proper size of array) and
+       the second time to actually copy the pointers.  Typically this function
+       it not called often (typically at the beginning of a session) and
+       the number of algorithms (i.e. number of iterations in one loop) are
+       not expected to become high (typically it does not exceed 20) for quite
+       a long time.
 
-      Thus double looping really should not be an issue and it is definitely
-      a better solution than reallocation several times.
-    */
+       Thus double looping really should not be an issue and it is definitely
+       a better solution than reallocation several times. */
 
     /* count the number of supported algorithms */
     for(i = 0, ialg = 0; mlist[i]; i++) {

--- a/src/kex.c
+++ b/src/kex.c
@@ -46,8 +46,7 @@
 
 #include <assert.h>
 
-static void sha_algo_value_hash(ssh2_hash_alg hash_alg,
-                                size_t digest_len,
+static void sha_algo_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
                                 LIBSSH2_SESSION *session,
                                 struct kmdhgGPshakex_state *exchange_state,
                                 unsigned char **data, size_t data_len,
@@ -100,8 +99,7 @@ static void sha_algo_value_hash(ssh2_hash_alg hash_alg,
     }
 }
 
-static int process_host_key(LIBSSH2_SESSION *session,
-                            struct string_buf *buf,
+static int process_host_key(LIBSSH2_SESSION *session, struct string_buf *buf,
                             const struct kmdhgGPshakex_state *exchange_state,
                             unsigned char *data, size_t data_len)
 {
@@ -3579,8 +3577,8 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
             if(ssh2_kex_agree_instr(crypt, crypt_len, s, method_len)) {
                 const struct crypt_method *method =
                     (const struct crypt_method *)kex_get_method_by_name(
-                         (char *)s, method_len,
-                         (const struct common_method **)cryptp);
+                        (char *)s, method_len,
+                        (const struct common_method **)cryptp);
 
                 if(!method)
                     return -1;  /* Invalid method -- Should never be reached */

--- a/src/kex.c
+++ b/src/kex.c
@@ -2769,7 +2769,7 @@ static int mlkem768x25519_sha256(
             goto clean_exit;
         }
 
-        /* Compute the x2559 shared secret K */
+        /* Compute the x25519 shared secret K */
         rc = ssh2_curve25519_gen_k(&exchange_state->k, private_t_key,
                                    server_public_key +
                                        SSH2_MLKEM_768_CIPHERTEXT);
@@ -3235,7 +3235,7 @@ static int kex_init(LIBSSH2_SESSION *session)
         }
         s += 16;
 
-        /* Ennumerating through these lists twice is probably (certainly?)
+        /* Enumerating through these lists twice is probably (certainly?)
            inefficient from a CPU standpoint, but it saves multiple
            malloc/realloc calls */
         KEX_METHOD_PREFS_STR(s, kex_len, session->kex_prefs, kex_methods);
@@ -3368,11 +3368,11 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
        (needle_len == haystack_len || haystack[needle_len] == ','))
         return haystack;
 
-    /* Search until we run out of comas or we run out of haystack,
+    /* Search until we run out of commas or we run out of haystack,
        whichever comes first */
     /* !checksrc! disable EQUALSNULL 1 */
     while((s = (unsigned char *)memchr((char *)s, ',', left)) != NULL) {
-        /* Advance buffer past coma if we can */
+        /* Advance buffer past comma if we can */
         left = end_haystack - s;
         if(left >= 1 && left <= haystack_len && left > needle_len) {
             s++;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -676,7 +676,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
     gcry_sexp_release(s_sig);
     gcry_sexp_release(s_hash);
 
-    return (rc == 0) ? 0 : -1;
+    return rc == 0 ? 0 : -1;
 }
 #endif
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1033,7 +1033,7 @@ cleanup:
     mbedtls_mpi_free(&pr);
     mbedtls_mpi_free(&ps);
 
-    return (rc == 0) ? 0 : -1;
+    return rc == 0 ? 0 : -1;
 }
 
 static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -309,10 +309,9 @@ static int mbed_bn_random(ssh2_bn *bn, int bits, int top, int bottom)
         return -1;
 
     /* Zero unused bits above the most significant bit */
-    for(i = (len * 8) - 1; (size_t)bits <= i; --i) {
+    for(i = (len * 8) - 1; (size_t)bits <= i; --i)
         if(mbedtls_mpi_set_bit(bn, i, 0))
             return -1;
-    }
 
     /* If `top` is -1, the most significant bit of the random number can be
        zero.  If top is 0, the most significant bit of the random number is
@@ -320,12 +319,10 @@ static int mbed_bn_random(ssh2_bn *bn, int bits, int top, int bottom)
        is set to 1, so that the product of two such random numbers always
        have 2 * bits length.
     */
-    if(top >= 0) {
-        for(i = 0; i <= (size_t)top; ++i) {
+    if(top >= 0)
+        for(i = 0; i <= (size_t)top; ++i)
             if(mbedtls_mpi_set_bit(bn, bits - i - 1, 1))
                 return -1;
-        }
-    }
 
     /* make odd by setting first bit in least significant byte */
     if(bottom && mbedtls_mpi_set_bit(bn, 0, 1))

--- a/src/misc.c
+++ b/src/misc.c
@@ -92,7 +92,7 @@ int ssh2_err_flags(LIBSSH2_SESSION *session, int errcode,
     if(!session) {
         ssh2_deb((session, LIBSSH2_TRACE_ERROR,
                  "ssh2_err_flags: session is NULL, error: %s",
-                 errmsg ? errmsg : "<null>"));
+                 errmsg ? errmsg : "(null)"));
         return errcode;
     }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -141,7 +141,7 @@ static int ossl_hmac_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen,
         return 0;
 
     params[0] = OSSL_PARAM_construct_octet_string(
-        OSSL_MAC_PARAM_KEY, (void *)key, keylen);
+        OSSL_MAC_PARAM_KEY, key, keylen);
     params[1] = OSSL_PARAM_construct_utf8_string(
         OSSL_MAC_PARAM_DIGEST, (char *)SSH2_UNCONST(digest_name), 0);
     params[2] = OSSL_PARAM_construct_end();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -380,7 +380,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 
     EVP_PKEY_CTX_free(ctx);
 
-    return (ret == 1) ? 0 : -1;
+    return ret == 1 ? 0 : -1;
 #else /* !USE_OPENSSL_3 */
     BIGNUM *e;
     BIGNUM *n;
@@ -490,7 +490,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsactx, size_t hash_len,
 
     free(hash);
 
-    return (ret == 1) ? 0 : -1;
+    return ret == 1 ? 0 : -1;
 }
 
 #if LIBSSH2_RSA_SHA1
@@ -600,7 +600,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsactx,
 
     EVP_PKEY_CTX_free(ctx);
 
-    return (ret == 1) ? 0 : -1;
+    return ret == 1 ? 0 : -1;
 #else /* !USE_OPENSSL_3 */
     BIGNUM *p_bn;
     BIGNUM *q_bn;
@@ -681,7 +681,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
 
     DSA_SIG_free(dsasig);
 
-    return (ret == 1) ? 0 : -1;
+    return ret == 1 ? 0 : -1;
 }
 #endif /* LIBSSH2_DSA */
 
@@ -830,7 +830,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
         ret = -1;
 #endif
 
-    return (ret == 1) ? 0 : -1;
+    return ret == 1 ? 0 : -1;
 }
 
 int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
@@ -922,7 +922,7 @@ cleanup:
     if(ecdsa_sig)
         ECDSA_SIG_free(ecdsa_sig);
 
-    return (ret == 1) ? 0 : -1;
+    return ret == 1 ? 0 : -1;
 }
 
 #endif /* LIBSSH2_ECDSA */
@@ -2585,7 +2585,7 @@ clean_exit:
     if(client_key)
         EVP_PKEY_free(client_key);
 
-    return (rc == 1) ? 0 : -1;
+    return rc == 1 ? 0 : -1;
 }
 
 #endif
@@ -3544,7 +3544,7 @@ clean_exit:
         BN_CTX_free(bn_ctx);
 #endif
 
-    return (ret == 1) ? 0 : -1;
+    return ret == 1 ? 0 : -1;
 }
 
 /*
@@ -3772,7 +3772,7 @@ clean_exit:
     if(md_ctx)
         EVP_MD_CTX_free(md_ctx);
 
-    return (rc == 1) ? 0 : -1;
+    return rc == 1 ? 0 : -1;
 }
 
 int ssh2_curve25519_gen_k(ssh2_bn **k,
@@ -3843,7 +3843,7 @@ clean_exit:
     if(bn_ctx)
         BN_CTX_free(bn_ctx);
 
-    return (rc == 1) ? 0 : -1;
+    return rc == 1 ? 0 : -1;
 }
 
 int ssh2_ed25519_verify(ssh2_ed25519_ctx *ctx, const uint8_t *s,
@@ -3865,7 +3865,7 @@ clean_exit:
 
     EVP_MD_CTX_free(md_ctx);
 
-    return (ret == 1) ? 0 : -1;
+    return ret == 1 ? 0 : -1;
 }
 
 #endif /* LIBSSH2_ED25519 */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2431,7 +2431,7 @@ int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,
 
 #if LIBSSH2_MLKEM
 
-int ssh2_mlkem_new(LIBSSH2_SESSION *session, int ml_kem_size,
+int ssh2_mlkem_new(LIBSSH2_SESSION *session, int mlkem_size,
                    unsigned char **out_public_key,
                    unsigned char **out_private_key)
 {
@@ -2442,7 +2442,7 @@ int ssh2_mlkem_new(LIBSSH2_SESSION *session, int ml_kem_size,
     size_t privLen, actualPrivLen, pubLen, actualPubLen;
     int rc = -1;
 
-    switch(ml_kem_size) {
+    switch(mlkem_size) {
     case 512:
         evp_name = "ML-KEM-512";
         privLen = SSH2_MLKEM_512_PRIVATE_KEY_LEN;
@@ -2518,7 +2518,7 @@ clean_exit:
     return rc;
 }
 
-int ssh2_mlkem_get_sk(unsigned char *out_shared_key, int ml_kem_size,
+int ssh2_mlkem_get_sk(unsigned char *out_shared_key, int mlkem_size,
                       uint8_t *private_key, uint8_t *server_ciphertext)
 {
     int rc = -1;
@@ -2528,7 +2528,7 @@ int ssh2_mlkem_get_sk(unsigned char *out_shared_key, int ml_kem_size,
     const char *evp_name;
     size_t privLen, ciphertextLen;
 
-    switch(ml_kem_size) {
+    switch(mlkem_size) {
     case 512:
         evp_name = "ML-KEM-512";
         privLen = SSH2_MLKEM_512_PRIVATE_KEY_LEN;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -352,7 +352,7 @@ static int sftp_packet_read(LIBSSH2_SFTP *sftp)
                                 "Unable to allocate SFTP packet");
             sftp->packet_header_len = 0;
             sftp->partial_packet = packet;
-            /* copy over packet type(4) and request id(1) */
+            /* copy over packet type(1) and request id(4) */
             sftp->partial_received = 5;
             memcpy(packet, sftp->packet_header + 4, 5);
 
@@ -1414,10 +1414,10 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
        but the state machine ensures we skip the first phase on the next call
        and resume sending.
 
-       ssh2_NB_state_sent2: In the third phase (indicated by ) we read the
-       data from the responses that have arrived so far.  Reading can be
-       interrupted with EAGAIN but the state machine ensures we skip the first
-       and second phases on the next call and resume sending.
+       ssh2_NB_state_sent2: In the third phase we read the data from
+       the responses that have arrived so far.  Reading can be interrupted with
+       EAGAIN but the state machine ensures we skip the first and second phases
+       on the next call and resume sending.
     */
 
     switch(sftp->read_state) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1795,7 +1795,7 @@ static int wcng_ecdsa_decode_uncompressed_point(
     if(encoded_point_len == 0 || encoded_point[0] != 4)
         return LIBSSH2_ERROR_INVAL;
 
-    for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
+    for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++)
         if(wcng_ecdsa_algs[curve].point_length ==
            (encoded_point_len - 1) / 2) {
 
@@ -1809,7 +1809,6 @@ static int wcng_ecdsa_decode_uncompressed_point(
 
             return LIBSSH2_ERROR_NONE;
         }
-    }
 
     return LIBSSH2_ERROR_INVAL;
 }
@@ -2353,12 +2352,11 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
     if(!name || !out_curve)
         return LIBSSH2_ERROR_INVAL;
 
-    for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
+    for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++)
         if(!strcmp(name, wcng_ecdsa_algs[curve].name)) {
             *out_curve = (ssh2_curve_type)curve;
             return LIBSSH2_ERROR_NONE;
         }
-    }
 
     return LIBSSH2_ERROR_INVAL;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -116,8 +116,10 @@ static void wcng_safe_free(void *buf, size_t len)
 /* Copy a big endian set of bits from src to dest.
  * if the size of src is smaller than dest then pad the "left" (MSB)
  * end with zeroes and copy the bits into the "right" (LSB) end. */
-static void wcng_memcpy_with_be_padding(unsigned char *dest, ULONG dest_len,
-                                        unsigned char *src, ULONG src_len)
+static void wcng_memcpy_with_be_padding(unsigned char *dest,
+                                        ULONG dest_len,
+                                        const unsigned char *src,
+                                        ULONG src_len)
 {
     if(dest_len > src_len)
         memset(dest, 0, dest_len - src_len);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1326,7 +1326,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     }
 
     *rsa = malloc(sizeof(ssh2_rsa_ctx));
-    if(!(*rsa)) {
+    if(!*rsa) {
         BCryptDestroyKey(hKey);
         wcng_safe_free(rsakey, keylen);
         return -1;
@@ -1367,7 +1367,7 @@ static int wcng_rsa_new_private_parse(ssh2_rsa_ctx **rsa,
     }
 
     *rsa = malloc(sizeof(ssh2_rsa_ctx));
-    if(!(*rsa)) {
+    if(!*rsa) {
         BCryptDestroyKey(hKey);
         wcng_safe_free(pbStructInfo, cbStructInfo);
         return -1;
@@ -1621,7 +1621,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     }
 
     *dsa = malloc(sizeof(ssh2_dsa_ctx));
-    if(!(*dsa)) {
+    if(!*dsa) {
         BCryptDestroyKey(hKey);
         wcng_safe_free(dsakey, keylen);
         return -1;

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -350,10 +350,10 @@ struct wcng_dh_ctx {
     /* holds our private and public key components */
     BCRYPT_KEY_HANDLE dh_handle;
     /* records the parsed out modulus and generator
-     * parameters that are shared  with the peer */
+       parameters that are shared with the peer */
     BCRYPT_DH_PARAMETER_HEADER *dh_params;
     /* records the parsed out private key component for
-     * fallback if the DH API raw KDF is not supported */
+       fallback if the DH API raw KDF is not supported */
     struct wcng_bn *dh_privbn;
 };
 


### PR DESCRIPTION
- fix comment typos and formatting.
- drop unnecessary parentheses.
- rename `ml_kem_size` → `mlkem_size` for consistency.
- drop a few `{}` blocks.
- docs/libssh2_version.md: fix code formatting.
- docs/libssh2_version.md: delete roff (?) escaping remains.
- `"<null>"` → `"(null)"` for consistency (also with curl).
- fix indent, clang-format.
- openssl: drop redundant cast.
- wincng: constify `wcng_memcpy_with_be_padding()` input buffer.