### PR TITLE
wincng: `sizeof(ssh2_ecdsa_ctx)` (tidy up)

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2114,7 +2114,7 @@ int ssh2_ecdsa_create_key(OUT ssh2_ecdsa_ctx **ec_ctx,
         goto cleanup;
     }
 
-    *ec_ctx = malloc(sizeof(struct wcng_ecdsa_ctx));
+    *ec_ctx = malloc(sizeof(ssh2_ecdsa_ctx));
     if(!*ec_ctx) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2170,7 +2170,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
 
-    *ec_ctx = malloc(sizeof(struct wcng_ecdsa_ctx));
+    *ec_ctx = malloc(sizeof(ssh2_ecdsa_ctx));
     if(!*ec_ctx) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2554,7 +2554,7 @@ static int wcng_parse_ecdsa_privatekey(OUT struct wcng_ecdsa_ctx **key,
     if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
 
-    *key = malloc(sizeof(struct wcng_ecdsa_ctx));
+    *key = malloc(sizeof(ssh2_ecdsa_ctx));
     if(!*key) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;


### PR DESCRIPTION
To match rest of code.

Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
