### PR TITLE
src: fix hash context leak on hash update fail

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -902,8 +902,10 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
         return -1;
 
     for(i = 0; i < veccount; i++)
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
             return -1;
+        }
 
     if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -226,8 +226,10 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     if(!ssh2_hash_init(&ctx, SSH2_SHA1_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(ctx, NULL, 0);
             return -1;
+        }
     }
     if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;
@@ -292,8 +294,10 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
     if(!ssh2_hash_init(&ctx, SSH2_SHA256_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(ctx, NULL, 0);
             return -1;
+        }
     }
     if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;
@@ -355,8 +359,10 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(ctx, NULL, 0);
             return -1;
+        }
     }
     if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;
@@ -647,8 +653,10 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
     *signature_len = 2 * SSH2_SHA1_DIG_LEN;
 
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len))
+        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(ctx, NULL, 0);
             return -1;
+        }
     }
     if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
         return -1;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -903,7 +903,7 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
 
     for(i = 0; i < veccount; i++)
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
+            (void)ssh2_hash_final(ctx, NULL, 0);
             return -1;
         }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -64,16 +64,21 @@ static void kex_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
         ssh2_hash_ctx hash;
         size_t len = 0;
         while(len < data_len) {
-            if(!ssh2_hash_init(&hash, hash_alg) ||
-               !ssh2_hash_update(hash, exchange_state->k_value,
+            if(!ssh2_hash_init(&hash, hash_alg)) {
+                SSH2_SAFEFREE(session, *data);
+                return;
+            }
+            if(!ssh2_hash_update(hash, exchange_state->k_value,
                                        exchange_state->k_value_len) ||
                !ssh2_hash_update(hash, exchange_state->h_sig_comp,
                                        digest_len)) {
+                (void)ssh2_hash_final(hash, NULL, 0);
                 SSH2_SAFEFREE(session, *data);
                 return;
             }
             if(len > 0) {
                 if(!ssh2_hash_update(hash, *data, len)) {
+                    (void)ssh2_hash_final(hash, NULL, 0);
                     SSH2_SAFEFREE(session, *data);
                     return;
                 }
@@ -82,6 +87,7 @@ static void kex_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
                 if(!ssh2_hash_update(hash, version, 1) ||
                    !ssh2_hash_update(hash, session->session_id,
                                            session->session_id_len)) {
+                    (void)ssh2_hash_final(hash, NULL, 0);
                     SSH2_SAFEFREE(session, *data);
                     return;
                 }

--- a/src/kex.c
+++ b/src/kex.c
@@ -642,12 +642,12 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
             }
         }
 
-        if(!ssh2_hash_init(ctx, hash_alg)) {
+        hok = ssh2_hash_init(ctx, hash_alg);
+        if(!hok) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                            "Unable to initialize hash context DH-SHA");
             goto clean_exit;
         }
-        hok = 1;
         if(session->local.banner) {
             ssh2_htonu32(exchange_state->h_sig_comp,
                 (uint32_t)(strlen((char *)session->local.banner) - 2));
@@ -1473,11 +1473,11 @@ static int kex_method_ec_sha_hash_create_verify(
     int err;
     int hok;
 
-    if(!ssh2_hash_init(&ctx, hash_alg))
+    hok = ssh2_hash_init(&ctx, hash_alg);
+    if(!hok)
         return ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                         "Unable to initialize hash context EC/ED");
 
-    hok = 1;
     if(session->local.banner) {
         ssh2_htonu32(exchange_state->h_sig_comp,
                      (uint32_t)(strlen((char *)session->local.banner) - 2));

--- a/src/kex.c
+++ b/src/kex.c
@@ -61,38 +61,25 @@ static void kex_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
         *data = SSH2_ALLOC(session, data_len + digest_len);
 
     if(*data) {
-        ssh2_hash_ctx hash;
         size_t len = 0;
         while(len < data_len) {
-            if(!ssh2_hash_init(&hash, hash_alg)) {
-                SSH2_SAFEFREE(session, *data);
-                return;
-            }
-            if(!ssh2_hash_update(hash, exchange_state->k_value,
-                                       exchange_state->k_value_len) ||
-               !ssh2_hash_update(hash, exchange_state->h_sig_comp,
-                                       digest_len)) {
-                (void)ssh2_hash_final(hash, NULL, 0);
-                SSH2_SAFEFREE(session, *data);
-                return;
-            }
-            if(len > 0) {
-                if(!ssh2_hash_update(hash, *data, len)) {
-                    (void)ssh2_hash_final(hash, NULL, 0);
-                    SSH2_SAFEFREE(session, *data);
-                    return;
+            ssh2_hash_ctx ctx;
+            int hok = ssh2_hash_init(&ctx, hash_alg);
+            if(hok) {
+                hok &= ssh2_hash_update(ctx, exchange_state->k_value,
+                                        exchange_state->k_value_len);
+                hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp,
+                                        digest_len);
+                if(len)
+                    hok &= ssh2_hash_update(ctx, *data, len);
+                else {
+                    hok &= ssh2_hash_update(ctx, version, 1);
+                    hok &= ssh2_hash_update(ctx, session->session_id,
+                                            session->session_id_len);
                 }
+                hok &= ssh2_hash_final(ctx, *data + len, digest_len);
             }
-            else {
-                if(!ssh2_hash_update(hash, version, 1) ||
-                   !ssh2_hash_update(hash, session->session_id,
-                                           session->session_id_len)) {
-                    (void)ssh2_hash_final(hash, NULL, 0);
-                    SSH2_SAFEFREE(session, *data);
-                    return;
-                }
-            }
-            if(!ssh2_hash_final(hash, *data + len, digest_len)) {
+            if(!hok) {
                 SSH2_SAFEFREE(session, *data);
                 return;
             }

--- a/src/kex.c
+++ b/src/kex.c
@@ -716,8 +716,8 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
         hok &= ssh2_hash_update(*ctx, exchange_state->k_value,
                                       exchange_state->k_value_len);
 
-        if(!hok || !ssh2_hash_final(*ctx, exchange_state->h_sig_comp,
-                                    sizeof(exchange_state->h_sig_comp))) {
+        if(!(hok & ssh2_hash_final(*ctx, exchange_state->h_sig_comp,
+                                   sizeof(exchange_state->h_sig_comp)))) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "Failed to calculate hash DH-SHA");
             goto clean_exit;
@@ -1540,8 +1540,8 @@ static int kex_method_ec_sha_hash_create_verify(
     hok &= ssh2_hash_update(ctx, exchange_state->k_value,
                                  exchange_state->k_value_len);
 
-    if(!hok || !ssh2_hash_final(ctx, exchange_state->h_sig_comp,
-                                sizeof(exchange_state->h_sig_comp)))
+    if(!(hok & ssh2_hash_final(ctx, exchange_state->h_sig_comp,
+                               sizeof(exchange_state->h_sig_comp))))
         return ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                         "Failed to calculate hash EC/ED");
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -722,8 +722,9 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
         hok &= ssh2_hash_update(*ctx, exchange_state->k_value,
                                       exchange_state->k_value_len);
 
-        if(!(hok & ssh2_hash_final(*ctx, exchange_state->h_sig_comp,
-                                   sizeof(exchange_state->h_sig_comp)))) {
+        hok &= ssh2_hash_final(*ctx, exchange_state->h_sig_comp,
+                                     sizeof(exchange_state->h_sig_comp));
+        if(!hok) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "Failed to calculate hash DH-SHA");
             goto clean_exit;
@@ -1546,8 +1547,9 @@ static int kex_method_ec_sha_hash_create_verify(
     hok &= ssh2_hash_update(ctx, exchange_state->k_value,
                                  exchange_state->k_value_len);
 
-    if(!(hok & ssh2_hash_final(ctx, exchange_state->h_sig_comp,
-                               sizeof(exchange_state->h_sig_comp))))
+    hok &= ssh2_hash_final(ctx, exchange_state->h_sig_comp,
+                                sizeof(exchange_state->h_sig_comp));
+    if(!hok)
         return ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                         "Failed to calculate hash EC/ED");
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -45,10 +45,12 @@
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len)
 {
     int ret = 0;
-    unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(ctx));
-    if(len >= digest_len) {
-        memcpy(hash, gcry_md_read(ctx, 0), digest_len);
-        ret = 1;
+    if(hash) {
+        unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(ctx));
+        if(len >= digest_len) {
+            memcpy(hash, gcry_md_read(ctx, 0), digest_len);
+            ret = 1;
+        }
     }
     gcry_md_close(ctx);
     return ret;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -191,6 +191,8 @@ int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
                          unsigned char *hash, size_t len)
 {
     size_t actual_len;
+    if(!hash)
+        return 0;
     return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS;
 }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -88,8 +88,10 @@ int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
 
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
 {
-    int ret = EVP_DigestFinal_ex(*ctx, out, NULL);
+    int ret = 0;
     (void)outlen;
+    if(out)
+        ret = EVP_DigestFinal_ex(*ctx, out, NULL);
     EVP_MD_CTX_free(*ctx);
     *ctx = NULL;
     return ret;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -952,6 +952,9 @@ int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx,
     Qus_EC_t errcode;
     (void)outlen;
 
+    if(!out)
+        return 0;
+
     ctx->Final_Op_Flag = Qc3_Final;
     set_EC_length(errcode, sizeof(errcode));
     Qc3CalculateHash(&data, &zero, Qc3_Data, (char *)ctx, Qc3_Alg_Token,

--- a/src/pem.c
+++ b/src/pem.c
@@ -284,21 +284,35 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         ssh2_hash_ctx fingerprint_ctx;
 
         /* Perform key derivation (PBKDF1/MD5) */
-        if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) ||
-           !ssh2_hash_update(fingerprint_ctx, passphrase,
+        if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG)) {
+            ret = -1;
+            goto out;
+        }
+        if(!ssh2_hash_update(fingerprint_ctx, passphrase,
                              strlen((const char *)passphrase)) ||
-           !ssh2_hash_update(fingerprint_ctx, iv, 8) ||
-           !ssh2_hash_final(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN)) {
+           !ssh2_hash_update(fingerprint_ctx, iv, 8)) {
+            (void)ssh2_hash_final(fingerprint_ctx, NULL, 0);
+            ret = -1;
+            goto out;
+        }
+        if(!ssh2_hash_final(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN)) {
             ret = -1;
             goto out;
         }
         if(method->secret_len > SSH2_MD5_DIG_LEN) {
-            if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) ||
-               !ssh2_hash_update(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN) ||
+            if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG)) {
+                ret = -1;
+                goto out;
+            }
+            if(!ssh2_hash_update(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN) ||
                !ssh2_hash_update(fingerprint_ctx, passphrase,
                                  strlen((const char *)passphrase)) ||
-               !ssh2_hash_update(fingerprint_ctx, iv, 8) ||
-               !ssh2_hash_final(fingerprint_ctx,
+               !ssh2_hash_update(fingerprint_ctx, iv, 8)) {
+                (void)ssh2_hash_final(fingerprint_ctx, NULL, 0);
+                ret = -1;
+                goto out;
+            }
+            if(!ssh2_hash_final(fingerprint_ctx,
                                 secret + SSH2_MD5_DIG_LEN, SSH2_MD5_DIG_LEN)) {
                 ret = -1;
                 goto out;

--- a/src/pem.c
+++ b/src/pem.c
@@ -281,39 +281,32 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         int blocksize = method->blocksize;
         void *abstract;
         unsigned char secret[2 * SSH2_MD5_DIG_LEN];
-        ssh2_hash_ctx fingerprint_ctx;
+        ssh2_hash_ctx ctx;  /* fingerprint */
+        int hok;
 
         /* Perform key derivation (PBKDF1/MD5) */
-        if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG)) {
-            ret = -1;
-            goto out;
+        hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
+        if(hok) {
+            hok &= ssh2_hash_update(ctx, passphrase,
+                                    strlen((const char *)passphrase));
+            hok &= ssh2_hash_update(ctx, iv, 8);
+            hok &= ssh2_hash_final(ctx, secret, SSH2_MD5_DIG_LEN);
         }
-        if(!ssh2_hash_update(fingerprint_ctx, passphrase,
-                             strlen((const char *)passphrase)) ||
-           !ssh2_hash_update(fingerprint_ctx, iv, 8)) {
-            (void)ssh2_hash_final(fingerprint_ctx, NULL, 0);
-            ret = -1;
-            goto out;
-        }
-        if(!ssh2_hash_final(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN)) {
+        if(!hok) {
             ret = -1;
             goto out;
         }
         if(method->secret_len > SSH2_MD5_DIG_LEN) {
-            if(!ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG)) {
-                ret = -1;
-                goto out;
+            hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
+            if(hok) {
+                hok &= ssh2_hash_update(ctx, secret, SSH2_MD5_DIG_LEN);
+                hok &= ssh2_hash_update(ctx, passphrase,
+                                        strlen((const char *)passphrase));
+                hok &= ssh2_hash_update(ctx, iv, 8);
+                hok &= ssh2_hash_final(ctx, secret + SSH2_MD5_DIG_LEN,
+                                       SSH2_MD5_DIG_LEN);
             }
-            if(!ssh2_hash_update(fingerprint_ctx, secret, SSH2_MD5_DIG_LEN) ||
-               !ssh2_hash_update(fingerprint_ctx, passphrase,
-                                 strlen((const char *)passphrase)) ||
-               !ssh2_hash_update(fingerprint_ctx, iv, 8)) {
-                (void)ssh2_hash_final(fingerprint_ctx, NULL, 0);
-                ret = -1;
-                goto out;
-            }
-            if(!ssh2_hash_final(fingerprint_ctx,
-                                secret + SSH2_MD5_DIG_LEN, SSH2_MD5_DIG_LEN)) {
+            if(!hok) {
                 ret = -1;
                 goto out;
             }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -761,7 +761,7 @@ int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
 {
     int ret = 0;
 
-    if(hashlen >= ctx->cbHash &&
+    if(hash && hashlen >= ctx->cbHash &&
        BCRYPT_SUCCESS(BCryptFinishHash(ctx->hHash, hash, ctx->cbHash, 0)))
         ret = 1;
 


### PR DESCRIPTION
Also:
- make `ssh2_hash_final()` support `NULL` output digest pointer to allow
  invoking for context cleanup without calculating the digest, for use
  in failure paths.                                            
- adjust to use similar pattern across the source.

Bug: https://github.com/libssh2/libssh2/pull/2171#discussion_r3509935294
Bug: https://github.com/libssh2/libssh2/pull/2184#discussion_r3517010324
    
Follow-up to 4718ede4e09e1a0cd593a3908a8af1aadcf6b2a5 #1303

---

- [x] try simplify kex, pem by using `&=`.
