### PR TITLE
openssl: drop no-op code from `ssh2_sk_pub_keyfilememory()`

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -315,7 +315,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               size_t *handle_len,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
-                              const char *passphrase);
+                              const unsigned char *passphrase);
 
 #ifndef ssh2_bn_ctx
 #define ssh2_bn_ctx              int

--- a/src/misc.c
+++ b/src/misc.c
@@ -971,7 +971,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               size_t *handle_len,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
-                              const char *passphrase)
+                              const unsigned char *passphrase)
 {
     (void)method;
     (void)method_len;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -158,22 +158,6 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                       size_t privatekeydata_len,
                                       const unsigned char *passphrase);
 
-static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
-                                         void **key_ctx,
-                                         const char *key_type,
-                                         unsigned char **method,
-                                         size_t *method_len,
-                                         unsigned char **pubkeydata,
-                                         size_t *pubkeydata_len,
-                                         int *algorithm,
-                                         unsigned char *flags,
-                                         const char **application,
-                                         const unsigned char **key_handle,
-                                         size_t *handle_len,
-                                         const char *privatekeydata,
-                                         size_t privatekeydata_len,
-                                         const unsigned char *passphrase);
-
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
 static unsigned char *ossl_write_bn(unsigned char *buf, const BIGNUM *bn,
                                     int bn_bytes)
@@ -3848,38 +3832,34 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
     return rc;
 }
 
-static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
-                                         void **key_ctx,
-                                         const char *key_type,
-                                         unsigned char **method,
-                                         size_t *method_len,
-                                         unsigned char **pubkeydata,
-                                         size_t *pubkeydata_len,
-                                         int *algorithm,
-                                         unsigned char *flags,
-                                         const char **application,
-                                         const unsigned char **key_handle,
-                                         size_t *handle_len,
-                                         const char *privatekeydata,
-                                         size_t privatekeydata_len,
-                                         const unsigned char *passphrase)
+int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
+                              unsigned char **method,
+                              size_t *method_len,
+                              unsigned char **pubkeydata,
+                              size_t *pubkeydata_len,
+                              int *algorithm,
+                              unsigned char *flags,
+                              const char **application,
+                              const unsigned char **key_handle,
+                              size_t *handle_len,
+                              const char *privatekeydata,
+                              size_t privatekeydata_len,
+                              const char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
 
-    if(key_ctx)
-        *key_ctx = NULL;
+    ssh2_deb((session, LIBSSH2_TRACE_AUTH,
+              "Computing public key from private key."));
 
     if(!session)
         return ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
 
-    if(key_type && strlen(key_type) < 7)
-        return ssh2_err(session, LIBSSH2_ERROR_PROTO, "type is invalid");
-
     OSSL_INIT_IF_NEEDED();
 
-    rc = ssh2_openssh_pem_parse_memory(session, passphrase,
+    rc = ssh2_openssh_pem_parse_memory(session,
+                                       (const unsigned char *)passphrase,
                                        privatekeydata,
                                        privatekeydata_len, &decrypted);
 
@@ -3909,14 +3889,13 @@ static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
 #if LIBSSH2_ED25519
     if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf)) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ED25519;
-        if(!key_type || !strcmp("sk-ssh-ed25519@openssh.com", key_type))
-            rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                        method, method_len,
-                                                        pubkeydata,
-                                                        pubkeydata_len,
-                                                        flags, application,
-                                                        key_handle, handle_len,
-                                                 (ssh2_ed25519_ctx **)key_ctx);
+        rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
+                                                    method, method_len,
+                                                    pubkeydata,
+                                                    pubkeydata_len,
+                                                    flags, application,
+                                                    key_handle, handle_len,
+                                                    NULL);
     }
 #endif
 #if LIBSSH2_ECDSA
@@ -3927,7 +3906,7 @@ static int ossl_key_sk_from_openssh_blob(LIBSSH2_SESSION *session,
                                                   pubkeydata, pubkeydata_len,
                                                   flags, application,
                                                   key_handle, handle_len,
-                                                  (ssh2_ecdsa_ctx **)key_ctx);
+                                                  NULL);
     }
 #endif
 
@@ -4034,47 +4013,6 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     }
 
     EVP_PKEY_free(pk);
-    return st;
-}
-
-int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
-                              unsigned char **method,
-                              size_t *method_len,
-                              unsigned char **pubkeydata,
-                              size_t *pubkeydata_len,
-                              int *algorithm,
-                              unsigned char *flags,
-                              const char **application,
-                              const unsigned char **key_handle,
-                              size_t *handle_len,
-                              const char *privatekeydata,
-                              size_t privatekeydata_len,
-                              const char *passphrase)
-{
-    int st = -1;
-    BIO *bp;
-    EVP_PKEY *pk;
-
-    ssh2_deb((session, LIBSSH2_TRACE_AUTH,
-              "Computing public key from private key."));
-
-    bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
-    if(!bp)
-        return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                        "Unable to allocate memory when computing public key");
-    (void)BIO_reset(bp);
-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, SSH2_UNCONST(passphrase));
-    BIO_free(bp);
-
-    if(!pk)
-        /* Try OpenSSH format */
-        st = ossl_key_sk_from_openssh_blob(session, NULL, NULL,
-                                           method, method_len,
-                                           pubkeydata, pubkeydata_len,
-                                           algorithm, flags, application,
-                                           key_handle, handle_len,
-                                           privatekeydata, privatekeydata_len,
-                                           (const unsigned char *)passphrase);
     return st;
 }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -984,6 +984,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                           SSH2_UNCONST(passphrase));
 #endif
     BIO_free(bp);
+
     if(!*rsa)
         rc = ossl_key_from_openssh_blob(session, (void **)rsa, "ssh-rsa",
                                         NULL, NULL, NULL, NULL,
@@ -3844,7 +3845,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               size_t *handle_len,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
-                              const char *passphrase)
+                              const unsigned char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;
@@ -3858,8 +3859,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 
     OSSL_INIT_IF_NEEDED();
 
-    rc = ssh2_openssh_pem_parse_memory(session,
-                                       (const unsigned char *)passphrase,
+    rc = ssh2_openssh_pem_parse_memory(session, passphrase,
                                        privatekeydata,
                                        privatekeydata_len, &decrypted);
 
@@ -3912,8 +3912,8 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
 
     if(rc == LIBSSH2_ERROR_FILE)
         rc = ssh2_err(session, LIBSSH2_ERROR_FILE,
-                      "Unable to extract public key from private key "
-                      "file: invalid/unrecognized private key file format");
+                      "Unable to extract public key from private key file: "
+                      "invalid/unrecognized private key file format");
 
     if(decrypted)
         ssh2_string_buf_free(session, decrypted);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3851,11 +3851,11 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
 
-    ssh2_deb((session, LIBSSH2_TRACE_AUTH,
-              "Computing public key from private key."));
-
     if(!session)
         return ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
+
+    ssh2_deb((session, LIBSSH2_TRACE_AUTH,
+              "Computing public key from private key."));
 
     OSSL_INIT_IF_NEEDED();
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2333,7 +2333,7 @@ int libssh2_userauth_publickey_sk(
                                      &sk_info.key_handle,
                                      &sk_info.handle_len,
                                      privatekeydata, privatekeydata_len,
-                                     passphrase))
+                                     (const unsigned char *)passphrase))
             return ssh2_err(session, LIBSSH2_ERROR_FILE,
                             "Unable to extract public key from private key.");
         else if(publickeydata_len == 0 || !publickeydata) {


### PR DESCRIPTION
Prior to this patch it was loading a PEM-formatted private key via
OpenSSL. When successful, it did nothing, when failed, it fell back
trying to load an OpenSSH-formatted key. This was no-op in itself, but
SK keys don't support the PEM format AFAIU, so the function went to the
OpenSSH codepath when used as intended. In both cases, it leaked the
OpenSSL memory object.

Drop the superfluous intermediate step and map this function directly to
the internal worker `ossl_key_sk_from_openssh_blob()`, also fixing the
memory leak and unnecessary processing.

Also:
- sync `passphrase` type with rest of internal APIs.

Memleak reported repeatedly by GitHub Code Quality
Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698

---

"`st` is initialized to -1 at line 4242, and is only assigned in the
`if(!pk)` branch. If `PEM_read_bio_PrivateKey` succeeds (i.e., `pk` is
non-NULL), `st` is never updated and the function always returns -1. The
non-NULL `pk` case should be handled, including freeing `pk` before
returning."

"When `PEM_read_bio_PrivateKey` succeeds (pk != NULL), `st` remains -1 
and the function immediately returns it without processing the key or
freeing `pk`. This causes a memory leak of the `EVP_PKEY` object and
always returns failure for PEM-format SK keys. The function needs to
handle the successful PEM parse case, and `EVP_PKEY_free(pk)` must be
called before returning."
