### PR TITLE
tidy-up: syntax nits and code layout

### DIFF
--- a/docs/HACKING-CRYPTO
+++ b/docs/HACKING-CRYPTO
@@ -612,7 +612,7 @@ This procedure is already prototyped in crypto.h.
 int ssh2_rsa_sha1_signv(LIBSSH2_SESSION *session,
                         unsigned char **sig, size_t *siglen,
                         int count, const struct iovec vector[],
-                        ssh2_rsa_ctx *ctx);
+                        ssh2_rsa_ctx *rsa);
 RSA signs the SHA-1 hash computed over the count data chunks in vector.
 Signature is stored at (sig, siglen).
 Signature buffer must be allocated from the given session.
@@ -620,7 +620,7 @@ Returns 0 if OK, else -1.
 Note: this procedure is optional: if provided, it MUST be defined as a macro.
 
 int ssh2_rsa_sha1_sign(LIBSSH2_SESSION *session,
-                       ssh2_rsa_ctx *rsactx,
+                       ssh2_rsa_ctx *ctx,
                        const unsigned char *hash,
                        size_t hash_len,
                        unsigned char **signature,
@@ -632,15 +632,15 @@ Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 Note: this procedure is not used if macro ssh2_rsa_sha1_signv() is defined.
 
-void ssh2_rsa_free(ssh2_rsa_ctx *rsactx);
-Releases the RSA computation context at rsactx.
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
+Releases the RSA computation context at ctx.
 
 LIBSSH2_RSA_SHA2
 #define as 1 if the crypto library supports RSA SHA2 256/512, else 0.
 If defined as 0, the rest of this section can be omitted.
 
 int ssh2_rsa_sha2_sign(LIBSSH2_SESSION *session,
-                       ssh2_rsa_ctx *rsactx,
+                       ssh2_rsa_ctx *ctx,
                        const unsigned char *hash,
                        size_t hash_len,
                        unsigned char **signature,
@@ -656,7 +656,7 @@ and ssh2_rsa_sha2_512_signv are defined.
 int ssh2_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
                             unsigned char **sig, size_t *siglen,
                             int count, const struct iovec vector[],
-                            ssh2_rsa_ctx *ctx);
+                            ssh2_rsa_ctx *rsa);
 RSA signs the SHA-256 hash computed over the count data chunks in vector.
 Signature is stored at (sig, siglen).
 Signature buffer must be allocated from the given session.
@@ -666,7 +666,7 @@ Note: this procedure is optional: if provided, it MUST be defined as a macro.
 int ssh2_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
                             unsigned char **sig, size_t *siglen,
                             int count, const struct iovec vector[],
-                            ssh2_rsa_ctx *ctx);
+                            ssh2_rsa_ctx *rsa);
 RSA signs the SHA-512 hash computed over the count data chunks in vector.
 Signature is stored at (sig, siglen).
 Signature buffer must be allocated from the given session.
@@ -725,7 +725,7 @@ Must call ssh2_init_if_needed().
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsactx,
+int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len);
 Verify (sig, siglen) signature of (m, m_len) using an SHA-1 hash and the
@@ -733,14 +733,14 @@ DSA context.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsactx,
+int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
                        const unsigned char *hash,
                        size_t hash_len, unsigned char *sig);
 DSA signs the (hash, hash_len) data using SHA-1 and store the signature at sig.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-void ssh2_dsa_free(ssh2_dsa_ctx *dsactx);
+void ssh2_dsa_free(ssh2_dsa_ctx *dsa);
 Releases the DSA computation context at dsactx.
 
 7.3) ECDSA
@@ -795,7 +795,7 @@ Must call ssh2_init_if_needed().
 Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ecdsactx,
+int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
                                          const unsigned char *k,
                                          size_t k_len,
                                          ssh2_curve_type type);
@@ -824,7 +824,7 @@ Signature buffer must be allocated from the given session.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ctx,
+int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
                       const unsigned char *r, size_t r_len,
                       const unsigned char *s, size_t s_len,
                       const unsigned char *m, size_t m_len);
@@ -833,7 +833,7 @@ using the hash algorithm configured in the ECDSA context ctx.
 Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ecdsactx);
+ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx);
 Returns the curve type associated with given context.
 This procedure is already prototyped in crypto.h.
 
@@ -845,7 +845,7 @@ Return 0 if OK, else -1.
 Currently used only from openssl backend (ought to be private).
 This procedure is already prototyped in crypto.h.
 
-void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ecdsactx);
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx);
 Releases the ECDSA computation context at ecdsactx.
 
 7.4) ED25519
@@ -856,7 +856,7 @@ If defined as 0, the rest of this section can be omitted.
 ssh2_ed25519_ctx
 Type of an ED25519 computation context. Generally a struct.
 
-int ssh2_curve25519_new(LIBSSH2_SESSION *session, ssh2_ed25519_ctx **ctx,
+int ssh2_curve25519_new(LIBSSH2_SESSION *session,
                         uint8_t **out_public_key,
                         uint8_t **out_private_key);
 Generates an ED25519 key pair, stores a pointer to them at out_private_key
@@ -898,7 +898,7 @@ Must call ssh2_init_if_needed().
 Return 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int ssh2_ed25519_sign(ssh2_ed25519_ctx *ctx, LIBSSH2_SESSION *session,
+int ssh2_ed25519_sign(ssh2_ed25519_ctx *ed_ctx, LIBSSH2_SESSION *session,
                       uint8_t **out_sig, size_t *out_sig_len,
                       const uint8_t *message, size_t message_len);
 ED25519 signs the (message, message_len) bytes and stores the allocated
@@ -907,7 +907,7 @@ Signature buffer is allocated from the given session.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-int ssh2_ed25519_verify(ssh2_ed25519_ctx *ctx, const uint8_t *s,
+int ssh2_ed25519_verify(ssh2_ed25519_ctx *ed_ctx, const uint8_t *s,
                         size_t s_len, const uint8_t *m, size_t m_len);
 Verify (s, s_len) signature of (m, m_len) using the given ED25519 context.
 Return 0 if OK, else -1.
@@ -922,8 +922,8 @@ have been initialized before calling this function.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in crypto.h.
 
-void ssh2_ed25519_free(ssh2_ed25519_ctx *ed25519ctx);
-Releases the ED25519 computation context at ed25519ctx.
+void ssh2_ed25519_free(ssh2_ed25519_ctx *ed_ctx);
+Releases the ED25519 computation context at ed_ctx.
 
 8) Miscellaneous
 

--- a/src/cipher-chachapoly.c
+++ b/src/cipher-chachapoly.c
@@ -24,7 +24,15 @@
 #include "misc.h"
 #include "cipher-chachapoly.h"
 
-int chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n);
+static int chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n)
+{
+    const unsigned char *p1 = b1, *p2 = b2;
+    int ret = 0;
+
+    for(; n > 0; n--)
+        ret |= *p1++ ^ *p2++;
+    return ret != 0;
+}
 
 int chachapoly_init(struct chachapoly_ctx *ctx, const unsigned char *key,
                     size_t keylen)
@@ -117,14 +125,4 @@ int chachapoly_get_length(struct chachapoly_ctx *ctx, unsigned int *plenp,
     chacha_encrypt_bytes(&ctx->header_ctx, cp, buf, 4);
     *plenp = ssh2_ntohu32(buf);
     return 0;
-}
-
-int chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n)
-{
-    const unsigned char *p1 = b1, *p2 = b2;
-    int ret = 0;
-
-    for(; n > 0; n--)
-        ret |= *p1++ ^ *p2++;
-    return ret != 0;
 }

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -227,7 +227,8 @@ int ssh2_curve25519_gen_k(
     uint8_t private_key[SSH2_ED25519_KEY_LEN],
     uint8_t server_public_key[SSH2_ED25519_KEY_LEN]);
 
-int ssh2_curve25519_new(LIBSSH2_SESSION *session, uint8_t **out_public_key,
+int ssh2_curve25519_new(LIBSSH2_SESSION *session,
+                        uint8_t **out_public_key,
                         uint8_t **out_private_key);
 
 int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -733,11 +733,11 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
     if(ssh2_get_string(&buf, &type_str, &len) || len != 19)
         return -1;
 
-    if(!strncmp((char *)type_str, "ecdsa-sha2-nistp256", 19))
+    if(!strncmp((const char *)type_str, "ecdsa-sha2-nistp256", 19))
         type = SSH2_EC_CURVE_NISTP256;
-    else if(!strncmp((char *)type_str, "ecdsa-sha2-nistp384", 19))
+    else if(!strncmp((const char *)type_str, "ecdsa-sha2-nistp384", 19))
         type = SSH2_EC_CURVE_NISTP384;
-    else if(!strncmp((char *)type_str, "ecdsa-sha2-nistp521", 19))
+    else if(!strncmp((const char *)type_str, "ecdsa-sha2-nistp521", 19))
         type = SSH2_EC_CURVE_NISTP521;
     else
         return -1;
@@ -746,13 +746,13 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
         return -1;
 
     if(type == SSH2_EC_CURVE_NISTP256 &&
-       strncmp((char *)domain, "nistp256", 8))
+       strncmp((const char *)domain, "nistp256", 8))
         return -1;
     else if(type == SSH2_EC_CURVE_NISTP384 &&
-            strncmp((char *)domain, "nistp384", 8))
+            strncmp((const char *)domain, "nistp384", 8))
         return -1;
     else if(type == SSH2_EC_CURVE_NISTP521 &&
-            strncmp((char *)domain, "nistp521", 8))
+            strncmp((const char *)domain, "nistp521", 8))
         return -1;
 
     /* public key */

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -50,8 +50,21 @@
  * ssh-rsa *
  ********* */
 
+/*
+ * Shutdown the hostkey
+ */
 static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
-                                       void **abstract);
+                                       void **abstract)
+{
+    ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
+    (void)session;
+
+    ssh2_rsa_free(rsactx);
+
+    *abstract = NULL;
+
+    return 0;
+}
 
 /*
  * Initialize the server hostkey working area with e/n pair
@@ -213,7 +226,6 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
                                         void **abstract)
 {
     ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
-
 #ifdef ssh2_rsa_sha1_signv
     return ssh2_rsa_sha1_signv(session, signature, signature_len,
                                veccount, datavec, rsactx);
@@ -242,13 +254,12 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     return 0;
 #endif
 }
-#endif
+#endif /* LIBSSH2_RSA_SHA1 */
 
+#if LIBSSH2_RSA_SHA2
 /*
  * Verify signature created by remote
  */
-#if LIBSSH2_RSA_SHA2
-
 static int hostkey_method_ssh_rsa_sha2_256_sig_verify(
     LIBSSH2_SESSION *session,
     const unsigned char *sig,
@@ -281,7 +292,6 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
                                                  void **abstract)
 {
     ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
-
 #ifdef ssh2_rsa_sha2_256_signv
     return ssh2_rsa_sha2_256_signv(session, signature, signature_len,
                                    veccount, datavec, rsactx);
@@ -346,7 +356,6 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
                                                  void **abstract)
 {
     ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
-
 #ifdef ssh2_rsa_sha2_512_signv
     return ssh2_rsa_sha2_512_signv(session, signature, signature_len,
                                    veccount, datavec, rsactx);
@@ -375,27 +384,9 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     return 0;
 #endif
 }
-
 #endif /* LIBSSH2_RSA_SHA2 */
 
-/*
- * Shutdown the hostkey
- */
-static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
-                                       void **abstract)
-{
-    ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
-    (void)session;
-
-    ssh2_rsa_free(rsactx);
-
-    *abstract = NULL;
-
-    return 0;
-}
-
 #if LIBSSH2_RSA_SHA1
-
 static const struct hostkey_method hostkey_method_ssh_rsa = {
     "ssh-rsa",
     SSH2_SHA1_DIG_LEN,
@@ -407,11 +398,8 @@ static const struct hostkey_method hostkey_method_ssh_rsa = {
     NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
-
 #endif /* LIBSSH2_RSA_SHA1 */
-
 #if LIBSSH2_RSA_SHA2
-
 static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256 = {
     "rsa-sha2-256",
     SSH2_SHA256_DIG_LEN,
@@ -435,11 +423,8 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512 = {
     NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
-
 #endif /* LIBSSH2_RSA_SHA2 */
-
 #if LIBSSH2_RSA_SHA1
-
 static const struct hostkey_method hostkey_method_ssh_rsa_cert = {
     "ssh-rsa-cert-v01@openssh.com",
     SSH2_SHA1_DIG_LEN,
@@ -451,11 +436,8 @@ static const struct hostkey_method hostkey_method_ssh_rsa_cert = {
     NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
-
 #endif /* LIBSSH2_RSA_SHA1 */
-
 #if LIBSSH2_RSA_SHA2
-
 static const struct hostkey_method hostkey_method_ssh_rsa_sha2_256_cert = {
     "rsa-sha2-256-cert-v01@openssh.com",
     SSH2_SHA256_DIG_LEN,
@@ -479,9 +461,7 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512_cert = {
     NULL, /* encrypt */
     hostkey_method_ssh_rsa_dtor,
 };
-
 #endif /* LIBSSH2_RSA_SHA2 */
-
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
@@ -489,8 +469,21 @@ static const struct hostkey_method hostkey_method_ssh_rsa_sha2_512_cert = {
  * ssh-dss *
  ********* */
 
+/*
+ * Shutdown the hostkey method
+ */
 static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
-                                       void **abstract);
+                                       void **abstract)
+{
+    ssh2_dsa_ctx *dsactx = (ssh2_dsa_ctx *)(*abstract);
+    (void)session;
+
+    ssh2_dsa_free(dsactx);
+
+    *abstract = NULL;
+
+    return 0;
+}
 
 /*
  * Initialize the server hostkey working area with p/q/g/y set
@@ -673,22 +666,6 @@ cleanup:
     return ret;
 }
 
-/*
- * Shutdown the hostkey method
- */
-static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
-                                       void **abstract)
-{
-    ssh2_dsa_ctx *dsactx = (ssh2_dsa_ctx *)(*abstract);
-    (void)session;
-
-    ssh2_dsa_free(dsactx);
-
-    *abstract = NULL;
-
-    return 0;
-}
-
 static const struct hostkey_method hostkey_method_ssh_dss = {
     "ssh-dss",
     SSH2_SHA1_DIG_LEN,
@@ -708,8 +685,22 @@ static const struct hostkey_method hostkey_method_ssh_dss = {
  * ecdsa-sha2-nistp256/384/521 *
  ***************************** */
 
+/*
+ * Shutdown the hostkey by freeing EC_KEY context
+ */
 static int hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
-                                         void **abstract);
+                                         void **abstract)
+{
+    ssh2_ecdsa_ctx *keyctx = (ssh2_ecdsa_ctx *)(*abstract);
+    (void)session;
+
+    if(keyctx)
+        ssh2_ecdsa_free(keyctx);
+
+    *abstract = NULL;
+
+    return 0;
+}
 
 /*
  * Initialize the server hostkey working area with e/n pair
@@ -926,23 +917,6 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
                            signature, signature_len);
 }
 
-/*
- * Shutdown the hostkey by freeing EC_KEY context
- */
-static int hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
-                                         void **abstract)
-{
-    ssh2_ecdsa_ctx *keyctx = (ssh2_ecdsa_ctx *)(*abstract);
-    (void)session;
-
-    if(keyctx)
-        ssh2_ecdsa_free(keyctx);
-
-    *abstract = NULL;
-
-    return 0;
-}
-
 static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp256 = {
     "ecdsa-sha2-nistp256",
     SSH2_SHA256_DIG_LEN,
@@ -1023,8 +997,22 @@ static const struct hostkey_method hostkey_method_ecdsa_ssh_nistp521_cert = {
  * ed25519 *
  ********* */
 
+/*
+ * Shutdown the hostkey by freeing key context
+ */
 static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
-                                           void **abstract);
+                                           void **abstract)
+{
+    ssh2_ed25519_ctx *keyctx = (ssh2_ed25519_ctx *)(*abstract);
+    (void)session;
+
+    if(keyctx)
+        ssh2_ed25519_free(keyctx);
+
+    *abstract = NULL;
+
+    return 0;
+}
 
 /*
  * Initialize the server hostkey working area with e/n pair
@@ -1225,23 +1213,6 @@ static int hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
     return ssh2_ed25519_sign(ctx, session, signature, signature_len,
                              (const uint8_t *)datavec[0].iov_base,
                              datavec[0].iov_len);
-}
-
-/*
- * Shutdown the hostkey by freeing key context
- */
-static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
-                                           void **abstract)
-{
-    ssh2_ed25519_ctx *keyctx = (ssh2_ed25519_ctx *)(*abstract);
-    (void)session;
-
-    if(keyctx)
-        ssh2_ed25519_free(keyctx);
-
-    *abstract = NULL;
-
-    return 0;
 }
 
 static const struct hostkey_method hostkey_method_ssh_ed25519 = {

--- a/src/kex.c
+++ b/src/kex.c
@@ -649,10 +649,10 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
         }
         if(session->local.banner) {
             ssh2_htonu32(exchange_state->h_sig_comp,
-                (uint32_t)(strlen((char *)session->local.banner) - 2));
+                (uint32_t)(strlen((const char *)session->local.banner) - 2));
             hok &= ssh2_hash_update(*ctx, exchange_state->h_sig_comp, 4);
             hok &= ssh2_hash_update(*ctx, session->local.banner,
-                                    strlen((char *)session->local.banner) - 2);
+                              strlen((const char *)session->local.banner) - 2);
         }
         else {
             ssh2_htonu32(exchange_state->h_sig_comp,
@@ -663,10 +663,10 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
         }
 
         ssh2_htonu32(exchange_state->h_sig_comp,
-                     (uint32_t)strlen((char *)session->remote.banner));
+                     (uint32_t)strlen((const char *)session->remote.banner));
         hok &= ssh2_hash_update(*ctx, exchange_state->h_sig_comp, 4);
         hok &= ssh2_hash_update(*ctx, session->remote.banner,
-                                      strlen((char *)session->remote.banner));
+                                 strlen((const char *)session->remote.banner));
 
         ssh2_htonu32(exchange_state->h_sig_comp,
                      (uint32_t)session->local.kexinit_len);
@@ -1479,10 +1479,10 @@ static int kex_method_ec_sha_hash_create_verify(
 
     if(session->local.banner) {
         ssh2_htonu32(exchange_state->h_sig_comp,
-                     (uint32_t)(strlen((char *)session->local.banner) - 2));
+                  (uint32_t)(strlen((const char *)session->local.banner) - 2));
         hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
         hok &= ssh2_hash_update(ctx, session->local.banner,
-                                strlen((char *)session->local.banner) - 2);
+                              strlen((const char *)session->local.banner) - 2);
     }
     else {
         ssh2_htonu32(exchange_state->h_sig_comp,
@@ -1493,10 +1493,10 @@ static int kex_method_ec_sha_hash_create_verify(
     }
 
     ssh2_htonu32(exchange_state->h_sig_comp,
-                 (uint32_t)strlen((char *)session->remote.banner));
+                 (uint32_t)strlen((const char *)session->remote.banner));
     hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
     hok &= ssh2_hash_update(ctx, session->remote.banner,
-                            strlen((char *)session->remote.banner));
+                            strlen((const char *)session->remote.banner));
 
     ssh2_htonu32(exchange_state->h_sig_comp,
                  (uint32_t)session->local.kexinit_len);
@@ -3259,7 +3259,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session,
 
         while(s && *s) {
             unsigned char *p = (unsigned char *)strchr((char *)s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
+            size_t method_len = p ? (size_t)(p - s) : strlen((const char *)s);
             if(ssh2_kex_agree_instr(hostkey, hostkey_len, s, method_len)) {
                 const struct hostkey_method *method =
                     (const struct hostkey_method *)kex_get_method_by_name(
@@ -3336,7 +3336,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
 
         while(s && *s) {
             unsigned char *q, *p = (unsigned char *)strchr((char *)s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
+            size_t method_len = p ? (size_t)(p - s) : strlen((const char *)s);
             q = ssh2_kex_agree_instr(kex, kex_len, s, method_len);
             if(q) {
                 const struct kex_method *method =
@@ -3411,7 +3411,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION *session,
 
         while(s && *s) {
             unsigned char *p = (unsigned char *)strchr((char *)s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
+            size_t method_len = p ? (size_t)(p - s) : strlen((const char *)s);
 
             if(ssh2_kex_agree_instr(crypt, crypt_len, s, method_len)) {
                 const struct crypt_method *method =
@@ -3470,7 +3470,7 @@ static int kex_agree_mac(LIBSSH2_SESSION *session,
 
         while(s && *s) {
             unsigned char *p = (unsigned char *)strchr((char *)s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
+            size_t method_len = p ? (size_t)(p - s) : strlen((const char *)s);
 
             if(ssh2_kex_agree_instr(mac, mac_len, s, method_len)) {
                 const struct mac_method *method =
@@ -3520,7 +3520,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
 
         while(s && *s) {
             unsigned char *p = (unsigned char *)strchr((char *)s, ',');
-            size_t method_len = (p ? (size_t)(p - s) : strlen((char *)s));
+            size_t method_len = p ? (size_t)(p - s) : strlen((const char *)s);
 
             if(ssh2_kex_agree_instr(comp, comp_len, s, method_len)) {
                 const struct comp_method *method =

--- a/src/kex.c
+++ b/src/kex.c
@@ -3203,7 +3203,7 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
     left = end_haystack - s;
 
     /* Needle at start of haystack */
-    if(!strncmp((char *)haystack, (const char *)needle, needle_len) &&
+    if(!strncmp((const char *)haystack, (const char *)needle, needle_len) &&
        (needle_len == haystack_len || haystack[needle_len] == ','))
         return haystack;
 
@@ -3221,7 +3221,7 @@ unsigned char *ssh2_kex_agree_instr(unsigned char *haystack,
             return NULL;
 
         /* Needle at X position */
-        if(!strncmp((char *)s, (const char *)needle, needle_len) &&
+        if(!strncmp((const char *)s, (const char *)needle, needle_len) &&
            (((s - haystack) + needle_len) == haystack_len ||
             s[needle_len] == ','))
             return s;

--- a/src/kex.c
+++ b/src/kex.c
@@ -118,8 +118,7 @@ static int kex_proc_hostkey(LIBSSH2_SESSION *session, struct string_buf *buf,
         session->server_hostkey_len = 0;
     }
 
-    if(ssh2_copy_string(session, buf, &(session->server_hostkey),
-                        &host_key_len))
+    if(ssh2_copy_string(session, buf, &session->server_hostkey, &host_key_len))
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                         "Could not copy host key");
 
@@ -583,8 +582,8 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
         if(ret)
             goto clean_exit;
 
-        if(ssh2_get_string(&buf, &(exchange_state->f_value),
-                           &(exchange_state->f_value_len))) {
+        if(ssh2_get_string(&buf, &exchange_state->f_value,
+                           &exchange_state->f_value_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Unable to get DH-SHA f value");
             goto clean_exit;
@@ -598,8 +597,8 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
             goto clean_exit;
         }
 
-        if(ssh2_get_string(&buf, &(exchange_state->h_sig),
-                           &(exchange_state->h_sig_len))) {
+        if(ssh2_get_string(&buf, &exchange_state->h_sig,
+                           &exchange_state->h_sig_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Unable to get DH-SHA h sig");
             goto clean_exit;
@@ -1682,7 +1681,7 @@ static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
 
         /* server signature */
         if(ssh2_get_string(&buf, &exchange_state->h_sig,
-                           &(exchange_state->h_sig_len))) {
+                           &exchange_state->h_sig_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Unexpected ECDH server sig length");
             goto clean_exit;
@@ -1992,7 +1991,7 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
 
         /* server signature */
         if(ssh2_get_string(&buf, &exchange_state->h_sig,
-                           &(exchange_state->h_sig_len))) {
+                           &exchange_state->h_sig_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Unexpected mlkemnistp server sig length");
             goto clean_exit;
@@ -2311,7 +2310,7 @@ static int kex_curve25519_sha256(
 
         /* server signature */
         if(ssh2_get_string(&buf, &exchange_state->h_sig,
-                           &(exchange_state->h_sig_len))) {
+                           &exchange_state->h_sig_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Unexpected curve25519 server sig length");
             goto clean_exit;
@@ -2597,7 +2596,7 @@ static int kex_mlkem768x25519_sha256(
 
         /* server signature */
         if(ssh2_get_string(&buf, &exchange_state->h_sig,
-                           &(exchange_state->h_sig_len))) {
+                           &exchange_state->h_sig_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Unexpected mlkem768x25519 server sig length");
             goto clean_exit;

--- a/src/misc.c
+++ b/src/misc.c
@@ -861,7 +861,7 @@ int ssh2_match_string(struct string_buf *buf, const char *match)
     unsigned char *out;
     size_t len = 0;
     if(ssh2_get_string(buf, &out, &len) || len != strlen(match) ||
-       strncmp((char *)out, match, strlen(match)))
+       strncmp((const char *)out, match, strlen(match)))
         return -1;
     return 0;
 }

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -301,8 +301,8 @@ typedef enum {
 #endif /* LIBSSH2_ECDSA */
 
 #if LIBSSH2_ED25519
-#define ssh2_ed25519_ctx       EVP_PKEY
-#define ssh2_ed25519_free(ctx) EVP_PKEY_free(ctx)
+#define ssh2_ed25519_ctx          EVP_PKEY
+#define ssh2_ed25519_free(ed_ctx) EVP_PKEY_free(ed_ctx)
 #endif /* LIBSSH2_ED25519 */
 
 #define SSH2_CIPHER_T(name) const EVP_CIPHER *(*(name))(void)

--- a/src/packet.c
+++ b/src/packet.c
@@ -89,29 +89,29 @@ static SSH2_INLINE int packet_queue_listener(
 
         buf.dataptr += offset;
 
-        if(ssh2_get_u32(&buf, &(listen_state->sender_channel)))
+        if(ssh2_get_u32(&buf, &listen_state->sender_channel))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting channel");
-        if(ssh2_get_u32(&buf, &(listen_state->initial_window_size)))
+        if(ssh2_get_u32(&buf, &listen_state->initial_window_size))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting window size");
-        if(ssh2_get_u32(&buf, &(listen_state->packet_size)))
+        if(ssh2_get_u32(&buf, &listen_state->packet_size))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting packet");
-        if(ssh2_get_string(&buf, &(listen_state->host), &temp_len))
+        if(ssh2_get_string(&buf, &listen_state->host, &temp_len))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting host");
         listen_state->host_len = (uint32_t)temp_len;
 
-        if(ssh2_get_u32(&buf, &(listen_state->port)))
+        if(ssh2_get_u32(&buf, &listen_state->port))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting port");
-        if(ssh2_get_string(&buf, &(listen_state->shost), &temp_len))
+        if(ssh2_get_string(&buf, &listen_state->shost, &temp_len))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting shost");
         listen_state->shost_len = (uint32_t)temp_len;
 
-        if(ssh2_get_u32(&buf, &(listen_state->sport)))
+        if(ssh2_get_u32(&buf, &listen_state->sport))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting sport");
 
@@ -289,18 +289,18 @@ static SSH2_INLINE int packet_x11_open(
 
         buf.dataptr += offset;
 
-        if(ssh2_get_u32(&buf, &(x11open_state->sender_channel))) {
+        if(ssh2_get_u32(&buf, &x11open_state->sender_channel)) {
             ssh2_err(session, LIBSSH2_ERROR_INVAL,
                      "unexpected sender channel size");
             failure_code = SSH_OPEN_CONNECT_FAILED;
             goto x11_exit;
         }
-        if(ssh2_get_u32(&buf, &(x11open_state->initial_window_size))) {
+        if(ssh2_get_u32(&buf, &x11open_state->initial_window_size)) {
             ssh2_err(session, LIBSSH2_ERROR_INVAL, "unexpected window size");
             failure_code = SSH_OPEN_CONNECT_FAILED;
             goto x11_exit;
         }
-        if(ssh2_get_u32(&buf, &(x11open_state->packet_size))) {
+        if(ssh2_get_u32(&buf, &x11open_state->packet_size)) {
             ssh2_err(session, LIBSSH2_ERROR_INVAL, "unexpected packet size");
             failure_code = SSH_OPEN_CONNECT_FAILED;
             goto x11_exit;
@@ -323,7 +323,7 @@ static SSH2_INLINE int packet_x11_open(
         memcpy(x11open_state->shost, temp_buf, x11open_state->shost_len);
         x11open_state->shost[x11open_state->shost_len] = '\0';
 
-        if(ssh2_get_u32(&buf, &(x11open_state->sport))) {
+        if(ssh2_get_u32(&buf, &x11open_state->sport)) {
             ssh2_err(session, LIBSSH2_ERROR_INVAL, "unexpected port size");
             failure_code = SSH_OPEN_CONNECT_FAILED;
             goto x11_exit;
@@ -471,13 +471,13 @@ static SSH2_INLINE int packet_authagent_open(
     buf.dataptr += offset;
 
     if(authagent_state->state == ssh2_NB_state_idle) {
-        if(ssh2_get_u32(&buf, &(authagent_state->sender_channel)))
+        if(ssh2_get_u32(&buf, &authagent_state->sender_channel))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting channel");
-        if(ssh2_get_u32(&buf, &(authagent_state->initial_window_size)))
+        if(ssh2_get_u32(&buf, &authagent_state->initial_window_size))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting window size");
-        if(ssh2_get_u32(&buf, &(authagent_state->packet_size)))
+        if(ssh2_get_u32(&buf, &authagent_state->packet_size))
             return ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                             "Data too short extracting packet");
 

--- a/src/scp.c
+++ b/src/scp.c
@@ -310,7 +310,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                       session->scpRecv_command_len,
                       "scp -%sf ", sb ? "p" : "");
 
-        cmd_len = strlen((char *)session->scpRecv_command);
+        cmd_len = strlen((const char *)session->scpRecv_command);
 
         if(!session->flag.quote_paths) {
             size_t path_len;
@@ -853,7 +853,7 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
                       session->scpSend_command_len,
                       "scp -%st ", (mtime || atime) ? "p" : "");
 
-        cmd_len = strlen((char *)session->scpSend_command);
+        cmd_len = strlen((const char *)session->scpSend_command);
 
         if(!session->flag.quote_paths) {
             size_t path_len;

--- a/src/session.c
+++ b/src/session.c
@@ -202,7 +202,7 @@ static int session_banner_send(LIBSSH2_SESSION *session)
     if(session->banner_TxRx_state == ssh2_NB_state_idle) {
         if(session->local.banner) {
             /* setopt_string has given us our \r\n characters */
-            banner_len = strlen((char *)session->local.banner);
+            banner_len = strlen((const char *)session->local.banner);
             banner = (char *)session->local.banner;
         }
 #ifdef LIBSSH2DEBUG

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -670,7 +670,7 @@ static ssize_t sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs,
     attrs->flags = flags;
 
     if(attrs->flags & LIBSSH2_SFTP_ATTR_SIZE) {
-        if(ssh2_get_u64(&buf, &(attrs->filesize)))
+        if(ssh2_get_u64(&buf, &attrs->filesize))
             return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
     }
 
@@ -921,7 +921,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
     buf.len = data_len;
     endp = &buf.data[data_len];
 
-    if(ssh2_get_u32(&buf, &(sftp_handle->version))) {
+    if(ssh2_get_u32(&buf, &sftp_handle->version)) {
         SSH2_FREE(session, data);
         ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                  "Data too short when extracting version");


### PR DESCRIPTION
- hostkey: move static functions to avoid forward declarations.
- drop redundant parentheses.
- add `const` to `strncmp()`, `strlen()` argument casts.
- cipher-chachapoly: make `chachapoly_timingsafe_bcmp()` static.
- HACKING-CRYPTO: update argument names.
  Follow-up to db0d10736af3229888e377819a36dd3a75f29314 #2195
- fix minor nits around.
