### PR TITLE
mbedtls: fix mismatched alloc/free, leaks, leaks on OOM, missing null-terminator

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1037,11 +1037,8 @@ cleanup:
     return rc == 0 ? 0 : -1;
 }
 
-static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx,
-                            mbedtls_pk_context *pkey,
-                            LIBSSH2_SESSION *session,
-                            const unsigned char *data,
-                            size_t data_len,
+static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx, mbedtls_pk_context *pkey,
+                            const unsigned char *data, size_t data_len,
                             const unsigned char *pwd)
 {
     size_t pwd_len;
@@ -1211,8 +1208,7 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
     if(fread(data, 1, data_len, fp) != data_len)
         goto cleanup;
 
-    if(mbed_parse_eckey(ec_ctx, &pkey, session,
-                        data, data_len, passphrase) == 0)
+    if(mbed_parse_eckey(ec_ctx, &pkey, data, data_len, passphrase) == 0)
         goto cleanup;
 
     mbed_parse_openssh_key(ec_ctx, session, data, data_len, passphrase);
@@ -1253,8 +1249,7 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
     memcpy(ntdata, blob, blob_len);
     ntdata[blob_len] = 0;
 
-    if(mbed_parse_eckey(ec_ctx, &pkey, session,
-                        ntdata, blob_len + 1, passphrase) == 0)
+    if(mbed_parse_eckey(ec_ctx, &pkey, ntdata, blob_len + 1, passphrase) == 0)
         goto cleanup;
 
     mbed_parse_openssh_key(ec_ctx, session,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -465,7 +465,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
                                &mbed_ctr_drbg);
-    mbed_safe_free(blob_nullterm, blob_len);
+    mbed_safe_free(blob_nullterm, blob_len + 1);
 
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -157,7 +157,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
     osize = blocksize + mbedtls_cipher_get_block_size(ctx);
 
-    output = (unsigned char *)mbedtls_calloc(osize, sizeof(char));
+    output = mbedtls_calloc(osize, sizeof(char));
     if(output) {
         size_t olen = 0, finish_olen = 0;
 
@@ -280,7 +280,7 @@ ssh2_bn *ssh2_mbed_bn_init(void)
 {
     ssh2_bn *bignum;
 
-    bignum = (ssh2_bn *)mbedtls_calloc(1, sizeof(ssh2_bn));
+    bignum = mbedtls_calloc(1, sizeof(ssh2_bn));
     if(bignum)
         mbedtls_mpi_init(bignum);
 
@@ -350,7 +350,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     int ret;
     ssh2_rsa_ctx *ctx;
 
-    ctx = (ssh2_rsa_ctx *)mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
+    ctx = mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
     if(!ctx)
         return -1;
 
@@ -438,7 +438,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     unsigned char *blob_nullterm;
     size_t pwd_len;
 
-    *rsa = (ssh2_rsa_ctx *)mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
+    *rsa = mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
     if(!*rsa)
         return -1;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -438,6 +438,8 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     unsigned char *blob_nullterm;
     size_t pwd_len;
 
+    (void)session;
+
     *rsa = mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
     if(!*rsa)
         return -1;
@@ -466,8 +468,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);
-        mbedtls_rsa_free(*rsa);
-        SSH2_FREE(session, *rsa);
+        ssh2_rsa_free(*rsa);
         *rsa = NULL;
         return -1;
     }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1263,7 +1263,7 @@ cleanup:
 
     mbedtls_pk_free(&pkey);
 
-    mbed_safe_free(ntdata, blob_len);
+    mbed_safe_free(ntdata, blob_len + 1);
 
     return *ec_ctx ? 0 : -1;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -731,7 +731,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     mbedtls_pk_context pkey;
     char buf[1024];
     int ret;
-    void *privatekeydata_nullterm;
+    unsigned char *privatekeydata_nullterm;
     size_t pwd_len;
 
     /* mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
@@ -747,8 +747,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 
     pwd_len = passphrase ? strlen((const char *)passphrase) : 0;
     ret = mbedtls_pk_parse_key(&pkey,
-                               (unsigned char *)privatekeydata_nullterm,
-                               privatekeydata_len + 1,
+                               privatekeydata_nullterm, privatekeydata_len + 1,
                                (const unsigned char *)passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
                                &mbed_ctr_drbg);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -859,7 +859,7 @@ int ssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
 {
     size_t plen = 0;
 
-    *out_private_key = SSH2_ALLOC(session, sizeof(mbedtls_ecp_keypair));
+    *out_private_key = mbedtls_calloc(1, sizeof(mbedtls_ecp_keypair));
     if(!*out_private_key)
         goto failed;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -860,7 +860,6 @@ int ssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
     size_t plen = 0;
 
     *out_private_key = SSH2_ALLOC(session, sizeof(mbedtls_ecp_keypair));
-
     if(!*out_private_key)
         goto failed;
 
@@ -872,8 +871,8 @@ int ssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
 
     plen = 2 * mbedtls_mpi_size(
         &(*out_private_key)->MBEDTLS_PRIVATE(grp).P) + 1;
-    *out_public_key_octal = SSH2_ALLOC(session, plen);
 
+    *out_public_key_octal = SSH2_ALLOC(session, plen);
     if(!*out_public_key_octal)
         goto failed;
 
@@ -903,7 +902,6 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     ssh2_curve_type curve)
 {
     *ec_ctx = mbedtls_calloc(1, sizeof(mbedtls_ecp_keypair));
-
     if(!*ec_ctx)
         goto failed;
 
@@ -1048,14 +1046,12 @@ static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx,
 
     if(mbedtls_pk_parse_key(pkey, data, data_len, pwd, pwd_len,
                             mbedtls_ctr_drbg_random, &mbed_ctr_drbg))
-
         goto failed;
 
     if(mbedtls_pk_get_type(pkey) != MBEDTLS_PK_ECKEY)
         goto failed;
 
     *ctx = SSH2_ALLOC(session, sizeof(ssh2_ecdsa_ctx));
-
     if(!*ctx)
         goto failed;
 
@@ -1139,7 +1135,6 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
         goto failed;
 
     *ctx = SSH2_ALLOC(session, sizeof(ssh2_ecdsa_ctx));
-
     if(!*ctx)
         goto failed;
 
@@ -1321,7 +1316,6 @@ int ssh2_ecdsa_sign(LIBSSH2_SESSION *session, ssh2_ecdsa_ctx *ec_ctx,
     tmp_sign_len = r_len + s_len + 8;
 
     tmp_sign = SSH2_CALLOC(session, tmp_sign_len);
-
     if(!tmp_sign)
         goto cleanup;
 
@@ -1332,7 +1326,6 @@ int ssh2_ecdsa_sign(LIBSSH2_SESSION *session, ssh2_ecdsa_ctx *ec_ctx,
     *signature_len = (size_t)(sp - tmp_sign);
 
     *signature = SSH2_CALLOC(session, *signature_len);
-
     if(!*signature)
         goto cleanup;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -889,6 +889,7 @@ failed:
     ssh2_ecdsa_free(*out_private_key);
     mbed_safe_free(*out_public_key_octal, plen);
     *out_private_key = NULL;
+    *out_public_key_octal = NULL;
 
     return -1;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -750,7 +750,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                (const unsigned char *)passphrase, pwd_len,
                                mbedtls_ctr_drbg_random,
                                &mbed_ctr_drbg);
-    mbed_safe_free(privatekeydata_nullterm, privatekeydata_len);
+    mbed_safe_free(privatekeydata_nullterm, privatekeydata_len + 1);
 
     if(ret) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -887,9 +887,11 @@ failed:
 
     ssh2_ecdsa_free(*out_private_key);
     *out_private_key = NULL;
-    ssh2_explicit_zero(*out_public_key_octal, plen);
-    SSH2_FREE(session, *out_public_key_octal);
-    *out_public_key_octal = NULL;
+    if(*out_public_key_octal) {
+        ssh2_explicit_zero(*out_public_key_octal, plen);
+        SSH2_FREE(session, *out_public_key_octal);
+        *out_public_key_octal = NULL;
+    }
 
     return -1;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1056,7 +1056,7 @@ static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx,
     if(mbedtls_pk_get_type(pkey) != MBEDTLS_PK_ECKEY)
         goto failed;
 
-    *ctx = SSH2_ALLOC(session, sizeof(ssh2_ecdsa_ctx));
+    *ctx = mbedtls_calloc(1, sizeof(ssh2_ecdsa_ctx));
     if(!*ctx)
         goto failed;
 
@@ -1139,7 +1139,7 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
     if(ssh2_get_bignum_bytes(decrypted, &exponent, &exponentlen))
         goto failed;
 
-    *ctx = SSH2_ALLOC(session, sizeof(ssh2_ecdsa_ctx));
+    *ctx = mbedtls_calloc(1, sizeof(ssh2_ecdsa_ctx));
     if(!*ctx)
         goto failed;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -457,6 +457,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     }
 
     memcpy(blob_nullterm, blob, blob_len);
+    blob_nullterm[blob_len] = 0;
 
     mbedtls_pk_init(&pkey);
 
@@ -740,6 +741,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
         return -1;
 
     memcpy(privatekeydata_nullterm, privatekeydata, privatekeydata_len);
+    privatekeydata_nullterm[privatekeydata_len] = 0;
 
     mbedtls_pk_init(&pkey);
 
@@ -1250,6 +1252,7 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
         goto cleanup;
 
     memcpy(ntdata, blob, blob_len);
+    ntdata[blob_len] = 0;
 
     if(mbed_parse_eckey(ec_ctx, &pkey, session,
                         ntdata, blob_len + 1, passphrase) == 0)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1240,10 +1240,11 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
     unsigned char *ntdata;
     mbedtls_pk_context pkey;
 
+    (void)session;
+
     mbedtls_pk_init(&pkey);
 
-    ntdata = SSH2_ALLOC(session, blob_len + 1);
-
+    ntdata = mbedtls_calloc(1, blob_len + 1);
     if(!ntdata)
         goto cleanup;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -886,9 +886,9 @@ int ssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
 failed:
 
     ssh2_ecdsa_free(*out_private_key);
+    *out_private_key = NULL;
     ssh2_explicit_zero(*out_public_key_octal, plen);
     SSH2_FREE(session, *out_public_key_octal);
-    *out_private_key = NULL;
     *out_public_key_octal = NULL;
 
     return -1;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -403,7 +403,9 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
     mbedtls_pk_context pkey;
     mbedtls_rsa_context *pk_rsa;
 
-    *rsa = SSH2_ALLOC(session, sizeof(ssh2_rsa_ctx));
+    (void)session;
+
+    *rsa = mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
     if(!*rsa)
         return -1;
 
@@ -414,8 +416,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                                    mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);
-        mbedtls_rsa_free(*rsa);
-        SSH2_FREE(session, *rsa);
+        ssh2_rsa_free(*rsa);
         *rsa = NULL;
         return -1;
     }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -447,8 +447,11 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     /* mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
        private-key from memory fails if the last byte is not a null byte */
     blob_nullterm = mbedtls_calloc(blob_len + 1, 1);
-    if(!blob_nullterm)
+    if(!blob_nullterm) {
+        ssh2_rsa_free(*rsa);
+        *rsa = NULL;
         return -1;
+    }
 
     memcpy(blob_nullterm, blob, blob_len);
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -886,7 +886,8 @@ int ssh2_ecdsa_create_key(LIBSSH2_SESSION *session,
 failed:
 
     ssh2_ecdsa_free(*out_private_key);
-    mbed_safe_free(*out_public_key_octal, plen);
+    ssh2_explicit_zero(*out_public_key_octal, plen);
+    SSH2_FREE(session, *out_public_key_octal);
     *out_private_key = NULL;
     *out_public_key_octal = NULL;
 


### PR DESCRIPTION
- fix memleak on internal buffer OOM in
  `ssh2_rsa_new_private_frommemory()`.

- fix to use mbedtls allocator to null-terminate the local buffer and 
  match the free call in `ssh2_ecdsa_new_private_frommemory()`.

- drop redundant casts for `mbedtls_calloc()` pointers.

- fix to free rsa object with `ssh2_rsa_free()` on key parse error in
  `ssh2_rsa_new_private_frommemory()`.

- fix to use mbedtls alloc/free for rsa object (to match
  `ssh2_rsa_free()`) in `ssh2_rsa_new_private()`.

- include terminating byte in `mbed_safe_free()` calls in.
  `ssh2_rsa_new_private_frommemory()`, `ssh2_pub_priv_keyfilememory()`,
  `ssh2_ecdsa_new_private_frommemory()`. For consistency/clarity only,
  the terminating byte is normally zero.

- reset `*out_public_key_octal` to NULL on fail in
  `ssh2_ecdsa_create_key()`.
                                                                    
- fix to use mbedtls allocator in `ssh2_ecdsa_create_key()`. This buffer
  is freed with `ssh2_ecdsa_free()`.

- fix to use libssh2 safe-free for `*out_public_key_octal` on fail in
  `ssh2_ecdsa_create_key()`. This buffer is freed with libssh2 free in
  the codebase.

- explicitly null-terminate buffers required to be so by mbedtls. Do not 
  rely on `mbedtls_calloc()` doing the zeroing. To ensure the bug in
  `ssh2_ecdsa_new_private_frommemory()` doesn't repeat.

- fix to use mbedtls allocator in `mbed_parse_eckey()`,.
  `mbed_parse_openssh_key()`. (also stop passing `sesssion *` where no 
  longer used after this.)

- fixup a type to avoid cast.

- drop newlines.

TL;DR most of these could cause crashes/leaks when using a custom
allocator, some were causing leaking crypto-backend objects, some leaks
on error path, `ssh2_ecdsa_new_private_frommemory()` failing randomly.

Ref: #2195 (few of these reported by Copilot)

---

- [ ] is there any advantage or obligation to use the mbedtls allocator?
- [x] rebase on #2200.
