### PR TITLE
mbedtls, openssl: make `ssh2_hmac_update()` a macro wrapper

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -88,7 +88,9 @@ int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx);
 int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
                    void *key, size_t keylen);
+#ifndef ssh2_hmac_update
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen);
+#endif
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen);
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -215,11 +215,6 @@ int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
     return 1;
 }
 
-int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
-{
-    return psa_mac_update(&ctx->mac, data, datalen) == PSA_SUCCESS;
-}
-
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
     size_t actual_len;

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -119,6 +119,9 @@ struct mbed_hash_ctx {
 
 #define ssh2_hmac_ctx struct mbed_hash_ctx
 
+#define ssh2_hmac_update(ctx, d, l) \
+    (psa_mac_update(ctx.mac, (const uint8_t *)(d), l) == PSA_SUCCESS)
+
 #if LIBSSH2_HMAC_RIPEMD
 #define SSH2_RIPEMD160_HMAC PSA_ALG_RIPEMD160
 #endif

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -120,7 +120,7 @@ struct mbed_hash_ctx {
 #define ssh2_hmac_ctx struct mbed_hash_ctx
 
 #define ssh2_hmac_update(ctx, d, l) \
-    (psa_mac_update(ctx.mac, (const uint8_t *)(d), l) == PSA_SUCCESS)
+    (psa_mac_update(&((ctx)->mac), (const uint8_t *)(d), l) == PSA_SUCCESS)
 
 #if LIBSSH2_HMAC_RIPEMD
 #define SSH2_RIPEMD160_HMAC PSA_ALG_RIPEMD160

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -128,18 +128,6 @@ int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
 #endif
 }
 
-int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
-{
-#ifdef USE_OPENSSL_3
-    return EVP_MAC_update(*ctx, data, datalen);
-#elif defined(LIBSSH2_WOLFSSL)
-    /* As of wolfSSL v5.9.1 datalen is int, not size_t */
-    return HMAC_Update(*ctx, data, (int)datalen);
-#else
-    return HMAC_Update(*ctx, data, datalen);
-#endif
-}
-
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
 {
 #ifdef USE_OPENSSL_3

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -240,6 +240,8 @@
 #ifdef USE_OPENSSL_3
 #define ssh2_hmac_ctx       EVP_MAC_CTX *
 #define ssh2_hmac_alg       const char *
+#define ssh2_hmac_update(ctx, d, l) \
+    EVP_MAC_update(*(ctx), (const unsigned char *)(d), l)
 #define SSH2_SHA1_HMAC      OSSL_DIGEST_NAME_SHA1
 #define SSH2_SHA256_HMAC    OSSL_DIGEST_NAME_SHA2_256
 #define SSH2_SHA512_HMAC    OSSL_DIGEST_NAME_SHA2_512
@@ -251,6 +253,13 @@
 #endif
 #else
 #define ssh2_hmac_ctx       HMAC_CTX *
+#ifdef LIBSSH2_WOLFSSL /* In wolfSSL length is int, not size_t */
+#define ssh2_hmac_update(ctx, d, l) \
+    HMAC_Update(*(ctx), (const unsigned char *)(d), (int)(l))
+#else
+#define ssh2_hmac_update(ctx, d, l) \
+    HMAC_Update(*(ctx), (const unsigned char *)(d), l)
+#endif
 #if LIBSSH2_HMAC_RIPEMD
 #define SSH2_RIPEMD160_HMAC EVP_ripemd160()
 #endif


### PR DESCRIPTION
To sync with `ssh2_hash_update()` in these backends, and possibly
improve performance.
