### PR TITLE
agent: fix to replace `TEXT()` with `_TEXT()` in CRT calls

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -345,11 +345,11 @@ static int agent_connect_openssh(LIBSSH2_AGENT *agent)
     }
     else {
         size_t len = 0;
-        if(!_tgetenv_s(&len, path, 0, TEXT(OPENSSH_AUTH_SOCK)) &&
+        if(!_tgetenv_s(&len, path, 0, _TEXT(OPENSSH_AUTH_SOCK)) &&
            len > 0 && len <= 32767) {
             path = SSH2_ALLOC(agent->session, len * sizeof(TCHAR));
             if(path) {
-                if(!_tgetenv_s(&len, path, len, TEXT(OPENSSH_AUTH_SOCK)))
+                if(!_tgetenv_s(&len, path, len, _TEXT(OPENSSH_AUTH_SOCK)))
                     path_to_free = 1;
                 else
                     SSH2_SAFEFREE(agent->session, path);


### PR DESCRIPTION
Did not cause an issue because `UNICODE` and `_UNICODE` are verified to
be set in pairs.

Ref: https://devblogs.microsoft.com/oldnewthing/20040212-00/?p=40643/
Follow-up to 49abb5e5688f8ec7894f82564afa65379caaea24 #2313

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
