### PR TITLE
wincng: return more accurate error in `ssh2_dsa_sha1_sign()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -58,6 +58,10 @@
 
 #include <stdlib.h>
 
+#ifndef STATUS_INVALID_PARAMETER
+#define STATUS_INVALID_PARAMETER ((NTSTATUS)0xC000000D)
+#endif
+
 #if LIBSSH2_ECDSA
 /* Define these manually to avoid including <ntstatus.h> and thus
    clashing with <windows.h> symbols. */
@@ -1704,7 +1708,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
                 ret = (NTSTATUS)STATUS_NO_MEMORY;
         }
         else
-            ret = (NTSTATUS)STATUS_NO_MEMORY;
+            ret = (NTSTATUS)STATUS_INVALID_PARAMETER;
     }
 
     wcng_zero_free(data, datalen);


### PR DESCRIPTION
"In `ssh2_dsa_sha1_sign`, when the returned signature length `siglen` is
not 40 bytes, the code sets `ret` to `STATUS_NO_MEMORY`. This is
incorrect: the condition indicates an unexpected signature size, not a
memory allocation failure. Using `STATUS_NO_MEMORY` here is misleading
and could cause confusion when diagnosing failures. A more appropriate
status code such as `STATUS_INVALID_PARAMETER` or a similar CNG error
should be used instead."

Reported by GitHub Code Quality
