### PR TITLE
crypto: de-dupe `*_supported_key_sign_algs()` into `userauth.c`

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -352,20 +352,6 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               size_t privatekeydata_len,
                               const char *passphrase);
 
-/**
- * @abstract Returns supported algorithms used for upgrading public
- * key signing RFC 8332
- * @discussion Based on the incoming key_method value, this function
- * returns supported algorithms that can upgrade the key method
- * @param key_method current key method, usually the default key sig method
- * @param key_method_len length of the key method buffer
- * @result comma separated list of supported upgrade options per RFC 8332, if
- * there is no upgrade option return NULL
- */
-const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                         unsigned char *key_method,
-                                         size_t key_method_len);
-
 #ifndef ssh2_bn_init
 ssh2_bn *ssh2_bn_init(void);
 void ssh2_bn_free(ssh2_bn *bn);

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -813,30 +813,4 @@ void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
     *dhctx = NULL;
 }
 
-/*
- * Return supported key hash algo upgrades, see crypto.h
- */
-const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                         unsigned char *key_method,
-                                         size_t key_method_len)
-{
-    (void)session;
-
-#if LIBSSH2_RSA_SHA2
-    if(key_method_len == 7 &&
-       !memcmp(key_method, "ssh-rsa", key_method_len)) {
-        return "rsa-sha2-512,rsa-sha2-256"
-#if LIBSSH2_RSA_SHA1
-            ",ssh-rsa"
-#endif
-            ;
-    }
-#else
-    (void)key_method;
-    (void)key_method_len;
-#endif
-
-    return NULL;
-}
-
 #endif /* LIBSSH2_LIBGCRYPT */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1303,30 +1303,4 @@ void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx)
 }
 #endif /* LIBSSH2_ECDSA */
 
-/*
- * Return supported key hash algo upgrades, see crypto.h
- */
-const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                         unsigned char *key_method,
-                                         size_t key_method_len)
-{
-    (void)session;
-
-#if LIBSSH2_RSA_SHA2
-    if(key_method_len == 7 &&
-       !memcmp(key_method, "ssh-rsa", key_method_len)) {
-        return "rsa-sha2-512,rsa-sha2-256"
-#if LIBSSH2_RSA_SHA1
-            ",ssh-rsa"
-#endif
-            ;
-    }
-#else
-    (void)key_method;
-    (void)key_method_len;
-#endif
-
-    return NULL;
-}
-
 #endif /* LIBSSH2_MBEDTLS */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -4310,32 +4310,4 @@ void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)
     *dhctx = NULL;
 }
 
-/*
- * Return supported key hash algo upgrades, see crypto.h
- */
-const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                         unsigned char *key_method,
-                                         size_t key_method_len)
-{
-    (void)session;
-
-#if LIBSSH2_RSA_SHA2
-    if((key_method_len == 7 &&
-        !memcmp(key_method, "ssh-rsa", key_method_len)) ||
-       (key_method_len == 28 &&
-        !memcmp(key_method, "ssh-rsa-cert-v01@openssh.com", key_method_len))) {
-        return "rsa-sha2-512,rsa-sha2-256"
-#if LIBSSH2_RSA_SHA1
-            ",ssh-rsa"
-#endif
-            ;
-    }
-#else
-    (void)key_method;
-    (void)key_method_len;
-#endif
-
-    return NULL;
-}
-
 #endif /* LIBSSH2_OPENSSL || LIBSSH2_WOLFSSL */

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2398,32 +2398,6 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session,
     return 0;
 }
 
-/*
- * Return supported key hash algo upgrades, see crypto.h
- */
-const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                         unsigned char *key_method,
-                                         size_t key_method_len)
-{
-    (void)session;
-
-#if LIBSSH2_RSA_SHA2
-    if(key_method_len == 7 &&
-       !memcmp(key_method, "ssh-rsa", key_method_len)) {
-        return "rsa-sha2-512,rsa-sha2-256"
-#if LIBSSH2_RSA_SHA1
-            ",ssh-rsa"
-#endif
-            ;
-    }
-#else
-    (void)key_method;
-    (void)key_method_len;
-#endif
-
-    return NULL;
-}
-
 #endif /* LIBSSH2_OS400QC3 */
 
 /* vim: set expandtab ts=4 sw=4: */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1314,7 +1314,7 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
         !memcmp(key_method, "ssh-rsa", key_method_len))
 #if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
        || (key_method_len == 28 &&
-          !memcmp(key_method, "ssh-rsa-cert-v01@openssh.com", key_method_len))
+           !memcmp(key_method, "ssh-rsa-cert-v01@openssh.com", key_method_len))
 #endif
       ) {
         return "rsa-sha2-512,rsa-sha2-256"

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1293,8 +1293,15 @@ static int userauth_is_version_less_than_78(const char *version)
     return 0;
 }
 
-/*
- * Return supported key hash algo upgrades, see crypto.h
+/**
+ * @abstract Returns supported algorithms used for upgrading public
+ * key signing RFC 8332
+ * @discussion Based on the incoming key_method value, this function
+ * returns supported algorithms that can upgrade the key method
+ * @param key_method current key method, usually the default key sig method
+ * @param key_method_len length of the key method buffer
+ * @result comma separated list of supported upgrade options per RFC 8332, if
+ * there is no upgrade option return NULL
  */
 static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
                                                     unsigned char *key_method,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1357,7 +1357,8 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
     const char * const remote_ver_pre = "OpenSSH_";
 
     const char *supported_algs =
-        userauth_supported_key_sign_algs(session, *key_method, *key_method_len);
+        userauth_supported_key_sign_algs(session,
+                                         *key_method, *key_method_len);
 
     if(!supported_algs || !session->server_sign_algorithms)
         /* no upgrading key algorithm supported, do nothing */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1336,7 +1336,7 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
  * @discussion Based on the incoming key_method value, this function
  * Upgrades the key method input based on user preferences,
  * server support algos and crypto backend support
- * @related ssh2_supported_key_sign_algs()
+ * @related userauth_supported_key_sign_algs()
  * @param key_method current key method, usually the default key sig method
  * @param key_method_len length of the key method buffer
  * @result error code or zero on success

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1293,6 +1293,37 @@ static int userauth_is_version_less_than_78(const char *version)
     return 0;
 }
 
+/*
+ * Return supported key hash algo upgrades, see crypto.h
+ */
+static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
+                                                    unsigned char *key_method,
+                                                    size_t key_method_len)
+{
+    (void)session;
+
+#if LIBSSH2_RSA_SHA2
+    if((key_method_len == 7 &&
+        !memcmp(key_method, "ssh-rsa", key_method_len))
+#if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
+       || (key_method_len == 28 &&
+          !memcmp(key_method, "ssh-rsa-cert-v01@openssh.com", key_method_len))
+#endif
+      ) {
+        return "rsa-sha2-512,rsa-sha2-256"
+#if LIBSSH2_RSA_SHA1
+            ",ssh-rsa"
+#endif
+            ;
+    }
+#else
+    (void)key_method;
+    (void)key_method_len;
+#endif
+
+    return NULL;
+}
+
 /**
  * @abstract Upgrades the algorithm used for public key signing RFC 8332
  * @discussion Based on the incoming key_method value, this function
@@ -1326,7 +1357,7 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
     const char * const remote_ver_pre = "OpenSSH_";
 
     const char *supported_algs =
-        ssh2_supported_key_sign_algs(session, *key_method, *key_method_len);
+        userauth_supported_key_sign_algs(session, *key_method, *key_method_len);
 
     if(!supported_algs || !session->server_sign_algorithms)
         /* no upgrading key algorithm supported, do nothing */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3502,30 +3502,4 @@ fallback:
     return wcng_bn_mod_exp(secret, f, dhctx->dh_privbn, p);
 }
 
-/*
- * Return supported key hash algo upgrades, see crypto.h
- */
-const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                         unsigned char *key_method,
-                                         size_t key_method_len)
-{
-    (void)session;
-
-#if LIBSSH2_RSA_SHA2
-    if(key_method_len == 7 &&
-       !memcmp(key_method, "ssh-rsa", key_method_len)) {
-        return "rsa-sha2-512,rsa-sha2-256"
-#if LIBSSH2_RSA_SHA1
-            ",ssh-rsa"
-#endif
-            ;
-    }
-#else
-    (void)key_method;
-    (void)key_method_len;
-#endif
-
-    return NULL;
-}
-
 #endif /* LIBSSH2_WINCNG */


### PR DESCRIPTION
They were shared between all crypto backends, except openssl, which
supports an extra key method. Retain this exception by using the
`LIBSSH2_OPENSSL` guards. This is a workaround, but I deem it fine, due
to already existing evidence for per-crypto-backend logic in non-crypto
code, and the codebase already making this exception in tests. 
                                                               
A better option would be introducing a crypto-feature macro flag, maybe
in a future commit. Perhaps also worth a check whether the exception is
necessary.

Ref: 3a6ab70dcfeb87a3acbb5af7ea6fc783c3981e04 #1314
Follow-up to 82ffc1b8aaabbd39e034b9993faadba81f821d65 #2248

---

- it may also happen the exception is unnecessary. To be tested in another PR.