### PR TITLE
tidy-up: `FILE *` variable names, configure warning option guard, printf mask

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -385,7 +385,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [jump-misses-init])
             tmp_CFLAGS="$tmp_CFLAGS -Wno-implicit-void-ptr-cast"
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [tentative-definition-compat])
-            if test "$curl_cv_native_windows" = "yes"; then
+            if test "x$have_windows_h" = "xyes"; then
               tmp_CFLAGS="$tmp_CFLAGS -Wno-c++-keyword"  # `wchar_t` triggers it on Windows
             else
               CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [c++-keyword])

--- a/src/agent.c
+++ b/src/agent.c
@@ -183,7 +183,7 @@ static int agent_transact_pageant(LIBSSH2_AGENT *agent,
                         "found no pageant");
 
     ssh2_snprintf(mapname, sizeof(mapname),
-                  "PageantRequest%08x", (unsigned)GetCurrentThreadId());
+                  "PageantRequest%08lx", GetCurrentThreadId());
     filemap = CreateFileMappingA(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
                                  0, AGENT_MAX_MSGLEN, mapname);
 

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -922,7 +922,7 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
 int libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
                                const char *filename, int type)
 {
-    FILE *file;
+    FILE *fp;
     int num = 0;
     char buf[4092];
 
@@ -930,9 +930,9 @@ int libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
         return ssh2_err(hosts->session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
                         "Unsupported type of known-host information store");
 
-    file = fopen(filename, FOPEN_READTEXT);
-    if(file) {
-        while(fgets(buf, sizeof(buf), file)) {
+    fp = fopen(filename, FOPEN_READTEXT);
+    if(fp) {
+        while(fgets(buf, sizeof(buf), fp)) {
             if(libssh2_knownhost_readline(hosts, buf, strlen(buf), type)) {
                 num = ssh2_err(hosts->session, LIBSSH2_ERROR_KNOWN_HOSTS,
                                "Failed to parse known hosts file");
@@ -940,7 +940,7 @@ int libssh2_knownhost_readfile(LIBSSH2_KNOWNHOSTS *hosts,
             }
             num++;
         }
-        fclose(file);
+        fclose(fp);
     }
     else
         return ssh2_err(hosts->session, LIBSSH2_ERROR_FILE,
@@ -1149,7 +1149,7 @@ int libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
                                 const char *filename, int type)
 {
     struct known_host *node;
-    FILE *file;
+    FILE *fp;
     int rc = LIBSSH2_ERROR_NONE;
     char buffer[4092];
 
@@ -1159,8 +1159,8 @@ int libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
         return ssh2_err(hosts->session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
                         "Unsupported type of known-host information store");
 
-    file = fopen(filename, FOPEN_WRITETEXT);
-    if(!file)
+    fp = fopen(filename, FOPEN_WRITETEXT);
+    if(!fp)
         return ssh2_err(hosts->session, LIBSSH2_ERROR_FILE,
                         "Failed to open file");
 
@@ -1174,14 +1174,14 @@ int libssh2_knownhost_writefile(LIBSSH2_KNOWNHOSTS *hosts,
         if(rc)
             break;
 
-        nwrote = fwrite(buffer, 1, wrote, file);
+        nwrote = fwrite(buffer, 1, wrote, fp);
         if(nwrote != wrote) {
             /* failed to write the whole thing, bail out */
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_FILE, "Write failed");
             break;
         }
     }
-    fclose(file);
+    fclose(fp);
 
     return rc;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2427,7 +2427,7 @@ int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **ec_ctx,
 {
     int result;
 
-    FILE *file_handle = NULL;
+    FILE *fp = NULL;
     unsigned char *data = NULL;
     size_t datalen = 0;
 
@@ -2442,8 +2442,8 @@ int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **ec_ctx,
                         "Passphrase-protected ECDSA private key "
                         "files are unsupported");
 
-    file_handle = fopen(filename, "rb");
-    if(!file_handle) {
+    fp = fopen(filename, "rb");
+    if(!fp) {
         result = ssh2_err(session, LIBSSH2_ERROR_INVAL,
                           "Opening the private key file failed");
         goto cleanup;
@@ -2452,7 +2452,7 @@ int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **ec_ctx,
     result = ssh2_pem_parse(session,
                             OPENSSH_PRIVKEY_HEADER,
                             OPENSSH_PRIVKEY_FOOTER,
-                            passphrase, file_handle, &data, &datalen);
+                            passphrase, fp, &data, &datalen);
     if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
 
@@ -2463,8 +2463,8 @@ int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **ec_ctx,
         goto cleanup;
 
 cleanup:
-    if(file_handle)
-        fclose(file_handle);
+    if(fp)
+        fclose(fp);
 
     if(data)
         SSH2_FREE(session, data);

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -233,19 +233,19 @@ static int is_running_inside_a_container(void)
     return 0;
 #else
     static const char *cgroup_filename = "/proc/self/cgroup";
-    FILE *f;
+    FILE *fp;
     char line[256];
     int found = 0;
-    f = fopen(cgroup_filename, "r");
-    if(!f)
+    fp = fopen(cgroup_filename, "r");
+    if(!fp)
         return 0;  /* Do not go further, we are not in a container */
-    while(fgets(line, sizeof(line), f)) {
+    while(fgets(line, sizeof(line), fp)) {
         if(strstr(line, "docker")) {
             found = 1;
             break;
         }
     }
-    fclose(f);
+    fclose(fp);
     return found;
 #endif
 }


### PR DESCRIPTION
- configure: fix wrong guard for `-Wno-c++-keyword`.
  Follow-up to 04ecdb22fe9b092ba49f1562b5f79a9acdeedb8b #1972

- sync most outlier `FILE *` variables names with rest of code.

- agent: replace cast with accurate printf mask when forming
  `PageantRequest` map name.
  Follow-up to 7b351eed36197877160659b31fc8dcc8524f22f8
