### PR TITLE
wincng: initialize returned values on fail in `wcng_bn_ltob()` (tidy up)

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1026,13 +1026,14 @@ static int wcng_asn_decode(unsigned char *pbEncoded, DWORD cbEncoded,
     return 0;
 }
 
-static int wcng_bn_ltob(unsigned char *pbInput,
-                        DWORD cbInput,
-                        unsigned char **ppbOutput,
-                        DWORD *pcbOutput)
+static int wcng_bn_ltob(unsigned char *pbInput, DWORD cbInput,
+                        unsigned char **ppbOutput, DWORD *pcbOutput)
 {
     unsigned char *pbOutput;
     DWORD cbOutput, index, offset, length;
+
+    *ppbOutput = NULL;
+    *pcbOutput = 0;
 
     if(cbInput < 1)
         return 0;


### PR DESCRIPTION
Not an error, the sole existing caller already did initialize them, but do it for robustness.

Reported by GitHub Code Quality

---

"When `cbInput` is 0, the function returns 0 (success) without initializing `*ppbOutput` or `*pcbOutput`. Callers such as `wcng_asn_decode_bn` (line 1073) immediately dereference the output pointer, leading to undefined behavior with an uninitialized pointer. The function should return an error (e.g., `-1`) for empty input, or explicitly set the output parameters to safe values."

(suggesting a different solution)

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
