### PR TITLE
sftp: fix wrong error code passed to `ssh2_err()`

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -2899,7 +2899,7 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
     uint32_t retcode;
 
     if(sftp->posix_rename_version != 1)
-        return ssh2_err(session, LIBSSH2_FX_OP_UNSUPPORTED,
+        return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "Server does not support posix-rename@openssh.com");
 
     /* 45 = packet_len(4) + packet_type(1) + request_id(4) +

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -2898,9 +2898,11 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
     ssize_t rc;
     uint32_t retcode;
 
-    if(sftp->posix_rename_version != 1)
+    if(sftp->posix_rename_version != 1) {
+        sftp->last_errno = LIBSSH2_FX_OP_UNSUPPORTED;
         return ssh2_err(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
                         "Server does not support posix-rename@openssh.com");
+    }
 
     /* 45 = packet_len(4) + packet_type(1) + request_id(4) +
        string_len(4) + strlen("posix-rename@openssh.com")(24) +


### PR DESCRIPTION
"`LIBSSH2_FX_OP_UNSUPPORTED` is an SFTP protocol status code (value 8),
not a libssh2 error code. Passing it as the second argument to
`ssh2_err()` (which expects a `LIBSSH2_ERROR_*` value) will cause
callers to receive an incorrect error code. This should be
`LIBSSH2_ERROR_SFTP_PROTOCOL` (or similar) to match the convention used
throughout this file."

Reported by GitHub Code Quality

Follow-up to fb6527468c26d18c800580f765ae8c8ea8edb88b #1386
