### PR TITLE
userauth: protect against NULL `abstract` `libssh2_sign_sk()`

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -884,11 +884,13 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
                     void **abstract)
 {
     int rc = LIBSSH2_ERROR_DECRYPT;
-    LIBSSH2_PRIVKEY_SK *sk_info = (LIBSSH2_PRIVKEY_SK *)(*abstract);
+    LIBSSH2_PRIVKEY_SK *sk_info;
     LIBSSH2_SK_SIG_INFO sig_info = { 0 };
 
-    if(!session)
+    if(!session || !abstract || !*abstract)
         return LIBSSH2_ERROR_BAD_USE;
+
+    sk_info = (LIBSSH2_PRIVKEY_SK *)(*abstract);
 
     if(sk_info->handle_len <= 0)
         return LIBSSH2_ERROR_DECRYPT;


### PR DESCRIPTION
Bug: https://github.com/libssh2/libssh2/pull/2290#discussion_r3575102632
Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698
