### PR TITLE
sftp: fix to return accurate libssh2 error code

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -335,7 +335,7 @@ static int sftp_packet_read(LIBSSH2_SFTP *sftp)
             }
 
             if(sftp->partial_len < 5)
-                return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
+                return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                 "Invalid SFTP packet size");
 
             ssh2_deb((session, LIBSSH2_TRACE_SFTP,


### PR DESCRIPTION
"The error code `LIBSSH2_ERROR_ALLOC` is used here to signal an invalid
packet size, which is misleading. No allocation failure has occurred;
this is a protocol/boundary error. A more appropriate error code would
be `LIBSSH2_ERROR_OUT_OF_BOUNDARY` or `LIBSSH2_ERROR_SFTP_PROTOCOL` to
accurately reflect the nature of the failure."

Reported by GitHub Code Quality

Follow-up to fc7e79e44274d259ba6fad511ea1b4213b8b6b35 #791
Follow-up to bac8d7d41109f2f96c664370e86a73ed00fbe428
