### PR TITLE
tidy-up: comment typos, parentheses, formatting

### DIFF
--- a/example/sftp.c
+++ b/example/sftp.c
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
 
-    /* Since we have set non-blocking, tell libssh2 we are blocking */
+    /* Since we have not set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);
 
     /* ... start it up. This trades welcome banners, exchange keys,

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
 
-    /* Since we have set non-blocking, tell libssh2 we are blocking */
+    /* Since we have not set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);
 
     /* ... start it up. This trades welcome banners, exchange keys,

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
 
-    /* Since we have set non-blocking, tell libssh2 we are blocking */
+    /* Since we have not set non-blocking, tell libssh2 we are blocking */
     libssh2_session_set_blocking(session, 1);
 
     /* ... start it up. This trades welcome banners, exchange keys,

--- a/src/agent.c
+++ b/src/agent.c
@@ -914,12 +914,13 @@ error:
 
 static int agent_list_identities(LIBSSH2_AGENT *agent)
 {
+    static const unsigned char c = SSH2_AGENTC_REQUEST_IDENTITIES;
+
     struct agent_transaction_ctx *transctx = &agent->transctx;
     ssize_t len;
     size_t num_identities;
     unsigned char *s;
     int rc;
-    static const unsigned char c = SSH2_AGENTC_REQUEST_IDENTITIES;
 
     /* Create a request to list identities */
     if(transctx->state == agent_NB_state_init) {

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -154,7 +154,6 @@ static void Blowfish_decipher(struct blf_ctx *c, uint32_t *xl, uint32_t *xr)
 static void Blowfish_initstate(struct blf_ctx *c)
 {
     /* P-box and S-box tables initialized with digits of Pi */
-
     static const struct blf_ctx initstate = {
         {
             {

--- a/src/channel.c
+++ b/src/channel.c
@@ -122,6 +122,7 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
         SSH_MSG_CHANNEL_OPEN_FAILURE,
         0
     };
+
     unsigned char *s;
     int rc;
 
@@ -499,9 +500,10 @@ static LIBSSH2_LISTENER *channel_forward_listen(LIBSSH2_SESSION *session,
                                                 int *bound_port,
                                                 int queue_maxsize)
 {
-    unsigned char *s;
     static const unsigned char reply_codes[3] =
         { SSH_MSG_REQUEST_SUCCESS, SSH_MSG_REQUEST_FAILURE, 0 };
+
+    unsigned char *s;
     int rc;
 
     if(!host)
@@ -813,10 +815,11 @@ static int channel_setenv(LIBSSH2_CHANNEL *channel,
                           const char *varname, unsigned int varname_len,
                           const char *value, unsigned int value_len)
 {
-    LIBSSH2_SESSION *session = channel->session;
-    unsigned char *s, *data;
     static const unsigned char reply_codes[3] =
         { SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_FAILURE, 0 };
+
+    LIBSSH2_SESSION *session = channel->session;
+    unsigned char *s, *data;
     size_t data_len;
     int rc;
 
@@ -930,10 +933,11 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
                                int width, int height,
                                int width_px, int height_px)
 {
-    LIBSSH2_SESSION *session = channel->session;
-    unsigned char *s;
     static const unsigned char reply_codes[3] =
         { SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_FAILURE, 0 };
+
+    LIBSSH2_SESSION *session = channel->session;
+    unsigned char *s;
     int rc;
 
     if(channel->reqPTY_state == ssh2_NB_state_idle) {
@@ -1023,10 +1027,11 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
                                       const char *request_str,
                                       int request_str_len)
 {
-    LIBSSH2_SESSION *session = channel->session;
-    unsigned char *s;
     static const unsigned char reply_codes[3] =
         { SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_FAILURE, 0 };
+
+    LIBSSH2_SESSION *session = channel->session;
+    unsigned char *s;
     int rc;
 
     if(channel->req_auth_agent_state == ssh2_NB_state_idle) {
@@ -1262,10 +1267,11 @@ static int channel_x11_req(LIBSSH2_CHANNEL *channel, int single_connection,
                            const char *auth_proto, const char *auth_cookie,
                            int screen_number)
 {
-    LIBSSH2_SESSION *session = channel->session;
-    unsigned char *s;
     static const unsigned char reply_codes[3] =
         { SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_FAILURE, 0 };
+
+    LIBSSH2_SESSION *session = channel->session;
+    unsigned char *s;
     size_t proto_len =
         auth_proto ? strlen(auth_proto) : (sizeof("MIT-MAGIC-COOKIE-1") - 1);
     size_t cookie_len =
@@ -1404,10 +1410,11 @@ int ssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                  const char *request, size_t request_len,
                                  const char *message, size_t message_len)
 {
-    LIBSSH2_SESSION *session = channel->session;
-    unsigned char *s;
     static const unsigned char reply_codes[3] =
         { SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_FAILURE, 0 };
+
+    LIBSSH2_SESSION *session = channel->session;
+    unsigned char *s;
     int rc;
 
     if(channel->process_state == ssh2_NB_state_end)

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -933,8 +933,7 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
     }
 
     if(!len || !*cp || *cp == '#' || *cp == '\n')
-        /* comment or empty line */
-        return LIBSSH2_ERROR_NONE;
+        return LIBSSH2_ERROR_NONE; /* comment or empty line */
 
     hostp = cp; /* the host part starts here */
 

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -761,7 +761,7 @@ static int knownhost_line_hashed(LIBSSH2_KNOWNHOSTS *hosts,
                              LIBSSH2_KNOWNHOST_KEYENC_BASE64, NULL);
     }
     else
-        return 0; /* XXX: This should be an error, should not it? */
+        return 0; /* XXX: This should be an error, should it not? */
 }
 
 /*

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -936,8 +936,7 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
         /* comment or empty line */
         return LIBSSH2_ERROR_NONE;
 
-    /* the host part starts here */
-    hostp = cp;
+    hostp = cp; /* the host part starts here */
 
     /* move over the host to the separator */
     while(len && *cp && *cp != ' ' && *cp != '\t') {

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -214,63 +214,63 @@ struct iovec {
 #define MAX_SHA_DIGEST_LEN SSH2_SHA512_DIG_LEN
 
 #define SSH2_ALLOC(session, count) \
-    session->alloc(count, &(session)->abstract)
+    (session)->alloc(count, &(session)->abstract)
 #define SSH2_CALLOC(session, count) ssh2_calloc(session, count)
 #define SSH2_REALLOC(session, ptr, count) \
     ((ptr) ? (session)->realloc(ptr, count, &(session)->abstract) : \
              (session)->alloc(count, &(session)->abstract))
 #define SSH2_FREE(session, ptr) \
-    session->free(ptr, &(session)->abstract)
+    (session)->free(ptr, &(session)->abstract)
 #define SSH2_SAFEFREE(session, ptr) \
     do {                            \
         SSH2_FREE(session, ptr);    \
         (ptr) = NULL;               \
     } while(0)
 #define SSH2_IGNORE(session, data, datalen) \
-    session->ssh_msg_ignore(session, data, (int)(datalen), \
-                            &(session)->abstract)
+    (session)->ssh_msg_ignore(session, data, (int)(datalen), \
+                              &(session)->abstract)
 #define SSH2_DEBUG(session, always_display, message, message_len, \
                    language, language_len) \
-    session->ssh_msg_debug(session, always_display, \
-                           message, (int)(message_len), \
-                           language, (int)(language_len), \
-                           &(session)->abstract)
+    (session)->ssh_msg_debug(session, always_display, \
+                             message, (int)(message_len), \
+                             language, (int)(language_len), \
+                             &(session)->abstract)
 #define SSH2_DISCONNECT(session, reason, message, message_len, \
                         language, language_len) \
-    session->ssh_msg_disconnect(session, reason, \
-                                message, (int)(message_len), \
-                                language, (int)(language_len), \
-                                &(session)->abstract)
+    (session)->ssh_msg_disconnect(session, reason, \
+                                  message, (int)(message_len), \
+                                  language, (int)(language_len), \
+                                  &(session)->abstract)
 
 #define SSH2_MACERROR(session, data, datalen) \
-    session->macerror(session, data, (int)(datalen), &(session)->abstract)
+    (session)->macerror(session, data, (int)(datalen), &(session)->abstract)
 #define SSH2_X11_OPEN(channel, shost, sport) \
-    channel->session->x11((channel)->session, channel, \
-                          shost, sport, &(channel)->session->abstract)
+    (channel)->session->x11((channel)->session, channel, \
+                            shost, sport, &(channel)->session->abstract)
 
 #define SSH2_AUTHAGENT(channel) \
-    channel->session->authagent((channel)->session, channel, \
-                                &(channel)->session->abstract)
+    (channel)->session->authagent((channel)->session, channel, \
+                                  &(channel)->session->abstract)
 
 #define SSH2_ADD_IDENTITIES(session, buffer, agentPath) \
-    session->addLocalIdentities(session, buffer, \
-                                agentPath, &(session)->abstract)
+    (session)->addLocalIdentities(session, buffer, \
+                                  agentPath, &(session)->abstract)
 
 #define SSH2_AUTHAGENT_SIGN(session, blob, blen, \
                             data, dlen, sig, sigLen, \
                             agentPath) \
-    session->agentSignCallback(session, blob, blen, \
-                               data, dlen, sig, sigLen, \
-                               agentPath, &(session)->abstract)
+    (session)->agentSignCallback(session, blob, blen, \
+                                 data, dlen, sig, sigLen, \
+                                 agentPath, &(session)->abstract)
 
 #define SSH2_CHANNEL_CLOSE(session, channel) \
-    channel->close_cb(session, &(session)->abstract, \
-                      channel, &(channel)->abstract)
+    (channel)->close_cb(session, &(session)->abstract, \
+                        channel, &(channel)->abstract)
 
 #define SSH2_SEND_FD(session, fd, buffer, length, flags) \
-    ((session)->send)(fd, buffer, length, flags, &(session)->abstract)
+    (session)->send(fd, buffer, length, flags, &(session)->abstract)
 #define SSH2_RECV_FD(session, fd, buffer, length, flags) \
-    ((session)->recv)(fd, buffer, length, flags, &(session)->abstract)
+    (session)->recv(fd, buffer, length, flags, &(session)->abstract)
 
 #define SSH2_SEND(session, buffer, length, flags) \
     SSH2_SEND_FD(session, (session)->socket_fd, buffer, length, flags)

--- a/src/misc.c
+++ b/src/misc.c
@@ -596,8 +596,8 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
     }
 
     if(session && session->tracehandler)
-        (session->tracehandler)(session, session->tracehandler_context, buffer,
-                                msglen);
+        session->tracehandler(session, session->tracehandler_context, buffer,
+                              msglen);
     else
         /* !checksrc! disable BANNEDFUNC 1 */
         fprintf(stderr, "%s\n", buffer);

--- a/src/misc.c
+++ b/src/misc.c
@@ -537,11 +537,6 @@ int libssh2_trace_sethandler(LIBSSH2_SESSION *session, void *context,
 void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
                   const char *format, ...)
 {
-    char buffer[1536];
-    int len, msglen, buflen = sizeof(buffer);
-    va_list vargs;
-    struct timeval now;
-    static long firstsec;
     static const char * const contexts[] = {
         "Unknown",
         "Transport",
@@ -554,6 +549,12 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         "Publickey",
         "Socket",
     };
+    static long firstsec;
+
+    char buffer[1536];
+    int len, msglen, buflen = sizeof(buffer);
+    va_list vargs;
+    struct timeval now;
     const char *contexttext = contexts[0];
     unsigned int contextindex;
 
@@ -576,7 +577,6 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
 
     len = ssh2_snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
                         (int)now.tv_sec, (int)now.tv_usec, contexttext);
-
     if(len >= buflen)
         msglen = buflen - 1;
     else {

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -1204,11 +1204,11 @@ static LIBSSH2_SFTP_HANDLE *sftp_open(LIBSSH2_SFTP *sftp,
     }
 
     if(sftp->open_state == ssh2_NB_state_sent) {
-        size_t data_len = 0;
-        unsigned char *data;
         static const unsigned char fopen_responses[2] = {
             SSH_FXP_HANDLE, SSH_FXP_STATUS
         };
+        size_t data_len = 0;
+        unsigned char *data;
         rc = sftp_packet_requirev(sftp, 2, fopen_responses,
                                   sftp->open_request_id, &data,
                                   &data_len, 1);
@@ -1584,12 +1584,12 @@ static ssize_t sftp_read(LIBSSH2_SFTP_HANDLE *handle,
         chunk = ssh2_list_first(&handle->packet_list);
 
         while(chunk) {
-            unsigned char *data;
-            size_t data_len = 0;
-            uint32_t rc32;
             static const unsigned char read_responses[2] = {
                 SSH_FXP_DATA, SSH_FXP_STATUS
             };
+            unsigned char *data;
+            size_t data_len = 0;
+            uint32_t rc32;
 
             if(chunk->lefttosend) {
                 /* if the chunk still has data left to send, we should not wait
@@ -1760,6 +1760,10 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
                             size_t longentry_maxlen,
                             LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
+    static const unsigned char read_responses[2] = {
+        SSH_FXP_NAME, SSH_FXP_STATUS
+    };
+
     LIBSSH2_SFTP *sftp = handle->sftp;
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -1768,9 +1772,6 @@ static ssize_t sftp_readdir(LIBSSH2_SFTP_HANDLE *handle, char *buffer,
     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + handle_len(4) */
     uint32_t packet_len = (uint32_t)(handle->handle_len + 13);
     unsigned char *s, *data;
-    static const unsigned char read_responses[2] = {
-        SSH_FXP_NAME, SSH_FXP_STATUS
-    };
     ssize_t retcode;
 
     if(sftp->readdir_state == ssh2_NB_state_idle) {
@@ -2341,6 +2342,10 @@ int libssh2_sftp_fsync(LIBSSH2_SFTP_HANDLE *handle)
 static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
                       LIBSSH2_SFTP_ATTRIBUTES *attrs, int setstat)
 {
+    static const unsigned char fstat_responses[2] = {
+        SSH_FXP_ATTRS, SSH_FXP_STATUS
+    };
+
     LIBSSH2_SFTP *sftp = handle->sftp;
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -2349,9 +2354,6 @@ static int sftp_fstat(LIBSSH2_SFTP_HANDLE *handle,
     uint32_t packet_len = (uint32_t)(handle->handle_len + 13 +
                                  (setstat ? sftp_attrsize(attrs->flags) : 0));
     unsigned char *s, *data = NULL;
-    static const unsigned char fstat_responses[2] = {
-        SSH_FXP_ATTRS, SSH_FXP_STATUS
-    };
     ssize_t rc;
 
     if(sftp->fstat_state == ssh2_NB_state_idle) {
@@ -3010,6 +3012,10 @@ int libssh2_sftp_posix_rename_ex(LIBSSH2_SFTP *sftp,
  */
 static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
 {
+    static const unsigned char responses[2] = {
+        SSH_FXP_EXTENDED_REPLY, SSH_FXP_STATUS
+    };
+
     LIBSSH2_SFTP *sftp = handle->sftp;
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
@@ -3018,9 +3024,6 @@ static int sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle, LIBSSH2_SFTP_STATVFS *st)
     unsigned char *packet, *s, *data = NULL;
     ssize_t rc;
     unsigned int flag;
-    static const unsigned char responses[2] = {
-        SSH_FXP_EXTENDED_REPLY, SSH_FXP_STATUS
-    };
 
     /* 17 = packet_len(4) + packet_type(1) + request_id(4) + ext_len(4)
        + handle_len (4) */
@@ -3151,6 +3154,10 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
                         const char *path, unsigned int path_len,
                         LIBSSH2_SFTP_STATVFS *st)
 {
+    static const unsigned char responses[2] = {
+        SSH_FXP_EXTENDED_REPLY, SSH_FXP_STATUS
+    };
+
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
     size_t data_len = 0;
@@ -3158,9 +3165,6 @@ static int sftp_statvfs(LIBSSH2_SFTP *sftp,
     unsigned char *packet, *s, *data = NULL;
     ssize_t rc;
     unsigned int flag;
-    static const unsigned char responses[2] = {
-        SSH_FXP_EXTENDED_REPLY, SSH_FXP_STATUS
-    };
 
     /* 17 = packet_len(4) + packet_type(1) + request_id(4) + ext_len(4)
        + path_len (4) */
@@ -3507,6 +3511,10 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
                      const char *path, unsigned int path_len,
                      int stat_type, LIBSSH2_SFTP_ATTRIBUTES *attrs)
 {
+    static const unsigned char stat_responses[2] = {
+        SSH_FXP_ATTRS, SSH_FXP_STATUS
+    };
+
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
     size_t data_len = 0;
@@ -3515,9 +3523,6 @@ static int sftp_stat(LIBSSH2_SFTP *sftp,
                     ((stat_type ==
                     LIBSSH2_SFTP_SETSTAT) ? sftp_attrsize(attrs->flags) : 0);
     unsigned char *s, *data = NULL;
-    static const unsigned char stat_responses[2] = {
-        SSH_FXP_ATTRS, SSH_FXP_STATUS
-    };
     int rc;
 
     if(packet_len + (uint32_t)path_len < packet_len)
@@ -3646,15 +3651,16 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp,
                         char *target, unsigned int target_len,
                         int link_type)
 {
+    static const unsigned char link_responses[2] = {
+        SSH_FXP_NAME, SSH_FXP_STATUS
+    };
+
     LIBSSH2_CHANNEL *channel = sftp->channel;
     LIBSSH2_SESSION *session = channel->session;
     size_t data_len = 0, lk_len;
     uint32_t packet_len;
     unsigned char *s, *data = NULL;
     struct string_buf buf;
-    static const unsigned char link_responses[2] = {
-        SSH_FXP_NAME, SSH_FXP_STATUS
-    };
     int retcode;
     unsigned char packet_type;
     uint32_t tmp_u32;

--- a/src/transport.c
+++ b/src/transport.c
@@ -48,12 +48,13 @@
 static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
                                 const unsigned char *ptr, size_t size)
 {
+    static const char *hex_chars = "0123456789ABCDEF";
+
     size_t i;
     size_t c;
     unsigned int width = 0x10;
     char buffer[256];  /* Must be enough for width*4 + about 30 or so */
     size_t used;
-    static const char *hex_chars = "0123456789ABCDEF";
 
     if(!(session->showmask & LIBSSH2_TRACE_TRANS))
         return;  /* not asked for, bail out */

--- a/src/transport.c
+++ b/src/transport.c
@@ -61,8 +61,8 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
     used = ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
                          desc, (unsigned long)size);
     if(session->tracehandler)
-        (session->tracehandler)(session, session->tracehandler_context,
-                                buffer, used);
+        session->tracehandler(session, session->tracehandler_context,
+                              buffer, used);
     else
         /* !checksrc! disable BANNEDFUNC 1 */
         fprintf(stderr, "%s", buffer);
@@ -91,15 +91,14 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
         buffer[used++] = ':';
         buffer[used++] = ' ';
 
-        for(c = 0; c < width && (i + c) < size; c++) {
+        for(c = 0; c < width && (i + c) < size; c++)
             buffer[used++] = isprint(ptr[i + c]) ?
                 ptr[i + c] : UNPRINTABLE_CHAR;
-        }
         buffer[used] = 0;
 
         if(session->tracehandler)
-            (session->tracehandler)(session, session->tracehandler_context,
-                                    buffer, used);
+            session->tracehandler(session, session->tracehandler_context,
+                                  buffer, used);
         else
             /* !checksrc! disable BANNEDFUNC 1 */
             fprintf(stderr, "%s\n", buffer);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -915,8 +915,7 @@ static int wcng_load_pem(LIBSSH2_SESSION *session,
         return -1;
 
     ret = ssh2_pem_parse(session, headerbegin, headerend,
-                         passphrase,
-                         fp, data, datalen);
+                         passphrase, fp, data, datalen);
 
     fclose(fp);
 


### PR DESCRIPTION
- move `static`s to the top of the block.
- add missing/drop redundant parentheses.
