### PR TITLE
publickey: fix potential OOB read

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -428,7 +428,8 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
                 /* Error */
                 unsigned long status, descr_len, lang_len;
 
-                if(session->pkeyInit_data_len >= 8) {
+                if(s + 8 <=
+                   session->pkeyInit_data + session->pkeyInit_data_len) {
                     status = ssh2_ntohu32(s);
                     s += 4;
                     descr_len = ssh2_ntohu32(s);


### PR DESCRIPTION
Fix by applying the pattern used in subsequent checks.

"The status-response parsing checks `session->pkeyInit_data_len < 8`,
but `s` has already been advanced by `publickey_response_id()`. On a
malformed packet where the total length is >= 8 but the remaining bytes
from `s` are < 8, this will read past the end when decoding
`status`/`descr_len` (and the later checks occur after those reads).
Please validate the remaining bytes relative to `s` before calling
`ssh2_ntohu32()`."

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2203#discussion_r3523007062
Follow-up to c02d9b7b731ef20fdafff54d8158c4d6c4822450
