### PR TITLE
scripts: minor fixes and improvements

### DIFF
--- a/scripts/cmakelint.sh
+++ b/scripts/cmakelint.sh
@@ -21,7 +21,7 @@
 
 set -eu
 
-cd "$(dirname "$0")"/..
+cd -- "$(dirname "$0")"/..
 
 {
   if [ -n "${1:-}" ]; then

--- a/scripts/maketgz
+++ b/scripts/maketgz
@@ -58,7 +58,7 @@ sed -i.bak \
   -e "s/^#define LIBSSH2_VERSION_PATCH .*/#define LIBSSH2_VERSION_PATCH $patch/g" \
   -e "s/^#define LIBSSH2_TIMESTAMP .*/#define LIBSSH2_TIMESTAMP \"$datestamp\"/g" \
   "$HEADER"
-rm -f "$HEADER.bak"
+rm -f -- "$HEADER.bak"
 
 if test -n "$only"; then
   # done!
@@ -120,7 +120,7 @@ fi
 
 retar() {
   tempdir=$1
-  rm -rf "$tempdir"
+  rm -rf "${tempdir:?}"
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
@@ -128,7 +128,7 @@ retar() {
   tar --create --format=ustar --owner=0 --group=0 --numeric-owner --sort=name libssh2-* | gzip --best --no-name > out.tar.gz
   mv out.tar.gz ../
   cd ..
-  rm -rf "$tempdir"
+  rm -rf "${tempdir:?}"
 }
 
 retar ".tarbuild"
@@ -158,14 +158,14 @@ gzip -dc "$targz" | xz -6e - > "$xz"
 # Now make a zip archive from the tar.gz original
 #
 makezip() {
-  rm -rf "$tempdir"
+  rm -rf "${tempdir:?}"
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
   find . | sort | zip -9 -X "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..
-  rm -rf "$tempdir"
+  rm -rf "${tempdir:?}"
 }
 
 zip="libssh2-$version.zip"

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -5,7 +5,7 @@
 
 set -eu
 
-cd "$(dirname "$0")"/..
+cd -- "$(dirname "$0")"/..
 
 git grep -z -l -E '^#!(/usr/bin/env bash|/bin/sh|/bin/bash)' | xargs -0 -r \
 shellcheck --exclude=1091 \

--- a/scripts/spellcheck.sh
+++ b/scripts/spellcheck.sh
@@ -4,7 +4,7 @@
 
 set -eu
 
-cd "$(dirname "$0")"/..
+cd -- "$(dirname "$0")"/..
 
 git ls-files -z | xargs -0 -r \
 codespell \

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -78,9 +78,8 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     -DCMAKE_INSTALL_PREFIX="${prefix}"
   "${cmake_provider}" --build "${bldp}" --verbose
   "${cmake_provider}" --install "${bldp}"
-  echo '::group::libcurl.pc'; cat "${prefix}"/lib/pkgconfig/*.pc || true; echo '::endgroup::'
-  echo '::group::curl-config.cmake'; cat "${prefix}"/lib/cmake/CURL/CURL* || true; echo '::endgroup::'
-  echo '::group::curl-config'; cat "${prefix}"/bin/curl-config || true; echo '::endgroup::'
+  echo '::group::libssh2.pc'; cat "${prefix}"/lib/pkgconfig/*.pc || true; echo '::endgroup::'
+  echo '::group::libssh2-config.cmake'; cat "${prefix}"/lib/cmake/libssh2/libssh2* || true; echo '::endgroup::'
   bldc='bld-find_package'
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${TEST_CMAKE_FLAGS:-} ${TEST_CMAKE_FLAGS_CONSUMER:-} \

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -7,7 +7,7 @@
 
 set -eu
 
-cd "$(dirname "$0")"
+cd -- "$(dirname "$0")"
 
 mode="${1:-all}"; shift
 
@@ -31,8 +31,8 @@ runresults() {
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'ExternalProject' ]; then
   (cd "${src}"; git archive --format=tar HEAD) | gzip > source.tar.gz
-  src="${PWD}/source.tar.gz"
-  sha="$(openssl dgst -sha256 "${src}" | grep -a -i -o -E '[0-9a-f]{64}$')"
+  src="$(pwd)/source.tar.gz"
+  sha="$(sha256sum "${src}" | grep -a -i -o -w -E '[0-9a-f]{64}')"
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${TEST_CMAKE_FLAGS:-} -DLIBSSH2_TEST_OPTS="${cmake_opts} -DCMAKE_UNITY_BUILD=ON $*" \
@@ -43,7 +43,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'ExternalProject' ]; then
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
-  src="${PWD}/${src}"
+  src="$(pwd)/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
@@ -70,14 +70,17 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
-  src="${PWD}/${src}"
+  src="$(pwd)/${src}"
   bldp='bld-libssh2'
-  prefix="${PWD}/${bldp}/_pkg"
+  prefix="$(pwd)/${bldp}/_pkg"
   rm -rf "${bldp}"
   "${cmake_provider}" -B "${bldp}" -S "${src}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} ${TEST_CMAKE_FLAGS_PROVIDER:-} "$@" \
     -DCMAKE_INSTALL_PREFIX="${prefix}"
   "${cmake_provider}" --build "${bldp}" --verbose
   "${cmake_provider}" --install "${bldp}"
+  echo '::group::libcurl.pc'; cat "${prefix}"/lib/pkgconfig/*.pc || true; echo '::endgroup::'
+  echo '::group::curl-config.cmake'; cat "${prefix}"/lib/cmake/CURL/CURL* || true; echo '::endgroup::'
+  echo '::group::curl-config'; cat "${prefix}"/bin/curl-config || true; echo '::endgroup::'
   bldc='bld-find_package'
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${TEST_CMAKE_FLAGS:-} ${TEST_CMAKE_FLAGS_CONSUMER:-} \

--- a/tests/gen_keys.sh
+++ b/tests/gen_keys.sh
@@ -28,8 +28,8 @@ pw='libssh2'
 id='identity'
 pr='libssh2'
 
-ssh-keygen -t dsa             -N ''          -m PEM -C 'key_dsa'                 -f 'key_dsa'
-ssh-keygen -t dsa             -N ''          -m PEM -C 'key_dsa_wrong'           -f 'key_dsa_wrong'         # not to add to 'authorized_keys'
+ssh-keygen -t dsa             -N ''          -m PEM -C 'key_dsa'                 -f 'key_dsa'               || touch key_dsa.pub
+ssh-keygen -t dsa             -N ''          -m PEM -C 'key_dsa_wrong'           -f 'key_dsa_wrong'         || true # not to add to 'authorized_keys'
 
 ssh-keygen -t rsa     -b 2048 -N ''          -m PEM -C 'key_rsa'                 -f 'key_rsa'
 ssh-keygen -t rsa     -b 2048 -N "${pw}"     -m PEM -C 'key_rsa_encrypted'       -f 'key_rsa_encrypted'
@@ -74,8 +74,8 @@ for fn in ./openssh_server/*_key.pub; do
   printf '====== %s\n' "${fn}"
   printf 'BASE64 %s\n' "${pub}"
   {
-    printf 'MD5    %s\n' "$(printf '%s' "${pub}" | openssl base64 -d -A | openssl dgst -hex -md5)"
-    printf 'SHA1   %s\n' "$(printf '%s' "${pub}" | openssl base64 -d -A | openssl dgst -hex -sha1)"
-    printf 'SHA256 %s\n' "$(printf '%s' "${pub}" | openssl base64 -d -A | openssl dgst -hex -sha256)"
+    printf 'MD5    %s\n' "$(printf '%s' "${pub}" | base64 -d | md5sum | tr -d ' -')"
+    printf 'SHA1   %s\n' "$(printf '%s' "${pub}" | base64 -d | sha1sum | tr -d ' -')"
+    printf 'SHA256 %s\n' "$(printf '%s' "${pub}" | base64 -d | sha256sum | tr -d ' -')"
   } | tr '[:lower:]' '[:upper:]'
 done

--- a/tests/ossfuzz/ossfuzz.sh
+++ b/tests/ossfuzz/ossfuzz.sh
@@ -17,7 +17,7 @@ echo "CFLAGS: ${CFLAGS:-}"
 echo "CXXFLAGS: ${CXXFLAGS:-}"
 echo "OUT: ${OUT:-}"
 
-MAKEFLAGS+="-j$(nproc)"
+MAKEFLAGS+=" -j$(nproc)"
 export MAKEFLAGS
 
 # Install dependencies


### PR DESCRIPTION
- pass `--` before passing input files.
- scripts/maketgz: robustify `rm` invocations.
- prefer `$(pwd)` or `$PWD`.
- tests/cmake/test.sh: dump configs to CI log.
- tests/gen_keys.sh: fix to skip DSA if missing.
- replace openssl with `base` and `*sum` tools.
- tests/ossfuzz/ossfuzz.sh: fix to add a space before `-j`.
