### PR TITLE
crypto: de-duplicate `ssh2_bn_ctx*` macro stubs into `crypto.h`

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -318,6 +318,12 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               size_t privatekeydata_len,
                               const char *passphrase);
 
+#ifndef ssh2_bn_ctx
+#define ssh2_bn_ctx              int
+#define ssh2_bn_ctx_new()        0
+#define ssh2_bn_ctx_free(bnctx)  ((void)0)
+#endif
+
 #ifndef ssh2_bn_init
 ssh2_bn *ssh2_bn_init(void);
 void ssh2_bn_free(ssh2_bn *bn);

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -112,10 +112,6 @@
 
 #define ssh2_cipher_dtor(ctx) gcry_cipher_close(*(ctx))
 
-#define ssh2_bn_ctx                    int /* not used */
-#define ssh2_bn_ctx_new()              0 /* not used */
-#define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
-
 #define ssh2_bn                        struct gcry_mpi
 #define ssh2_bn_init()                 gcry_mpi_new(0)
 #define ssh2_bn_init_from_bin()        NULL  /* because gcry_mpi_scan()

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -214,10 +214,6 @@ typedef enum {
  * mbedTLS backend: BigNumber Support
  */
 
-#define ssh2_bn_ctx                    int /* not used */
-#define ssh2_bn_ctx_new()              0 /* not used */
-#define ssh2_bn_ctx_free(bnctx)        ((void)0) /* not used */
-
 #define ssh2_bn                        mbedtls_mpi
 #define ssh2_bn_set_word(bn, word)     mbedtls_mpi_lset(bn, word)
 #define ssh2_bn_from_bin(bn, bin, len) mbedtls_mpi_read_binary(bn, bin, len)

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -238,10 +238,6 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 
 /* Bignum */
 
-#define ssh2_bn_ctx              int /* not used */
-#define ssh2_bn_ctx_new()        0 /* not used */
-#define ssh2_bn_ctx_free(bnctx)  ((void)0) /* not used */
-
 #define ssh2_bn                  struct os400qc3_bn
 #define ssh2_bn_bytes(bn)        ((bn)->length)
 

--- a/src/wincng.h
+++ b/src/wincng.h
@@ -265,10 +265,6 @@ struct wcng_cipher_t {
  * Windows CNG backend: BigNumber support
  */
 
-#define ssh2_bn_ctx              int /* not used */
-#define ssh2_bn_ctx_new()        0 /* not used */
-#define ssh2_bn_ctx_free(bnctx)  ((void)0) /* not used */
-
 struct wcng_bn {
     unsigned char *bignum;
     size_t length;


### PR DESCRIPTION
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
