### PR TITLE
userauth: check for NULL `session`, where missing

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -245,6 +245,10 @@ char *libssh2_userauth_list(LIBSSH2_SESSION *session,
                             const char *username, unsigned int username_len)
 {
     char *ptr;
+
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
+
     BLOCK_ADJUST_ERRNO(ptr, session,
                        userauth_list(session, username, username_len));
     return ptr;
@@ -276,6 +280,9 @@ int libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
  */
 int libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
 {
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
+
     return (session->state & SSH2_STATE_AUTHENTICATED) ? 1 : 0;
 }
 
@@ -530,6 +537,10 @@ int libssh2_userauth_password_ex(
     LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb))
 {
     int rc;
+
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
+
     BLOCK_ADJUST(rc, session,
                  userauth_password(session, username, username_len,
                                    (const unsigned char *)password,
@@ -873,6 +884,9 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
     LIBSSH2_PRIVKEY_SK *sk_info = (LIBSSH2_PRIVKEY_SK *)(*abstract);
     LIBSSH2_SK_SIG_INFO sig_info = { 0 };
 
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
+
     if(sk_info->handle_len <= 0)
         return LIBSSH2_ERROR_DECRYPT;
 
@@ -1207,6 +1221,10 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
                                            unsigned int local_username_len)
 {
     int rc;
+
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
+
     BLOCK_ADJUST(rc, session,
                  userauth_hostbased_fromfile(session,
                                              username, username_len,
@@ -1974,6 +1992,9 @@ int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
 {
     int rc;
 
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
+
     if(!passphrase)
         /* if given a NULL pointer, make it point to a zero-length
            string to save us from having to check this all over */
@@ -2001,6 +2022,9 @@ int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
                                            const char *passphrase)
 {
     int rc;
+
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
 
     if(!passphrase)
         /* if given a NULL pointer, make it point to a zero-length
@@ -2285,6 +2309,10 @@ int libssh2_userauth_keyboard_interactive_ex(
     LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(*response_callback))
 {
     int rc;
+
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
+
     BLOCK_ADJUST(rc, session,
                  userauth_keyboard_interactive(session, username, username_len,
                                                response_callback));
@@ -2316,6 +2344,9 @@ int libssh2_userauth_publickey_sk(
 
     LIBSSH2_PRIVKEY_SK sk_info = { 0 };
     void *sign_abstract = &sk_info;
+
+    if(!session)
+        return LIBSSH2_ERROR_BAD_USE;
 
     sk_info.sign_callback = sign_callback;
     sk_info.orig_abstract = abstract;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -247,7 +247,7 @@ char *libssh2_userauth_list(LIBSSH2_SESSION *session,
     char *ptr;
 
     if(!session)
-        return LIBSSH2_ERROR_BAD_USE;
+        return NULL;
 
     BLOCK_ADJUST_ERRNO(ptr, session,
                        userauth_list(session, username, username_len));

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -281,7 +281,7 @@ int libssh2_userauth_banner(LIBSSH2_SESSION *session, char **banner)
 int libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
 {
     if(!session)
-        return LIBSSH2_ERROR_BAD_USE;
+        return 0;
 
     return (session->state & SSH2_STATE_AUTHENTICATED) ? 1 : 0;
 }


### PR DESCRIPTION
To avoid NULL dereference when called with `session == NULL`.
