### PR TITLE
userauth: drop busyloop on EAGAIN in `libssh2_userauth_publickey_sk()`

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2392,16 +2392,10 @@ int libssh2_userauth_publickey_sk(
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Invalid data in public and private key.");
 
-    if(rc == LIBSSH2_ERROR_NONE) {
+    if(rc == LIBSSH2_ERROR_NONE)
         rc = ssh2_userauth_publickey(session, username, username_len,
                                      pubkeydata, pubkeydata_len,
                                      libssh2_sign_sk, &sign_abstract);
-
-        while(rc == LIBSSH2_ERROR_EAGAIN)
-            rc = ssh2_userauth_publickey(session, username, username_len,
-                                         pubkeydata, pubkeydata_len,
-                                         libssh2_sign_sk, &sign_abstract);
-    }
 
     if(tmp_publickeydata)
         SSH2_FREE(session, tmp_publickeydata);


### PR DESCRIPTION
"This busy-wait loop spins on `LIBSSH2_ERROR_EAGAIN` without yielding or
waiting for socket readiness. In non-blocking mode this will monopolize
the CPU without making progress, and in blocking mode it bypasses the
session's blocking infrastructure (e.g. `ssh2_wait_socket`). The
enclosing public API function should instead return
`LIBSSH2_ERROR_EAGAIN` to the caller when the inner call returns it, so
the caller can drive retries as it does for every other `userauth`
function in this file."

Reported by GitHub Code Quality

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698

---

/cc @MichaelBuckley 