### PR TITLE
crypto: make rsa context the 1st arg in `*_signv()` functions

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -517,10 +517,9 @@ Return 0 if OK, else -1.
 This procedure is already prototyped in `crypto.h`.
 
 ```c
-int ssh2_rsa_sha1_signv(LIBSSH2_SESSION *session,
+int ssh2_rsa_sha1_signv(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                         unsigned char **sig, size_t *siglen,
-                        int count, const struct iovec vector[],
-                        ssh2_rsa_ctx *rsa);
+                        int count, const struct iovec vector[]);
 ```
 RSA signs the SHA-1 hash computed over the count data chunks in vector.
 Signature is stored at (`sig`, `siglen`).
@@ -565,10 +564,9 @@ Note: this procedure is not used if both macros `ssh2_rsa_sha2_256_signv()`
 and `ssh2_rsa_sha2_512_signv()` are defined.
 
 ```c
-int ssh2_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
+int ssh2_rsa_sha2_256_signv(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                             unsigned char **sig, size_t *siglen,
-                            int count, const struct iovec vector[],
-                            ssh2_rsa_ctx *rsa);
+                            int count, const struct iovec vector[]);
 ```
 RSA signs the SHA-256 hash computed over the count data chunks in vector.
 Signature is stored at (`sig`, `siglen`).
@@ -577,10 +575,9 @@ Returns 0 if OK, else -1.
 Note: this procedure is optional: if provided, it MUST be defined as a macro.
 
 ```c
-int ssh2_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
+int ssh2_rsa_sha2_512_signv(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                             unsigned char **sig, size_t *siglen,
-                            int count, const struct iovec vector[],
-                            ssh2_rsa_ctx *rsa);
+                            int count, const struct iovec vector[]);
 ```
 RSA signs the SHA-512 hash computed over the count data chunks in vector.
 Signature is stored at (`sig`, `siglen`).

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -213,8 +213,8 @@ static int hostkey_method_ssh_rsa_signv(LIBSSH2_SESSION *session,
 {
     ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
 #ifdef ssh2_rsa_sha1_signv
-    return ssh2_rsa_sha1_signv(session, signature, signature_len,
-                               veccount, datavec, rsactx);
+    return ssh2_rsa_sha1_signv(rsactx, session, signature, signature_len,
+                               veccount, datavec);
 #else
     int i;
     unsigned char hash[SSH2_SHA1_DIG_LEN];
@@ -277,8 +277,8 @@ static int hostkey_method_ssh_rsa_sha2_256_signv(LIBSSH2_SESSION *session,
 {
     ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
 #ifdef ssh2_rsa_sha2_256_signv
-    return ssh2_rsa_sha2_256_signv(session, signature, signature_len,
-                                   veccount, datavec, rsactx);
+    return ssh2_rsa_sha2_256_signv(rsactx, session, signature, signature_len,
+                                   veccount, datavec);
 #else
     int i;
     unsigned char hash[SSH2_SHA256_DIG_LEN];
@@ -339,8 +339,8 @@ static int hostkey_method_ssh_rsa_sha2_512_signv(LIBSSH2_SESSION *session,
 {
     ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
 #ifdef ssh2_rsa_sha2_512_signv
-    return ssh2_rsa_sha2_512_signv(session, signature, signature_len,
-                                   veccount, datavec, rsactx);
+    return ssh2_rsa_sha2_512_signv(rsactx, session, signature, signature_len,
+                                   veccount, datavec);
 #else
     int i;
     unsigned char hash[SSH2_SHA512_DIG_LEN];

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2343,13 +2343,10 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
                                 sig, sig_len, m, m_len);
 }
 
-int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session,
+int ssh2_os400qc3_rsa_signv(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                             int algo,
-                            unsigned char **signature,
-                            size_t *signature_len,
-                            int veccount,
-                            const struct iovec vector[],
-                            ssh2_rsa_ctx *rsa)
+                            unsigned char **signature, size_t *signature_len,
+                            int veccount, const struct iovec vector[])
 {
     Qus_EC_t errcode;
     Qc3_Format_ALGD0400_T algd;

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -267,19 +267,17 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
     (ssh2_os400qc3_crypto_dtor(rsa), free((char *)rsa))
 #define ssh2_prepare_iovec(vec, len) \
     memset((char *)(vec), 0, (len) * sizeof(struct iovec))
-#define ssh2_rsa_sha1_signv(session, sig, siglen, count, vector, rsa) \
-    ssh2_os400qc3_rsa_signv(session, Qc3_SHA1, sig, siglen, count, vector, rsa)
-#define ssh2_rsa_sha2_256_signv(session, sig, siglen, cnt, vector, rsa) \
-    ssh2_os400qc3_rsa_signv(session, Qc3_SHA256, sig, siglen, cnt, vector, rsa)
-#define ssh2_rsa_sha2_512_signv(session, sig, siglen, cnt, vector, rsa) \
-    ssh2_os400qc3_rsa_signv(session, Qc3_SHA512, sig, siglen, cnt, vector, rsa)
+#define ssh2_rsa_sha1_signv(rsa, session, sig, siglen, count, vector) \
+    ssh2_os400qc3_rsa_signv(rsa, session, Qc3_SHA1, sig, siglen, count, vector)
+#define ssh2_rsa_sha2_256_signv(rsa, session, sig, siglen, cnt, vector) \
+    ssh2_os400qc3_rsa_signv(rsa, session, Qc3_SHA256, sig, siglen, cnt, vector)
+#define ssh2_rsa_sha2_512_signv(rsa, session, sig, siglen, cnt, vector) \
+    ssh2_os400qc3_rsa_signv(rsa, session, Qc3_SHA512, sig, siglen, cnt, vector)
 
-int ssh2_os400qc3_rsa_signv(LIBSSH2_SESSION *session, int algo,
-                            unsigned char **signature,
-                            size_t *signature_len,
-                            int veccount,
-                            const struct iovec vector[],
-                            ssh2_rsa_ctx *ctx);
+int ssh2_os400qc3_rsa_signv(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
+                            int algo,
+                            unsigned char **signature, size_t *signature_len,
+                            int veccount, const struct iovec vector[]);
 
 #define ssh2_dh_ctx              struct os400qc3_dh_ctx
 


### PR DESCRIPTION
To sync with the rest of crypto APIs.
