### PR TITLE
wincng: fix another resource leak in `ssh2_ecdh_gen_k()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2291,7 +2291,7 @@ cleanup:
         *k = NULL;
     }
 
-    if(result != LIBSSH2_ERROR_NONE && agreed_secret_handle)
+    if(agreed_secret_handle)
         BCryptDestroySecret(agreed_secret_handle);
 
     return result;


### PR DESCRIPTION
"In `ssh2_ecdh_gen_k`, `agreed_secret_handle` is only destroyed when
`result != LIBSSH2_ERROR_NONE`. On the success path, the handle is never
passed to `BCryptDestroySecret`, causing a resource leak. The handle
should be destroyed unconditionally in the cleanup block, regardless of
success or failure."

Ref: 2f7f107fe5f24942d2748fbc291d13dfc1facbd3 #2038
Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315
