### PR TITLE
tests: revert to use system `snprintf()`

### DIFF
--- a/tests/.checksrc
+++ b/tests/.checksrc
@@ -5,4 +5,5 @@ allowfunc atoi
 allowfunc fopen
 allowfunc fprintf
 allowfunc printf
+allowfunc snprintf
 allowfunc vsnprintf

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -110,7 +110,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
         return -1;
     }
 
-    ret = ssh2_snprintf(buf, sizeof(buf), redirect_stderr, command_buf);
+    ret = snprintf(buf, sizeof(buf), redirect_stderr, command_buf);
     if(ret < 0 || (size_t)ret >= sizeof(buf)) {
         fprintf(stderr, "Unable to rewrite command (%s)\n", command);
         return -1;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -246,8 +246,8 @@ const char *srcdir_path(const char *file)
         abort();
     }
 
-    len = ssh2_snprintf(filepath[curpath], sizeof(filepath[0]), "%s/%s",
-                        srcdir, file);
+    len = snprintf(filepath[curpath], sizeof(filepath[0]), "%s/%s",
+                   srcdir, file);
     if(len < 0 || (size_t)len >= sizeof(filepath[0])) {
         fprintf(stderr, "srcdir_path: path too long. srcdir='%s', fn='%s'\n",
                 srcdir, file);

--- a/tests/test_hostkey_hash.c
+++ b/tests/test_hostkey_hash.c
@@ -59,7 +59,7 @@ static void calculate_digest(const char *hash, size_t hash_len, char *buffer,
     char *end = buffer + buffer_len;
 
     for(i = 0; i < hash_len && (end - p) >= 3; ++i, p += 2)
-        ssh2_snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
+        snprintf(p, (size_t)(end - p), "%02X", (unsigned char)hash[i]);
 }
 
 int test(LIBSSH2_SESSION *session)

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -86,9 +86,9 @@ int test(LIBSSH2_SESSION *session)
     }
 
     /* command to transfer the desired amount of data */
-    ssh2_snprintf(remote_command, sizeof(remote_command),
-                  "dd if=/dev/zero bs=%lu count=%lu status=none",
-                  xfer_bs, xfer_count);
+    snprintf(remote_command, sizeof(remote_command),
+             "dd if=/dev/zero bs=%lu count=%lu status=none",
+             xfer_bs, xfer_count);
 
     /* Send the command to transfer data */
     if(libssh2_channel_exec(channel, remote_command)) {


### PR DESCRIPTION
Cannot use the local one because most tests are built against
`libssh2.dll` which does not export it.

It needs a deeper overhaul of tests binaries to make using the static
lib practical in tests, and then this can be reintroduced.

Follow-up to dcd0dbab6b45a4f3cf5973ff03e87c9526096643 #2103
