### PR TITLE
wincng: fix memleak on fail path in `ssh2_ecdsa_verify()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2361,7 +2361,8 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
         break;
 
     default:
-        return LIBSSH2_ERROR_INVAL;
+        result = LIBSSH2_ERROR_INVAL;
+        goto cleanup;
     }
 
     hash = malloc(hash_len);


### PR DESCRIPTION
Reported by GitHub Code Quality

Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315
