### PR TITLE
crypto, openssl: drop 4 unused private global functions

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -221,24 +221,6 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                       const char *blob, size_t blob_len,
                                       const unsigned char *passphrase);
 
-int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
-                              LIBSSH2_SESSION *session,
-                              unsigned char *flags,
-                              const char **application,
-                              const unsigned char **key_handle,
-                              size_t *handle_len,
-                              const char *filename,
-                              const unsigned char *passphrase);
-
-int ssh2_ecdsa_new_private_frommemory_sk(ssh2_ecdsa_ctx **ec_ctx,
-                                         LIBSSH2_SESSION *session,
-                                         unsigned char *flags,
-                                         const char **application,
-                                         const unsigned char **key_handle,
-                                         size_t *handle_len,
-                                         const char *blob, size_t blob_len,
-                                         const unsigned char *passphrase);
-
 int ssh2_ecdsa_sign(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                     const unsigned char *hash, size_t hash_len,
                     unsigned char **signature, size_t *signature_len);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -258,24 +258,6 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         const char *blob, size_t blob_len,
                                         const unsigned char *passphrase);
 
-int ssh2_ed25519_new_private_sk(ssh2_ed25519_ctx **ed_ctx,
-                                LIBSSH2_SESSION *session,
-                                unsigned char *flags,
-                                const char **application,
-                                const unsigned char **key_handle,
-                                size_t *handle_len,
-                                const char *filename,
-                                const uint8_t *passphrase);
-
-int ssh2_ed25519_new_private_frommemory_sk(ssh2_ed25519_ctx **ed_ctx,
-                                           LIBSSH2_SESSION *session,
-                                           unsigned char *flags,
-                                           const char **application,
-                                           const unsigned char **key_handle,
-                                           size_t *handle_len,
-                                           const char *blob, size_t blob_len,
-                                           const unsigned char *passphrase);
-
 int ssh2_ed25519_sign(ssh2_ed25519_ctx *ed_ctx, LIBSSH2_SESSION *session,
                       uint8_t **out_sig, size_t *out_sig_len,
                       const uint8_t *message, size_t message_len);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2175,71 +2175,6 @@ int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
     return rc;
 }
 
-int ssh2_ed25519_new_private_sk(ssh2_ed25519_ctx **ed_ctx,
-                                LIBSSH2_SESSION *session,
-                                unsigned char *flags,
-                                const char **application,
-                                const unsigned char **key_handle,
-                                size_t *handle_len,
-                                const char *filename,
-                                const uint8_t *passphrase)
-{
-    int rc;
-    FILE *fp;
-    unsigned char *buf;
-    struct string_buf *decrypted = NULL;
-    ssh2_ed25519_ctx *ctx = NULL;
-
-    if(!session) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
-        return -1;
-    }
-
-    OSSL_INIT_IF_NEEDED();
-
-    fp = fopen(filename, "r");
-    if(!fp) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Unable to open ED25519 SK private key file");
-        return -1;
-    }
-
-    rc = ssh2_openssh_pem_parse(session, passphrase, fp, &decrypted);
-    fclose(fp);
-    if(rc)
-        return rc;
-
-    /* We have a new key file, now try and parse it using supported types  */
-    rc = ssh2_get_string(decrypted, &buf, NULL);
-
-    if(rc || !buf) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                 "Public key type in decrypted key data not found");
-        return -1;
-    }
-
-    if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf))
-        rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                    NULL, NULL, NULL, NULL,
-                                                    flags, application,
-                                                    key_handle, handle_len,
-                                                    &ctx);
-    else
-        rc = -1;
-
-    if(decrypted)
-        ssh2_string_buf_free(session, decrypted);
-
-    if(rc == 0) {
-        if(ed_ctx)
-            *ed_ctx = ctx;
-        else if(ctx)
-            ssh2_ed25519_free(ctx);
-    }
-
-    return rc;
-}
-
 int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         LIBSSH2_SESSION *session,
                                         const char *blob, size_t blob_len,
@@ -2270,25 +2205,6 @@ int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
     return ossl_key_from_openssh_blob(session, (void **)ed_ctx, "ssh-ed25519",
                                       NULL, NULL, NULL, NULL,
                                       blob, blob_len, passphrase);
-}
-
-int ssh2_ed25519_new_private_frommemory_sk(ssh2_ed25519_ctx **ed_ctx,
-                                           LIBSSH2_SESSION *session,
-                                           unsigned char *flags,
-                                           const char **application,
-                                           const unsigned char **key_handle,
-                                           size_t *handle_len,
-                                           const char *blob, size_t blob_len,
-                                           const unsigned char *passphrase)
-{
-    int algorithm;
-    return ossl_key_sk_from_openssh_blob(session, (void **)ed_ctx,
-                                         "sk-ssh-ed25519@openssh.com",
-                                         NULL, NULL, NULL, NULL,
-                                         &algorithm, flags, application,
-                                         key_handle, handle_len,
-                                         blob, blob_len,
-                                         passphrase);
 }
 
 int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1710,26 +1710,6 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                         blob, blob_len, passphrase);
     return rc;
 }
-
-int ssh2_ecdsa_new_private_frommemory_sk(ssh2_ecdsa_ctx **ec_ctx,
-                                         LIBSSH2_SESSION *session,
-                                         unsigned char *flags,
-                                         const char **application,
-                                         const unsigned char **key_handle,
-                                         size_t *handle_len,
-                                         const char *blob, size_t blob_len,
-                                         const unsigned char *passphrase)
-{
-    int algorithm;
-    return ossl_key_sk_from_openssh_blob(session, (void **)ec_ctx,
-                                         "sk-ecdsa-sha2-nistp256@openssh.com",
-                                         NULL, NULL, NULL, NULL,
-                                         &algorithm, flags, application,
-                                         key_handle, handle_len,
-                                         blob, blob_len,
-                                         passphrase);
-}
-
 #endif /* LIBSSH2_ECDSA */
 
 #if LIBSSH2_ED25519
@@ -3216,63 +3196,6 @@ static int ossl_ecdsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
     return rc;
 }
 
-static int ossl_ecdsa_sk_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
-                                          LIBSSH2_SESSION *session,
-                                          uint8_t *flags,
-                                          const char **application,
-                                          const unsigned char **key_handle,
-                                          size_t *handle_len,
-                                          const char *filename,
-                                          const unsigned char *passphrase)
-{
-    FILE *fp;
-    int rc;
-    unsigned char *buf = NULL;
-    struct string_buf *decrypted = NULL;
-
-    if(!session) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
-        return -1;
-    }
-
-    OSSL_INIT_IF_NEEDED();
-
-    fp = fopen(filename, "r");
-    if(!fp) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Unable to open OpenSSH ECDSA private key file");
-        return -1;
-    }
-
-    rc = ssh2_openssh_pem_parse(session, passphrase, fp, &decrypted);
-    fclose(fp);
-    if(rc)
-        return rc;
-
-    /* We have a new key file, now try and parse it using supported types  */
-    rc = ssh2_get_string(decrypted, &buf, NULL);
-
-    if(rc || !buf) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                 "Public key type in decrypted key data not found");
-        return -1;
-    }
-
-    if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf))
-        rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                  NULL, NULL, NULL, NULL,
-                                                  flags, application,
-                                                  key_handle, handle_len,
-                                                  ec_ctx);
-    else
-        rc = -1;
-
-    if(decrypted)
-        ssh2_string_buf_free(session, decrypted);
-
-    return rc;
-}
-
 int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                            LIBSSH2_SESSION *session,
                            const char *filename,
@@ -3297,39 +3220,6 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
     if(!*ec_ctx)
         rc = ossl_ecdsa_openssh_priv_new(ec_ctx, session, filename,
                                          passphrase);
-    return rc;
-}
-
-int ssh2_ecdsa_new_private_sk(ssh2_ecdsa_ctx **ec_ctx,
-                              LIBSSH2_SESSION *session,
-                              unsigned char *flags,
-                              const char **application,
-                              const unsigned char **key_handle,
-                              size_t *handle_len,
-                              const char *filename,
-                              const unsigned char *passphrase)
-{
-    int rc = 0;
-    BIO *bp;
-
-    OSSL_INIT_IF_NEEDED();
-
-    bp = BIO_new_file(filename, "r");
-    if(bp)
-#ifdef USE_OPENSSL_3
-        *ec_ctx = PEM_read_bio_PrivateKey(bp, NULL, ossl_passphrase_cb,
-                                          SSH2_UNCONST(passphrase));
-#else
-        *ec_ctx = PEM_read_bio_ECPrivateKey(bp, NULL, ossl_passphrase_cb,
-                                            SSH2_UNCONST(passphrase));
-#endif
-    BIO_free(bp);
-
-    if(!*ec_ctx)
-        rc = ossl_ecdsa_sk_openssh_priv_new(ec_ctx, session,
-                                            flags, application,
-                                            key_handle, handle_len,
-                                            filename, passphrase);
     return rc;
 }
 


### PR DESCRIPTION
And the openssl local functions they called. These functions were not
called by any public interface, or tests.

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698
