### PR TITLE
kex: fix `shared_secret` memleak on `EAGAIN`

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -2186,12 +2186,13 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
     if(exchange_state->state == ssh2_NB_state_sent2) {
         ret = kex_finish(session, exchange_state, hash_alg, digest_len);
         if(ret == LIBSSH2_ERROR_EAGAIN)
-            return ret;
+            goto clean_free;
     }
 
 clean_exit:
     kex_mlkem_nistp_exchange_state_cleanup(session, exchange_state);
 
+clean_free:
     if(shared_secret)
         SSH2_FREE(session, shared_secret);
 


### PR DESCRIPTION
"`shared_secret` is a local variable allocated at line 2113 within the
`ssh2_NB_state_created` block. When `ssh2_transport_send` returns
`LIBSSH2_ERROR_EAGAIN` here, the function returns immediately without
freeing `shared_secret`. On re-entry the variable is re-initialized to
`NULL` at line 2016, so the previous allocation is permanently leaked.
The `shared_secret` should be freed before returning EAGAIN, or its
lifetime should be extended beyond the local scope (e.g., stored in
`exchange_state`) so it can be cleaned up on re-entry or at
`clean_exit`."

Reported by GitHub Code Quality

Follow-up to 3ba252e2a6fe04d17ea13ad870698a4028c8ab4c #1644
