### PR TITLE
src: stop redefining system symbol `gettimeofday()`

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -146,15 +146,6 @@ int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
     SSH2_PRINTF(3, 4);
 #endif
 
-#ifdef HAVE_GETTIMEOFDAY
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif
-#define ssh2_gettimeofday gettimeofday
-#else
-int ssh2_gettimeofday(struct timeval *tp, void *tzp);
-#endif
-
 #ifndef SSH2_FALLTHROUGH
 #if (defined(__GNUC__) && __GNUC__ >= 7) || \
     (defined(__clang__) && __clang_major__ >= 10)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -146,14 +146,13 @@ int ssh2_snprintf(char *cp, size_t cp_max_len, const char *fmt, ...)
     SSH2_PRINTF(3, 4);
 #endif
 
-#ifndef HAVE_GETTIMEOFDAY
-#define HAVE_GETTIMEOFDAY
-#undef gettimeofday
-#define gettimeofday ssh2_gettimeofday
-#define LIBSSH2_GETTIMEOFDAY
-int ssh2_gettimeofday(struct timeval *tp, void *tzp);
-#elif defined(HAVE_SYS_TIME_H)
+#ifdef HAVE_GETTIMEOFDAY
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif
+#define ssh2_gettimeofday gettimeofday
+#else
+int ssh2_gettimeofday(struct timeval *tp, void *tzp);
 #endif
 
 #ifndef SSH2_FALLTHROUGH

--- a/src/misc.c
+++ b/src/misc.c
@@ -570,7 +570,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         }
     }
 
-    gettimeofday(&now, NULL);
+    ssh2_gettimeofday(&now, NULL);
     if(!firstsec)
         firstsec = now.tv_sec;
     now.tv_sec -= firstsec;
@@ -714,9 +714,7 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
 
 #endif
 
-/* Defined in libssh2_priv.h for the correct platforms */
-#ifdef LIBSSH2_GETTIMEOFDAY
-
+#ifndef HAVE_GETTIMEOFDAY
 /*
  * Implementation according to:
  * The Open Group Base Specifications Issue 6
@@ -757,7 +755,7 @@ int ssh2_gettimeofday(struct timeval *tp, void *tzp)
        Do not set errno on error.  */
     return 0;
 }
-#endif
+#endif /* HAVE_GETTIMEOFDAY */
 
 void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size)
 {

--- a/src/misc.c
+++ b/src/misc.c
@@ -755,7 +755,7 @@ int ssh2_gettimeofday(struct timeval *tp, void *tzp)
        Do not set errno on error.  */
     return 0;
 }
-#endif /* HAVE_GETTIMEOFDAY */
+#endif /* !HAVE_GETTIMEOFDAY */
 
 void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size)
 {

--- a/src/misc.c
+++ b/src/misc.c
@@ -711,7 +711,6 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
     /* entry's head is the same as after's */
     entry->head = after->head;
 }
-
 #endif
 
 #ifndef HAVE_GETTIMEOFDAY

--- a/src/misc.h
+++ b/src/misc.h
@@ -61,6 +61,15 @@ void ssh2_memzero(void *buf, size_t size);
 #define ssh2_explicit_zero(buf, size) ssh2_memzero(buf, size)
 #endif
 
+#ifdef HAVE_GETTIMEOFDAY
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#define ssh2_gettimeofday gettimeofday
+#else
+int ssh2_gettimeofday(struct timeval *tp, void *tzp);
+#endif
+
 struct list_head {
     struct list_node *last;
     struct list_node *first;

--- a/src/misc.h
+++ b/src/misc.h
@@ -61,10 +61,11 @@ void ssh2_memzero(void *buf, size_t size);
 #define ssh2_explicit_zero(buf, size) ssh2_memzero(buf, size)
 #endif
 
-#ifdef HAVE_GETTIMEOFDAY
 #ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
+#include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif
+
+#ifdef HAVE_GETTIMEOFDAY
 #define ssh2_gettimeofday gettimeofday
 #else
 int ssh2_gettimeofday(struct timeval *tp, void *tzp);

--- a/src/session.c
+++ b/src/session.c
@@ -1608,9 +1608,9 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 #ifdef HAVE_POLL
         {
             struct timeval tv_begin, tv_end;
-            gettimeofday(&tv_begin, NULL);
+            ssh2_gettimeofday(&tv_begin, NULL);
             sysret = poll(sockets, nfds, (int)timeout_remaining);
-            gettimeofday(&tv_end, NULL);
+            ssh2_gettimeofday(&tv_end, NULL);
             timeout_remaining -= (tv_end.tv_sec - tv_begin.tv_sec) * 1000;
             timeout_remaining -= (tv_end.tv_usec - tv_begin.tv_usec) / 1000;
         }
@@ -1664,9 +1664,9 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
 #endif
         {
             struct timeval tv_begin, tv_end;
-            gettimeofday(&tv_begin, NULL);
+            ssh2_gettimeofday(&tv_begin, NULL);
             sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
-            gettimeofday(&tv_end, NULL);
+            ssh2_gettimeofday(&tv_end, NULL);
             timeout_remaining -= (tv_end.tv_sec - tv_begin.tv_sec) * 1000;
             timeout_remaining -= (tv_end.tv_usec - tv_begin.tv_usec) / 1000;
         }


### PR DESCRIPTION
Replace with local macro mapping to the original if available, or fill
in with a local implementation otherwise.

To use the same pattern used in sibling cases.
