### PR TITLE
kex: de-duplicate hash calculations in `kex_mlkem_nistp()` and `kex_ecdh_sha2_nistp()`

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -2019,6 +2019,7 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
         size_t shared_secret_len;
         size_t server_public_key_len;
         struct string_buf buf;
+        ssh2_hash_ctx k_ctx;
 
         if(!data) {
             ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -2099,70 +2100,32 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
         }
 
         /* verify hash */
-        switch(type) {
-        case SSH2_EC_CURVE_NISTP256: {
-            ssh2_hash_ctx k_ctx;
-            if(!ssh2_hash_init(&k_ctx, SSH2_SHA256_ALG)) {
-                ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
-                               "kex: failed to initialize hash");
-                goto clean_exit;
-            }
-
-            if(!ssh2_hash_update(k_ctx, shared_secret, shared_secret_len)) {
-                ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
-                               "kex: failed to calculate hash");
-                goto clean_exit;
-            }
-
-            if(!ssh2_hash_final(k_ctx,
-                                exchange_state->k_value + 4, digest_len)) {
-                ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
-                               "kex: failed to calculate hash");
-                goto clean_exit;
-            }
-            ret = kex_method_ec_sha_hash_create_verify(session,
-                     exchange_state,
-                     public_t_key, public_t_key_len,
-                     public_pq_key, public_pq_key_len,
-                     server_public_key, server_public_key_len,
-                     SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
-                     "Unable to verify hostkey signature mlkemnistp");
-            break;
-        }
-        case SSH2_EC_CURVE_NISTP384: {
-            ssh2_hash_ctx k_ctx;
-            if(!ssh2_hash_init(&k_ctx, SSH2_SHA384_ALG)) {
-                ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
-                               "kex: failed to initialize hash");
-                goto clean_exit;
-            }
-
-            if(!ssh2_hash_update(k_ctx, shared_secret, shared_secret_len)) {
-                ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
-                               "kex: failed to calculate hash");
-                goto clean_exit;
-            }
-
-            if(!ssh2_hash_final(k_ctx,
-                                exchange_state->k_value + 4, digest_len)) {
-                ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
-                               "kex: failed to calculate hash");
-                goto clean_exit;
-            }
-            ret = kex_method_ec_sha_hash_create_verify(session,
-                     exchange_state,
-                     public_t_key, public_t_key_len,
-                     public_pq_key, public_pq_key_len,
-                     server_public_key, server_public_key_len,
-                     SSH2_SHA384_ALG, SSH2_SHA384_DIG_LEN,
-                     "Unable to verify hostkey signature mlkemnistp");
-            break;
-        }
-        default:
-            ret = ssh2_err(session, -1,
-                           "Unexpected KEX hybrid nistp curve type");
+        if(!ssh2_hash_init(&k_ctx, hash_alg)) {
+            ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
+                           "kex: failed to initialize hash");
+            goto clean_exit;
         }
 
+        if(!ssh2_hash_update(k_ctx, shared_secret, shared_secret_len)) {
+            ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
+                           "kex: failed to calculate hash");
+            goto clean_exit;
+        }
+
+        if(!ssh2_hash_final(k_ctx,
+                            exchange_state->k_value + 4, digest_len)) {
+            ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
+                           "kex: failed to calculate hash");
+            goto clean_exit;
+        }
+
+        ret = kex_method_ec_sha_hash_create_verify(session,
+                 exchange_state,
+                 public_t_key, public_t_key_len,
+                 public_pq_key, public_pq_key_len,
+                 server_public_key, server_public_key_len,
+                 hash_alg, digest_len,
+                 "Unable to verify hostkey signature mlkemnistp");
         if(ret)
             goto clean_exit;
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -2101,8 +2101,7 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        ret = kex_method_ec_sha_hash_create_verify(session,
-                 exchange_state,
+        ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                  public_t_key, public_t_key_len,
                  public_pq_key, public_pq_key_len,
                  server_public_key, server_public_key_len,
@@ -2714,8 +2713,7 @@ static int kex_mlkem768x25519_sha256(
         }
 
         /* verify hash */
-        ret = kex_method_ec_sha_hash_create_verify(session,
-                 exchange_state,
+        ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                  public_t_key, public_t_key_len,
                  public_pq_key, public_pq_key_len,
                  server_public_key, server_public_key_len,

--- a/src/kex.c
+++ b/src/kex.c
@@ -2685,6 +2685,7 @@ static int kex_mlkem768x25519_sha256(
             goto clean_exit;
         }
 
+        /* verify hash */
         if(!ssh2_hash_init(&k_ctx, SSH2_SHA256_ALG)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                            "kex: failed to initialize hash");

--- a/src/kex.c
+++ b/src/kex.c
@@ -1659,6 +1659,27 @@ static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
     int ret = 0;
     int rc;
 
+    ssh2_hash_alg hash_alg;
+    size_t digest_len = 0;
+
+    if(type == SSH2_EC_CURVE_NISTP256) {
+        hash_alg = SSH2_SHA256_ALG;
+        digest_len = SSH2_SHA256_DIG_LEN;
+    }
+    else if(type == SSH2_EC_CURVE_NISTP384) {
+        hash_alg = SSH2_SHA384_ALG;
+        digest_len = SSH2_SHA384_DIG_LEN;
+    }
+    else if(type == SSH2_EC_CURVE_NISTP521) {
+        hash_alg = SSH2_SHA512_ALG;
+        digest_len = SSH2_SHA512_DIG_LEN;
+    }
+    else {
+        ret = ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
+                       "Unrecognized SHA digest for EC curve");
+        goto clean_exit;
+    }
+
     if(exchange_state->state == ssh2_NB_state_idle) {
 
         /* Setup initial values */
@@ -1740,30 +1761,11 @@ static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
         }
 
         /* verify hash */
-        switch(type) {
-        case SSH2_EC_CURVE_NISTP256:
-            ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
-                     public_key, public_key_len, NULL, 0,
-                     server_public_key, server_public_key_len,
-                     SSH2_SHA256_ALG, SSH2_SHA256_DIG_LEN,
-                     "Unable to verify hostkey signature ECDH");
-            break;
-        case SSH2_EC_CURVE_NISTP384:
-            ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
-                     public_key, public_key_len, NULL, 0,
-                     server_public_key, server_public_key_len,
-                     SSH2_SHA384_ALG, SSH2_SHA384_DIG_LEN,
-                     "Unable to verify hostkey signature ECDH");
-            break;
-        case SSH2_EC_CURVE_NISTP521:
-            ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
-                     public_key, public_key_len, NULL, 0,
-                     server_public_key, server_public_key_len,
-                     SSH2_SHA512_ALG, SSH2_SHA512_DIG_LEN,
-                     "Unable to verify hostkey signature ECDH");
-            break;
-        }
-
+        ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
+                 public_key, public_key_len, NULL, 0,
+                 server_public_key, server_public_key_len,
+                 hash_alg, digest_len,
+                 "Unable to verify hostkey signature ECDH");
         if(ret)
             goto clean_exit;
 
@@ -1784,26 +1786,6 @@ static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
     }
 
     if(exchange_state->state == ssh2_NB_state_sent2) {
-        ssh2_hash_alg hash_alg;
-        size_t digest_len = 0;
-
-        if(type == SSH2_EC_CURVE_NISTP256) {
-            hash_alg = SSH2_SHA256_ALG;
-            digest_len = SSH2_SHA256_DIG_LEN;
-        }
-        else if(type == SSH2_EC_CURVE_NISTP384) {
-            hash_alg = SSH2_SHA384_ALG;
-            digest_len = SSH2_SHA384_DIG_LEN;
-        }
-        else if(type == SSH2_EC_CURVE_NISTP521) {
-            hash_alg = SSH2_SHA512_ALG;
-            digest_len = SSH2_SHA512_DIG_LEN;
-        }
-        else {
-            ret = ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
-                           "Unrecognized SHA digest for EC curve");
-            goto clean_exit;
-        }
         ret = kex_finish(session, exchange_state, hash_alg, digest_len);
         if(ret == LIBSSH2_ERROR_EAGAIN)
             return ret;

--- a/src/kex.c
+++ b/src/kex.c
@@ -1676,7 +1676,7 @@ static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
     }
     else {
         ret = ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
-                       "Unrecognized SHA digest for EC curve");
+                       "Unexpected ecdh-sha2-nistp curve type");
         goto clean_exit;
     }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -1681,10 +1681,8 @@ static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
     }
 
     if(exchange_state->state == ssh2_NB_state_idle) {
-
         /* Setup initial values */
         exchange_state->k = ssh2_bn_init();
-
         exchange_state->state = ssh2_NB_state_created;
     }
 
@@ -1988,10 +1986,8 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
     }
 
     if(exchange_state->state == ssh2_NB_state_idle) {
-
         /* Setup initial values */
         exchange_state->k = ssh2_bn_init();
-
         exchange_state->state = ssh2_NB_state_created;
     }
 
@@ -2324,7 +2320,6 @@ static int kex_curve25519_sha256(
     if(exchange_state->state == ssh2_NB_state_idle) {
         /* Setup initial values */
         exchange_state->k = ssh2_bn_init();
-
         exchange_state->state = ssh2_NB_state_created;
     }
 
@@ -2606,7 +2601,6 @@ static int kex_mlkem768x25519_sha256(
     if(exchange_state->state == ssh2_NB_state_idle) {
         /* Setup initial values */
         exchange_state->k = ssh2_bn_init();
-
         exchange_state->state = ssh2_NB_state_created;
     }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -2707,7 +2707,6 @@ static int kex_mlkem768x25519_sha256(
             goto clean_exit;
         }
 
-        /* verify hash */
         ret = kex_method_ec_sha_hash_create_verify(session, exchange_state,
                  public_t_key, public_t_key_len,
                  public_pq_key, public_pq_key_len,


### PR DESCRIPTION
Also fix an error string.

Follow-up to b0e1b08def1ed3199a72fe4f860df6cb6b648822 #2187
Follow-up to f2b416053b936c580305286ad0c2eec325d2e1d5 #2184
Follow-up to bef08f38429959c0dc19659e5c86e6d5add44ab8 #2171

---

https://github.com/libssh2/libssh2/pull/2228/files?w=1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
