### PR TITLE
userauth: fix crash on OOM in `libssh2_userauth_publickey_sk()`

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2319,6 +2319,10 @@ int libssh2_userauth_publickey_sk(
                 session->userauth_pblc_method_len = strlen(ecdsa);
                 session->userauth_pblc_method =
                     SSH2_ALLOC(session, session->userauth_pblc_method_len);
+                if(!session->userauth_pblc_method)
+                    return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
+                                    "Unable to allocate memory "
+                                    "for public key method ECDSA");
 
                 memcpy(session->userauth_pblc_method, ecdsa,
                        session->userauth_pblc_method_len);
@@ -2328,6 +2332,10 @@ int libssh2_userauth_publickey_sk(
                 session->userauth_pblc_method_len = strlen(ed25519);
                 session->userauth_pblc_method =
                     SSH2_ALLOC(session, session->userauth_pblc_method_len);
+                if(!session->userauth_pblc_method)
+                    return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
+                                    "Unable to allocate memory "
+                                    "for public key method ED25519");
 
                 memcpy(session->userauth_pblc_method, ed25519,
                        session->userauth_pblc_method_len);

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2317,7 +2317,7 @@ int libssh2_userauth_publickey_sk(
 
             if(!strncmp((const char *)publickeydata, ecdsa, strlen(ecdsa))) {
                 if(session->userauth_pblc_method)
-                    SSH2_FREE(session->userauth_pblc_method);
+                    SSH2_FREE(session, session->userauth_pblc_method);
                 session->userauth_pblc_method_len = strlen(ecdsa);
                 session->userauth_pblc_method =
                     SSH2_ALLOC(session, session->userauth_pblc_method_len);
@@ -2332,7 +2332,7 @@ int libssh2_userauth_publickey_sk(
             else if(!strncmp((const char *)publickeydata, ed25519,
                              strlen(ed25519))) {
                 if(session->userauth_pblc_method)
-                    SSH2_FREE(session->userauth_pblc_method);
+                    SSH2_FREE(session, session->userauth_pblc_method);
                 session->userauth_pblc_method_len = strlen(ed25519);
                 session->userauth_pblc_method =
                     SSH2_ALLOC(session, session->userauth_pblc_method_len);

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2316,6 +2316,8 @@ int libssh2_userauth_publickey_sk(
                 SSH2_FREE(session, tmp_method);
 
             if(!strncmp((const char *)publickeydata, ecdsa, strlen(ecdsa))) {
+                if(session->userauth_pblc_method)
+                    SSH2_FREE(session->userauth_pblc_method);
                 session->userauth_pblc_method_len = strlen(ecdsa);
                 session->userauth_pblc_method =
                     SSH2_ALLOC(session, session->userauth_pblc_method_len);
@@ -2329,6 +2331,8 @@ int libssh2_userauth_publickey_sk(
             }
             else if(!strncmp((const char *)publickeydata, ed25519,
                              strlen(ed25519))) {
+                if(session->userauth_pblc_method)
+                    SSH2_FREE(session->userauth_pblc_method);
                 session->userauth_pblc_method_len = strlen(ed25519);
                 session->userauth_pblc_method =
                     SSH2_ALLOC(session, session->userauth_pblc_method_len);


### PR DESCRIPTION
Also free the buffers if set before allocating.

Reported by GitHub Code Quality and Copilot

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
