### PR TITLE
src: fix handling `snprintf()` return values

### DIFF
--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
         "</capabilities>"
         "</hello>\n"
         "]]>]]>\n");
-    if(len < 0 || len >= sizeof(buf))
+    if(len < 0 || len >= (int)sizeof(buf))
         goto shutdown;
     if(netconf_write(channel, buf, (size_t)len) == -1)
         goto shutdown;
@@ -274,7 +274,7 @@ int main(int argc, char *argv[])
         "<get-interface-information><terse/></get-interface-information>"
         "</rpc>\n"
         "]]>]]>\n");
-    if(len < 0 || len >= sizeof(buf))
+    if(len < 0 || len >= (int)sizeof(buf))
         goto shutdown;
     if(netconf_write(channel, buf, (size_t)len) == -1)
         goto shutdown;

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -254,14 +254,14 @@ int main(int argc, char *argv[])
         "</capabilities>"
         "</hello>\n"
         "]]>]]>\n");
-    if(len < 0)
+    if(len < 0 || len >= sizeof(buf))
         goto shutdown;
-    if(-1 == netconf_write(channel, buf, (size_t)len))
+    if(netconf_write(channel, buf, (size_t)len) == -1)
         goto shutdown;
 
     fprintf(stderr, "Reading NETCONF server <hello>\n");
     len = netconf_read_until(channel, "</hello>", buf, sizeof(buf));
-    if(-1 == len)
+    if(len == -1)
         goto shutdown;
 
     fprintf(stderr, "Got %ld bytes:\n----------------------\n%s",
@@ -274,14 +274,14 @@ int main(int argc, char *argv[])
         "<get-interface-information><terse/></get-interface-information>"
         "</rpc>\n"
         "]]>]]>\n");
-    if(len < 0)
+    if(len < 0 || len >= sizeof(buf))
         goto shutdown;
-    if(-1 == netconf_write(channel, buf, (size_t)len))
+    if(netconf_write(channel, buf, (size_t)len) == -1)
         goto shutdown;
 
     fprintf(stderr, "Reading NETCONF <rpc-reply>\n");
     len = netconf_read_until(channel, "</rpc-reply>", buf, sizeof(buf));
-    if(-1 == len)
+    if(len == -1)
         goto shutdown;
 
     fprintf(stderr, "Got %ld bytes:\n----------------------\n%s",

--- a/src/misc.c
+++ b/src/misc.c
@@ -578,8 +578,10 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
     /* '[libssh2] 9999999999.9999999999 Failure Event: ' */
     len = ssh2_snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
                         (int)now.tv_sec, (int)now.tv_usec, contexttext);
-    if(len < 0 || len >= buflen)
+    if(len < 0 || len >= buflen) {
         msglen = buflen - 1;
+        buffer[msglen] = 0;
+    }
     else {
         buflen -= len;
         msglen = len;
@@ -593,7 +595,12 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
 #pragma GCC diagnostic pop
 #endif
         va_end(vargs);
-        msglen += (len >= 0 && len < buflen) ? len : buflen - 1;
+        if(len >= 0 && len < buflen)
+            msglen += len;
+        else {
+            msglen += buflen - 1;
+            buffer[msglen] = 0;
+        }
     }
 
     if(session && session->tracehandler)

--- a/src/misc.c
+++ b/src/misc.c
@@ -595,12 +595,12 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
 #pragma GCC diagnostic pop
 #endif
         va_end(vargs);
-        if(len >= 0 && len < buflen)
-            msglen += len;
-        else {
+        if(len < 0 || len >= buflen) {
             msglen += buflen - 1;
             buffer[msglen] = 0;
         }
+        else
+            msglen += len;
     }
 
     if(session && session->tracehandler)

--- a/src/misc.c
+++ b/src/misc.c
@@ -579,7 +579,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
     len = ssh2_snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
                         (int)now.tv_sec, (int)now.tv_usec, contexttext);
     if(len < 0 || len >= buflen) {
-        msglen = buflen - 1;
+        msglen = len < 0 ? 0 : (buflen - 1);
         buffer[msglen] = 0;
     }
     else {
@@ -596,7 +596,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
 #endif
         va_end(vargs);
         if(len < 0 || len >= buflen) {
-            msglen += buflen - 1;
+            msglen += len < 0 ? 0 : (buflen - 1);
             buffer[msglen] = 0;
         }
         else

--- a/src/misc.c
+++ b/src/misc.c
@@ -593,7 +593,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
 #pragma GCC diagnostic pop
 #endif
         va_end(vargs);
-        msglen += len < buflen ? len : buflen - 1;
+        msglen += (len >= 0 && len < buflen) ? len : buflen - 1;
     }
 
     if(session && session->tracehandler)

--- a/src/misc.c
+++ b/src/misc.c
@@ -575,9 +575,10 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         firstsec = now.tv_sec;
     now.tv_sec -= firstsec;
 
+    /* '[libssh2] 9999999999.9999999999 Failure Event: ' */
     len = ssh2_snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
                         (int)now.tv_sec, (int)now.tv_usec, contexttext);
-    if(len >= buflen)
+    if(len < 0 || len >= buflen)
         msglen = buflen - 1;
     else {
         buflen -= len;

--- a/src/transport.c
+++ b/src/transport.c
@@ -65,7 +65,7 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
     used = ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
                          desc, (unsigned long)size);
     if(used < 0 || used >= (int)sizeof(buffer)) {
-        used = (int)sizeof(buffer) - 1;
+        used = used < 0 ? 0 : ((int)sizeof(buffer) - 1);
         buffer[used] = 0;
     }
 
@@ -81,7 +81,7 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
         used = ssh2_snprintf(buffer, sizeof(buffer), "%04lx: ",
                              (unsigned long)i);
         if(used < 0 || used >= (int)sizeof(buffer)) {
-            used = (int)sizeof(buffer) - 1;
+            used = used < 0 ? 0 : ((int)sizeof(buffer) - 1);
             buffer[used] = 0;
         }
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -80,10 +80,8 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
 
         used = ssh2_snprintf(buffer, sizeof(buffer), "%04lx: ",
                              (unsigned long)i);
-        if(used < 0 || used >= (int)sizeof(buffer)) {
-            used = used < 0 ? 0 : ((int)sizeof(buffer) - 1);
-            buffer[used] = 0;
-        }
+        if(used < 0 || used >= (int)sizeof(buffer))
+            return;
 
         /* hex not disabled, show it */
         for(c = 0; c < width; c++) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -59,11 +59,11 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
     if(!(session->showmask & LIBSSH2_TRACE_TRANS))
         return;  /* not asked for, bail out */
 
-    used = ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
-                         desc, (unsigned long)size);
+    ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
+                  desc, (unsigned long)size);
     if(session->tracehandler)
         session->tracehandler(session, session->tracehandler_context,
-                              buffer, used);
+                              buffer, strlen(buffer));
     else
         /* !checksrc! disable BANNEDFUNC 1 */
         fprintf(stderr, "%s", buffer);

--- a/src/transport.c
+++ b/src/transport.c
@@ -81,8 +81,8 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
         used = ssh2_snprintf(buffer, sizeof(buffer), "%04lx: ",
                              (unsigned long)i);
         if(used < 0 || used >= (int)sizeof(buffer)) {
-            used = 0;
-            buffer[sizeof(buffer) - 1] = 0;
+            used = (int)sizeof(buffer) - 1;
+            buffer[used] = 0;
         }
 
         /* hex not disabled, show it */

--- a/src/transport.c
+++ b/src/transport.c
@@ -62,11 +62,15 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
     if(size > INT_MAX)
         return;  /* blob too large */
 
-    ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
-                  desc, (unsigned long)size);
+    used = ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
+                         desc, (unsigned long)size);
+    if(used < 0 || used >= (int)sizeof(buffer)) {
+        used = (int)sizeof(buffer) - 1;
+        buffer[used] = 0;
+    }
     if(session->tracehandler)
         session->tracehandler(session, session->tracehandler_context,
-                              buffer, strlen(buffer));
+                              buffer, used);
     else
         /* !checksrc! disable BANNEDFUNC 1 */
         fprintf(stderr, "%s", buffer);
@@ -75,9 +79,10 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
 
         used = ssh2_snprintf(buffer, sizeof(buffer), "%04lx: ",
                              (unsigned long)i);
-        if(used < 0 || used >= (int)sizeof(buffer))
+        if(used < 0 || used >= (int)sizeof(buffer)) {
+            buffer[sizeof(buffer) - 1];
             used = 0;
-
+        }
         /* hex not disabled, show it */
         for(c = 0; c < width; c++) {
             if(i + c < size) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -60,7 +60,7 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
         return;  /* not asked for, bail out */
 
     if(size > INT_MAX)
-        return;  /* blob too large */
+        return;  /* input too large */
 
     used = ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
                          desc, (unsigned long)size);

--- a/src/transport.c
+++ b/src/transport.c
@@ -59,7 +59,7 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
     if(!(session->showmask & LIBSSH2_TRACE_TRANS))
         return;  /* not asked for, bail out */
 
-    if(size > ULONG_MAX)
+    if(size > (4 * 1024 * 1024))
         return;  /* input too large */
 
     used = ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",

--- a/src/transport.c
+++ b/src/transport.c
@@ -72,6 +72,8 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
 
         used = ssh2_snprintf(buffer, sizeof(buffer), "%04lx: ",
                              (unsigned long)i);
+        if(used < 0 || used >= sizeof(buffer))
+            used = 0;
 
         /* hex not disabled, show it */
         for(c = 0; c < width; c++) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -54,10 +54,13 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
     size_t c;
     unsigned int width = 0x10;
     char buffer[256];  /* Must be enough for width*4 + about 30 or so */
-    size_t used;
+    int used;
 
     if(!(session->showmask & LIBSSH2_TRACE_TRANS))
         return;  /* not asked for, bail out */
+
+    if(size > INT_MAX)
+        return;  /* blob too large */
 
     ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",
                   desc, (unsigned long)size);
@@ -72,7 +75,7 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
 
         used = ssh2_snprintf(buffer, sizeof(buffer), "%04lx: ",
                              (unsigned long)i);
-        if(used < 0 || used >= sizeof(buffer))
+        if(used < 0 || used >= (int)sizeof(buffer))
             used = 0;
 
         /* hex not disabled, show it */

--- a/src/transport.c
+++ b/src/transport.c
@@ -68,6 +68,7 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
         used = (int)sizeof(buffer) - 1;
         buffer[used] = 0;
     }
+
     if(session->tracehandler)
         session->tracehandler(session, session->tracehandler_context,
                               buffer, used);
@@ -80,9 +81,10 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
         used = ssh2_snprintf(buffer, sizeof(buffer), "%04lx: ",
                              (unsigned long)i);
         if(used < 0 || used >= (int)sizeof(buffer)) {
-            buffer[sizeof(buffer) - 1];
             used = 0;
+            buffer[sizeof(buffer) - 1] = 0;
         }
+
         /* hex not disabled, show it */
         for(c = 0; c < width; c++) {
             if(i + c < size) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -59,7 +59,7 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
     if(!(session->showmask & LIBSSH2_TRACE_TRANS))
         return;  /* not asked for, bail out */
 
-    if(size > INT_MAX)
+    if(size > ULONG_MAX)
         return;  /* input too large */
 
     used = ssh2_snprintf(buffer, sizeof(buffer), "=> %s (%lu bytes)\n",


### PR DESCRIPTION
Prepare for -1 (potentially without null-terminator), and larger than 
buffer size values.

Also:
- tackle two cases in example/subsystem_netconf.c.
- cap input size at 4 MiB in `transport_debugdump()`.

Refs:
https://pubs.opengroup.org/onlinepubs/9799919799/functions/fprintf.html
https://pubs.opengroup.org/onlinepubs/9799919799/functions/vfprintf.html