### PR TITLE
misc: drop `ssh2_fopen()` macro redirect on Windows

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1193,7 +1193,7 @@ cleanup:
     return !!*out;
 }
 
-FILE *ssh2_win32_fopen(const char *filename, const char *mode)
+FILE *ssh2_fopen(const char *filename, const char *mode)
 {
     FILE *fp = NULL;
     TCHAR *fixed = NULL;

--- a/src/misc.h
+++ b/src/misc.h
@@ -35,8 +35,7 @@
 #include <errno.h>
 
 #ifdef _WIN32
-FILE *ssh2_win32_fopen(const char *filename, const char *mode);
-#define ssh2_fopen ssh2_win32_fopen
+FILE *ssh2_fopen(const char *filename, const char *mode);
 #else
 #define ssh2_fopen fopen
 #endif


### PR DESCRIPTION
To follow the pattern used for sibling cases.

Follow-up to 521146a4f1ddd926117ae07156542da4a517521d #2318

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
