### PR TITLE
tests: use `ssh2_fopen()`

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1193,7 +1193,7 @@ cleanup:
     return !!*out;
 }
 
-FILE *ssh2_win32_fopen(const char *filename, const char *mode)
+FILE *ssh2_fopen(const char *filename, const char *mode)
 {
     FILE *fp = NULL;
     TCHAR *fixed = NULL;

--- a/src/misc.h
+++ b/src/misc.h
@@ -35,8 +35,7 @@
 #include <errno.h>
 
 #ifdef _WIN32
-FILE *ssh2_win32_fopen(const char *filename, const char *mode);
-#define ssh2_fopen ssh2_win32_fopen
+FILE *ssh2_fopen(const char *filename, const char *mode);
 #else
 #define ssh2_fopen fopen
 #endif

--- a/tests/.checksrc
+++ b/tests/.checksrc
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 allowfunc atoi
-allowfunc fopen
 allowfunc fprintf
 allowfunc printf
 allowfunc vsnprintf

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -236,7 +236,7 @@ static int is_running_inside_a_container(void)
     FILE *fp;
     char line[256];
     int found = 0;
-    fp = fopen(cgroup_filename, "r");
+    fp = ssh2_fopen(cgroup_filename, "r");
     if(!fp)
         return 0;  /* Do not go further, we are not in a container */
     while(fgets(line, sizeof(line), fp)) {

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -390,7 +390,7 @@ static int read_file(const char *path, char **out_buffer, size_t *out_len)
     *out_buffer = NULL;
     *out_len = 0;
 
-    fp = fopen(path, "r");
+    fp = ssh2_fopen(path, "r");
 
     if(!fp) {
         fprintf(stderr, "File could not be read: %s\n", path);

--- a/tests/session_fixture.h
+++ b/tests/session_fixture.h
@@ -36,6 +36,7 @@
 #define LIBSSH2_TESTS
 
 #include "libssh2_priv.h"
+#include "misc.h"
 
 LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err);
 void stop_session_fixture(void);


### PR DESCRIPTION
Follow-up to 521146a4f1ddd926117ae07156542da4a517521d #2318

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
