### PR TITLE
agent: list supported backends in `libssh2_build_options()`

### DIFF
--- a/docs/libssh2_build_options.md
+++ b/docs/libssh2_build_options.md
@@ -29,9 +29,14 @@ enabled/disabled statuses.
 # RETURN VALUE
 
 A read-only, space-separated list of key:value pairs describing build options.
-Options use `on` or `off`, except `crypto` which may report these values:
-`AWS-LC`, `BoringSSL`, `Libgcrypt`, `LibreSSL`, `mbedTLS`, `OpenSSL`,
-`OpenSSL/1.1.1`, `OS400QC3`, `WinCNG`, `wolfSSL`.
+Options use `on` or `off`, except:
+
+- `crypto` which may report these values:
+  `AWS-LC`, `BoringSSL`, `Libgcrypt`, `LibreSSL`, `mbedTLS`, `OpenSSL`,
+  `OpenSSL/1.1.1`, `OS400QC3`, `WinCNG`, `wolfSSL`.
+
+- `agent` which is listed for each supported agent backend:
+  `Pageant` (Windows-specific), `OpenSSH` (Windows-specific), `Unix`.
 
 # EXAMPLE
 

--- a/docs/libssh2_build_options.md
+++ b/docs/libssh2_build_options.md
@@ -31,12 +31,12 @@ enabled/disabled statuses.
 A read-only, space-separated list of key:value pairs describing build options.
 Options use `on` or `off`, except:
 
-- `crypto` which may report these values:
-  `AWS-LC`, `BoringSSL`, `Libgcrypt`, `LibreSSL`, `mbedTLS`, `OpenSSL`,
-  `OpenSSL/1.1.1`, `OS400QC3`, `WinCNG`, `wolfSSL`.
+`crypto`, which reports one of these values:
+`AWS-LC`, `BoringSSL`, `Libgcrypt`, `LibreSSL`, `mbedTLS`, `OpenSSL`,
+`OpenSSL/1.1.1`, `OS400QC3`, `WinCNG`, `wolfSSL`.
 
-- `agent` which is listed for each supported agent backend:
-  `Pageant` (Windows-specific), `OpenSSH` (Windows-specific), `Unix`.
+`agent`, which is listed for each supported agent backend:
+`Pageant` (Windows-specific), `OpenSSH` (Windows-specific), `Unix`.
 
 # EXAMPLE
 

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -36,6 +36,7 @@ CSOURCES =              \
   wincng.c
 
 HHEADERS =              \
+  agent.h               \
   chacha.h              \
   channel.h             \
   cipher-chachapoly.h   \

--- a/src/agent.c
+++ b/src/agent.c
@@ -36,19 +36,7 @@
 
 #include <stdlib.h>  /* for getenv() */
 
-#ifdef HAVE_SYS_UN_H
-/* Use the existence of sys/un.h as a test if Unix domain socket (AF_UNIX)
-   is supported. Windows also supports it via winsock*.h, but not used here
-   at this time. */
-#include <sys/un.h>
-#define SSH2_AGENT_BACKEND_UNIX "Unix"
-#endif
-
-#if defined(_WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
-#define SSH2_AGENT_BACKEND_WIN32_PAGEANT "Pageant"
-#define SSH2_AGENT_BACKEND_WIN32_OPENSSH "OpenSSH"
-#endif
-
+#include "agent.h"
 #include "userauth.h"
 #include "session.h"
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -37,15 +37,16 @@
 #include <stdlib.h>  /* for getenv() */
 
 #ifdef HAVE_SYS_UN_H
-/* Use the existence of sys/un.h as a test if Unix domain socket is
-   supported. Windows also supports it via winsock*.h, but not used
-   here at this time. */
+/* Use the existence of sys/un.h as a test if Unix domain socket (AF_UNIX)
+   is supported. Windows also supports it via winsock*.h, but not used here
+   at this time. */
 #include <sys/un.h>
-#define HAVE_AF_UNIX
+#define SSH2_AGENT_BACKEND_UNIX "Unix"
 #endif
 
 #if defined(_WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
-#define HAVE_WIN32_AGENTS
+#define SSH2_AGENT_BACKEND_WIN32_PAGEANT "Pageant"
+#define SSH2_AGENT_BACKEND_WIN32_OPENSSH "OpenSSH"
 #endif
 
 #include "userauth.h"
@@ -141,14 +142,14 @@ struct _LIBSSH2_AGENT {
 
     char *identity_agent_path; /* Path to a custom identity agent socket */
 
-#ifdef HAVE_WIN32_AGENTS
+#ifdef SSH2_AGENT_BACKEND_WIN32_OPENSSH
     OVERLAPPED overlapped;
     HANDLE pipe;
     BOOL pending_io;
 #endif
 };
 
-#ifdef HAVE_WIN32_AGENTS
+#ifdef SSH2_AGENT_BACKEND_WIN32_PAGEANT
 /* Code to talk to Pageant was taken from PuTTY.
  *
  * Portions copyright Robert de Bath, Joris van Rantwijk, Delian
@@ -253,9 +254,9 @@ static struct agent_ops agent_ops_pageant = {
     agent_transact_pageant,
     agent_disconnect_pageant
 };
-#endif /* HAVE_WIN32_AGENTS */
+#endif /* SSH2_AGENT_BACKEND_WIN32_PAGEANT */
 
-#ifdef HAVE_WIN32_AGENTS
+#ifdef SSH2_AGENT_BACKEND_WIN32_OPENSSH
 
 /* Code to talk to OpenSSH was taken and modified from the Win32 port of
  * Portable OpenSSH by the PowerShell team. Commit
@@ -537,9 +538,9 @@ static struct agent_ops agent_ops_openssh = {
     agent_disconnect_openssh
 };
 
-#endif /* HAVE_WIN32_AGENTS */
+#endif /* SSH2_AGENT_BACKEND_WIN32_OPENSSH */
 
-#ifdef HAVE_AF_UNIX
+#ifdef SSH2_AGENT_BACKEND_UNIX
 static int agent_connect_unix(LIBSSH2_AGENT *agent)
 {
     const char *path;
@@ -702,18 +703,20 @@ static struct agent_ops agent_ops_unix = {
     agent_transact_unix,
     agent_disconnect_unix
 };
-#endif /* HAVE_AF_UNIX */
+#endif /* SSH2_AGENT_BACKEND_UNIX */
 
 static struct {
     const char *name;
     struct agent_ops *ops;
 } agent_supported_backends[] = {
-#ifdef HAVE_WIN32_AGENTS
-    { "Pageant", &agent_ops_pageant },
-    { "OpenSSH", &agent_ops_openssh },
+#ifdef SSH2_AGENT_BACKEND_WIN32_PAGEANT
+    { SSH2_AGENT_BACKEND_WIN32_PAGEANT, &agent_ops_pageant },
 #endif
-#ifdef HAVE_AF_UNIX
-    { "Unix", &agent_ops_unix },
+#ifdef SSH2_AGENT_BACKEND_WIN32_OPENSSH
+    { SSH2_AGENT_BACKEND_WIN32_OPENSSH, &agent_ops_openssh },
+#endif
+#ifdef SSH2_AGENT_BACKEND_UNIX
+    { SSH2_AGENT_BACKEND_UNIX, &agent_ops_unix },
 #endif
     { NULL, NULL }
 };
@@ -1075,7 +1078,7 @@ LIBSSH2_AGENT *libssh2_agent_init(LIBSSH2_SESSION *session)
     agent->identity_agent_path = NULL;
     ssh2_list_init(&agent->head);
 
-#ifdef HAVE_WIN32_AGENTS
+#ifdef SSH2_AGENT_BACKEND_WIN32_OPENSSH
     agent->pipe = INVALID_HANDLE_VALUE;
     memset(&agent->overlapped, 0, sizeof(OVERLAPPED));
     agent->pending_io = FALSE;

--- a/src/agent.h
+++ b/src/agent.h
@@ -1,0 +1,52 @@
+#ifndef LIBSSH2_AGENT_H
+#define LIBSSH2_AGENT_H
+/*
+ * Copyright (C) Daiki Ueno
+ * Copyright (C) Daniel Stenberg
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "libssh2_priv.h"
+
+#ifdef HAVE_SYS_UN_H
+/* Use the existence of sys/un.h as a test if Unix domain socket (AF_UNIX)
+   is supported. Windows also supports it via winsock*.h, but not used here
+   at this time. */
+#include <sys/un.h>
+#define SSH2_AGENT_BACKEND_UNIX "Unix"
+#endif
+
+#if defined(_WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
+#define SSH2_AGENT_BACKEND_WIN32_PAGEANT "Pageant"
+#define SSH2_AGENT_BACKEND_WIN32_OPENSSH "OpenSSH"
+#endif
+
+#endif /* LIBSSH2_AGENT_H */

--- a/src/agent.h
+++ b/src/agent.h
@@ -36,17 +36,17 @@
 
 #include "libssh2_priv.h"
 
+#if defined(_WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
+#define SSH2_AGENT_BACKEND_WIN32_PAGEANT "Pageant"
+#define SSH2_AGENT_BACKEND_WIN32_OPENSSH "OpenSSH"
+#endif
+
 #ifdef HAVE_SYS_UN_H
 /* Use the existence of sys/un.h as a test if Unix domain socket (AF_UNIX)
    is supported. Windows also supports it via winsock*.h, but not used here
    at this time. */
 #include <sys/un.h>
 #define SSH2_AGENT_BACKEND_UNIX "Unix"
-#endif
-
-#if defined(_WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
-#define SSH2_AGENT_BACKEND_WIN32_PAGEANT "Pageant"
-#define SSH2_AGENT_BACKEND_WIN32_OPENSSH "OpenSSH"
 #endif
 
 #endif /* LIBSSH2_AGENT_H */

--- a/src/agent.h
+++ b/src/agent.h
@@ -1,35 +1,7 @@
 #ifndef LIBSSH2_AGENT_H
 #define LIBSSH2_AGENT_H
-/*
- * Copyright (C) Daiki Ueno
+/* Copyright (C) Daiki Ueno
  * Copyright (C) Daniel Stenberg
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from this
- *    software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/src/version.c
+++ b/src/version.c
@@ -47,8 +47,7 @@ libssh2_crypto_engine_t libssh2_crypto_engine(void)
 }
 
 static const char *ssh2_build_options =
-    "crypto:"
-    SSH2_CRYPTO_ENGINE_NAME
+    "crypto:" SSH2_CRYPTO_ENGINE_NAME
     " "
     "MD5:"
 #if LIBSSH2_MD5
@@ -170,18 +169,15 @@ static const char *ssh2_build_options =
 #endif
     " "
 #ifdef SSH2_AGENT_BACKEND_WIN32_PAGEANT
-    "agent:"
-    SSH2_AGENT_BACKEND_WIN32_PAGEANT
+    "agent:" SSH2_AGENT_BACKEND_WIN32_PAGEANT
     " "
 #endif
 #ifdef SSH2_AGENT_BACKEND_WIN32_OPENSSH
-    "agent:"
-    SSH2_AGENT_BACKEND_WIN32_OPENSSH
+    "agent:" SSH2_AGENT_BACKEND_WIN32_OPENSSH
     " "
 #endif
 #ifdef SSH2_AGENT_BACKEND_UNIX
-    "agent:"
-    SSH2_AGENT_BACKEND_UNIX
+    "agent:" SSH2_AGENT_BACKEND_UNIX
     " "
 #endif
     "clear-memory:"

--- a/src/version.c
+++ b/src/version.c
@@ -32,6 +32,8 @@
 
 #include "libssh2_priv.h"
 
+#include "agent.h"
+
 const char *libssh2_version(int req_version_num)
 {
     if(req_version_num <= LIBSSH2_VERSION_NUM)
@@ -167,6 +169,21 @@ static const char *ssh2_build_options =
     "off"
 #endif
     " "
+#ifdef SSH2_AGENT_BACKEND_WIN32_PAGEANT
+    "agent:"
+    SSH2_AGENT_BACKEND_WIN32_PAGEANT
+    " "
+#endif
+#ifdef SSH2_AGENT_BACKEND_WIN32_OPENSSH
+    "agent:"
+    SSH2_AGENT_BACKEND_WIN32_OPENSSH
+    " "
+#endif
+#ifdef SSH2_AGENT_BACKEND_UNIX
+    "agent:"
+    SSH2_AGENT_BACKEND_UNIX
+    " "
+#endif
     "clear-memory:"
 #ifndef LIBSSH2_NO_CLEAR_MEMORY
     "on"


### PR DESCRIPTION
Internally: make the agent backend guards unique for each backend, make
them contain the backend name. Use them in `agent.c`, move them to a
separate header and also reuse them from `version.c`.

Ref: https://github.com/libssh2/libssh2/pull/2285#discussion_r3572085858
Follow-up to 2673970d2a60075630a7bfdc84b64ddba016595e #2178
