### PR TITLE
hash: pass through context as-is in `ssh2_hash_*()` macros

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -230,15 +230,15 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA1_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_hash_init(ctx, SSH2_SHA1_ALG))
+    if(!ssh2_hash_init(&ctx, SSH2_SHA1_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
+        if(!ssh2_hash_update(&ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(&ctx, hash, sizeof(hash));
             return -1;
         }
     }
-    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(&ctx, hash, sizeof(hash)))
         return -1;
 
     if(ssh2_rsa_sha1_sign(session, rsactx, hash, SSH2_SHA1_DIG_LEN,
@@ -294,15 +294,15 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA256_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_hash_init(ctx, SSH2_SHA256_ALG))
+    if(!ssh2_hash_init(&ctx, SSH2_SHA256_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
+        if(!ssh2_hash_update(&ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(&ctx, hash, sizeof(hash));
             return -1;
         }
     }
-    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(&ctx, hash, sizeof(hash)))
         return -1;
 
     if(ssh2_rsa_sha2_sign(session, rsactx, hash, SSH2_SHA256_DIG_LEN,
@@ -356,15 +356,15 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA512_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_hash_init(ctx, SSH2_SHA512_ALG))
+    if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
+        if(!ssh2_hash_update(&ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(&ctx, hash, sizeof(hash));
             return -1;
         }
     }
-    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(&ctx, hash, sizeof(hash)))
         return -1;
 
     if(ssh2_rsa_sha2_sign(session, rsactx, hash, SSH2_SHA512_DIG_LEN,
@@ -626,15 +626,15 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
 
     *signature_len = 2 * SSH2_SHA1_DIG_LEN;
 
-    if(!ssh2_hash_init(ctx, SSH2_SHA1_ALG))
+    if(!ssh2_hash_init(&ctx, SSH2_SHA1_ALG))
         goto cleanup;
     for(i = 0; i < veccount; i++) {
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
+        if(!ssh2_hash_update(&ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(&ctx, hash, sizeof(hash));
             goto cleanup;
         }
     }
-    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(&ctx, hash, sizeof(hash)))
         goto cleanup;
 
     if(ssh2_dsa_sha1_sign(dsactx, hash, SSH2_SHA1_DIG_LEN, *signature))
@@ -883,16 +883,16 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
     else
         return -1;
 
-    if(!ssh2_hash_init(ctx, hash_alg))
+    if(!ssh2_hash_init(&ctx, hash_alg))
         return -1;
 
     for(i = 0; i < veccount; i++)
-        if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
-            (void)ssh2_hash_final(ctx, hash, sizeof(hash));
+        if(!ssh2_hash_update(&ctx, datavec[i].iov_base, datavec[i].iov_len)) {
+            (void)ssh2_hash_final(&ctx, hash, sizeof(hash));
             return -1;
         }
 
-    if(!ssh2_hash_final(ctx, hash, sizeof(hash)))
+    if(!ssh2_hash_final(&ctx, hash, sizeof(hash)))
         return -1;
 
     return ssh2_ecdsa_sign(session, ec_ctx, hash, hash_len,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -230,7 +230,7 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA1_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_hash_init(&ctx, SSH2_SHA1_ALG))
+    if(!ssh2_hash_init(ctx, SSH2_SHA1_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
@@ -294,7 +294,7 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA256_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_hash_init(&ctx, SSH2_SHA256_ALG))
+    if(!ssh2_hash_init(ctx, SSH2_SHA256_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
@@ -356,7 +356,7 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
     unsigned char hash[SSH2_SHA512_DIG_LEN];
     ssh2_hash_ctx ctx;
 
-    if(!ssh2_hash_init(&ctx, SSH2_SHA512_ALG))
+    if(!ssh2_hash_init(ctx, SSH2_SHA512_ALG))
         return -1;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
@@ -626,7 +626,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
 
     *signature_len = 2 * SSH2_SHA1_DIG_LEN;
 
-    if(!ssh2_hash_init(&ctx, SSH2_SHA1_ALG))
+    if(!ssh2_hash_init(ctx, SSH2_SHA1_ALG))
         goto cleanup;
     for(i = 0; i < veccount; i++) {
         if(!ssh2_hash_update(ctx, datavec[i].iov_base, datavec[i].iov_len)) {
@@ -883,7 +883,7 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
     else
         return -1;
 
-    if(!ssh2_hash_init(&ctx, hash_alg))
+    if(!ssh2_hash_init(ctx, hash_alg))
         return -1;
 
     for(i = 0; i < veccount; i++)

--- a/src/kex.c
+++ b/src/kex.c
@@ -64,7 +64,7 @@ static void kex_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
         size_t len = 0;
         while(len < data_len) {
             ssh2_hash_ctx ctx;
-            int hok = ssh2_hash_init(&ctx, hash_alg);
+            int hok = ssh2_hash_init(ctx, hash_alg);
             if(hok) {
                 hok &= ssh2_hash_update(ctx, exchange_state->k_value,
                                         exchange_state->k_value_len);
@@ -640,7 +640,7 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
             }
         }
 
-        hok = ssh2_hash_init(&ctx, hash_alg);
+        hok = ssh2_hash_init(ctx, hash_alg);
         if(!hok) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                            "Unable to initialize hash context DH-SHA");
@@ -1457,7 +1457,7 @@ static int kex_method_ec_sha_hash_create_verify(
     int err;
     int hok;
 
-    hok = ssh2_hash_init(&ctx, hash_alg);
+    hok = ssh2_hash_init(ctx, hash_alg);
     if(!hok)
         return ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                         "Unable to initialize hash context EC/ED");

--- a/src/kex.c
+++ b/src/kex.c
@@ -1503,10 +1503,9 @@ static int kex_method_ec_sha_hash_create_verify(
     ssh2_htonu32(exchange_state->h_sig_comp,
                  (uint32_t)(public_pq_key_len + public_key_len));
     hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-    if(public_pq_key && public_pq_key_len) {
+    if(public_pq_key && public_pq_key_len)
         hok &= ssh2_hash_update(ctx, public_pq_key,
                                      public_pq_key_len);
-    }
     hok &= ssh2_hash_update(ctx, public_key,
                                  public_key_len);
 
@@ -2999,10 +2998,9 @@ static uint32_t kex_method_list(unsigned char *buf, uint32_t list_strlen,
             memcpy(buf, prefvar, prefvarlen);                                 \
             (buf) += (prefvarlen);                                            \
         }                                                                     \
-        else {                                                                \
+        else                                                                  \
             (buf) += kex_method_list(buf, prefvarlen,                         \
                                 (const struct common_method **)(defaultvar)); \
-        }                                                                     \
     } while(0)
 
 /*

--- a/src/kex.c
+++ b/src/kex.c
@@ -64,20 +64,20 @@ static void kex_value_hash(ssh2_hash_alg hash_alg, size_t digest_len,
         size_t len = 0;
         while(len < data_len) {
             ssh2_hash_ctx ctx;
-            int hok = ssh2_hash_init(ctx, hash_alg);
+            int hok = ssh2_hash_init(&ctx, hash_alg);
             if(hok) {
-                hok &= ssh2_hash_update(ctx, exchange_state->k_value,
-                                        exchange_state->k_value_len);
-                hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp,
-                                        digest_len);
+                hok &= ssh2_hash_update(&ctx, exchange_state->k_value,
+                                              exchange_state->k_value_len);
+                hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp,
+                                              digest_len);
                 if(len)
-                    hok &= ssh2_hash_update(ctx, *data, len);
+                    hok &= ssh2_hash_update(&ctx, *data, len);
                 else {
-                    hok &= ssh2_hash_update(ctx, version, 1);
-                    hok &= ssh2_hash_update(ctx, session->session_id,
-                                            session->session_id_len);
+                    hok &= ssh2_hash_update(&ctx, version, 1);
+                    hok &= ssh2_hash_update(&ctx, session->session_id,
+                                                  session->session_id_len);
                 }
-                hok &= ssh2_hash_final(ctx, *data + len, digest_len);
+                hok &= ssh2_hash_final(&ctx, *data + len, digest_len);
             }
             if(!hok) {
                 SSH2_SAFEFREE(session, *data);
@@ -640,7 +640,7 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
             }
         }
 
-        hok = ssh2_hash_init(ctx, hash_alg);
+        hok = ssh2_hash_init(&ctx, hash_alg);
         if(!hok) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                            "Unable to initialize hash context DH-SHA");
@@ -649,66 +649,66 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
         if(session->local.banner) {
             ssh2_htonu32(exchange_state->h_sig_comp,
                 (uint32_t)(strlen((const char *)session->local.banner) - 2));
-            hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-            hok &= ssh2_hash_update(ctx, session->local.banner,
+            hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+            hok &= ssh2_hash_update(&ctx, session->local.banner,
                               strlen((const char *)session->local.banner) - 2);
         }
         else {
             ssh2_htonu32(exchange_state->h_sig_comp,
                          sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
-            hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-            hok &= ssh2_hash_update(ctx, LIBSSH2_SSH_DEFAULT_BANNER,
+            hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+            hok &= ssh2_hash_update(&ctx, LIBSSH2_SSH_DEFAULT_BANNER,
                                     sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
         }
 
         ssh2_htonu32(exchange_state->h_sig_comp,
                      (uint32_t)strlen((const char *)session->remote.banner));
-        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-        hok &= ssh2_hash_update(ctx, session->remote.banner,
+        hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+        hok &= ssh2_hash_update(&ctx, session->remote.banner,
                                 strlen((const char *)session->remote.banner));
 
         ssh2_htonu32(exchange_state->h_sig_comp,
                      (uint32_t)session->local.kexinit_len);
-        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-        hok &= ssh2_hash_update(ctx, session->local.kexinit,
-                                     session->local.kexinit_len);
+        hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+        hok &= ssh2_hash_update(&ctx, session->local.kexinit,
+                                      session->local.kexinit_len);
 
         ssh2_htonu32(exchange_state->h_sig_comp,
                      (uint32_t)session->remote.kexinit_len);
-        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-        hok &= ssh2_hash_update(ctx, session->remote.kexinit,
-                                     session->remote.kexinit_len);
+        hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+        hok &= ssh2_hash_update(&ctx, session->remote.kexinit,
+                                      session->remote.kexinit_len);
 
         ssh2_htonu32(exchange_state->h_sig_comp, session->server_hostkey_len);
-        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-        hok &= ssh2_hash_update(ctx, session->server_hostkey,
-                                     session->server_hostkey_len);
+        hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+        hok &= ssh2_hash_update(&ctx, session->server_hostkey,
+                                      session->server_hostkey_len);
 
         if(packet_type_init == SSH_MSG_KEX_DH_GEX_INIT) {
             /* diffie-hellman-group-exchange hashes additional fields */
             ssh2_htonu32(exchange_state->h_sig_comp, SSH2_DH_GEX_MINGROUP);
             ssh2_htonu32(exchange_state->h_sig_comp + 4, SSH2_DH_GEX_OPTGROUP);
             ssh2_htonu32(exchange_state->h_sig_comp + 8, SSH2_DH_GEX_MAXGROUP);
-            hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 12);
+            hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 12);
         }
 
         if(midhash)
-            hok &= ssh2_hash_update(ctx, midhash, midhash_len);
+            hok &= ssh2_hash_update(&ctx, midhash, midhash_len);
 
-        hok &= ssh2_hash_update(ctx, exchange_state->e_packet + 1,
-                                     exchange_state->e_packet_len - 1);
+        hok &= ssh2_hash_update(&ctx, exchange_state->e_packet + 1,
+                                      exchange_state->e_packet_len - 1);
 
         ssh2_htonu32(exchange_state->h_sig_comp,
                      (uint32_t)exchange_state->f_value_len);
-        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-        hok &= ssh2_hash_update(ctx, exchange_state->f_value,
-                                     exchange_state->f_value_len);
+        hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+        hok &= ssh2_hash_update(&ctx, exchange_state->f_value,
+                                      exchange_state->f_value_len);
 
-        hok &= ssh2_hash_update(ctx, exchange_state->k_value,
-                                     exchange_state->k_value_len);
+        hok &= ssh2_hash_update(&ctx, exchange_state->k_value,
+                                      exchange_state->k_value_len);
 
-        hok &= ssh2_hash_final(ctx, exchange_state->h_sig_comp,
-                                    sizeof(exchange_state->h_sig_comp));
+        hok &= ssh2_hash_final(&ctx, exchange_state->h_sig_comp,
+                                     sizeof(exchange_state->h_sig_comp));
         if(!hok) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                            "Failed to calculate hash DH-SHA");
@@ -1457,7 +1457,7 @@ static int kex_method_ec_sha_hash_create_verify(
     int err;
     int hok;
 
-    hok = ssh2_hash_init(ctx, hash_alg);
+    hok = ssh2_hash_init(&ctx, hash_alg);
     if(!hok)
         return ssh2_err(session, LIBSSH2_ERROR_HASH_INIT,
                         "Unable to initialize hash context EC/ED");
@@ -1465,60 +1465,60 @@ static int kex_method_ec_sha_hash_create_verify(
     if(session->local.banner) {
         ssh2_htonu32(exchange_state->h_sig_comp,
                   (uint32_t)(strlen((const char *)session->local.banner) - 2));
-        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-        hok &= ssh2_hash_update(ctx, session->local.banner,
+        hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+        hok &= ssh2_hash_update(&ctx, session->local.banner,
                               strlen((const char *)session->local.banner) - 2);
     }
     else {
         ssh2_htonu32(exchange_state->h_sig_comp,
                      sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
-        hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-        hok &= ssh2_hash_update(ctx, LIBSSH2_SSH_DEFAULT_BANNER,
+        hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+        hok &= ssh2_hash_update(&ctx, LIBSSH2_SSH_DEFAULT_BANNER,
                                 sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
     }
 
     ssh2_htonu32(exchange_state->h_sig_comp,
                  (uint32_t)strlen((const char *)session->remote.banner));
-    hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-    hok &= ssh2_hash_update(ctx, session->remote.banner,
+    hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+    hok &= ssh2_hash_update(&ctx, session->remote.banner,
                             strlen((const char *)session->remote.banner));
 
     ssh2_htonu32(exchange_state->h_sig_comp,
                  (uint32_t)session->local.kexinit_len);
-    hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-    hok &= ssh2_hash_update(ctx, session->local.kexinit,
-                                 session->local.kexinit_len);
+    hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+    hok &= ssh2_hash_update(&ctx, session->local.kexinit,
+                                  session->local.kexinit_len);
 
     ssh2_htonu32(exchange_state->h_sig_comp,
                  (uint32_t)session->remote.kexinit_len);
-    hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-    hok &= ssh2_hash_update(ctx, session->remote.kexinit,
-                                 session->remote.kexinit_len);
+    hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+    hok &= ssh2_hash_update(&ctx, session->remote.kexinit,
+                                  session->remote.kexinit_len);
 
     ssh2_htonu32(exchange_state->h_sig_comp, session->server_hostkey_len);
-    hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-    hok &= ssh2_hash_update(ctx, session->server_hostkey,
-                                 session->server_hostkey_len);
+    hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+    hok &= ssh2_hash_update(&ctx, session->server_hostkey,
+                                  session->server_hostkey_len);
 
     ssh2_htonu32(exchange_state->h_sig_comp,
                  (uint32_t)(public_pq_key_len + public_key_len));
-    hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
+    hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
     if(public_pq_key && public_pq_key_len)
-        hok &= ssh2_hash_update(ctx, public_pq_key,
-                                     public_pq_key_len);
-    hok &= ssh2_hash_update(ctx, public_key,
-                                 public_key_len);
+        hok &= ssh2_hash_update(&ctx, public_pq_key,
+                                      public_pq_key_len);
+    hok &= ssh2_hash_update(&ctx, public_key,
+                                  public_key_len);
 
     ssh2_htonu32(exchange_state->h_sig_comp, (uint32_t)server_public_key_len);
-    hok &= ssh2_hash_update(ctx, exchange_state->h_sig_comp, 4);
-    hok &= ssh2_hash_update(ctx, server_public_key,
-                                 server_public_key_len);
+    hok &= ssh2_hash_update(&ctx, exchange_state->h_sig_comp, 4);
+    hok &= ssh2_hash_update(&ctx, server_public_key,
+                                  server_public_key_len);
 
-    hok &= ssh2_hash_update(ctx, exchange_state->k_value,
-                                 exchange_state->k_value_len);
+    hok &= ssh2_hash_update(&ctx, exchange_state->k_value,
+                                  exchange_state->k_value_len);
 
-    hok &= ssh2_hash_final(ctx, exchange_state->h_sig_comp,
-                                sizeof(exchange_state->h_sig_comp));
+    hok &= ssh2_hash_final(&ctx, exchange_state->h_sig_comp,
+                                 sizeof(exchange_state->h_sig_comp));
     if(!hok)
         return ssh2_err(session, LIBSSH2_ERROR_HASH_CALC,
                         "Failed to calculate hash EC/ED");

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -86,8 +86,8 @@
 #endif
 
 /* returns 0 in case of failure */
-#define ssh2_hash_init(pctx, alg) \
-    (gcry_md_open(pctx, alg, 0) == GPG_ERR_NO_ERROR)
+#define ssh2_hash_init(ctx, alg) \
+    (gcry_md_open(&(ctx), alg, 0) == GPG_ERR_NO_ERROR)
 #define ssh2_hash_update(ctx, d, l) (gcry_md_write(ctx, d, l), 1)
 #define ssh2_hash_final(ctx, h, l)  ssh2_lgcr_hash_final(ctx, h, l)
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -87,9 +87,9 @@
 
 /* returns 0 in case of failure */
 #define ssh2_hash_init(ctx, alg) \
-    (gcry_md_open(&(ctx), alg, 0) == GPG_ERR_NO_ERROR)
-#define ssh2_hash_update(ctx, d, l) (gcry_md_write(ctx, d, l), 1)
-#define ssh2_hash_final(ctx, h, l)  ssh2_lgcr_hash_final(ctx, h, l)
+    (gcry_md_open(ctx, alg, 0) == GPG_ERR_NO_ERROR)
+#define ssh2_hash_update(ctx, d, l) (gcry_md_write(*(ctx), d, l), 1)
+#define ssh2_hash_final(ctx, h, l)  ssh2_lgcr_hash_final(*(ctx), h, l)
 
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len);
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -88,10 +88,8 @@
 /* returns 0 in case of failure */
 #define ssh2_hash_init(pctx, alg) \
     (gcry_md_open(pctx, alg, 0) == GPG_ERR_NO_ERROR)
-#define ssh2_hash_update(ctx, d, l) \
-    (gcry_md_write(ctx, d, l), 1)
-#define ssh2_hash_final(ctx, h, l) \
-    ssh2_lgcr_hash_final(ctx, h, l)
+#define ssh2_hash_update(ctx, d, l) (gcry_md_write(ctx, d, l), 1)
+#define ssh2_hash_final(ctx, h, l)  ssh2_lgcr_hash_final(ctx, h, l)
 
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len);
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -143,8 +143,8 @@ struct mbed_hash_ctx {
  * mbedTLS backend: hash functions
  */
 
-#define ssh2_hash_ctx psa_hash_operation_t
-#define ssh2_hash_alg psa_algorithm_t
+#define ssh2_hash_ctx   psa_hash_operation_t
+#define ssh2_hash_alg   psa_algorithm_t
 
 #define SSH2_SHA1_ALG   PSA_ALG_SHA_1
 #define SSH2_SHA256_ALG PSA_ALG_SHA_256
@@ -154,12 +154,10 @@ struct mbed_hash_ctx {
 #define SSH2_MD5_ALG    PSA_ALG_MD5
 #endif
 
-#define ssh2_hash_init(pctx, alg) \
-    ssh2_mbed_hash_init(pctx, alg)
+#define ssh2_hash_init(pctx, alg)   ssh2_mbed_hash_init(pctx, alg)
 #define ssh2_hash_update(ctx, d, l) \
     (psa_hash_update(&(ctx), (const uint8_t *)(d), l) == PSA_SUCCESS)
-#define ssh2_hash_final(ctx, h, l) \
-    ssh2_mbed_hash_final(&(ctx), h, l)
+#define ssh2_hash_final(ctx, h, l)  ssh2_mbed_hash_final(&(ctx), h, l)
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -154,7 +154,7 @@ struct mbed_hash_ctx {
 #define SSH2_MD5_ALG    PSA_ALG_MD5
 #endif
 
-#define ssh2_hash_init(pctx, alg)   ssh2_mbed_hash_init(pctx, alg)
+#define ssh2_hash_init(ctx, alg)    ssh2_mbed_hash_init(&(ctx), alg)
 #define ssh2_hash_update(ctx, d, l) \
     (psa_hash_update(&(ctx), (const uint8_t *)(d), l) == PSA_SUCCESS)
 #define ssh2_hash_final(ctx, h, l)  ssh2_mbed_hash_final(&(ctx), h, l)

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -154,10 +154,10 @@ struct mbed_hash_ctx {
 #define SSH2_MD5_ALG    PSA_ALG_MD5
 #endif
 
-#define ssh2_hash_init(ctx, alg)    ssh2_mbed_hash_init(&(ctx), alg)
+#define ssh2_hash_init(ctx, alg)    ssh2_mbed_hash_init(ctx, alg)
 #define ssh2_hash_update(ctx, d, l) \
-    (psa_hash_update(&(ctx), (const uint8_t *)(d), l) == PSA_SUCCESS)
-#define ssh2_hash_final(ctx, h, l)  ssh2_mbed_hash_final(&(ctx), h, l)
+    (psa_hash_update(ctx, (const uint8_t *)(d), l) == PSA_SUCCESS)
+#define ssh2_hash_final(ctx, h, l)  ssh2_mbed_hash_final(ctx, h, l)
 
 int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
 int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,

--- a/src/misc.c
+++ b/src/misc.c
@@ -335,7 +335,7 @@ int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
               unsigned char *digest, size_t digest_len)
 {
     ssh2_hash_ctx ctx;
-    int success = ssh2_hash_init(&ctx, alg);
+    int success = ssh2_hash_init(ctx, alg);
     if(success) {
         success &= ssh2_hash_update(ctx, input, input_len);
         success &= ssh2_hash_final(ctx, digest, digest_len);

--- a/src/misc.c
+++ b/src/misc.c
@@ -335,10 +335,10 @@ int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
               unsigned char *digest, size_t digest_len)
 {
     ssh2_hash_ctx ctx;
-    int success = ssh2_hash_init(ctx, alg);
+    int success = ssh2_hash_init(&ctx, alg);
     if(success) {
-        success &= ssh2_hash_update(ctx, input, input_len);
-        success &= ssh2_hash_final(ctx, digest, digest_len);
+        success &= ssh2_hash_update(&ctx, input, input_len);
+        success &= ssh2_hash_final(&ctx, digest, digest_len);
     }
     return success;
 }

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -252,7 +252,7 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 #define SSH2_MD5_ALG    EVP_md5()
 #endif
 
-#define ssh2_hash_init(pctx, alg)     ssh2_ossl_hash_init(pctx, alg)
+#define ssh2_hash_init(ctx, alg)      ssh2_ossl_hash_init(&(ctx), alg)
 #define ssh2_hash_update(ctx, d, l)   EVP_DigestUpdate(ctx, d, l)
 #define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)
 

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -252,9 +252,9 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 #define SSH2_MD5_ALG    EVP_md5()
 #endif
 
-#define ssh2_hash_init(ctx, alg)      ssh2_ossl_hash_init(&(ctx), alg)
-#define ssh2_hash_update(ctx, d, l)   EVP_DigestUpdate(ctx, d, l)
-#define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(&(ctx), h, l)
+#define ssh2_hash_init(ctx, alg)      ssh2_ossl_hash_init(ctx, alg)
+#define ssh2_hash_update(ctx, d, l)   EVP_DigestUpdate(*(ctx), d, l)
+#define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(ctx, h, l)
 
 #ifdef USE_OPENSSL_3
 #define ssh2_hmac_ctx EVP_MAC_CTX *

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -243,7 +243,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define SSH2_MD5_ALG    Qc3_MD5
 #endif
 
-#define ssh2_hash_init(pctx, alg)    ssh2_os400qc3_hash_init(pctx, alg)
+#define ssh2_hash_init(ctx, alg)     ssh2_os400qc3_hash_init(&(ctx), alg)
 #define ssh2_hash_update(ctx, d, l)  ssh2_os400qc3_hash_update(&(ctx), d, l)
 #define ssh2_hash_final(ctx, h, l)   ssh2_os400qc3_hash_final(&(ctx), h, l)
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -243,9 +243,9 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define SSH2_MD5_ALG    Qc3_MD5
 #endif
 
-#define ssh2_hash_init(ctx, alg)     ssh2_os400qc3_hash_init(&(ctx), alg)
-#define ssh2_hash_update(ctx, d, l)  ssh2_os400qc3_hash_update(&(ctx), d, l)
-#define ssh2_hash_final(ctx, h, l)   ssh2_os400qc3_hash_final(&(ctx), h, l)
+#define ssh2_hash_init(ctx, alg)     ssh2_os400qc3_hash_init(ctx, alg)
+#define ssh2_hash_update(ctx, d, l)  ssh2_os400qc3_hash_update(ctx, d, l)
+#define ssh2_hash_final(ctx, h, l)   ssh2_os400qc3_hash_final(ctx, h, l)
 
 int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algo);
 int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,

--- a/src/pem.c
+++ b/src/pem.c
@@ -285,7 +285,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         int hok;
 
         /* Perform key derivation (PBKDF1/MD5) */
-        hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
+        hok = ssh2_hash_init(ctx, SSH2_MD5_ALG);
         if(hok) {
             hok &= ssh2_hash_update(ctx, passphrase,
                                     strlen((const char *)passphrase));
@@ -297,7 +297,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
             goto out;
         }
         if(method->secret_len > SSH2_MD5_DIG_LEN) {
-            hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
+            hok = ssh2_hash_init(ctx, SSH2_MD5_ALG);
             if(hok) {
                 hok &= ssh2_hash_update(ctx, secret, SSH2_MD5_DIG_LEN);
                 hok &= ssh2_hash_update(ctx, passphrase,

--- a/src/pem.c
+++ b/src/pem.c
@@ -285,25 +285,25 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         int hok;
 
         /* Perform key derivation (PBKDF1/MD5) */
-        hok = ssh2_hash_init(ctx, SSH2_MD5_ALG);
+        hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
         if(hok) {
-            hok &= ssh2_hash_update(ctx, passphrase,
+            hok &= ssh2_hash_update(&ctx, passphrase,
                                     strlen((const char *)passphrase));
-            hok &= ssh2_hash_update(ctx, iv, 8);
-            hok &= ssh2_hash_final(ctx, secret, SSH2_MD5_DIG_LEN);
+            hok &= ssh2_hash_update(&ctx, iv, 8);
+            hok &= ssh2_hash_final(&ctx, secret, SSH2_MD5_DIG_LEN);
         }
         if(!hok) {
             ret = -1;
             goto out;
         }
         if(method->secret_len > SSH2_MD5_DIG_LEN) {
-            hok = ssh2_hash_init(ctx, SSH2_MD5_ALG);
+            hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
             if(hok) {
-                hok &= ssh2_hash_update(ctx, secret, SSH2_MD5_DIG_LEN);
-                hok &= ssh2_hash_update(ctx, passphrase,
+                hok &= ssh2_hash_update(&ctx, secret, SSH2_MD5_DIG_LEN);
+                hok &= ssh2_hash_update(&ctx, passphrase,
                                         strlen((const char *)passphrase));
-                hok &= ssh2_hash_update(ctx, iv, 8);
-                hok &= ssh2_hash_final(ctx, secret + SSH2_MD5_DIG_LEN,
+                hok &= ssh2_hash_update(&ctx, iv, 8);
+                hok &= ssh2_hash_final(&ctx, secret + SSH2_MD5_DIG_LEN,
                                        SSH2_MD5_DIG_LEN);
             }
             if(!hok) {

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -174,9 +174,9 @@ struct wcng_hash_ctx {
 #endif
 
 /* returns 0 in case of failure */
-#define ssh2_hash_init(ctx, alg)    ssh2_wcng_hash_init(&(ctx), alg, NULL, 0)
-#define ssh2_hash_update(ctx, d, l) ssh2_wcng_hash_update(&(ctx), d, l)
-#define ssh2_hash_final(ctx, h, l)  ssh2_wcng_hash_final(&(ctx), h, l)
+#define ssh2_hash_init(ctx, alg)    ssh2_wcng_hash_init(ctx, alg, NULL, 0)
+#define ssh2_hash_update(ctx, d, l) ssh2_wcng_hash_update(ctx, d, l)
+#define ssh2_hash_final(ctx, h, l)  ssh2_wcng_hash_final(ctx, h, l)
 
 int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
                         unsigned char *key, ULONG keylen);

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -174,7 +174,7 @@ struct wcng_hash_ctx {
 #endif
 
 /* returns 0 in case of failure */
-#define ssh2_hash_init(pctx, alg)   ssh2_wcng_hash_init(pctx, alg, NULL, 0)
+#define ssh2_hash_init(ctx, alg)    ssh2_wcng_hash_init(&(ctx), alg, NULL, 0)
 #define ssh2_hash_update(ctx, d, l) ssh2_wcng_hash_update(&(ctx), d, l)
 #define ssh2_hash_final(ctx, h, l)  ssh2_wcng_hash_final(&(ctx), h, l)
 


### PR DESCRIPTION
To reduce macro magic, sync with rest of macros.

Also: drop two single-instruction `{}` blocks.
