### PR TITLE
knownhost: fix potential off-by-one read in `libssh2_knownhost_readline()`

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -958,7 +958,6 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
                         "Failed to parse known_hosts line");
 
     keyp = cp; /* the key starts here */
-    keylen = len;
 
     /* check if the line (key) ends with a newline and if so kill it */
     while(len && *cp && *cp != '\n') {

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -966,9 +966,8 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
         len--;
     }
 
-    /* null-terminate where the newline or eob is */
-    if(*cp == '\n' || *cp == '\0')
-        keylen--; /* do not include this in the count */
+    /* key length is the parsed span, naturally excluding newline */
+    keylen = cp - keyp;
 
     /* deal with this one host+key line */
     rc = knownhost_line(hosts, hostp, hostlen, keyp, keylen);


### PR DESCRIPTION
It happens when the passed knownhosts line is missing a newline. Besides
overreading a byte in the line buffer, it may also miss to include the
last valid character of the key.

knownhosts line example:
```
line 1234<no newline here>
```

"At this point in the code, `len` has been decremented as `cp` advanced.
If the line ends without a newline and `len` reaches 0, `cp` may point
to a `'\0'` terminator outside the original `len` boundary.
Additionally, `keylen` is decremented unconditionally if `*cp` is
`'\0'`, but a null terminator may simply mean end-of-buffer rather than
a character to exclude from the key. This could lead to `keylen` being
off by one in certain cases. A more robust approach would be to
calculate `keylen` directly as `cp - keyp` after the loop, which
naturally excludes the newline."

Reported by GitHub Code Quality

Follow-up to bf33b9439dd327aa2e068608fcea7d195a88a6c6 #2053 #2012
