### PR TITLE
mbedtls: drop no-op checks from `mbed_mpi_write_binary()`

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1239,21 +1239,15 @@ static unsigned char *mbed_mpi_write_binary(unsigned char *buf,
     unsigned char *p = buf;
     uint32_t size = (uint32_t)bytes;
 
-    if(sizeof(&p) / sizeof(p[0]) < 4)
-        goto done;
+    p += 4;  /* Left space for bn size which is written below. */
 
-    p += 4;
     *p = 0;
+    mbedtls_mpi_write_binary(mpi, p + 1, size - 1);
 
-    if(size > 0)
-        mbedtls_mpi_write_binary(mpi, p + 1, size - 1);
-
-    if(size > 0 && !(*(p + 1) & 0x80))
+    if(!(p[1] & 0x80))
         memmove(p, p + 1, --size);
 
     ssh2_htonu32(p - 4, size);
-
-done:
 
     return p + size;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -180,8 +180,7 @@ static unsigned char *ossl_write_bn(unsigned char *buf, const BIGNUM *bn,
 {
     unsigned char *p = buf;
 
-    /* Left space for bn size which is written below. */
-    p += 4;
+    p += 4;  /* Left space for bn size which is written below. */
 
     *p = 0;
     BN_bn2bin(bn, p + 1);


### PR DESCRIPTION
To sync with `ossl_write_bn()` sibling function.

Reported by GitHub Code Quality
Follow-up to 5528f3da02eba1de425535481de049b21c48e9eb #385

---

https://github.com/libssh2/libssh2/pull/2278/files?w=1
