### PR TITLE
build: make examples a separate target, add quick-build for cmake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
       MATRIX_BUILD: '${{ matrix.build }}'
       MATRIX_COMPILER: '${{ matrix.compiler }}'
       MATRIX_CRYPTO: '${{ matrix.crypto }}'
+      MATRIX_TARGET: '${{ matrix.target }}'
       MATRIX_ZLIB: '${{ matrix.zlib }}'
       FIXTURE_TRACE_ALL_CONNECT: 0
       AWSLC_VERSION: 5.0.0
@@ -604,9 +605,12 @@ jobs:
             else
               options+=' --with-libz'
             fi
+            if [ "${MATRIX_TARGET}" != 'distcheck' ]; then
+              options+=' --disable-examples-build'
+            fi
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               ${options} \
-              --disable-dependency-tracking --disable-examples-build
+              --disable-dependency-tracking
           fi
 
       - name: 'configure log'
@@ -649,6 +653,7 @@ jobs:
           fi
 
       - name: 'build examples'
+        if: ${{ !matrix.target }}
         run: |
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             cmake --build bld --verbose --target libssh2-examples-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,7 +606,7 @@ jobs:
             fi
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               ${options} \
-              --disable-dependency-tracking
+              --disable-dependency-tracking --disable-examples-build
           fi
 
       - name: 'configure log'
@@ -646,6 +646,14 @@ jobs:
             cd bld && ctest -VV --output-on-failure
           else
             make -C bld check V=1 || { cat bld/tests/*.log; false; }
+          fi
+
+      - name: 'build examples'
+        run: |
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
+            cmake --build bld --verbose --target libssh2-examples-build
+          else
+            make -C bld V=1 examples
           fi
 
       - name: 'autotools distcheck'
@@ -736,7 +744,7 @@ jobs:
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               --host="${TRIPLET}" \
-              --disable-dependency-tracking
+              --disable-dependency-tracking --disable-examples-build
           fi
 
       - name: 'configure log'
@@ -754,6 +762,14 @@ jobs:
             cmake --build bld
           else
             make -C bld
+          fi
+
+      - name: 'build examples'
+        run: |
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
+            cmake --build bld --verbose --target libssh2-examples-build
+          else
+            make -C bld V=1 examples
           fi
 
   build_cygwin:
@@ -808,7 +824,7 @@ jobs:
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               --with-crypto=openssl \
               --disable-docker-tests \
-              --disable-dependency-tracking
+              --disable-dependency-tracking --disable-examples-build
           fi
 
       - name: 'configure log'
@@ -838,6 +854,14 @@ jobs:
             cd bld && ctest -VV --output-on-failure
           else
             make -C bld check V=1 || { cat bld/tests/*.log; false; }
+          fi
+
+      - name: 'build examples'
+        run: |
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
+            cmake --build bld --verbose --target libssh2-examples-build
+          else
+            make -C bld V=1 examples
           fi
 
   build_msys2:
@@ -934,7 +958,7 @@ jobs:
               --disable-docker-tests \
               --disable-sshd-tests \
               ${options} \
-              --disable-dependency-tracking
+              --disable-dependency-tracking --disable-examples-build
           fi
 
       - name: 'configure log'
@@ -963,6 +987,14 @@ jobs:
             fi
           else
             make -C bld check V=1 || { cat bld/tests/*.log; false; }
+          fi
+
+      - name: 'build examples'
+        run: |
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
+            cmake --build bld --verbose --target libssh2-examples-build
+          else
+            make -C bld V=1 examples
           fi
 
   build_msvc:
@@ -1044,6 +1076,9 @@ jobs:
         timeout-minutes: 10
         run: cd bld && ctest -VV -C Release --output-on-failure
 
+      - name: 'build examples'
+        run: cmake --build bld --verbose --target libssh2-examples-build
+
   build_macos:
     name: 'macOS (${{ matrix.build }}, ${{ matrix.crypto.name }})'
     runs-on: macos-latest
@@ -1119,7 +1154,7 @@ jobs:
               --with-libz ${MATRIX_CONFIGURE} \
               --disable-docker-tests \
               --disable-sshd-tests \
-              --disable-dependency-tracking
+              --disable-dependency-tracking --disable-examples-build
           fi
 
       - name: 'configure log'
@@ -1148,8 +1183,16 @@ jobs:
             make -C bld check V=1 || { cat bld/tests/*.log; false; }
           fi
 
+      - name: 'build examples'
+        run: |
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
+            cmake --build bld --verbose --target libssh2-examples-build
+          else
+            make -C bld V=1 examples
+          fi
+
   cross:
-    name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.cc }} ${{ matrix.desc }} ${{ matrix.arch }}"
+    name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build }} ${{ matrix.cc }} ${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-26.04
     timeout-minutes: 10
     defaults:
@@ -1166,37 +1209,37 @@ jobs:
       matrix:
         include:
           # https://github.com/DragonFlyBSD/DPorts
-          # { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'libgcrypt skiprun',
+          # { os: 'dragonflybsd', version: '6.4.2', build: 'AM', arch: 'x86_64', cc: 'gcc'  , desc: 'libgcrypt skiprun',
           #   install: 'autoconf automake libtool libgcrypt',
           #   options: '--with-crypto=libgcrypt --with-libgcrypt-prefix=/usr/local' }
 
           # https://ports.freebsd.org/
-          - { os: 'freebsd'     , version: '15.1',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
+          - { os: 'freebsd'     , version: '15.1',  build: 'AM', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               install: 'autoconf automake libtool gettext',
               options: '--with-crypto=openssl' }
 
-          - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl skiprun',
+          - { os: 'freebsd'     , version: '14.3',  build: 'CM', arch: 'arm64' , cc: 'clang', desc: 'openssl skiprun',
               install: 'cmake-core ninja',
               options: '-DCRYPTO_BACKEND=OpenSSL' }
 
           # https://app.midnightbsd.org/
           # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'CM', arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
               install: 'cmake-core ninja',
               options: '-DCRYPTO_BACKEND=OpenSSL' }
 
           # https://pkgsrc.se/
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
+          - { os: 'netbsd'      , version: '10.1' , build: 'CM', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
               install: 'cmake ninja-build',
               options: '-DCRYPTO_BACKEND=OpenSSL' }
 
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'arm64' , cc: 'gcc'  , desc: 'openssl skiprun',
+          - { os: 'netbsd'      , version: '10.1' , build: 'CM', arch: 'arm64' , cc: 'gcc'  , desc: 'openssl skiprun',
               install: 'cmake ninja-build',
               options: '-DCRYPTO_BACKEND=OpenSSL' }
 
           # https://openbsd.app/
           # https://www.openbsd.org/faq/faq15.html
-          - { os: 'openbsd'     , version: '7.9'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl skiprun',
+          - { os: 'openbsd'     , version: '7.9'  , build: 'CM', arch: 'x86_64', cc: 'clang', desc: 'libressl skiprun',
               install: 'cmake ninja',
               options: '-DCRYPTO_BACKEND=OpenSSL' }
 
@@ -1229,12 +1272,12 @@ jobs:
           fi
 
       - name: 'autoreconf'
-        if: ${{ matrix.build == 'autotools' }}
+        if: ${{ matrix.build == 'AM' }}
         run: autoreconf -fi
 
       - name: 'configure'
         run: |
-          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
             cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON \
               -DENABLE_WERROR=ON \
@@ -1247,7 +1290,7 @@ jobs:
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               --disable-docker-tests \
-              --disable-dependency-tracking \
+              --disable-dependency-tracking --disable-examples-build \
               ${MATRIX_OPTIONS}
           fi
 
@@ -1262,18 +1305,26 @@ jobs:
 
       - name: 'build'
         run: |
-          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
             cmake --build bld
           else
             make -C bld
           fi
 
-      - name: 'run tests'
+      - name: 'tests'
         if: ${{ matrix.arch == 'x86_64' && !contains(matrix.desc, 'skiprun') }}  # Slow on emulated CPU
         run: |
           export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures on FreeBSD
-          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
             cmake --build bld --verbose --target test-ci
           else
             make -C bld check V=1 || { cat bld/tests/*.log; false; }
+          fi
+
+      - name: 'build examples'
+        run: |
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
+            cmake --build bld --verbose --target libssh2-examples-build
+          else
+            make -C bld V=1 examples
           fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,8 @@ SUBDIRS = src docs
 SUBDIRS += tests
 if BUILD_EXAMPLES
 SUBDIRS += example
+else
+DIST_SUBDIRS = $(SUBDIRS) example
 endif
 
 pkgconfigdir = $(libdir)/pkgconfig
@@ -95,3 +97,6 @@ coverage: init-coverage build-coverage gen-coverage
 
 checksrc:
 	scripts/checksrc-all.pl
+
+examples:
+	@(cd example; $(MAKE))

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,8 +6,6 @@ SUBDIRS = src docs
 SUBDIRS += tests
 if BUILD_EXAMPLES
 SUBDIRS += example
-else
-DIST_SUBDIRS = $(SUBDIRS) example
 endif
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -44,12 +44,16 @@ fi
 cmake -B _bld \
   -DCMAKE_UNITY_BUILD=ON -DENABLE_WERROR=ON \
   -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
-  -DBUILD_EXAMPLES=OFF \
   -DLIBSSH2_BUILD_DOCS=OFF \
   ${CMAKE_GENERATE:-} \
   ${options}
 echo 'libssh2_config.h'; grep -F '#define' _bld/src/libssh2_config.h | sort || true
-cmake --build _bld --config "${CMAKE_CONFIGURATION}" --parallel 2
+time cmake --build _bld --config "${CMAKE_CONFIGURATION}" --parallel 2
+
+# build examples
+if [[ "${APPVEYOR_JOB_NAME}" = *'examples'* ]]; then
+  time cmake --build _bld --config "${CMAKE_CONFIGURATION}" --parallel 2 --target libssh2-examples-build
+fi
 
 # Install docker-cli for tests
 if [ "${SKIP_CTEST:-}" != 'yes' ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ environment:
     - job_name: 'VS2010, WinCNG, x64, Server 2012 R2, Build-only, non-unity, examples, docs'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       CMAKE_GENERATOR: 'Visual Studio 10 2010'
-      CMAKE_GENERATE: '-A x64 -DCRYPTO_BACKEND=WinCNG -DCMAKE_UNITY_BUILD=OFF -DBUILD_EXAMPLES=ON -DLIBSSH2_BUILD_DOCS=ON'
+      CMAKE_GENERATE: '-A x64 -DCRYPTO_BACKEND=WinCNG -DCMAKE_UNITY_BUILD=OFF -DLIBSSH2_BUILD_DOCS=ON'
       #SKIP_CTEST: 'yes'
 
   # Re-enable when tests work again

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -36,14 +36,34 @@ libssh2_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makef
 # Get noinst_PROGRAMS variable
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-foreach(_example IN LISTS noinst_PROGRAMS)
-  add_executable(${_example} "${_example}.c")
-  list(APPEND _example_targets ${_example})
-  # to find generated header
-  target_include_directories(${_example} PRIVATE
+add_custom_target(libssh2-examples)
+
+set(_all_src "")
+set(_all_canary "")
+set(_all "all")
+foreach(_target IN LISTS noinst_PROGRAMS _all)  # keep '_all' last
+  if(_target STREQUAL "all")
+    set(_target "libssh2-example-${_all}")
+    add_library(${_target} OBJECT EXCLUDE_FROM_ALL ${_all_src})
+    if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")  # MSVC but exclude clang-cl
+      # CMake generates a static library for the OBJECT target. Silence these 'lib.exe' warnings:
+      # warning LNK4006: main already defined in ....obj; second definition ignored
+      # warning LNK4221: This object file does not define any previously undefined public symbols,
+      #                  [...] not be used by any link operation that consumes this library
+      set_target_properties(${_target} PROPERTIES STATIC_LIBRARY_OPTIONS "-ignore:4006;-ignore:4221")
+    endif()
+    add_custom_target(libssh2-examples-build)  # Special target to compile all tests quickly and build a single test to probe linkage
+    add_dependencies(libssh2-examples-build ${_target} ${_all_canary})  # Include a full build of a single test
+  else()
+    set(_all_canary ${_target})  # Save the last test for the libssh2-examples-build target
+    list(APPEND _all_src "${_target}.c")
+    add_executable(${_target} EXCLUDE_FROM_ALL "${_target}.c")
+    add_dependencies(libssh2-examples ${_target})
+  endif()
+  target_include_directories(${_target} PRIVATE
     "${PROJECT_BINARY_DIR}/src"
     "${PROJECT_SOURCE_DIR}/src")
-  target_link_libraries(${_example} ${LIB_SELECTED} ${LIBSSH2_LIBS})
-  set_property(TARGET ${_example} APPEND PROPERTY COMPILE_OPTIONS "${LIBSSH2_PICKY_C_FLAGS}")
-  set_target_properties(${_example} PROPERTIES UNITY_BUILD OFF)
+  target_link_libraries(${_target} ${LIB_SELECTED} ${LIBSSH2_LIBS})
+  set_property(TARGET ${_target} APPEND PROPERTY COMPILE_OPTIONS "${LIBSSH2_PICKY_C_FLAGS}")
+  set_target_properties(${_target} PROPERTIES UNITY_BUILD OFF)
 endforeach()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -52,7 +52,7 @@ foreach(_target IN LISTS noinst_PROGRAMS _all)  # keep '_all' last
       #                  [...] not be used by any link operation that consumes this library
       set_target_properties(${_target} PROPERTIES STATIC_LIBRARY_OPTIONS "-ignore:4006;-ignore:4221")
     endif()
-    add_custom_target(libssh2-examples-build)  # Special target to compile all tests quickly and build a single test to probe linkage
+    add_custom_target(libssh2-examples-build) # Special target to compile all tests quickly and build a single test to probe linkage
     add_dependencies(libssh2-examples-build ${_target} ${_all_canary})  # Include a full build of a single test
   else()
     set(_all_canary ${_target})  # Save the last test for the libssh2-examples-build target

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -16,7 +16,7 @@ cmake_provider="${TEST_CMAKE_PROVIDER:-${cmake_consumer}}"
 
 gen="${TEST_CMAKE_GENERATOR:-Ninja}"
 
-cmake_opts='-DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DENABLE_ZLIB_COMPRESSION=ON'
+cmake_opts='-DBUILD_TESTING=OFF -DENABLE_ZLIB_COMPRESSION=ON'
 
 src='../..'
 


### PR DESCRIPTION
- cmake: do not build examples automatically. This makes the
  `BUILD_EXAMPLES=OFF` option redundant.
- cmake: build all examples with target `libssh2-examples`.
- cmake: build-test all examples with target `libssh2-examples-build`.
  To save linking them 23 times in CI.
- autotools: add root `examples` build target to build examples.
- CI: build examples in a separate step.
  (for autotools, make them not build in the main build step by
  configuring with `--disable-examples-build`)

To make the build more transparent, scale better, be faster in CI, also
syncing with curl.

Slight downsides after this patch:
- cmake and autotools have different default behavior for building
  examples.
- cmake needs an extra step to build examples. (an explicit option is
  planned to restore the old behavior.)

Also:
- sync BSD matrix build-tool naming with rest of jobs.
