### PR TITLE
version: add `Unicode:on/off` to `libssh2_build_options()`

### DIFF
--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -51,6 +51,13 @@
 
 #ifdef _WIN32
 
+#if defined(UNICODE) && !defined(_UNICODE)
+#  error "UNICODE is defined but _UNICODE is not defined"
+#endif
+#if defined(_UNICODE) && !defined(UNICODE)
+#  error "_UNICODE is defined but UNICODE is not defined"
+#endif
+
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/src/version.c
+++ b/src/version.c
@@ -180,6 +180,15 @@ static const char *ssh2_build_options =
     "agent:" SSH2_AGENT_BACKEND_UNIX
     " "
 #endif
+#ifdef _WIN32
+    "Unicode:"
+#if defined(UNICODE) && defined(_UNICODE)
+    "on"
+#else
+    "off"
+#endif
+    " "
+#endif
     "clear-memory:"
 #ifndef LIBSSH2_NO_CLEAR_MEMORY
     "on"


### PR DESCRIPTION
Also: fail the build if `UNICODE` is set without `_UNICODE` or vice 
versa.                                                         
