### PR TITLE
openssl: check `EVP_PKEY_CTX_new_id()` result in `ssh2_rsa_new()`/`ssh2_dsa_new()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -267,7 +267,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     *rsa = NULL;
     ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
 
-    if(EVP_PKEY_fromdata_init(ctx) > 0)
+    if(ctx && EVP_PKEY_fromdata_init(ctx) > 0)
         ret = EVP_PKEY_fromdata(ctx, rsa, EVP_PKEY_KEYPAIR, params);
 
     if(nbuf)
@@ -480,7 +480,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     *dsa = NULL;
     ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_DSA, NULL);
 
-    if(EVP_PKEY_fromdata_init(ctx) > 0)
+    if(ctx && EVP_PKEY_fromdata_init(ctx) > 0)
         ret = EVP_PKEY_fromdata(ctx, dsa, EVP_PKEY_KEYPAIR, params);
 
     if(p_buf)


### PR DESCRIPTION
With OpenSSL 3.

Reported by GitHub Code Quality

---

"If `EVP_PKEY_CTX_new_id` returns NULL, `EVP_PKEY_fromdata_init(ctx)` is called with a NULL pointer, resulting in undefined behavior. A NULL check on `ctx` is needed before calling `EVP_PKEY_fromdata_init`. The same issue exists in `ssh2_dsa_new` at line 483 for the DSA path."

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
