### PR TITLE
hash: drop interim macros, sync up types

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -99,6 +99,13 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 #define SSH2_MLKEM_1024_PUBLIC_KEY_LEN  1568
 #define SSH2_MLKEM_1024_CIPHERTEXT      1568
 
+int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg);
+#ifdef ssh2_hash_update
+int ssh2_hash_update(ssh2_hash_ctx *ctx,
+                     const unsigned char *input, int input_len);
+#endif
+int ssh2_hash_final(ssh2_hash_ctx *ctx,
+                    unsigned char *digest, size_t digest_len);
 int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
               unsigned char *digest, size_t digest_len);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -102,13 +102,11 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 /* returns 0 in case of failure */
 int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg);
 #ifndef ssh2_hash_update
-int ssh2_hash_update(ssh2_hash_ctx *ctx,
-                     const unsigned char *input, size_t input_len);
+int ssh2_hash_update(ssh2_hash_ctx *ctx, const void *input, size_t input_len);
 #endif
-int ssh2_hash_final(ssh2_hash_ctx *ctx,
-                    unsigned char *digest, size_t digest_len);
+int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len);
 int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
-              unsigned char *digest, size_t digest_len);
+              void *digest, size_t digest_len);
 
 #if LIBSSH2_RSA
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -99,8 +99,9 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 #define SSH2_MLKEM_1024_PUBLIC_KEY_LEN  1568
 #define SSH2_MLKEM_1024_CIPHERTEXT      1568
 
+/* returns 0 in case of failure */
 int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg);
-#ifdef ssh2_hash_update
+#ifndef ssh2_hash_update
 int ssh2_hash_update(ssh2_hash_ctx *ctx,
                      const unsigned char *input, int input_len);
 #endif

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -56,6 +56,15 @@
 #endif
 
 /* return: success = 1, error = 0 */
+int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg);
+#ifndef ssh2_hash_update
+int ssh2_hash_update(ssh2_hash_ctx *ctx, const void *input, size_t input_len);
+#endif
+int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len);
+int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
+              void *digest, size_t digest_len);
+
+/* return: success = 1, error = 0 */
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx);
 #if LIBSSH2_MD5
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen);
@@ -98,15 +107,6 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 #define SSH2_MLKEM_1024_PRIVATE_KEY_LEN 3168
 #define SSH2_MLKEM_1024_PUBLIC_KEY_LEN  1568
 #define SSH2_MLKEM_1024_CIPHERTEXT      1568
-
-/* returns 0 in case of failure */
-int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg);
-#ifndef ssh2_hash_update
-int ssh2_hash_update(ssh2_hash_ctx *ctx, const void *input, size_t input_len);
-#endif
-int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len);
-int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
-              void *digest, size_t digest_len);
 
 #if LIBSSH2_RSA
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -103,7 +103,7 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg);
 #ifndef ssh2_hash_update
 int ssh2_hash_update(ssh2_hash_ctx *ctx,
-                     const unsigned char *input, int input_len);
+                     const unsigned char *input, size_t input_len);
 #endif
 int ssh2_hash_final(ssh2_hash_ctx *ctx,
                     unsigned char *digest, size_t digest_len);

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -47,7 +47,7 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
     return gcry_md_open(ctx, alg, 0) == GPG_ERR_NO_ERROR;
 }
 
-int ssh2_hash_final(ssh2_hash_ctx *ctx, unsigned char *digest, size_t len)
+int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t len)
 {
     int ret = 0;
     unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx));

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -47,6 +47,12 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
     return gcry_md_open(ctx, alg, 0) == GPG_ERR_NO_ERROR;
 }
 
+int ssh2_hash_update(ssh2_hash_ctx *ctx, const void *input, size_t input_len)
+{
+    gcry_md_write(*ctx, input, input_len);
+    return 1;
+}
+
 int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t len)
 {
     int ret = 0;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -53,12 +53,12 @@ int ssh2_hash_update(ssh2_hash_ctx *ctx, const void *input, size_t input_len)
     return 1;
 }
 
-int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t len)
+int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
 {
     int ret = 0;
-    unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx));
-    if(len >= digest_len) {
-        memcpy(digest, gcry_md_read(*ctx, 0), digest_len);
+    unsigned int actual_len = gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx));
+    if(digest_len >= actual_len) {
+        memcpy(digest, gcry_md_read(*ctx, 0), actual_len);
         ret = 1;
     }
     gcry_md_close(*ctx);

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -42,7 +42,12 @@
 
 #ifdef LIBSSH2_LIBGCRYPT
 
-int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len)
+int ssh2_hash_init(gcry_md_hd_t ctx, ssh2_hash_alg alg)
+{
+    return gcry_md_open(ctx, alg, 0) == GPG_ERR_NO_ERROR;
+}
+
+int ssh2_hash_final(gcry_md_hd_t ctx, void *hash, size_t len)
 {
     int ret = 0;
     unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(ctx));

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -42,20 +42,20 @@
 
 #ifdef LIBSSH2_LIBGCRYPT
 
-int ssh2_hash_init(gcry_md_hd_t ctx, ssh2_hash_alg alg)
+int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 {
     return gcry_md_open(ctx, alg, 0) == GPG_ERR_NO_ERROR;
 }
 
-int ssh2_hash_final(gcry_md_hd_t ctx, void *hash, size_t len)
+int ssh2_hash_final(ssh2_hash_ctx *ctx, unsigned char *digest, size_t len)
 {
     int ret = 0;
-    unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(ctx));
+    unsigned int digest_len = gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx));
     if(len >= digest_len) {
-        memcpy(hash, gcry_md_read(ctx, 0), digest_len);
+        memcpy(digest, gcry_md_read(*ctx, 0), digest_len);
         ret = 1;
     }
-    gcry_md_close(ctx);
+    gcry_md_close(*ctx);
     return ret;
 }
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -89,7 +89,6 @@
 #define ssh2_hash_init(ctx, alg) \
     (gcry_md_open(ctx, alg, 0) == GPG_ERR_NO_ERROR)
 #define ssh2_hash_update(ctx, d, l) (gcry_md_write(*(ctx), d, l), 1)
-#define ssh2_hash_final(ctx, h, l)  ssh2_lgcr_hash_final(*(ctx), h, l)
 
 int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len);
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -76,6 +76,7 @@
 
 #define ssh2_hash_ctx gcry_md_hd_t
 #define ssh2_hash_alg int
+#define ssh2_hash_update(ctx, d, l) (gcry_md_write(*(ctx), d, l), 1)
 
 #define SSH2_SHA1_ALG   GCRY_MD_SHA1
 #define SSH2_SHA256_ALG GCRY_MD_SHA256
@@ -84,13 +85,6 @@
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_ALG    GCRY_MD_MD5
 #endif
-
-/* returns 0 in case of failure */
-#define ssh2_hash_init(ctx, alg) \
-    (gcry_md_open(ctx, alg, 0) == GPG_ERR_NO_ERROR)
-#define ssh2_hash_update(ctx, d, l) (gcry_md_write(*(ctx), d, l), 1)
-
-int ssh2_lgcr_hash_final(gcry_md_hd_t ctx, void *hash, size_t len);
 
 #define ssh2_hmac_ctx         gcry_md_hd_t
 

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -76,7 +76,6 @@
 
 #define ssh2_hash_ctx gcry_md_hd_t
 #define ssh2_hash_alg int
-#define ssh2_hash_update(ctx, d, l) (gcry_md_write(*(ctx), d, l), 1)
 
 #define SSH2_SHA1_ALG   GCRY_MD_SHA1
 #define SSH2_SHA256_ALG GCRY_MD_SHA256

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -181,17 +181,17 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return ret == 0 ? 0 : -1;
 }
 
-int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg)
+int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 {
     *ctx = psa_hash_operation_init();
     return psa_hash_setup(ctx, alg) == PSA_SUCCESS;
 }
 
-int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
-                         unsigned char *hash, size_t len)
+int ssh2_hash_final(ssh2_hash_ctx *ctx,
+                    unsigned char *digest, size_t digest_len)
 {
-    size_t actual_len;
-    return psa_hash_finish(ctx, hash, len, &actual_len) == PSA_SUCCESS;
+    size_t act_len;
+    return psa_hash_finish(ctx, digest, digest_len, &act_len) == PSA_SUCCESS;
 }
 
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -189,8 +189,9 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 
 int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
 {
-    size_t act_len;
-    return psa_hash_finish(ctx, digest, digest_len, &act_len) == PSA_SUCCESS;
+    size_t actual_len;
+    return psa_hash_finish(ctx, digest, digest_len,
+                           &actual_len) == PSA_SUCCESS;
 }
 
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -187,8 +187,7 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
     return psa_hash_setup(ctx, alg) == PSA_SUCCESS;
 }
 
-int ssh2_hash_final(ssh2_hash_ctx *ctx,
-                    unsigned char *digest, size_t digest_len)
+int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
 {
     size_t act_len;
     return psa_hash_finish(ctx, digest, digest_len, &act_len) == PSA_SUCCESS;

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -154,14 +154,8 @@ struct mbed_hash_ctx {
 #define SSH2_MD5_ALG    PSA_ALG_MD5
 #endif
 
-#define ssh2_hash_init(ctx, alg)    ssh2_mbed_hash_init(ctx, alg)
 #define ssh2_hash_update(ctx, d, l) \
     (psa_hash_update(ctx, (const uint8_t *)(d), l) == PSA_SUCCESS)
-#define ssh2_hash_final(ctx, h, l)  ssh2_mbed_hash_final(ctx, h, l)
-
-int ssh2_mbed_hash_init(psa_hash_operation_t *ctx, psa_algorithm_t alg);
-int ssh2_mbed_hash_final(psa_hash_operation_t *ctx,
-                         unsigned char *hash, size_t len);
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -145,6 +145,8 @@ struct mbed_hash_ctx {
 
 #define ssh2_hash_ctx   psa_hash_operation_t
 #define ssh2_hash_alg   psa_algorithm_t
+#define ssh2_hash_update(ctx, d, l) \
+    (psa_hash_update(ctx, (const uint8_t *)(d), l) == PSA_SUCCESS)
 
 #define SSH2_SHA1_ALG   PSA_ALG_SHA_1
 #define SSH2_SHA256_ALG PSA_ALG_SHA_256
@@ -153,9 +155,6 @@ struct mbed_hash_ctx {
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_ALG    PSA_ALG_MD5
 #endif
-
-#define ssh2_hash_update(ctx, d, l) \
-    (psa_hash_update(ctx, (const uint8_t *)(d), l) == PSA_SUCCESS)
 
 /*******************************************************************/
 /*

--- a/src/misc.c
+++ b/src/misc.c
@@ -332,7 +332,7 @@ int ssh2_store_bignum_bytes(unsigned char **buf,
 }
 
 int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
-              unsigned char *digest, size_t digest_len)
+              void *digest, size_t digest_len)
 {
     ssh2_hash_ctx ctx;
     int success = ssh2_hash_init(&ctx, alg);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -56,7 +56,7 @@ void ssh2_crypto_init(void)
 #endif
 }
 
-int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
+int ssh2_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
 {
 #if !defined(USE_OPENSSL_3) && \
     !defined(LIBRESSL_VERSION_NUMBER) && \
@@ -86,7 +86,7 @@ int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
     return 0;
 }
 
-int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
+int ssh2_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
 {
     int ret = EVP_DigestFinal_ex(*ctx, out, NULL);
     (void)outlen;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -61,7 +61,7 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 #if !defined(USE_OPENSSL_3) && \
     !defined(LIBRESSL_VERSION_NUMBER) && \
     !defined(LIBSSH2_WOLFSSL) && \
-    LIBSSH2_MD5
+    (LIBSSH2_MD5 || LIBSSH2_MD5_PEM)
     /* OpenSSL 1.1.1
      * MD5 digest is not supported in OpenSSL FIPS mode
      * Trying to init it results in a latent OpenSSL error:

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -441,15 +441,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
-        ret = ossl_hash(EVP_sha1(), m, m_len, hash);
+        ret = ossl_hash(SSH2_SHA1_ALG, m, m_len, hash);
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
-        ret = ossl_hash(EVP_sha256(), m, m_len, hash);
+        ret = ossl_hash(SSH2_SHA256_ALG, m, m_len, hash);
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
-        ret = ossl_hash(EVP_sha512(), m, m_len, hash);
+        ret = ossl_hash(SSH2_SHA512_ALG, m, m_len, hash);
     }
     else {
         nid_type = 0;
@@ -656,7 +656,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     ctx = EVP_PKEY_CTX_new(dsa, NULL);
     der_len = i2d_DSA_SIG(dsasig, &der);
 
-    if(ctx && !ossl_hash(EVP_sha1(), m, m_len, hash)) {
+    if(ctx && !ossl_hash(SSH2_SHA1_ALG, m, m_len, hash)) {
         /* ossl_hash() succeeded */
         if(EVP_PKEY_verify_init(ctx) > 0)
             ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
@@ -668,7 +668,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     if(der)
         OPENSSL_clear_free(der, der_len);
 #else
-    if(!ossl_hash(EVP_sha1(), m, m_len, hash))
+    if(!ossl_hash(SSH2_SHA1_ALG, m, m_len, hash))
         /* ossl_hash() succeeded */
         ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsa);
 #endif
@@ -864,7 +864,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
 
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(EVP_sha256(), m, m_len, hash) == 0) {
+        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -872,7 +872,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(EVP_sha384(), m, m_len, hash) == 0) {
+        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -880,7 +880,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(EVP_sha512(), m, m_len, hash) == 0) {
+        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -896,17 +896,17 @@ cleanup:
 #else
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(EVP_sha256(), m, m_len, hash) == 0)
+        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(EVP_sha384(), m, m_len, hash) == 0)
+        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(EVP_sha512(), m, m_len, hash) == 0)
+        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
 #endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -444,9 +444,9 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
         return -1; /* failure */
     }
 
+#ifdef USE_OPENSSL_3
     ret = 0;
 
-#ifdef USE_OPENSSL_3
     ctx = EVP_PKEY_CTX_new(rsa, NULL);
 
     if(nid_type == NID_sha1)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -56,7 +56,7 @@ void ssh2_crypto_init(void)
 #endif
 }
 
-int ssh2_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
+int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg digest)
 {
 #if !defined(USE_OPENSSL_3) && \
     !defined(LIBRESSL_VERSION_NUMBER) && \
@@ -86,10 +86,11 @@ int ssh2_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest)
     return 0;
 }
 
-int ssh2_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen)
+int ssh2_hash_final(ssh2_hash_ctx *ctx,
+                    unsigned char *digest, size_t digest_len)
 {
-    int ret = EVP_DigestFinal_ex(*ctx, out, NULL);
-    (void)outlen;
+    int ret = EVP_DigestFinal_ex(*ctx, digest, NULL);
+    (void)digest_len;
     EVP_MD_CTX_free(*ctx);
     *ctx = NULL;
     return ret;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -86,8 +86,7 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg digest)
     return 0;
 }
 
-int ssh2_hash_final(ssh2_hash_ctx *ctx,
-                    unsigned char *digest, size_t digest_len)
+int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
 {
     int ret = EVP_DigestFinal_ex(*ctx, digest, NULL);
     (void)digest_len;
@@ -96,8 +95,8 @@ int ssh2_hash_final(ssh2_hash_ctx *ctx,
     return ret;
 }
 
-static int ossl_hash(const unsigned char *message, size_t len,
-                     unsigned char *out, const EVP_MD *digest)
+static int ossl_hash(const void *message, size_t len,
+                     void *out, const EVP_MD *digest)
 {
     int ret = 1; /* error */
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -95,8 +95,8 @@ int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
     return ret;
 }
 
-static int ossl_hash(ssh2_hash_alg alg,
-                     const void *input, size_t input_len, void *digest)
+static int ossl_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
+                     void *digest)
 {
     int ret = 1; /* error */
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -56,7 +56,7 @@ void ssh2_crypto_init(void)
 #endif
 }
 
-int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg digest)
+int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 {
 #if !defined(USE_OPENSSL_3) && \
     !defined(LIBRESSL_VERSION_NUMBER) && \
@@ -67,7 +67,7 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg digest)
      * "digital envelope routines:FIPS_DIGESTINIT:disabled for fips"
      * Thus, return 0 in FIPS mode
      */
-    if(digest == EVP_md5() && FIPS_mode()) {
+    if(alg == SSH2_MD5_ALG && FIPS_mode()) {
         *ctx = NULL;
         return 0;
     }
@@ -77,7 +77,7 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg digest)
     if(!*ctx)
         return 0;
 
-    if(EVP_DigestInit_ex(*ctx, digest, NULL))
+    if(EVP_DigestInit_ex(*ctx, alg, NULL))
         return 1;
 
     EVP_MD_CTX_free(*ctx);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -96,10 +96,11 @@ int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
 }
 
 static int ossl_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
-                     void *digest)
+                     void *digest, size_t digest_len)
 {
     int ret = 1; /* error */
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    (void)digest_len;
 
     if(ctx) {
         if(EVP_DigestInit_ex(ctx, alg, NULL) &&
@@ -441,15 +442,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
-        ret = ossl_hash(SSH2_SHA1_ALG, m, m_len, hash);
+        ret = ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash));
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
-        ret = ossl_hash(SSH2_SHA256_ALG, m, m_len, hash);
+        ret = ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash));
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
-        ret = ossl_hash(SSH2_SHA512_ALG, m, m_len, hash);
+        ret = ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash));
     }
     else {
         nid_type = 0;
@@ -656,7 +657,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     ctx = EVP_PKEY_CTX_new(dsa, NULL);
     der_len = i2d_DSA_SIG(dsasig, &der);
 
-    if(ctx && !ossl_hash(SSH2_SHA1_ALG, m, m_len, hash)) {
+    if(ctx && !ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash))) {
         /* ossl_hash() succeeded */
         if(EVP_PKEY_verify_init(ctx) > 0)
             ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
@@ -668,7 +669,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     if(der)
         OPENSSL_clear_free(der, der_len);
 #else
-    if(!ossl_hash(SSH2_SHA1_ALG, m, m_len, hash))
+    if(!ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash)))
         /* ossl_hash() succeeded */
         ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsa);
 #endif
@@ -864,7 +865,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
 
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash) == 0) {
+        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -872,7 +873,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash) == 0) {
+        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -880,7 +881,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash) == 0) {
+        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -896,17 +897,17 @@ cleanup:
 #else
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash) == 0)
+        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash) == 0)
+        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash) == 0)
+        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
 #endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -95,24 +95,6 @@ int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
     return ret;
 }
 
-static int ossl_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
-                     void *digest, size_t digest_len)
-{
-    int ret = 0; /* error */
-    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-    (void)digest_len;
-
-    if(ctx) {
-        if(EVP_DigestInit_ex(ctx, alg, NULL) &&
-           EVP_DigestUpdate(ctx, input, input_len) &&
-           EVP_DigestFinal_ex(ctx, digest, NULL))
-            ret = 1; /* success */
-        EVP_MD_CTX_free(ctx);
-    }
-
-    return ret;
-}
-
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 {
 #ifdef USE_OPENSSL_3
@@ -442,15 +424,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
-        ret = ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash));
+        ret = ssh2_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash));
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
-        ret = ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash));
+        ret = ssh2_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash));
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
-        ret = ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash));
+        ret = ssh2_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash));
     }
     else {
         nid_type = 0;
@@ -659,7 +641,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     ctx = EVP_PKEY_CTX_new(dsa, NULL);
     der_len = i2d_DSA_SIG(dsasig, &der);
 
-    if(ctx && ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash)))
+    if(ctx && ssh2_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash)))
         if(EVP_PKEY_verify_init(ctx) > 0)
             ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
 
@@ -669,7 +651,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     if(der)
         OPENSSL_clear_free(der, der_len);
 #else
-    if(ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash)))
+    if(ssh2_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash)))
         ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsa);
 #endif
 
@@ -864,7 +846,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
 
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash))) {
+        if(ssh2_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -872,7 +854,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash))) {
+        if(ssh2_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -880,7 +862,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash))) {
+        if(ssh2_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -896,17 +878,17 @@ cleanup:
 #else
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)))
+        if(ssh2_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)))
+        if(ssh2_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)))
+        if(ssh2_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
 #endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -98,7 +98,7 @@ int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
 static int ossl_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
                      void *digest, size_t digest_len)
 {
-    int ret = 1; /* error */
+    int ret = 0; /* error */
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
     (void)digest_len;
 
@@ -106,7 +106,7 @@ static int ossl_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
         if(EVP_DigestInit_ex(ctx, alg, NULL) &&
            EVP_DigestUpdate(ctx, input, input_len) &&
            EVP_DigestFinal_ex(ctx, digest, NULL))
-            ret = 0; /* success */
+            ret = 1; /* success */
         EVP_MD_CTX_free(ctx);
     }
 
@@ -454,13 +454,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
     }
     else {
         nid_type = 0;
-        ret = -1; /* unsupported digest */
+        ret = 0; /* unsupported digest */
     }
 
-    if(ret) {
+    if(!ret) {
         free(hash);
         return -1; /* failure */
     }
+
+    ret = 0;
 
 #ifdef USE_OPENSSL_3
     ctx = EVP_PKEY_CTX_new(rsa, NULL);
@@ -657,11 +659,9 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     ctx = EVP_PKEY_CTX_new(dsa, NULL);
     der_len = i2d_DSA_SIG(dsasig, &der);
 
-    if(ctx && !ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash))) {
-        /* ossl_hash() succeeded */
+    if(ctx && ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash)))
         if(EVP_PKEY_verify_init(ctx) > 0)
             ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
-    }
 
     if(ctx)
         EVP_PKEY_CTX_free(ctx);
@@ -669,8 +669,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     if(der)
         OPENSSL_clear_free(der, der_len);
 #else
-    if(!ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash)))
-        /* ossl_hash() succeeded */
+    if(ossl_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash)))
         ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsa);
 #endif
 
@@ -865,7 +864,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
 
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)) == 0) {
+        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -873,7 +872,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)) == 0) {
+        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -881,7 +880,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)) == 0) {
+        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -897,17 +896,17 @@ cleanup:
 #else
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)) == 0)
+        if(ossl_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)) == 0)
+        if(ossl_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)) == 0)
+        if(ossl_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
 #endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -425,15 +425,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
-        ret = ssh2_hash(SSH2_SHA1_ALG, m, m_len, hash, sizeof(hash));
+        ret = ssh2_hash(SSH2_SHA1_ALG, m, m_len, hash, hash_len);
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
-        ret = ssh2_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash));
+        ret = ssh2_hash(SSH2_SHA256_ALG, m, m_len, hash, hash_len);
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
-        ret = ssh2_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash));
+        ret = ssh2_hash(SSH2_SHA512_ALG, m, m_len, hash, hash_len);
     }
     else {
         nid_type = 0;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -95,16 +95,16 @@ int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
     return ret;
 }
 
-static int ossl_hash(const void *message, size_t len,
-                     void *out, const EVP_MD *digest)
+static int ossl_hash(ssh2_hash_alg alg,
+                     const void *input, size_t input_len, void *digest)
 {
     int ret = 1; /* error */
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
     if(ctx) {
-        if(EVP_DigestInit_ex(ctx, digest, NULL) &&
-           EVP_DigestUpdate(ctx, message, len) &&
-           EVP_DigestFinal_ex(ctx, out, NULL))
+        if(EVP_DigestInit_ex(ctx, alg, NULL) &&
+           EVP_DigestUpdate(ctx, input, input_len) &&
+           EVP_DigestFinal_ex(ctx, digest, NULL))
             ret = 0; /* success */
         EVP_MD_CTX_free(ctx);
     }
@@ -441,15 +441,15 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
 
     if(hash_len == SSH2_SHA1_DIG_LEN) {
         nid_type = NID_sha1;
-        ret = ossl_hash(m, m_len, hash, EVP_sha1());
+        ret = ossl_hash(EVP_sha1(), m, m_len, hash);
     }
     else if(hash_len == SSH2_SHA256_DIG_LEN) {
         nid_type = NID_sha256;
-        ret = ossl_hash(m, m_len, hash, EVP_sha256());
+        ret = ossl_hash(EVP_sha256(), m, m_len, hash);
     }
     else if(hash_len == SSH2_SHA512_DIG_LEN) {
         nid_type = NID_sha512;
-        ret = ossl_hash(m, m_len, hash, EVP_sha512());
+        ret = ossl_hash(EVP_sha512(), m, m_len, hash);
     }
     else {
         nid_type = 0;
@@ -656,7 +656,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     ctx = EVP_PKEY_CTX_new(dsa, NULL);
     der_len = i2d_DSA_SIG(dsasig, &der);
 
-    if(ctx && !ossl_hash(m, m_len, hash, EVP_sha1())) {
+    if(ctx && !ossl_hash(EVP_sha1(), m, m_len, hash)) {
         /* ossl_hash() succeeded */
         if(EVP_PKEY_verify_init(ctx) > 0)
             ret = EVP_PKEY_verify(ctx, der, der_len, hash, SSH2_SHA1_DIG_LEN);
@@ -668,7 +668,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     if(der)
         OPENSSL_clear_free(der, der_len);
 #else
-    if(!ossl_hash(m, m_len, hash, EVP_sha1()))
+    if(!ossl_hash(EVP_sha1(), m, m_len, hash))
         /* ossl_hash() succeeded */
         ret = DSA_do_verify(hash, SSH2_SHA1_DIG_LEN, dsasig, dsa);
 #endif
@@ -864,7 +864,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
 
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(m, m_len, hash, EVP_sha256()) == 0) {
+        if(ossl_hash(EVP_sha256(), m, m_len, hash) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -872,7 +872,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(m, m_len, hash, EVP_sha384()) == 0) {
+        if(ossl_hash(EVP_sha384(), m, m_len, hash) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -880,7 +880,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(m, m_len, hash, EVP_sha512()) == 0) {
+        if(ossl_hash(EVP_sha512(), m, m_len, hash) == 0) {
             ret = EVP_PKEY_verify_init(ctx);
             if(ret > 0)
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
@@ -896,17 +896,17 @@ cleanup:
 #else
     if(type == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
-        if(ossl_hash(m, m_len, hash, EVP_sha256()) == 0)
+        if(ossl_hash(EVP_sha256(), m, m_len, hash) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
-        if(ossl_hash(m, m_len, hash, EVP_sha384()) == 0)
+        if(ossl_hash(EVP_sha384(), m, m_len, hash) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
     else if(type == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
-        if(ossl_hash(m, m_len, hash, EVP_sha512()) == 0)
+        if(ossl_hash(EVP_sha512(), m, m_len, hash) == 0)
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
 #endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -60,7 +60,8 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 {
 #if !defined(USE_OPENSSL_3) && \
     !defined(LIBRESSL_VERSION_NUMBER) && \
-    !defined(LIBSSH2_WOLFSSL)
+    !defined(LIBSSH2_WOLFSSL) && \
+    LIBSSH2_MD5
     /* OpenSSL 1.1.1
      * MD5 digest is not supported in OpenSSL FIPS mode
      * Trying to init it results in a latent OpenSSL error:

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -237,10 +237,6 @@ int ssh2_random(unsigned char *buf, size_t len);
 
 #define ssh2_prepare_iovec(vec, len)  /* Empty. */
 
-/* returns 0 in case of failure */
-int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest);
-int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
-
 #define ssh2_hash_ctx                EVP_MD_CTX *
 #define ssh2_hash_alg                const EVP_MD *
 #define ssh2_hash_update(ctx, d, l)  EVP_DigestUpdate(*(ctx), d, l)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -241,8 +241,9 @@ int ssh2_random(unsigned char *buf, size_t len);
 int ssh2_ossl_hash_init(EVP_MD_CTX **ctx, const EVP_MD *digest);
 int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 
-#define ssh2_hash_ctx                 EVP_MD_CTX *
-#define ssh2_hash_alg                 const EVP_MD *
+#define ssh2_hash_ctx                EVP_MD_CTX *
+#define ssh2_hash_alg                const EVP_MD *
+#define ssh2_hash_update(ctx, d, l)  EVP_DigestUpdate(*(ctx), d, l)
 
 #define SSH2_SHA1_ALG   EVP_sha1()
 #define SSH2_SHA256_ALG EVP_sha256()
@@ -251,8 +252,6 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
 #define SSH2_MD5_ALG    EVP_md5()
 #endif
-
-#define ssh2_hash_update(ctx, d, l)  EVP_DigestUpdate(*(ctx), d, l)
 
 #ifdef USE_OPENSSL_3
 #define ssh2_hmac_ctx EVP_MAC_CTX *

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -252,9 +252,7 @@ int ssh2_ossl_hash_final(EVP_MD_CTX **ctx, unsigned char *out, size_t outlen);
 #define SSH2_MD5_ALG    EVP_md5()
 #endif
 
-#define ssh2_hash_init(ctx, alg)      ssh2_ossl_hash_init(ctx, alg)
-#define ssh2_hash_update(ctx, d, l)   EVP_DigestUpdate(*(ctx), d, l)
-#define ssh2_hash_final(ctx, h, l)    ssh2_ossl_hash_final(ctx, h, l)
+#define ssh2_hash_update(ctx, d, l)  EVP_DigestUpdate(*(ctx), d, l)
 
 #ifdef USE_OPENSSL_3
 #define ssh2_hmac_ctx EVP_MAC_CTX *

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -933,15 +933,16 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 }
 
 int ssh2_hash_update(ssh2_hash_ctx *ctx,
-                     const unsigned char *input, int input_len)
+                     const unsigned char *input, size_t input_len)
 {
     char dummy[64];
     Qus_EC_t errcode;
+    int len = (int)input_len;
 
     ctx->Final_Op_Flag = Qc3_Continue;
     set_EC_length(errcode, sizeof(errcode));
-    Qc3CalculateHash((char *)input, &input_len, Qc3_Data, (char *)ctx,
-                     Qc3_Alg_Token, anycsp, NULL, dummy, &errcode);
+    Qc3CalculateHash((char *)input, &len, Qc3_Data, (char *)ctx, Qc3_Alg_Token,
+                     anycsp, NULL, dummy, &errcode);
     return errcode.Bytes_Available ? 0 : 1;
 }
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -915,47 +915,47 @@ void ssh2_os400qc3_crypto_dtor(struct os400qc3_crypto_ctx *x)
  *
  *******************************************************************/
 
-int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algorithm)
+int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 {
     Qc3_Format_ALGD0500_T algd;
     Qus_EC_t errcode;
 
-    if(!x)
+    if(!ctx)
         return 0;
 
-    memset((char *)x, 0, sizeof(*x));
-    x->Final_Op_Flag = Qc3_Continue;
-    algd.Hash_Alg = algorithm;
+    memset((char *)ctx, 0, sizeof(*ctx));
+    ctx->Final_Op_Flag = Qc3_Continue;
+    algd.Hash_Alg = alg;
     set_EC_length(errcode, sizeof(errcode));
     Qc3CreateAlgorithmContext((char *)&algd, Qc3_Alg_Hash,
-                              x->Alg_Context_Token, &errcode);
+                              ctx->Alg_Context_Token, &errcode);
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,
-                              const unsigned char *data, int len)
+int ssh2_hash_update(ssh2_hash_ctx *ctx,
+                     const unsigned char *input, int input_len)
 {
     char dummy[64];
     Qus_EC_t errcode;
 
     ctx->Final_Op_Flag = Qc3_Continue;
     set_EC_length(errcode, sizeof(errcode));
-    Qc3CalculateHash((char *)data, &len, Qc3_Data, (char *)ctx, Qc3_Alg_Token,
-                     anycsp, NULL, dummy, &errcode);
+    Qc3CalculateHash((char *)input, &input_len, Qc3_Data, (char *)ctx,
+                     Qc3_Alg_Token, anycsp, NULL, dummy, &errcode);
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx,
-                             unsigned char *out, size_t outlen)
+int ssh2_hash_final(ssh2_hash_ctx *ctx,
+                    unsigned char *digest, size_t digest_len)
 {
     char data;
     Qus_EC_t errcode;
-    (void)outlen;
+    (void)digest_len;
 
     ctx->Final_Op_Flag = Qc3_Final;
     set_EC_length(errcode, sizeof(errcode));
     Qc3CalculateHash(&data, &zero, Qc3_Data, (char *)ctx, Qc3_Alg_Token,
-                     anycsp, NULL, (char *)out, &errcode);
+                     anycsp, NULL, (char *)digest, &errcode);
     Qc3DestroyAlgorithmContext(ctx->Alg_Context_Token, (char *)&ecnull);
     memset(ctx->Alg_Context_Token, 0, sizeof(ctx->Alg_Context_Token));
     return errcode.Bytes_Available ? 0 : 1;
@@ -978,7 +978,7 @@ static int os400qc3_hmac_init(struct os400qc3_crypto_ctx *ctx,
         key = (void *)lkey;
         keylen = minkeylen;
     }
-    if(!ssh2_os400qc3_hash_init(&ctx->hash, algo))
+    if(!ssh2_hash_init(&ctx->hash, algo))
         return 0;
     set_EC_length(errcode, sizeof(errcode));
     Qc3CreateKeyContext((char *)key, &keylen, binstring, &algo, qc3clear,
@@ -1375,8 +1375,8 @@ static int pbkdf1(LIBSSH2_SESSION *session, char **dk,
     errcode.Bytes_Available = 1; /* Defaults to error flagging. */
 
     /* Initial hash. */
-    if(ssh2_os400qc3_hash_init(&hctx, pkcs5->hash)) {
-        if(ssh2_os400qc3_hash_update(&hctx, passphrase, strlen(passphrase))) {
+    if(ssh2_hash_init(&hctx, pkcs5->hash)) {
+        if(ssh2_hash_update(&hctx, passphrase, strlen(passphrase))) {
             hctx.Final_Op_Flag = Qc3_Final;
             Qc3CalculateHash((char *)pkcs5->salt, &len, Qc3_Data,
                              (char *)&hctx, Qc3_Alg_Token, anycsp, NULL, *dk,

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -932,8 +932,7 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_hash_update(ssh2_hash_ctx *ctx,
-                     const unsigned char *input, size_t input_len)
+int ssh2_hash_update(ssh2_hash_ctx *ctx, const void *input, size_t input_len)
 {
     char dummy[64];
     Qus_EC_t errcode;
@@ -946,8 +945,7 @@ int ssh2_hash_update(ssh2_hash_ctx *ctx,
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_hash_final(ssh2_hash_ctx *ctx,
-                    unsigned char *digest, size_t digest_len)
+int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
 {
     char data;
     Qus_EC_t errcode;

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -243,16 +243,6 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define SSH2_MD5_ALG    Qc3_MD5
 #endif
 
-#define ssh2_hash_init(ctx, alg)     ssh2_os400qc3_hash_init(ctx, alg)
-#define ssh2_hash_update(ctx, d, l)  ssh2_os400qc3_hash_update(ctx, d, l)
-#define ssh2_hash_final(ctx, h, l)   ssh2_os400qc3_hash_final(ctx, h, l)
-
-int ssh2_os400qc3_hash_init(Qc3_Format_ALGD0100_T *x, unsigned int algo);
-int ssh2_os400qc3_hash_update(Qc3_Format_ALGD0100_T *ctx,
-                              const unsigned char *data, int len);
-int ssh2_os400qc3_hash_final(Qc3_Format_ALGD0100_T *ctx,
-                             unsigned char *out, size_t outlen);
-
 /* Bignum */
 
 #define ssh2_bn_ctx              int /* not used */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -753,16 +753,14 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
     return ssh2_hash_init_low(ctx, alg, NULL, 0);
 }
 
-int ssh2_hash_update(ssh2_hash_ctx *ctx,
-                     const unsigned char *input, size_t input_len)
+int ssh2_hash_update(ssh2_hash_ctx *ctx, const void *input, size_t input_len)
 {
     return input_len <= ULONG_MAX &&
         BCRYPT_SUCCESS(BCryptHashData(ctx->hHash, SSH2_UNCONST(input),
                                       (ULONG)input_len, 0));
 }
 
-int ssh2_hash_final(ssh2_hash_ctx *ctx,
-                    unsigned char *digest, size_t digest_len)
+int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
 {
     int ret = 0;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -754,9 +754,9 @@ int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 }
 
 int ssh2_hash_update(ssh2_hash_ctx *ctx,
-                     const unsigned char *input, int input_len)
+                     const unsigned char *input, size_t input_len)
 {
-    return (ULONG)input_len <= ULONG_MAX &&
+    return input_len <= ULONG_MAX &&
         BCRYPT_SUCCESS(BCryptHashData(ctx->hHash, SSH2_UNCONST(input),
                                       (ULONG)input_len, 0));
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -706,22 +706,22 @@ int ssh2_random(unsigned char *buf, size_t len)
  * Windows CNG backend: Hash functions
  */
 
-int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
-                        unsigned char *key, ULONG keylen)
+static int ssh2_hash_init_low(ssh2_hash_ctx *ctx, ssh2_hash_alg alg,
+                              unsigned char *key, ULONG keylen)
 {
     BCRYPT_HASH_HANDLE hHash;
     unsigned char *pbHashObject;
     ULONG dwHashObject, dwHash, cbData;
     int ret;
 
-    ret = BCryptGetProperty(hAlg, BCRYPT_HASH_LENGTH,
+    ret = BCryptGetProperty(alg, BCRYPT_HASH_LENGTH,
                             (unsigned char *)&dwHash,
                             sizeof(dwHash),
                             &cbData, 0);
     if(!BCRYPT_SUCCESS(ret))
         return 0;
 
-    ret = BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH,
+    ret = BCryptGetProperty(alg, BCRYPT_OBJECT_LENGTH,
                             (unsigned char *)&dwHashObject,
                             sizeof(dwHashObject),
                             &cbData, 0);
@@ -732,7 +732,7 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
     if(!pbHashObject)
         return 0;
 
-    ret = BCryptCreateHash(hAlg, &hHash,
+    ret = BCryptCreateHash(alg, &hHash,
                            pbHashObject, dwHashObject,
                            key, keylen, 0);
     if(!BCRYPT_SUCCESS(ret)) {
@@ -748,21 +748,26 @@ int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
     return 1;
 }
 
-int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
-                          const void *data, size_t datalen)
+int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 {
-    return datalen <= ULONG_MAX &&
-        BCRYPT_SUCCESS(BCryptHashData(ctx->hHash,
-                                      SSH2_UNCONST(data), (ULONG)datalen, 0));
+    return ssh2_hash_init_low(ctx, alg, NULL, 0);
 }
 
-int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
-                         size_t hashlen)
+int ssh2_hash_update(ssh2_hash_ctx *ctx,
+                     const unsigned char *input, int input_len)
+{
+    return (ULONG)input_len <= ULONG_MAX &&
+        BCRYPT_SUCCESS(BCryptHashData(ctx->hHash, SSH2_UNCONST(input),
+                                      (ULONG)input_len, 0));
+}
+
+int ssh2_hash_final(ssh2_hash_ctx *ctx,
+                    unsigned char *digest, size_t digest_len)
 {
     int ret = 0;
 
-    if(hashlen >= ctx->cbHash &&
-       BCRYPT_SUCCESS(BCryptFinishHash(ctx->hHash, hash, ctx->cbHash, 0)))
+    if(digest_len >= ctx->cbHash &&
+       BCRYPT_SUCCESS(BCryptFinishHash(ctx->hHash, digest, ctx->cbHash, 0)))
         ret = 1;
 
     BCryptDestroyHash(ctx->hHash);
@@ -772,22 +777,6 @@ int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
     ctx->pbHashObject = NULL;
     ctx->dwHashObject = 0;
     ctx->cbHash = 0;
-
-    return ret;
-}
-
-static int wcng_hash(const unsigned char *data, ULONG datalen,
-                     BCRYPT_ALG_HANDLE hAlg,
-                     unsigned char *hash, ULONG hashlen)
-{
-    struct wcng_hash_ctx ctx;
-    int ret;
-
-    ret = ssh2_wcng_hash_init(&ctx, hAlg, NULL, 0);
-    if(ret) {
-        ret = ssh2_wcng_hash_update(&ctx, data, datalen);
-        ret &= ssh2_wcng_hash_final(&ctx, hash, hashlen);
-    }
 
     return ret;
 }
@@ -806,32 +795,32 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 #if LIBSSH2_MD5
 int ssh2_hmac_md5_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacMD5,
-                               key, (ULONG)keylen);
+    return ssh2_hash_init_low(ctx, ssh2_wcng.hAlgHmacMD5,
+                              key, (ULONG)keylen);
 }
 #endif
 
 int ssh2_hmac_sha1_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA1,
-                               key, (ULONG)keylen);
+    return ssh2_hash_init_low(ctx, ssh2_wcng.hAlgHmacSHA1,
+                              key, (ULONG)keylen);
 }
 
 int ssh2_hmac_sha256_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA256,
-                               key, (ULONG)keylen);
+    return ssh2_hash_init_low(ctx, ssh2_wcng.hAlgHmacSHA256,
+                              key, (ULONG)keylen);
 }
 
 int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 {
-    return ssh2_wcng_hash_init(ctx, ssh2_wcng.hAlgHmacSHA512,
-                               key, (ULONG)keylen);
+    return ssh2_hash_init_low(ctx, ssh2_wcng.hAlgHmacSHA512,
+                              key, (ULONG)keylen);
 }
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 {
-    return ssh2_wcng_hash_update(ctx, data, datalen);
+    return ssh2_hash_update(ctx, data, (int)datalen);
 }
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
@@ -898,7 +887,7 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx, ULONG hashlen,
     }
     memcpy(data, m, datalen);
 
-    ret = wcng_hash(data, datalen, hAlgHash, hash, hashlen);
+    ret = ssh2_hash(hAlgHash, data, datalen, hash, hashlen);
     wcng_zero_free(data, datalen);
 
     if(!ret) {
@@ -2409,7 +2398,7 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
     }
-    if(!wcng_hash(m, (ULONG)m_len, hash_alg, hash, hash_len)) {
+    if(!ssh2_hash(hash_alg, m, (ULONG)m_len, hash, hash_len)) {
         result = LIBSSH2_ERROR_PUBLICKEY_PROTOCOL;
         goto cleanup;
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -848,26 +848,26 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx, ULONG hashlen,
                                ULONG flags)
 {
     BCRYPT_PKCS1_PADDING_INFO paddingInfoPKCS1;
-    BCRYPT_ALG_HANDLE hAlgHash;
+    ssh2_hash_alg hash_alg;
     void *pPaddingInfo;
     unsigned char *data, *hash;
     ULONG datalen;
     int ret;
 
     if(hashlen == SSH2_SHA1_DIG_LEN) {
-        hAlgHash = ssh2_wcng.hAlgHashSHA1;
+        hash_alg = SSH2_SHA1_ALG;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA1_ALGORITHM;
     }
     else if(hashlen == SSH2_SHA256_DIG_LEN) {
-        hAlgHash = ssh2_wcng.hAlgHashSHA256;
+        hash_alg = SSH2_SHA256_ALG;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA256_ALGORITHM;
     }
     else if(hashlen == SSH2_SHA384_DIG_LEN) {
-        hAlgHash = ssh2_wcng.hAlgHashSHA384;
+        hash_alg = SSH2_SHA384_ALG;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA384_ALGORITHM;
     }
     else if(hashlen == SSH2_SHA512_DIG_LEN) {
-        hAlgHash = ssh2_wcng.hAlgHashSHA512;
+        hash_alg = SSH2_SHA512_ALG;
         paddingInfoPKCS1.pszAlgId = BCRYPT_SHA512_ALGORITHM;
     }
     else
@@ -885,7 +885,7 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx, ULONG hashlen,
     }
     memcpy(data, m, datalen);
 
-    ret = ssh2_hash(hAlgHash, data, datalen, hash, hashlen);
+    ret = ssh2_hash(hash_alg, data, datalen, hash, hashlen);
     wcng_zero_free(data, datalen);
 
     if(!ret) {
@@ -2354,16 +2354,14 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
 
     PUCHAR signature_p1363 = NULL;
     size_t signature_p1363_len;
-    ULONG hash_len;
+    size_t hash_len;
     PUCHAR hash = NULL;
-    BCRYPT_ALG_HANDLE hash_alg;
+    ssh2_hash_alg hash_alg;
 
     /* CNG expects signatures in IEEE P-1363 format. */
     result = wcng_p1363signature_from_point(
-        r,
-        r_len,
-        s,
-        s_len,
+        r, r_len,
+        s, s_len,
         ssh2_ecdsa_get_curve_type(ec_ctx),
         &signature_p1363,
         &signature_p1363_len);
@@ -2373,18 +2371,18 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
     /* Create hash over m */
     switch(ssh2_ecdsa_get_curve_type(ec_ctx)) {
     case SSH2_EC_CURVE_NISTP256:
-        hash_len = 256 / 8;
-        hash_alg = ssh2_wcng.hAlgHashSHA256;
+        hash_len = SSH2_SHA256_DIG_LEN;
+        hash_alg = SSH2_SHA256_ALG;
         break;
 
     case SSH2_EC_CURVE_NISTP384:
-        hash_len = 384 / 8;
-        hash_alg = ssh2_wcng.hAlgHashSHA384;
+        hash_len = SSH2_SHA384_DIG_LEN;
+        hash_alg = SSH2_SHA384_ALG;
         break;
 
     case SSH2_EC_CURVE_NISTP521:
-        hash_len = 512 / 8;
-        hash_alg = ssh2_wcng.hAlgHashSHA512;
+        hash_len = SSH2_SHA512_DIG_LEN;
+        hash_alg = SSH2_SHA512_ALG;
         break;
 
     default:
@@ -2396,7 +2394,7 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
     }
-    if(!ssh2_hash(hash_alg, m, (ULONG)m_len, hash, hash_len)) {
+    if(!ssh2_hash(hash_alg, m, m_len, hash, hash_len)) {
         result = LIBSSH2_ERROR_PUBLICKEY_PROTOCOL;
         goto cleanup;
     }
@@ -2406,7 +2404,7 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
         ec_ctx->handle,
         NULL,
         hash,
-        hash_len,
+        (ULONG)hash_len,
         signature_p1363,
         (ULONG)signature_p1363_len,
         0);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -818,7 +818,7 @@ int ssh2_hmac_sha512_init(ssh2_hmac_ctx *ctx, void *key, size_t keylen)
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 {
-    return ssh2_hash_update(ctx, data, (int)datalen);
+    return ssh2_hash_update(ctx, data, datalen);
 }
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -173,20 +173,6 @@ struct wcng_hash_ctx {
 #define SSH2_MD5_ALG    ssh2_wcng.hAlgHashMD5
 #endif
 
-/* returns 0 in case of failure */
-#define ssh2_hash_init(ctx, alg)    ssh2_wcng_hash_init(ctx, alg, NULL, 0)
-#define ssh2_hash_update(ctx, d, l) ssh2_wcng_hash_update(ctx, d, l)
-#define ssh2_hash_final(ctx, h, l)  ssh2_wcng_hash_final(ctx, h, l)
-
-int ssh2_wcng_hash_init(struct wcng_hash_ctx *ctx, BCRYPT_ALG_HANDLE hAlg,
-                        unsigned char *key, ULONG keylen);
-int ssh2_wcng_hash_update(struct wcng_hash_ctx *ctx,
-                          const void *data, size_t datalen);
-int ssh2_wcng_hash_final(struct wcng_hash_ctx *ctx, unsigned char *hash,
-                         size_t hashlen);
-int ssh2_wcng_hash(const unsigned char *data, ULONG datalen,
-                   BCRYPT_ALG_HANDLE hAlg, unsigned char *hash, ULONG hashlen);
-
 /*
  * Windows CNG backend: HMAC functions
  */


### PR DESCRIPTION
- make all buffers `void *`, input data size `size_t`.
- sync up types and argument names across cypto backends.
- openssl: replace local one-shot hash implementation with
  `ssh2_hash()`. (also syncing success/failure values to reduce
  confusion across the codebase.)
- openssl: fix to exclude MD5 FIPS logic from no-`LIBSSH2_MD5` builds.
- wincng: use ssh2 types/constants when calling `ssh2_hash()`.

Follow-up to 81e6f8ff6a2f52300bb79c5304e9a6f870a3481b #2241
