### PR TITLE
tidy-up: C nits

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -806,7 +806,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename,
-                             const uint8_t *passphrase);
+                             const unsigned char *passphrase);
 ```
 Reads an ED25519 private key from PEM file `filename` into a new ED25519
 context.

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -250,7 +250,7 @@ int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,
 int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename,
-                             const uint8_t *passphrase);
+                             const unsigned char *passphrase);
 
 int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         LIBSSH2_SESSION *session,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -111,13 +111,9 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    if(ssh2_get_string(&buf, &e, &e_len))
-        return -1;
-
-    if(ssh2_get_string(&buf, &n, &n_len))
-        return -1;
-
-    if(!ssh2_eob(&buf))
+    if(ssh2_get_string(&buf, &e, &e_len) ||
+       ssh2_get_string(&buf, &n, &n_len) ||
+       !ssh2_eob(&buf))
         return -1;
 
     if(ssh2_rsa_new(&rsactx, e, e_len, n, n_len,
@@ -492,22 +488,12 @@ static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
     buf.dataptr = buf.data;
     buf.len = hostkey_data_len;
 
-    if(ssh2_match_string(&buf, "ssh-dss"))
-        return -1;
-
-    if(ssh2_get_string(&buf, &p, &p_len))
-        return -1;
-
-    if(ssh2_get_string(&buf, &q, &q_len))
-        return -1;
-
-    if(ssh2_get_string(&buf, &g, &g_len))
-        return -1;
-
-    if(ssh2_get_string(&buf, &y, &y_len))
-        return -1;
-
-    if(!ssh2_eob(&buf))
+    if(ssh2_match_string(&buf, "ssh-dss") ||
+       ssh2_get_string(&buf, &p, &p_len) ||
+       ssh2_get_string(&buf, &q, &q_len) ||
+       ssh2_get_string(&buf, &g, &g_len) ||
+       ssh2_get_string(&buf, &y, &y_len) ||
+       !ssh2_eob(&buf))
         return -1;
 
     if(ssh2_dsa_new(&dsactx, p, p_len, q, q_len, g, g_len, y, y_len, NULL, 0))

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -134,7 +134,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         return ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL,
                         "No key type set");
 
-    entry = SSH2_CALLOC(hosts->session, sizeof(struct known_host));
+    entry = SSH2_CALLOC(hosts->session, sizeof(*entry));
     if(!entry)
         return ssh2_err(hosts->session, LIBSSH2_ERROR_ALLOC,
                         "Unable to allocate memory for known host entry");
@@ -564,7 +564,7 @@ int libssh2_knownhost_del(LIBSSH2_KNOWNHOSTS *hosts,
 
     /* clear the struct now since the memory in which it is allocated is
        about to be freed! */
-    memset(entry, 0, sizeof(struct libssh2_knownhost));
+    memset(entry, 0, sizeof(*entry));
 
     /* free all resources */
     knownhost_entry_free(hosts->session, node);

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -418,7 +418,7 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                     unsigned char hash[SSH2_SHA1_DIG_LEN];
                     ssh2_hmac_ctx ctx;
 
-                    if(SSH2_SHA1_DIG_LEN != node->name_len)
+                    if(node->name_len != sizeof(hash))
                         /* the name hash length must be the SHA1 size or
                            we cannot match it */
                         break;
@@ -427,13 +427,13 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                     if(!ssh2_hmac_init(&ctx, SSH2_SHA1_HMAC,
                                        node->salt, node->salt_len) ||
                        !ssh2_hmac_update(&ctx, host, strlen(host)) ||
-                       !ssh2_hmac_final(&ctx, hash, SSH2_SHA1_DIG_LEN)) {
+                       !ssh2_hmac_final(&ctx, hash, sizeof(hash))) {
                         ssh2_hmac_cleanup(&ctx);
                         break;
                     }
                     ssh2_hmac_cleanup(&ctx);
 
-                    if(!memcmp(hash, node->name, SSH2_SHA1_DIG_LEN))
+                    if(!memcmp(hash, node->name, sizeof(hash)))
                         /* this is a node we are interested in */
                         match = 1;
                 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2240,10 +2240,10 @@ int ssh2_mlkem_new(LIBSSH2_SESSION *session, int mlkem_size,
 
     if(out_private_key) {
         priv = SSH2_ALLOC(session, privLen);
-        actualPrivLen = privLen;
         if(!priv)
             goto clean_exit;
 
+        actualPrivLen = privLen;
         if(EVP_PKEY_get_raw_private_key(key, priv, &actualPrivLen) != 1 ||
            privLen != actualPrivLen) {
             goto clean_exit;
@@ -2255,10 +2255,10 @@ int ssh2_mlkem_new(LIBSSH2_SESSION *session, int mlkem_size,
 
     if(out_public_key) {
         pub = SSH2_ALLOC(session, pubLen);
-        actualPubLen = pubLen;
         if(!pub)
             goto clean_exit;
 
+        actualPubLen = pubLen;
         if(EVP_PKEY_get_raw_public_key(key, pub, &actualPubLen) != 1 ||
            pubLen != actualPubLen) {
             goto clean_exit;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2089,7 +2089,7 @@ clean_exit:
 int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename,
-                             const uint8_t *passphrase)
+                             const unsigned char *passphrase)
 {
     int rc;
     FILE *fp;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2903,7 +2903,7 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     size_t *method_len,
     unsigned char **pubkeydata,
     size_t *pubkeydata_len,
-    uint8_t *flags,
+    unsigned char *flags,
     const char **application,
     const unsigned char **key_handle,
     size_t *handle_len,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -892,7 +892,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
 
     sk_info = (LIBSSH2_PRIVKEY_SK *)(*abstract);
 
-    if(sk_info->handle_len <= 0)
+    if(!sk_info->handle_len)
         return LIBSSH2_ERROR_DECRYPT;
 
     rc = sk_info->sign_callback(session,


### PR DESCRIPTION
- crypto, openssl: sync passphrase type with rest of code in
  `ssh2_ed25519_new_private()`.
- hostkey: merge `if()s` in `hostkey_method_ssh_rsa_init()`.
- hostkey: merge `if()s` in `hostkey_method_ssh_dss_init()`.
- knownhost: `sizeof()` the target variable, not its manually resolved type.
  For robustness.
- knownhost: replace repeate LENGTH references with `sizeof()`.
- openssl: move two assigns later in `ssh2_mlkem_new()`.
  To keep the alloc/check pattern intact and avoid unnecessary
  assignments on OOM.
- userauth: do not check unsigned value for negative in
  `libssh2_sign_sk()`.
- openssl: sync `flags` type with sibling function in
  `ossl_ecdsa_sk_openssh_priv_to_pubkey()`.
