### PR TITLE
knownhost: fix off-by-one reads in `knownhost_add()`

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -210,7 +210,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
                           "Unable to allocate memory for key");
             goto error;
         }
-        memcpy(entry->key, key, keylen + 1);
+        memcpy(entry->key, key, keylen);
         entry->key[keylen] = 0; /* force a null-terminator */
     }
     else {
@@ -245,7 +245,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
                           "Unable to allocate memory for comment");
             goto error;
         }
-        memcpy(entry->comment, comment, commentlen + 1);
+        memcpy(entry->comment, comment, commentlen);
         entry->comment[commentlen] = 0; /* force a null-terminator */
         entry->comment_len = commentlen;
     }


### PR DESCRIPTION
For `key`, and `comment` (if passed).

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2333#discussion_r3599153879
Bug: https://github.com/libssh2/libssh2/pull/2333#discussion_r3599153899

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
