### PR TITLE
kex: fix mismatched ECDSA private key free in ML-KEM cleanup

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -1968,7 +1968,7 @@ static void kex_method_mlkem_nistp_cleanup(
     }
 
     if(key_state->private_key) {
-        SSH2_FREE(session, key_state->private_key);
+        ssh2_ecdsa_free(key_state->private_key);
         key_state->private_key = NULL;
     }
 


### PR DESCRIPTION
Replace `SSH2_FREE()` with `ssh2_ecdsa_free()` in
`kex_method_mlkem_nistp_cleanup()`. This buffer is allocated with the
crypto backend's allocator, and may also require backend-specific 
cleanup beforehand.

Follow-up to 3ba252e2a6fe04d17ea13ad870698a4028c8ab4c #1644
Cherry-picked from #2196
