### PR TITLE
publickey: fix out-of-bounds read in `publickey_init()`

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -476,6 +476,12 @@ static LIBSSH2_PUBLICKEY *publickey_init(LIBSSH2_SESSION *session)
 
             case SSH2_PUBLICKEY_RESPONSE_VERSION:
                 /* What we want */
+                if(session->pkeyInit_data_len <
+                   (size_t)(s - session->pkeyInit_data) + 4) {
+                    ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
+                             "Public key init data too small");
+                    goto err_exit;
+                }
                 session->pkeyInit_pkey->version = ssh2_ntohu32(s);
                 if(session->pkeyInit_pkey->version > SSH2_PUBLICKEY_VERSION) {
                     ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY,


### PR DESCRIPTION
publickey_init reads the version field with ssh2_ntohu32 after publickey_response_id has already advanced s past the length prefix and the response name, but the length guard ahead of the switch only checks pkeyInit_data_len against 4 for the whole buffer, not against what is left at s. publickey_packet_receive allocates the response buffer at exactly the length the server sent, so a server answering libssh2_publickey_init with the 11 bytes `00 00 00 07 "version"` makes that read run 4 bytes off the end of an 11-byte allocation. the status case right below it, publickey_response_success and libssh2_publickey_list_fetch all already compare against (s - data) + n, so this mirrors them rather than inventing a new shape. checked with asan driving publickey_init against that response: heap-buffer-overflow read at publickey.c:479 before, clean BUFFER_TOO_SMALL reject after. the parse sits behind channel reads so there is no seam for a unit test like test_auth_keyboard_info_request, happy to add one if you would rather have the seam.