### PR TITLE
src: backtrack on NULL digest buffer support in `ssh2_hash_final()`

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -227,7 +227,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, NULL, 0);
+            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
             return -1;
         }
     }
@@ -295,7 +295,7 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, NULL, 0);
+            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
             return -1;
         }
     }
@@ -360,7 +360,7 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, NULL, 0);
+            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
             return -1;
         }
     }
@@ -654,7 +654,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
 
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, NULL, 0);
+            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
             return -1;
         }
     }
@@ -911,7 +911,7 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
 
     for(i = 0; i < veccount; i++)
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, NULL, 0);
+            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
             return -1;
         }
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -45,12 +45,10 @@
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len)
 {
     int ret = 0;
-    if(hash) {
-        unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(ctx));
-        if(len >= digest_len) {
-            memcpy(hash, gcry_md_read(ctx, 0), digest_len);
-            ret = 1;
-        }
+    unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(ctx));
+    if(len >= digest_len) {
+        memcpy(hash, gcry_md_read(ctx, 0), digest_len);
+        ret = 1;
     }
     gcry_md_close(ctx);
     return ret;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -191,8 +191,10 @@ int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
                          unsigned char *hash, size_t len)
 {
     size_t actual_len;
-    if(!hash)
+    if(!hash) {
+        (void)psa_hash_abort(ctx);
         return 0;
+    }
     return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS;
 }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -191,10 +191,6 @@ int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
                          unsigned char *hash, size_t len)
 {
     size_t actual_len;
-    if(!hash) {
-        (void)psa_hash_abort(ctx);
-        return 0;
-    }
     return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS;
 }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -88,10 +88,8 @@ int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
 
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
 {
-    int ret = 0;
+    int ret = EVP_DigestFinal_ex(*ctx, out, NULL);
     (void)outlen;
-    if(out)
-        ret = EVP_DigestFinal_ex(*ctx, out, NULL);
     EVP_MD_CTX_free(*ctx);
     *ctx = NULL;
     return ret;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -948,20 +948,17 @@ int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,
 int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx,
                              unsigned char *out, size_t outlen)
 {
-    int ret = 0;
+    char data;
+    Qus_EC_t errcode;
     (void)outlen;
-    if(out) {
-        char data;
-        Qus_EC_t errcode;
-        ctx->Final_Op_Flag = Qc3_Final;
-        set_EC_length(errcode, sizeof(errcode));
-        Qc3CalculateHash(&data, &zero, Qc3_Data, (char *)ctx, Qc3_Alg_Token,
-                         anycsp, NULL, (char *)out, &errcode);
-        ret = errcode.Bytes_Available ? 0 : 1;
-    }
+
+    ctx->Final_Op_Flag = Qc3_Final;
+    set_EC_length(errcode, sizeof(errcode));
+    Qc3CalculateHash(&data, &zero, Qc3_Data, (char *)ctx, Qc3_Alg_Token,
+                     anycsp, NULL, (char *)out, &errcode);
     Qc3DestroyAlgorithmContext(ctx->Alg_Context_Token, (char *)&ecnull);
     memset(ctx->Alg_Context_Token, 0, sizeof(ctx->Alg_Context_Token));
-    return ret;
+    return errcode.Bytes_Available ? 0 : 1;
 }
 
 static int os400qc3_hmac_init(struct os400qc3_crypto_ctx *ctx,

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -948,20 +948,20 @@ int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,
 int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx,
                              unsigned char *out, size_t outlen)
 {
-    char data;
-    Qus_EC_t errcode;
+    int ret = 0;
     (void)outlen;
-
-    if(!out)
-        return 0;
-
-    ctx->Final_Op_Flag = Qc3_Final;
-    set_EC_length(errcode, sizeof(errcode));
-    Qc3CalculateHash(&data, &zero, Qc3_Data, (char *)ctx, Qc3_Alg_Token,
-                     anycsp, NULL, (char *)out, &errcode);
+    if(out) {
+        char data;
+        Qus_EC_t errcode;
+        ctx->Final_Op_Flag = Qc3_Final;
+        set_EC_length(errcode, sizeof(errcode));
+        Qc3CalculateHash(&data, &zero, Qc3_Data, (char *)ctx, Qc3_Alg_Token,
+                         anycsp, NULL, (char *)out, &errcode);
+        ret = errcode.Bytes_Available ? 0 : 1;
+    }
     Qc3DestroyAlgorithmContext(ctx->Alg_Context_Token, (char *)&ecnull);
     memset(ctx->Alg_Context_Token, 0, sizeof(ctx->Alg_Context_Token));
-    return errcode.Bytes_Available ? 0 : 1;
+    return ret;
 }
 
 static int os400qc3_hmac_init(struct os400qc3_crypto_ctx *ctx,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -761,7 +761,7 @@ int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
 {
     int ret = 0;
 
-    if(hash && hashlen >= ctx->cbHash &&
+    if(hashlen >= ctx->cbHash &&
        BCRYPT_SUCCESS(BCryptFinishHash(ctx->hHash, hash, ctx->cbHash, 0)))
         ret = 1;
 


### PR DESCRIPTION
It was only 5 callers (in hostkey.c) using this feature at the end, and
those can easily do the calculation instead. To keep things simple.

Follow-up to e006aa58accc6b4be19041a77986eb5dd213efe0 #2226

---

Otherwise both mbedtls and os400c3 would also need fixes. They're
in two subcommits of this PR.