### PR TITLE
knownhost: fix hmac context memleaks on error paths

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -431,9 +431,9 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                         break;
                     if(!ssh2_hmac_ctx_init(&ctx))
                         break;
-                    if(!ssh2_hmac_sha1_init(&ctx, node->salt, node->salt_len))
-                        break;
-                    if(!ssh2_hmac_update(&ctx, host, strlen(host)) ||
+                    if(!ssh2_hmac_sha1_init(&ctx,
+                                            node->salt, node->salt_len) ||
+                       !ssh2_hmac_update(&ctx, host, strlen(host)) ||
                        !ssh2_hmac_final(&ctx, hash, SSH2_SHA1_DIG_LEN)) {
                         ssh2_hmac_cleanup(&ctx);
                         break;

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -424,12 +424,12 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                        stored hash. */
                     unsigned char hash[SSH2_SHA1_DIG_LEN];
                     ssh2_hmac_ctx ctx;
-                    if(!ssh2_hmac_ctx_init(&ctx))
-                        break;
 
                     if(SSH2_SHA1_DIG_LEN != node->name_len)
                         /* the name hash length must be the sha1 size or
                            we cannot match it */
+                        break;
+                    if(!ssh2_hmac_ctx_init(&ctx))
                         break;
                     if(!ssh2_hmac_sha1_init(&ctx, node->salt, node->salt_len))
                         break;


### PR DESCRIPTION
Bug: https://github.com/libssh2/libssh2/pull/2244#discussion_r3539968455
