### PR TITLE
wolfssl: guard `OPENSSL_VERSION_NUMBER` off for wolfSSL

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -159,7 +159,8 @@
 # define LIBSSH2_ED25519 1
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x30500000L && \
+#if !defined(LIBSSH2_WOLFSSL) && \
+    OPENSSL_VERSION_NUMBER >= 0x30500000L && \
     !defined(LIBRESSL_VERSION_NUMBER)
 # define LIBSSH2_MLKEM 1
 #else


### PR DESCRIPTION
It may cause a confusing compiler warning in some cases, and also not
needed for wolfSSL builds.

Follow-up to 3ba252e2a6fe04d17ea13ad870698a4028c8ab4c #1644

---

The compiler warning may only happen when building with a wolfSSL not
suited for libssh2. I'm still investigating. Either way, this patch is valid.
