### PR TITLE
misc: make `ssh2_snprintf()` use safe CRT functions and make it `snprintf()`-compatible

### DIFF
--- a/src/cipher-chachapoly.c
+++ b/src/cipher-chachapoly.c
@@ -21,7 +21,6 @@
 /* $OpenBSD: cipher-chachapoly.c,v 1.8 2016/08/03 05:41:57 djm Exp $ */
 
 #include "libssh2_priv.h"
-#include "misc.h"
 #include "cipher-chachapoly.h"
 
 static int chachapoly_timingsafe_bcmp(const void *b1, const void *b2, size_t n)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -140,10 +140,13 @@
 
 /* Use local implementation with <VS2015 */
 #if defined(_MSC_VER) && _MSC_VER < 1900
+int ssh2_vsnprintf(char *buf, size_t buf_len, const char *fmt, va_list args)
+    SSH2_PRINTF(3, 0);
 int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
     SSH2_PRINTF(3, 4);
 #else
-#define ssh2_snprintf snprintf
+#define ssh2_vsnprintf  vsnprintf
+#define ssh2_snprintf   snprintf
 #endif
 
 #ifndef SSH2_FALLTHROUGH

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -140,7 +140,7 @@
 
 /* Use local implementation with <VS2015 */
 #if defined(_MSC_VER) && _MSC_VER < 1900
-int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
+int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
     SSH2_PRINTF(3, 4);
 #else
 #define ssh2_snprintf snprintf

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -89,7 +89,6 @@
 #include "libssh2.h"
 #include "libssh2_publickey.h"
 #include "libssh2_sftp.h"
-#include "misc.h"
 
 #ifdef _WIN32
 /* Detect Windows App environment which has a restricted access
@@ -168,6 +167,8 @@
    Define to the empty string to be on the safe side. */
 #  define SSH2_INLINE /* empty */
 #endif
+
+#include "misc.h"
 
 /* 3DS does not seem to have iovec */
 #if defined(_WIN32) || defined(_3DS)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -138,17 +138,6 @@
 #define SSH2_PRINTF(fmt, arg)
 #endif
 
-/* Use local implementation with <VS2015 */
-#if defined(_MSC_VER) && _MSC_VER < 1900
-int ssh2_vsnprintf(char *buf, size_t buf_len, const char *fmt, va_list args)
-    SSH2_PRINTF(3, 0);
-int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
-    SSH2_PRINTF(3, 4);
-#else
-#define ssh2_vsnprintf  vsnprintf
-#define ssh2_snprintf   snprintf
-#endif
-
 #ifndef SSH2_FALLTHROUGH
 #if (defined(__GNUC__) && __GNUC__ >= 7) || \
     (defined(__clang__) && __clang_major__ >= 10)

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -70,9 +70,6 @@
 #  undef _FILE_OFFSET_BITS
 #  define _FILE_OFFSET_BITS 64
 #elif defined(_MSC_VER)
-#  ifndef _CRT_SECURE_NO_WARNINGS
-#  define _CRT_SECURE_NO_WARNINGS  /* for vsnprintf() */
-#  endif
 #  if !defined(LIBSSH2_LIBRARY) || defined(LIBSSH2_TESTS)
      /* apply to examples and tests only */
 #    ifndef _CRT_SECURE_NO_WARNINGS

--- a/src/misc.c
+++ b/src/misc.c
@@ -52,7 +52,6 @@
 #if defined(_MSC_VER) && _MSC_VER < 1900
 /* snprintf is not in pre-VS2015 CRTs and _snprintf dangerously incompatible.
    Replicate standard snprintf using _vsnprintf_s and _vscprintf. */
-#include <stdarg.h>
 #if _MSC_VER < 1800  /* for VS2010, VS2012 */
 #define va_copy(dest, src) ((dest) = (src))
 #endif
@@ -517,8 +516,6 @@ void libssh2_free(LIBSSH2_SESSION *session, void *ptr)
 }
 
 #ifdef LIBSSH2DEBUG
-#include <stdarg.h>
-
 int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     if(!session)
@@ -605,8 +602,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         /* !checksrc! disable BANNEDFUNC 1 */
         fprintf(stderr, "%s\n", buffer);
 }
-
-#else
+#else /* !LIBSSH2DEBUG */
 int libssh2_trace(LIBSSH2_SESSION *session, int bitmask)
 {
     (void)session;

--- a/src/misc.c
+++ b/src/misc.c
@@ -50,31 +50,35 @@
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
-/* snprintf is not in pre-VS2015 CRTs and _snprintf dangerously incompatible.
-   Replicate VS2015+ snprintf using _vsnprintf_s and _vscprintf. */
+/* snprintf() is not in pre-VS2015 CRTs and _snprintf() incompatible.
+   Replicate standard snprintf() using _vsnprintf_s() and _vscprintf(). */
 #include <stdarg.h>
-int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
+int ssh2_vsnprintf(char *buf, size_t buf_len, const char *fmt, va_list args)
 {
-    va_list args;
-    int ret;
-
     if(!fmt) {
         if(buf && buf_len)
             *buf = 0;
         return -1;
     }
     else if(buf && buf_len) {
-        va_start(args, fmt);
-        ret = _vsnprintf_s(buf, buf_len, _TRUNCATE, fmt, args);
-        va_end(args);
+        int ret;
+        va_list args_dupe;
+        va_copy(args_dupe, args);
+        ret = _vsnprintf_s(buf, buf_len, _TRUNCATE, fmt, args_dupe);
+        va_end(args_dupe);
         if(ret >= 0)
             return ret;
     }
+    return _vscprintf(fmt, args);
+}
 
+int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
+{
+    int ret;
+    va_list args;
     va_start(args, fmt);
-    ret = _vscprintf(fmt, args);
+    ret = ssh2_vsnprintf(buf, buf_len, fmt, args);
     va_end(args);
-
     return ret;
 }
 #endif
@@ -588,8 +592,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
-        /* !checksrc! disable BANNEDFUNC 1 */
-        len = vsnprintf(buffer + msglen, buflen, format, vargs);
+        len = ssh2_vsnprintf(buffer + msglen, buflen, format, vargs);
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/misc.c
+++ b/src/misc.c
@@ -49,32 +49,33 @@
 #define SSH2_SEND_LOW  send
 #endif
 
-/* snprintf is not in pre-VS2015 CRTs and _snprintf dangerously incompatible.
-   We provide a safe wrapper for these environments */
 #if defined(_MSC_VER) && _MSC_VER < 1900
+/* snprintf is not in pre-VS2015 CRTs and _snprintf dangerously incompatible.
+   Replicate VS2015+ snprintf using _vsnprintf_s and _vscprintf. */
 #include <stdarg.h>
-
-/* Want safe, 'n += snprintf(b + n ...)' like function. Returns number of chars
-   placed in cp excluding the null-terminator. For cp_max_len > 0 the return
-   value is always < cp_max_len; for cp_max_len == 0 the return value is 0 (and
-   no chars are written to cp). Always null-terminate the output. */
-int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
+int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
 {
     va_list args;
-    int n;
-    if(!cp_max_len)
-        return 0;
-    if(cp_max_len == 1) {
-        if(cp)
-            cp[0] = 0;
-        return 0;
+    int ret;
+
+    if(!fmt) {
+        if(buf && buf_len)
+            *buf = 0;
+        return -1;
     }
+    else if(buf && buf_len) {
+        va_start(args, fmt);
+        ret = _vsnprintf_s(buf, buf_len, _TRUNCATE, fmt, args);
+        va_end(args);
+        if(ret >= 0)
+            return ret;
+    }
+
     va_start(args, fmt);
-    n = _vsnprintf_s(cp, cp_max_len, _TRUNCATE, fmt, args);
-    if(cp)
-        cp[cp_max_len - 1] = 0;
+    ret = _vscprintf(fmt, args);
     va_end(args);
-    return (n < (int)cp_max_len) ? n : (int)(cp_max_len - 1);
+
+    return ret;
 }
 #endif
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -53,6 +53,9 @@
 /* snprintf() is not in pre-VS2015 CRTs and _snprintf() incompatible.
    Replicate standard snprintf() using _vsnprintf_s() and _vscprintf(). */
 #include <stdarg.h>
+#if _MSC_VER < 1800  /* for VS2010, VS2012 */
+#define va_copy(dest, src) ((dest) = (src))
+#endif
 int ssh2_vsnprintf(char *buf, size_t buf_len, const char *fmt, va_list args)
 {
     if(!fmt) {

--- a/src/misc.c
+++ b/src/misc.c
@@ -50,8 +50,8 @@
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
-/* snprintf() is not in pre-VS2015 CRTs and _snprintf() incompatible.
-   Replicate standard snprintf() using _vsnprintf_s() and _vscprintf(). */
+/* snprintf is not in pre-VS2015 CRTs and _snprintf dangerously incompatible.
+   Replicate standard snprintf using _vsnprintf_s and _vscprintf. */
 #include <stdarg.h>
 #if _MSC_VER < 1800  /* for VS2010, VS2012 */
 #define va_copy(dest, src) ((dest) = (src))

--- a/src/misc.c
+++ b/src/misc.c
@@ -70,8 +70,7 @@ int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
         return 0;
     }
     va_start(args, fmt);
-    /* !checksrc! disable BANNEDFUNC 1 */
-    n = vsnprintf(cp, cp_max_len, fmt, args);
+    n = _vsnprintf_s(cp, cp_max_len, _TRUNCATE, fmt, args);
     if(cp)
         cp[cp_max_len - 1] = 0;
     va_end(args);

--- a/src/misc.c
+++ b/src/misc.c
@@ -58,11 +58,6 @@
 #endif
 int ssh2_vsnprintf(char *buf, size_t buf_len, const char *fmt, va_list args)
 {
-    if(!fmt) {
-        if(buf && buf_len)
-            *buf = 0;
-        return -1;
-    }
     if(buf && buf_len) {
         int ret;
         va_list args_dupe;

--- a/src/misc.c
+++ b/src/misc.c
@@ -63,7 +63,7 @@ int ssh2_vsnprintf(char *buf, size_t buf_len, const char *fmt, va_list args)
             *buf = 0;
         return -1;
     }
-    else if(buf && buf_len) {
+    if(buf && buf_len) {
         int ret;
         va_list args_dupe;
         va_copy(args_dupe, args);

--- a/src/misc.h
+++ b/src/misc.h
@@ -33,11 +33,23 @@
  */
 
 #include <errno.h>
+#include <stdarg.h>
 
 #ifdef _WIN32
 FILE *ssh2_fopen(const char *filename, const char *mode);
 #else
 #define ssh2_fopen fopen
+#endif
+
+/* Use local implementation with <VS2015 */
+#if defined(_MSC_VER) && _MSC_VER < 1900
+int ssh2_vsnprintf(char *buf, size_t buf_len, const char *fmt, va_list args)
+    SSH2_PRINTF(3, 0);
+int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
+    SSH2_PRINTF(3, 4);
+#else
+#define ssh2_vsnprintf  vsnprintf
+#define ssh2_snprintf   snprintf
 #endif
 
 #ifdef LIBSSH2_NO_CLEAR_MEMORY


### PR DESCRIPTION
To avoid using `vsnprintf()` (which in turn requires setting macro
`_CRT_SECURE_NO_WARNINGS` to suppress MSVC compiler warnings), and to 
make the local implementation follow the VS2015+ `snprintf()`
implementation (and therefore the standard one) more closely. Use
`_vsnprintf_s()` and `_vscprintf()` instead.

The old implementation returned the number of bytes written, while the
new one returns the number of bytes required.

Affects <VS2015 builds.

Also: 
- implement `ssh2_vsnprintf()` and replace the single caller from lib
  with it.
- stop setting `_CRT_SECURE_NO_WARNINGS` for lib code. It's no longer
  necessary.
- move declarations/macros to `misc.h` to match the source and dedupe,
  fixup `stdarg.h` includes.
- drop a redundant direct `misc.h` include.

Refs:
https://learn.microsoft.com/cpp/c-runtime-library/reference/snprintf-s-snprintf-s-l-snwprintf-s-snwprintf-s-l
https://learn.microsoft.com/cpp/c-runtime-library/reference/vscprintf-vscprintf-l-vscwprintf-vscwprintf-l

Ref: https://ci.appveyor.com/project/libssh2org/libssh2/builds/54381255/job/k8dk5fybtlf8qy40
Follow-up to 663830048f778893d7be890cd82b7aeeac65e268 #2105
Follow-up to 4cdf785cd313c3272d04c2ef7458a35d44533d8b #812
Follow-up to 6bf898336889b5151503f882e1f76eecd480a191

---

- [x] there is a remaining `vsnprintf()` call in `ssh2_deb_low()`.

https://learn.microsoft.com/cpp/c-runtime-library/reference/va-arg-va-copy-va-end-va-start
https://stackoverflow.com/questions/558223/va-copy-porting-to-visual-c#558259
https://www.bailopan.net/blog/?p=30