### PR TITLE
windows: stop setting `_CRT_NONSTDC_NO_DEPRECATE` for MSVC

### DIFF
--- a/example/sftp.c
+++ b/example/sftp.c
@@ -15,6 +15,7 @@
 #include <libssh2_sftp.h>
 
 #ifdef _WIN32
+#define strdup          _strdup
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -14,6 +14,10 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#ifdef _WIN32
+#define strdup _strdup
+#endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -18,6 +18,10 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#ifdef _WIN32
+#define strdup _strdup
+#endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -193,6 +193,7 @@ struct iovec {
 #if defined(_WIN32) && !defined(LIBSSH2_LIBRARY) && !defined(LIBSSH2_TESTS)
 /* apply to examples only */
 #define write(fd, buf, count) (ssize_t)_write(fd, buf, (unsigned int)(count))
+#define strdup _strdup
 #endif
 
 #include "crypto.h"

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -190,12 +190,6 @@ struct iovec {
 #define send(s, b, l, f)  send(s, (unsigned char *)(b), l, f)
 #endif
 
-#if defined(_WIN32) && !defined(LIBSSH2_LIBRARY) && !defined(LIBSSH2_TESTS)
-/* apply to examples only */
-#define write(fd, buf, count) (ssize_t)_write(fd, buf, (unsigned int)(count))
-#define strdup _strdup
-#endif
-
 #include "crypto.h"
 
 #ifndef SIZE_MAX

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -190,6 +190,11 @@ struct iovec {
 #define send(s, b, l, f)  send(s, (unsigned char *)(b), l, f)
 #endif
 
+#if defined(_WIN32) && !defined(LIBSSH2_LIBRARY) && !defined(LIBSSH2_TESTS)
+/* apply to examples only */
+#define write(fd, buf, count) (ssize_t)_write(fd, buf, (unsigned int)(count))
+#endif
+
 #include "crypto.h"
 
 #ifndef SIZE_MAX

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -76,7 +76,8 @@
 #  if !defined(LIBSSH2_LIBRARY) || defined(LIBSSH2_TESTS)
      /* apply to examples and tests only */
 #    ifndef _CRT_SECURE_NO_WARNINGS
-#    define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv() */
+#    define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv(),
+                                        in tests: vsnprintf() */
 #    endif
 #    ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
 #    define _WINSOCK_DEPRECATED_NO_WARNINGS  /* for inet_addr() */
@@ -91,12 +92,6 @@
      /* apply to examples only */
 #    ifndef _CRT_NONSTDC_NO_DEPRECATE
 #    define _CRT_NONSTDC_NO_DEPRECATE  /* for write() */
-#    endif
-#  endif
-#  ifdef LIBSSH2_TESTS
-     /* apply to tests only */
-#    ifndef _CRT_SECURE_NO_WARNINGS
-#    define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv(), vsnprintf() */
 #    endif
 #  endif
 #  if _MSC_VER < 1900

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -90,8 +90,7 @@
 #  endif
 #  if !defined(LIBSSH2_LIBRARY) && !defined(LIBSSH2_TESTS)
      /* apply to examples only */
-#    define write(fd, buf, count) \
-         (ssize_t)_write(fd, buf, (unsigned int)(count))
+#    define write(fd, buf, len) (ssize_t)_write(fd, buf, (unsigned int)(len))
 #  endif
 #  if _MSC_VER < 1900
 /* Silence bogus warning C4127: conditional expression is constant */

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -76,10 +76,7 @@
 #  if !defined(LIBSSH2_LIBRARY) || defined(LIBSSH2_TESTS)
      /* apply to examples and tests only */
 #    ifndef _CRT_SECURE_NO_WARNINGS
-#    define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv() */
-#    endif
-#    ifndef _CRT_NONSTDC_NO_DEPRECATE
-#    define _CRT_NONSTDC_NO_DEPRECATE  /* for write() */
+#    define _CRT_SECURE_NO_WARNINGS  /* for fopen() (examples), getenv() */
 #    endif
 #    ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
 #    define _WINSOCK_DEPRECATED_NO_WARNINGS  /* for inet_addr() */
@@ -88,6 +85,12 @@
         tests when linking to a shared libssh2. */
 #    if _MSC_VER < 1900
 #      define snprintf _snprintf
+#    endif
+#  endif
+#  if !defined(LIBSSH2_LIBRARY) && !defined(LIBSSH2_TESTS)
+#    /* apply to examples only */
+#    ifndef _CRT_NONSTDC_NO_DEPRECATE
+#    define _CRT_NONSTDC_NO_DEPRECATE  /* for write() */
 #    endif
 #  endif
 #  if _MSC_VER < 1900

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -88,10 +88,6 @@
 #      define snprintf _snprintf
 #    endif
 #  endif
-#  if !defined(LIBSSH2_LIBRARY) && !defined(LIBSSH2_TESTS)
-     /* apply to examples only */
-#    define write(fd, buf, len) (ssize_t)_write(fd, buf, (unsigned int)(len))
-#  endif
 #  if _MSC_VER < 1900
 /* Silence bogus warning C4127: conditional expression is constant */
 #  pragma warning(disable:4127)

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -90,9 +90,8 @@
 #  endif
 #  if !defined(LIBSSH2_LIBRARY) && !defined(LIBSSH2_TESTS)
      /* apply to examples only */
-#    ifndef _CRT_NONSTDC_NO_DEPRECATE
-#    define _CRT_NONSTDC_NO_DEPRECATE  /* for write() */
-#    endif
+#    define write(fd, buf, count) \
+         (ssize_t)_write(fd, buf, (unsigned int)(count))
 #  endif
 #  if _MSC_VER < 1900
 /* Silence bogus warning C4127: conditional expression is constant */

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -76,7 +76,7 @@
 #  if !defined(LIBSSH2_LIBRARY) || defined(LIBSSH2_TESTS)
      /* apply to examples and tests only */
 #    ifndef _CRT_SECURE_NO_WARNINGS
-#    define _CRT_SECURE_NO_WARNINGS  /* for fopen() (examples), getenv() */
+#    define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv() */
 #    endif
 #    ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
 #    define _WINSOCK_DEPRECATED_NO_WARNINGS  /* for inet_addr() */
@@ -88,9 +88,15 @@
 #    endif
 #  endif
 #  if !defined(LIBSSH2_LIBRARY) && !defined(LIBSSH2_TESTS)
-#    /* apply to examples only */
+     /* apply to examples only */
 #    ifndef _CRT_NONSTDC_NO_DEPRECATE
 #    define _CRT_NONSTDC_NO_DEPRECATE  /* for write() */
+#    endif
+#  endif
+#  ifdef LIBSSH2_TESTS
+     /* apply to tests only */
+#    ifndef _CRT_SECURE_NO_WARNINGS
+#    define _CRT_SECURE_NO_WARNINGS  /* for fopen(), getenv(), vsnprintf() */
 #    endif
 #  endif
 #  if _MSC_VER < 1900


### PR DESCRIPTION
It wasn't needed anymore for `write()` in contratry to the comment,
because mapping it earlier to `_write()` in examples. But, it was needed
again for `strdup()` due to a regression. Fix it by mapping it again to
`_strdup()` in examples.

Also: document `vsnprintf()` used in tests.

Follow-up to ca43b304cf8ac844f161f47fb688180c85d6f256 #2042
Follow-up to e8e6bc2c50cf2ae0fc46ab46c7ca490c327764e2 #1688
