### PR TITLE
src: bump RSA/DSA parameter sizes to `size_t`

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -125,14 +125,14 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 
 #if LIBSSH2_RSA
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, unsigned long elen,
-                 const unsigned char *ndata, unsigned long nlen,
-                 const unsigned char *ddata, unsigned long dlen,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *e1data, unsigned long e1len,
-                 const unsigned char *e2data, unsigned long e2len,
-                 const unsigned char *coeffdata, unsigned long coefflen);
+                 const unsigned char *edata, size_t elen,
+                 const unsigned char *ndata, size_t nlen,
+                 const unsigned char *ddata, size_t dlen,
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *e1data, size_t e1len,
+                 const unsigned char *e2data, size_t e2len,
+                 const unsigned char *coeffdata, size_t coefflen);
 int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
@@ -164,11 +164,11 @@ void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
 
 #if LIBSSH2_DSA
 int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *gdata, unsigned long glen,
-                 const unsigned char *ydata, unsigned long ylen,
-                 const unsigned char *xdata, unsigned long xlen);
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *gdata, size_t glen,
+                 const unsigned char *ydata, size_t ylen,
+                 const unsigned char *xdata, size_t xlen);
 int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -120,11 +120,8 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
     if(!ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_rsa_new(&rsactx,
-                    e, (unsigned long)e_len,
-                    n, (unsigned long)n_len,
-                    NULL, 0, NULL, 0, NULL, 0,
-                    NULL, 0, NULL, 0, NULL, 0))
+    if(ssh2_rsa_new(&rsactx, e, e_len, n, n_len,
+                    NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0))
         return -1;
 
     *abstract = rsactx;
@@ -513,12 +510,7 @@ static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
     if(!ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_dsa_new(&dsactx,
-                    p, (unsigned long)p_len,
-                    q, (unsigned long)q_len,
-                    g, (unsigned long)g_len,
-                    y, (unsigned long)y_len,
-                    NULL, 0))
+    if(ssh2_dsa_new(&dsactx, p, p_len, q, q_len, g, g_len, y, y_len, NULL, 0))
         return -1;
 
     *abstract = dsactx;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -99,14 +99,14 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 
 #if LIBSSH2_RSA
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, unsigned long elen,
-                 const unsigned char *ndata, unsigned long nlen,
-                 const unsigned char *ddata, unsigned long dlen,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *e1data, unsigned long e1len,
-                 const unsigned char *e2data, unsigned long e2len,
-                 const unsigned char *coeffdata, unsigned long coefflen)
+                 const unsigned char *edata, size_t elen,
+                 const unsigned char *ndata, size_t nlen,
+                 const unsigned char *ddata, size_t dlen,
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *e1data, size_t e1len,
+                 const unsigned char *e2data, size_t e2len,
+                 const unsigned char *coeffdata, size_t coefflen)
 {
     int rc;
 
@@ -118,11 +118,11 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     if(ddata)
         rc = gcry_sexp_build(rsa, NULL,
                  "(private-key(rsa(n%b)(e%b)(d%b)(q%b)(p%b)(u%b)))",
-                 nlen, ndata, elen, edata, dlen, ddata, plen, pdata,
-                 qlen, qdata, coefflen, coeffdata);
+                 (int)nlen, ndata, (int)elen, edata, (int)dlen, ddata,
+                 (int)plen, pdata, (int)qlen, qdata, (int)coefflen, coeffdata);
     else
         rc = gcry_sexp_build(rsa, NULL, "(public-key(rsa(n%b)(e%b)))",
-                             nlen, ndata, elen, edata);
+                             (int)nlen, ndata, (int)elen, edata);
 
     if(rc) {
         *rsa = NULL;
@@ -208,24 +208,25 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
 
 #if LIBSSH2_DSA
 int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *gdata, unsigned long glen,
-                 const unsigned char *ydata, unsigned long ylen,
-                 const unsigned char *xdata, unsigned long xlen)
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *gdata, size_t glen,
+                 const unsigned char *ydata, size_t ylen,
+                 const unsigned char *xdata, size_t xlen)
 {
     int rc;
 
     if(xlen)
         rc = gcry_sexp_build(dsa, NULL,
                              "(private-key(dsa(p%b)(q%b)(g%b)(y%b)(x%b)))",
-                             plen, pdata, qlen, qdata, glen, gdata,
-                             ylen, ydata, xlen, xdata);
+                             (int)plen, pdata, (int)qlen, qdata,
+                             (int)glen, gdata, (int)ylen, ydata,
+                             (int)xlen, xdata);
     else
         rc = gcry_sexp_build(dsa, NULL,
                              "(public-key(dsa(p%b)(q%b)(g%b)(y%b)))",
-                             plen, pdata, qlen, qdata, glen, gdata,
-                             ylen, ydata);
+                             (int)plen, pdata, (int)qlen, qdata,
+                             (int)glen, gdata, (int)ylen, ydata);
 
     if(rc) {
         *dsa = NULL;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -294,14 +294,14 @@ static int mbed_bn_random(ssh2_bn *bn, int bits, int top, int bottom)
  */
 
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, unsigned long elen,
-                 const unsigned char *ndata, unsigned long nlen,
-                 const unsigned char *ddata, unsigned long dlen,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *e1data, unsigned long e1len,
-                 const unsigned char *e2data, unsigned long e2len,
-                 const unsigned char *coeffdata, unsigned long coefflen)
+                 const unsigned char *edata, size_t elen,
+                 const unsigned char *ndata, size_t nlen,
+                 const unsigned char *ddata, size_t dlen,
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *e1data, size_t e1len,
+                 const unsigned char *e2data, size_t e2len,
+                 const unsigned char *coeffdata, size_t coefflen)
 {
     int ret;
     ssh2_rsa_ctx *ctx;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -301,8 +301,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
                  const unsigned char *qdata, unsigned long qlen,
                  const unsigned char *e1data, unsigned long e1len,
                  const unsigned char *e2data, unsigned long e2len,
-                 const unsigned char *coeffdata,
-                 unsigned long coefflen)
+                 const unsigned char *coeffdata, unsigned long coefflen)
 {
     int ret;
     ssh2_rsa_ctx *ctx;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1236,14 +1236,8 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_rsa_new(&rsa,
-                      e, (unsigned long)elen,
-                      n, (unsigned long)nlen,
-                      d, (unsigned long)dlen,
-                      p, (unsigned long)plen,
-                      q, (unsigned long)qlen,
-                      NULL, 0, NULL, 0,
-                      coeff, (unsigned long)coefflen);
+    rc = ssh2_rsa_new(&rsa, e, elen, n, nlen, d, dlen,
+                      p, plen, q, qlen, NULL, 0, NULL, 0, coeff, coefflen);
     if(rc) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                   "Could not create RSA private key"));
@@ -1559,12 +1553,8 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_dsa_new(&dsa,
-                      p, (unsigned long)plen,
-                      q, (unsigned long)qlen,
-                      g, (unsigned long)glen,
-                      pub_key, (unsigned long)pub_len,
-                      priv_key, (unsigned long)priv_len);
+    rc = ssh2_dsa_new(&dsa, p, plen, q, qlen, g, glen,
+                      pub_key, pub_len, priv_key, priv_len);
     if(rc) {
         ssh2_deb((session, LIBSSH2_ERROR_PROTO,
                   "Could not create DSA private key"));

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -220,14 +220,14 @@ int ssh2_random(unsigned char *buf, size_t len)
 
 #if LIBSSH2_RSA
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, unsigned long elen,
-                 const unsigned char *ndata, unsigned long nlen,
-                 const unsigned char *ddata, unsigned long dlen,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *e1data, unsigned long e1len,
-                 const unsigned char *e2data, unsigned long e2len,
-                 const unsigned char *coeffdata, unsigned long coefflen)
+                 const unsigned char *edata, size_t elen,
+                 const unsigned char *ndata, size_t nlen,
+                 const unsigned char *ddata, size_t dlen,
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *e1data, size_t e1len,
+                 const unsigned char *e2data, size_t e2len,
+                 const unsigned char *coeffdata, size_t coefflen)
 {
 #ifdef USE_OPENSSL_3
     int ret = 0;
@@ -426,11 +426,11 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
 
 #if LIBSSH2_DSA
 int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *gdata, unsigned long glen,
-                 const unsigned char *ydata, unsigned long ylen,
-                 const unsigned char *xdata, unsigned long xlen)
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *gdata, size_t glen,
+                 const unsigned char *ydata, size_t ylen,
+                 const unsigned char *xdata, size_t xlen)
 {
 #ifdef USE_OPENSSL_3
     int ret = 0;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1012,7 +1012,7 @@ static unsigned char *ossl_rsa_to_pubkey(LIBSSH2_SESSION *session,
                                          ssh2_rsa_ctx *rsa, size_t *key_len)
 {
     int e_bytes, n_bytes;
-    unsigned long len;
+    size_t len;
     unsigned char *key = NULL;
     unsigned char *p;
 
@@ -1392,7 +1392,7 @@ static unsigned char *ossl_dsa_to_pubkey(LIBSSH2_SESSION *session,
                                          ssh2_dsa_ctx *dsa, size_t *key_len)
 {
     int p_bytes, q_bytes, g_bytes, k_bytes;
-    unsigned long len;
+    size_t len;
     unsigned char *key = NULL;
     unsigned char *p;
 
@@ -1441,7 +1441,7 @@ static unsigned char *ossl_dsa_to_pubkey(LIBSSH2_SESSION *session,
     p = ossl_write_bn(p, g, g_bytes);
     p = ossl_write_bn(p, pub_key, k_bytes);
 
-    *key_len = (size_t)(p - key);
+    *key_len = p - key;
 fail:
 #ifdef USE_OPENSSL_3
     BN_clear_free(p_bn);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -196,13 +196,12 @@ static unsigned char *ossl_write_bn(unsigned char *buf, const BIGNUM *bn,
 #endif
 
 #ifdef USE_OPENSSL_3
-static SSH2_INLINE void ossl_swap_bytes(unsigned char *buf, unsigned long len)
+static SSH2_INLINE void ossl_swap_bytes(unsigned char *buf, size_t len)
 {
 #if !defined(WORDS_BIGENDIAN) || !WORDS_BIGENDIAN
-    unsigned long i, j;
-    unsigned char temp;
+    size_t i, j;
     for(i = 0, j = len - 1; i < j; i++, j--) {
-        temp = buf[i];
+        unsigned char temp = buf[i];
         buf[i] = buf[j];
         buf[j] = temp;
     }
@@ -2841,7 +2840,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
 
     /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
     memcpy(group_name, n, strlen(n));
-    ossl_swap_bytes(exponent, (unsigned long)exponentlen);
+    ossl_swap_bytes(exponent, exponentlen);
 
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
                                                  group_name, 0);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1113,14 +1113,14 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
  *******************************************************************/
 
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, unsigned long elen,
-                 const unsigned char *ndata, unsigned long nlen,
-                 const unsigned char *ddata, unsigned long dlen,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *e1data, unsigned long e1len,
-                 const unsigned char *e2data, unsigned long e2len,
-                 const unsigned char *coeffdata, unsigned long coefflen)
+                 const unsigned char *edata, size_t elen,
+                 const unsigned char *ndata, size_t nlen,
+                 const unsigned char *ddata, size_t dlen,
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *e1data, size_t e1len,
+                 const unsigned char *e2data, size_t e2len,
+                 const unsigned char *coeffdata, size_t coefflen)
 {
     ssh2_rsa_ctx *ctx;
     ssh2_bn *e = ssh2_bn_init_from_bin();

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1143,9 +1143,9 @@ static int wcng_asn_decode_bns(unsigned char *pbEncoded,
     return ret;
 }
 
-static ULONG wcng_bn_size(const unsigned char *bignum, ULONG length)
+static size_t wcng_bn_size(const unsigned char *bignum, size_t length)
 {
-    ULONG offset;
+    size_t offset;
 
     if(!bignum || length == 0)
         return 0;
@@ -1169,19 +1169,19 @@ static ULONG wcng_bn_size(const unsigned char *bignum, ULONG length)
  */
 
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, unsigned long elen,
-                 const unsigned char *ndata, unsigned long nlen,
-                 const unsigned char *ddata, unsigned long dlen,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *e1data, unsigned long e1len,
-                 const unsigned char *e2data, unsigned long e2len,
-                 const unsigned char *coeffdata, unsigned long coefflen)
+                 const unsigned char *edata, size_t elen,
+                 const unsigned char *ndata, size_t nlen,
+                 const unsigned char *ddata, size_t dlen,
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *e1data, size_t e1len,
+                 const unsigned char *e2data, size_t e2len,
+                 const unsigned char *coeffdata, size_t coefflen)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_RSAKEY_BLOB *rsakey;
     LPCWSTR lpszBlobType;
-    ULONG keylen, offset, mlen, p1len = 0, p2len = 0;
+    size_t keylen, offset, mlen, p1len = 0, p2len = 0;
     int ret;
 
     mlen = max(wcng_bn_size(ndata, nlen),
@@ -1278,7 +1278,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     }
 
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgRSA, NULL, lpszBlobType,
-                              &hKey, (PUCHAR)rsakey, keylen, 0);
+                              &hKey, (PUCHAR)rsakey, (ULONG)keylen, 0);
     if(!BCRYPT_SUCCESS(ret)) {
         wcng_zero_free(rsakey, keylen);
         return -1;
@@ -1293,7 +1293,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 
     (*rsa)->hKey = hKey;
     (*rsa)->pbKeyObject = rsakey;
-    (*rsa)->cbKeyObject = keylen;
+    (*rsa)->cbKeyObject = (DWORD)keylen;
 
     return 0;
 }
@@ -1490,16 +1490,16 @@ void ssh2_rsa_free(ssh2_rsa_ctx *rsa)
 
 #if LIBSSH2_DSA
 int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, unsigned long plen,
-                 const unsigned char *qdata, unsigned long qlen,
-                 const unsigned char *gdata, unsigned long glen,
-                 const unsigned char *ydata, unsigned long ylen,
-                 const unsigned char *xdata, unsigned long xlen)
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *gdata, size_t glen,
+                 const unsigned char *ydata, size_t ylen,
+                 const unsigned char *xdata, size_t xlen)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_DSA_KEY_BLOB *dsakey;
     LPCWSTR lpszBlobType;
-    ULONG keylen, offset, length;
+    size_t keylen, offset, length;
     int ret;
 
     length = max(max(wcng_bn_size(pdata, plen),
@@ -1567,7 +1567,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     }
 
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgDSA, NULL, lpszBlobType,
-                              &hKey, (PUCHAR)dsakey, keylen, 0);
+                              &hKey, (PUCHAR)dsakey, (ULONG)keylen, 0);
     if(!BCRYPT_SUCCESS(ret)) {
         wcng_zero_free(dsakey, keylen);
         return -1;
@@ -1582,7 +1582,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
 
     (*dsa)->hKey = hKey;
     (*dsa)->pbKeyObject = dsakey;
-    (*dsa)->cbKeyObject = keylen;
+    (*dsa)->cbKeyObject = (DWORD)keylen;
 
     return 0;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1203,9 +1203,9 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     memset(rsakey, 0, keylen);
 
     /* https://learn.microsoft.com/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_rsakey_blob */
-    rsakey->BitLength = mlen * 8;
-    rsakey->cbPublicExp = elen;
-    rsakey->cbModulus = mlen;
+    rsakey->BitLength = (ULONG)(mlen * 8);
+    rsakey->cbPublicExp = (ULONG)elen;
+    rsakey->cbModulus = (ULONG)mlen;
 
     memcpy((unsigned char *)rsakey + offset, edata, elen);
     offset += elen;
@@ -1267,8 +1267,8 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 
         lpszBlobType = BCRYPT_RSAFULLPRIVATE_BLOB;
         rsakey->Magic = BCRYPT_RSAFULLPRIVATE_MAGIC;
-        rsakey->cbPrime1 = p1len;
-        rsakey->cbPrime2 = p2len;
+        rsakey->cbPrime1 = (ULONG)p1len;
+        rsakey->cbPrime2 = (ULONG)p2len;
     }
     else {
         lpszBlobType = BCRYPT_RSAPUBLIC_BLOB;
@@ -1517,7 +1517,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     memset(dsakey, 0, keylen);
 
     /* https://learn.microsoft.com/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_dsa_key_blob */
-    dsakey->cbKey = length;
+    dsakey->cbKey = (ULONG)length;
 
     memset(dsakey->Count, -1, sizeof(dsakey->Count));
     memset(dsakey->Seed, -1, sizeof(dsakey->Seed));

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1176,8 +1176,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
                  const unsigned char *qdata, unsigned long qlen,
                  const unsigned char *e1data, unsigned long e1len,
                  const unsigned char *e2data, unsigned long e2len,
-                 const unsigned char *coeffdata,
-                 unsigned long coefflen)
+                 const unsigned char *coeffdata, unsigned long coefflen)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_RSAKEY_BLOB *rsakey;


### PR DESCRIPTION
Also related internal types in openssl.c.

To reduce internal casts and match most modern crypto APIs.
