### PR TITLE
libgcrypt: check for more errors in `ssh2_hash_final()`/`ssh_hmac_final()`

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -51,8 +51,11 @@ int ssh2_hash_final(ssh2_hash_ctx *ctx, void *digest, size_t digest_len)
     int ret = 0;
     unsigned int actual_len = gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx));
     if(digest_len >= actual_len) {
-        memcpy(digest, gcry_md_read(*ctx, 0), actual_len);
-        ret = 1;
+        unsigned char *res = gcry_md_read(*ctx, 0);
+        if(res) {
+            memcpy(digest, res, actual_len);
+            ret = 1;
+        }
     }
     gcry_md_close(*ctx);
     return ret;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -91,15 +91,16 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
-    unsigned char *res = gcry_md_read(*ctx, 0);
-    (void)maclen;
-
-    if(!res)
-        return 0;
-
-    memcpy(mac, res, gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx)));
-
-    return 1;
+    int ret = 0;
+    unsigned int actual_len = gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx));
+    if(maclen >= actual_len) {
+        unsigned char *res = gcry_md_read(*ctx, 0);
+        if(res) {
+            memcpy(mac, res, actual_len);
+            ret = 1;
+        }
+    }
+    return ret;
 }
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)


### PR DESCRIPTION
- check `gcry_md_read()` success in `ssh2_hash_final()`, to sync
  with `ssh2_hmac_final()` and libgcrypt documentation.
- check if result fits into return buffer in `ssh2_hmac_final()`, to sync
  with `ssh2_hash_final()`.

Ref: https://www.gnupg.org/documentation/manuals/gcrypt/Working-with-hash-algorithms.html

---

https://github.com/libssh2/libssh2/pull/2250/files?w=1
