### PR TITLE
publickey: fix uninitialized free on fail in `libssh2_publickey_list_fetch()`

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -914,6 +914,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                 list = newlist;
                 memset(&list[keys], 0, sizeof(list[keys]));
             }
+            list[keys].packet = NULL;
             if(pkey->version == 1) {
                 unsigned long comment_len;
 


### PR DESCRIPTION
Reported-by: Vladimir Eli Tokarev
Fixes GHSA-w6g9-cpfp-22gc
