### PR TITLE
src: add one-shot hash function `ssh2_hash()` and use it

### DIFF
--- a/src/bcrypt_pbkdf.c
+++ b/src/bcrypt_pbkdf.c
@@ -105,7 +105,6 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
     size_t i, j, amt, stride;
     uint32_t count;
     size_t origkeylen = keylen;
-    ssh2_hash_ctx ctx;
 
     /* nothing crazy */
     if(rounds < 1)
@@ -124,9 +123,8 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
     memcpy(countsalt, salt, saltlen);
 
     /* collapse password */
-    if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG) ||
-       !ssh2_hash_update(ctx, pass, passlen) ||
-       !ssh2_hash_final(ctx, sha2pass, sizeof(sha2pass))) {
+    if(!ssh2_hash(SSH2_SHA512_ALG, pass, passlen,
+                  sha2pass, sizeof(sha2pass))) {
         free(countsalt);
         return -1;
     }
@@ -139,9 +137,8 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
         countsalt[saltlen + 3] = count & 0xff;
 
         /* first round, salt is salt */
-        if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG) ||
-           !ssh2_hash_update(ctx, countsalt, saltlen + 4) ||
-           !ssh2_hash_final(ctx, sha2salt, sizeof(sha2salt))) {
+        if(!ssh2_hash(SSH2_SHA512_ALG, countsalt, saltlen + 4,
+                      sha2salt, sizeof(sha2salt))) {
             ssh2_explicit_zero(out, sizeof(out));
             free(countsalt);
             return -1;
@@ -152,9 +149,8 @@ static int bcrypt_pbkdf(const char *pass, size_t passlen,
 
         for(i = 1; i < rounds; i++) {
             /* subsequent rounds, salt is previous output */
-            if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG) ||
-               !ssh2_hash_update(ctx, tmpout, sizeof(tmpout)) ||
-               !ssh2_hash_final(ctx, sha2salt, sizeof(sha2salt))) {
+            if(!ssh2_hash(SSH2_SHA512_ALG, tmpout, sizeof(tmpout),
+                          sha2salt, sizeof(sha2salt))) {
                 ssh2_explicit_zero(out, sizeof(out));
                 free(countsalt);
                 return -1;

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -99,6 +99,9 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 #define SSH2_MLKEM_1024_PUBLIC_KEY_LEN  1568
 #define SSH2_MLKEM_1024_CIPHERTEXT      1568
 
+int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
+              unsigned char *digest, size_t digest_len);
+
 #if LIBSSH2_RSA
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
                  const unsigned char *edata, unsigned long elen,

--- a/src/kex.c
+++ b/src/kex.c
@@ -2064,8 +2064,7 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        if(!ssh2_hash_final(k_ctx,
-                            exchange_state->k_value + 4, digest_len)) {
+        if(!ssh2_hash_final(k_ctx, exchange_state->k_value + 4, digest_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
             goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -1971,7 +1971,6 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
         size_t shared_secret_len;
         size_t server_public_key_len;
         struct string_buf buf;
-        ssh2_hash_ctx k_ctx;
 
         if(!data) {
             ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -2052,20 +2051,8 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
         }
 
         /* verify hash */
-        if(!ssh2_hash_init(&k_ctx, hash_alg)) {
-            ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
-                           "kex: failed to initialize hash");
-            goto clean_exit;
-        }
-
-        if(!ssh2_hash_update(k_ctx, shared_secret, shared_secret_len)) {
-            ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
-                           "kex: failed to calculate hash");
-            (void)ssh2_hash_final(k_ctx, NULL, 0);
-            goto clean_exit;
-        }
-
-        if(!ssh2_hash_final(k_ctx, exchange_state->k_value + 4, digest_len)) {
+        if(!ssh2_hash(hash_alg, shared_secret, shared_secret_len,
+                      exchange_state->k_value + 4, digest_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
             goto clean_exit;
@@ -2587,7 +2574,6 @@ static int kex_mlkem768x25519_sha256(
                                     SSH2_ED25519_KEY_LEN];
         size_t server_public_key_len;
         struct string_buf buf;
-        ssh2_hash_ctx k_ctx;
 
         if(!data) {
             ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -2660,23 +2646,9 @@ static int kex_mlkem768x25519_sha256(
         }
 
         /* verify hash */
-        if(!ssh2_hash_init(&k_ctx, SSH2_SHA256_ALG)) {
-            ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
-                           "kex: failed to initialize hash");
-            goto clean_exit;
-        }
-
-        if(!ssh2_hash_update(k_ctx, shared_secret,
-                             SSH2_MLKEM_SHARED_SECRET_LEN +
-                                 SSH2_ED25519_KEY_LEN)) {
-            ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
-                           "kex: failed to calculate hash");
-            (void)ssh2_hash_final(k_ctx, NULL, 0);
-            goto clean_exit;
-        }
-
-        if(!ssh2_hash_final(k_ctx, exchange_state->k_value + 4,
-                            SSH2_SHA256_DIG_LEN)) {
+        if(!ssh2_hash(SSH2_SHA256_ALG, shared_secret,
+                      SSH2_MLKEM_SHARED_SECRET_LEN + SSH2_ED25519_KEY_LEN,
+                      exchange_state->k_value + 4, SSH2_SHA256_DIG_LEN)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
             goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -2061,6 +2061,7 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
         if(!ssh2_hash_update(k_ctx, shared_secret, shared_secret_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
+            (void)ssh2_hash_final(k_ctx, NULL, 0);
             goto clean_exit;
         }
 
@@ -2670,6 +2671,7 @@ static int kex_mlkem768x25519_sha256(
                                  SSH2_ED25519_KEY_LEN)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "kex: failed to calculate hash");
+            (void)ssh2_hash_final(k_ctx, NULL, 0);
             goto clean_exit;
         }
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -133,18 +133,9 @@ static int kex_proc_hostkey(LIBSSH2_SESSION *session, struct string_buf *buf,
     session->server_hostkey_len = (uint32_t)host_key_len;
 
 #if LIBSSH2_MD5
-    {
-        ssh2_hash_ctx fingerprint_ctx;
-
-        if(ssh2_hash_init(&fingerprint_ctx, SSH2_MD5_ALG) &&
-           ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
-                            session->server_hostkey_len) &&
-           ssh2_hash_final(fingerprint_ctx, session->server_hostkey_md5,
-                           sizeof(session->server_hostkey_md5)))
-            session->server_hostkey_md5_valid = TRUE;
-        else
-            session->server_hostkey_md5_valid = FALSE;
-    }
+    session->server_hostkey_md5_valid = ssh2_hash(SSH2_MD5_ALG,
+        session->server_hostkey, session->server_hostkey_len,
+        session->server_hostkey_md5, sizeof(session->server_hostkey_md5));
 #ifdef LIBSSH2DEBUG
     {
         char fingerprint[SSH2_MD5_DIG_LEN * 3 + 1];
@@ -159,18 +150,9 @@ static int kex_proc_hostkey(LIBSSH2_SESSION *session, struct string_buf *buf,
 #endif /* LIBSSH2DEBUG */
 #endif /* !LIBSSH2_MD5 */
 
-    {
-        ssh2_hash_ctx fingerprint_ctx;
-
-        if(ssh2_hash_init(&fingerprint_ctx, SSH2_SHA1_ALG) &&
-           ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
-                            session->server_hostkey_len) &&
-           ssh2_hash_final(fingerprint_ctx, session->server_hostkey_sha1,
-                           sizeof(session->server_hostkey_sha1)))
-            session->server_hostkey_sha1_valid = TRUE;
-        else
-            session->server_hostkey_sha1_valid = FALSE;
-    }
+    session->server_hostkey_sha1_valid = ssh2_hash(SSH2_SHA1_ALG,
+        session->server_hostkey, session->server_hostkey_len,
+        session->server_hostkey_sha1, sizeof(session->server_hostkey_sha1));
 #ifdef LIBSSH2DEBUG
     {
         char fingerprint[SSH2_SHA1_DIG_LEN * 3 + 1];
@@ -184,18 +166,10 @@ static int kex_proc_hostkey(LIBSSH2_SESSION *session, struct string_buf *buf,
     }
 #endif /* LIBSSH2DEBUG */
 
-    {
-        ssh2_hash_ctx fingerprint_ctx;
-
-        if(ssh2_hash_init(&fingerprint_ctx, SSH2_SHA256_ALG) &&
-           ssh2_hash_update(fingerprint_ctx, session->server_hostkey,
-                            session->server_hostkey_len) &&
-           ssh2_hash_final(fingerprint_ctx, session->server_hostkey_sha256,
-                           sizeof(session->server_hostkey_sha256)))
-            session->server_hostkey_sha256_valid = TRUE;
-        else
-            session->server_hostkey_sha256_valid = FALSE;
-    }
+    session->server_hostkey_sha256_valid = ssh2_hash(SSH2_SHA256_ALG,
+        session->server_hostkey, session->server_hostkey_len,
+        session->server_hostkey_sha256,
+        sizeof(session->server_hostkey_sha256));
 #ifdef LIBSSH2DEBUG
     {
         char *base64Fingerprint = NULL;

--- a/src/misc.c
+++ b/src/misc.c
@@ -335,13 +335,11 @@ int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
               unsigned char *digest, size_t digest_len)
 {
     ssh2_hash_ctx ctx;
-    int success = 0;
-
-    if(ssh2_hash_init(&ctx, alg)) {
-        success = ssh2_hash_update(ctx, input, input_len);
+    int success = ssh2_hash_init(&ctx, alg);
+    if(success) {
+        success &= ssh2_hash_update(ctx, input, input_len);
         success &= ssh2_hash_final(ctx, digest, digest_len);
     }
-
     return success;
 }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -331,6 +331,20 @@ int ssh2_store_bignum_bytes(unsigned char **buf,
     return len_stored == len;
 }
 
+int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
+              unsigned char *digest, size_t digest_len)
+{
+    ssh2_hash_ctx ctx;
+    int success = 0;
+
+    if(ssh2_hash_init(&ctx, alg)) {
+        success = ssh2_hash_update(ctx, input, input_len);
+        success &= ssh2_hash_final(ctx, digest, digest_len);
+    }
+
+    return success;
+}
+
 /* Base64 Conversion */
 
 static const short ssh2_base64_reverse_table[256] = {


### PR DESCRIPTION
To simplify code and error handling in callers with a single 
`ssh2_hash_update()` stage.

Cherry-picked from #2226
