### PR TITLE
wincng: fix NULL deref on OOM in `ssh2_ecdsa_sign()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2737,6 +2737,10 @@ int ssh2_ecdsa_sign(IN ssh2_ecdsa_ctx *ec_ctx,
         cng_signature_len / 2 + 5;  /* mpint(s) */
 
     *signature = SSH2_ALLOC(session, signature_maxlen);
+    if(!*signature) {
+        result = LIBSSH2_ERROR_ALLOC;
+        goto cleanup;
+    }
     signature_ptr = *signature;
 
     if(ssh2_store_bignum_bytes(&signature_ptr,


### PR DESCRIPTION
Reported by GitHub Code Quality

Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
