### PR TITLE
src: return `LIBSSH2_ERROR_BAD_USE` when `session == NULL`

### DIFF
--- a/docs/libssh2_trace.md
+++ b/docs/libssh2_trace.md
@@ -66,4 +66,4 @@ Public Key debugging
 
 # RETURN VALUE
 
-Currently always 0, no error.
+0 on success, `LIBSSH2_ERROR_BAD_USE` if the session is invalid.

--- a/docs/libssh2_trace_sethandler.md
+++ b/docs/libssh2_trace_sethandler.md
@@ -39,6 +39,10 @@ and a typical "release build" might not.
 
 **context** can be used to pass arbitrary user defined data back into the callback when invoked.
 
+# RETURN VALUE
+
+0 on success, `LIBSSH2_ERROR_BAD_USE` if the session is invalid.
+
 # AVAILABILITY
 
 Added in libssh2 version 1.2.3

--- a/src/misc.c
+++ b/src/misc.c
@@ -519,16 +519,20 @@ void libssh2_free(LIBSSH2_SESSION *session, void *ptr)
 
 int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
     session->showmask = bitmask;
-    return 0;
+    return LIBSSH2_ERROR_NONE;
 }
 
 int libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
                              libssh2_trace_handler_func callback)
 {
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
     session->tracehandler = callback;
     session->tracehandler_context = context;
-    return 0;
+    return LIBSSH2_ERROR_NONE;
 }
 
 void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
@@ -606,7 +610,7 @@ int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     (void)session;
     (void)bitmask;
-    return 0;
+    return LIBSSH2_ERROR_NONE;
 }
 
 int libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
@@ -615,7 +619,7 @@ int libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
     (void)session;
     (void)context;
     (void)callback;
-    return 0;
+    return LIBSSH2_ERROR_NONE;
 }
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1275,10 +1275,8 @@ static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
 
-    if(!session) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
+    if(!session)
         return -1;
-    }
 
     OSSL_INIT_IF_NEEDED();
 
@@ -1587,10 +1585,8 @@ static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
 
-    if(!session) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
+    if(!session)
         return -1;
-    }
 
     OSSL_INIT_IF_NEEDED();
 
@@ -2101,10 +2097,8 @@ int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
     struct string_buf *decrypted = NULL;
     ssh2_ed25519_ctx *ctx = NULL;
 
-    if(!session) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
+    if(!session)
         return -1;
-    }
 
     OSSL_INIT_IF_NEEDED();
 
@@ -3043,10 +3037,8 @@ static int ossl_ecdsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
     struct string_buf *decrypted = NULL;
     ssh2_curve_type type;
 
-    if(!session) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
+    if(!session)
         return -1;
-    }
 
     OSSL_INIT_IF_NEEDED();
 
@@ -3567,10 +3559,8 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
     ssh2_curve_type type;
 #endif
 
-    if(!session) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
+    if(!session)
         return -1;
-    }
 
     OSSL_INIT_IF_NEEDED();
 
@@ -3746,7 +3736,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
         *key_ctx = NULL;
 
     if(!session)
-        return ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
+        return LIBSSH2_ERROR_BAD_USE;
 
     if(key_type && (strlen(key_type) > 11 || strlen(key_type) < 7))
         return ssh2_err(session, LIBSSH2_ERROR_PROTO, "type is invalid");
@@ -3852,7 +3842,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
     struct string_buf *decrypted = NULL;
 
     if(!session)
-        return ssh2_err(session, LIBSSH2_ERROR_PROTO, "Session is required");
+        return LIBSSH2_ERROR_BAD_USE;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing public key from private key."));

--- a/src/session.c
+++ b/src/session.c
@@ -660,11 +660,8 @@ static int session_startup(LIBSSH2_SESSION *session, libssh2_socket_t sock)
 {
     int rc;
 
-    if(!session) {
-        ssh2_deb((session, LIBSSH2_TRACE_TRANS,
-                  "session_startup: session is NULL"));
-        return LIBSSH2_ERROR_PROTO;
-    }
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
 
     if(session->startup_state == ssh2_NB_state_idle) {
         ssh2_deb((session, LIBSSH2_TRACE_TRANS,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -258,7 +258,7 @@ char *libssh2_userauth_list(LIBSSH2_SESSION *session,
 int libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
 {
     if(!session)
-        return LIBSSH2_ERROR_MISSING_USERAUTH_BANNER;
+        return LIBSSH2_ERROR_BAD_USE;
 
     if(!session->userauth_banner)
         return ssh2_err(session, LIBSSH2_ERROR_MISSING_USERAUTH_BANNER,


### PR DESCRIPTION
Replacing various stray error codes and/or calling `ssh2_err()` with
the NULL `session`, resulting in a NULL pointer dereference.

Also:
- return it from `libssh2_trace()` and `libssh2_trace_sethandler()`.

Ref: #2282
