### PR TITLE
mbedtls: drop unused Blowfish, RC4, make 3DES conditional

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -118,8 +118,12 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     if(!ret &&
        (algo == MBEDTLS_CIPHER_AES_128_CBC ||
         algo == MBEDTLS_CIPHER_AES_192_CBC ||
-        algo == MBEDTLS_CIPHER_AES_256_CBC ||
-        algo == MBEDTLS_CIPHER_DES_EDE3_CBC)) {
+        algo == MBEDTLS_CIPHER_AES_256_CBC
+#if LIBSSH2_3DES
+        || algo == MBEDTLS_CIPHER_DES_EDE3_CBC
+#endif
+       )
+      ) {
         ret = mbedtls_cipher_set_padding_mode(ctx, MBEDTLS_PADDING_NONE);
     }
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -91,7 +91,11 @@
 # define LIBSSH2_RC4 0
 #endif
 #define LIBSSH2_CAST 0
-#define LIBSSH2_3DES 1
+#ifdef MBEDTLS_CIPHER_DES_EDE3_CBC
+# define LIBSSH2_3DES 1
+#else
+# define LIBSSH2_3DES 0
+#endif
 
 #define LIBSSH2_RSA 1
 #define LIBSSH2_RSA_SHA1 1
@@ -194,13 +198,15 @@ typedef enum {
 #define ssh2_cipher_aes256     MBEDTLS_CIPHER_AES_256_CBC
 #define ssh2_cipher_aes192     MBEDTLS_CIPHER_AES_192_CBC
 #define ssh2_cipher_aes128     MBEDTLS_CIPHER_AES_128_CBC
-#ifdef MBEDTLS_CIPHER_BLOWFISH_CBC
+#if LIBSSH2_BLOWFISH
 #define ssh2_cipher_blowfish   MBEDTLS_CIPHER_BLOWFISH_CBC
 #endif
-#ifdef MBEDTLS_CIPHER_ARC4_128
+#if LIBSSH2_RC4
 #define ssh2_cipher_arcfour    MBEDTLS_CIPHER_ARC4_128
 #endif
+#if LIBSSH2_3DES
 #define ssh2_cipher_3des       MBEDTLS_CIPHER_DES_EDE3_CBC
+#endif
 #define ssh2_cipher_chacha20   MBEDTLS_CIPHER_CHACHA20_POLY1305
 
 /*******************************************************************/

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -80,16 +80,8 @@
 #define LIBSSH2_AES_CBC 1
 #define LIBSSH2_AES_CTR 1
 #define LIBSSH2_AES_GCM 0
-#ifdef MBEDTLS_CIPHER_BLOWFISH_CBC
-# define LIBSSH2_BLOWFISH 1
-#else
-# define LIBSSH2_BLOWFISH 0
-#endif
-#ifdef MBEDTLS_CIPHER_ARC4_128
-# define LIBSSH2_RC4 1
-#else
-# define LIBSSH2_RC4 0
-#endif
+#define LIBSSH2_BLOWFISH 0
+#define LIBSSH2_RC4 0
 #define LIBSSH2_CAST 0
 #ifdef MBEDTLS_CIPHER_DES_EDE3_CBC
 # define LIBSSH2_3DES 1
@@ -198,12 +190,6 @@ typedef enum {
 #define ssh2_cipher_aes256     MBEDTLS_CIPHER_AES_256_CBC
 #define ssh2_cipher_aes192     MBEDTLS_CIPHER_AES_192_CBC
 #define ssh2_cipher_aes128     MBEDTLS_CIPHER_AES_128_CBC
-#if LIBSSH2_BLOWFISH
-#define ssh2_cipher_blowfish   MBEDTLS_CIPHER_BLOWFISH_CBC
-#endif
-#if LIBSSH2_RC4
-#define ssh2_cipher_arcfour    MBEDTLS_CIPHER_ARC4_128
-#endif
 #if LIBSSH2_3DES
 #define ssh2_cipher_3des       MBEDTLS_CIPHER_DES_EDE3_CBC
 #endif


### PR DESCRIPTION
RC4 and Blowfish not supported by mbedTLS 3+.
3DES not supported by mbedTLS 4+.

Follow-up to f63f68b3500ed924115d0dc39bae212cde42a87f #1727

---

https://github.com/libssh2/libssh2/pull/2277/files?w=1
