### PR TITLE
tidy-up: argument names, minor nits

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -291,10 +291,10 @@ cleanup:
                                                                        \
     while(*(total) < (length)) {                                       \
         if(!(agent)->pending_io)                                       \
-            ret = func((agent)->pipe, (char *)(buffer) + *(total),     \
-                       (DWORD)((length) - *(total)),                   \
-                       &bytes_transferred,                             \
-                       &(agent)->overlapped);                          \
+            ret = (func)((agent)->pipe, (char *)(buffer) + *(total),   \
+                         (DWORD)((length) - *(total)),                 \
+                         &bytes_transferred,                           \
+                         &(agent)->overlapped);                        \
         else                                                           \
             ret = GetOverlappedResult((agent)->pipe,                   \
                                       &(agent)->overlapped,            \
@@ -473,22 +473,22 @@ static int agent_connect_unix(LIBSSH2_AGENT *agent)
     return LIBSSH2_ERROR_NONE;
 }
 
-#define RECV_SEND_ALL(func, socket, buffer, length, flags, abstract)    \
-    do {                                                                \
-        size_t finished = 0;                                            \
-                                                                        \
-        while(finished < (length)) {                                    \
-            ssize_t rc;                                                 \
-            rc = func(socket,                                           \
-                      (char *)(buffer) + finished, (length) - finished, \
-                      flags, abstract);                                 \
-            if(rc < 0)                                                  \
-                return rc;                                              \
-                                                                        \
-            finished += rc;                                             \
-        }                                                               \
-                                                                        \
-        return finished;                                                \
+#define RECV_SEND_ALL(func, socket, buffer, length, flags, abstract)      \
+    do {                                                                  \
+        size_t finished = 0;                                              \
+                                                                          \
+        while(finished < (length)) {                                      \
+            ssize_t rc;                                                   \
+            rc = (func)(socket,                                           \
+                        (char *)(buffer) + finished, (length) - finished, \
+                        flags, abstract);                                 \
+            if(rc < 0)                                                    \
+                return rc;                                                \
+                                                                          \
+            finished += rc;                                               \
+        }                                                                 \
+                                                                          \
+        return finished;                                                  \
     } while(0)
 
 static ssize_t agent_send_all(LIBSSH2_SEND_FUNC(func), libssh2_socket_t socket,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -87,11 +87,11 @@ int ssh2_hash(ssh2_hash_alg alg, const void *input, size_t input_len,
 /* return: success = 1, error = 0 */
 int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx);
 int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
-                   void *key, size_t keylen);
+                   void *key, size_t key_len);
 #ifndef ssh2_hmac_update
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len);
 #endif
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen);
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t mac_len);
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -314,7 +314,7 @@ int ssh2_mlkem_get_sk(unsigned char *out_shared_key,
                       uint8_t *server_ciphertext);
 #endif /* LIBSSH2_MLKEM */
 
-int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
+int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt);
 int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -89,7 +89,7 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx);
 int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
                    void *key, size_t keylen);
 #ifndef ssh2_hmac_update
-int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen);
+int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len);
 #endif
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen);
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -326,8 +326,8 @@ static int hostkey_method_ssh_rsa_sha2_512_sig_verify(
 
     sig += 20;
     sig_len -= 20;
-    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA512_DIG_LEN, sig,
-                                sig_len, m, m_len);
+    return ssh2_rsa_sha2_verify(rsactx, SSH2_SHA512_DIG_LEN, sig, sig_len,
+                                m, m_len);
 }
 
 /*

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -643,7 +643,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
 }
 #endif
 
-int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
+int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
     int ret;
@@ -653,24 +653,24 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
 
     (void)encrypt;
 
-    ret = gcry_cipher_open(h, cipher, mode, 0);
+    ret = gcry_cipher_open(ctx, cipher, mode, 0);
     if(ret)
         return -1;
 
-    ret = gcry_cipher_setkey(*h, secret, keylen);
+    ret = gcry_cipher_setkey(*ctx, secret, keylen);
     if(ret) {
-        gcry_cipher_close(*h);
+        gcry_cipher_close(*ctx);
         return -1;
     }
 
     if(mode != GCRY_CIPHER_MODE_STREAM) {
         size_t blklen = gcry_cipher_get_algo_blklen(cipher);
         if(mode == GCRY_CIPHER_MODE_CTR)
-            ret = gcry_cipher_setctr(*h, iv, blklen);
+            ret = gcry_cipher_setctr(*ctx, iv, blklen);
         else
-            ret = gcry_cipher_setiv(*h, iv, blklen);
+            ret = gcry_cipher_setiv(*ctx, iv, blklen);
         if(ret) {
-            gcry_cipher_close(*h);
+            gcry_cipher_close(*ctx);
             return -1;
         }
     }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -72,9 +72,9 @@ int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
     return 1;
 }
 
-int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
+int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len)
 {
-    gcry_md_write(*ctx, data, datalen);
+    gcry_md_write(*ctx, input, input_len);
     return 1;
 }
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -60,13 +60,13 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 }
 
 int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
-                   void *key, size_t keylen)
+                   void *key, size_t key_len)
 {
     gcry_error_t err;
     err = gcry_md_open(ctx, alg, GCRY_MD_FLAG_HMAC);
     if(gcry_err_code(err) != GPG_ERR_NO_ERROR)
         return 0;
-    err = gcry_md_setkey(*ctx, key, keylen);
+    err = gcry_md_setkey(*ctx, key, key_len);
     if(gcry_err_code(err) != GPG_ERR_NO_ERROR)
         return 0;
     return 1;
@@ -78,11 +78,11 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len)
     return 1;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t mac_len)
 {
     int ret = 0;
     unsigned int actual_len = gcry_md_get_algo_dlen(gcry_md_get_algo(*ctx));
-    if(maclen >= actual_len) {
+    if(mac_len >= actual_len) {
         unsigned char *res = gcry_md_read(*ctx, 0);
         if(res) {
             memcpy(mac, res, actual_len);

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -130,6 +130,8 @@
 #define ssh2_bn_bits(bn)               gcry_mpi_get_nbits(bn)
 #define ssh2_bn_free(bn)               gcry_mpi_release(bn)
 
+#define ssh2_dh_ctx                    struct gcry_mpi *
+
 /* Default generate and safe prime sizes for
    diffie-hellman-group-exchange-sha1 */
 #define SSH2_DH_GEX_MINGROUP     2048
@@ -137,7 +139,5 @@
 #define SSH2_DH_GEX_MAXGROUP     8192
 
 #define SSH2_DH_MAX_MODULUS_BITS 16384
-
-#define ssh2_dh_ctx struct gcry_mpi *
 
 #endif /* LIBSSH2_LIBGCRYPT_H */

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -68,15 +68,15 @@
 
 #define ssh2_random(buf, len) (gcry_randomize(buf, len, GCRY_STRONG_RANDOM), 0)
 
-#define ssh2_hash_ctx gcry_md_hd_t
-#define ssh2_hash_alg int
+#define ssh2_hash_ctx         gcry_md_hd_t
+#define ssh2_hash_alg         int
 
-#define SSH2_SHA1_ALG   GCRY_MD_SHA1
-#define SSH2_SHA256_ALG GCRY_MD_SHA256
-#define SSH2_SHA384_ALG GCRY_MD_SHA384
-#define SSH2_SHA512_ALG GCRY_MD_SHA512
+#define SSH2_SHA1_ALG         GCRY_MD_SHA1
+#define SSH2_SHA256_ALG       GCRY_MD_SHA256
+#define SSH2_SHA384_ALG       GCRY_MD_SHA384
+#define SSH2_SHA512_ALG       GCRY_MD_SHA512
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define SSH2_MD5_ALG    GCRY_MD_MD5
+#define SSH2_MD5_ALG          GCRY_MD_MD5
 #endif
 
 #define ssh2_hmac_ctx         gcry_md_hd_t

--- a/src/mac.c
+++ b/src/mac.c
@@ -248,7 +248,7 @@ static int mac_method_hmac_sha1_96_hash(LIBSSH2_SESSION *session,
                        packet, packet_len, addtl, addtl_len, abstract))
         return 1;
 
-    memcpy(buf, (char *)temp, 96 / 8);
+    memcpy(buf, (char *)temp, 96 / 8 /* 12 */);
     return 0;
 }
 
@@ -304,7 +304,7 @@ static int mac_method_hmac_md5_96_hash(LIBSSH2_SESSION *session,
                        packet, packet_len, addtl, addtl_len, abstract))
         return 1;
 
-    memcpy(buf, (char *)temp, 96 / 8);
+    memcpy(buf, (char *)temp, 96 / 8 /* 12 */);
     return 0;
 }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -195,7 +195,7 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 }
 
 int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
-                   void *key, size_t keylen)
+                   void *key, size_t key_len)
 {
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg_hmac = PSA_ALG_HMAC(alg);
@@ -204,7 +204,7 @@ int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
     psa_set_key_algorithm(&attributes, alg_hmac);
     psa_set_key_type(&attributes, PSA_KEY_TYPE_HMAC);
 
-    if(psa_import_key(&attributes, key, keylen, &ctx->key_id) != PSA_SUCCESS)
+    if(psa_import_key(&attributes, key, key_len, &ctx->key_id) != PSA_SUCCESS)
         return 0;
 
     if(psa_mac_sign_setup(&ctx->mac, ctx->key_id, alg_hmac) != PSA_SUCCESS) {
@@ -215,10 +215,10 @@ int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
     return 1;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t mac_len)
 {
     size_t actual_len;
-    return psa_mac_sign_finish(&ctx->mac, mac, maclen,
+    return psa_mac_sign_finish(&ctx->mac, mac, mac_len,
                                &actual_len) == PSA_SUCCESS;
 }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -92,14 +92,14 @@ static void mbed_zero_free(void *buf, size_t len)
     mbedtls_free(buf);
 }
 
-int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
+int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
     const mbedtls_cipher_info_t *cipher_info;
     mbedtls_operation_t op;
     int ret;
 
-    if(!h)
+    if(!ctx)
         return -1;
 
     op = encrypt ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
@@ -108,8 +108,8 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
     if(!cipher_info)
         return -1;
 
-    mbedtls_cipher_init(h);
-    ret = mbedtls_cipher_setup(h, cipher_info);
+    mbedtls_cipher_init(ctx);
+    ret = mbedtls_cipher_setup(ctx, cipher_info);
 
     /* libssh2 computes and adds SSH packet padding itself, so for CBC
        tell mbedTLS to expect no padding on the cipher layer. Only call
@@ -120,16 +120,16 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
         algo == MBEDTLS_CIPHER_AES_192_CBC ||
         algo == MBEDTLS_CIPHER_AES_256_CBC ||
         algo == MBEDTLS_CIPHER_DES_EDE3_CBC)) {
-        ret = mbedtls_cipher_set_padding_mode(h, MBEDTLS_PADDING_NONE);
+        ret = mbedtls_cipher_set_padding_mode(ctx, MBEDTLS_PADDING_NONE);
     }
 
     if(!ret)
-        ret = mbedtls_cipher_setkey(h,
+        ret = mbedtls_cipher_setkey(ctx,
                   secret,
                   (int)mbedtls_cipher_info_get_key_bitlen(cipher_info), op);
 
     if(!ret)
-        ret = mbedtls_cipher_set_iv(h, iv,
+        ret = mbedtls_cipher_set_iv(ctx, iv,
                   mbedtls_cipher_info_get_iv_size(cipher_info));
 
     return ret == 0 ? 0 : -1;

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -231,6 +231,8 @@ typedef enum {
  * mbedTLS backend: Diffie-Hellman support.
  */
 
+#define ssh2_dh_ctx                    mbedtls_mpi *
+
 /* Default generate and safe prime sizes for
    diffie-hellman-group-exchange-sha1 */
 #define SSH2_DH_GEX_MINGROUP     2048
@@ -238,7 +240,5 @@ typedef enum {
 #define SSH2_DH_GEX_MAXGROUP     8192
 
 #define SSH2_DH_MAX_MODULUS_BITS 16384
-
-#define ssh2_dh_ctx mbedtls_mpi *
 
 #endif /* LIBSSH2_MBEDTLS_H */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -836,7 +836,7 @@ cleanup:
 
 #endif /* LIBSSH2_ECDSA */
 
-int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
+int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
 #if LIBSSH2_AES_GCM
@@ -845,12 +845,12 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
 #endif /* LIBSSH2_AES_GCM */
     int rc;
 
-    *h = EVP_CIPHER_CTX_new();
-    rc = !EVP_CipherInit(*h, algo(), secret, iv, encrypt);
+    *ctx = EVP_CIPHER_CTX_new();
+    rc = !EVP_CipherInit(*ctx, algo(), secret, iv, encrypt);
 #if LIBSSH2_AES_GCM
     if(is_aesgcm)
         /* Sets both fixed and invocation_counter parts of IV */
-        rc |= !EVP_CIPHER_CTX_ctrl(*h, EVP_CTRL_AEAD_SET_IV_FIXED, -1, iv);
+        rc |= !EVP_CIPHER_CTX_ctrl(*ctx, EVP_CTRL_AEAD_SET_IV_FIXED, -1, iv);
 #endif /* LIBSSH2_AES_GCM */
 
     return rc;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -101,7 +101,7 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 }
 
 int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
-                   void *key, size_t keylen)
+                   void *key, size_t key_len)
 {
 #ifdef USE_OPENSSL_3
     EVP_MAC *mac;
@@ -117,23 +117,23 @@ int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
         return 0;
 
     params[0] = OSSL_PARAM_construct_octet_string(
-        OSSL_MAC_PARAM_KEY, key, keylen);
+        OSSL_MAC_PARAM_KEY, key, key_len);
     params[1] = OSSL_PARAM_construct_utf8_string(
         OSSL_MAC_PARAM_DIGEST, (char *)SSH2_UNCONST(alg), 0);
     params[2] = OSSL_PARAM_construct_end();
 
     return EVP_MAC_init(*ctx, NULL, 0, params);
 #else
-    return HMAC_Init_ex(*ctx, key, (int)keylen, alg, NULL);
+    return HMAC_Init_ex(*ctx, key, (int)key_len, alg, NULL);
 #endif
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t mac_len)
 {
 #ifdef USE_OPENSSL_3
-    return EVP_MAC_final(*ctx, mac, NULL, maclen);
+    return EVP_MAC_final(*ctx, mac, NULL, mac_len);
 #else
-    (void)maclen;
+    (void)mac_len;
     return HMAC_Final(*ctx, mac, NULL);
 #endif
 }

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -224,36 +224,36 @@
 
 #include "crypto_config.h"
 
-#define ssh2_crypto_exit() do {} while(0)
+#define ssh2_crypto_exit()           do {} while(0)
 
 #define ssh2_hash_ctx                EVP_MD_CTX *
 #define ssh2_hash_alg                const EVP_MD *
 #define ssh2_hash_update(ctx, d, l)  EVP_DigestUpdate(*(ctx), d, l)
 
-#define SSH2_SHA1_ALG       EVP_sha1()
-#define SSH2_SHA256_ALG     EVP_sha256()
-#define SSH2_SHA384_ALG     EVP_sha384()
-#define SSH2_SHA512_ALG     EVP_sha512()
+#define SSH2_SHA1_ALG                EVP_sha1()
+#define SSH2_SHA256_ALG              EVP_sha256()
+#define SSH2_SHA384_ALG              EVP_sha384()
+#define SSH2_SHA512_ALG              EVP_sha512()
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define SSH2_MD5_ALG        EVP_md5()
+#define SSH2_MD5_ALG                 EVP_md5()
 #endif
 
 #ifdef USE_OPENSSL_3
-#define ssh2_hmac_ctx       EVP_MAC_CTX *
-#define ssh2_hmac_alg       const char *
+#define ssh2_hmac_ctx                EVP_MAC_CTX *
+#define ssh2_hmac_alg                const char *
 #define ssh2_hmac_update(ctx, d, l) \
     EVP_MAC_update(*(ctx), (const unsigned char *)(d), l)
-#define SSH2_SHA1_HMAC      OSSL_DIGEST_NAME_SHA1
-#define SSH2_SHA256_HMAC    OSSL_DIGEST_NAME_SHA2_256
-#define SSH2_SHA512_HMAC    OSSL_DIGEST_NAME_SHA2_512
+#define SSH2_SHA1_HMAC               OSSL_DIGEST_NAME_SHA1
+#define SSH2_SHA256_HMAC             OSSL_DIGEST_NAME_SHA2_256
+#define SSH2_SHA512_HMAC             OSSL_DIGEST_NAME_SHA2_512
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define SSH2_MD5_HMAC       OSSL_DIGEST_NAME_MD5
+#define SSH2_MD5_HMAC                OSSL_DIGEST_NAME_MD5
 #endif
 #if LIBSSH2_HMAC_RIPEMD
-#define SSH2_RIPEMD160_HMAC OSSL_DIGEST_NAME_RIPEMD160
+#define SSH2_RIPEMD160_HMAC          OSSL_DIGEST_NAME_RIPEMD160
 #endif
 #else
-#define ssh2_hmac_ctx       HMAC_CTX *
+#define ssh2_hmac_ctx                HMAC_CTX *
 #ifdef LIBSSH2_WOLFSSL /* In wolfSSL length is int, not size_t */
 #define ssh2_hmac_update(ctx, d, l) \
     HMAC_Update(*(ctx), (const unsigned char *)(d), (int)(l))
@@ -262,39 +262,39 @@
     HMAC_Update(*(ctx), (const unsigned char *)(d), l)
 #endif
 #if LIBSSH2_HMAC_RIPEMD
-#define SSH2_RIPEMD160_HMAC EVP_ripemd160()
+#define SSH2_RIPEMD160_HMAC          EVP_ripemd160()
 #endif
 #endif /* USE_OPENSSL_3 */
 
 #if LIBSSH2_RSA
 #ifdef USE_OPENSSL_3
-#define ssh2_rsa_ctx             EVP_PKEY
-#define ssh2_rsa_free(rsa)       EVP_PKEY_free(rsa)
+#define ssh2_rsa_ctx                 EVP_PKEY
+#define ssh2_rsa_free(rsa)           EVP_PKEY_free(rsa)
 #else
-#define ssh2_rsa_ctx             RSA
-#define ssh2_rsa_free(rsa)       RSA_free(rsa)
+#define ssh2_rsa_ctx                 RSA
+#define ssh2_rsa_free(rsa)           RSA_free(rsa)
 #endif
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
 #ifdef USE_OPENSSL_3
-#define ssh2_dsa_ctx             EVP_PKEY
-#define ssh2_dsa_free(dsa)       EVP_PKEY_free(dsa)
+#define ssh2_dsa_ctx                 EVP_PKEY
+#define ssh2_dsa_free(dsa)           EVP_PKEY_free(dsa)
 #else
-#define ssh2_dsa_ctx             DSA
-#define ssh2_dsa_free(dsa)       DSA_free(dsa)
+#define ssh2_dsa_ctx                 DSA
+#define ssh2_dsa_free(dsa)           DSA_free(dsa)
 #endif
 #endif /* LIBSSH2_DSA */
 
 #if LIBSSH2_ECDSA
 #ifdef USE_OPENSSL_3
-#define ssh2_ecdsa_ctx           EVP_PKEY
-#define ssh2_ecdsa_free(ec_ctx)  EVP_PKEY_free(ec_ctx)
-#define ssh2_ec_key              EVP_PKEY
+#define ssh2_ecdsa_ctx               EVP_PKEY
+#define ssh2_ecdsa_free(ec_ctx)      EVP_PKEY_free(ec_ctx)
+#define ssh2_ec_key                  EVP_PKEY
 #else
-#define ssh2_ecdsa_ctx           EC_KEY
-#define ssh2_ecdsa_free(ec_ctx)  EC_KEY_free(ec_ctx)
-#define ssh2_ec_key              EC_KEY
+#define ssh2_ecdsa_ctx               EC_KEY
+#define ssh2_ecdsa_free(ec_ctx)      EC_KEY_free(ec_ctx)
+#define ssh2_ec_key                  EC_KEY
 #endif
 
 typedef enum {
@@ -305,30 +305,30 @@ typedef enum {
 #endif /* LIBSSH2_ECDSA */
 
 #if LIBSSH2_ED25519
-#define ssh2_ed25519_ctx          EVP_PKEY
-#define ssh2_ed25519_free(ed_ctx) EVP_PKEY_free(ed_ctx)
+#define ssh2_ed25519_ctx             EVP_PKEY
+#define ssh2_ed25519_free(ed_ctx)    EVP_PKEY_free(ed_ctx)
 #endif /* LIBSSH2_ED25519 */
 
-#define SSH2_CIPHER_T(name) const EVP_CIPHER *(*(name))(void)
+#define SSH2_CIPHER_T(name)          const EVP_CIPHER *(*(name))(void)
 
-#define ssh2_cipher_ctx EVP_CIPHER_CTX *
+#define ssh2_cipher_ctx              EVP_CIPHER_CTX *
 
-#define ssh2_cipher_aes256gcm EVP_aes_256_gcm
-#define ssh2_cipher_aes128gcm EVP_aes_128_gcm
+#define ssh2_cipher_aes256gcm        EVP_aes_256_gcm
+#define ssh2_cipher_aes128gcm        EVP_aes_128_gcm
 
-#define ssh2_cipher_aes256    EVP_aes_256_cbc
-#define ssh2_cipher_aes192    EVP_aes_192_cbc
-#define ssh2_cipher_aes128    EVP_aes_128_cbc
-#define ssh2_cipher_aes128ctr EVP_aes_128_ctr
-#define ssh2_cipher_aes192ctr EVP_aes_192_ctr
-#define ssh2_cipher_aes256ctr EVP_aes_256_ctr
-#define ssh2_cipher_blowfish  EVP_bf_cbc
-#define ssh2_cipher_arcfour   EVP_rc4
-#define ssh2_cipher_cast5     EVP_cast5_cbc
-#define ssh2_cipher_3des      EVP_des_ede3_cbc
-#define ssh2_cipher_chacha20  NULL
+#define ssh2_cipher_aes256           EVP_aes_256_cbc
+#define ssh2_cipher_aes192           EVP_aes_192_cbc
+#define ssh2_cipher_aes128           EVP_aes_128_cbc
+#define ssh2_cipher_aes128ctr        EVP_aes_128_ctr
+#define ssh2_cipher_aes192ctr        EVP_aes_192_ctr
+#define ssh2_cipher_aes256ctr        EVP_aes_256_ctr
+#define ssh2_cipher_blowfish         EVP_bf_cbc
+#define ssh2_cipher_arcfour          EVP_rc4
+#define ssh2_cipher_cast5            EVP_cast5_cbc
+#define ssh2_cipher_3des             EVP_des_ede3_cbc
+#define ssh2_cipher_chacha20         NULL
 
-#define ssh2_cipher_dtor(ctx) EVP_CIPHER_CTX_free(*(ctx))
+#define ssh2_cipher_dtor(ctx)        EVP_CIPHER_CTX_free(*(ctx))
 
 #define ssh2_bn_ctx                  BN_CTX
 #define ssh2_bn_ctx_new()            BN_CTX_new()

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -343,6 +343,8 @@ typedef enum {
 #define ssh2_bn_bits(bn)             BN_num_bits(bn)
 #define ssh2_bn_free(bn)             BN_clear_free(bn)
 
+#define ssh2_dh_ctx                  BIGNUM *
+
 /* Default generate and safe prime sizes for
    diffie-hellman-group-exchange-sha1 */
 #define SSH2_DH_GEX_MINGROUP     2048
@@ -350,7 +352,5 @@ typedef enum {
 #define SSH2_DH_GEX_MAXGROUP     8192
 
 #define SSH2_DH_MAX_MODULUS_BITS 16384
-
-#define ssh2_dh_ctx BIGNUM *
 
 #endif /* LIBSSH2_OPENSSL_H */

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1003,15 +1003,15 @@ int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
     return os400qc3_hmac_init(ctx, alg, minkeylen, key, keylen);
 }
 
-int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
+int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len)
 {
     char dummy[64];
-    int len = (int)datalen;
+    int len = (int)input_len;
     Qus_EC_t errcode;
 
     ctx->hash.Final_Op_Flag = Qc3_Continue;
     set_EC_length(errcode, sizeof(errcode));
-    Qc3CalculateHMAC((char *)data, &len, Qc3_Data, (char *)&ctx->hash,
+    Qc3CalculateHMAC((char *)input, &len, Qc3_Data, (char *)&ctx->hash,
                      Qc3_Alg_Token, ctx->key.Key_Context_Token, Qc3_Key_Token,
                      anycsp, NULL, dummy, (char *)&errcode);
     return errcode.Bytes_Available ? 0 : 1;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1042,7 +1042,7 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
  *
  *******************************************************************/
 
-int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
+int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
     Qc3_Format_ALGD0200_T algd;
@@ -1050,10 +1050,10 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
 
     (void)encrypt;
 
-    if(!h)
+    if(!ctx)
         return -1;
 
-    init_crypto_ctx(h);
+    init_crypto_ctx(ctx);
     algd.Block_Cipher_Alg = algo.algo;
     algd.Block_Length = algo.size;
     algd.Mode = algo.mode;
@@ -1067,14 +1067,14 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
         memcpy(algd.Init_Vector, iv, algo.size);
     set_EC_length(errcode, sizeof(errcode));
     Qc3CreateAlgorithmContext((char *)&algd, algo.fmt,
-                              h->hash.Alg_Context_Token, &errcode);
+                              ctx->hash.Alg_Context_Token, &errcode);
     if(errcode.Bytes_Available)
         return -1;
     Qc3CreateKeyContext((char *)secret, &algo.keylen, binstring,
                         &algo.algo, qc3clear, NULL, NULL,
-                        h->key.Key_Context_Token, (char *)&errcode);
+                        ctx->key.Key_Context_Token, (char *)&errcode);
     if(errcode.Bytes_Available) {
-        ssh2_os400qc3_crypto_dtor(h);
+        ssh2_os400qc3_crypto_dtor(ctx);
         return -1;
     }
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -960,47 +960,47 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 }
 
 static int os400qc3_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
-                              size_t minkeylen, void *key, int keylen)
+                              size_t min_key_len, void *key, int key_len)
 {
     Qus_EC_t errcode;
 
-    if(keylen < minkeylen) {
-        char *lkey = alloca(minkeylen);
+    if(key_len < min_key_len) {
+        char *lkey = alloca(min_key_len);
 
         /* Pad key with zeroes if too short. */
         if(!lkey)
             return 0;
-        memcpy(lkey, (char *)key, keylen);
-        memset(lkey + keylen, 0, minkeylen - keylen);
+        memcpy(lkey, (char *)key, key_len);
+        memset(lkey + key_len, 0, min_key_len - key_len);
         key = (void *)lkey;
-        keylen = minkeylen;
+        key_len = min_key_len;
     }
     if(!ssh2_hash_init(&ctx->hash, alg))
         return 0;
     set_EC_length(errcode, sizeof(errcode));
-    Qc3CreateKeyContext((char *)key, &keylen, binstring, &alg, qc3clear,
+    Qc3CreateKeyContext((char *)key, &key_len, binstring, &alg, qc3clear,
                         NULL, NULL, ctx->key.Key_Context_Token,
                         (char *)&errcode);
     return errcode.Bytes_Available ? 0 : 1;
 }
 
 int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
-                   void *key, size_t keylen)
+                   void *key, size_t key_len)
 {
-    size_t minkeylen;
+    size_t min_key_len;
     if(alg == SSH2_SHA1_HMAC)
-        minkeylen = SSH2_SHA1_DIG_LEN;
+        min_key_len = SSH2_SHA1_DIG_LEN;
     else if(alg == SSH2_SHA256_HMAC)
-        minkeylen = SSH2_SHA256_DIG_LEN;
+        min_key_len = SSH2_SHA256_DIG_LEN;
     else if(alg == SSH2_SHA512_HMAC)
-        minkeylen = SSH2_SHA512_DIG_LEN;
+        min_key_len = SSH2_SHA512_DIG_LEN;
 #if LIBSSH2_MD5
     else if(alg == SSH2_MD5_HMAC)
-        minkeylen = SSH2_MD5_DIG_LEN;
+        min_key_len = SSH2_MD5_DIG_LEN;
 #endif
     else
         return 0;
-    return os400qc3_hmac_init(ctx, alg, minkeylen, key, keylen);
+    return os400qc3_hmac_init(ctx, alg, min_key_len, key, key_len);
 }
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len)
@@ -1017,11 +1017,11 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len)
     return errcode.Bytes_Available ? 0 : 1;
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t mac_len)
 {
     char data;
     Qus_EC_t errcode;
-    (void)maclen;
+    (void)mac_len;
 
     ctx->hash.Final_Op_Flag = Qc3_Final;
     set_EC_length(errcode, sizeof(errcode));

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -220,20 +220,20 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
  *
  *******************************************************************/
 
-#define ssh2_crypto_init()   do {} while(0)
-#define ssh2_crypto_exit()   do {} while(0)
+#define ssh2_crypto_init()       do {} while(0)
+#define ssh2_crypto_exit()       do {} while(0)
 
-#define ssh2_hash_ctx        Qc3_Format_ALGD0100_T
-#define ssh2_hash_alg        unsigned int
-#define ssh2_hmac_ctx        struct os400qc3_crypto_ctx
-#define ssh2_cipher_ctx      struct os400qc3_crypto_ctx
+#define ssh2_hash_ctx            Qc3_Format_ALGD0100_T
+#define ssh2_hash_alg            unsigned int
+#define ssh2_hmac_ctx            struct os400qc3_crypto_ctx
+#define ssh2_cipher_ctx          struct os400qc3_crypto_ctx
 
-#define SSH2_SHA1_ALG   Qc3_SHA1
-#define SSH2_SHA256_ALG Qc3_SHA256
-#define SSH2_SHA384_ALG Qc3_SHA384
-#define SSH2_SHA512_ALG Qc3_SHA512
+#define SSH2_SHA1_ALG            Qc3_SHA1
+#define SSH2_SHA256_ALG          Qc3_SHA256
+#define SSH2_SHA384_ALG          Qc3_SHA384
+#define SSH2_SHA512_ALG          Qc3_SHA512
 #if LIBSSH2_MD5 || LIBSSH2_MD5_PEM
-#define SSH2_MD5_ALG    Qc3_MD5
+#define SSH2_MD5_ALG             Qc3_MD5
 #endif
 
 /* Bignum */
@@ -247,21 +247,22 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 
 /* Cipher */
 
-#define SSH2_CIPHER_T(name)   struct os400qc3_cipher name
-#define ssh2_cipher_aes128    {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 16}
-#define ssh2_cipher_aes192    {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 24}
-#define ssh2_cipher_aes256    {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 32}
-#define ssh2_cipher_aes128ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CTR, 16}
-#define ssh2_cipher_aes192ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CTR, 24}
-#define ssh2_cipher_aes256ctr {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CTR, 32}
-#define ssh2_cipher_3des      {Qc3_Alg_Block_Cipher, Qc3_TDES, 8, Qc3_CBC, 24}
+#define SSH2_CIPHER_T(name)      struct os400qc3_cipher name
+
+#define ssh2_cipher_aes128     {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 16}
+#define ssh2_cipher_aes192     {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 24}
+#define ssh2_cipher_aes256     {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CBC, 32}
+#define ssh2_cipher_aes128ctr  {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CTR, 16}
+#define ssh2_cipher_aes192ctr  {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CTR, 24}
+#define ssh2_cipher_aes256ctr  {Qc3_Alg_Block_Cipher, Qc3_AES, 16, Qc3_CTR, 32}
+#define ssh2_cipher_3des       {Qc3_Alg_Block_Cipher, Qc3_TDES, 8, Qc3_CBC, 24}
 /* Nonsense values for chacha20-poly1305 */
-#define ssh2_cipher_chacha20  {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
-#define ssh2_cipher_arcfour   {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
+#define ssh2_cipher_chacha20   {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
+#define ssh2_cipher_arcfour    {Qc3_Alg_Stream_Cipher, Qc3_RC4, 8, 0, 16}
 
-#define ssh2_cipher_dtor(ctx) ssh2_os400qc3_crypto_dtor(ctx)
+#define ssh2_cipher_dtor(ctx)    ssh2_os400qc3_crypto_dtor(ctx)
 
-#define ssh2_rsa_ctx         struct os400qc3_crypto_ctx
+#define ssh2_rsa_ctx             struct os400qc3_crypto_ctx
 #define ssh2_rsa_free(ctx) \
     (ssh2_os400qc3_crypto_dtor(ctx), free((char *)ctx))
 #define ssh2_prepare_iovec(vec, len) \
@@ -280,6 +281,8 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
                             const struct iovec vector[],
                             ssh2_rsa_ctx *ctx);
 
+#define ssh2_dh_ctx              struct os400qc3_dh_ctx
+
 /* Default generate and safe prime sizes for diffie-hellman-group-exchange-sha1
    Qc3 is limited to a maximum 2048-bit modulus/key size. */
 #define SSH2_DH_GEX_MINGROUP     1024
@@ -287,8 +290,6 @@ int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
 #define SSH2_DH_GEX_MAXGROUP     2048
 
 #define SSH2_DH_MAX_MODULUS_BITS 2048
-
-#define ssh2_dh_ctx struct os400qc3_dh_ctx
 
 /*******************************************************************
  *

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -789,9 +789,9 @@ int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
     return ssh2_hash_init_low(ctx, alg, key, (ULONG)keylen);
 }
 
-int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *data, size_t datalen)
+int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len)
 {
-    return ssh2_hash_update(ctx, data, datalen);
+    return ssh2_hash_update(ctx, input, input_len);
 }
 
 int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2988,7 +2988,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 /*
  * Windows CNG backend: Cipher functions
  */
-int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
+int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
     BCRYPT_KEY_HANDLE hKey;
@@ -3066,14 +3066,14 @@ int ssh2_cipher_init(ssh2_cipher_ctx *h, SSH2_CIPHER_T(algo),
         }
     }
 
-    h->hKey = hKey;
-    h->pbKeyObject = pbKeyObject;
-    h->pbIV = pbIV;
-    h->pbCtr = pbCtr;
-    h->dwKeyObject = dwKeyObject;
-    h->dwIV = dwIV;
-    h->dwBlockLength = dwBlockLength;
-    h->dwCtrLength = dwCtrLength;
+    ctx->hKey = hKey;
+    ctx->pbKeyObject = pbKeyObject;
+    ctx->pbIV = pbIV;
+    ctx->pbCtr = pbCtr;
+    ctx->dwKeyObject = dwKeyObject;
+    ctx->dwIV = dwIV;
+    ctx->dwBlockLength = dwBlockLength;
+    ctx->dwCtrLength = dwCtrLength;
 
     return 0;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -700,7 +700,7 @@ int ssh2_random(unsigned char *buf, size_t len)
  */
 
 static int ssh2_hash_init_low(ssh2_hash_ctx *ctx, ssh2_hash_alg alg,
-                              unsigned char *key, ULONG keylen)
+                              unsigned char *key, ULONG key_len)
 {
     BCRYPT_HASH_HANDLE hHash;
     unsigned char *pbHashObject;
@@ -727,7 +727,7 @@ static int ssh2_hash_init_low(ssh2_hash_ctx *ctx, ssh2_hash_alg alg,
 
     ret = BCryptCreateHash(alg, &hHash,
                            pbHashObject, dwHashObject,
-                           key, keylen, 0);
+                           key, key_len, 0);
     if(!BCRYPT_SUCCESS(ret)) {
         wcng_zero_free(pbHashObject, dwHashObject);
         return 0;
@@ -784,9 +784,9 @@ int ssh2_hmac_ctx_init(ssh2_hmac_ctx *ctx)
 }
 
 int ssh2_hmac_init(ssh2_hmac_ctx *ctx, ssh2_hmac_alg alg,
-                   void *key, size_t keylen)
+                   void *key, size_t key_len)
 {
-    return ssh2_hash_init_low(ctx, alg, key, (ULONG)keylen);
+    return ssh2_hash_init_low(ctx, alg, key, (ULONG)key_len);
 }
 
 int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len)
@@ -794,9 +794,10 @@ int ssh2_hmac_update(ssh2_hmac_ctx *ctx, const void *input, size_t input_len)
     return ssh2_hash_update(ctx, input, input_len);
 }
 
-int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t maclen)
+int ssh2_hmac_final(ssh2_hmac_ctx *ctx, void *mac, size_t mac_len)
 {
-    return BCRYPT_SUCCESS(BCryptFinishHash(ctx->hHash, mac, (ULONG)maclen, 0));
+    return BCRYPT_SUCCESS(BCryptFinishHash(ctx->hHash,
+                                           mac, (ULONG)mac_len, 0));
 }
 
 void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -281,14 +281,6 @@ struct wcng_bn {
  * Windows CNG backend: Diffie-Hellman support
  */
 
-/* Default generate and safe prime sizes for
-   diffie-hellman-group-exchange-sha1 */
-#define SSH2_DH_GEX_MINGROUP     2048
-#define SSH2_DH_GEX_OPTGROUP     4096
-#define SSH2_DH_GEX_MAXGROUP     4096
-
-#define SSH2_DH_MAX_MODULUS_BITS 16384
-
 struct wcng_dh_ctx {
     /* holds our private and public key components */
     BCRYPT_KEY_HANDLE dh_handle;
@@ -300,6 +292,14 @@ struct wcng_dh_ctx {
     struct wcng_bn *dh_privbn;
 };
 
-#define ssh2_dh_ctx struct wcng_dh_ctx
+#define ssh2_dh_ctx              struct wcng_dh_ctx
+
+/* Default generate and safe prime sizes for
+   diffie-hellman-group-exchange-sha1 */
+#define SSH2_DH_GEX_MINGROUP     2048
+#define SSH2_DH_GEX_OPTGROUP     4096
+#define SSH2_DH_GEX_MAXGROUP     4096
+
+#define SSH2_DH_MAX_MODULUS_BITS 16384
 
 #endif /* LIBSSH2_WINCNG_H */

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -244,7 +244,7 @@ struct wcng_cipher_t {
     int ctrMode;
 };
 
-#define SSH2_CIPHER_T(type) struct wcng_cipher_t type
+#define SSH2_CIPHER_T(type)   struct wcng_cipher_t type
 
 #define ssh2_cipher_aes256ctr { &ssh2_wcng.hAlgAES_ECB, 32, 0, 1 }
 #define ssh2_cipher_aes192ctr { &ssh2_wcng.hAlgAES_ECB, 24, 0, 1 }


### PR DESCRIPTION
- agent: add missing parentheses in macro values.
- crypto: rename `ssh2_cipher_init()` arg in proto to match rest of API.
- crypto: sync `hmac_update` argument names with `hash_update`.
- crypto: sync `hmac_init`/`hmac_final` argument name style with hash.
- libgcrypt, openssl, wincng: re-align macro definitions (formatting).

---

https://github.com/libssh2/libssh2/pull/2257/files?w=1
