### PR TITLE
kex: NULL check `data` in `kex_mlkem768x25519_sha256()` to match siblings

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -2676,6 +2676,12 @@ static int kex_mlkem768x25519_sha256(
         struct string_buf buf;
         ssh2_hash_ctx k_ctx;
 
+        if(!data) {
+            ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
+                           "Missing host key data");
+            goto clean_exit;
+        }
+
         ret = kex_proc_hostkey(session, &buf, exchange_state, data, data_len);
         if(ret)
             goto clean_exit;


### PR DESCRIPTION
Suggested by GitHub Code Quality

Follow-up to 3ba252e2a6fe04d17ea13ad870698a4028c8ab4c #1644