### PR TITLE
src: move static function names to local namespace, where missing

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -1650,11 +1650,11 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
 /*
  * Elliptic Curve Diffie Hellman Key Exchange
  */
-static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
-                           unsigned char *data, size_t data_len,
-                           unsigned char *public_key,
-                           size_t public_key_len, ssh2_ec_key *private_key,
-                           struct kmdhgGPshakex_state *exchange_state)
+static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
+                               unsigned char *data, size_t data_len,
+                               unsigned char *public_key,
+                               size_t public_key_len, ssh2_ec_key *private_key,
+                               struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc;
@@ -1898,12 +1898,12 @@ static int kex_method_ecdh_key_exchange(
             goto ecdh_clean_exit;
         }
 
-        ret = ecdh_sha2_nistp(session, type, key_state->data,
-                              key_state->data_len,
-                              (unsigned char *)key_state->public_key_oct,
-                              key_state->public_key_oct_len,
-                              key_state->private_key,
-                              &key_state->exchange_state);
+        ret = kex_ecdh_sha2_nistp(session, type, key_state->data,
+                                  key_state->data_len,
+                                  (unsigned char *)key_state->public_key_oct,
+                                  key_state->public_key_oct_len,
+                                  key_state->private_key,
+                                  &key_state->exchange_state);
 
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;

--- a/src/kex.c
+++ b/src/kex.c
@@ -2596,7 +2596,7 @@ clean_exit:
 
 #if LIBSSH2_MLKEM
 
-static void mlkem768x25519_exchange_state_cleanup(
+static void kex_mlkem768x25519_exchange_state_cleanup(
     LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     ssh2_bn_free(exchange_state->k);
@@ -2798,7 +2798,7 @@ static int mlkem768x25519_sha256(
     }
 
 clean_exit:
-    mlkem768x25519_exchange_state_cleanup(session, exchange_state);
+    kex_mlkem768x25519_exchange_state_cleanup(session, exchange_state);
 
     return ret;
 }

--- a/src/kex.c
+++ b/src/kex.c
@@ -46,11 +46,11 @@
 
 #include <assert.h>
 
-static void sha_algo_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
-                                LIBSSH2_SESSION *session,
-                                struct kmdhgGPshakex_state *exchange_state,
-                                unsigned char **data, size_t data_len,
-                                const unsigned char *version)
+static void kex_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
+                           LIBSSH2_SESSION *session,
+                           struct kmdhgGPshakex_state *exchange_state,
+                           unsigned char **data, size_t data_len,
+                           const unsigned char *version)
 {
     if(!digest_len || digest_len > MAX_SHA_DIGEST_LEN) {
         *data = NULL;
@@ -263,18 +263,16 @@ static int finish_kex(LIBSSH2_SESSION *session,
         unsigned char *iv = NULL, *secret = NULL;
         int free_iv = 0, free_secret = 0;
 
-        sha_algo_value_hash(hash_alg, digest_len, session,
-                            exchange_state, &iv,
-                            session->local.crypt->iv_len,
-                            (const unsigned char *)"A");
+        kex_value_hash(hash_alg, digest_len, session, exchange_state,
+                       &iv, session->local.crypt->iv_len,
+                       (const unsigned char *)"A");
         if(!iv)
             return ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
                             "Unable to generate IV for key exchange");
 
-        sha_algo_value_hash(hash_alg, digest_len, session,
-                            exchange_state, &secret,
-                            session->local.crypt->secret_len,
-                            (const unsigned char *)"C");
+        kex_value_hash(hash_alg, digest_len, session, exchange_state,
+                       &secret, session->local.crypt->secret_len,
+                       (const unsigned char *)"C");
         if(!secret) {
             SSH2_FREE(session, iv);
             return ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
@@ -311,18 +309,16 @@ static int finish_kex(LIBSSH2_SESSION *session,
         unsigned char *iv = NULL, *secret = NULL;
         int free_iv = 0, free_secret = 0;
 
-        sha_algo_value_hash(hash_alg, digest_len, session,
-                            exchange_state, &iv,
-                            session->remote.crypt->iv_len,
-                            (const unsigned char *)"B");
+        kex_value_hash(hash_alg, digest_len, session, exchange_state,
+                       &iv, session->remote.crypt->iv_len,
+                       (const unsigned char *)"B");
         if(!iv)
             return ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
                             "Failed to derive remote IV during key exchange");
 
-        sha_algo_value_hash(hash_alg, digest_len, session,
-                            exchange_state, &secret,
-                            session->remote.crypt->secret_len,
-                            (const unsigned char *)"D");
+        kex_value_hash(hash_alg, digest_len, session, exchange_state,
+                       &secret, session->remote.crypt->secret_len,
+                       (const unsigned char *)"D");
         if(!secret) {
             SSH2_FREE(session, iv);
             return ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
@@ -358,10 +354,9 @@ static int finish_kex(LIBSSH2_SESSION *session,
         unsigned char *key = NULL;
         int free_key = 0;
 
-        sha_algo_value_hash(hash_alg, digest_len, session,
-                            exchange_state, &key,
-                            session->local.mac->key_len,
-                            (const unsigned char *)"E");
+        kex_value_hash(hash_alg, digest_len, session, exchange_state,
+                       &key, session->local.mac->key_len,
+                       (const unsigned char *)"E");
         if(!key)
             return ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
                             "Unable to derive client-to-server MAC key");
@@ -383,10 +378,9 @@ static int finish_kex(LIBSSH2_SESSION *session,
         unsigned char *key = NULL;
         int free_key = 0;
 
-        sha_algo_value_hash(hash_alg, digest_len, session,
-                            exchange_state, &key,
-                            session->remote.mac->key_len,
-                            (const unsigned char *)"F");
+        kex_value_hash(hash_alg, digest_len, session, exchange_state,
+                       &key, session->remote.mac->key_len,
+                       (const unsigned char *)"F");
         if(!key)
             return ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
                             "Unable to derive server-to-client MAC key");

--- a/src/kex.c
+++ b/src/kex.c
@@ -2327,7 +2327,7 @@ clean_exit:
 
 #if LIBSSH2_ED25519
 
-static void curve25519_exchange_state_cleanup(
+static void kex_curve25519_exchange_state_cleanup(
     LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     ssh2_bn_free(exchange_state->k);
@@ -2360,7 +2360,8 @@ static void kex_method_curve25519_cleanup(
     key_state->state = ssh2_NB_state_idle;
 
     if(key_state->exchange_state.state != ssh2_NB_state_idle)
-        curve25519_exchange_state_cleanup(session, &key_state->exchange_state);
+        kex_curve25519_exchange_state_cleanup(session,
+                                              &key_state->exchange_state);
 }
 
 /*
@@ -2494,7 +2495,7 @@ static int kex_curve25519_sha256(
     }
 
 clean_exit:
-    curve25519_exchange_state_cleanup(session, exchange_state);
+    kex_curve25519_exchange_state_cleanup(session, exchange_state);
 
     return ret;
 }
@@ -2642,7 +2643,8 @@ static void kex_method_mlkem768x25519_cleanup(
     key_state->state = ssh2_NB_state_idle;
 
     if(key_state->exchange_state.state != ssh2_NB_state_idle)
-        curve25519_exchange_state_cleanup(session, &key_state->exchange_state);
+        kex_curve25519_exchange_state_cleanup(session,
+                                              &key_state->exchange_state);
 }
 
 static int mlkem768x25519_sha256(

--- a/src/kex.c
+++ b/src/kex.c
@@ -1615,7 +1615,7 @@ static int kex_session_ecdh_curve_type(const char *name,
     return 0;
 }
 
-static void ecdh_exchange_state_cleanup(
+static void kex_ecdh_exchange_state_cleanup(
     LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     ssh2_bn_free(exchange_state->k);
@@ -1644,7 +1644,7 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
     key_state->state = ssh2_NB_state_idle;
 
     if(key_state->exchange_state.state != ssh2_NB_state_idle)
-        ecdh_exchange_state_cleanup(session, &key_state->exchange_state);
+        kex_ecdh_exchange_state_cleanup(session, &key_state->exchange_state);
 }
 
 /*
@@ -1810,7 +1810,7 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
     }
 
 clean_exit:
-    ecdh_exchange_state_cleanup(session, exchange_state);
+    kex_ecdh_exchange_state_cleanup(session, exchange_state);
 
     return ret;
 }
@@ -1961,7 +1961,7 @@ static void kex_method_mlkem_nistp_cleanup(
     key_state->state = ssh2_NB_state_idle;
 
     if(key_state->exchange_state.state != ssh2_NB_state_idle)
-        ecdh_exchange_state_cleanup(session, &key_state->exchange_state);
+        kex_ecdh_exchange_state_cleanup(session, &key_state->exchange_state);
 }
 
 static int mlkem_nistp(LIBSSH2_SESSION *session,

--- a/src/kex.c
+++ b/src/kex.c
@@ -2647,7 +2647,7 @@ static void kex_method_mlkem768x25519_cleanup(
                                               &key_state->exchange_state);
 }
 
-static int mlkem768x25519_sha256(
+static int kex_mlkem768x25519_sha256(
     LIBSSH2_SESSION *session,
     unsigned char *data, size_t data_len,
     unsigned char public_t_key[SSH2_ED25519_KEY_LEN],
@@ -2885,13 +2885,13 @@ static int kex_method_mlkem768x25519_key_exchange(
 
     if(key_state->state == ssh2_NB_state_sent2) {
 
-        ret = mlkem768x25519_sha256(session, key_state->data,
-                                    key_state->data_len,
-                                    key_state->curve25519_public_key,
-                                    key_state->curve25519_private_key,
-                                    key_state->mlkem_public_key,
-                                    key_state->mlkem_private_key,
-                                    &key_state->exchange_state);
+        ret = kex_mlkem768x25519_sha256(session, key_state->data,
+                                        key_state->data_len,
+                                        key_state->curve25519_public_key,
+                                        key_state->curve25519_private_key,
+                                        key_state->mlkem_public_key,
+                                        key_state->mlkem_private_key,
+                                        &key_state->exchange_state);
 
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;

--- a/src/kex.c
+++ b/src/kex.c
@@ -1918,7 +1918,7 @@ ecdh_clean_exit:
 
 #if LIBSSH2_MLKEM
 
-static void mlkem_nistp_exchange_state_cleanup(
+static void kex_mlkem_nistp_exchange_state_cleanup(
     LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     ssh2_bn_free(exchange_state->k);
@@ -2191,7 +2191,7 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
     }
 
 clean_exit:
-    mlkem_nistp_exchange_state_cleanup(session, exchange_state);
+    kex_mlkem_nistp_exchange_state_cleanup(session, exchange_state);
 
     if(shared_secret)
         SSH2_FREE(session, shared_secret);

--- a/src/kex.c
+++ b/src/kex.c
@@ -423,7 +423,7 @@ static int kex_finish(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static void diffie_hellman_state_cleanup(
+static void kex_diffie_hellman_state_cleanup(
     LIBSSH2_SESSION *session, struct kmdhgGPshakex_state *exchange_state)
 {
     ssh2_dh_dtor(&exchange_state->x);
@@ -461,7 +461,7 @@ static void kex_diffie_hellman_cleanup(
     }
 
     if(key_state->exchange_state.state != ssh2_NB_state_idle)
-        diffie_hellman_state_cleanup(session, &key_state->exchange_state);
+        kex_diffie_hellman_state_cleanup(session, &key_state->exchange_state);
 }
 
 /*
@@ -791,7 +791,7 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
     }
 
 clean_exit:
-    diffie_hellman_state_cleanup(session, exchange_state);
+    kex_diffie_hellman_state_cleanup(session, exchange_state);
 
     return ret;
 }

--- a/src/kex.c
+++ b/src/kex.c
@@ -1964,14 +1964,14 @@ static void kex_method_mlkem_nistp_cleanup(
         kex_ecdh_exchange_state_cleanup(session, &key_state->exchange_state);
 }
 
-static int mlkem_nistp(LIBSSH2_SESSION *session,
-                       unsigned char *data, size_t data_len,
-                       unsigned char *public_t_key,
-                       size_t public_t_key_len,
-                       ssh2_ec_key *private_t_key,
-                       unsigned char *public_pq_key,
-                       unsigned char *private_pq_key,
-                       struct kmdhgGPshakex_state *exchange_state)
+static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
+                           unsigned char *data, size_t data_len,
+                           unsigned char *public_t_key,
+                           size_t public_t_key_len,
+                           ssh2_ec_key *private_t_key,
+                           unsigned char *public_pq_key,
+                           unsigned char *private_pq_key,
+                           struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc, mlkem_size;
@@ -2304,13 +2304,13 @@ static int kex_method_mlkem_nistp_key_exchange(
     }
 
     if(key_state->state == ssh2_NB_state_sent2) {
-        ret = mlkem_nistp(session, key_state->data, key_state->data_len,
-                          (unsigned char *)key_state->public_key_oct,
-                          key_state->public_key_oct_len,
-                          key_state->private_key,
-                          key_state->mlkem_public_key,
-                          key_state->mlkem_private_key,
-                          &key_state->exchange_state);
+        ret = kex_mlkem_nistp(session, key_state->data, key_state->data_len,
+                              (unsigned char *)key_state->public_key_oct,
+                              key_state->public_key_oct_len,
+                              key_state->private_key,
+                              key_state->mlkem_public_key,
+                              key_state->mlkem_private_key,
+                              &key_state->exchange_state);
 
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;

--- a/src/kex.c
+++ b/src/kex.c
@@ -95,7 +95,7 @@ static void sha_algo_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
     }
 }
 
-static int process_host_key(LIBSSH2_SESSION *session, struct string_buf *buf,
+static int kex_proc_hostkey(LIBSSH2_SESSION *session, struct string_buf *buf,
                             const struct kmdhgGPshakex_state *exchange_state,
                             unsigned char *data, size_t data_len)
 {
@@ -618,7 +618,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        ret = process_host_key(session, &buf, exchange_state, NULL, 0);
+        ret = kex_proc_hostkey(session, &buf, exchange_state, NULL, 0);
         if(ret)
             goto clean_exit;
 
@@ -1687,7 +1687,7 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
             goto clean_exit;
         }
 
-        ret = process_host_key(session, &buf, exchange_state, data, data_len);
+        ret = kex_proc_hostkey(session, &buf, exchange_state, data, data_len);
         if(ret)
             goto clean_exit;
 
@@ -2033,7 +2033,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        ret = process_host_key(session, &buf, exchange_state, data, data_len);
+        ret = kex_proc_hostkey(session, &buf, exchange_state, data, data_len);
         if(ret)
             goto clean_exit;
 
@@ -2401,7 +2401,7 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
             goto clean_exit;
         }
 
-        ret = process_host_key(session, &buf, exchange_state, data, data_len);
+        ret = kex_proc_hostkey(session, &buf, exchange_state, data, data_len);
         if(ret)
             goto clean_exit;
 
@@ -2679,7 +2679,7 @@ static int mlkem768x25519_sha256(
         struct string_buf buf;
         ssh2_hash_ctx k_ctx;
 
-        ret = process_host_key(session, &buf, exchange_state, data, data_len);
+        ret = kex_proc_hostkey(session, &buf, exchange_state, data, data_len);
         if(ret)
             goto clean_exit;
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -2366,11 +2366,12 @@ static void kex_method_curve25519_cleanup(
 /*
  * Elliptic Curve Key Exchange
  */
-static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
-                             size_t data_len,
-                             unsigned char public_key[SSH2_ED25519_KEY_LEN],
-                             unsigned char private_key[SSH2_ED25519_KEY_LEN],
-                             struct kmdhgGPshakex_state *exchange_state)
+static int kex_curve25519_sha256(
+    LIBSSH2_SESSION *session,
+    unsigned char *data, size_t data_len,
+    unsigned char public_key[SSH2_ED25519_KEY_LEN],
+    unsigned char private_key[SSH2_ED25519_KEY_LEN],
+    struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc;
@@ -2575,10 +2576,11 @@ static int kex_method_curve25519_key_exchange(
 
     if(key_state->state == ssh2_NB_state_sent2) {
 
-        ret = curve25519_sha256(session, key_state->data, key_state->data_len,
-                                key_state->curve25519_public_key,
-                                key_state->curve25519_private_key,
-                                &key_state->exchange_state);
+        ret = kex_curve25519_sha256(session,
+                                    key_state->data, key_state->data_len,
+                                    key_state->curve25519_public_key,
+                                    key_state->curve25519_private_key,
+                                    &key_state->exchange_state);
 
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;

--- a/src/kex.c
+++ b/src/kex.c
@@ -221,7 +221,7 @@ static int kex_proc_hostkey(LIBSSH2_SESSION *session, struct string_buf *buf,
     return 0;
 }
 
-static int finish_kex(LIBSSH2_SESSION *session,
+static int kex_finish(LIBSSH2_SESSION *session,
                       struct kmdhgGPshakex_state *exchange_state,
                       ssh2_hash_alg hash_alg, size_t digest_len)
 {
@@ -785,7 +785,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
     }
 
     if(exchange_state->state == ssh2_NB_state_sent3) {
-        ret = finish_kex(session, exchange_state, hash_alg, digest_len);
+        ret = kex_finish(session, exchange_state, hash_alg, digest_len);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
     }
@@ -1804,7 +1804,7 @@ static int ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
                            "Unrecognized SHA digest for EC curve");
             goto clean_exit;
         }
-        ret = finish_kex(session, exchange_state, hash_alg, digest_len);
+        ret = kex_finish(session, exchange_state, hash_alg, digest_len);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
     }
@@ -2185,7 +2185,7 @@ static int mlkem_nistp(LIBSSH2_SESSION *session,
     }
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
-        ret = finish_kex(session, exchange_state, hash_alg, digest_len);
+        ret = kex_finish(session, exchange_state, hash_alg, digest_len);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
     }
@@ -2486,7 +2486,7 @@ static int curve25519_sha256(LIBSSH2_SESSION *session, unsigned char *data,
     }
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
-        ret = finish_kex(session, exchange_state,
+        ret = kex_finish(session, exchange_state,
                          SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
@@ -2787,7 +2787,7 @@ static int mlkem768x25519_sha256(
     }
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
-        ret = finish_kex(session, exchange_state,
+        ret = kex_finish(session, exchange_state,
                          SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;

--- a/src/kex.c
+++ b/src/kex.c
@@ -469,18 +469,18 @@ static void kex_diffie_hellman_cleanup(
  * SHA Algorithm Agnostic
  * @result 0 on success, error code on failure
  */
-static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
-                                   ssh2_bn *g,
-                                   ssh2_bn *p,
-                                   int group_order,
-                                   ssh2_hash_alg hash_alg,
-                                   size_t digest_len,
-                                   ssh2_hash_ctx *exchange_hash_ctx,
-                                   unsigned char packet_type_init,
-                                   unsigned char packet_type_reply,
-                                   unsigned char *midhash,
-                                   size_t midhash_len,
-                                   struct kmdhgGPshakex_state *exchange_state)
+static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
+                                  ssh2_bn *g,
+                                  ssh2_bn *p,
+                                  int group_order,
+                                  ssh2_hash_alg hash_alg,
+                                  size_t digest_len,
+                                  ssh2_hash_ctx *exchange_hash_ctx,
+                                  unsigned char packet_type_init,
+                                  unsigned char packet_type_reply,
+                                  unsigned char *midhash,
+                                  size_t midhash_len,
+                                  struct kmdhgGPshakex_state *exchange_state)
 {
     int ret = 0;
     int rc;
@@ -848,11 +848,11 @@ static int kex_method_diffie_hellman_group1_sha1_key_exchange(
         key_state->state = ssh2_NB_state_created;
     }
 
-    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 128,
-                                  SSH2_SHA1_ALG, SSH2_SHA1_DIG_LEN,
-                                  &exchange_hash_ctx,
-                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
-                                  NULL, 0, &key_state->exchange_state);
+    ret = kex_diffie_hellman_sha(session, key_state->g, key_state->p, 128,
+                                 SSH2_SHA1_ALG, SSH2_SHA1_DIG_LEN,
+                                 &exchange_hash_ctx,
+                                 SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
+                                 NULL, 0, &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN)
         return ret;
 
@@ -966,7 +966,7 @@ static int kex_method_diffie_hellman_group14_sha1_key_exchange(
 {
     ssh2_hash_ctx ctx;
     return kex_method_diffie_hellman_group14_key_exchange(session, key_state,
-        SSH2_SHA1_ALG, SSH2_SHA1_DIG_LEN, &ctx, diffie_hellman_sha_algo);
+        SSH2_SHA1_ALG, SSH2_SHA1_DIG_LEN, &ctx, kex_diffie_hellman_sha);
 }
 
 /*
@@ -977,7 +977,7 @@ static int kex_method_diffie_hellman_group14_sha256_key_exchange(
 {
     ssh2_hash_ctx ctx;
     return kex_method_diffie_hellman_group14_key_exchange(session, key_state,
-        SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN, &ctx, diffie_hellman_sha_algo);
+        SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN, &ctx, kex_diffie_hellman_sha);
 }
 
 /*
@@ -1058,11 +1058,11 @@ static int kex_method_diffie_hellman_group16_sha512_key_exchange(
         key_state->state = ssh2_NB_state_created;
     }
 
-    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 512,
-                                  SSH2_SHA512_ALG, SSH2_SHA512_DIG_LEN,
-                                  &exchange_hash_ctx,
-                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
-                                  NULL, 0, &key_state->exchange_state);
+    ret = kex_diffie_hellman_sha(session, key_state->g, key_state->p, 512,
+                                 SSH2_SHA512_ALG, SSH2_SHA512_DIG_LEN,
+                                 &exchange_hash_ctx,
+                                 SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
+                                 NULL, 0, &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN)
         return ret;
 
@@ -1194,11 +1194,11 @@ static int kex_method_diffie_hellman_group18_sha512_key_exchange(
         key_state->state = ssh2_NB_state_created;
     }
 
-    ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p, 1024,
-                                  SSH2_SHA512_ALG, SSH2_SHA512_DIG_LEN,
-                                  &exchange_hash_ctx,
-                                  SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
-                                  NULL, 0, &key_state->exchange_state);
+    ret = kex_diffie_hellman_sha(session, key_state->g, key_state->p, 1024,
+                                 SSH2_SHA512_ALG, SSH2_SHA512_DIG_LEN,
+                                 &exchange_hash_ctx,
+                                 SSH_MSG_KEXDH_INIT, SSH_MSG_KEXDH_REPLY,
+                                 NULL, 0, &key_state->exchange_state);
     if(ret == LIBSSH2_ERROR_EAGAIN)
         return ret;
 
@@ -1310,15 +1310,15 @@ static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p,
-                                      (int)p_len,
-                                      SSH2_SHA1_ALG, SSH2_SHA1_DIG_LEN,
-                                      &exchange_hash_ctx,
-                                      SSH_MSG_KEX_DH_GEX_INIT,
-                                      SSH_MSG_KEX_DH_GEX_REPLY,
-                                      key_state->data + 1,
-                                      key_state->data_len - 1,
-                                      &key_state->exchange_state);
+        ret = kex_diffie_hellman_sha(session, key_state->g, key_state->p,
+                                     (int)p_len,
+                                     SSH2_SHA1_ALG, SSH2_SHA1_DIG_LEN,
+                                     &exchange_hash_ctx,
+                                     SSH_MSG_KEX_DH_GEX_INIT,
+                                     SSH_MSG_KEX_DH_GEX_REPLY,
+                                     key_state->data + 1,
+                                     key_state->data_len - 1,
+                                     &key_state->exchange_state);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
     }
@@ -1434,15 +1434,15 @@ static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        ret = diffie_hellman_sha_algo(session, key_state->g, key_state->p,
-                                      (int)p_len,
-                                      SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
-                                      &exchange_hash_ctx,
-                                      SSH_MSG_KEX_DH_GEX_INIT,
-                                      SSH_MSG_KEX_DH_GEX_REPLY,
-                                      key_state->data + 1,
-                                      key_state->data_len - 1,
-                                      &key_state->exchange_state);
+        ret = kex_diffie_hellman_sha(session, key_state->g, key_state->p,
+                                     (int)p_len,
+                                     SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
+                                     &exchange_hash_ctx,
+                                     SSH_MSG_KEX_DH_GEX_INIT,
+                                     SSH_MSG_KEX_DH_GEX_REPLY,
+                                     key_state->data + 1,
+                                     key_state->data_len - 1,
+                                     &key_state->exchange_state);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;
     }

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -937,7 +937,7 @@ struct _LIBSSH2_SESSION {
     struct packet_x11_open_state packAdd_x11open_state;
     struct packet_authagent_state packAdd_authagent_state;
 
-    /* State variables used in fullpacket() */
+    /* State variables used in transport_fullpacket() */
     ssh2_NB_states fullpacket_state;
     int fullpacket_macstate;
     size_t fullpacket_payload_len;

--- a/src/misc.c
+++ b/src/misc.c
@@ -333,7 +333,7 @@ int ssh2_store_bignum_bytes(unsigned char **buf,
 
 /* Base64 Conversion */
 
-static const short base64_reverse_table[256] = {
+static const short ssh2_base64_reverse_table[256] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,
@@ -392,7 +392,7 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
                         "Unable to allocate memory for base64 decoding");
 
     for(s = src; s < (src + src_len); s++) {
-        v = base64_reverse_table[(unsigned char)*s];
+        v = ssh2_base64_reverse_table[(unsigned char)*s];
         if(v < 0)
             continue;
         switch(i % 4) {

--- a/src/pem.c
+++ b/src/pem.c
@@ -40,7 +40,7 @@
 
 #include "libssh2_priv.h"
 
-static int readline(char *line, int line_size, FILE *fp)
+static int pem_readline_file(char *line, int line_size, FILE *fp)
 {
     size_t len;
 
@@ -726,11 +726,11 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
     do {
         *line = '\0';
 
-        if(readline(line, LINE_SIZE, fp))
+        if(pem_readline_file(line, LINE_SIZE, fp))
             return -1;
     } while(strcmp(line, OPENSSH_PRIVKEY_HEADER));
 
-    if(readline(line, LINE_SIZE, fp))
+    if(pem_readline_file(line, LINE_SIZE, fp))
         return -1;
 
     do {
@@ -753,7 +753,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
 
         *line = '\0';
 
-        if(readline(line, LINE_SIZE, fp)) {
+        if(pem_readline_file(line, LINE_SIZE, fp)) {
             ret = -1;
             goto out;
         }

--- a/src/pem.c
+++ b/src/pem.c
@@ -97,7 +97,7 @@ static int pem_readline_blob(char *line, size_t line_size,
 
 static const char *crypt_annotation = "Proc-Type: 4,ENCRYPTED";
 
-static unsigned char hex_decode(char digit)
+static unsigned char pem_hex_decode(char digit)
 {
     return (unsigned char)
         ((digit >= 'A') ? (0xA + (digit - 'A')) : (digit - '0'));
@@ -220,8 +220,8 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
 
         /* Decode IV from hex */
         for(i = 0; i < method->iv_len; ++i) {
-            iv[i] = (unsigned char)(hex_decode(iv[2 * i]) << 4);
-            iv[i] |= hex_decode(iv[2 * i + 1]);
+            iv[i] = (unsigned char)(pem_hex_decode(iv[2 * i]) << 4);
+            iv[i] |= pem_hex_decode(iv[2 * i + 1]);
         }
 
         /* skip to the next line */

--- a/src/pem.c
+++ b/src/pem.c
@@ -64,7 +64,7 @@ static int pem_readline_file(char *line, int line_size, FILE *fp)
     return 0;
 }
 
-static int readline_memory(char *line, size_t line_size,
+static int pem_readline_blob(char *line, size_t line_size,
                            const char *filedata, size_t filedata_len,
                            size_t *filedata_offset)
 {
@@ -181,11 +181,11 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
     do {
         *line = '\0';
 
-        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off))
+        if(pem_readline_blob(line, LINE_SIZE, filedata, filedata_len, &off))
             return -1;
     } while(strcmp(line, headerbegin));
 
-    if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off))
+    if(pem_readline_blob(line, LINE_SIZE, filedata, filedata_len, &off))
         return -1;
 
     if(passphrase &&
@@ -193,7 +193,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         const struct crypt_method **all_methods, *cur_method;
         int i;
 
-        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
+        if(pem_readline_blob(line, LINE_SIZE, filedata, filedata_len, &off)) {
             ret = -1;
             goto out;
         }
@@ -225,7 +225,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         }
 
         /* skip to the next line */
-        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
+        if(pem_readline_blob(line, LINE_SIZE, filedata, filedata_len, &off)) {
             ret = -1;
             goto out;
         }
@@ -251,7 +251,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
 
         *line = '\0';
 
-        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
+        if(pem_readline_blob(line, LINE_SIZE, filedata, filedata_len, &off)) {
             ret = -1;
             goto out;
         }
@@ -799,7 +799,7 @@ int ssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                             "Error parsing PEM: OpenSSH header not found");
 
-        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off))
+        if(pem_readline_blob(line, LINE_SIZE, filedata, filedata_len, &off))
             return -1;
     } while(strcmp(line, OPENSSH_PRIVKEY_HEADER));
 
@@ -830,7 +830,7 @@ int ssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(readline_memory(line, LINE_SIZE, filedata, filedata_len, &off)) {
+        if(pem_readline_blob(line, LINE_SIZE, filedata, filedata_len, &off)) {
             ret = -1;
             goto out;
         }

--- a/src/session.c
+++ b/src/session.c
@@ -300,7 +300,7 @@ static int session_nonblock(libssh2_socket_t sockfd,   /* operate on this */
 /*
  * gets the given blocking or non-blocking state of the socket.
  */
-static int get_socket_nonblocking(libssh2_socket_t sockfd)
+static int session_get_socket_nonblocking(libssh2_socket_t sockfd)
 {                                 /* operate on this */
 #ifdef HAVE_O_NONBLOCK  /* most recent unix versions */
     int flags = fcntl(sockfd, F_GETFL, 0);
@@ -682,7 +682,7 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
         session->socket_fd = sock;
 
         session->socket_prev_blockstate =
-            !get_socket_nonblocking(session->socket_fd);
+            !session_get_socket_nonblocking(session->socket_fd);
 
         if(session->socket_prev_blockstate) {
             /* If in blocking state change to non-blocking */

--- a/src/transport.c
+++ b/src/transport.c
@@ -171,10 +171,11 @@ static int transport_decrypt(LIBSSH2_SESSION *session, unsigned char *source,
 }
 
 /*
- * fullpacket() gets called when a full packet has been received and properly
- * collected.
+ * transport_fullpacket() gets called when a full packet has been received and
+ * properly collected.
  */
-static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
+static int transport_fullpacket(LIBSSH2_SESSION *session,
+                                int encrypted /* 1 or 0 */)
 {
     unsigned char macbuf[MAX_MACSIZE];
     struct transportpacket *p = &session->packet;
@@ -856,12 +857,12 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
         if(!remainpack) {
             /* we have a full packet */
 ssh2_transport_read_point1:
-            rc = fullpacket(session, encrypted);
+            rc = transport_fullpacket(session, encrypted);
             if(rc == LIBSSH2_ERROR_EAGAIN) {
 
                 if(session->packAdd_state != ssh2_NB_state_idle) {
-                    /* fullpacket only returns LIBSSH2_ERROR_EAGAIN if
-                     * ssh2_packet_add() returns LIBSSH2_ERROR_EAGAIN. If
+                    /* transport_fullpacket() only returns LIBSSH2_ERROR_EAGAIN
+                     * if ssh2_packet_add() returns LIBSSH2_ERROR_EAGAIN. If
                      * that returns LIBSSH2_ERROR_EAGAIN but the packAdd_state
                      * is idle, then the packet has been added to the brigade,
                      * but some immediate action that was taken based on the

--- a/src/transport.c
+++ b/src/transport.c
@@ -52,8 +52,8 @@
 
 #ifdef LIBSSH2DEBUG
 #define UNPRINTABLE_CHAR '.'
-static void debugdump(LIBSSH2_SESSION *session,
-                      const char *desc, const unsigned char *ptr, size_t size)
+static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
+                                const unsigned char *ptr, size_t size)
 {
     size_t i;
     size_t c;
@@ -113,7 +113,7 @@ static void debugdump(LIBSSH2_SESSION *session,
     }
 }
 #else
-#define debugdump(a, x, y, z) do {} while(0)
+#define transport_debugdump(a, x, y, z) do {} while(0)
 #endif
 
 /* transport_decrypt() decrypts 'len' bytes from 'source' to 'dest' in units of
@@ -316,8 +316,8 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
 
         session->fullpacket_packet_type = p->payload[0];
 
-        debugdump(session, "ssh2_transport_read() plain",
-                  p->payload, session->fullpacket_payload_len);
+        transport_debugdump(session, "ssh2_transport_read() plain",
+                            p->payload, session->fullpacket_payload_len);
 
         session->fullpacket_state = ssh2_NB_state_created;
     }
@@ -500,8 +500,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                       (long)(PACKETBUFSIZE - remainbuf), (void *)p->buf,
                       (long)remainbuf));
 
-            debugdump(session, "ssh2_transport_read() raw",
-                      &p->buf[remainbuf], nread);
+            transport_debugdump(session, "ssh2_transport_read() raw",
+                                &p->buf[remainbuf], nread);
             /* advance write pointer */
             p->writeidx += nread;
 
@@ -923,8 +923,8 @@ static int send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
         ssh2_deb((session, LIBSSH2_TRACE_SOCKET,
                   "Sent %ld/%ld bytes at %p+%lu", (long)rc, (long)length,
                   (void *)p->outbuf, (unsigned long)p->osent));
-        debugdump(session, "ssh2_transport_send()",
-                  &p->outbuf[p->osent], rc);
+        transport_debugdump(session, "ssh2_transport_send()",
+                            &p->outbuf[p->osent], rc);
     }
 
     if(rc == length) {
@@ -993,9 +993,11 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
     size_t orgdata_len = data_len;
     size_t crypt_offset, etm_crypt_offset;
 
-    debugdump(session, "ssh2_transport_send() plain", data, data_len);
+    transport_debugdump(session, "ssh2_transport_send() plain",
+                        data, data_len);
     if(data2)
-        debugdump(session, "ssh2_transport_send() plain2", data2, data2_len);
+        transport_debugdump(session, "ssh2_transport_send() plain2",
+                            data2, data2_len);
 
     /* Finish flushing any partially-sent packet BEFORE redirecting into a key
      * re-exchange. A packet already in transmission can only be completed by
@@ -1263,7 +1265,7 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
         ssh2_deb((session, LIBSSH2_TRACE_SOCKET,
                   "Sent %ld/%ld bytes at %p",
                   (long)ret, (long)total_length, (void *)p->outbuf));
-        debugdump(session, "ssh2_transport_send()", p->outbuf, ret);
+        transport_debugdump(session, "ssh2_transport_send()", p->outbuf, ret);
     }
 
     if(ret != total_length) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -886,8 +886,9 @@ ssh2_transport_read_point1:
     return LIBSSH2_ERROR_SOCKET_RECV; /* we never reach this point */
 }
 
-static int send_existing(LIBSSH2_SESSION *session, const unsigned char *data,
-                         size_t data_len, ssize_t *ret)
+static int transport_send_existing(LIBSSH2_SESSION *session,
+                                   const unsigned char *data,
+                                   size_t data_len, ssize_t *ret)
 {
     ssize_t rc;
     ssize_t length;
@@ -1002,23 +1003,24 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
 
     /* Finish flushing any partially-sent packet BEFORE redirecting into a key
      * re-exchange. A packet already in transmission can only be completed by
-     * a transport_send call with that same packet (send_existing rejects
-     * a different data pointer with EAGAIN). If rekey runs first, a packet
-     * caught mid-send when rekey starts can never be flushed and the session
-     * deadlocks. RFC 4253 7.1 requires completing the in-flight packet; only
-     * NEW packets are withheld, which the rekey redirect (reached only once
-     * nothing is pending) still does.
+     * a transport_send call with that same packet (transport_send_existing()
+     * rejects a different data pointer with EAGAIN). If rekey runs first,
+     * a packet caught mid-send when rekey starts can never be flushed and
+     * the session deadlocks. RFC 4253 7.1 requires completing the in-flight
+     * packet; only NEW packets are withheld, which the rekey redirect (reached
+     * only once nothing is pending) still does.
      *
-     * send_existing only sanity-checks data and data_len, not data2/data2_len.
+     * transport_send_existing() only sanity-checks data and data_len, not
+     * data2/data2_len.
      */
-    rc = send_existing(session, data, data_len, &ret);
+    rc = transport_send_existing(session, data, data_len, &ret);
     if(rc)
         return rc;
 
     session->socket_block_directions &= ~LIBSSH2_SESSION_BLOCK_OUTBOUND;
 
     if(ret)
-        /* set by send_existing if data was sent */
+        /* set by transport_send_existing() if data was sent */
         return rc;
 
     /*

--- a/src/transport.c
+++ b/src/transport.c
@@ -116,13 +116,13 @@ static void debugdump(LIBSSH2_SESSION *session,
 #define debugdump(a, x, y, z) do {} while(0)
 #endif
 
-/* decrypt() decrypts 'len' bytes from 'source' to 'dest' in units of
+/* transport_decrypt() decrypts 'len' bytes from 'source' to 'dest' in units of
  * blocksize.
  *
  * returns 0 on success and negative on failure
  */
-static int decrypt(LIBSSH2_SESSION *session, unsigned char *source,
-                   unsigned char *dest, ssize_t len, int firstlast)
+static int transport_decrypt(LIBSSH2_SESSION *session, unsigned char *source,
+                             unsigned char *dest, ssize_t len, int firstlast)
 {
     struct transportpacket *p = &session->packet;
     int blocksize = session->remote.crypt->blocksize;
@@ -235,8 +235,8 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
 
                 first_block[0] = 0;
 
-                rc = decrypt(session, p->payload + 4,
-                             first_block, blocksize, FIRST_BLOCK);
+                rc = transport_decrypt(session, p->payload + 4,
+                                       first_block, blocksize, FIRST_BLOCK);
                 if(rc)
                     return rc;
 
@@ -260,9 +260,11 @@ static int fullpacket(LIBSSH2_SESSION *session, int encrypted /* 1 or 0 */)
 
                 /* decrypt all other blocks packet */
                 if(blocksize < decrypt_size) {
-                    rc = decrypt(session, p->payload + blocksize + 4,
-                                 decrypt_buffer + blocksize - 1,
-                                 decrypt_size - blocksize, LAST_BLOCK);
+                    rc = transport_decrypt(session,
+                                           p->payload + blocksize + 4,
+                                           decrypt_buffer + blocksize - 1,
+                                           decrypt_size - blocksize,
+                                           LAST_BLOCK);
                     if(rc) {
                         SSH2_FREE(session, decrypt_buffer);
                         return rc;
@@ -566,8 +568,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
             else {
                 if(encrypted) {
                     /* first decrypted block */
-                    rc = decrypt(session, &p->buf[p->readidx],
-                                 block, blocksize, FIRST_BLOCK);
+                    rc = transport_decrypt(session, &p->buf[p->readidx],
+                                           block, blocksize, FIRST_BLOCK);
                     if(rc != LIBSSH2_ERROR_NONE)
                         return rc;
                     /* Save the first 5 bytes of the decrypted package, to be
@@ -807,8 +809,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                     return LIBSSH2_ERROR_DECRYPT;
             }
             else {
-                rc = decrypt(session, &p->buf[p->readidx], p->wptr, numdecrypt,
-                             firstlast);
+                rc = transport_decrypt(session, &p->buf[p->readidx], p->wptr,
+                                       numdecrypt, firstlast);
 
                 if(rc != LIBSSH2_ERROR_NONE) {
                     p->total_num = 0; /* no packet buffer available */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -544,13 +544,11 @@ int libssh2_userauth_password_ex(
     return rc;
 }
 
-static int userauth_read_blob_pubkey(LIBSSH2_SESSION *session,
-                                     unsigned char **method,
-                                     size_t *method_len,
-                                     unsigned char **pubkeydata,
-                                     size_t *pubkeydata_len,
-                                     const char *pubkeyfiledata,
-                                     size_t pubkeyfiledata_len)
+static int userauth_read_blob_pubkey(
+    LIBSSH2_SESSION *session,
+    unsigned char **method, size_t *method_len,
+    unsigned char **pubkeydata, size_t *pubkeydata_len,
+    const char *pubkeyfiledata, size_t pubkeyfiledata_len)
 {
     unsigned char *pubkey = NULL, *sp1, *sp2, *tmp;
     size_t pubkey_len = pubkeyfiledata_len;
@@ -712,14 +710,12 @@ static int file_read_publickey(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static int memory_read_privatekey(LIBSSH2_SESSION *session,
-                                  const struct hostkey_method **hostkey_method,
-                                  void **hostkey_abstract,
-                                  const unsigned char *method,
-                                  size_t method_len,
-                                  const char *privkeyfiledata,
-                                  size_t privkeyfiledata_len,
-                                  const char *passphrase)
+static int userauth_read_blob_privkey(
+    LIBSSH2_SESSION *session,
+    const struct hostkey_method **hostkey_method, void **hostkey_abstract,
+    const unsigned char *method, size_t method_len,
+    const char *privkeyfiledata, size_t privkeyfiledata_len,
+    const char *passphrase)
 {
     const struct hostkey_method **hostkey_methods_avail =
         ssh2_hostkey_methods();
@@ -813,12 +809,12 @@ static int userauth_sign_fromblob(LIBSSH2_SESSION *session,
     struct iovec datavec;
     int rc;
 
-    rc = memory_read_privatekey(session, &privkeyobj, &hostkey_abstract,
-                                session->userauth_pblc_method,
-                                session->userauth_pblc_method_len,
-                                pk_mem->data,
-                                pk_mem->data_len,
-                                pk_mem->passphrase);
+    rc = userauth_read_blob_privkey(session, &privkeyobj, &hostkey_abstract,
+                                    session->userauth_pblc_method,
+                                    session->userauth_pblc_method_len,
+                                    pk_mem->data,
+                                    pk_mem->data_len,
+                                    pk_mem->passphrase);
     if(rc)
         return rc;
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -619,12 +619,11 @@ static int userauth_read_blob_pubkey(
  * Returns an allocated string containing the key method (e.g. "ssh-dss")
  * in method on success.
  */
-static int file_read_publickey(LIBSSH2_SESSION *session,
-                               unsigned char **method,
-                               size_t *method_len,
-                               unsigned char **pubkeydata,
-                               size_t *pubkeydata_len,
-                               const char *pubkeyfile)
+static int userauth_read_file_pubkey(
+    LIBSSH2_SESSION *session,
+    unsigned char **method, size_t *method_len,
+    unsigned char **pubkeydata, size_t *pubkeydata_len,
+    const char *pubkeyfile)
 {
     FILE *fd;
     char c;
@@ -749,13 +748,12 @@ static int userauth_read_blob_privkey(
 /*
  * Read a PEM encoded private key from an id_??? style file
  */
-static int file_read_privatekey(LIBSSH2_SESSION *session,
-                                const struct hostkey_method **hostkey_method,
-                                void **hostkey_abstract,
-                                const unsigned char *method,
-                                size_t method_len,
-                                const char *privkeyfile,
-                                const char *passphrase)
+static int userauth_read_file_privkey(
+    LIBSSH2_SESSION *session,
+    const struct hostkey_method **hostkey_method, void **hostkey_abstract,
+    const unsigned char *method, size_t method_len,
+    const char *privkeyfile,
+    const char *passphrase)
 {
     const struct hostkey_method **hostkey_methods_avail =
         ssh2_hostkey_methods();
@@ -848,11 +846,11 @@ static int userauth_sign_fromfile(LIBSSH2_SESSION *session,
     struct iovec datavec;
     int rc;
 
-    rc = file_read_privatekey(session, &privkeyobj, &hostkey_abstract,
-                              session->userauth_pblc_method,
-                              session->userauth_pblc_method_len,
-                              privkey_file->filename,
-                              privkey_file->passphrase);
+    rc = userauth_read_file_privkey(session, &privkeyobj, &hostkey_abstract,
+                                    session->userauth_pblc_method,
+                                    session->userauth_pblc_method_len,
+                                    privkey_file->filename,
+                                    privkey_file->passphrase);
     if(rc)
         return rc;
 
@@ -1006,11 +1004,13 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                sizeof(session->userauth_host_packet_requirev_state));
 
         if(publickey) {
-            rc = file_read_publickey(session, &session->userauth_host_method,
-                                     &session->userauth_host_method_len,
-                                     &pubkeydata, &pubkeydata_len, publickey);
+            rc = userauth_read_file_pubkey(session,
+                                           &session->userauth_host_method,
+                                           &session->userauth_host_method_len,
+                                           &pubkeydata, &pubkeydata_len,
+                                           publickey);
             if(rc)
-                /* Note: file_read_publickey() calls ssh2_err() */
+                /* Note: userauth_read_file_pubkey() calls ssh2_err() */
                 return rc;
         }
         else {
@@ -1076,12 +1076,12 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         ssh2_store_str(&session->userauth_host_s, local_username,
                        local_username_len);
 
-        rc = file_read_privatekey(session, &privkeyobj, &abstract,
-                                  session->userauth_host_method,
-                                  session->userauth_host_method_len,
-                                  privatekey, passphrase);
+        rc = userauth_read_file_privkey(session, &privkeyobj, &abstract,
+                                        session->userauth_host_method,
+                                        session->userauth_host_method_len,
+                                        privatekey, passphrase);
         if(rc) {
-            /* Note: file_read_privatekey() calls ssh2_err() */
+            /* Note: userauth_read_file_privkey() calls ssh2_err() */
             SSH2_SAFEFREE(session, session->userauth_host_method);
             SSH2_SAFEFREE(session, session->userauth_host_packet);
             return rc;
@@ -1468,10 +1468,8 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
 
 int ssh2_userauth_publickey(
     LIBSSH2_SESSION *session,
-    const char *username,
-    size_t username_len,
-    const unsigned char *pubkeydata,
-    size_t pubkeydata_len,
+    const char *username, size_t username_len,
+    const unsigned char *pubkeydata, size_t pubkeydata_len,
     LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC(*sign_callback),
     void *abstract)
 {
@@ -1909,9 +1907,11 @@ static int userauth_publickey_fromfile(LIBSSH2_SESSION *session,
 
     if(session->userauth_pblc_state == ssh2_NB_state_idle) {
         if(publickey) {
-            rc = file_read_publickey(session, &session->userauth_pblc_method,
-                                     &session->userauth_pblc_method_len,
-                                     &pubkeydata, &pubkeydata_len, publickey);
+            rc = userauth_read_file_pubkey(session,
+                                           &session->userauth_pblc_method,
+                                           &session->userauth_pblc_method_len,
+                                           &pubkeydata, &pubkeydata_len,
+                                           publickey);
             if(rc)
                 return rc;
         }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -544,13 +544,13 @@ int libssh2_userauth_password_ex(
     return rc;
 }
 
-static int memory_read_publickey(LIBSSH2_SESSION *session,
-                                 unsigned char **method,
-                                 size_t *method_len,
-                                 unsigned char **pubkeydata,
-                                 size_t *pubkeydata_len,
-                                 const char *pubkeyfiledata,
-                                 size_t pubkeyfiledata_len)
+static int userauth_read_blob_pubkey(LIBSSH2_SESSION *session,
+                                     unsigned char **method,
+                                     size_t *method_len,
+                                     unsigned char **pubkeydata,
+                                     size_t *pubkeydata_len,
+                                     const char *pubkeyfiledata,
+                                     size_t pubkeyfiledata_len)
 {
     unsigned char *pubkey = NULL, *sp1, *sp2, *tmp;
     size_t pubkey_len = pubkeyfiledata_len;
@@ -1858,10 +1858,11 @@ static int userauth_publickey_frommemory(LIBSSH2_SESSION *session,
 
     if(session->userauth_pblc_state == ssh2_NB_state_idle) {
         if(publickeydata_len && publickeydata) {
-            rc = memory_read_publickey(session, &session->userauth_pblc_method,
-                                       &session->userauth_pblc_method_len,
-                                       &pubkeydata, &pubkeydata_len,
-                                       publickeydata, publickeydata_len);
+            rc = userauth_read_blob_pubkey(session,
+                                           &session->userauth_pblc_method,
+                                           &session->userauth_pblc_method_len,
+                                           &pubkeydata, &pubkeydata_len,
+                                           publickeydata, publickeydata_len);
             if(rc)
                 return rc;
         }
@@ -2349,12 +2350,12 @@ int libssh2_userauth_publickey_sk(
                        session->userauth_pblc_method_len);
             }
 
-            rc = memory_read_publickey(session,
-                                       &session->userauth_pblc_method,
-                                       &session->userauth_pblc_method_len,
-                                       &pubkeydata, &pubkeydata_len,
-                                       (const char *)publickeydata,
-                                       publickeydata_len);
+            rc = userauth_read_blob_pubkey(session,
+                                           &session->userauth_pblc_method,
+                                           &session->userauth_pblc_method_len,
+                                           &pubkeydata, &pubkeydata_len,
+                                           (const char *)publickeydata,
+                                           publickeydata_len);
         }
     }
     else {


### PR DESCRIPTION
```
base64_reverse_table -> ssh2_base64_reverse_table

curve25519_exchange_state_cleanup -> kex_curve25519_exchange_state_cleanup
curve25519_sha256 -> kex_curve25519_sha256
diffie_hellman_sha_algo -> kex_diffie_hellman_sha
diffie_hellman_state_cleanup -> kex_diffie_hellman_state_cleanup
ecdh_exchange_state_cleanup -> kex_ecdh_exchange_state_cleanup
ecdh_sha2_nistp -> kex_ecdh_sha2_nistp
finish_kex -> kex_finish
mlkem_nistp -> kex_mlkem_nistp
mlkem_nistp_exchange_state_cleanup -> kex_mlkem_nistp_exchange_state_cleanup
mlkem768x25519_exchange_state_cleanup -> kex_mlkem768x25519_exchange_state_cleanup
mlkem768x25519_sha256 -> kex_mlkem768x25519_sha256
process_host_key -> kex_proc_hostkey
sha_algo_value_hash -> kex_value_hash

hex_decode -> pem_hex_decode 
readline -> pem_readline_file
readline_memory -> pem_readline_blob

debugdump -> transport_debugdump
decrypt -> transport_decrypt
fullpacket -> transport_fullpacket
send_existing -> transport_send_existing

get_socket_nonblocking -> session_get_socket_nonblocking

file_read_privatekey -> userauth_read_file_privkey
file_read_publickey -> userauth_read_file_pubkey
memory_read_privatekey -> userauth_read_blob_privkey
memory_read_publickey -> userauth_read_blob_pubkey
```
