### PR TITLE
src: drop interim macros for bignum functions, where applicable

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -342,11 +342,6 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
                                          unsigned char *key_method,
                                          size_t key_method_len);
 
-#if 0
-#define ssh2_bn_init_from_bin()        ssh2_bn_init()
-#define ssh2_bn_bytes(bn)              ((bn)->length)
-#endif
-
 #ifndef ssh2_bn_init
 ssh2_bn *ssh2_bn_init(void);
 void ssh2_bn_free(ssh2_bn *bn);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -342,6 +342,18 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
                                          unsigned char *key_method,
                                          size_t key_method_len);
 
+#if 0
+#define ssh2_bn_init_from_bin()        ssh2_bn_init()
+#define ssh2_bn_bytes(bn)              ((bn)->length)
+#endif
+
+ssh2_bn *ssh2_bn_init(void);
+int ssh2_bn_set_word(ssh2_bn *bn, ULONG word);
+ULONG ssh2_bn_bits(const ssh2_bn *bn);
+int ssh2_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin);
+int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
+void ssh2_bn_free(ssh2_bn *bn);
+
 void ssh2_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                      ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -348,9 +348,9 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 #endif
 
 ssh2_bn *ssh2_bn_init(void);
-int ssh2_bn_set_word(ssh2_bn *bn, ULONG word);
-ULONG ssh2_bn_bits(const ssh2_bn *bn);
-int ssh2_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin);
+int ssh2_bn_set_word(ssh2_bn *bn, size_t word);
+size_t ssh2_bn_bits(const ssh2_bn *bn);
+int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin);
 int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
 void ssh2_bn_free(ssh2_bn *bn);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -347,12 +347,18 @@ const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
 #define ssh2_bn_bytes(bn)              ((bn)->length)
 #endif
 
+#ifndef ssh2_bn_init
 ssh2_bn *ssh2_bn_init(void);
+void ssh2_bn_free(ssh2_bn *bn);
+#endif
+#ifndef ssh2_bn_set_word
 int ssh2_bn_set_word(ssh2_bn *bn, size_t word);
 size_t ssh2_bn_bits(const ssh2_bn *bn);
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin);
 int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
-void ssh2_bn_free(ssh2_bn *bn);
+#endif
+#ifndef ssh2_bn_from_bin
+int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin);
+#endif
 
 void ssh2_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -349,8 +349,8 @@ void ssh2_bn_free(ssh2_bn *bn);
 #ifndef ssh2_bn_set_word
 int ssh2_bn_set_word(ssh2_bn *bn, unsigned long word);
 unsigned long ssh2_bn_bits(const ssh2_bn *bn);
-int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
 int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin);
+int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
 #endif
 #ifndef ssh2_bn_init_from_bin
 #define ssh2_bn_init_from_bin()  ssh2_bn_init()

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -347,8 +347,8 @@ ssh2_bn *ssh2_bn_init(void);
 void ssh2_bn_free(ssh2_bn *bn);
 #endif
 #ifndef ssh2_bn_set_word
-int ssh2_bn_set_word(ssh2_bn *bn, size_t word);
-size_t ssh2_bn_bits(const ssh2_bn *bn);
+int ssh2_bn_set_word(ssh2_bn *bn, unsigned long word);
+unsigned long ssh2_bn_bits(const ssh2_bn *bn);
 int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
 #endif
 #ifndef ssh2_bn_from_bin

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -350,8 +350,6 @@ void ssh2_bn_free(ssh2_bn *bn);
 int ssh2_bn_set_word(ssh2_bn *bn, unsigned long word);
 unsigned long ssh2_bn_bits(const ssh2_bn *bn);
 int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
-#endif
-#ifndef ssh2_bn_from_bin
 int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin);
 #endif
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -352,6 +352,9 @@ unsigned long ssh2_bn_bits(const ssh2_bn *bn);
 int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
 int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin);
 #endif
+#ifndef ssh2_bn_init_from_bin
+#define ssh2_bn_init_from_bin()  ssh2_bn_init()
+#endif
 
 void ssh2_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -122,7 +122,6 @@
 #define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
 
 #define ssh2_bn                        struct gcry_mpi
-
 #define ssh2_bn_init()                 gcry_mpi_new(0)
 #define ssh2_bn_init_from_bin()        NULL  /* because gcry_mpi_scan()
                                                 creates a new bignum */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -122,6 +122,7 @@
 #define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
 
 #define ssh2_bn                        struct gcry_mpi
+
 #define ssh2_bn_init()                 gcry_mpi_new(0)
 #define ssh2_bn_init_from_bin()        NULL  /* because gcry_mpi_scan()
                                                 creates a new bignum */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -275,7 +275,7 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
  * mbedTLS backend: BigNumber functions
  */
 
-ssh2_bn *ssh2_mbed_bn_init(void)
+ssh2_bn *ssh2_bn_init(void)
 {
     ssh2_bn *bignum;
 
@@ -286,7 +286,7 @@ ssh2_bn *ssh2_mbed_bn_init(void)
     return bignum;
 }
 
-void ssh2_mbed_bn_free(ssh2_bn *bn)
+void ssh2_bn_free(ssh2_bn *bn)
 {
     if(bn) {
         mbedtls_mpi_free(bn);
@@ -800,7 +800,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 
 void ssh2_dh_init(ssh2_dh_ctx *dhctx)
 {
-    *dhctx = ssh2_mbed_bn_init(); /* Random from client */
+    *dhctx = ssh2_bn_init(); /* Random from client */
 }
 
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
@@ -830,7 +830,7 @@ int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
 
 void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
 {
-    ssh2_mbed_bn_free(*dhctx);
+    ssh2_bn_free(*dhctx);
     *dhctx = NULL;
 }
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -235,7 +235,6 @@ void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx);
 #define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
 
 #define ssh2_bn                        mbedtls_mpi
-#define ssh2_bn_init_from_bin()        ssh2_bn_init()
 #define ssh2_bn_set_word(bn, word)     mbedtls_mpi_lset(bn, word)
 #define ssh2_bn_from_bin(bn, len, bin) mbedtls_mpi_read_binary(bn, bin, len)
 #define ssh2_bn_to_bin(bn, bin) \

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -235,18 +235,14 @@ void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx);
 #define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
 
 #define ssh2_bn                        mbedtls_mpi
-#define ssh2_bn_init()                 ssh2_mbed_bn_init()
-#define ssh2_bn_init_from_bin()        ssh2_mbed_bn_init()
+
+#define ssh2_bn_init_from_bin()        ssh2_bn_init()
 #define ssh2_bn_set_word(bn, word)     mbedtls_mpi_lset(bn, word)
 #define ssh2_bn_from_bin(bn, len, bin) mbedtls_mpi_read_binary(bn, bin, len)
 #define ssh2_bn_to_bin(bn, bin) \
     mbedtls_mpi_write_binary(bn, bin, mbedtls_mpi_size(bn))
 #define ssh2_bn_bytes(bn)              mbedtls_mpi_size(bn)
 #define ssh2_bn_bits(bn)               mbedtls_mpi_bitlen(bn)
-#define ssh2_bn_free(bn)               ssh2_mbed_bn_free(bn)
-
-ssh2_bn *ssh2_mbed_bn_init(void);
-void ssh2_mbed_bn_free(ssh2_bn *bn);
 
 /*******************************************************************/
 /*

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -235,7 +235,6 @@ void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ctx);
 #define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
 
 #define ssh2_bn                        mbedtls_mpi
-
 #define ssh2_bn_init_from_bin()        ssh2_bn_init()
 #define ssh2_bn_set_word(bn, word)     mbedtls_mpi_lset(bn, word)
 #define ssh2_bn_from_bin(bn, len, bin) mbedtls_mpi_read_binary(bn, bin, len)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4364,13 +4364,6 @@ void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
     *dhctx = NULL;
 }
 
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val)
-{
-    if(!BN_bin2bn(val, (int)len, bn))
-        return -1;
-    return 0;
-}
-
 /*
  * Return supported key hash algo upgrades, see crypto.h
  */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -319,18 +319,18 @@ typedef enum {
 
 #define ssh2_cipher_dtor(ctx) EVP_CIPHER_CTX_free(*(ctx))
 
-#define ssh2_bn_ctx                    BN_CTX
-#define ssh2_bn_ctx_new()              BN_CTX_new()
-#define ssh2_bn_ctx_free(bnctx)        BN_CTX_free(bnctx)
+#define ssh2_bn_ctx                  BN_CTX
+#define ssh2_bn_ctx_new()            BN_CTX_new()
+#define ssh2_bn_ctx_free(bnctx)      BN_CTX_free(bnctx)
 
-#define ssh2_bn                        BIGNUM
-#define ssh2_bn_init()                 BN_new()
-#define ssh2_bn_set_word(bn, val)      !BN_set_word(bn, val)
-#define ssh2_bn_to_bin(bn, val)        (BN_bn2bin(bn, val) <= 0)
-#define ssh2_bn_from_bin(bn, l, bin)   (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
-#define ssh2_bn_bytes(bn)              BN_num_bytes(bn)
-#define ssh2_bn_bits(bn)               BN_num_bits(bn)
-#define ssh2_bn_free(bn)               BN_clear_free(bn)
+#define ssh2_bn                      BIGNUM
+#define ssh2_bn_init()               BN_new()
+#define ssh2_bn_set_word(bn, val)    !BN_set_word(bn, val)
+#define ssh2_bn_to_bin(bn, val)      (BN_bn2bin(bn, val) <= 0)
+#define ssh2_bn_from_bin(bn, l, bin) (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
+#define ssh2_bn_bytes(bn)            BN_num_bytes(bn)
+#define ssh2_bn_bits(bn)             BN_num_bits(bn)
+#define ssh2_bn_free(bn)             BN_clear_free(bn)
 
 /* Default generate and safe prime sizes for
    diffie-hellman-group-exchange-sha1 */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -327,7 +327,6 @@ typedef enum {
 #define ssh2_bn_init()            BN_new()
 #define ssh2_bn_init_from_bin()   ssh2_bn_init()
 #define ssh2_bn_set_word(bn, val) !BN_set_word(bn, val)
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val);
 #define ssh2_bn_to_bin(bn, val)   (BN_bn2bin(bn, val) <= 0)
 #define ssh2_bn_bytes(bn)         BN_num_bytes(bn)
 #define ssh2_bn_bits(bn)          BN_num_bits(bn)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -325,7 +325,6 @@ typedef enum {
 
 #define ssh2_bn                        BIGNUM
 #define ssh2_bn_init()                 BN_new()
-#define ssh2_bn_init_from_bin()        ssh2_bn_init()
 #define ssh2_bn_set_word(bn, val)      !BN_set_word(bn, val)
 #define ssh2_bn_to_bin(bn, val)        (BN_bn2bin(bn, val) <= 0)
 #define ssh2_bn_from_bin(bn, len, bin) (BN_bin2bn(bin, (int)len, bn) ? 0 : -1)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -319,18 +319,19 @@ typedef enum {
 
 #define ssh2_cipher_dtor(ctx) EVP_CIPHER_CTX_free(*(ctx))
 
-#define ssh2_bn_ctx               BN_CTX
-#define ssh2_bn_ctx_new()         BN_CTX_new()
-#define ssh2_bn_ctx_free(bnctx)   BN_CTX_free(bnctx)
+#define ssh2_bn_ctx                    BN_CTX
+#define ssh2_bn_ctx_new()              BN_CTX_new()
+#define ssh2_bn_ctx_free(bnctx)        BN_CTX_free(bnctx)
 
-#define ssh2_bn                   BIGNUM
-#define ssh2_bn_init()            BN_new()
-#define ssh2_bn_init_from_bin()   ssh2_bn_init()
-#define ssh2_bn_set_word(bn, val) !BN_set_word(bn, val)
-#define ssh2_bn_to_bin(bn, val)   (BN_bn2bin(bn, val) <= 0)
-#define ssh2_bn_bytes(bn)         BN_num_bytes(bn)
-#define ssh2_bn_bits(bn)          BN_num_bits(bn)
-#define ssh2_bn_free(bn)          BN_clear_free(bn)
+#define ssh2_bn                        BIGNUM
+#define ssh2_bn_init()                 BN_new()
+#define ssh2_bn_init_from_bin()        ssh2_bn_init()
+#define ssh2_bn_set_word(bn, val)      !BN_set_word(bn, val)
+#define ssh2_bn_to_bin(bn, val)        (BN_bn2bin(bn, val) <= 0)
+#define ssh2_bn_from_bin(bn, len, bin) (BN_bin2bn(bin, (int)len, bn) ? 0 : -1)
+#define ssh2_bn_bytes(bn)              BN_num_bytes(bn)
+#define ssh2_bn_bits(bn)               BN_num_bits(bn)
+#define ssh2_bn_free(bn)               BN_clear_free(bn)
 
 /* Default generate and safe prime sizes for
    diffie-hellman-group-exchange-sha1 */

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -326,8 +326,8 @@ typedef enum {
 #define ssh2_bn                      BIGNUM
 #define ssh2_bn_init()               BN_new()
 #define ssh2_bn_set_word(bn, val)    !BN_set_word(bn, val)
-#define ssh2_bn_to_bin(bn, val)      (BN_bn2bin(bn, val) <= 0)
 #define ssh2_bn_from_bin(bn, l, bin) (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
+#define ssh2_bn_to_bin(bn, val)      (BN_bn2bin(bn, val) <= 0)
 #define ssh2_bn_bytes(bn)            BN_num_bytes(bn)
 #define ssh2_bn_bits(bn)             BN_num_bits(bn)
 #define ssh2_bn_free(bn)             BN_clear_free(bn)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -327,7 +327,7 @@ typedef enum {
 #define ssh2_bn_init()                 BN_new()
 #define ssh2_bn_set_word(bn, val)      !BN_set_word(bn, val)
 #define ssh2_bn_to_bin(bn, val)        (BN_bn2bin(bn, val) <= 0)
-#define ssh2_bn_from_bin(bn, len, bin) (BN_bin2bn(bin, (int)len, bn) ? 0 : -1)
+#define ssh2_bn_from_bin(bn, l, bin)   (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
 #define ssh2_bn_bytes(bn)              BN_num_bytes(bn)
 #define ssh2_bn_bits(bn)               BN_num_bits(bn)
 #define ssh2_bn_free(bn)               BN_clear_free(bn)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -429,7 +429,7 @@ static int bn_resize(ssh2_bn *bn, size_t newlen)
     return 0;
 }
 
-unsigned long ssh2_bn_bits(ssh2_bn *bn)
+unsigned long ssh2_bn_bits(const ssh2_bn *bn)
 {
     unsigned int i;
     unsigned char b;
@@ -475,7 +475,7 @@ int ssh2_bn_set_word(ssh2_bn *bn, unsigned long val)
     return ssh2_bn_from_bin(bn, sizeof(val), (unsigned char *)&val);
 }
 
-int ssh2_bn_to_bin(ssh2_bn *bn, unsigned char *val)
+int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *val)
 {
     int i;
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -251,6 +251,9 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 
 #define ssh2_bn struct os400qc3_bn
 
+#define ssh2_bn_init_from_bin()  ssh2_bn_init()
+#define ssh2_bn_bytes(bn)        ((bn)->length)
+
 /* Cipher */
 
 #define SSH2_CIPHER_T(name)   struct os400qc3_cipher name

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -249,8 +249,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_bn_ctx_new()        0 /* not used */
 #define ssh2_bn_ctx_free(bnctx)  ((void)0) /* not used */
 
-#define ssh2_bn struct os400qc3_bn
-
+#define ssh2_bn                  struct os400qc3_bn
 #define ssh2_bn_init_from_bin()  ssh2_bn_init()
 #define ssh2_bn_bytes(bn)        ((bn)->length)
 

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -251,15 +251,6 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 
 #define ssh2_bn struct os400qc3_bn
 
-ssh2_bn *ssh2_bn_init(void);
-#define ssh2_bn_init_from_bin()  ssh2_bn_init()
-int ssh2_bn_set_word(ssh2_bn *bn, unsigned long val);
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *v);
-int ssh2_bn_to_bin(ssh2_bn *bn, unsigned char *val);
-#define ssh2_bn_bytes(bn)        ((bn)->length)
-unsigned long ssh2_bn_bits(ssh2_bn *bn);
-void ssh2_bn_free(ssh2_bn *bn);
-
 /* Cipher */
 
 #define SSH2_CIPHER_T(name)   struct os400qc3_cipher name

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -250,7 +250,6 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #define ssh2_bn_ctx_free(bnctx)  ((void)0) /* not used */
 
 #define ssh2_bn                  struct os400qc3_bn
-#define ssh2_bn_init_from_bin()  ssh2_bn_init()
 #define ssh2_bn_bytes(bn)        ((bn)->length)
 
 /* Cipher */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -147,7 +147,7 @@ static void wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
  * Windows CNG backend: BigNumber functions
  */
 
-ssh2_bn *ssh2_wcng_bn_init(void)
+ssh2_bn *ssh2_bn_init(void)
 {
     ssh2_bn *bignum = malloc(sizeof(ssh2_bn));
     if(bignum) {
@@ -291,7 +291,7 @@ static int wcng_bn_mod_exp(ssh2_bn *r, ssh2_bn *a, ssh2_bn *p, ssh2_bn *m)
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-int ssh2_wcng_bn_set_word(ssh2_bn *bn, ULONG word)
+int ssh2_bn_set_word(ssh2_bn *bn, ULONG word)
 {
     ULONG offset, number, bits, length;
 
@@ -314,7 +314,7 @@ int ssh2_wcng_bn_set_word(ssh2_bn *bn, ULONG word)
     return 0;
 }
 
-ULONG ssh2_wcng_bn_bits(const ssh2_bn *bn)
+ULONG ssh2_bn_bits(const ssh2_bn *bn)
 {
     unsigned char number;
     ULONG offset, length, bits;
@@ -336,7 +336,7 @@ ULONG ssh2_wcng_bn_bits(const ssh2_bn *bn)
     return bits;
 }
 
-int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin)
+int ssh2_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin)
 {
     unsigned char *bignum;
     ULONG offset, length, bits;
@@ -349,7 +349,7 @@ int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin)
 
     memcpy(bn->bignum, bin, len);
 
-    bits = ssh2_wcng_bn_bits(bn);
+    bits = ssh2_bn_bits(bn);
     length = (bits + 7) / 8;
 
     offset = bn->length - length;
@@ -370,7 +370,7 @@ int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin)
     return 0;
 }
 
-int ssh2_wcng_bn_to_bin(const ssh2_bn *bn, unsigned char *bin)
+int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin)
 {
     if(bin && bn && bn->bignum && bn->length > 0) {
         memcpy(bin, bn->bignum, bn->length);
@@ -380,7 +380,7 @@ int ssh2_wcng_bn_to_bin(const ssh2_bn *bn, unsigned char *bin)
     return -1;
 }
 
-void ssh2_wcng_bn_free(ssh2_bn *bn)
+void ssh2_bn_free(ssh2_bn *bn)
 {
     if(bn) {
         if(bn->bignum) {
@@ -2278,7 +2278,7 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **k,
     }
 
     /* Allocate a secret bignum to be ready to receive the derived secret */
-    *k = ssh2_wcng_bn_init();
+    *k = ssh2_bn_init();
     if(!*k) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2313,7 +2313,7 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **k,
 
 cleanup:
     if(result != LIBSSH2_ERROR_NONE && *k) {
-        ssh2_wcng_bn_free(*k);
+        ssh2_bn_free(*k);
         *k = NULL;
     }
 
@@ -3224,7 +3224,7 @@ void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
         dhctx->dh_params = NULL;
     }
     if(dhctx->dh_privbn) {
-        ssh2_wcng_bn_free(dhctx->dh_privbn);
+        ssh2_bn_free(dhctx->dh_privbn);
         dhctx->dh_privbn = NULL;
     }
 }
@@ -3365,7 +3365,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
 
         if(dh_key_blob->dwMagic == BCRYPT_DH_PRIVATE_MAGIC) {
             /* BCRYPT_DH_PRIVATE_BLOB additionally contains the Private data */
-            dhctx->dh_privbn = ssh2_wcng_bn_init();
+            dhctx->dh_privbn = ssh2_bn_init();
             if(!dhctx->dh_privbn) {
                 wcng_zero_free(dh_key_blob, key_length_bytes);
                 return -1;
@@ -3399,7 +3399,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     }
 
     /* Generate x and e */
-    dhctx->dh_privbn = ssh2_wcng_bn_init();
+    dhctx->dh_privbn = ssh2_bn_init();
     if(!dhctx->dh_privbn)
         return -1;
     if(wcng_bn_random(dhctx->dh_privbn, (group_order * 8) - 1, 0, -1))

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -291,7 +291,7 @@ static int wcng_bn_mod_exp(ssh2_bn *r, ssh2_bn *a, ssh2_bn *p, ssh2_bn *m)
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-int ssh2_bn_set_word(ssh2_bn *bn, ULONG word)
+int ssh2_bn_set_word(ssh2_bn *bn, size_t word)
 {
     ULONG offset, number, bits, length;
 
@@ -299,7 +299,7 @@ int ssh2_bn_set_word(ssh2_bn *bn, ULONG word)
         return -1;
 
     bits = 0;
-    number = word;
+    number = (ULONG)word;
     while(number >>= 1)
         bits++;
     bits++;
@@ -309,15 +309,16 @@ int ssh2_bn_set_word(ssh2_bn *bn, ULONG word)
         return -1;
 
     for(offset = 0; offset < length; offset++)
-        bn->bignum[offset] = (word >> (offset * 8)) & 0xff;
+        bn->bignum[offset] = ((ULONG)word >> (offset * 8)) & 0xff;
 
     return 0;
 }
 
-ULONG ssh2_bn_bits(const ssh2_bn *bn)
+size_t ssh2_bn_bits(const ssh2_bn *bn)
 {
     unsigned char number;
-    ULONG offset, length, bits;
+    ULONG offset, length;
+    size_t bits;
 
     if(!bn || !bn->bignum || !bn->length)
         return 0;
@@ -336,21 +337,22 @@ ULONG ssh2_bn_bits(const ssh2_bn *bn)
     return bits;
 }
 
-int ssh2_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin)
+int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin)
 {
     unsigned char *bignum;
-    ULONG offset, length, bits;
+    ULONG offset, length;
+    size_t bits;
 
     if(!bn || !bin || !len)
         return -1;
 
-    if(wcng_bn_resize(bn, len))
+    if(wcng_bn_resize(bn, (ULONG)len))
         return -1;
 
     memcpy(bn->bignum, bin, len);
 
     bits = ssh2_bn_bits(bn);
-    length = (bits + 7) / 8;
+    length = ((ULONG)bits + 7) / 8;
 
     offset = bn->length - length;
     if(offset > 0) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -291,7 +291,7 @@ static int wcng_bn_mod_exp(ssh2_bn *r, ssh2_bn *a, ssh2_bn *p, ssh2_bn *m)
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-int ssh2_bn_set_word(ssh2_bn *bn, size_t word)
+int ssh2_bn_set_word(ssh2_bn *bn, unsigned long word)
 {
     ULONG offset, number, bits, length;
 
@@ -299,7 +299,7 @@ int ssh2_bn_set_word(ssh2_bn *bn, size_t word)
         return -1;
 
     bits = 0;
-    number = (ULONG)word;
+    number = word;
     while(number >>= 1)
         bits++;
     bits++;
@@ -309,16 +309,15 @@ int ssh2_bn_set_word(ssh2_bn *bn, size_t word)
         return -1;
 
     for(offset = 0; offset < length; offset++)
-        bn->bignum[offset] = ((ULONG)word >> (offset * 8)) & 0xff;
+        bn->bignum[offset] = (word >> (offset * 8)) & 0xff;
 
     return 0;
 }
 
-size_t ssh2_bn_bits(const ssh2_bn *bn)
+unsigned long ssh2_bn_bits(const ssh2_bn *bn)
 {
     unsigned char number;
-    ULONG offset, length;
-    size_t bits;
+    ULONG offset, length, bits;
 
     if(!bn || !bn->bignum || !bn->length)
         return 0;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -339,8 +339,7 @@ unsigned long ssh2_bn_bits(const ssh2_bn *bn)
 int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin)
 {
     unsigned char *bignum;
-    ULONG offset, length;
-    size_t bits;
+    ULONG offset, length, bits;
 
     if(!bn || !bin || !len)
         return -1;
@@ -351,7 +350,7 @@ int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin)
     memcpy(bn->bignum, bin, len);
 
     bits = ssh2_bn_bits(bn);
-    length = ((ULONG)bits + 7) / 8;
+    length = (bits + 7) / 8;
 
     offset = bn->length - length;
     if(offset > 0) {

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -300,26 +300,8 @@ struct wcng_bn {
 
 #define ssh2_bn struct wcng_bn
 
-/*
- * Windows CNG backend: BigNumber functions
- */
-
-#define ssh2_bn_init()                 ssh2_wcng_bn_init()
 #define ssh2_bn_init_from_bin()        ssh2_bn_init()
-#define ssh2_bn_set_word(bn, word)     ssh2_wcng_bn_set_word(bn, word)
-#define ssh2_bn_from_bin(bn, len, bin) \
-    ssh2_wcng_bn_from_bin(bn, (ULONG)(len), bin)
-#define ssh2_bn_to_bin(bn, bin)        ssh2_wcng_bn_to_bin(bn, bin)
 #define ssh2_bn_bytes(bn)              ((bn)->length)
-#define ssh2_bn_bits(bn)               ssh2_wcng_bn_bits(bn)
-#define ssh2_bn_free(bn)               ssh2_wcng_bn_free(bn)
-
-ssh2_bn *ssh2_wcng_bn_init(void);
-int ssh2_wcng_bn_set_word(ssh2_bn *bn, ULONG word);
-ULONG ssh2_wcng_bn_bits(const ssh2_bn *bn);
-int ssh2_wcng_bn_from_bin(ssh2_bn *bn, ULONG len, const unsigned char *bin);
-int ssh2_wcng_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
-void ssh2_wcng_bn_free(ssh2_bn *bn);
 
 /*
  * Windows CNG backend: Diffie-Hellman support

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -294,7 +294,6 @@ struct wcng_bn {
 };
 
 #define ssh2_bn                  struct wcng_bn
-
 #define ssh2_bn_init_from_bin()  ssh2_bn_init()
 #define ssh2_bn_bytes(bn)        ((bn)->length)
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -281,17 +281,12 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
 
 /*******************************************************************/
 /*
- * Windows CNG backend: BigNumber Context
+ * Windows CNG backend: BigNumber support
  */
 
 #define ssh2_bn_ctx             int /* not used */
 #define ssh2_bn_ctx_new()       0 /* not used */
 #define ssh2_bn_ctx_free(bnctx) ((void)0) /* not used */
-
-/*******************************************************************/
-/*
- * Windows CNG backend: BigNumber structure
- */
 
 struct wcng_bn {
     unsigned char *bignum;

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -294,7 +294,6 @@ struct wcng_bn {
 };
 
 #define ssh2_bn                  struct wcng_bn
-#define ssh2_bn_init_from_bin()  ssh2_bn_init()
 #define ssh2_bn_bytes(bn)        ((bn)->length)
 
 /*

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -284,19 +284,19 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
  * Windows CNG backend: BigNumber support
  */
 
-#define ssh2_bn_ctx             int /* not used */
-#define ssh2_bn_ctx_new()       0 /* not used */
-#define ssh2_bn_ctx_free(bnctx) ((void)0) /* not used */
+#define ssh2_bn_ctx              int /* not used */
+#define ssh2_bn_ctx_new()        0 /* not used */
+#define ssh2_bn_ctx_free(bnctx)  ((void)0) /* not used */
 
 struct wcng_bn {
     unsigned char *bignum;
     ULONG length;
 };
 
-#define ssh2_bn struct wcng_bn
+#define ssh2_bn                  struct wcng_bn
 
-#define ssh2_bn_init_from_bin()        ssh2_bn_init()
-#define ssh2_bn_bytes(bn)              ((bn)->length)
+#define ssh2_bn_init_from_bin()  ssh2_bn_init()
+#define ssh2_bn_bytes(bn)        ((bn)->length)
 
 /*
  * Windows CNG backend: Diffie-Hellman support


### PR DESCRIPTION
To simplify, reduce boilerplate.

Also:
- sync minor type differences between backends.
- openssl: replace local wrapper with macro mapping.

---

https://github.com/libssh2/libssh2/pull/2243/files?w=1
