### PR TITLE
agent: add backend API

### DIFF
--- a/docs/Makefile.inc
+++ b/docs/Makefile.inc
@@ -7,12 +7,17 @@ man_MANS = \
   libssh2_agent_connect.3 \
   libssh2_agent_disconnect.3 \
   libssh2_agent_free.3 \
+  libssh2_agent_get_backend_list_size.3 \
+  libssh2_agent_get_backend_name.3 \
+  libssh2_agent_get_backend_to_use.3 \
+  libssh2_agent_get_backend_used.3 \
   libssh2_agent_get_identity.3 \
   libssh2_agent_get_identity_path.3 \
   libssh2_agent_init.3 \
   libssh2_agent_list_identities.3 \
   libssh2_agent_set_identity_path.3 \
   libssh2_agent_sign.3 \
+  libssh2_agent_set_backend_to_use.3 \
   libssh2_agent_userauth.3 \
   libssh2_banner_set.3 \
   libssh2_base64_decode.3 \

--- a/docs/libssh2_agent_get_backend_list_size.md
+++ b/docs/libssh2_agent_get_backend_list_size.md
@@ -1,0 +1,35 @@
+---
+c: Copyright (C) Michel Gillet
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_agent_get_backend_list_size
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_agent_get_backend_name(3)
+  - libssh2_agent_connect(3)
+---
+
+# NAME
+
+libssh2_agent_get_backend_list_size - get the number of available ssh-agent backends
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+int libssh2_agent_get_backend_list_size(void);
+~~~
+
+# DESCRIPTION
+
+*libssh2_agent_get_backend_list_size(3)* returns the number of ssh-agent
+backend implementations exposed by libssh2. This value can be used together
+with *libssh2_agent_get_backend_name(3)* to iterate over the supported
+backends.
+
+# RETURN VALUE
+
+Returns the number of supported backends, or a negative value on error.
+
+# AVAILABILITY

--- a/docs/libssh2_agent_get_backend_name.md
+++ b/docs/libssh2_agent_get_backend_name.md
@@ -1,0 +1,34 @@
+---
+c: Copyright (C) Michel Gillet
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_agent_get_backend_name
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_agent_get_backend_list_size(3)
+  - libssh2_agent_set_backend_to_use(3)
+---
+
+# NAME
+
+libssh2_agent_get_backend_name - get the name of an ssh-agent backend
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+const char *libssh2_agent_get_backend_name(int idx);
+~~~
+
+# DESCRIPTION
+
+*libssh2_agent_get_backend_name(3)* returns the human-readable name of the
+ssh-agent backend at index *idx*. The index should be within the range
+returned by *libssh2_agent_get_backend_list_size(3)*.
+
+# RETURN VALUE
+
+Returns a pointer to the backend name, or NULL if the index is invalid.
+
+# AVAILABILITY

--- a/docs/libssh2_agent_get_backend_to_use.md
+++ b/docs/libssh2_agent_get_backend_to_use.md
@@ -1,0 +1,36 @@
+---
+c: Copyright (C) Michel Gillet
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_agent_get_backend_to_use
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_agent_set_backend_to_use(3)
+  - libssh2_agent_get_backend_used(3)
+---
+
+# NAME
+
+libssh2_agent_get_backend_to_use - get the preferred ssh-agent backend index
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+int libssh2_agent_get_backend_to_use(LIBSSH2_AGENT *agent);
+~~~
+
+# DESCRIPTION
+
+*libssh2_agent_get_backend_to_use(3)* returns the backend index that has been
+selected for the agent with *libssh2_agent_set_backend_to_use(3)*. A value of
+-1 indicates that no specific backend has been selected and libssh2 will try
+the available backends in its default order.
+
+# RETURN VALUE
+
+Returns the configured backend index, or -1 if no explicit backend has been
+selected.
+
+# AVAILABILITY

--- a/docs/libssh2_agent_get_backend_used.md
+++ b/docs/libssh2_agent_get_backend_used.md
@@ -1,0 +1,36 @@
+---
+c: Copyright (C) Michel Gillet
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_agent_get_backend_used
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_agent_get_backend_to_use(3)
+  - libssh2_agent_connect(3)
+---
+
+# NAME
+
+libssh2_agent_get_backend_used - get the ssh-agent backend selected for a connection
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+int libssh2_agent_get_backend_used(LIBSSH2_AGENT *agent);
+~~~
+
+# DESCRIPTION
+
+*libssh2_agent_get_backend_used(3)* returns the index of the backend that was
+selected when the agent was connected. This is useful after a successful call
+to *libssh2_agent_connect(3)* when the application wants to inspect which
+backend was actually used.
+
+# RETURN VALUE
+
+Returns the backend index that was used, or -1 if no backend has been
+selected yet.
+
+# AVAILABILITY

--- a/docs/libssh2_agent_set_backend_to_use.md
+++ b/docs/libssh2_agent_set_backend_to_use.md
@@ -1,0 +1,35 @@
+---
+c: Copyright (C) Michel Gillet
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_agent_set_backend_to_use
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_agent_get_backend_to_use(3)
+  - libssh2_agent_connect(3)
+---
+
+# NAME
+
+libssh2_agent_set_backend_to_use - select the ssh-agent backend to use
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+void libssh2_agent_set_backend_to_use(LIBSSH2_AGENT *agent, int idx);
+~~~
+
+# DESCRIPTION
+
+*libssh2_agent_set_backend_to_use(3)* sets the preferred backend index for
+subsequent calls to *libssh2_agent_connect(3)*. The *idx* value must be a
+valid index returned by *libssh2_agent_get_backend_list_size(3)*, or -1 to
+allow libssh2 to choose the backend automatically.
+
+# RETURN VALUE
+
+This function does not return a value.
+
+# AVAILABILITY

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1323,7 +1323,8 @@ LIBSSH2_API int libssh2_agent_get_backend_list_size(void);
 * Set the index of the backend to use.
 *
 */
-LIBSSH2_API void libssh2_agent_set_backend_to_use(LIBSSH2_AGENT *agent, int idx);
+LIBSSH2_API void libssh2_agent_set_backend_to_use(LIBSSH2_AGENT *agent,
+                                                  int idx);
 
 /*
 * libssh2_agent_get_backend_to_use()

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1310,6 +1310,46 @@ struct libssh2_agent_publickey {
 };
 
 /*
+* libssh2_agent_get_backend_list_size()
+*
+* Returns size the backend list.
+*
+*/
+LIBSSH2_API int libssh2_agent_get_backend_list_size(void);
+
+/*
+* libssh2_agent_set_backend_to_use()
+*
+* Set the index of the backend to use.
+*
+*/
+LIBSSH2_API void libssh2_agent_set_backend_to_use(LIBSSH2_AGENT *agent, int idx);
+
+/*
+* libssh2_agent_get_backend_to_use()
+*
+* Get the index of the backend to use.
+*
+*/
+LIBSSH2_API int libssh2_agent_get_backend_to_use(LIBSSH2_AGENT *agent);
+
+/*
+* libssh2_agent_get_backend_used()
+*
+* Get the index of the backend used.
+*
+*/
+LIBSSH2_API int libssh2_agent_get_backend_used(LIBSSH2_AGENT *agent);
+
+/*
+* libssh2_agent_get_backend_name()
+*
+* Returns the name of the backend used.
+*
+*/
+LIBSSH2_API const char *libssh2_agent_get_backend_name(int idx);
+
+/*
  * libssh2_agent_init()
  *
  * Init an ssh-agent handle. Returns the pointer to the handle.

--- a/src/agent.c
+++ b/src/agent.c
@@ -142,6 +142,9 @@ struct _LIBSSH2_AGENT {
 
     char *identity_agent_path; /* Path to a custom identity agent socket */
 
+    int backend_to_use_idx; /* Index of the backend to use */
+    int backend_used_idx;   /* Index of the backend used */
+
 #ifdef HAVE_WIN32_AGENTS
     OVERLAPPED overlapped;
     HANDLE pipe;
@@ -1074,6 +1077,9 @@ LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
     agent->identity_agent_path = NULL;
     ssh2_list_init(&agent->head);
 
+    agent->backend_to_use_idx = -1;
+    agent->backend_used_idx = -1;
+
 #ifdef HAVE_WIN32_AGENTS
     agent->pipe = INVALID_HANDLE_VALUE;
     memset(&agent->overlapped, 0, sizeof(OVERLAPPED));
@@ -1084,6 +1090,55 @@ LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
 }
 
 /*
+ * Returns size the backend list.
+ */
+int libssh2_agent_get_backend_list_size(void)
+{
+    int count = 0;
+    int i = 0;
+
+    for(i = 0; agent_supported_backends[i].name; i++) count++;
+    return count;
+}
+
+/*
+ * Set the index of the backend to use.
+ */
+void libssh2_agent_set_backend_to_use(LIBSSH2_AGENT *agent, int idx)
+{
+    agent->backend_to_use_idx = idx;
+}
+
+/*
+ * Get the index of the backend to use.
+ */
+int libssh2_agent_get_backend_to_use(LIBSSH2_AGENT *agent)
+{
+    return agent->backend_to_use_idx;
+}
+
+/*
+ * Get the index of the backend used.
+ */
+int libssh2_agent_get_backend_used(LIBSSH2_AGENT *agent)
+{
+    return agent->backend_used_idx;
+}
+
+/*
+ * Returns the name of the backend used.
+ */
+const char *libssh2_agent_get_backend_name(int idx)
+{
+    if(idx == -1)
+        return NULL;
+    if(idx >= libssh2_agent_get_backend_list_size())
+        return NULL;
+
+    return agent_supported_backends[idx].name;
+}
+
+/*
  * Connect to an ssh-agent.
  *
  * Returns 0 if succeeded, or a negative value for error.
@@ -1091,10 +1146,21 @@ LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
 int libssh2_agent_connect(LIBSSH2_AGENT *agent)
 {
     int i, rc = LIBSSH2_ERROR_METHOD_NOT_SUPPORTED;
-    for(i = 0; agent_supported_backends[i].name; i++) {
-        agent->ops = agent_supported_backends[i].ops;
+    if(agent->backend_to_use_idx == -1) {
+        for(i = 0; agent_supported_backends[i].name; i++) {
+            agent->ops = agent_supported_backends[i].ops;
+            rc = agent->ops->connect(agent);
+            if(!rc) {
+                agent->backend_used_idx = i;
+                return LIBSSH2_ERROR_NONE;
+            }
+        }
+    }
+    else if(agent->backend_to_use_idx < libssh2_agent_get_backend_list_size()) {
+        agent->ops = agent_supported_backends[agent->backend_to_use_idx].ops;
         rc = agent->ops->connect(agent);
-        if(!rc)
+        if(!rc) {
+            agent->backend_used_idx = agent->backend_to_use_idx;
             return LIBSSH2_ERROR_NONE;
     }
     return rc;

--- a/src/agent.c
+++ b/src/agent.c
@@ -1156,7 +1156,8 @@ int libssh2_agent_connect(LIBSSH2_AGENT *agent)
             }
         }
     }
-    else if(agent->backend_to_use_idx < libssh2_agent_get_backend_list_size()) {
+    else if(agent->backend_to_use_idx <
+        libssh2_agent_get_backend_list_size()) {
         agent->ops = agent_supported_backends[agent->backend_to_use_idx].ops;
         rc = agent->ops->connect(agent);
         if(!rc) {


### PR DESCRIPTION
I have issues using libgit2 with libssh2 because both have their own idea of “try another agent.” The problem arises under Windows because there are several backends. libssh2 will pick the first agent backend which can be connected, without any notion that the keys needed by libgit2 are in a different agent. 

To fix this, there are 2 options:
- make libssh2 more complex, by adding logic to walk the list of agents, and have a user, e.g, ligit2, register a callback which could indicate to libssh2 if this is the correct agent to use. So libgit2 could control how libssh2 walk the list of backends.
- keep libssh2 simpler, but provide a mechanism to walk the agent backends outside of libsh2, so for example in libgit2

Since this issue is currently purely under Windows, I chose the second simpler option. And this is the core of this PR.
