### PR TITLE
crypto: tidy up bignum argument names and order

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -356,9 +356,9 @@ size_t ssh2_bn_bits(ssh2_bn *bn);
 Returns the number of bits of multiple precision number at `bn`.
 
 ```c
-int ssh2_bn_set_word(ssh2_bn *bn, uint32_t val);
+int ssh2_bn_set_word(ssh2_bn *bn, uint32_t word);
 ```
-Sets the value of `bn` to `val`.
+Sets the value of `bn` to `word`.
 Returns 1 on success, 0 otherwise.
 
 ```c

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -362,7 +362,7 @@ Sets the value of `bn` to `word`.
 Returns 1 on success, 0 otherwise.
 
 ```c
-ssh2_bn *ssh2_bn_from_bin(ssh2_bn *bn, int len, const unsigned char *bin);
+ssh2_bn *ssh2_bn_from_bin(ssh2_bn *bn, const unsigned char *bin, size_t len);
 ```
 
 Converts the positive integer in big-endian form of length `len` at `bin` into

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -362,11 +362,10 @@ Sets the value of `bn` to `word`.
 Returns 1 on success, 0 otherwise.
 
 ```c
-ssh2_bn *ssh2_bn_from_bin(ssh2_bn *bn, int len,
-                          const unsigned char *val);
+ssh2_bn *ssh2_bn_from_bin(ssh2_bn *bn, int len, const unsigned char *bin);
 ```
 
-Converts the positive integer in big-endian form of length `len` at `val` into
+Converts the positive integer in big-endian form of length `len` at `bin` into
 an `ssh2_bn` and place it in `bn`. If `bn` is NULL, a new `ssh2_bn` is
 created.
 

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -373,9 +373,9 @@ created.
 Returns a pointer to target `ssh2_bn` or NULL if error.
 
 ```c
-int ssh2_bn_to_bin(ssh2_bn *bn, unsigned char *val);
+int ssh2_bn_to_bin(ssh2_bn *bn, unsigned char *bin);
 ```
-Converts the absolute value of bn into big-endian form and store it at `val`.
+Converts the absolute value of bn into big-endian form and store it at `bin`.
 val must point to `ssh2_bn_bytes(bn)` bytes of memory.
 Returns the length of the big-endian number.
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -325,7 +325,7 @@ void ssh2_bn_free(ssh2_bn *bn);
 #ifndef ssh2_bn_set_word
 int ssh2_bn_set_word(ssh2_bn *bn, uint32_t word);
 size_t ssh2_bn_bits(const ssh2_bn *bn);
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin);
+int ssh2_bn_from_bin(ssh2_bn *bn, const unsigned char *bin, size_t len);
 int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
 #endif
 #ifndef ssh2_bn_init_from_bin

--- a/src/kex.c
+++ b/src/kex.c
@@ -582,8 +582,8 @@ static int kex_diffie_hellman_sha(LIBSSH2_SESSION *session,
         }
 
         if(ssh2_bn_from_bin(exchange_state->f,
-                            exchange_state->f_value_len,
-                            exchange_state->f_value)) {
+                            exchange_state->f_value,
+                            exchange_state->f_value_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_HOSTKEY_INIT,
                            "Invalid DH-SHA f value");
             goto clean_exit;
@@ -794,7 +794,7 @@ static int kex_method_diffie_hellman_group1_sha1_key_exchange(
                            "Failed to allocate key state g.");
             goto clean_exit;
         }
-        if(!key_state->p || ssh2_bn_from_bin(key_state->p, 128, p_value)) {
+        if(!key_state->p || ssh2_bn_from_bin(key_state->p, p_value, 128)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                            "Failed to allocate key state p.");
             goto clean_exit;
@@ -890,7 +890,7 @@ static int kex_method_diffie_hellman_group14_key_exchange(
             goto clean_exit;
         }
         else if(!key_state->p ||
-                ssh2_bn_from_bin(key_state->p, 256, p_value)) {
+                ssh2_bn_from_bin(key_state->p, p_value, 256)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                            "Failed to allocate key state p.");
             goto clean_exit;
@@ -998,7 +998,7 @@ static int kex_method_diffie_hellman_group16_sha512_key_exchange(
                            "Failed to allocate key state g.");
             goto clean_exit;
         }
-        if(!key_state->p || ssh2_bn_from_bin(key_state->p, 512, p_value)) {
+        if(!key_state->p || ssh2_bn_from_bin(key_state->p, p_value, 512)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                            "Failed to allocate key state p.");
             goto clean_exit;
@@ -1132,7 +1132,7 @@ static int kex_method_diffie_hellman_group18_sha512_key_exchange(
             goto clean_exit;
         }
         else if(!key_state->p ||
-                ssh2_bn_from_bin(key_state->p, 1024, p_value)) {
+                ssh2_bn_from_bin(key_state->p, p_value, 1024)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                            "Failed to allocate key state p.");
             goto clean_exit;
@@ -1240,7 +1240,7 @@ static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        if(ssh2_bn_from_bin(key_state->p, p_len, p)) {
+        if(ssh2_bn_from_bin(key_state->p, p, p_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "Invalid DH-SHA1 p");
             goto dh_gex_clean_exit;
         }
@@ -1253,7 +1253,7 @@ static int kex_method_diffie_hellman_group_exchange_sha1_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        if(ssh2_bn_from_bin(key_state->g, g_len, g)) {
+        if(ssh2_bn_from_bin(key_state->g, g, g_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "Invalid DH-SHA1 g");
             goto dh_gex_clean_exit;
         }
@@ -1360,7 +1360,7 @@ static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        if(ssh2_bn_from_bin(key_state->p, p_len, p)) {
+        if(ssh2_bn_from_bin(key_state->p, p, p_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                            "Invalid DH-SHA256 p");
             goto dh_gex_clean_exit;
@@ -1374,7 +1374,7 @@ static int kex_method_diffie_hellman_group_exchange_sha256_key_exchange(
             goto dh_gex_clean_exit;
         }
 
-        if(ssh2_bn_from_bin(key_state->g, g_len, g)) {
+        if(ssh2_bn_from_bin(key_state->g, g, g_len)) {
             ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                            "Invalid DH-SHA256 g");
             goto dh_gex_clean_exit;

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -120,7 +120,7 @@
 #define ssh2_bn_init()                 gcry_mpi_new(0)
 #define ssh2_bn_init_from_bin()        NULL  /* because gcry_mpi_scan()
                                                 creates a new bignum */
-#define ssh2_bn_set_word(bn, val)      gcry_mpi_set_ui(bn, val)
+#define ssh2_bn_set_word(bn, word)     gcry_mpi_set_ui(bn, word)
 #define ssh2_bn_from_bin(bn, len, val) \
     gcry_mpi_scan(&(bn), GCRYMPI_FMT_USG, val, len, NULL)
 #define ssh2_bn_to_bin(bn, val) \

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -123,8 +123,8 @@
 #define ssh2_bn_set_word(bn, word)     gcry_mpi_set_ui(bn, word)
 #define ssh2_bn_from_bin(bn, len, val) \
     gcry_mpi_scan(&(bn), GCRYMPI_FMT_USG, val, len, NULL)
-#define ssh2_bn_to_bin(bn, val) \
-    gcry_mpi_print(GCRYMPI_FMT_USG, val, ssh2_bn_bytes(bn), NULL, bn)
+#define ssh2_bn_to_bin(bn, bin) \
+    gcry_mpi_print(GCRYMPI_FMT_USG, bin, ssh2_bn_bytes(bn), NULL, bn)
 #define ssh2_bn_bytes(bn) \
     (gcry_mpi_get_nbits(bn) / 8 + ((gcry_mpi_get_nbits(bn) % 8 == 0) ? 0 : 1))
 #define ssh2_bn_bits(bn)               gcry_mpi_get_nbits(bn)

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -121,7 +121,7 @@
 #define ssh2_bn_init_from_bin()        NULL  /* because gcry_mpi_scan()
                                                 creates a new bignum */
 #define ssh2_bn_set_word(bn, word)     gcry_mpi_set_ui(bn, word)
-#define ssh2_bn_from_bin(bn, len, bin) \
+#define ssh2_bn_from_bin(bn, bin, len) \
     gcry_mpi_scan(&(bn), GCRYMPI_FMT_USG, bin, len, NULL)
 #define ssh2_bn_to_bin(bn, bin) \
     gcry_mpi_print(GCRYMPI_FMT_USG, bin, ssh2_bn_bytes(bn), NULL, bn)

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -121,8 +121,8 @@
 #define ssh2_bn_init_from_bin()        NULL  /* because gcry_mpi_scan()
                                                 creates a new bignum */
 #define ssh2_bn_set_word(bn, word)     gcry_mpi_set_ui(bn, word)
-#define ssh2_bn_from_bin(bn, len, val) \
-    gcry_mpi_scan(&(bn), GCRYMPI_FMT_USG, val, len, NULL)
+#define ssh2_bn_from_bin(bn, len, bin) \
+    gcry_mpi_scan(&(bn), GCRYMPI_FMT_USG, bin, len, NULL)
 #define ssh2_bn_to_bin(bn, bin) \
     gcry_mpi_print(GCRYMPI_FMT_USG, bin, ssh2_bn_bytes(bn), NULL, bn)
 #define ssh2_bn_bytes(bn) \

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -220,7 +220,7 @@ typedef enum {
 
 #define ssh2_bn                        mbedtls_mpi
 #define ssh2_bn_set_word(bn, word)     mbedtls_mpi_lset(bn, word)
-#define ssh2_bn_from_bin(bn, len, bin) mbedtls_mpi_read_binary(bn, bin, len)
+#define ssh2_bn_from_bin(bn, bin, len) mbedtls_mpi_read_binary(bn, bin, len)
 #define ssh2_bn_to_bin(bn, bin) \
     mbedtls_mpi_write_binary(bn, bin, mbedtls_mpi_size(bn))
 #define ssh2_bn_bytes(bn)              mbedtls_mpi_size(bn)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -339,7 +339,7 @@ typedef enum {
 #define ssh2_bn                      BIGNUM
 #define ssh2_bn_init()               BN_new()
 #define ssh2_bn_set_word(bn, word)   !BN_set_word(bn, word)
-#define ssh2_bn_from_bin(bn, l, bin) (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
+#define ssh2_bn_from_bin(bn, bin, l) (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
 #define ssh2_bn_to_bin(bn, bin)      (BN_bn2bin(bn, bin) <= 0)
 #define ssh2_bn_bytes(bn)            BN_num_bytes(bn)
 #define ssh2_bn_bits(bn)             BN_num_bits(bn)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -338,7 +338,7 @@ typedef enum {
 
 #define ssh2_bn                      BIGNUM
 #define ssh2_bn_init()               BN_new()
-#define ssh2_bn_set_word(bn, val)    !BN_set_word(bn, val)
+#define ssh2_bn_set_word(bn, word)   !BN_set_word(bn, word)
 #define ssh2_bn_from_bin(bn, l, bin) (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
 #define ssh2_bn_to_bin(bn, val)      (BN_bn2bin(bn, val) <= 0)
 #define ssh2_bn_bytes(bn)            BN_num_bytes(bn)

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -340,7 +340,7 @@ typedef enum {
 #define ssh2_bn_init()               BN_new()
 #define ssh2_bn_set_word(bn, word)   !BN_set_word(bn, word)
 #define ssh2_bn_from_bin(bn, l, bin) (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
-#define ssh2_bn_to_bin(bn, val)      (BN_bn2bin(bn, val) <= 0)
+#define ssh2_bn_to_bin(bn, bin)      (BN_bn2bin(bn, bin) <= 0)
 #define ssh2_bn_bytes(bn)            BN_num_bytes(bn)
 #define ssh2_bn_bits(bn)             BN_num_bits(bn)
 #define ssh2_bn_free(bn)             BN_clear_free(bn)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -441,21 +441,21 @@ size_t ssh2_bn_bits(const ssh2_bn *bn)
     return 0;
 }
 
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val)
+int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin)
 {
     size_t i;
 
-    if(!bn || (len && !val))
+    if(!bn || (len && !bin))
         return -1;
 
-    for(; len && !*val; len--)
-        val++;
+    for(; len && !*bin; len--)
+        bin++;
 
     if(bn_resize(bn, len))
         return -1;
 
     for(i = len; i--;)
-        bn->bignum[i] = *val++;
+        bn->bignum[i] = *bin++;
 
     return 0;
 }

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -441,7 +441,7 @@ size_t ssh2_bn_bits(const ssh2_bn *bn)
     return 0;
 }
 
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin)
+int ssh2_bn_from_bin(ssh2_bn *bn, const unsigned char *bin, size_t len)
 {
     size_t i;
 

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -466,15 +466,15 @@ int ssh2_bn_set_word(ssh2_bn *bn, uint32_t word)
     return ssh2_bn_from_bin(bn, sizeof(word), (unsigned char *)&word);
 }
 
-int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *val)
+int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin)
 {
     int i;
 
-    if(!bn || !val)
+    if(!bn || !bin)
         return -1;
 
     for(i = bn->length; i--;)
-        *val++ = bn->bignum[i];
+        *bin++ = bn->bignum[i];
 
     return 0;
 }

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -463,7 +463,7 @@ int ssh2_bn_from_bin(ssh2_bn *bn, const unsigned char *bin, size_t len)
 int ssh2_bn_set_word(ssh2_bn *bn, uint32_t word)
 {
     word = htonl(word);
-    return ssh2_bn_from_bin(bn, sizeof(word), (unsigned char *)&word);
+    return ssh2_bn_from_bin(bn, (unsigned char *)&word, sizeof(word));
 }
 
 int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin)
@@ -1139,25 +1139,25 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     if(!ctx)
         ret = -1;
     if(!ret) {
-        ssh2_bn_from_bin(e, elen, edata);
-        ssh2_bn_from_bin(n, nlen, ndata);
+        ssh2_bn_from_bin(e, edata, elen);
+        ssh2_bn_from_bin(n, ndata, nlen);
         if(!e || !n)
             ret = -1;
     }
     if(!ret && ddata) {
         /* Private key. */
         d = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(d, dlen, ddata);
+        ssh2_bn_from_bin(d, ddata, dlen);
         p = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(p, plen, pdata);
+        ssh2_bn_from_bin(p, pdata, plen);
         q = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(q, qlen, qdata);
+        ssh2_bn_from_bin(q, qdata, qlen);
         e1 = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(e1, e1len, e1data);
+        ssh2_bn_from_bin(e1, e1data, e1len);
         e2 = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(e2, e2len, e2data);
+        ssh2_bn_from_bin(e2, e2data, e2len);
         coeff = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(coeff, coefflen, coeffdata);
+        ssh2_bn_from_bin(coeff, coeffdata, coefflen);
         if(!d || !p || !q || !e1 || !e2 || !coeff)
             ret = -1;
 
@@ -1265,7 +1265,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     asn1delete(pkcs3);
     if(errcode.Bytes_Available)
         return -1;
-    return ssh2_bn_from_bin(pub, pubkeylen, (unsigned char *)pubkey);
+    return ssh2_bn_from_bin(pub, (unsigned char *)pubkey, pubkeylen);
 }
 
 int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
@@ -1290,7 +1290,7 @@ int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                             &secretbufsize, &secretbuflen, &errcode);
     if(errcode.Bytes_Available)
         return -1;
-    return ssh2_bn_from_bin(secret, secretbuflen, (unsigned char *)secretbuf);
+    return ssh2_bn_from_bin(secret, (unsigned char *)secretbuf, secretbuflen);
 }
 
 void ssh2_dh_dtor(ssh2_dh_ctx *dhctx)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -460,10 +460,10 @@ int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *val)
     return 0;
 }
 
-int ssh2_bn_set_word(ssh2_bn *bn, uint32_t val)
+int ssh2_bn_set_word(ssh2_bn *bn, uint32_t word)
 {
-    val = htonl(val);
-    return ssh2_bn_from_bin(bn, sizeof(val), (unsigned char *)&val);
+    word = htonl(word);
+    return ssh2_bn_from_bin(bn, sizeof(word), (unsigned char *)&word);
 }
 
 int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *val)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -330,7 +330,7 @@ size_t ssh2_bn_bits(const ssh2_bn *bn)
     return bits;
 }
 
-int ssh2_bn_from_bin(ssh2_bn *bn, size_t len, const unsigned char *bin)
+int ssh2_bn_from_bin(ssh2_bn *bn, const unsigned char *bin, size_t len)
 {
     unsigned char *bignum;
     size_t offset, length, bits;


### PR DESCRIPTION
- `val` → `word`, `bin`.
- pass length _after_ buffer pointer.
