### PR TITLE
src: add `SSH2_SAFEFREE()` macro and use it

### DIFF
--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -984,9 +984,13 @@ sub scanfile {
             }
         }
         if($l) {
-            if($l =~ /^( *)(curlx_free|SSH2_FREE)\(([^)]+)\);/) {
+            if($l =~ /^( *)curlx_free\(([^)]+)\);/) {
                 $prevfreeindent = $1;
                 $prevfreevar = $2;
+            }
+            elsif($l =~ /^( *)SSH2_FREE\(([^)]+), ([^)]+)\);/) {
+                $prevfreeindent = $1;
+                $prevfreevar = $3;
             }
             else {
                 $prevfreeindent = "";

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -984,7 +984,7 @@ sub scanfile {
             }
         }
         if($l) {
-            if($l =~ /^( *)curlx_free\(([^)]+)\);/) {
+            if($l =~ /^( *)(curlx_free|SSH2_FREE)\(([^)]+)\);/) {
                 $prevfreeindent = $1;
                 $prevfreevar = $2;
             }

--- a/src/agent.c
+++ b/src/agent.c
@@ -808,8 +808,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     if(rc)
         goto error;
 
-    SSH2_FREE(session, transctx->request);
-    transctx->request = NULL;
+    SSH2_FREENULL(session, transctx->request);
 
     len = transctx->response_len;
     s = transctx->response;
@@ -900,11 +899,8 @@ error:
     if(method_name)
         SSH2_FREE(session, method_name);
 
-    SSH2_FREE(session, transctx->request);
-    transctx->request = NULL;
-
-    SSH2_FREE(session, transctx->response);
-    transctx->response = NULL;
+    SSH2_FREENULL(session, transctx->request);
+    SSH2_FREENULL(session, transctx->response);
 
     transctx->state = agent_NB_state_init;
 
@@ -940,8 +936,7 @@ static int agent_list_identities(LIBSSH2_AGENT *agent)
 
     rc = agent->ops->transact(agent, transctx);
     if(rc) {
-        SSH2_FREE(agent->session, transctx->response);
-        transctx->response = NULL;
+        SSH2_FREENULL(agent->session, transctx->response);
         return rc;
     }
     transctx->request = NULL;
@@ -1055,8 +1050,7 @@ static int agent_list_identities(LIBSSH2_AGENT *agent)
         ssh2_list_add(&agent->head, &identity->node);
     }
 error:
-    SSH2_FREE(agent->session, transctx->response);
-    transctx->response = NULL;
+    SSH2_FREENULL(agent->session, transctx->response);
 
     return ssh2_err(agent->session, rc, "agent list id failed");
 }
@@ -1249,8 +1243,7 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
 
     rc = agent_sign(agent->session, sig, s_len, data, d_len, &abstract);
 
-    SSH2_FREE(agent->session, agent->session->userauth_pblc_method);
-    agent->session->userauth_pblc_method = NULL;
+    SSH2_FREENULL(agent->session, agent->session->userauth_pblc_method);
     agent->session->userauth_pblc_method_len = 0;
 
     return rc;
@@ -1290,10 +1283,8 @@ void libssh2_agent_free(LIBSSH2_AGENT *agent)
  */
 void libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
 {
-    if(agent->identity_agent_path) {
-        SSH2_FREE(agent->session, agent->identity_agent_path);
-        agent->identity_agent_path = NULL;
-    }
+    if(agent->identity_agent_path)
+        SSH2_FREENULL(agent->session, agent->identity_agent_path);
 
     if(path) {
         size_t path_len = strlen(path);

--- a/src/agent.c
+++ b/src/agent.c
@@ -808,7 +808,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     if(rc)
         goto error;
 
-    SSH2_FREENULL(session, transctx->request);
+    SSH2_SAFEFREE(session, transctx->request);
 
     len = transctx->response_len;
     s = transctx->response;
@@ -899,8 +899,8 @@ error:
     if(method_name)
         SSH2_FREE(session, method_name);
 
-    SSH2_FREENULL(session, transctx->request);
-    SSH2_FREENULL(session, transctx->response);
+    SSH2_SAFEFREE(session, transctx->request);
+    SSH2_SAFEFREE(session, transctx->response);
 
     transctx->state = agent_NB_state_init;
 
@@ -936,7 +936,7 @@ static int agent_list_identities(LIBSSH2_AGENT *agent)
 
     rc = agent->ops->transact(agent, transctx);
     if(rc) {
-        SSH2_FREENULL(agent->session, transctx->response);
+        SSH2_SAFEFREE(agent->session, transctx->response);
         return rc;
     }
     transctx->request = NULL;
@@ -1050,7 +1050,7 @@ static int agent_list_identities(LIBSSH2_AGENT *agent)
         ssh2_list_add(&agent->head, &identity->node);
     }
 error:
-    SSH2_FREENULL(agent->session, transctx->response);
+    SSH2_SAFEFREE(agent->session, transctx->response);
 
     return ssh2_err(agent->session, rc, "agent list id failed");
 }
@@ -1243,7 +1243,7 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
 
     rc = agent_sign(agent->session, sig, s_len, data, d_len, &abstract);
 
-    SSH2_FREENULL(agent->session, agent->session->userauth_pblc_method);
+    SSH2_SAFEFREE(agent->session, agent->session->userauth_pblc_method);
     agent->session->userauth_pblc_method_len = 0;
 
     return rc;
@@ -1284,7 +1284,7 @@ void libssh2_agent_free(LIBSSH2_AGENT *agent)
 void libssh2_agent_set_identity_path(LIBSSH2_AGENT *agent, const char *path)
 {
     if(agent->identity_agent_path)
-        SSH2_FREENULL(agent->session, agent->identity_agent_path);
+        SSH2_SAFEFREE(agent->session, agent->identity_agent_path);
 
     if(path) {
         size_t path_len = strlen(path);

--- a/src/channel.c
+++ b/src/channel.c
@@ -160,7 +160,7 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
         if(!session->open_channel->channel_type) {
             ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                      "Failed allocating memory for channel type name");
-            SSH2_FREENULL(session, session->open_channel);
+            SSH2_SAFEFREE(session, session->open_channel);
             return NULL;
         }
         memcpy(session->open_channel->channel_type, channel_type,
@@ -256,8 +256,8 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
                       session->open_channel->remote.window_size,
                       session->open_channel->local.packet_size,
                       session->open_channel->remote.packet_size));
-            SSH2_FREENULL(session, session->open_packet);
-            SSH2_FREENULL(session, session->open_data);
+            SSH2_SAFEFREE(session, session->open_packet);
+            SSH2_SAFEFREE(session, session->open_data);
             session->open_state = ssh2_NB_state_idle;
             return session->open_channel;
         }
@@ -299,9 +299,9 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
 channel_error:
 
     if(session->open_data)
-        SSH2_FREENULL(session, session->open_data);
+        SSH2_SAFEFREE(session, session->open_data);
     if(session->open_packet)
-        SSH2_FREENULL(session, session->open_packet);
+        SSH2_SAFEFREE(session, session->open_packet);
     if(session->open_channel) {
         unsigned char channel_id[4];
         SSH2_FREE(session, session->open_channel->channel_type);
@@ -316,10 +316,10 @@ channel_error:
               ssh2_packet_ask(session, SSH_MSG_CHANNEL_EXTENDED_DATA,
                               &session->open_data, &session->open_data_len, 1,
                               channel_id, 4) >= 0) {
-            SSH2_FREENULL(session, session->open_data);
+            SSH2_SAFEFREE(session, session->open_data);
         }
 
-        SSH2_FREENULL(session, session->open_channel);
+        SSH2_SAFEFREE(session, session->open_channel);
     }
 
     session->open_state = ssh2_NB_state_idle;
@@ -402,7 +402,7 @@ static LIBSSH2_CHANNEL *channel_direct_tcpip(LIBSSH2_SESSION *session,
     /* by default we set (keep?) idle state... */
     session->direct_state = ssh2_NB_state_idle;
 
-    SSH2_FREENULL(session, session->direct_message);
+    SSH2_SAFEFREE(session, session->direct_message);
 
     return channel;
 }
@@ -475,7 +475,7 @@ static LIBSSH2_CHANNEL *channel_direct_streamlocal(LIBSSH2_SESSION *session,
     /* by default we set (keep?) idle state... */
     session->direct_state = ssh2_NB_state_idle;
 
-    SSH2_FREENULL(session, session->direct_message);
+    SSH2_SAFEFREE(session, session->direct_message);
 
     return channel;
 }
@@ -562,11 +562,11 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
             ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                      "Unable to send global-request packet for forward "
                      "listen request");
-            SSH2_FREENULL(session, session->fwdLstn_packet);
+            SSH2_SAFEFREE(session, session->fwdLstn_packet);
             session->fwdLstn_state = ssh2_NB_state_idle;
             return NULL;
         }
-        SSH2_FREENULL(session, session->fwdLstn_packet);
+        SSH2_SAFEFREE(session, session->fwdLstn_packet);
         session->fwdLstn_state = ssh2_NB_state_sent;
     }
 
@@ -599,7 +599,7 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
                 if(!listener->host) {
                     ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                              "Unable to allocate memory for listener queue");
-                    SSH2_FREENULL(session, listener);
+                    SSH2_SAFEFREE(session, listener);
                 }
                 else {
                     listener->session = session;
@@ -866,13 +866,13 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
             return rc;
         }
         else if(rc) {
-            SSH2_FREENULL(session, channel->setenv_packet);
+            SSH2_SAFEFREE(session, channel->setenv_packet);
             channel->setenv_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send channel-request packet for "
                             "setenv request");
         }
-        SSH2_FREENULL(session, channel->setenv_packet);
+        SSH2_SAFEFREE(session, channel->setenv_packet);
 
         ssh2_htonu32(channel->setenv_local_channel, channel->local.id);
 
@@ -1348,11 +1348,11 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
             return rc;
         }
         if(rc) {
-            SSH2_FREENULL(session, channel->reqX11_packet);
+            SSH2_SAFEFREE(session, channel->reqX11_packet);
             channel->reqX11_state = ssh2_NB_state_idle;
             return ssh2_err(session, rc, "Unable to send x11-req packet");
         }
-        SSH2_FREENULL(session, channel->reqX11_packet);
+        SSH2_SAFEFREE(session, channel->reqX11_packet);
 
         ssh2_htonu32(channel->reqX11_local_channel, channel->local.id);
 
@@ -1466,11 +1466,11 @@ int ssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
             return rc;
         }
         else if(rc) {
-            SSH2_FREENULL(session, channel->process_packet);
+            SSH2_SAFEFREE(session, channel->process_packet);
             channel->process_state = ssh2_NB_state_end;
             return ssh2_err(session, rc, "Unable to send channel request");
         }
-        SSH2_FREENULL(session, channel->process_packet);
+        SSH2_SAFEFREE(session, channel->process_packet);
 
         ssh2_htonu32(channel->process_local_channel, channel->local.id);
 
@@ -2656,15 +2656,15 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
         session->open_channel = NULL;
         session->open_state = ssh2_NB_state_idle;
         if(session->open_packet)
-            SSH2_FREENULL(session, session->open_packet);
+            SSH2_SAFEFREE(session, session->open_packet);
         if(session->open_data)
-            SSH2_FREENULL(session, session->open_data);
+            SSH2_SAFEFREE(session, session->open_data);
     }
     if(session->pkeyInit_channel == channel) {
         session->pkeyInit_channel = NULL;
         session->pkeyInit_state = ssh2_NB_state_idle;
         if(session->pkeyInit_data)
-            SSH2_FREENULL(session, session->pkeyInit_data);
+            SSH2_SAFEFREE(session, session->pkeyInit_data);
     }
     if(session->packAdd_channelp == channel) {
         session->packAdd_channelp = NULL;
@@ -2674,13 +2674,13 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
         session->scpSend_channel = NULL;
         session->scpSend_state = ssh2_NB_state_idle;
         if(session->scpSend_command)
-            SSH2_FREENULL(session, session->scpSend_command);
+            SSH2_SAFEFREE(session, session->scpSend_command);
     }
     if(session->scpRecv_channel == channel) {
         session->scpRecv_channel = NULL;
         session->scpRecv_state = ssh2_NB_state_idle;
         if(session->scpRecv_command)
-            SSH2_FREENULL(session, session->scpRecv_command);
+            SSH2_SAFEFREE(session, session->scpRecv_command);
     }
 
     SSH2_FREE(session, channel);

--- a/src/channel.c
+++ b/src/channel.c
@@ -160,8 +160,7 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
         if(!session->open_channel->channel_type) {
             ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                      "Failed allocating memory for channel type name");
-            SSH2_FREE(session, session->open_channel);
-            session->open_channel = NULL;
+            SSH2_FREENULL(session, session->open_channel);
             return NULL;
         }
         memcpy(session->open_channel->channel_type, channel_type,
@@ -257,11 +256,8 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
                       session->open_channel->remote.window_size,
                       session->open_channel->local.packet_size,
                       session->open_channel->remote.packet_size));
-            SSH2_FREE(session, session->open_packet);
-            session->open_packet = NULL;
-            SSH2_FREE(session, session->open_data);
-            session->open_data = NULL;
-
+            SSH2_FREENULL(session, session->open_packet);
+            SSH2_FREENULL(session, session->open_data);
             session->open_state = ssh2_NB_state_idle;
             return session->open_channel;
         }
@@ -302,14 +298,10 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
 
 channel_error:
 
-    if(session->open_data) {
-        SSH2_FREE(session, session->open_data);
-        session->open_data = NULL;
-    }
-    if(session->open_packet) {
-        SSH2_FREE(session, session->open_packet);
-        session->open_packet = NULL;
-    }
+    if(session->open_data)
+        SSH2_FREENULL(session, session->open_data);
+    if(session->open_packet)
+        SSH2_FREENULL(session, session->open_packet);
     if(session->open_channel) {
         unsigned char channel_id[4];
         SSH2_FREE(session, session->open_channel->channel_type);
@@ -324,12 +316,10 @@ channel_error:
               ssh2_packet_ask(session, SSH_MSG_CHANNEL_EXTENDED_DATA,
                               &session->open_data, &session->open_data_len, 1,
                               channel_id, 4) >= 0) {
-            SSH2_FREE(session, session->open_data);
-            session->open_data = NULL;
+            SSH2_FREENULL(session, session->open_data);
         }
 
-        SSH2_FREE(session, session->open_channel);
-        session->open_channel = NULL;
+        SSH2_FREENULL(session, session->open_channel);
     }
 
     session->open_state = ssh2_NB_state_idle;
@@ -412,8 +402,7 @@ static LIBSSH2_CHANNEL *channel_direct_tcpip(LIBSSH2_SESSION *session,
     /* by default we set (keep?) idle state... */
     session->direct_state = ssh2_NB_state_idle;
 
-    SSH2_FREE(session, session->direct_message);
-    session->direct_message = NULL;
+    SSH2_FREENULL(session, session->direct_message);
 
     return channel;
 }
@@ -486,8 +475,7 @@ static LIBSSH2_CHANNEL *channel_direct_streamlocal(LIBSSH2_SESSION *session,
     /* by default we set (keep?) idle state... */
     session->direct_state = ssh2_NB_state_idle;
 
-    SSH2_FREE(session, session->direct_message);
-    session->direct_message = NULL;
+    SSH2_FREENULL(session, session->direct_message);
 
     return channel;
 }
@@ -574,14 +562,11 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
             ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                      "Unable to send global-request packet for forward "
                      "listen request");
-            SSH2_FREE(session, session->fwdLstn_packet);
-            session->fwdLstn_packet = NULL;
+            SSH2_FREENULL(session, session->fwdLstn_packet);
             session->fwdLstn_state = ssh2_NB_state_idle;
             return NULL;
         }
-        SSH2_FREE(session, session->fwdLstn_packet);
-        session->fwdLstn_packet = NULL;
-
+        SSH2_FREENULL(session, session->fwdLstn_packet);
         session->fwdLstn_state = ssh2_NB_state_sent;
     }
 
@@ -614,8 +599,7 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
                 if(!listener->host) {
                     ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                              "Unable to allocate memory for listener queue");
-                    SSH2_FREE(session, listener);
-                    listener = NULL;
+                    SSH2_FREENULL(session, listener);
                 }
                 else {
                     listener->session = session;
@@ -882,15 +866,13 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
             return rc;
         }
         else if(rc) {
-            SSH2_FREE(session, channel->setenv_packet);
-            channel->setenv_packet = NULL;
+            SSH2_FREENULL(session, channel->setenv_packet);
             channel->setenv_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send channel-request packet for "
                             "setenv request");
         }
-        SSH2_FREE(session, channel->setenv_packet);
-        channel->setenv_packet = NULL;
+        SSH2_FREENULL(session, channel->setenv_packet);
 
         ssh2_htonu32(channel->setenv_local_channel, channel->local.id);
 
@@ -1366,13 +1348,11 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
             return rc;
         }
         if(rc) {
-            SSH2_FREE(session, channel->reqX11_packet);
-            channel->reqX11_packet = NULL;
+            SSH2_FREENULL(session, channel->reqX11_packet);
             channel->reqX11_state = ssh2_NB_state_idle;
             return ssh2_err(session, rc, "Unable to send x11-req packet");
         }
-        SSH2_FREE(session, channel->reqX11_packet);
-        channel->reqX11_packet = NULL;
+        SSH2_FREENULL(session, channel->reqX11_packet);
 
         ssh2_htonu32(channel->reqX11_local_channel, channel->local.id);
 
@@ -1486,13 +1466,11 @@ int ssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
             return rc;
         }
         else if(rc) {
-            SSH2_FREE(session, channel->process_packet);
-            channel->process_packet = NULL;
+            SSH2_FREENULL(session, channel->process_packet);
             channel->process_state = ssh2_NB_state_end;
             return ssh2_err(session, rc, "Unable to send channel request");
         }
-        SSH2_FREE(session, channel->process_packet);
-        channel->process_packet = NULL;
+        SSH2_FREENULL(session, channel->process_packet);
 
         ssh2_htonu32(channel->process_local_channel, channel->local.id);
 
@@ -2677,22 +2655,16 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
     if(session->open_channel == channel) {
         session->open_channel = NULL;
         session->open_state = ssh2_NB_state_idle;
-        if(session->open_packet) {
-            SSH2_FREE(session, session->open_packet);
-            session->open_packet = NULL;
-        }
-        if(session->open_data) {
-            SSH2_FREE(session, session->open_data);
-            session->open_data = NULL;
-        }
+        if(session->open_packet)
+            SSH2_FREENULL(session, session->open_packet);
+        if(session->open_data)
+            SSH2_FREENULL(session, session->open_data);
     }
     if(session->pkeyInit_channel == channel) {
         session->pkeyInit_channel = NULL;
         session->pkeyInit_state = ssh2_NB_state_idle;
-        if(session->pkeyInit_data) {
-            SSH2_FREE(session, session->pkeyInit_data);
-            session->pkeyInit_data = NULL;
-        }
+        if(session->pkeyInit_data)
+            SSH2_FREENULL(session, session->pkeyInit_data);
     }
     if(session->packAdd_channelp == channel) {
         session->packAdd_channelp = NULL;
@@ -2701,18 +2673,14 @@ int ssh2_channel_free(LIBSSH2_CHANNEL *channel)
     if(session->scpSend_channel == channel) {
         session->scpSend_channel = NULL;
         session->scpSend_state = ssh2_NB_state_idle;
-        if(session->scpSend_command) {
-            SSH2_FREE(session, session->scpSend_command);
-            session->scpSend_command = NULL;
-        }
+        if(session->scpSend_command)
+            SSH2_FREENULL(session, session->scpSend_command);
     }
     if(session->scpRecv_channel == channel) {
         session->scpRecv_channel = NULL;
         session->scpRecv_state = ssh2_NB_state_idle;
-        if(session->scpRecv_command) {
-            SSH2_FREE(session, session->scpRecv_command);
-            session->scpRecv_command = NULL;
-        }
+        if(session->scpRecv_command)
+            SSH2_FREENULL(session, session->scpRecv_command);
     }
 
     SSH2_FREE(session, channel);

--- a/src/kex.c
+++ b/src/kex.c
@@ -69,12 +69,12 @@ static void sha_algo_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
                                        exchange_state->k_value_len) ||
                !ssh2_hash_update(hash, exchange_state->h_sig_comp,
                                        digest_len)) {
-                SSH2_FREENULL(session, *data);
+                SSH2_SAFEFREE(session, *data);
                 return;
             }
             if(len > 0) {
                 if(!ssh2_hash_update(hash, *data, len)) {
-                    SSH2_FREENULL(session, *data);
+                    SSH2_SAFEFREE(session, *data);
                     return;
                 }
             }
@@ -82,12 +82,12 @@ static void sha_algo_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
                 if(!ssh2_hash_update(hash, version, 1) ||
                    !ssh2_hash_update(hash, session->session_id,
                                            session->session_id_len)) {
-                    SSH2_FREENULL(session, *data);
+                    SSH2_SAFEFREE(session, *data);
                     return;
                 }
             }
             if(!ssh2_hash_final(hash, *data + len, digest_len)) {
-                SSH2_FREENULL(session, *data);
+                SSH2_SAFEFREE(session, *data);
                 return;
             }
             len += digest_len;
@@ -121,7 +121,7 @@ static int process_host_key(LIBSSH2_SESSION *session, struct string_buf *buf,
     buf->dataptr++; /* advance past type */
 
     if(session->server_hostkey) {
-        SSH2_FREENULL(session, session->server_hostkey);
+        SSH2_SAFEFREE(session, session->server_hostkey);
         session->server_hostkey_len = 0;
     }
 
@@ -443,11 +443,11 @@ static void diffie_hellman_state_cleanup(
     exchange_state->ctx = NULL;
 
     if(exchange_state->e_packet)
-        SSH2_FREENULL(session, exchange_state->e_packet);
+        SSH2_SAFEFREE(session, exchange_state->e_packet);
     if(exchange_state->s_packet)
-        SSH2_FREENULL(session, exchange_state->s_packet);
+        SSH2_SAFEFREE(session, exchange_state->s_packet);
     if(exchange_state->k_value)
-        SSH2_FREENULL(session, exchange_state->k_value);
+        SSH2_SAFEFREE(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -462,7 +462,7 @@ static void kex_diffie_hellman_cleanup(
         key_state->g = NULL;
 
         if(key_state->data)
-            SSH2_FREENULL(session, key_state->data);
+            SSH2_SAFEFREE(session, key_state->data);
         key_state->state = ssh2_NB_state_idle;
     }
 
@@ -1628,7 +1628,7 @@ static void ecdh_exchange_state_cleanup(
     exchange_state->k = NULL;
 
     if(exchange_state->k_value)
-        SSH2_FREENULL(session, exchange_state->k_value);
+        SSH2_SAFEFREE(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -1637,7 +1637,7 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
                                     struct key_exchange_state_low *key_state)
 {
     if(key_state->public_key_oct)
-        SSH2_FREENULL(session, key_state->public_key_oct);
+        SSH2_SAFEFREE(session, key_state->public_key_oct);
 
     if(key_state->private_key) {
         ssh2_ecdsa_free(key_state->private_key);
@@ -1645,7 +1645,7 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
     }
 
     if(key_state->data)
-        SSH2_FREENULL(session, key_state->data);
+        SSH2_SAFEFREE(session, key_state->data);
 
     key_state->state = ssh2_NB_state_idle;
 
@@ -1931,7 +1931,7 @@ static void mlkem_nistp_exchange_state_cleanup(
     exchange_state->k = NULL;
 
     if(exchange_state->k_value)
-        SSH2_FREENULL(session, exchange_state->k_value);
+        SSH2_SAFEFREE(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -1940,7 +1940,7 @@ static void kex_method_mlkem_nistp_cleanup(
     LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
     if(key_state->public_key_oct)
-        SSH2_FREENULL(session, key_state->public_key_oct);
+        SSH2_SAFEFREE(session, key_state->public_key_oct);
 
     if(key_state->private_key) {
         ssh2_ecdsa_free(key_state->private_key);
@@ -1950,19 +1950,19 @@ static void kex_method_mlkem_nistp_cleanup(
     if(key_state->mlkem_public_key) {
         ssh2_explicit_zero(key_state->mlkem_public_key,
                            key_state->mlkem_public_key_len);
-        SSH2_FREENULL(session, key_state->mlkem_public_key);
+        SSH2_SAFEFREE(session, key_state->mlkem_public_key);
         key_state->mlkem_public_key_len = 0;
     }
 
     if(key_state->mlkem_private_key) {
         ssh2_explicit_zero(key_state->mlkem_private_key,
                            key_state->mlkem_private_key_len);
-        SSH2_FREENULL(session, key_state->mlkem_private_key);
+        SSH2_SAFEFREE(session, key_state->mlkem_private_key);
         key_state->mlkem_private_key_len = 0;
     }
 
     if(key_state->data)
-        SSH2_FREENULL(session, key_state->data);
+        SSH2_SAFEFREE(session, key_state->data);
 
     key_state->state = ssh2_NB_state_idle;
 
@@ -2340,7 +2340,7 @@ static void curve25519_exchange_state_cleanup(
     exchange_state->k = NULL;
 
     if(exchange_state->k_value)
-        SSH2_FREENULL(session, exchange_state->k_value);
+        SSH2_SAFEFREE(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -2351,17 +2351,17 @@ static void kex_method_curve25519_cleanup(
     if(key_state->curve25519_public_key) {
         ssh2_explicit_zero(key_state->curve25519_public_key,
                            SSH2_ED25519_KEY_LEN);
-        SSH2_FREENULL(session, key_state->curve25519_public_key);
+        SSH2_SAFEFREE(session, key_state->curve25519_public_key);
     }
 
     if(key_state->curve25519_private_key) {
         ssh2_explicit_zero(key_state->curve25519_private_key,
                            SSH2_ED25519_KEY_LEN);
-        SSH2_FREENULL(session, key_state->curve25519_private_key);
+        SSH2_SAFEFREE(session, key_state->curve25519_private_key);
     }
 
     if(key_state->data)
-        SSH2_FREENULL(session, key_state->data);
+        SSH2_SAFEFREE(session, key_state->data);
 
     key_state->state = ssh2_NB_state_idle;
 
@@ -2606,7 +2606,7 @@ static void mlkem768x25519_exchange_state_cleanup(
     exchange_state->k = NULL;
 
     if(exchange_state->k_value)
-        SSH2_FREENULL(session, exchange_state->k_value);
+        SSH2_SAFEFREE(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -2617,31 +2617,31 @@ static void kex_method_mlkem768x25519_cleanup(
     if(key_state->curve25519_public_key) {
         ssh2_explicit_zero(key_state->curve25519_public_key,
                            SSH2_ED25519_KEY_LEN);
-        SSH2_FREENULL(session, key_state->curve25519_public_key);
+        SSH2_SAFEFREE(session, key_state->curve25519_public_key);
     }
 
     if(key_state->curve25519_private_key) {
         ssh2_explicit_zero(key_state->curve25519_private_key,
                            SSH2_ED25519_KEY_LEN);
-        SSH2_FREENULL(session, key_state->curve25519_private_key);
+        SSH2_SAFEFREE(session, key_state->curve25519_private_key);
     }
 
     if(key_state->mlkem_public_key) {
         ssh2_explicit_zero(key_state->mlkem_public_key,
                            key_state->mlkem_public_key_len);
-        SSH2_FREENULL(session, key_state->mlkem_public_key);
+        SSH2_SAFEFREE(session, key_state->mlkem_public_key);
         key_state->mlkem_public_key_len = 0;
     }
 
     if(key_state->mlkem_private_key) {
         ssh2_explicit_zero(key_state->mlkem_private_key,
                            key_state->mlkem_private_key_len);
-        SSH2_FREENULL(session, key_state->mlkem_private_key);
+        SSH2_SAFEFREE(session, key_state->mlkem_private_key);
         key_state->mlkem_private_key_len = 0;
     }
 
     if(key_state->data)
-        SSH2_FREENULL(session, key_state->data);
+        SSH2_SAFEFREE(session, key_state->data);
 
     key_state->state = ssh2_NB_state_idle;
 
@@ -3893,9 +3893,9 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
 
     /* Done with kexinit buffers */
     if(session->local.kexinit)
-        SSH2_FREENULL(session, session->local.kexinit);
+        SSH2_SAFEFREE(session, session->local.kexinit);
     if(session->remote.kexinit)
-        SSH2_FREENULL(session, session->remote.kexinit);
+        SSH2_SAFEFREE(session, session->remote.kexinit);
 
     session->state &= ~SSH2_STATE_INITIAL_KEX;
     session->state &= ~SSH2_STATE_KEX_ACTIVE;
@@ -4141,7 +4141,7 @@ int libssh2_session_supported_algs(LIBSSH2_SESSION *session,
 
     /* correct number of pointers copied? (test the code above) */
     if(j != ialg) {
-        SSH2_FREENULL(session, *algs);  /* deallocate buffer */
+        SSH2_SAFEFREE(session, *algs);  /* deallocate buffer */
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "Internal error");
     }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -69,14 +69,12 @@ static void sha_algo_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
                                        exchange_state->k_value_len) ||
                !ssh2_hash_update(hash, exchange_state->h_sig_comp,
                                        digest_len)) {
-                SSH2_FREE(session, *data);
-                *data = NULL;
+                SSH2_FREENULL(session, *data);
                 return;
             }
             if(len > 0) {
                 if(!ssh2_hash_update(hash, *data, len)) {
-                    SSH2_FREE(session, *data);
-                    *data = NULL;
+                    SSH2_FREENULL(session, *data);
                     return;
                 }
             }
@@ -84,14 +82,12 @@ static void sha_algo_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
                 if(!ssh2_hash_update(hash, version, 1) ||
                    !ssh2_hash_update(hash, session->session_id,
                                            session->session_id_len)) {
-                    SSH2_FREE(session, *data);
-                    *data = NULL;
+                    SSH2_FREENULL(session, *data);
                     return;
                 }
             }
             if(!ssh2_hash_final(hash, *data + len, digest_len)) {
-                SSH2_FREE(session, *data);
-                *data = NULL;
+                SSH2_FREENULL(session, *data);
                 return;
             }
             len += digest_len;
@@ -125,8 +121,7 @@ static int process_host_key(LIBSSH2_SESSION *session, struct string_buf *buf,
     buf->dataptr++; /* advance past type */
 
     if(session->server_hostkey) {
-        SSH2_FREE(session, session->server_hostkey);
-        session->server_hostkey = NULL;
+        SSH2_FREENULL(session, session->server_hostkey);
         session->server_hostkey_len = 0;
     }
 
@@ -447,20 +442,12 @@ static void diffie_hellman_state_cleanup(
     ssh2_bn_ctx_free(exchange_state->ctx);
     exchange_state->ctx = NULL;
 
-    if(exchange_state->e_packet) {
-        SSH2_FREE(session, exchange_state->e_packet);
-        exchange_state->e_packet = NULL;
-    }
-
-    if(exchange_state->s_packet) {
-        SSH2_FREE(session, exchange_state->s_packet);
-        exchange_state->s_packet = NULL;
-    }
-
-    if(exchange_state->k_value) {
-        SSH2_FREE(session, exchange_state->k_value);
-        exchange_state->k_value = NULL;
-    }
+    if(exchange_state->e_packet)
+        SSH2_FREENULL(session, exchange_state->e_packet);
+    if(exchange_state->s_packet)
+        SSH2_FREENULL(session, exchange_state->s_packet);
+    if(exchange_state->k_value)
+        SSH2_FREENULL(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -474,10 +461,8 @@ static void kex_diffie_hellman_cleanup(
         ssh2_bn_free(key_state->g);
         key_state->g = NULL;
 
-        if(key_state->data) {
-            SSH2_FREE(session, key_state->data);
-            key_state->data = NULL;
-        }
+        if(key_state->data)
+            SSH2_FREENULL(session, key_state->data);
         key_state->state = ssh2_NB_state_idle;
     }
 
@@ -1642,10 +1627,8 @@ static void ecdh_exchange_state_cleanup(
     ssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
 
-    if(exchange_state->k_value) {
-        SSH2_FREE(session, exchange_state->k_value);
-        exchange_state->k_value = NULL;
-    }
+    if(exchange_state->k_value)
+        SSH2_FREENULL(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -1653,20 +1636,16 @@ static void ecdh_exchange_state_cleanup(
 static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
                                     struct key_exchange_state_low *key_state)
 {
-    if(key_state->public_key_oct) {
-        SSH2_FREE(session, key_state->public_key_oct);
-        key_state->public_key_oct = NULL;
-    }
+    if(key_state->public_key_oct)
+        SSH2_FREENULL(session, key_state->public_key_oct);
 
     if(key_state->private_key) {
         ssh2_ecdsa_free(key_state->private_key);
         key_state->private_key = NULL;
     }
 
-    if(key_state->data) {
-        SSH2_FREE(session, key_state->data);
-        key_state->data = NULL;
-    }
+    if(key_state->data)
+        SSH2_FREENULL(session, key_state->data);
 
     key_state->state = ssh2_NB_state_idle;
 
@@ -1951,10 +1930,8 @@ static void mlkem_nistp_exchange_state_cleanup(
     ssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
 
-    if(exchange_state->k_value) {
-        SSH2_FREE(session, exchange_state->k_value);
-        exchange_state->k_value = NULL;
-    }
+    if(exchange_state->k_value)
+        SSH2_FREENULL(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -1962,10 +1939,8 @@ static void mlkem_nistp_exchange_state_cleanup(
 static void kex_method_mlkem_nistp_cleanup(
     LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
-    if(key_state->public_key_oct) {
-        SSH2_FREE(session, key_state->public_key_oct);
-        key_state->public_key_oct = NULL;
-    }
+    if(key_state->public_key_oct)
+        SSH2_FREENULL(session, key_state->public_key_oct);
 
     if(key_state->private_key) {
         ssh2_ecdsa_free(key_state->private_key);
@@ -1975,23 +1950,19 @@ static void kex_method_mlkem_nistp_cleanup(
     if(key_state->mlkem_public_key) {
         ssh2_explicit_zero(key_state->mlkem_public_key,
                            key_state->mlkem_public_key_len);
-        SSH2_FREE(session, key_state->mlkem_public_key);
-        key_state->mlkem_public_key = NULL;
+        SSH2_FREENULL(session, key_state->mlkem_public_key);
         key_state->mlkem_public_key_len = 0;
     }
 
     if(key_state->mlkem_private_key) {
         ssh2_explicit_zero(key_state->mlkem_private_key,
                            key_state->mlkem_private_key_len);
-        SSH2_FREE(session, key_state->mlkem_private_key);
-        key_state->mlkem_private_key = NULL;
+        SSH2_FREENULL(session, key_state->mlkem_private_key);
         key_state->mlkem_private_key_len = 0;
     }
 
-    if(key_state->data) {
-        SSH2_FREE(session, key_state->data);
-        key_state->data = NULL;
-    }
+    if(key_state->data)
+        SSH2_FREENULL(session, key_state->data);
 
     key_state->state = ssh2_NB_state_idle;
 
@@ -2368,10 +2339,8 @@ static void curve25519_exchange_state_cleanup(
     ssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
 
-    if(exchange_state->k_value) {
-        SSH2_FREE(session, exchange_state->k_value);
-        exchange_state->k_value = NULL;
-    }
+    if(exchange_state->k_value)
+        SSH2_FREENULL(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -2382,21 +2351,17 @@ static void kex_method_curve25519_cleanup(
     if(key_state->curve25519_public_key) {
         ssh2_explicit_zero(key_state->curve25519_public_key,
                            SSH2_ED25519_KEY_LEN);
-        SSH2_FREE(session, key_state->curve25519_public_key);
-        key_state->curve25519_public_key = NULL;
+        SSH2_FREENULL(session, key_state->curve25519_public_key);
     }
 
     if(key_state->curve25519_private_key) {
         ssh2_explicit_zero(key_state->curve25519_private_key,
                            SSH2_ED25519_KEY_LEN);
-        SSH2_FREE(session, key_state->curve25519_private_key);
-        key_state->curve25519_private_key = NULL;
+        SSH2_FREENULL(session, key_state->curve25519_private_key);
     }
 
-    if(key_state->data) {
-        SSH2_FREE(session, key_state->data);
-        key_state->data = NULL;
-    }
+    if(key_state->data)
+        SSH2_FREENULL(session, key_state->data);
 
     key_state->state = ssh2_NB_state_idle;
 
@@ -2640,10 +2605,8 @@ static void mlkem768x25519_exchange_state_cleanup(
     ssh2_bn_free(exchange_state->k);
     exchange_state->k = NULL;
 
-    if(exchange_state->k_value) {
-        SSH2_FREE(session, exchange_state->k_value);
-        exchange_state->k_value = NULL;
-    }
+    if(exchange_state->k_value)
+        SSH2_FREENULL(session, exchange_state->k_value);
 
     exchange_state->state = ssh2_NB_state_idle;
 }
@@ -2654,37 +2617,31 @@ static void kex_method_mlkem768x25519_cleanup(
     if(key_state->curve25519_public_key) {
         ssh2_explicit_zero(key_state->curve25519_public_key,
                            SSH2_ED25519_KEY_LEN);
-        SSH2_FREE(session, key_state->curve25519_public_key);
-        key_state->curve25519_public_key = NULL;
+        SSH2_FREENULL(session, key_state->curve25519_public_key);
     }
 
     if(key_state->curve25519_private_key) {
         ssh2_explicit_zero(key_state->curve25519_private_key,
                            SSH2_ED25519_KEY_LEN);
-        SSH2_FREE(session, key_state->curve25519_private_key);
-        key_state->curve25519_private_key = NULL;
+        SSH2_FREENULL(session, key_state->curve25519_private_key);
     }
 
     if(key_state->mlkem_public_key) {
         ssh2_explicit_zero(key_state->mlkem_public_key,
                            key_state->mlkem_public_key_len);
-        SSH2_FREE(session, key_state->mlkem_public_key);
-        key_state->mlkem_public_key = NULL;
+        SSH2_FREENULL(session, key_state->mlkem_public_key);
         key_state->mlkem_public_key_len = 0;
     }
 
     if(key_state->mlkem_private_key) {
         ssh2_explicit_zero(key_state->mlkem_private_key,
                            key_state->mlkem_private_key_len);
-        SSH2_FREE(session, key_state->mlkem_private_key);
-        key_state->mlkem_private_key = NULL;
+        SSH2_FREENULL(session, key_state->mlkem_private_key);
         key_state->mlkem_private_key_len = 0;
     }
 
-    if(key_state->data) {
-        SSH2_FREE(session, key_state->data);
-        key_state->data = NULL;
-    }
+    if(key_state->data)
+        SSH2_FREENULL(session, key_state->data);
 
     key_state->state = ssh2_NB_state_idle;
 
@@ -3935,14 +3892,10 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
     }
 
     /* Done with kexinit buffers */
-    if(session->local.kexinit) {
-        SSH2_FREE(session, session->local.kexinit);
-        session->local.kexinit = NULL;
-    }
-    if(session->remote.kexinit) {
-        SSH2_FREE(session, session->remote.kexinit);
-        session->remote.kexinit = NULL;
-    }
+    if(session->local.kexinit)
+        SSH2_FREENULL(session, session->local.kexinit);
+    if(session->remote.kexinit)
+        SSH2_FREENULL(session, session->remote.kexinit);
 
     session->state &= ~SSH2_STATE_INITIAL_KEX;
     session->state &= ~SSH2_STATE_KEX_ACTIVE;
@@ -4188,10 +4141,7 @@ int libssh2_session_supported_algs(LIBSSH2_SESSION *session,
 
     /* correct number of pointers copied? (test the code above) */
     if(j != ialg) {
-        /* deallocate buffer */
-        SSH2_FREE(session, (void *)*algs);
-        *algs = NULL;
-
+        SSH2_FREENULL(session, *algs);  /* deallocate buffer */
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "Internal error");
     }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -4141,7 +4141,8 @@ int libssh2_session_supported_algs(LIBSSH2_SESSION *session,
 
     /* correct number of pointers copied? (test the code above) */
     if(j != ialg) {
-        SSH2_SAFEFREE(session, *algs);  /* deallocate buffer */
+        SSH2_FREE(session, (void *)*algs);  /* deallocate buffer */
+        *algs = NULL;
         return ssh2_err(session, LIBSSH2_ERROR_BAD_USE, "Internal error");
     }
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -247,6 +247,11 @@ struct iovec {
              (session)->alloc(count, &(session)->abstract))
 #define SSH2_FREE(session, ptr) \
     session->free(ptr, &(session)->abstract)
+#define SSH2_FREESAFE(ptr) \
+    do {                   \
+        SSH2_FREE(ptr);    \
+        (ptr) = NULL;      \
+    } while(0)
 #define SSH2_IGNORE(session, data, datalen) \
     session->ssh_msg_ignore(session, data, (int)(datalen), \
                             &(session)->abstract)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -247,7 +247,7 @@ struct iovec {
              (session)->alloc(count, &(session)->abstract))
 #define SSH2_FREE(session, ptr) \
     session->free(ptr, &(session)->abstract)
-#define SSH2_FREENULL(ptr) \
+#define SSH2_SAFEFREE(ptr) \
     do {                   \
         SSH2_FREE(ptr);    \
         (ptr) = NULL;      \

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -247,7 +247,7 @@ struct iovec {
              (session)->alloc(count, &(session)->abstract))
 #define SSH2_FREE(session, ptr) \
     session->free(ptr, &(session)->abstract)
-#define SSH2_FREESAFE(ptr) \
+#define SSH2_FREENULL(ptr) \
     do {                   \
         SSH2_FREE(ptr);    \
         (ptr) = NULL;      \

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -247,10 +247,10 @@ struct iovec {
              (session)->alloc(count, &(session)->abstract))
 #define SSH2_FREE(session, ptr) \
     session->free(ptr, &(session)->abstract)
-#define SSH2_SAFEFREE(ptr) \
-    do {                   \
-        SSH2_FREE(ptr);    \
-        (ptr) = NULL;      \
+#define SSH2_SAFEFREE(session, ptr) \
+    do {                            \
+        SSH2_FREE(session, ptr);    \
+        (ptr) = NULL;               \
     } while(0)
 #define SSH2_IGNORE(session, data, datalen) \
     session->ssh_msg_ignore(session, data, (int)(datalen), \

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -890,8 +890,7 @@ failed:
     *out_private_key = NULL;
     if(*out_public_key_octal) {
         ssh2_explicit_zero(*out_public_key_octal, plen);
-        SSH2_FREE(session, *out_public_key_octal);
-        *out_public_key_octal = NULL;
+        SSH2_SAFEFREE(session, *out_public_key_octal);
     }
 
     return -1;

--- a/src/misc.c
+++ b/src/misc.c
@@ -416,8 +416,7 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
     if((i % 4) == 1) {
         /* Invalid -- We have a byte which belongs exclusively to a partial
            octet */
-        SSH2_FREE(session, *data);
-        *data = NULL;
+        SSH2_FREENULL(session, *data);
         return ssh2_err(session, LIBSSH2_ERROR_INVAL, "Invalid base64");
     }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -416,7 +416,7 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
     if((i % 4) == 1) {
         /* Invalid -- We have a byte which belongs exclusively to a partial
            octet */
-        SSH2_FREENULL(session, *data);
+        SSH2_SAFEFREE(session, *data);
         return ssh2_err(session, LIBSSH2_ERROR_INVAL, "Invalid base64");
     }
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1394,8 +1394,7 @@ static int pbkdf1(LIBSSH2_SESSION *session, char **dk,
     }
 
     if(errcode.Bytes_Available) {
-        SSH2_FREE(session, *dk);
-        *dk = NULL;
+        SSH2_FREENULL(session, *dk);
         return -1;
     }
 
@@ -1448,8 +1447,7 @@ static int pbkdf2(LIBSSH2_SESSION *session, char **dk,
         if(!ssh2_hmac_update(&hctx, pkcs5->salt, pkcs5->saltlen) ||
            !ssh2_hmac_update(&hctx, &ni, sizeof(ni)) ||
            !ssh2_hmac_final(&hctx, mac, pkcs5->hashlen)) {
-            SSH2_FREE(session, buf);
-            *dk = NULL;
+            SSH2_FREENULL(session, *dk);
             ssh2_os400qc3_crypto_dtor(&hctx);
             return -1;
         }
@@ -1457,8 +1455,7 @@ static int pbkdf2(LIBSSH2_SESSION *session, char **dk,
         for(j = 1; j < pkcs5->itercount; j++) {
             if(!ssh2_hmac_update(&hctx, mac, pkcs5->hashlen) ||
                !ssh2_hmac_final(&hctx, mac, pkcs5->hashlen)) {
-                SSH2_FREE(session, buf);
-                *dk = NULL;
+                SSH2_FREE(session, *dk);
                 ssh2_os400qc3_crypto_dtor(&hctx);
                 return -1;
             }
@@ -2019,10 +2016,8 @@ static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
                 return 0;
         }
 
-        if(data) {
-            SSH2_FREE(session, data);
-            data = NULL;
-        }
+        if(data)
+            SSH2_FREENULL(session, data);
         c = getc(fp);
 
         if(c == EOF)
@@ -2145,11 +2140,10 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 
     if(ret) {
         if(*method)
-            SSH2_FREE(session, *method);
+            SSH2_FREENULL(session, *method);
+        *method_len = 0;
         if(p.data)
             SSH2_FREE(session, (void *)p.data);
-        *method = NULL;
-        *method_len = 0;
     }
     else {
         *pubkeydata = (unsigned char *)p.data;
@@ -2310,11 +2304,10 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     }
     if(ret) {
         if(*method)
-            SSH2_FREE(session, *method);
+            SSH2_FREENULL(session, *method);
+        *method_len = 0;
         if(p.data)
             SSH2_FREE(session, (void *)p.data);
-        *method = NULL;
-        *method_len = 0;
     }
     else {
         *pubkeydata = (unsigned char *)p.data;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1394,7 +1394,7 @@ static int pbkdf1(LIBSSH2_SESSION *session, char **dk,
     }
 
     if(errcode.Bytes_Available) {
-        SSH2_FREENULL(session, *dk);
+        SSH2_SAFEFREE(session, *dk);
         return -1;
     }
 
@@ -1447,7 +1447,7 @@ static int pbkdf2(LIBSSH2_SESSION *session, char **dk,
         if(!ssh2_hmac_update(&hctx, pkcs5->salt, pkcs5->saltlen) ||
            !ssh2_hmac_update(&hctx, &ni, sizeof(ni)) ||
            !ssh2_hmac_final(&hctx, mac, pkcs5->hashlen)) {
-            SSH2_FREENULL(session, *dk);
+            SSH2_SAFEFREE(session, *dk);
             ssh2_os400qc3_crypto_dtor(&hctx);
             return -1;
         }
@@ -2017,7 +2017,7 @@ static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
         }
 
         if(data)
-            SSH2_FREENULL(session, data);
+            SSH2_SAFEFREE(session, data);
         c = getc(fp);
 
         if(c == EOF)
@@ -2140,7 +2140,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 
     if(ret) {
         if(*method)
-            SSH2_FREENULL(session, *method);
+            SSH2_SAFEFREE(session, *method);
         *method_len = 0;
         if(p.data)
             SSH2_FREE(session, (void *)p.data);
@@ -2304,7 +2304,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     }
     if(ret) {
         if(*method)
-            SSH2_FREENULL(session, *method);
+            SSH2_SAFEFREE(session, *method);
         *method_len = 0;
         if(p.data)
             SSH2_FREE(session, (void *)p.data);

--- a/src/packet.c
+++ b/src/packet.c
@@ -397,8 +397,7 @@ static SSH2_INLINE int packet_x11_open(
             if(rc == LIBSSH2_ERROR_EAGAIN)
                 return rc;
             else if(rc) {
-                SSH2_FREE(session, x11open_state->shost);
-                x11open_state->shost = NULL;
+                SSH2_FREENULL(session, x11open_state->shost);
                 x11open_state->state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                                 "Unable to send channel open confirmation");
@@ -414,8 +413,7 @@ static SSH2_INLINE int packet_x11_open(
             SSH2_X11_OPEN(channel, (char *)x11open_state->shost,
                           x11open_state->sport);
 
-            SSH2_FREE(session, x11open_state->shost);
-            x11open_state->shost = NULL;
+            SSH2_FREENULL(session, x11open_state->shost);
             x11open_state->state = ssh2_NB_state_idle;
             return 0;
         }
@@ -424,8 +422,7 @@ static SSH2_INLINE int packet_x11_open(
         failure_code = SSH_OPEN_RESOURCE_SHORTAGE;
     /* fall-through */
 x11_exit:
-    SSH2_FREE(session, x11open_state->shost);
-    x11open_state->shost = NULL;
+    SSH2_FREENULL(session, x11open_state->shost);
 
     p = x11open_state->packet;
     *(p++) = SSH_MSG_CHANNEL_OPEN_FAILURE;

--- a/src/packet.c
+++ b/src/packet.c
@@ -397,7 +397,7 @@ static SSH2_INLINE int packet_x11_open(
             if(rc == LIBSSH2_ERROR_EAGAIN)
                 return rc;
             else if(rc) {
-                SSH2_FREENULL(session, x11open_state->shost);
+                SSH2_SAFEFREE(session, x11open_state->shost);
                 x11open_state->state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                                 "Unable to send channel open confirmation");
@@ -413,7 +413,7 @@ static SSH2_INLINE int packet_x11_open(
             SSH2_X11_OPEN(channel, (char *)x11open_state->shost,
                           x11open_state->sport);
 
-            SSH2_FREENULL(session, x11open_state->shost);
+            SSH2_SAFEFREE(session, x11open_state->shost);
             x11open_state->state = ssh2_NB_state_idle;
             return 0;
         }
@@ -422,7 +422,7 @@ static SSH2_INLINE int packet_x11_open(
         failure_code = SSH_OPEN_RESOURCE_SHORTAGE;
     /* fall-through */
 x11_exit:
-    SSH2_FREENULL(session, x11open_state->shost);
+    SSH2_SAFEFREE(session, x11open_state->shost);
 
     p = x11open_state->packet;
     *(p++) = SSH_MSG_CHANNEL_OPEN_FAILURE;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -153,7 +153,7 @@ static int publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
         else if(rc != (ssize_t)pkey->receive_packet_len) {
-            SSH2_FREENULL(session, pkey->receive_packet);
+            SSH2_SAFEFREE(session, pkey->receive_packet);
             pkey->receive_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_TIMEOUT,
                             "Timeout waiting for publickey subsystem "
@@ -492,7 +492,7 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
                 ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY,
                           "Enabling publickey subsystem version %u",
                           session->pkeyInit_pkey->version));
-                SSH2_FREENULL(session, session->pkeyInit_data);
+                SSH2_SAFEFREE(session, session->pkeyInit_data);
                 session->pkeyInit_state = ssh2_NB_state_idle;
                 return session->pkeyInit_pkey;
 
@@ -500,7 +500,7 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
                 /* Unknown/Unexpected */
                 ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                          "Unexpected publickey subsystem response, ignoring");
-                SSH2_FREENULL(session, session->pkeyInit_data);
+                SSH2_SAFEFREE(session, session->pkeyInit_data);
             }
         }
     }
@@ -517,9 +517,9 @@ err_exit:
         }
     }
     if(session->pkeyInit_pkey)
-        SSH2_FREENULL(session, session->pkeyInit_pkey);
+        SSH2_SAFEFREE(session, session->pkeyInit_pkey);
     if(session->pkeyInit_data)
-        SSH2_FREENULL(session, session->pkeyInit_data);
+        SSH2_SAFEFREE(session, session->pkeyInit_data);
     session->pkeyInit_state = ssh2_NB_state_idle;
     return NULL;
 }
@@ -657,11 +657,11 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((pkey->add_s - pkey->add_packet) != nwritten) {
-            SSH2_FREENULL(session, pkey->add_packet);
+            SSH2_SAFEFREE(session, pkey->add_packet);
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send publickey add packet");
         }
-        SSH2_FREENULL(session, pkey->add_packet);
+        SSH2_SAFEFREE(session, pkey->add_packet);
         pkey->add_state = ssh2_NB_state_sent;
     }
 
@@ -736,12 +736,12 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((pkey->remove_s - pkey->remove_packet) != nwritten) {
-            SSH2_FREENULL(session, pkey->remove_packet);
+            SSH2_SAFEFREE(session, pkey->remove_packet);
             pkey->remove_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send publickey remove packet");
         }
-        SSH2_FREENULL(session, pkey->remove_packet);
+        SSH2_SAFEFREE(session, pkey->remove_packet);
         pkey->remove_state = ssh2_NB_state_sent;
     }
 
@@ -884,7 +884,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
             }
 
             if(status == SSH2_PUBLICKEY_SUCCESS) {
-                SSH2_FREENULL(session, pkey->listFetch_data);
+                SSH2_SAFEFREE(session, pkey->listFetch_data);
                 *pkey_list = list;
                 *num_keys = keys;
                 pkey->listFetch_state = ssh2_NB_state_idle;
@@ -1157,14 +1157,14 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
             /* Unknown/Unexpected */
             ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                      "Unexpected publickey subsystem response");
-            SSH2_FREENULL(session, pkey->listFetch_data);
+            SSH2_SAFEFREE(session, pkey->listFetch_data);
         }
     }
 
     /* Only reached via explicit goto */
 err_exit:
     if(pkey->listFetch_data)
-        SSH2_FREENULL(session, pkey->listFetch_data);
+        SSH2_SAFEFREE(session, pkey->listFetch_data);
     if(list)
         libssh2_publickey_list_free(pkey, list);
     pkey->listFetch_state = ssh2_NB_state_idle;
@@ -1212,13 +1212,13 @@ int libssh2_publickey_shutdown(LIBSSH2_PUBLICKEY *pkey)
      * Make sure all memory used in the state variables are free
      */
     if(pkey->receive_packet)
-        SSH2_FREENULL(session, pkey->receive_packet);
+        SSH2_SAFEFREE(session, pkey->receive_packet);
     if(pkey->add_packet)
-        SSH2_FREENULL(session, pkey->add_packet);
+        SSH2_SAFEFREE(session, pkey->add_packet);
     if(pkey->remove_packet)
-        SSH2_FREENULL(session, pkey->remove_packet);
+        SSH2_SAFEFREE(session, pkey->remove_packet);
     if(pkey->listFetch_data)
-        SSH2_FREENULL(session, pkey->listFetch_data);
+        SSH2_SAFEFREE(session, pkey->listFetch_data);
 
     rc = ssh2_channel_free(pkey->channel);
     if(rc == LIBSSH2_ERROR_EAGAIN)

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -153,8 +153,7 @@ static int publickey_packet_receive(LIBSSH2_PUBLICKEY *pkey,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
         else if(rc != (ssize_t)pkey->receive_packet_len) {
-            SSH2_FREE(session, pkey->receive_packet);
-            pkey->receive_packet = NULL;
+            SSH2_FREENULL(session, pkey->receive_packet);
             pkey->receive_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_TIMEOUT,
                             "Timeout waiting for publickey subsystem "
@@ -493,8 +492,7 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
                 ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY,
                           "Enabling publickey subsystem version %u",
                           session->pkeyInit_pkey->version));
-                SSH2_FREE(session, session->pkeyInit_data);
-                session->pkeyInit_data = NULL;
+                SSH2_FREENULL(session, session->pkeyInit_data);
                 session->pkeyInit_state = ssh2_NB_state_idle;
                 return session->pkeyInit_pkey;
 
@@ -502,8 +500,7 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
                 /* Unknown/Unexpected */
                 ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                          "Unexpected publickey subsystem response, ignoring");
-                SSH2_FREE(session, session->pkeyInit_data);
-                session->pkeyInit_data = NULL;
+                SSH2_FREENULL(session, session->pkeyInit_data);
             }
         }
     }
@@ -519,14 +516,10 @@ err_exit:
             return NULL;
         }
     }
-    if(session->pkeyInit_pkey) {
-        SSH2_FREE(session, session->pkeyInit_pkey);
-        session->pkeyInit_pkey = NULL;
-    }
-    if(session->pkeyInit_data) {
-        SSH2_FREE(session, session->pkeyInit_data);
-        session->pkeyInit_data = NULL;
-    }
+    if(session->pkeyInit_pkey)
+        SSH2_FREENULL(session, session->pkeyInit_pkey);
+    if(session->pkeyInit_data)
+        SSH2_FREENULL(session, session->pkeyInit_data);
     session->pkeyInit_state = ssh2_NB_state_idle;
     return NULL;
 }
@@ -664,14 +657,11 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((pkey->add_s - pkey->add_packet) != nwritten) {
-            SSH2_FREE(session, pkey->add_packet);
-            pkey->add_packet = NULL;
+            SSH2_FREENULL(session, pkey->add_packet);
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send publickey add packet");
         }
-        SSH2_FREE(session, pkey->add_packet);
-        pkey->add_packet = NULL;
-
+        SSH2_FREENULL(session, pkey->add_packet);
         pkey->add_state = ssh2_NB_state_sent;
     }
 
@@ -746,15 +736,12 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((pkey->remove_s - pkey->remove_packet) != nwritten) {
-            SSH2_FREE(session, pkey->remove_packet);
-            pkey->remove_packet = NULL;
+            SSH2_FREENULL(session, pkey->remove_packet);
             pkey->remove_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send publickey remove packet");
         }
-        SSH2_FREE(session, pkey->remove_packet);
-        pkey->remove_packet = NULL;
-
+        SSH2_FREENULL(session, pkey->remove_packet);
         pkey->remove_state = ssh2_NB_state_sent;
     }
 
@@ -897,8 +884,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
             }
 
             if(status == SSH2_PUBLICKEY_SUCCESS) {
-                SSH2_FREE(session, pkey->listFetch_data);
-                pkey->listFetch_data = NULL;
+                SSH2_FREENULL(session, pkey->listFetch_data);
                 *pkey_list = list;
                 *num_keys = keys;
                 pkey->listFetch_state = ssh2_NB_state_idle;
@@ -1171,17 +1157,14 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
             /* Unknown/Unexpected */
             ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL,
                      "Unexpected publickey subsystem response");
-            SSH2_FREE(session, pkey->listFetch_data);
-            pkey->listFetch_data = NULL;
+            SSH2_FREENULL(session, pkey->listFetch_data);
         }
     }
 
     /* Only reached via explicit goto */
 err_exit:
-    if(pkey->listFetch_data) {
-        SSH2_FREE(session, pkey->listFetch_data);
-        pkey->listFetch_data = NULL;
-    }
+    if(pkey->listFetch_data)
+        SSH2_FREENULL(session, pkey->listFetch_data);
     if(list)
         libssh2_publickey_list_free(pkey, list);
     pkey->listFetch_state = ssh2_NB_state_idle;
@@ -1228,22 +1211,14 @@ int libssh2_publickey_shutdown(LIBSSH2_PUBLICKEY *pkey)
     /*
      * Make sure all memory used in the state variables are free
      */
-    if(pkey->receive_packet) {
-        SSH2_FREE(session, pkey->receive_packet);
-        pkey->receive_packet = NULL;
-    }
-    if(pkey->add_packet) {
-        SSH2_FREE(session, pkey->add_packet);
-        pkey->add_packet = NULL;
-    }
-    if(pkey->remove_packet) {
-        SSH2_FREE(session, pkey->remove_packet);
-        pkey->remove_packet = NULL;
-    }
-    if(pkey->listFetch_data) {
-        SSH2_FREE(session, pkey->listFetch_data);
-        pkey->listFetch_data = NULL;
-    }
+    if(pkey->receive_packet)
+        SSH2_FREENULL(session, pkey->receive_packet);
+    if(pkey->add_packet)
+        SSH2_FREENULL(session, pkey->add_packet);
+    if(pkey->remove_packet)
+        SSH2_FREENULL(session, pkey->remove_packet);
+    if(pkey->listFetch_data)
+        SSH2_FREENULL(session, pkey->listFetch_data);
 
     rc = ssh2_channel_free(pkey->channel);
     if(rc == LIBSSH2_ERROR_EAGAIN)

--- a/src/scp.c
+++ b/src/scp.c
@@ -345,8 +345,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                               LIBSSH2_CHANNEL_PACKET_DEFAULT, NULL, 0);
         if(!session->scpRecv_channel) {
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-                SSH2_FREE(session, session->scpRecv_command);
-                session->scpRecv_command = NULL;
+                SSH2_FREENULL(session, session->scpRecv_command);
                 session->scpRecv_state = ssh2_NB_state_idle;
             }
             else
@@ -370,12 +369,10 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
             return NULL;
         }
         else if(rc) {
-            SSH2_FREE(session, session->scpRecv_command);
-            session->scpRecv_command = NULL;
+            SSH2_FREENULL(session, session->scpRecv_command);
             goto scp_recv_error;
         }
-        SSH2_FREE(session, session->scpRecv_command);
-        session->scpRecv_command = NULL;
+        SSH2_FREENULL(session, session->scpRecv_command);
 
         ssh2_deb((session, LIBSSH2_TRACE_SCP, "Sending initial wakeup"));
         /* SCP ACK */
@@ -891,8 +888,7 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
                 /* previous call set libssh2_session_last_error(), pass it
                    through */
-                SSH2_FREE(session, session->scpSend_command);
-                session->scpSend_command = NULL;
+                SSH2_FREENULL(session, session->scpSend_command);
                 session->scpSend_state = ssh2_NB_state_idle;
             }
             else
@@ -918,15 +914,12 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
         else if(rc) {
             /* previous call set libssh2_session_last_error(), pass it
                through */
-            SSH2_FREE(session, session->scpSend_command);
-            session->scpSend_command = NULL;
+            SSH2_FREENULL(session, session->scpSend_command);
             ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                      "Unknown error while getting error string");
             goto scp_send_error;
         }
-        SSH2_FREE(session, session->scpSend_command);
-        session->scpSend_command = NULL;
-
+        SSH2_FREENULL(session, session->scpSend_command);
         session->scpSend_state = ssh2_NB_state_sent1;
     }
 

--- a/src/scp.c
+++ b/src/scp.c
@@ -345,7 +345,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                               LIBSSH2_CHANNEL_PACKET_DEFAULT, NULL, 0);
         if(!session->scpRecv_channel) {
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
-                SSH2_FREENULL(session, session->scpRecv_command);
+                SSH2_SAFEFREE(session, session->scpRecv_command);
                 session->scpRecv_state = ssh2_NB_state_idle;
             }
             else
@@ -369,10 +369,10 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
             return NULL;
         }
         else if(rc) {
-            SSH2_FREENULL(session, session->scpRecv_command);
+            SSH2_SAFEFREE(session, session->scpRecv_command);
             goto scp_recv_error;
         }
-        SSH2_FREENULL(session, session->scpRecv_command);
+        SSH2_SAFEFREE(session, session->scpRecv_command);
 
         ssh2_deb((session, LIBSSH2_TRACE_SCP, "Sending initial wakeup"));
         /* SCP ACK */
@@ -888,7 +888,7 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
                 /* previous call set libssh2_session_last_error(), pass it
                    through */
-                SSH2_FREENULL(session, session->scpSend_command);
+                SSH2_SAFEFREE(session, session->scpSend_command);
                 session->scpSend_state = ssh2_NB_state_idle;
             }
             else
@@ -914,12 +914,12 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
         else if(rc) {
             /* previous call set libssh2_session_last_error(), pass it
                through */
-            SSH2_FREENULL(session, session->scpSend_command);
+            SSH2_SAFEFREE(session, session->scpSend_command);
             ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                      "Unknown error while getting error string");
             goto scp_send_error;
         }
-        SSH2_FREENULL(session, session->scpSend_command);
+        SSH2_SAFEFREE(session, session->scpSend_command);
         session->scpSend_state = ssh2_NB_state_sent1;
     }
 

--- a/src/session.c
+++ b/src/session.c
@@ -345,7 +345,7 @@ int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
     size_t banner_len = banner ? strlen(banner) : 0;
 
     if(session->local.banner)
-        SSH2_FREENULL(session, session->local.banner);
+        SSH2_SAFEFREE(session, session->local.banner);
 
     if(!banner_len)
         return 0;
@@ -773,14 +773,14 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
         buf.dataptr++;
 
         if(ssh2_match_string(&buf, "ssh-userauth")) {
-            SSH2_FREENULL(session, session->startup_data);
+            SSH2_SAFEFREE(session, session->startup_data);
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                             "Invalid response received from server");
         }
 
         session->startup_service_length = (sizeof("ssh-userauth") - 1);
 
-        SSH2_FREENULL(session, session->startup_data);
+        SSH2_SAFEFREE(session, session->startup_data);
 
         session->startup_state = ssh2_NB_state_idle;
 
@@ -994,7 +994,7 @@ static int session_free(LIBSSH2_SESSION *session)
 
     /* Free payload buffer */
     if(session->packet.payload)
-        SSH2_FREENULL(session, session->packet.payload);
+        SSH2_SAFEFREE(session, session->packet.payload);
 
     /* Cleanup all remaining packets */
     /* !checksrc! disable EQUALSNULL 1 */

--- a/src/session.c
+++ b/src/session.c
@@ -344,10 +344,8 @@ int libssh2_session_banner_set(LIBSSH2_SESSION *session, const char *banner)
 {
     size_t banner_len = banner ? strlen(banner) : 0;
 
-    if(session->local.banner) {
-        SSH2_FREE(session, session->local.banner);
-        session->local.banner = NULL;
-    }
+    if(session->local.banner)
+        SSH2_FREENULL(session, session->local.banner);
 
     if(!banner_len)
         return 0;
@@ -775,16 +773,14 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
         buf.dataptr++;
 
         if(ssh2_match_string(&buf, "ssh-userauth")) {
-            SSH2_FREE(session, session->startup_data);
-            session->startup_data = NULL;
+            SSH2_FREENULL(session, session->startup_data);
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                             "Invalid response received from server");
         }
 
         session->startup_service_length = (sizeof("ssh-userauth") - 1);
 
-        SSH2_FREE(session, session->startup_data);
-        session->startup_data = NULL;
+        SSH2_FREENULL(session, session->startup_data);
 
         session->startup_state = ssh2_NB_state_idle;
 
@@ -997,10 +993,8 @@ static int session_free(LIBSSH2_SESSION *session)
         SSH2_FREE(session, session->sftpInit_sftp);
 
     /* Free payload buffer */
-    if(session->packet.payload) {
-        SSH2_FREE(session, session->packet.payload);
-        session->packet.payload = NULL;
-    }
+    if(session->packet.payload)
+        SSH2_FREENULL(session, session->packet.payload);
 
     /* Cleanup all remaining packets */
     /* !checksrc! disable EQUALSNULL 1 */

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -896,7 +896,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         }
         session->sftpInit_channel = NULL;
         if(session->sftpInit_sftp)
-            SSH2_FREENULL(session, session->sftpInit_sftp);
+            SSH2_SAFEFREE(session, session->sftpInit_sftp);
         session->sftpInit_state = ssh2_NB_state_idle;
         return NULL;
     }
@@ -1032,31 +1032,31 @@ static int sftp_shutdown(LIBSSH2_SFTP *sftp)
      * Make sure all memory used in the state variables are free
      */
     if(sftp->partial_packet)
-        SSH2_FREENULL(session, sftp->partial_packet);
+        SSH2_SAFEFREE(session, sftp->partial_packet);
     if(sftp->open_packet)
-        SSH2_FREENULL(session, sftp->open_packet);
+        SSH2_SAFEFREE(session, sftp->open_packet);
     if(sftp->readdir_packet)
-        SSH2_FREENULL(session, sftp->readdir_packet);
+        SSH2_SAFEFREE(session, sftp->readdir_packet);
     if(sftp->fstat_packet)
-        SSH2_FREENULL(session, sftp->fstat_packet);
+        SSH2_SAFEFREE(session, sftp->fstat_packet);
     if(sftp->unlink_packet)
-        SSH2_FREENULL(session, sftp->unlink_packet);
+        SSH2_SAFEFREE(session, sftp->unlink_packet);
     if(sftp->rename_packet)
-        SSH2_FREENULL(session, sftp->rename_packet);
+        SSH2_SAFEFREE(session, sftp->rename_packet);
     if(sftp->fstatvfs_packet)
-        SSH2_FREENULL(session, sftp->fstatvfs_packet);
+        SSH2_SAFEFREE(session, sftp->fstatvfs_packet);
     if(sftp->statvfs_packet)
-        SSH2_FREENULL(session, sftp->statvfs_packet);
+        SSH2_SAFEFREE(session, sftp->statvfs_packet);
     if(sftp->mkdir_packet)
-        SSH2_FREENULL(session, sftp->mkdir_packet);
+        SSH2_SAFEFREE(session, sftp->mkdir_packet);
     if(sftp->rmdir_packet)
-        SSH2_FREENULL(session, sftp->rmdir_packet);
+        SSH2_SAFEFREE(session, sftp->rmdir_packet);
     if(sftp->stat_packet)
-        SSH2_FREENULL(session, sftp->stat_packet);
+        SSH2_SAFEFREE(session, sftp->stat_packet);
     if(sftp->symlink_packet)
-        SSH2_FREENULL(session, sftp->symlink_packet);
+        SSH2_SAFEFREE(session, sftp->symlink_packet);
     if(sftp->fsync_packet)
-        SSH2_FREENULL(session, sftp->fsync_packet);
+        SSH2_SAFEFREE(session, sftp->fsync_packet);
 
     sftp_packet_flush(sftp);
 
@@ -1167,7 +1167,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
         }
         else if(rc < 0) {
             ssh2_err(session, (int)rc, "Unable to send FXP_OPEN*");
-            SSH2_FREENULL(session, sftp->open_packet);
+            SSH2_SAFEFREE(session, sftp->open_packet);
             sftp->open_state = ssh2_NB_state_idle;
             return NULL;
         }
@@ -1177,7 +1177,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
         sftp->open_packet_sent += rc;
 
         if(sftp->open_packet_len == sftp->open_packet_sent) {
-            SSH2_FREENULL(session, sftp->open_packet);
+            SSH2_SAFEFREE(session, sftp->open_packet);
             sftp->open_state = ssh2_NB_state_sent;
         }
     }
@@ -1228,7 +1228,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
             if(LIBSSH2_FX_OK == sftp->last_errno) {
                 ssh2_deb((session, LIBSSH2_TRACE_SFTP, "got HANDLE FXOK"));
 
-                SSH2_FREENULL(session, data);
+                SSH2_SAFEFREE(session, data);
 
                 /* silly situation, but check for a HANDLE */
                 rc = sftp_packet_require(sftp, SSH_FXP_HANDLE,
@@ -1406,7 +1406,7 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
             filep->offset += copy;
 
             if(!filep->data_left)
-                SSH2_FREENULL(session, filep->data);
+                SSH2_SAFEFREE(session, filep->data);
 
             return copy;
         }
@@ -1884,13 +1884,13 @@ end:
         if(retcode == LIBSSH2_ERROR_EAGAIN)
             return retcode;
         else if((ssize_t)packet_len != retcode) {
-            SSH2_FREENULL(session, sftp->readdir_packet);
+            SSH2_SAFEFREE(session, sftp->readdir_packet);
             sftp->readdir_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "ssh2_channel_write() failed");
         }
 
-        SSH2_FREENULL(session, sftp->readdir_packet);
+        SSH2_SAFEFREE(session, sftp->readdir_packet);
         sftp->readdir_state = ssh2_NB_state_sent;
     }
 
@@ -2364,13 +2364,13 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
         else if((ssize_t)packet_len != rc) {
-            SSH2_FREENULL(session, sftp->fstat_packet);
+            SSH2_SAFEFREE(session, sftp->fstat_packet);
             sftp->fstat_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             (setstat ? "Unable to send FXP_FSETSTAT"
                                      : "Unable to send FXP_FSTAT command"));
         }
-        SSH2_FREENULL(session, sftp->fstat_packet);
+        SSH2_SAFEFREE(session, sftp->fstat_packet);
         sftp->fstat_state = ssh2_NB_state_sent;
     }
 
@@ -2447,7 +2447,7 @@ void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle, libssh2_uint64_t offset)
 
     /* free the left received buffered data */
     if(handle->u.file.data_left) {
-        SSH2_FREENULL(handle->sftp->channel->session, handle->u.file.data);
+        SSH2_SAFEFREE(handle->sftp->channel->session, handle->u.file.data);
         handle->u.file.data_left = handle->u.file.data_len = 0;
     }
 
@@ -2573,7 +2573,7 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((ssize_t)packet_len != nwritten) {
-            SSH2_FREENULL(session, handle->close_packet);
+            SSH2_SAFEFREE(session, handle->close_packet);
             handle->close_state = ssh2_NB_state_idle;
             rc = ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                           "Unable to send FXP_CLOSE command");
@@ -2581,7 +2581,7 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
         else
             handle->close_state = ssh2_NB_state_sent;
 
-        SSH2_FREENULL(session, handle->close_packet);
+        SSH2_SAFEFREE(session, handle->close_packet);
     }
 
     if(handle->close_state == ssh2_NB_state_sent) {
@@ -2701,12 +2701,12 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((ssize_t)packet_len != nwritten) {
-            SSH2_FREENULL(session, sftp->unlink_packet);
+            SSH2_SAFEFREE(session, sftp->unlink_packet);
             sftp->unlink_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send FXP_REMOVE command");
         }
-        SSH2_FREENULL(session, sftp->unlink_packet);
+        SSH2_SAFEFREE(session, sftp->unlink_packet);
         sftp->unlink_state = ssh2_NB_state_sent;
     }
 
@@ -2818,12 +2818,12 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
         else if((ssize_t)packet_len != rc) {
-            SSH2_FREENULL(session, sftp->rename_packet);
+            SSH2_SAFEFREE(session, sftp->rename_packet);
             sftp->rename_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send FXP_RENAME command");
         }
-        SSH2_FREENULL(session, sftp->rename_packet);
+        SSH2_SAFEFREE(session, sftp->rename_packet);
         sftp->rename_state = ssh2_NB_state_sent;
     }
 
@@ -3463,12 +3463,12 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((ssize_t)packet_len != nwritten) {
-            SSH2_FREENULL(session, sftp->rmdir_packet);
+            SSH2_SAFEFREE(session, sftp->rmdir_packet);
             sftp->rmdir_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send FXP_RMDIR command");
         }
-        SSH2_FREENULL(session, sftp->rmdir_packet);
+        SSH2_SAFEFREE(session, sftp->rmdir_packet);
         sftp->rmdir_state = ssh2_NB_state_sent;
     }
 
@@ -3583,12 +3583,12 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((ssize_t)packet_len != nwritten) {
-            SSH2_FREENULL(session, sftp->stat_packet);
+            SSH2_SAFEFREE(session, sftp->stat_packet);
             sftp->stat_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send STAT/LSTAT/SETSTAT command");
         }
-        SSH2_FREENULL(session, sftp->stat_packet);
+        SSH2_SAFEFREE(session, sftp->stat_packet);
         sftp->stat_state = ssh2_NB_state_sent;
     }
 
@@ -3742,12 +3742,12 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
         else if((ssize_t)packet_len != rc) {
-            SSH2_FREENULL(session, sftp->symlink_packet);
+            SSH2_SAFEFREE(session, sftp->symlink_packet);
             sftp->symlink_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send SYMLINK/READLINK command");
         }
-        SSH2_FREENULL(session, sftp->symlink_packet);
+        SSH2_SAFEFREE(session, sftp->symlink_packet);
         sftp->symlink_state = ssh2_NB_state_sent;
     }
 

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -895,10 +895,8 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
             return NULL;
         }
         session->sftpInit_channel = NULL;
-        if(session->sftpInit_sftp) {
-            SSH2_FREE(session, session->sftpInit_sftp);
-            session->sftpInit_sftp = NULL;
-        }
+        if(session->sftpInit_sftp)
+            SSH2_FREENULL(session, session->sftpInit_sftp);
         session->sftpInit_state = ssh2_NB_state_idle;
         return NULL;
     }
@@ -1033,58 +1031,32 @@ static int sftp_shutdown(LIBSSH2_SFTP *sftp)
     /*
      * Make sure all memory used in the state variables are free
      */
-    if(sftp->partial_packet) {
-        SSH2_FREE(session, sftp->partial_packet);
-        sftp->partial_packet = NULL;
-    }
-    if(sftp->open_packet) {
-        SSH2_FREE(session, sftp->open_packet);
-        sftp->open_packet = NULL;
-    }
-    if(sftp->readdir_packet) {
-        SSH2_FREE(session, sftp->readdir_packet);
-        sftp->readdir_packet = NULL;
-    }
-    if(sftp->fstat_packet) {
-        SSH2_FREE(session, sftp->fstat_packet);
-        sftp->fstat_packet = NULL;
-    }
-    if(sftp->unlink_packet) {
-        SSH2_FREE(session, sftp->unlink_packet);
-        sftp->unlink_packet = NULL;
-    }
-    if(sftp->rename_packet) {
-        SSH2_FREE(session, sftp->rename_packet);
-        sftp->rename_packet = NULL;
-    }
-    if(sftp->fstatvfs_packet) {
-        SSH2_FREE(session, sftp->fstatvfs_packet);
-        sftp->fstatvfs_packet = NULL;
-    }
-    if(sftp->statvfs_packet) {
-        SSH2_FREE(session, sftp->statvfs_packet);
-        sftp->statvfs_packet = NULL;
-    }
-    if(sftp->mkdir_packet) {
-        SSH2_FREE(session, sftp->mkdir_packet);
-        sftp->mkdir_packet = NULL;
-    }
-    if(sftp->rmdir_packet) {
-        SSH2_FREE(session, sftp->rmdir_packet);
-        sftp->rmdir_packet = NULL;
-    }
-    if(sftp->stat_packet) {
-        SSH2_FREE(session, sftp->stat_packet);
-        sftp->stat_packet = NULL;
-    }
-    if(sftp->symlink_packet) {
-        SSH2_FREE(session, sftp->symlink_packet);
-        sftp->symlink_packet = NULL;
-    }
-    if(sftp->fsync_packet) {
-        SSH2_FREE(session, sftp->fsync_packet);
-        sftp->fsync_packet = NULL;
-    }
+    if(sftp->partial_packet)
+        SSH2_FREENULL(session, sftp->partial_packet);
+    if(sftp->open_packet)
+        SSH2_FREENULL(session, sftp->open_packet);
+    if(sftp->readdir_packet)
+        SSH2_FREENULL(session, sftp->readdir_packet);
+    if(sftp->fstat_packet)
+        SSH2_FREENULL(session, sftp->fstat_packet);
+    if(sftp->unlink_packet)
+        SSH2_FREENULL(session, sftp->unlink_packet);
+    if(sftp->rename_packet)
+        SSH2_FREENULL(session, sftp->rename_packet);
+    if(sftp->fstatvfs_packet)
+        SSH2_FREENULL(session, sftp->fstatvfs_packet);
+    if(sftp->statvfs_packet)
+        SSH2_FREENULL(session, sftp->statvfs_packet);
+    if(sftp->mkdir_packet)
+        SSH2_FREENULL(session, sftp->mkdir_packet);
+    if(sftp->rmdir_packet)
+        SSH2_FREENULL(session, sftp->rmdir_packet);
+    if(sftp->stat_packet)
+        SSH2_FREENULL(session, sftp->stat_packet);
+    if(sftp->symlink_packet)
+        SSH2_FREENULL(session, sftp->symlink_packet);
+    if(sftp->fsync_packet)
+        SSH2_FREENULL(session, sftp->fsync_packet);
 
     sftp_packet_flush(sftp);
 
@@ -1195,8 +1167,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
         }
         else if(rc < 0) {
             ssh2_err(session, (int)rc, "Unable to send FXP_OPEN*");
-            SSH2_FREE(session, sftp->open_packet);
-            sftp->open_packet = NULL;
+            SSH2_FREENULL(session, sftp->open_packet);
             sftp->open_state = ssh2_NB_state_idle;
             return NULL;
         }
@@ -1206,9 +1177,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
         sftp->open_packet_sent += rc;
 
         if(sftp->open_packet_len == sftp->open_packet_sent) {
-            SSH2_FREE(session, sftp->open_packet);
-            sftp->open_packet = NULL;
-
+            SSH2_FREENULL(session, sftp->open_packet);
             sftp->open_state = ssh2_NB_state_sent;
         }
     }
@@ -1259,8 +1228,7 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
             if(LIBSSH2_FX_OK == sftp->last_errno) {
                 ssh2_deb((session, LIBSSH2_TRACE_SFTP, "got HANDLE FXOK"));
 
-                SSH2_FREE(session, data);
-                data = NULL;
+                SSH2_FREENULL(session, data);
 
                 /* silly situation, but check for a HANDLE */
                 rc = sftp_packet_require(sftp, SSH_FXP_HANDLE,
@@ -1437,10 +1405,8 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
             filep->data_left -= copy;
             filep->offset += copy;
 
-            if(!filep->data_left) {
-                SSH2_FREE(session, filep->data);
-                filep->data = NULL;
-            }
+            if(!filep->data_left)
+                SSH2_FREENULL(session, filep->data);
 
             return copy;
         }
@@ -1918,16 +1884,13 @@ end:
         if(retcode == LIBSSH2_ERROR_EAGAIN)
             return retcode;
         else if((ssize_t)packet_len != retcode) {
-            SSH2_FREE(session, sftp->readdir_packet);
-            sftp->readdir_packet = NULL;
+            SSH2_FREENULL(session, sftp->readdir_packet);
             sftp->readdir_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "ssh2_channel_write() failed");
         }
 
-        SSH2_FREE(session, sftp->readdir_packet);
-        sftp->readdir_packet = NULL;
-
+        SSH2_FREENULL(session, sftp->readdir_packet);
         sftp->readdir_state = ssh2_NB_state_sent;
     }
 
@@ -2401,16 +2364,13 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
         else if((ssize_t)packet_len != rc) {
-            SSH2_FREE(session, sftp->fstat_packet);
-            sftp->fstat_packet = NULL;
+            SSH2_FREENULL(session, sftp->fstat_packet);
             sftp->fstat_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             (setstat ? "Unable to send FXP_FSETSTAT"
                                      : "Unable to send FXP_FSTAT command"));
         }
-        SSH2_FREE(session, sftp->fstat_packet);
-        sftp->fstat_packet = NULL;
-
+        SSH2_FREENULL(session, sftp->fstat_packet);
         sftp->fstat_state = ssh2_NB_state_sent;
     }
 
@@ -2487,9 +2447,8 @@ void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle, libssh2_uint64_t offset)
 
     /* free the left received buffered data */
     if(handle->u.file.data_left) {
-        SSH2_FREE(handle->sftp->channel->session, handle->u.file.data);
+        SSH2_FREENULL(handle->sftp->channel->session, handle->u.file.data);
         handle->u.file.data_left = handle->u.file.data_len = 0;
-        handle->u.file.data = NULL;
     }
 
     /* reset EOF to False */
@@ -2614,8 +2573,7 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((ssize_t)packet_len != nwritten) {
-            SSH2_FREE(session, handle->close_packet);
-            handle->close_packet = NULL;
+            SSH2_FREENULL(session, handle->close_packet);
             handle->close_state = ssh2_NB_state_idle;
             rc = ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                           "Unable to send FXP_CLOSE command");
@@ -2623,8 +2581,7 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
         else
             handle->close_state = ssh2_NB_state_sent;
 
-        SSH2_FREE(session, handle->close_packet);
-        handle->close_packet = NULL;
+        SSH2_FREENULL(session, handle->close_packet);
     }
 
     if(handle->close_state == ssh2_NB_state_sent) {
@@ -2634,7 +2591,7 @@ static int sftp_close_handle(LIBSSH2_SFTP_HANDLE *handle)
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return rc;
         else if(rc == LIBSSH2_ERROR_BUFFER_TOO_SMALL) {
-            if(data_len > 0)
+            if(data_len > 0)  /* FIXME: should this be 'if(data)'? */
                 SSH2_FREE(session, data);
             data = NULL;
             ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
@@ -2744,15 +2701,12 @@ static int sftp_unlink(LIBSSH2_SFTP *sftp,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((ssize_t)packet_len != nwritten) {
-            SSH2_FREE(session, sftp->unlink_packet);
-            sftp->unlink_packet = NULL;
+            SSH2_FREENULL(session, sftp->unlink_packet);
             sftp->unlink_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send FXP_REMOVE command");
         }
-        SSH2_FREE(session, sftp->unlink_packet);
-        sftp->unlink_packet = NULL;
-
+        SSH2_FREENULL(session, sftp->unlink_packet);
         sftp->unlink_state = ssh2_NB_state_sent;
     }
 
@@ -2864,15 +2818,12 @@ static int sftp_rename(LIBSSH2_SFTP *sftp,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
         else if((ssize_t)packet_len != rc) {
-            SSH2_FREE(session, sftp->rename_packet);
-            sftp->rename_packet = NULL;
+            SSH2_FREENULL(session, sftp->rename_packet);
             sftp->rename_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send FXP_RENAME command");
         }
-        SSH2_FREE(session, sftp->rename_packet);
-        sftp->rename_packet = NULL;
-
+        SSH2_FREENULL(session, sftp->rename_packet);
         sftp->rename_state = ssh2_NB_state_sent;
     }
 
@@ -3417,8 +3368,8 @@ static int sftp_mkdir(LIBSSH2_SFTP *sftp,
                             "ssh2_channel_write() failed");
         }
         SSH2_FREE(session, packet);
-        sftp->mkdir_state = ssh2_NB_state_sent;
         sftp->mkdir_packet = NULL;
+        sftp->mkdir_state = ssh2_NB_state_sent;
     }
 
     rc = sftp_packet_require(sftp, SSH_FXP_STATUS, sftp->mkdir_request_id,
@@ -3512,15 +3463,12 @@ static int sftp_rmdir(LIBSSH2_SFTP *sftp, const char *path,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((ssize_t)packet_len != nwritten) {
-            SSH2_FREE(session, sftp->rmdir_packet);
-            sftp->rmdir_packet = NULL;
+            SSH2_FREENULL(session, sftp->rmdir_packet);
             sftp->rmdir_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send FXP_RMDIR command");
         }
-        SSH2_FREE(session, sftp->rmdir_packet);
-        sftp->rmdir_packet = NULL;
-
+        SSH2_FREENULL(session, sftp->rmdir_packet);
         sftp->rmdir_state = ssh2_NB_state_sent;
     }
 
@@ -3635,15 +3583,12 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
         if(nwritten == LIBSSH2_ERROR_EAGAIN)
             return (int)nwritten;
         else if((ssize_t)packet_len != nwritten) {
-            SSH2_FREE(session, sftp->stat_packet);
-            sftp->stat_packet = NULL;
+            SSH2_FREENULL(session, sftp->stat_packet);
             sftp->stat_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send STAT/LSTAT/SETSTAT command");
         }
-        SSH2_FREE(session, sftp->stat_packet);
-        sftp->stat_packet = NULL;
-
+        SSH2_FREENULL(session, sftp->stat_packet);
         sftp->stat_state = ssh2_NB_state_sent;
     }
 
@@ -3797,15 +3742,12 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return (int)rc;
         else if((ssize_t)packet_len != rc) {
-            SSH2_FREE(session, sftp->symlink_packet);
-            sftp->symlink_packet = NULL;
+            SSH2_FREENULL(session, sftp->symlink_packet);
             sftp->symlink_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send SYMLINK/READLINK command");
         }
-        SSH2_FREE(session, sftp->symlink_packet);
-        sftp->symlink_packet = NULL;
-
+        SSH2_FREENULL(session, sftp->symlink_packet);
         sftp->symlink_state = ssh2_NB_state_sent;
     }
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -154,7 +154,7 @@ static int decrypt(LIBSSH2_SESSION *session, unsigned char *source,
         if(session->remote.crypt->crypt(session, 0, source, decryptlen,
                                         &session->remote.crypt_abstract,
                                         lowerfirstlast)) {
-            SSH2_FREENULL(session, p->payload);
+            SSH2_SAFEFREE(session, p->payload);
             return LIBSSH2_ERROR_DECRYPT;
         }
 
@@ -304,7 +304,7 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
                                               p->payload,
                                               session->fullpacket_payload_len,
                                               &session->remote.comp_abstract);
-            SSH2_FREENULL(session, p->payload);
+            SSH2_SAFEFREE(session, p->payload);
             if(rc)
                 return rc;
 
@@ -552,7 +552,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 if(rc != LIBSSH2_ERROR_NONE) {
                     p->total_num = 0; /* no packet buffer available */
                     if(p->payload)
-                        SSH2_FREENULL(session, p->payload);
+                        SSH2_SAFEFREE(session, p->payload);
                     return rc;
                 }
 
@@ -680,7 +680,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                     }
                     else {
                         if(p->payload)
-                            SSH2_FREENULL(session, p->payload);
+                            SSH2_SAFEFREE(session, p->payload);
                         return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
                     }
                 }
@@ -835,7 +835,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 memcpy(p->wptr, &p->buf[p->readidx], numbytes);
             else {
                 if(p->payload)
-                    SSH2_FREENULL(session, p->payload);
+                    SSH2_SAFEFREE(session, p->payload);
                 return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
             }
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -154,8 +154,7 @@ static int decrypt(LIBSSH2_SESSION *session, unsigned char *source,
         if(session->remote.crypt->crypt(session, 0, source, decryptlen,
                                         &session->remote.crypt_abstract,
                                         lowerfirstlast)) {
-            SSH2_FREE(session, p->payload);
-            p->payload = NULL;
+            SSH2_FREENULL(session, p->payload);
             return LIBSSH2_ERROR_DECRYPT;
         }
 
@@ -305,8 +304,7 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
                                               p->payload,
                                               session->fullpacket_payload_len,
                                               &session->remote.comp_abstract);
-            SSH2_FREE(session, p->payload);
-            p->payload = NULL;
+            SSH2_FREENULL(session, p->payload);
             if(rc)
                 return rc;
 
@@ -554,8 +552,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 if(rc != LIBSSH2_ERROR_NONE) {
                     p->total_num = 0; /* no packet buffer available */
                     if(p->payload)
-                        SSH2_FREE(session, p->payload);
-                    p->payload = NULL;
+                        SSH2_FREENULL(session, p->payload);
                     return rc;
                 }
 
@@ -683,8 +680,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                     }
                     else {
                         if(p->payload)
-                            SSH2_FREE(session, p->payload);
-                        p->payload = NULL;
+                            SSH2_FREENULL(session, p->payload);
                         return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
                     }
                 }
@@ -839,8 +835,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 memcpy(p->wptr, &p->buf[p->readidx], numbytes);
             else {
                 if(p->payload)
-                    SSH2_FREE(session, p->payload);
-                p->payload = NULL;
+                    SSH2_FREENULL(session, p->payload);
                 return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
             }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -128,8 +128,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
             return NULL;
         }
         /* now free the packet that was sent */
-        SSH2_FREE(session, session->userauth_list_data);
-        session->userauth_list_data = NULL;
+        SSH2_FREENULL(session, session->userauth_list_data);
 
         if(rc) {
             ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -160,16 +159,14 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
 
         if(session->userauth_list_data[0] == SSH_MSG_USERAUTH_BANNER) {
             if(session->userauth_list_data_len < 5) {
-                SSH2_FREE(session, session->userauth_list_data);
-                session->userauth_list_data = NULL;
+                SSH2_FREENULL(session, session->userauth_list_data);
                 ssh2_err(session, LIBSSH2_ERROR_PROTO,
                          "Unexpected packet size");
                 return NULL;
             }
             banner_len = ssh2_ntohu32(session->userauth_list_data + 1);
             if(banner_len > session->userauth_list_data_len - 5) {
-                SSH2_FREE(session, session->userauth_list_data);
-                session->userauth_list_data = NULL;
+                SSH2_FREENULL(session, session->userauth_list_data);
                 ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                          "Unexpected userauth banner size");
                 return NULL;
@@ -180,8 +177,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
 
             session->userauth_banner = SSH2_ALLOC(session, banner_len + 1);
             if(!session->userauth_banner) {
-                SSH2_FREE(session, session->userauth_list_data);
-                session->userauth_list_data = NULL;
+                SSH2_FREENULL(session, session->userauth_list_data);
                 ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                          "Unable to allocate memory for userauth banner");
                 return NULL;
@@ -191,8 +187,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
             session->userauth_banner[banner_len] = '\0';
             ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Banner: %s",
                       session->userauth_banner));
-            SSH2_FREE(session, session->userauth_list_data);
-            session->userauth_list_data = NULL;
+            SSH2_FREENULL(session, session->userauth_list_data);
             /* SSH_MSG_USERAUTH_BANNER has been handled */
             reply_codes[2] = 0;
             rc = ssh2_packet_requirev(session, reply_codes,
@@ -215,16 +210,14 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
         if(session->userauth_list_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
             /* Wow, who'dve thought... */
             ssh2_err(session, LIBSSH2_ERROR_NONE, "No error");
-            SSH2_FREE(session, session->userauth_list_data);
-            session->userauth_list_data = NULL;
+            SSH2_FREENULL(session, session->userauth_list_data);
             session->state |= SSH2_STATE_AUTHENTICATED;
             session->userauth_list_state = ssh2_NB_state_idle;
             return NULL;
         }
 
         if(session->userauth_list_data_len < 5) {
-            SSH2_FREE(session, session->userauth_list_data);
-            session->userauth_list_data = NULL;
+            SSH2_FREENULL(session, session->userauth_list_data);
             ssh2_err(session, LIBSSH2_ERROR_PROTO, "Unexpected packet size");
             return NULL;
         }
@@ -361,8 +354,7 @@ static int userauth_password(LIBSSH2_SESSION *session,
                             "Would block writing password request");
 
         /* now free the sent packet */
-        SSH2_FREE(session, session->userauth_pswd_data);
-        session->userauth_pswd_data = NULL;
+        SSH2_FREENULL(session, session->userauth_pswd_data);
 
         if(rc) {
             session->userauth_pswd_state = ssh2_NB_state_idle;
@@ -401,8 +393,7 @@ password_response:
             if(session->userauth_pswd_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
                 ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                           "Password authentication successful"));
-                SSH2_FREE(session, session->userauth_pswd_data);
-                session->userauth_pswd_data = NULL;
+                SSH2_FREENULL(session, session->userauth_pswd_data);
                 session->state |= SSH2_STATE_AUTHENTICATED;
                 session->userauth_pswd_state = ssh2_NB_state_idle;
                 return 0;
@@ -411,8 +402,7 @@ password_response:
                     SSH_MSG_USERAUTH_FAILURE) {
                 ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                           "Password authentication failed"));
-                SSH2_FREE(session, session->userauth_pswd_data);
-                session->userauth_pswd_data = NULL;
+                SSH2_FREENULL(session, session->userauth_pswd_data);
                 session->userauth_pswd_state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
                                 "Authentication failed (username/password)");
@@ -441,8 +431,7 @@ password_response:
                 if(session->userauth_pswd_state == ssh2_NB_state_sent1) {
                     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                               "Password change required"));
-                    SSH2_FREE(session, session->userauth_pswd_data);
-                    session->userauth_pswd_data = NULL;
+                    SSH2_FREENULL(session, session->userauth_pswd_data);
                 }
                 if(passwd_change_cb) {
                     if(session->userauth_pswd_state == ssh2_NB_state_sent1) {
@@ -470,8 +459,8 @@ password_response:
                         }
 
                         if(!session->userauth_pswd_data) {
-                            SSH2_FREE(session, session->userauth_pswd_newpw);
-                            session->userauth_pswd_newpw = NULL;
+                            SSH2_FREENULL(session,
+                                          session->userauth_pswd_newpw);
                             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                             "Unable to allocate memory "
                                             "for userauth password "
@@ -504,10 +493,8 @@ password_response:
                                             "Would block waiting");
 
                         /* free the allocated packets again */
-                        SSH2_FREE(session, session->userauth_pswd_data);
-                        session->userauth_pswd_data = NULL;
-                        SSH2_FREE(session, session->userauth_pswd_newpw);
-                        session->userauth_pswd_newpw = NULL;
+                        SSH2_FREENULL(session, session->userauth_pswd_data);
+                        SSH2_FREENULL(session, session->userauth_pswd_newpw);
 
                         if(rc)
                             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -532,8 +519,7 @@ password_response:
     }
 
     /* FAILURE */
-    SSH2_FREE(session, session->userauth_pswd_data);
-    session->userauth_pswd_data = NULL;
+    SSH2_FREENULL(session, session->userauth_pswd_data);
     session->userauth_pswd_state = ssh2_NB_state_idle;
 
     return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
@@ -943,8 +929,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
                     ssh2_deb((session, LIBSSH2_ERROR_STORE_OVERFLOW,
                               "Write operation exceeded buffer size."));
                     rc = LIBSSH2_ERROR_STORE_OVERFLOW;
-                    SSH2_FREE(session, *sig);
-                    *sig = NULL;
+                    SSH2_FREENULL(session, *sig);
                     *sig_len = 0;
                     p = NULL;
                 }
@@ -1049,8 +1034,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
            hostname_len > MAX_INPUT_LEN ||
            local_username_len > MAX_INPUT_LEN ||
            pubkeydata_len > MAX_INPUT_LEN) {
-            SSH2_FREE(session, session->userauth_host_method);
-            session->userauth_host_method = NULL;
+            SSH2_FREENULL(session, session->userauth_host_method);
             SSH2_FREE(session, pubkeydata);
             return ssh2_err(session, LIBSSH2_ERROR_INVAL,
                             "Input parameter length too large");
@@ -1077,8 +1061,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                        4 + session->userauth_host_method_len +
                        4 + pubkeydata_len);
         if(!session->userauth_host_packet) {
-            SSH2_FREE(session, session->userauth_host_method);
-            session->userauth_host_method = NULL;
+            SSH2_FREENULL(session, session->userauth_host_method);
             SSH2_FREE(session, pubkeydata);
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC, "Out of memory");
         }
@@ -1103,10 +1086,8 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                   privatekey, passphrase);
         if(rc) {
             /* Note: file_read_privatekey() calls ssh2_err() */
-            SSH2_FREE(session, session->userauth_host_method);
-            session->userauth_host_method = NULL;
-            SSH2_FREE(session, session->userauth_host_packet);
-            session->userauth_host_packet = NULL;
+            SSH2_FREENULL(session, session->userauth_host_method);
+            SSH2_FREENULL(session, session->userauth_host_packet);
             return rc;
         }
 
@@ -1121,10 +1102,8 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
 
         if(privkeyobj && privkeyobj->signv &&
            privkeyobj->signv(session, &sig, &sig_len, 3, datavec, &abstract)) {
-            SSH2_FREE(session, session->userauth_host_method);
-            session->userauth_host_method = NULL;
-            SSH2_FREE(session, session->userauth_host_packet);
-            session->userauth_host_packet = NULL;
+            SSH2_FREENULL(session, session->userauth_host_method);
+            SSH2_FREENULL(session, session->userauth_host_packet);
             if(privkeyobj->dtor)
                 privkeyobj->dtor(session, &abstract);
             return -1;
@@ -1142,10 +1121,8 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                      4 + sig_len); /* PK sigblob */
             if(!newpacket) {
                 SSH2_FREE(session, sig);
-                SSH2_FREE(session, session->userauth_host_packet);
-                session->userauth_host_packet = NULL;
-                SSH2_FREE(session, session->userauth_host_method);
-                session->userauth_host_method = NULL;
+                SSH2_FREENULL(session, session->userauth_host_packet);
+                SSH2_FREENULL(session, session->userauth_host_method);
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Failed allocating additional space for "
                                 "userauth-hostbased packet");
@@ -1162,8 +1139,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         ssh2_store_str(&session->userauth_host_s,
                        (const char *)session->userauth_host_method,
                        session->userauth_host_method_len);
-        SSH2_FREE(session, session->userauth_host_method);
-        session->userauth_host_method = NULL;
+        SSH2_FREENULL(session, session->userauth_host_method);
 
         ssh2_store_str(&session->userauth_host_s, (const char *)sig, sig_len);
         SSH2_FREE(session, sig);
@@ -1182,14 +1158,12 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc) {
-            SSH2_FREE(session, session->userauth_host_packet);
-            session->userauth_host_packet = NULL;
+            SSH2_FREENULL(session, session->userauth_host_packet);
             session->userauth_host_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send userauth-hostbased request");
         }
-        SSH2_FREE(session, session->userauth_host_packet);
-        session->userauth_host_packet = NULL;
+        SSH2_FREENULL(session, session->userauth_host_packet);
 
         session->userauth_host_state = ssh2_NB_state_sent;
     }
@@ -1218,16 +1192,14 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
             ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                       "Hostbased authentication successful"));
             /* We are us and we have proved it. */
-            SSH2_FREE(session, session->userauth_host_data);
-            session->userauth_host_data = NULL;
+            SSH2_FREENULL(session, session->userauth_host_data);
             session->state |= SSH2_STATE_AUTHENTICATED;
             return 0;
         }
     }
 
     /* This public key is not allowed for this user on this server */
-    SSH2_FREE(session, session->userauth_host_data);
-    session->userauth_host_data = NULL;
+    SSH2_FREENULL(session, session->userauth_host_data);
     return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                     "Invalid signature for supplied public key, or bad "
                     "username/public key combination");
@@ -1614,8 +1586,7 @@ retry_auth:
                        4 + session->userauth_pblc_method_len +
                        4 + pubkeydata_len);
         if(!session->userauth_pblc_packet) {
-            SSH2_FREE(session, session->userauth_pblc_method);
-            session->userauth_pblc_method = NULL;
+            SSH2_FREENULL(session, session->userauth_pblc_method);
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC, "Out of memory");
         }
 
@@ -1644,10 +1615,8 @@ retry_auth:
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc) {
-            SSH2_FREE(session, session->userauth_pblc_packet);
-            session->userauth_pblc_packet = NULL;
-            SSH2_FREE(session, session->userauth_pblc_method);
-            session->userauth_pblc_method = NULL;
+            SSH2_FREENULL(session, session->userauth_pblc_packet);
+            SSH2_FREENULL(session, session->userauth_pblc_method);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send userauth-publickey request");
@@ -1666,10 +1635,8 @@ retry_auth:
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc || session->userauth_pblc_data_len < 1) {
-            SSH2_FREE(session, session->userauth_pblc_packet);
-            session->userauth_pblc_packet = NULL;
-            SSH2_FREE(session, session->userauth_pblc_method);
-            session->userauth_pblc_method = NULL;
+            SSH2_FREENULL(session, session->userauth_pblc_packet);
+            SSH2_FREENULL(session, session->userauth_pblc_method);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                             "Waiting for USERAUTH response");
@@ -1682,12 +1649,9 @@ retry_auth:
              * God help any SSH server that allows an UNVERIFIED
              * public key to validate the user
              */
-            SSH2_FREE(session, session->userauth_pblc_data);
-            session->userauth_pblc_data = NULL;
-            SSH2_FREE(session, session->userauth_pblc_packet);
-            session->userauth_pblc_packet = NULL;
-            SSH2_FREE(session, session->userauth_pblc_method);
-            session->userauth_pblc_method = NULL;
+            SSH2_FREENULL(session, session->userauth_pblc_data);
+            SSH2_FREENULL(session, session->userauth_pblc_packet);
+            SSH2_FREENULL(session, session->userauth_pblc_method);
             session->state |= SSH2_STATE_AUTHENTICATED;
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return 0;
@@ -1695,20 +1659,16 @@ retry_auth:
 
         if(session->userauth_pblc_data[0] == SSH_MSG_USERAUTH_FAILURE) {
             /* This public key is not allowed for this user on this server */
-            SSH2_FREE(session, session->userauth_pblc_data);
-            session->userauth_pblc_data = NULL;
-            SSH2_FREE(session, session->userauth_pblc_packet);
-            session->userauth_pblc_packet = NULL;
-            SSH2_FREE(session, session->userauth_pblc_method);
-            session->userauth_pblc_method = NULL;
+            SSH2_FREENULL(session, session->userauth_pblc_data);
+            SSH2_FREENULL(session, session->userauth_pblc_packet);
+            SSH2_FREENULL(session, session->userauth_pblc_method);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
                             "Username/PublicKey combination invalid");
         }
 
         /* Semi-Success! */
-        SSH2_FREE(session, session->userauth_pblc_data);
-        session->userauth_pblc_data = NULL;
+        SSH2_FREENULL(session, session->userauth_pblc_data);
 
         *session->userauth_pblc_b = 0x01;
         session->userauth_pblc_state = ssh2_NB_state_sent1;
@@ -1740,19 +1700,15 @@ retry_auth:
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc == LIBSSH2_ERROR_ALGO_UNSUPPORTED && auth_attempts == 1) {
             /* try again with the default key algo */
-            SSH2_FREE(session, session->userauth_pblc_method);
-            session->userauth_pblc_method = NULL;
-            SSH2_FREE(session, session->userauth_pblc_packet);
-            session->userauth_pblc_packet = NULL;
+            SSH2_FREENULL(session, session->userauth_pblc_method);
+            SSH2_FREENULL(session, session->userauth_pblc_packet);
             session->userauth_pblc_state = ssh2_NB_state_idle;
 
             goto retry_auth;
         }
         else if(rc) {
-            SSH2_FREE(session, session->userauth_pblc_method);
-            session->userauth_pblc_method = NULL;
-            SSH2_FREE(session, session->userauth_pblc_packet);
-            session->userauth_pblc_packet = NULL;
+            SSH2_FREENULL(session, session->userauth_pblc_method);
+            SSH2_FREENULL(session, session->userauth_pblc_packet);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                             "Callback returned error");
@@ -1776,10 +1732,8 @@ retry_auth:
                                      4 + sig_len); /* PK sigblob */
             if(!newpacket) {
                 SSH2_FREE(session, sig);
-                SSH2_FREE(session, session->userauth_pblc_packet);
-                session->userauth_pblc_packet = NULL;
-                SSH2_FREE(session, session->userauth_pblc_method);
-                session->userauth_pblc_method = NULL;
+                SSH2_FREENULL(session, session->userauth_pblc_packet);
+                SSH2_FREENULL(session, session->userauth_pblc_method);
                 session->userauth_pblc_state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Failed allocating additional space for "
@@ -1818,9 +1772,7 @@ retry_auth:
             ssh2_store_str(&s, (const char *)sig, sig_len);
         }
 
-        SSH2_FREE(session, session->userauth_pblc_method);
-        session->userauth_pblc_method = NULL;
-
+        SSH2_FREENULL(session, session->userauth_pblc_method);
         SSH2_FREE(session, sig);
 
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1838,14 +1790,12 @@ retry_auth:
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc) {
-            SSH2_FREE(session, session->userauth_pblc_packet);
-            session->userauth_pblc_packet = NULL;
+            SSH2_FREENULL(session, session->userauth_pblc_packet);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send userauth-publickey request");
         }
-        SSH2_FREE(session, session->userauth_pblc_packet);
-        session->userauth_pblc_packet = NULL;
+        SSH2_FREENULL(session, session->userauth_pblc_packet);
 
         session->userauth_pblc_state = ssh2_NB_state_sent3;
     }
@@ -1870,16 +1820,14 @@ retry_auth:
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                   "Publickey authentication successful"));
         /* We are us and we have proved it. */
-        SSH2_FREE(session, session->userauth_pblc_data);
-        session->userauth_pblc_data = NULL;
+        SSH2_FREENULL(session, session->userauth_pblc_data);
         session->state |= SSH2_STATE_AUTHENTICATED;
         session->userauth_pblc_state = ssh2_NB_state_idle;
         return 0;
     }
 
     /* This public key is not allowed for this user on this server */
-    SSH2_FREE(session, session->userauth_pblc_data);
-    session->userauth_pblc_data = NULL;
+    SSH2_FREENULL(session, session->userauth_pblc_data);
     session->userauth_pblc_state = ssh2_NB_state_idle;
     return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                     "Invalid signature for supplied public key, or bad "
@@ -2151,14 +2099,12 @@ static int userauth_keyboard_interactive(
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc) {
-            SSH2_FREE(session, session->userauth_kybd_data);
-            session->userauth_kybd_data = NULL;
+            SSH2_FREENULL(session, session->userauth_kybd_data);
             session->userauth_kybd_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send keyboard-interactive request");
         }
-        SSH2_FREE(session, session->userauth_kybd_data);
-        session->userauth_kybd_data = NULL;
+        SSH2_FREENULL(session, session->userauth_kybd_data);
 
         session->userauth_kybd_state = ssh2_NB_state_sent;
     }
@@ -2182,8 +2128,7 @@ static int userauth_keyboard_interactive(
             if(session->userauth_kybd_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
                 ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                           "Keyboard-interactive authentication successful"));
-                SSH2_FREE(session, session->userauth_kybd_data);
-                session->userauth_kybd_data = NULL;
+                SSH2_FREENULL(session, session->userauth_kybd_data);
                 session->state |= SSH2_STATE_AUTHENTICATED;
                 session->userauth_kybd_state = ssh2_NB_state_idle;
                 return 0;
@@ -2192,8 +2137,7 @@ static int userauth_keyboard_interactive(
             if(session->userauth_kybd_data[0] == SSH_MSG_USERAUTH_FAILURE) {
                 ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                           "Keyboard-interactive authentication failed"));
-                SSH2_FREE(session, session->userauth_kybd_data);
-                session->userauth_kybd_data = NULL;
+                SSH2_FREENULL(session, session->userauth_kybd_data);
                 session->userauth_kybd_state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
                                 "Authentication failed "
@@ -2284,39 +2228,25 @@ cleanup:
          * are filled by zeroes
          */
 
-        SSH2_FREE(session, session->userauth_kybd_data);
-        session->userauth_kybd_data = NULL;
+        SSH2_FREENULL(session, session->userauth_kybd_data);
 
-        if(session->userauth_kybd_prompts) {
+        if(session->userauth_kybd_prompts)
+            for(i = 0; i < session->userauth_kybd_num_prompts; i++)
+                SSH2_FREENULL(session, session->userauth_kybd_prompts[i].text);
+
+        if(session->userauth_kybd_responses)
             for(i = 0; i < session->userauth_kybd_num_prompts; i++) {
-                SSH2_FREE(session, session->userauth_kybd_prompts[i].text);
-                session->userauth_kybd_prompts[i].text = NULL;
-            }
-        }
+                SSH2_FREENULL(session,
+                              session->userauth_kybd_responses[i].text);
 
-        if(session->userauth_kybd_responses) {
-            for(i = 0; i < session->userauth_kybd_num_prompts; i++) {
-                SSH2_FREE(session, session->userauth_kybd_responses[i].text);
-                session->userauth_kybd_responses[i].text = NULL;
-            }
-        }
-
-        if(session->userauth_kybd_prompts) {
-            SSH2_FREE(session, session->userauth_kybd_prompts);
-            session->userauth_kybd_prompts = NULL;
-        }
-        if(session->userauth_kybd_responses) {
-            SSH2_FREE(session, session->userauth_kybd_responses);
-            session->userauth_kybd_responses = NULL;
-        }
-        if(session->userauth_kybd_auth_name) {
-            SSH2_FREE(session, session->userauth_kybd_auth_name);
-            session->userauth_kybd_auth_name = NULL;
-        }
-        if(session->userauth_kybd_auth_instruction) {
-            SSH2_FREE(session, session->userauth_kybd_auth_instruction);
-            session->userauth_kybd_auth_instruction = NULL;
-        }
+        if(session->userauth_kybd_prompts)
+            SSH2_FREENULL(session, session->userauth_kybd_prompts);
+        if(session->userauth_kybd_responses)
+            SSH2_FREENULL(session, session->userauth_kybd_responses);
+        if(session->userauth_kybd_auth_name)
+            SSH2_FREENULL(session, session->userauth_kybd_auth_name);
+        if(session->userauth_kybd_auth_instruction)
+            SSH2_FREENULL(session, session->userauth_kybd_auth_instruction);
 
         if(session->userauth_kybd_auth_failure) {
             session->userauth_kybd_state = ssh2_NB_state_idle;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -128,7 +128,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
             return NULL;
         }
         /* now free the packet that was sent */
-        SSH2_FREENULL(session, session->userauth_list_data);
+        SSH2_SAFEFREE(session, session->userauth_list_data);
 
         if(rc) {
             ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -159,14 +159,14 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
 
         if(session->userauth_list_data[0] == SSH_MSG_USERAUTH_BANNER) {
             if(session->userauth_list_data_len < 5) {
-                SSH2_FREENULL(session, session->userauth_list_data);
+                SSH2_SAFEFREE(session, session->userauth_list_data);
                 ssh2_err(session, LIBSSH2_ERROR_PROTO,
                          "Unexpected packet size");
                 return NULL;
             }
             banner_len = ssh2_ntohu32(session->userauth_list_data + 1);
             if(banner_len > session->userauth_list_data_len - 5) {
-                SSH2_FREENULL(session, session->userauth_list_data);
+                SSH2_SAFEFREE(session, session->userauth_list_data);
                 ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                          "Unexpected userauth banner size");
                 return NULL;
@@ -177,7 +177,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
 
             session->userauth_banner = SSH2_ALLOC(session, banner_len + 1);
             if(!session->userauth_banner) {
-                SSH2_FREENULL(session, session->userauth_list_data);
+                SSH2_SAFEFREE(session, session->userauth_list_data);
                 ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                          "Unable to allocate memory for userauth banner");
                 return NULL;
@@ -187,7 +187,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
             session->userauth_banner[banner_len] = '\0';
             ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Banner: %s",
                       session->userauth_banner));
-            SSH2_FREENULL(session, session->userauth_list_data);
+            SSH2_SAFEFREE(session, session->userauth_list_data);
             /* SSH_MSG_USERAUTH_BANNER has been handled */
             reply_codes[2] = 0;
             rc = ssh2_packet_requirev(session, reply_codes,
@@ -210,14 +210,14 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
         if(session->userauth_list_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
             /* Wow, who'dve thought... */
             ssh2_err(session, LIBSSH2_ERROR_NONE, "No error");
-            SSH2_FREENULL(session, session->userauth_list_data);
+            SSH2_SAFEFREE(session, session->userauth_list_data);
             session->state |= SSH2_STATE_AUTHENTICATED;
             session->userauth_list_state = ssh2_NB_state_idle;
             return NULL;
         }
 
         if(session->userauth_list_data_len < 5) {
-            SSH2_FREENULL(session, session->userauth_list_data);
+            SSH2_SAFEFREE(session, session->userauth_list_data);
             ssh2_err(session, LIBSSH2_ERROR_PROTO, "Unexpected packet size");
             return NULL;
         }
@@ -354,7 +354,7 @@ static int userauth_password(LIBSSH2_SESSION *session,
                             "Would block writing password request");
 
         /* now free the sent packet */
-        SSH2_FREENULL(session, session->userauth_pswd_data);
+        SSH2_SAFEFREE(session, session->userauth_pswd_data);
 
         if(rc) {
             session->userauth_pswd_state = ssh2_NB_state_idle;
@@ -393,7 +393,7 @@ password_response:
             if(session->userauth_pswd_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
                 ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                           "Password authentication successful"));
-                SSH2_FREENULL(session, session->userauth_pswd_data);
+                SSH2_SAFEFREE(session, session->userauth_pswd_data);
                 session->state |= SSH2_STATE_AUTHENTICATED;
                 session->userauth_pswd_state = ssh2_NB_state_idle;
                 return 0;
@@ -402,7 +402,7 @@ password_response:
                     SSH_MSG_USERAUTH_FAILURE) {
                 ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                           "Password authentication failed"));
-                SSH2_FREENULL(session, session->userauth_pswd_data);
+                SSH2_SAFEFREE(session, session->userauth_pswd_data);
                 session->userauth_pswd_state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
                                 "Authentication failed (username/password)");
@@ -431,7 +431,7 @@ password_response:
                 if(session->userauth_pswd_state == ssh2_NB_state_sent1) {
                     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                               "Password change required"));
-                    SSH2_FREENULL(session, session->userauth_pswd_data);
+                    SSH2_SAFEFREE(session, session->userauth_pswd_data);
                 }
                 if(passwd_change_cb) {
                     if(session->userauth_pswd_state == ssh2_NB_state_sent1) {
@@ -459,7 +459,7 @@ password_response:
                         }
 
                         if(!session->userauth_pswd_data) {
-                            SSH2_FREENULL(session,
+                            SSH2_SAFEFREE(session,
                                           session->userauth_pswd_newpw);
                             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                             "Unable to allocate memory "
@@ -493,8 +493,8 @@ password_response:
                                             "Would block waiting");
 
                         /* free the allocated packets again */
-                        SSH2_FREENULL(session, session->userauth_pswd_data);
-                        SSH2_FREENULL(session, session->userauth_pswd_newpw);
+                        SSH2_SAFEFREE(session, session->userauth_pswd_data);
+                        SSH2_SAFEFREE(session, session->userauth_pswd_newpw);
 
                         if(rc)
                             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
@@ -519,7 +519,7 @@ password_response:
     }
 
     /* FAILURE */
-    SSH2_FREENULL(session, session->userauth_pswd_data);
+    SSH2_SAFEFREE(session, session->userauth_pswd_data);
     session->userauth_pswd_state = ssh2_NB_state_idle;
 
     return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
@@ -929,7 +929,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
                     ssh2_deb((session, LIBSSH2_ERROR_STORE_OVERFLOW,
                               "Write operation exceeded buffer size."));
                     rc = LIBSSH2_ERROR_STORE_OVERFLOW;
-                    SSH2_FREENULL(session, *sig);
+                    SSH2_SAFEFREE(session, *sig);
                     *sig_len = 0;
                     p = NULL;
                 }
@@ -1034,7 +1034,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
            hostname_len > MAX_INPUT_LEN ||
            local_username_len > MAX_INPUT_LEN ||
            pubkeydata_len > MAX_INPUT_LEN) {
-            SSH2_FREENULL(session, session->userauth_host_method);
+            SSH2_SAFEFREE(session, session->userauth_host_method);
             SSH2_FREE(session, pubkeydata);
             return ssh2_err(session, LIBSSH2_ERROR_INVAL,
                             "Input parameter length too large");
@@ -1061,7 +1061,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                        4 + session->userauth_host_method_len +
                        4 + pubkeydata_len);
         if(!session->userauth_host_packet) {
-            SSH2_FREENULL(session, session->userauth_host_method);
+            SSH2_SAFEFREE(session, session->userauth_host_method);
             SSH2_FREE(session, pubkeydata);
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC, "Out of memory");
         }
@@ -1086,8 +1086,8 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                   privatekey, passphrase);
         if(rc) {
             /* Note: file_read_privatekey() calls ssh2_err() */
-            SSH2_FREENULL(session, session->userauth_host_method);
-            SSH2_FREENULL(session, session->userauth_host_packet);
+            SSH2_SAFEFREE(session, session->userauth_host_method);
+            SSH2_SAFEFREE(session, session->userauth_host_packet);
             return rc;
         }
 
@@ -1102,8 +1102,8 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
 
         if(privkeyobj && privkeyobj->signv &&
            privkeyobj->signv(session, &sig, &sig_len, 3, datavec, &abstract)) {
-            SSH2_FREENULL(session, session->userauth_host_method);
-            SSH2_FREENULL(session, session->userauth_host_packet);
+            SSH2_SAFEFREE(session, session->userauth_host_method);
+            SSH2_SAFEFREE(session, session->userauth_host_packet);
             if(privkeyobj->dtor)
                 privkeyobj->dtor(session, &abstract);
             return -1;
@@ -1121,8 +1121,8 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                      4 + sig_len); /* PK sigblob */
             if(!newpacket) {
                 SSH2_FREE(session, sig);
-                SSH2_FREENULL(session, session->userauth_host_packet);
-                SSH2_FREENULL(session, session->userauth_host_method);
+                SSH2_SAFEFREE(session, session->userauth_host_packet);
+                SSH2_SAFEFREE(session, session->userauth_host_method);
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Failed allocating additional space for "
                                 "userauth-hostbased packet");
@@ -1139,7 +1139,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         ssh2_store_str(&session->userauth_host_s,
                        (const char *)session->userauth_host_method,
                        session->userauth_host_method_len);
-        SSH2_FREENULL(session, session->userauth_host_method);
+        SSH2_SAFEFREE(session, session->userauth_host_method);
 
         ssh2_store_str(&session->userauth_host_s, (const char *)sig, sig_len);
         SSH2_FREE(session, sig);
@@ -1158,12 +1158,12 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc) {
-            SSH2_FREENULL(session, session->userauth_host_packet);
+            SSH2_SAFEFREE(session, session->userauth_host_packet);
             session->userauth_host_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send userauth-hostbased request");
         }
-        SSH2_FREENULL(session, session->userauth_host_packet);
+        SSH2_SAFEFREE(session, session->userauth_host_packet);
 
         session->userauth_host_state = ssh2_NB_state_sent;
     }
@@ -1192,14 +1192,14 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
             ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                       "Hostbased authentication successful"));
             /* We are us and we have proved it. */
-            SSH2_FREENULL(session, session->userauth_host_data);
+            SSH2_SAFEFREE(session, session->userauth_host_data);
             session->state |= SSH2_STATE_AUTHENTICATED;
             return 0;
         }
     }
 
     /* This public key is not allowed for this user on this server */
-    SSH2_FREENULL(session, session->userauth_host_data);
+    SSH2_SAFEFREE(session, session->userauth_host_data);
     return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                     "Invalid signature for supplied public key, or bad "
                     "username/public key combination");
@@ -1586,7 +1586,7 @@ retry_auth:
                        4 + session->userauth_pblc_method_len +
                        4 + pubkeydata_len);
         if(!session->userauth_pblc_packet) {
-            SSH2_FREENULL(session, session->userauth_pblc_method);
+            SSH2_SAFEFREE(session, session->userauth_pblc_method);
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC, "Out of memory");
         }
 
@@ -1615,8 +1615,8 @@ retry_auth:
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc) {
-            SSH2_FREENULL(session, session->userauth_pblc_packet);
-            SSH2_FREENULL(session, session->userauth_pblc_method);
+            SSH2_SAFEFREE(session, session->userauth_pblc_packet);
+            SSH2_SAFEFREE(session, session->userauth_pblc_method);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send userauth-publickey request");
@@ -1635,8 +1635,8 @@ retry_auth:
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc || session->userauth_pblc_data_len < 1) {
-            SSH2_FREENULL(session, session->userauth_pblc_packet);
-            SSH2_FREENULL(session, session->userauth_pblc_method);
+            SSH2_SAFEFREE(session, session->userauth_pblc_packet);
+            SSH2_SAFEFREE(session, session->userauth_pblc_method);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                             "Waiting for USERAUTH response");
@@ -1649,9 +1649,9 @@ retry_auth:
              * God help any SSH server that allows an UNVERIFIED
              * public key to validate the user
              */
-            SSH2_FREENULL(session, session->userauth_pblc_data);
-            SSH2_FREENULL(session, session->userauth_pblc_packet);
-            SSH2_FREENULL(session, session->userauth_pblc_method);
+            SSH2_SAFEFREE(session, session->userauth_pblc_data);
+            SSH2_SAFEFREE(session, session->userauth_pblc_packet);
+            SSH2_SAFEFREE(session, session->userauth_pblc_method);
             session->state |= SSH2_STATE_AUTHENTICATED;
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return 0;
@@ -1659,16 +1659,16 @@ retry_auth:
 
         if(session->userauth_pblc_data[0] == SSH_MSG_USERAUTH_FAILURE) {
             /* This public key is not allowed for this user on this server */
-            SSH2_FREENULL(session, session->userauth_pblc_data);
-            SSH2_FREENULL(session, session->userauth_pblc_packet);
-            SSH2_FREENULL(session, session->userauth_pblc_method);
+            SSH2_SAFEFREE(session, session->userauth_pblc_data);
+            SSH2_SAFEFREE(session, session->userauth_pblc_packet);
+            SSH2_SAFEFREE(session, session->userauth_pblc_method);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
                             "Username/PublicKey combination invalid");
         }
 
         /* Semi-Success! */
-        SSH2_FREENULL(session, session->userauth_pblc_data);
+        SSH2_SAFEFREE(session, session->userauth_pblc_data);
 
         *session->userauth_pblc_b = 0x01;
         session->userauth_pblc_state = ssh2_NB_state_sent1;
@@ -1700,15 +1700,15 @@ retry_auth:
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc == LIBSSH2_ERROR_ALGO_UNSUPPORTED && auth_attempts == 1) {
             /* try again with the default key algo */
-            SSH2_FREENULL(session, session->userauth_pblc_method);
-            SSH2_FREENULL(session, session->userauth_pblc_packet);
+            SSH2_SAFEFREE(session, session->userauth_pblc_method);
+            SSH2_SAFEFREE(session, session->userauth_pblc_packet);
             session->userauth_pblc_state = ssh2_NB_state_idle;
 
             goto retry_auth;
         }
         else if(rc) {
-            SSH2_FREENULL(session, session->userauth_pblc_method);
-            SSH2_FREENULL(session, session->userauth_pblc_packet);
+            SSH2_SAFEFREE(session, session->userauth_pblc_method);
+            SSH2_SAFEFREE(session, session->userauth_pblc_packet);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                             "Callback returned error");
@@ -1732,8 +1732,8 @@ retry_auth:
                                      4 + sig_len); /* PK sigblob */
             if(!newpacket) {
                 SSH2_FREE(session, sig);
-                SSH2_FREENULL(session, session->userauth_pblc_packet);
-                SSH2_FREENULL(session, session->userauth_pblc_method);
+                SSH2_SAFEFREE(session, session->userauth_pblc_packet);
+                SSH2_SAFEFREE(session, session->userauth_pblc_method);
                 session->userauth_pblc_state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Failed allocating additional space for "
@@ -1772,7 +1772,7 @@ retry_auth:
             ssh2_store_str(&s, (const char *)sig, sig_len);
         }
 
-        SSH2_FREENULL(session, session->userauth_pblc_method);
+        SSH2_SAFEFREE(session, session->userauth_pblc_method);
         SSH2_FREE(session, sig);
 
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1790,12 +1790,12 @@ retry_auth:
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc) {
-            SSH2_FREENULL(session, session->userauth_pblc_packet);
+            SSH2_SAFEFREE(session, session->userauth_pblc_packet);
             session->userauth_pblc_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send userauth-publickey request");
         }
-        SSH2_FREENULL(session, session->userauth_pblc_packet);
+        SSH2_SAFEFREE(session, session->userauth_pblc_packet);
 
         session->userauth_pblc_state = ssh2_NB_state_sent3;
     }
@@ -1820,14 +1820,14 @@ retry_auth:
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                   "Publickey authentication successful"));
         /* We are us and we have proved it. */
-        SSH2_FREENULL(session, session->userauth_pblc_data);
+        SSH2_SAFEFREE(session, session->userauth_pblc_data);
         session->state |= SSH2_STATE_AUTHENTICATED;
         session->userauth_pblc_state = ssh2_NB_state_idle;
         return 0;
     }
 
     /* This public key is not allowed for this user on this server */
-    SSH2_FREENULL(session, session->userauth_pblc_data);
+    SSH2_SAFEFREE(session, session->userauth_pblc_data);
     session->userauth_pblc_state = ssh2_NB_state_idle;
     return ssh2_err(session, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED,
                     "Invalid signature for supplied public key, or bad "
@@ -2099,12 +2099,12 @@ static int userauth_keyboard_interactive(
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN, "Would block");
         else if(rc) {
-            SSH2_FREENULL(session, session->userauth_kybd_data);
+            SSH2_SAFEFREE(session, session->userauth_kybd_data);
             session->userauth_kybd_state = ssh2_NB_state_idle;
             return ssh2_err(session, LIBSSH2_ERROR_SOCKET_SEND,
                             "Unable to send keyboard-interactive request");
         }
-        SSH2_FREENULL(session, session->userauth_kybd_data);
+        SSH2_SAFEFREE(session, session->userauth_kybd_data);
 
         session->userauth_kybd_state = ssh2_NB_state_sent;
     }
@@ -2128,7 +2128,7 @@ static int userauth_keyboard_interactive(
             if(session->userauth_kybd_data[0] == SSH_MSG_USERAUTH_SUCCESS) {
                 ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                           "Keyboard-interactive authentication successful"));
-                SSH2_FREENULL(session, session->userauth_kybd_data);
+                SSH2_SAFEFREE(session, session->userauth_kybd_data);
                 session->state |= SSH2_STATE_AUTHENTICATED;
                 session->userauth_kybd_state = ssh2_NB_state_idle;
                 return 0;
@@ -2137,7 +2137,7 @@ static int userauth_keyboard_interactive(
             if(session->userauth_kybd_data[0] == SSH_MSG_USERAUTH_FAILURE) {
                 ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                           "Keyboard-interactive authentication failed"));
-                SSH2_FREENULL(session, session->userauth_kybd_data);
+                SSH2_SAFEFREE(session, session->userauth_kybd_data);
                 session->userauth_kybd_state = ssh2_NB_state_idle;
                 return ssh2_err(session, LIBSSH2_ERROR_AUTHENTICATION_FAILED,
                                 "Authentication failed "
@@ -2228,25 +2228,25 @@ cleanup:
          * are filled by zeroes
          */
 
-        SSH2_FREENULL(session, session->userauth_kybd_data);
+        SSH2_SAFEFREE(session, session->userauth_kybd_data);
 
         if(session->userauth_kybd_prompts)
             for(i = 0; i < session->userauth_kybd_num_prompts; i++)
-                SSH2_FREENULL(session, session->userauth_kybd_prompts[i].text);
+                SSH2_SAFEFREE(session, session->userauth_kybd_prompts[i].text);
 
         if(session->userauth_kybd_responses)
             for(i = 0; i < session->userauth_kybd_num_prompts; i++) {
-                SSH2_FREENULL(session,
+                SSH2_SAFEFREE(session,
                               session->userauth_kybd_responses[i].text);
 
         if(session->userauth_kybd_prompts)
-            SSH2_FREENULL(session, session->userauth_kybd_prompts);
+            SSH2_SAFEFREE(session, session->userauth_kybd_prompts);
         if(session->userauth_kybd_responses)
-            SSH2_FREENULL(session, session->userauth_kybd_responses);
+            SSH2_SAFEFREE(session, session->userauth_kybd_responses);
         if(session->userauth_kybd_auth_name)
-            SSH2_FREENULL(session, session->userauth_kybd_auth_name);
+            SSH2_SAFEFREE(session, session->userauth_kybd_auth_name);
         if(session->userauth_kybd_auth_instruction)
-            SSH2_FREENULL(session, session->userauth_kybd_auth_instruction);
+            SSH2_SAFEFREE(session, session->userauth_kybd_auth_instruction);
 
         if(session->userauth_kybd_auth_failure) {
             session->userauth_kybd_state = ssh2_NB_state_idle;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2235,7 +2235,7 @@ cleanup:
                 SSH2_SAFEFREE(session, session->userauth_kybd_prompts[i].text);
 
         if(session->userauth_kybd_responses)
-            for(i = 0; i < session->userauth_kybd_num_prompts; i++) {
+            for(i = 0; i < session->userauth_kybd_num_prompts; i++)
                 SSH2_SAFEFREE(session,
                               session->userauth_kybd_responses[i].text);
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2797,8 +2797,7 @@ int ssh2_ecdsa_sign(IN LIBSSH2_SESSION *session,
 
 cleanup:
     if(result != LIBSSH2_ERROR_NONE && *signature) {
-        SSH2_FREE(session, *signature);
-        *signature = NULL;
+        SSH2_FREENULL(session, *signature);
         *signature_len = 0;
     }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2797,7 +2797,7 @@ int ssh2_ecdsa_sign(IN LIBSSH2_SESSION *session,
 
 cleanup:
     if(result != LIBSSH2_ERROR_NONE && *signature) {
-        SSH2_FREENULL(session, *signature);
+        SSH2_SAFEFREE(session, *signature);
         *signature_len = 0;
     }
 


### PR DESCRIPTION
Like `SSH2_FREE()` but also assign `NULL` to the freed pointer variable.

Also add checksrc rule to verify.

Ref: #2208

---

There may be a few more, hidden, cases where the freeing and NULL-ing
are applied to different variables, which are possibly aliases. Also possibly
more places where the NULL-ing would be useful to do, but isn't done yet.

There is one place where the freeing is done only when a corresponding
length is non-zero, and the NULL-ing unconditionally. I left a FIXME there,
as this may be a mistake and can cause a memleak or crash.
