### PR TITLE
publickey: sanitize public API input arguments

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -600,6 +600,10 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
             }
         }
 
+        if(packet_len > LIBSSH2_PACKET_MAXPAYLOAD)
+            return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                            "Packet too large");
+
         pkey->add_packet = SSH2_ALLOC(session, packet_len);
         if(!pkey->add_packet)
             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
@@ -704,7 +708,7 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
     unsigned long packet_len;
     int rc;
 
-    if(!pkey)
+    if(!pkey || !name || !blob)
         return LIBSSH2_ERROR_BAD_USE;
 
     if(name_len > LIBSSH2_PACKET_MAXPAYLOAD ||
@@ -720,6 +724,10 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
 
     if(pkey->remove_state == ssh2_NB_state_idle) {
         pkey->remove_packet = NULL;
+
+        if(packet_len > LIBSSH2_PACKET_MAXPAYLOAD)
+            return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                            "Packet too large");
 
         pkey->remove_packet = SSH2_ALLOC(session, packet_len);
         if(!pkey->remove_packet)

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -525,9 +525,14 @@ LIBSSH2_PUBLICKEY *libssh2_publickey_init(LIBSSH2_SESSION *session)
 {
     LIBSSH2_PUBLICKEY *ptr;
 
+    if(!session)
+        return NULL;
+
     BLOCK_ADJUST_ERRNO(ptr, session, publickey_init(session));
     return ptr;
 }
+
+#define PUBLICKEY_ATTRS_MAX  1024
 
 /*
  * Add a new public key entry
@@ -541,15 +546,22 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
 {
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_SESSION *session;
-    /* 19 = packet_len(4) + add_len(4) + "add"(3) + name_len(4) + {name}
-       blob_len(4) + {blob} */
-    unsigned long i, packet_len = 19 + name_len + blob_len;
+    unsigned long i, packet_len;
     const unsigned char *comment = NULL;
     unsigned long comment_len = 0;
     int rc;
 
     if(!pkey)
         return LIBSSH2_ERROR_BAD_USE;
+
+    if(name_len > LIBSSH2_PACKET_MAXPAYLOAD ||
+       blob_len > LIBSSH2_PACKET_MAXPAYLOAD ||
+       num_attrs > PUBLICKEY_ATTRS_MAX)
+        return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
+
+    /* 19 = packet_len(4) + add_len(4) + "add"(3) + name_len(4) + {name}
+       blob_len(4) + {blob} */
+    packet_len = 19 + name_len + blob_len;
 
     channel = pkey->channel;
     session = channel->session;
@@ -570,13 +582,19 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
                     break;
                 }
             }
+            if(comment_len > LIBSSH2_PACKET_MAXPAYLOAD)
+                return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
             packet_len += 4 + comment_len;
         }
         else {
             packet_len += 5; /* overwrite(1) + attribute_count(4) */
-            for(i = 0; i < num_attrs; i++)
+            for(i = 0; i < num_attrs; i++) {
+                if(attrs[i].name_len > LIBSSH2_PACKET_MAXPAYLOAD ||
+                   attrs[i].value_len > LIBSSH2_PACKET_MAXPAYLOAD)
+                    return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
                 /* name_len(4) + value_len(4) + mandatory(1) */
                 packet_len += 9 + attrs[i].name_len + attrs[i].value_len;
+            }
         }
 
         pkey->add_packet = SSH2_ALLOC(session, packet_len);
@@ -680,13 +698,19 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
 {
     LIBSSH2_CHANNEL *channel;
     LIBSSH2_SESSION *session;
-    /* 22 = packet_len(4) + remove_len(4) + "remove"(6) + name_len(4) + {name}
-       + blob_len(4) + {blob} */
-    unsigned long packet_len = 22 + name_len + blob_len;
+    unsigned long packet_len;
     int rc;
 
     if(!pkey)
         return LIBSSH2_ERROR_BAD_USE;
+
+    if(name_len > LIBSSH2_PACKET_MAXPAYLOAD ||
+       blob_len > LIBSSH2_PACKET_MAXPAYLOAD)
+        return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
+
+    /* 22 = packet_len(4) + remove_len(4) + "remove"(6) + name_len(4) + {name}
+       + blob_len(4) + {blob} */
+    packet_len = 22 + name_len + blob_len;
 
     channel = pkey->channel;
     session = channel->session;
@@ -1063,7 +1087,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                 pkey->listFetch_s += 4;
 
                 if(list[keys].num_attrs) {
-                    if(list[keys].num_attrs > 1024) {
+                    if(list[keys].num_attrs > PUBLICKEY_ATTRS_MAX) {
                         ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                  "Too many publickey attributes");
                         goto err_exit;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -577,19 +577,22 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
                 /* Search for a comment attribute */
                 if(attrs[i].name_len == (sizeof("comment") - 1) &&
                    !strncmp(attrs[i].name, "comment", sizeof("comment") - 1)) {
+                    if(!attrs[i].value ||
+                       attrs[i].value_len > LIBSSH2_PACKET_MAXPAYLOAD)
+                        return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
                     comment = (const unsigned char *)attrs[i].value;
                     comment_len = attrs[i].value_len;
                     break;
                 }
             }
-            if(comment_len > LIBSSH2_PACKET_MAXPAYLOAD)
-                return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
             packet_len += 4 + comment_len;
         }
         else {
             packet_len += 5; /* overwrite(1) + attribute_count(4) */
             for(i = 0; i < num_attrs; i++) {
-                if(attrs[i].name_len > LIBSSH2_PACKET_MAXPAYLOAD ||
+                if(!attrs[i].name ||
+                   !attrs[i].value ||
+                   attrs[i].name_len > LIBSSH2_PACKET_MAXPAYLOAD ||
                    attrs[i].value_len > LIBSSH2_PACKET_MAXPAYLOAD)
                     return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
                 /* name_len(4) + value_len(4) + mandatory(1) */

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -551,7 +551,7 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
     unsigned long comment_len = 0;
     int rc;
 
-    if(!pkey)
+    if(!pkey || !name || !blob || (num_attrs && !attrs))
         return LIBSSH2_ERROR_BAD_USE;
 
     if(name_len > LIBSSH2_PACKET_MAXPAYLOAD ||

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -578,8 +578,9 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
                 if(attrs[i].name_len == (sizeof("comment") - 1) &&
                    attrs[i].name &&
                    !strncmp(attrs[i].name, "comment", sizeof("comment") - 1)) {
-                    if(!attrs[i].value ||
-                       attrs[i].value_len > LIBSSH2_PACKET_MAXPAYLOAD)
+                    if(!attrs[i].value)
+                        return LIBSSH2_ERROR_BAD_USE;
+                    if(attrs[i].value_len > LIBSSH2_PACKET_MAXPAYLOAD)
                         return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
                     comment = (const unsigned char *)attrs[i].value;
                     comment_len = attrs[i].value_len;
@@ -592,8 +593,9 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
             packet_len += 5; /* overwrite(1) + attribute_count(4) */
             for(i = 0; i < num_attrs; i++) {
                 if(!attrs[i].name ||
-                   !attrs[i].value ||
-                   attrs[i].name_len > LIBSSH2_PACKET_MAXPAYLOAD ||
+                   !attrs[i].value)
+                    return LIBSSH2_ERROR_BAD_USE;
+                if(attrs[i].name_len > LIBSSH2_PACKET_MAXPAYLOAD ||
                    attrs[i].value_len > LIBSSH2_PACKET_MAXPAYLOAD)
                     return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
                 /* name_len(4) + value_len(4) + mandatory(1) */

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -576,6 +576,7 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
             for(i = 0; i < num_attrs; i++) {
                 /* Search for a comment attribute */
                 if(attrs[i].name_len == (sizeof("comment") - 1) &&
+                   attrs[i].name &&
                    !strncmp(attrs[i].name, "comment", sizeof("comment") - 1)) {
                     if(!attrs[i].value ||
                        attrs[i].value_len > LIBSSH2_PACKET_MAXPAYLOAD)
@@ -600,7 +601,7 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
             }
         }
 
-        if(packet_len > LIBSSH2_PACKET_MAXPAYLOAD)
+        if((packet_len - 4) > LIBSSH2_PACKET_MAXPAYLOAD)
             return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                             "Packet too large");
 
@@ -725,7 +726,7 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
     if(pkey->remove_state == ssh2_NB_state_idle) {
         pkey->remove_packet = NULL;
 
-        if(packet_len > LIBSSH2_PACKET_MAXPAYLOAD)
+        if((packet_len - 4) > LIBSSH2_PACKET_MAXPAYLOAD)
             return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                             "Packet too large");
 


### PR DESCRIPTION
In `libssh2_publickey_add*()`, `libssh2_publickey_remove*()`,
`libssh2_publickey_init()`.

Check them for NULL, keep them within packet size limits. Also apply
attribute count limit introduced earlier for received data.

To avoid crashing or sending inconsistent / broken, overly large packets
when called with bad arguments.
