### PR TITLE
userauth: delete no-op code with memleaks in `libssh2_userauth_publickey_sk()`

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2380,21 +2380,8 @@ int libssh2_userauth_publickey_sk(
             pubkeydata = tmp_publickeydata;
         }
         else {
-            const char *ecdsa = "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-            const char *ed25519 = "sk-ssh-ed25519-cert-v01@openssh.com";
-
             if(tmp_method)
                 SSH2_FREE(session, tmp_method);
-
-            if(!strncmp((const char *)publickeydata, ecdsa, strlen(ecdsa))) {
-                /* Method will be parsed and allocated by
-                   userauth_read_blob_pubkey(). */
-            }
-            else if(!strncmp((const char *)publickeydata, ed25519,
-                             strlen(ed25519))) {
-                /* Method will be parsed and allocated by
-                   userauth_read_blob_pubkey(). */
-            }
 
             rc = userauth_read_blob_pubkey(session,
                                            &session->userauth_pblc_method,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2387,33 +2387,13 @@ int libssh2_userauth_publickey_sk(
                 SSH2_FREE(session, tmp_method);
 
             if(!strncmp((const char *)publickeydata, ecdsa, strlen(ecdsa))) {
-                if(session->userauth_pblc_method)
-                    SSH2_FREE(session, session->userauth_pblc_method);
-                session->userauth_pblc_method_len = strlen(ecdsa);
-                session->userauth_pblc_method =
-                    SSH2_ALLOC(session, session->userauth_pblc_method_len);
-                if(!session->userauth_pblc_method)
-                    return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                                    "Unable to allocate memory "
-                                    "for public key method ECDSA");
-
-                memcpy(session->userauth_pblc_method, ecdsa,
-                       session->userauth_pblc_method_len);
+                /* Method will be parsed and allocated by
+                   userauth_read_blob_pubkey(). */
             }
             else if(!strncmp((const char *)publickeydata, ed25519,
                              strlen(ed25519))) {
-                if(session->userauth_pblc_method)
-                    SSH2_FREE(session, session->userauth_pblc_method);
-                session->userauth_pblc_method_len = strlen(ed25519);
-                session->userauth_pblc_method =
-                    SSH2_ALLOC(session, session->userauth_pblc_method_len);
-                if(!session->userauth_pblc_method)
-                    return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                                    "Unable to allocate memory "
-                                    "for public key method ED25519");
-
-                memcpy(session->userauth_pblc_method, ed25519,
-                       session->userauth_pblc_method_len);
+                /* Method will be parsed and allocated by
+                   userauth_read_blob_pubkey(). */
             }
 
             rc = userauth_read_blob_pubkey(session,


### PR DESCRIPTION
This code section was merged as part of PR #752, which seems to me
unrelated to the intent of the patch, and also possibly unrelated to
the description of its subcommit:
"Add support for certificate signing with ssh-agent"
https://github.com/libssh2/libssh2/commit/55abcb049500ab3d8e16152bb8cf232a0ef6db8a#diff-8213ab9c800f30c1a7aff37863954e756f946a3b3f6bd7be376d634fd9beb9f4R2369

"`session->userauth_pblc_method` is allocated in the ecdsa/ed25519
branches (lines 2393–2416), but then `userauth_read_blob_pubkey` is
called immediately afterward with `&session->userauth_pblc_method` as an
output parameter. Inside `userauth_read_blob_pubkey`, `*method` is
unconditionally overwritten with a newly allocated buffer (see the
`*method = pubkey` assignment), causing the allocation made just above
to be leaked. The allocation in the ecdsa/ed25519 branches should be
removed since `userauth_read_blob_pubkey` will derive and allocate the
method from the public key data itself."

Reported by GitHub Code Quality

Follow-up to bc4e619e76071393e466c29220fc4ef5764c2820 #752
Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698

---

/cc @MichaelBuckley 