### PR TITLE
kex: harden remote public key length check in `kex_mlkem_nistp()`

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -2016,10 +2016,6 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        ssh2_deb((session, LIBSSH2_TRACE_KEX,
-                  "kex_mlkem_nistp(): server_public_key_len=%lu",
-                  (unsigned long)server_public_key_len));
-
         if(server_public_key_len <= mlkem_cipher_len ||
            server_public_key_len > (256 * 1024)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,

--- a/src/kex.c
+++ b/src/kex.c
@@ -2016,6 +2016,10 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
+        ssh2_deb((session, LIBSSH2_TRACE_KEX,
+                  "kex_mlkem_nistp(): server_public_key_len=%lu",
+                  (unsigned long)server_public_key_len));
+
         if(server_public_key_len <= mlkem_cipher_len ||
            server_public_key_len > (256 * 1024)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,

--- a/src/kex.c
+++ b/src/kex.c
@@ -2016,7 +2016,8 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        if(server_public_key_len <= mlkem_cipher_len) {
+        if(server_public_key_len <= mlkem_cipher_len ||
+           server_public_key_len > (256 * 1024)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Unexpected mlkemnistp server public key length");
             goto clean_exit;


### PR DESCRIPTION
Cap to 256 KiB.
    
Follow-up to 3ba252e2a6fe04d17ea13ad870698a4028c8ab4c #1644
