### PR TITLE
cmake: add `MBEDTLS_USE_STATIC_LIBS` option

### DIFF
--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -6,14 +6,15 @@
 #
 # Input variables:
 #
-# - `MBEDTLS_INCLUDE_DIR`:  Absolute path to mbedTLS include directory.
-# - `MBEDCRYPTO_LIBRARY`:   Absolute path to `mbedcrypto` library.
+# - `MBEDTLS_INCLUDE_DIR`:      Absolute path to mbedTLS include directory.
+# - `MBEDCRYPTO_LIBRARY`:       Absolute path to `mbedcrypto` library.
+# - `MBEDTLS_USE_STATIC_LIBS`:  Configure for static mbedTLS libraries.
 #
 # Defines:
 #
-# - `MBEDTLS_FOUND`:        System has mbedTLS.
-# - `MBEDTLS_VERSION`:      Version of mbedTLS.
-# - `libssh2::mbedcrypto`:  mbedcrypto library target.
+# - `MBEDTLS_FOUND`:            System has mbedTLS.
+# - `MBEDTLS_VERSION`:          Version of mbedTLS.
+# - `libssh2::mbedcrypto`:      mbedcrypto library target.
 
 set(_mbedtls_pc_requires "mbedcrypto")
 
@@ -28,12 +29,22 @@ if(_mbedtls_FOUND)
   set(MbedTLS_FOUND TRUE)
   set(MBEDTLS_FOUND TRUE)
   set(MBEDTLS_VERSION ${_mbedtls_VERSION})
+  if(MBEDTLS_USE_STATIC_LIBS)
+    set(_mbedtls_CFLAGS       "${_mbedtls_STATIC_CFLAGS}")
+    set(_mbedtls_INCLUDE_DIRS "${_mbedtls_STATIC_INCLUDE_DIRS}")
+    set(_mbedtls_LIBRARY_DIRS "${_mbedtls_STATIC_LIBRARY_DIRS}")
+    set(_mbedtls_LIBRARIES    "${_mbedtls_STATIC_LIBRARIES}")
+  endif()
   message(STATUS "Found MbedTLS (via pkg-config): ${_mbedtls_INCLUDE_DIRS} (found version \"${MBEDTLS_VERSION}\")")
 else()
   set(_mbedtls_pc_requires "")
 
   find_path(MBEDTLS_INCLUDE_DIR NAMES "mbedtls/version.h")
-  find_library(MBEDCRYPTO_LIBRARY NAMES "mbedcrypto" "libmbedcrypto")
+  if(MBEDTLS_USE_STATIC_LIBS)
+    find_library(MBEDCRYPTO_LIBRARY NAMES "mbedcrypto_static" "libmbedcrypto_static" "mbedcrypto" "libmbedcrypto")
+  else()
+    find_library(MBEDCRYPTO_LIBRARY NAMES "mbedcrypto" "libmbedcrypto")
+  endif()
 
   unset(MBEDTLS_VERSION CACHE)
   if(MBEDTLS_INCLUDE_DIR AND EXISTS "${MBEDTLS_INCLUDE_DIR}/mbedtls/build_info.h")


### PR DESCRIPTION
When enabled, make a "best effort" finding static lib first and set
the "build static" macro (on Windows) as required by the dependency.

When doing `pkg-config`-based detections, make the build select the
static configuration, which shall set the "build static" macro also.

This option resemble CMake's `OPENSSL_USE_STATIC_LIBS` and
`ZLIB_USE_STATIC_LIBS` (the latter does not support `pkg-config` as of
CMake v4.2.2).

Shared/static library selection based on loose filename conventions is
fragile and prone to break if the non-static-suffixed library is found
and happens to be a shared library, or, if the linker decides to pick up
a shared copy (e.g. `.a.dll`) that shadows the static one. It may help
to provide either static or shared, but not both, on the disk, and match
that with this setting.

Experimental.

Refs:
https://github.com/curl/curl/commit/26c39d8df182a63d28d81ed2b044e6a343519d1a
https://github.com/curl/curl/pull/20015
