### PR TITLE
openssl: fix leaking `key` buffer on error in `ossl_ecdsa_sk_openssh_priv_to_pubkey()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2914,7 +2914,7 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
 {
     int rc = 0;
     size_t curvelen, pointlen, key_len, app_len;
-    unsigned char *curve, *point_buf, *p, *key, *app;
+    unsigned char *curve, *point_buf, *p, *key = NULL, *app;
     ssh2_ecdsa_ctx *ec_key = NULL;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Extracting ECDSA-SK public key"));
@@ -3012,6 +3012,9 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
 fail:
     if(ec_key)
         ssh2_ecdsa_free(ec_key);
+
+    if(key)
+        SSH2_FREE(session, key);
 
     if(application && *application) {
         SSH2_FREE(session, SSH2_UNCONST(*application));


### PR DESCRIPTION
Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
