### PR TITLE
misc: fix NULL `session` derefs in `ssh2_deb()`

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -554,7 +554,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
     const char *contexttext = contexts[0];
     unsigned int contextindex;
 
-    if(!(session->showmask & context))
+    if(session && !(session->showmask & context))
         return;  /* no such output asked for */
 
     /* Find the first matching context string for this message */
@@ -593,7 +593,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         msglen += len < buflen ? len : buflen - 1;
     }
 
-    if(session->tracehandler)
+    if(session && session->tracehandler)
         (session->tracehandler)(session, session->tracehandler_context, buffer,
                                 msglen);
     else


### PR DESCRIPTION
The codebase calls `ssh2_err(session, ...)` from many places when it
sees `session == NULL` in public APIs, then `ssh2_err()` falls back to
`ssh2_deb()` because of the NULL session, and then that function
crashes.

This is still wrong, because `ssh2_deb()` does an `fprintf()` in this
case which is weird from a library. To be fixed separately.

Ref: #2283
