### PR TITLE
GHA: try enabling trace output to debug FreeBSD flaky fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1267,5 +1267,8 @@ jobs:
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target test-ci
           else
-            make -C bld check V=1 || { cat tests/*.log; false; }
+            make -C bld check V=1
+            echo '-----------------'
+            find . | sort
+            echo '-----------------'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1267,5 +1267,5 @@ jobs:
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target test-ci
           else
-            make -C bld check V=1 || { cat tests/*.log; false; }
+            make -C bld check V=1 || { cat bld/tests/*.log; false; }
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1267,8 +1267,5 @@ jobs:
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target test-ci
           else
-            make -C bld check V=1
-            echo '-----------------'
-            find . | sort
-            echo '-----------------'
+            make -C bld check V=1 || { cat tests/*.log; false; }
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1263,7 +1263,6 @@ jobs:
       - name: 'run tests'
         if: ${{ matrix.arch == 'x86_64' && !contains(matrix.desc, 'skiprun') }}  # Slow on emulated CPU
         run: |
-          export TFLAGS='-j8'
           export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures on FreeBSD
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target test-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1264,9 +1264,7 @@ jobs:
         if: ${{ matrix.arch == 'x86_64' && !contains(matrix.desc, 'skiprun') }}  # Slow on emulated CPU
         run: |
           export TFLAGS='-j8'
-          if [ "${MATRIX_OS}" = 'openbsd' ]; then
-            TFLAGS="$TFLAGS !2707"  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
-          fi
+          export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures on FreeBSD
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target test-ci
           else


### PR DESCRIPTION
Refs:
https://github.com/libssh2/libssh2/actions/runs/28740149966/job/85221371725
https://github.com/libssh2/libssh2/actions/runs/28745018411/job/85234337471?pr=2215
https://github.com/libssh2/libssh2/actions/runs/28756588534/job/85264629489?pr=2226

Also:
- fix dumping log files in BSD jobs.
  Follow-up to e4f700e9343d483c11df2a2ed722da619f2e61cb #1948
- delete copy-paste leftovers.
  Follow-up to e4f700e9343d483c11df2a2ed722da619f2e61cb #1948

Bug: https://github.com/libssh2/libssh2/pull/2215#issuecomment-4886565064

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
