### PR TITLE
userauth: try allowing `ssh-rsa-cert-v01@openssh.com` for all backends

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1311,12 +1311,9 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
 
 #if LIBSSH2_RSA_SHA2
     if((key_method_len == 7 &&
-        !memcmp(key_method, "ssh-rsa", key_method_len))
-#if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
-       || (key_method_len == 28 &&
-           !memcmp(key_method, "ssh-rsa-cert-v01@openssh.com", key_method_len))
-#endif
-      ) {
+        !memcmp(key_method, "ssh-rsa", key_method_len)) ||
+       (key_method_len == 28 &&
+        !memcmp(key_method, "ssh-rsa-cert-v01@openssh.com", key_method_len))) {
         return "rsa-sha2-512,rsa-sha2-256"
 #if LIBSSH2_RSA_SHA1
             ",ssh-rsa"

--- a/tests/test_auth_pubkey_ok_ecdsa_signed.c
+++ b/tests/test_auth_pubkey_ok_ecdsa_signed.c
@@ -7,8 +7,7 @@
 
 int test(LIBSSH2_SESSION *session)
 {
-#if LIBSSH2_ECDSA && \
-    (defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL))
+#if LIBSSH2_ECDSA
     /* set in Dockerfile */
     return test_auth_pubkey(session, 0,
                             "libssh2",

--- a/tests/test_auth_pubkey_ok_ecdsa_signed.c
+++ b/tests/test_auth_pubkey_ok_ecdsa_signed.c
@@ -7,7 +7,8 @@
 
 int test(LIBSSH2_SESSION *session)
 {
-#if LIBSSH2_ECDSA
+#if LIBSSH2_ECDSA && \
+    (defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL))
     /* set in Dockerfile */
     return test_auth_pubkey(session, 0,
                             "libssh2",

--- a/tests/test_auth_pubkey_ok_rsa_sha2_256_signed.c
+++ b/tests/test_auth_pubkey_ok_rsa_sha2_256_signed.c
@@ -7,8 +7,7 @@
 
 int test(LIBSSH2_SESSION *session)
 {
-#if LIBSSH2_RSA_SHA2 && \
-    (defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL))
+#if LIBSSH2_RSA_SHA2
     /* set in Dockerfile */
     return test_auth_pubkey(session, 0,
                             "libssh2",


### PR DESCRIPTION
The PR implementing this did not add anything OpenSSL-specific, yet it 
gated the feature OpenSSL only. This may be due to OpenSSL supporting a
necessary feature built-in, while others don't. Yet, I wonder if enabling
it everywhere could cause issues?

Ref: https://github.com/libssh2/libssh2/pull/1314#discussion_r3542830756
Follow-up to 1410efad7ab2f11b47bf16affaa9862a721d33fd #2249
Follow-up to 3a6ab70dcfeb87a3acbb5af7ea6fc783c3981e04 #1314

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
