### PR TITLE
openssl: fix NULL derefs on OOM in `ossl_e*_sk_openssh_priv_to_pubkey()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3001,6 +3001,7 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
             if(!*application) {
                 ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                          "Unable to allocate memory for ECDSA application");
+                rc = -1;
                 goto fail;
             }
             ssh2_explicit_zero(SSH2_UNCONST(*application), app_len + 1);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2998,6 +2998,11 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
 
         if(application && app_len > 0) {
             *application = SSH2_ALLOC(session, app_len + 1);
+            if(!*application) {
+                ssh2_err(session, LIBSSH2_ERROR_ALLOC,
+                         "Unable to allocate memory for ED25519 application");
+                goto clean_exit;
+            }
             ssh2_explicit_zero(SSH2_UNCONST(*application), app_len + 1);
             memcpy(SSH2_UNCONST(*application), app, app_len);
         }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3000,8 +3000,8 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
             *application = SSH2_ALLOC(session, app_len + 1);
             if(!*application) {
                 ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                         "Unable to allocate memory for ED25519 application");
-                goto clean_exit;
+                         "Unable to allocate memory for ECDSA application");
+                goto fail;
             }
             ssh2_explicit_zero(SSH2_UNCONST(*application), app_len + 1);
             memcpy(SSH2_UNCONST(*application), app, app_len);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1992,7 +1992,7 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
 
         if(*handle_len > 0) {
             *key_handle = SSH2_ALLOC(session, *handle_len);
-            if(key_handle && *key_handle)
+            if(*key_handle)
                 memcpy(SSH2_UNCONST(*key_handle), handle, *handle_len);
         }
     }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2031,6 +2031,11 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
 
         if(application && app_len > 0) {
             *application = SSH2_ALLOC(session, app_len + 1);
+            if(!*application) {
+                ssh2_err(session, LIBSSH2_ERROR_ALLOC,
+                         "Unable to allocate memory for ED25519 application");
+                goto clean_exit;
+            }
             ssh2_explicit_zero(SSH2_UNCONST(*application), app_len + 1);
             memcpy(SSH2_UNCONST(*application), app, app_len);
         }


### PR DESCRIPTION
"If `SSH2_ALLOC` returns NULL, `ssh2_explicit_zero` and `memcpy` will
dereference a NULL pointer. The return value of `SSH2_ALLOC` should be
checked before use. The same issue exists in
`ossl_ecdsa_sk_openssh_priv_to_pubkey` at lines 3132-3134."

Also: drop a redundant NULL check.

Reported by GitHub Code Quality and Copilot

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698
