### PR TITLE
transport: flush partial send before key re-exchange redirect

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -996,12 +996,35 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
     size_t orgdata_len = data_len;
     size_t crypt_offset, etm_crypt_offset;
 
+    debugdump(session, "ssh2_transport_send() plain", data, data_len);
+    if(data2)
+        debugdump(session, "ssh2_transport_send() plain2", data2, data2_len);
+
+    /* Finish flushing any partially-sent packet BEFORE redirecting into a key
+     * re-exchange. A packet already in transmission can only be completed by a
+     * transport_send call with that same packet (send_existing rejects a
+     * different data pointer with EAGAIN). If rekey runs first, a packet
+     * caught mid-send when rekey starts can never be flushed and the session
+     * deadlocks. RFC 4253 7.1 requires completing the in-flight packet; only
+     * NEW packets are withheld, which the rekey redirect (reached only once
+     * nothing is pending) still does.
+     *
+     * send_existing only sanity-checks data and data_len, not data2/data2_len.
+     */
+    rc = send_existing(session, data, data_len, &ret);
+    if(rc)
+        return rc;
+
+    session->socket_block_directions &= ~LIBSSH2_SESSION_BLOCK_OUTBOUND;
+
+    if(ret)
+        /* set by send_existing if data was sent */
+        return rc;
+
     /*
      * If the last read operation was interrupted in the middle of a key
-     * exchange, we must complete that key exchange before continuing to write
-     * further data.
-     *
-     * See the similar block in ssh2_transport_read() for more details.
+     * exchange, we must complete that key exchange before writing further
+     * *new* data. See the similar block in ssh2_transport_read().
      */
     if(session->state & SSH2_STATE_EXCHANGING_KEYS &&
        !(session->state & SSH2_STATE_KEX_ACTIVE)) {
@@ -1013,22 +1036,6 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
         if(rc)
             return rc;
     }
-
-    debugdump(session, "ssh2_transport_send() plain", data, data_len);
-    if(data2)
-        debugdump(session, "ssh2_transport_send() plain2", data2, data2_len);
-
-    /* FIRST, check if we have a pending write to complete. send_existing
-       only sanity-check data and data_len and not data2 and data2_len! */
-    rc = send_existing(session, data, data_len, &ret);
-    if(rc)
-        return rc;
-
-    session->socket_block_directions &= ~LIBSSH2_SESSION_BLOCK_OUTBOUND;
-
-    if(ret)
-        /* set by send_existing if data was sent */
-        return rc;
 
     encrypted = (session->state & SSH2_STATE_NEWKEYS) ? 1 : 0;
 


### PR DESCRIPTION
## Summary

Fixes a permanent non-blocking deadlock when a key re-exchange starts while a channel packet is only partially written to the socket.

## Problem

In `ssh2_transport_send()`, the `SSH2_STATE_EXCHANGING_KEYS` redirect ran **before** `send_existing()`. If a partial packet was already in flight:

1. Rekey runs and may return `EAGAIN` or complete while the partial remains pending.
2. Later calls with different `data` pointers hit `send_existing()`'s "Address is different" path and return `EAGAIN` forever.
3. Callers see `LIBSSH2_SESSION_BLOCK_OUTBOUND` with no progress on `send()`.

## Fix

Flush any pending partial via `send_existing()` **first**, then run the rekey redirect only for **new** packets. This matches RFC 4253 §7.1 (finish the in-flight packet; withhold new packets during rekey).

The comment above the old `send_existing` call already said "FIRST"; the rekey block had been ordered ahead of it.

## Testing

- `cmake --build` (full tree including tests) succeeds on macOS arm64.
- Manual review of control flow against the reproducer described in the issue.

## References

- Closes https://github.com/libssh2/libssh2/issues/2110
- Maintainer invited a PR on that issue (2026-06-21).