### PR TITLE
agent: fix unused macro compiler warnings in UWP non-unity builds

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -38,14 +38,14 @@
 #include "userauth.h"
 #include "session.h"
 
+#if defined(SSH2_AGENT_BACKEND_WIN32_OPENSSH) || \
+    defined(SSH2_AGENT_BACKEND_UNIX)
 #include <stdlib.h>  /* for getenv(), getenv_s(), _wgetenv_s() */
 #ifdef SSH2_AGENT_BACKEND_WIN32_OPENSSH
 #include <tchar.h>  /* for _tgetenv_s() */
 #endif
-
 #define OPENSSH_AUTH_SOCK "SSH_AUTH_SOCK"
-
-#define AGENT_MAX_MSGLEN  8192
+#endif
 
 /* Requests from client to agent for protocol 2 key operations */
 #define SSH2_AGENTC_REQUEST_IDENTITIES 11

--- a/src/agent.h
+++ b/src/agent.h
@@ -8,6 +8,8 @@
 
 #include "libssh2_priv.h"
 
+#define AGENT_MAX_MSGLEN  8192
+
 #if defined(_WIN32) && !defined(LIBSSH2_WINDOWS_UWP)
 #define SSH2_AGENT_BACKEND_WIN32_PAGEANT "Pageant"
 #define SSH2_AGENT_BACKEND_WIN32_OPENSSH "OpenSSH"


### PR DESCRIPTION
```
src/agent.c:48:9: error: macro is not used [-Wunused-macros]
   48 | #define AGENT_MAX_MSGLEN  8192
      |         ^
src/agent.c:46:9: error: macro is not used [-Wunused-macros]
   46 | #define OPENSSH_AUTH_SOCK "SSH_AUTH_SOCK"
      |         ^
```

Follow-up to 49abb5e5688f8ec7894f82564afa65379caaea24 #2313
