### PR TITLE
src: use abstract internal time type, bump resolution to milliseconds

### DIFF
--- a/docs/libssh2_keepalive_config.md
+++ b/docs/libssh2_keepalive_config.md
@@ -19,14 +19,14 @@ libssh2_keepalive_config - short function description
 
 void libssh2_keepalive_config(LIBSSH2_SESSION *session,
                               int want_reply,
-                              unsigned int interval);
+                              unsigned int interval_s);
 ~~~
 
 # DESCRIPTION
 
 Set how often keepalive messages should be sent. **want_reply** indicates
 whether the keepalive messages should request a response from the server.
-**interval** is number of seconds that can pass without any I/O, use 0 (the
+**interval_s** is number of seconds that can pass without any I/O, use 0 (the
 default) to disable keepalives. To avoid some busy-loop corner-cases, if you
 specify an interval of 1 it is treated as 2.
 

--- a/docs/libssh2_keepalive_config.md
+++ b/docs/libssh2_keepalive_config.md
@@ -28,7 +28,7 @@ Set how often keepalive messages should be sent. **want_reply** indicates
 whether the keepalive messages should request a response from the server.
 **interval_s** is number of seconds that can pass without any I/O, use 0 (the
 default) to disable keepalives. To avoid some busy-loop corner-cases, if you
-specify an interval of 1 it is treated as 2.
+specify an **interval_s** of 1 it is treated as 2.
 
 Note that non-blocking applications are responsible for sending the keepalive
 messages using **libssh2_keepalive_send(3)**.

--- a/docs/libssh2_poll.md
+++ b/docs/libssh2_poll.md
@@ -17,7 +17,7 @@ libssh2_poll - poll for activity on a socket, channel or listener
 ~~~c
 #include <libssh2.h>
 
-int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout);
+int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms);
 ~~~
 
 # DESCRIPTION

--- a/docs/libssh2_session_set_read_timeout.md
+++ b/docs/libssh2_session_set_read_timeout.md
@@ -17,12 +17,13 @@ libssh2_session_set_read_timeout - set timeout for packet read functions
 ~~~c
 #include <libssh2.h>
 
-void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout);
+void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session,
+                                      long timeout_s);
 ~~~
 
 # DESCRIPTION
 
-Set the **timeout** in seconds for how long libssh2 packet read
+Set the **timeout_s** in seconds for how long libssh2 packet read
 function calls may wait until they consider the situation an error and return
 LIBSSH2_ERROR_TIMEOUT.
 

--- a/docs/libssh2_session_set_timeout.md
+++ b/docs/libssh2_session_set_timeout.md
@@ -17,12 +17,12 @@ libssh2_session_set_timeout - set timeout for blocking functions
 ~~~c
 #include <libssh2.h>
 
-void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout);
+void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout_ms);
 ~~~
 
 # DESCRIPTION
 
-Set the **timeout** in milliseconds for how long a blocking the libssh2
+Set the **timeout_ms** in milliseconds for how long a blocking the libssh2
 function calls may wait until they consider the situation an error and return
 LIBSSH2_ERROR_TIMEOUT.
 

--- a/docs/libssh2_session_set_timeout.md
+++ b/docs/libssh2_session_set_timeout.md
@@ -22,8 +22,8 @@ void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout_ms);
 
 # DESCRIPTION
 
-Set the **timeout_ms** in milliseconds for how long a blocking the libssh2
-function calls may wait until they consider the situation an error and return
+Set the **timeout_ms** in milliseconds for how long a blocking libssh2 function
+call may wait before it considers the situation an error and returns
 LIBSSH2_ERROR_TIMEOUT.
 
 By default or if you set the timeout to zero, libssh2 has no timeout for

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -781,7 +781,7 @@ LIBSSH2_API int libssh2_sign_sk(LIBSSH2_SESSION *session,
 #ifndef LIBSSH2_NO_DEPRECATED
 LIBSSH2_DEPRECATED(1.2.0, "Use system poll() or select()")
 LIBSSH2_API int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds,
-                             long timeout);
+                             long timeout_ms);
 #endif
 
 /* Channel API */
@@ -957,11 +957,11 @@ LIBSSH2_API void libssh2_channel_set_blocking(LIBSSH2_CHANNEL *channel,
                                               int blocking);
 
 LIBSSH2_API void libssh2_session_set_timeout(LIBSSH2_SESSION *session,
-                                             long timeout);
+                                             long timeout_ms);
 LIBSSH2_API long libssh2_session_get_timeout(LIBSSH2_SESSION *session);
 
 LIBSSH2_API void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session,
-                                                  long timeout);
+                                                  long timeout_s);
 LIBSSH2_API long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session);
 
 #ifndef LIBSSH2_NO_DEPRECATED

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1430,7 +1430,7 @@ LIBSSH2_API const char *libssh2_agent_get_identity_path(LIBSSH2_AGENT *agent);
  */
 LIBSSH2_API void libssh2_keepalive_config(LIBSSH2_SESSION *session,
                                           int want_reply,
-                                          unsigned int interval);
+                                          unsigned int interval_s);
 
 /*
  * libssh2_keepalive_send()

--- a/src/global.c
+++ b/src/global.c
@@ -41,13 +41,12 @@ int libssh2_init(int flags)
     if(ssh2_s_initialized == 0 && !(flags & LIBSSH2_INIT_NO_CRYPTO))
         ssh2_crypto_init();
 
+#ifdef _WIN32
+    ssh2_now_init();
+#endif
+
     ssh2_s_initialized++;
     ssh2_s_init_flags |= flags;
-
-#ifdef _WIN32
-    if(!ssh2_now_init())
-        return LIBSSH2_ERROR_METHOD_NOT_SUPPORTED;
-#endif
 
     return 0;
 }

--- a/src/global.c
+++ b/src/global.c
@@ -44,6 +44,11 @@ int libssh2_init(int flags)
     ssh2_s_initialized++;
     ssh2_s_init_flags |= flags;
 
+#ifdef _WIN32
+    if(!ssh2_now_init())
+        return LIBSSH2_ERROR_METHOD_NOT_SUPPORTED;
+#endif
+
     return 0;
 }
 

--- a/src/global.c
+++ b/src/global.c
@@ -41,10 +41,6 @@ int libssh2_init(int flags)
     if(ssh2_s_initialized == 0 && !(flags & LIBSSH2_INIT_NO_CRYPTO))
         ssh2_crypto_init();
 
-#ifdef _WIN32
-    ssh2_now_init();
-#endif
-
     ssh2_s_initialized++;
     ssh2_s_init_flags |= flags;
 

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -88,7 +88,8 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 
     if(seconds_to_next) {
         ssh2_timediff_t to_next = ssh2_timediff_to_sec(
-            session->keepalive_interval + session->keepalive_last_sent - now);
+            session->keepalive_interval +
+            (ssh2_timediff_t)(session->keepalive_last_sent - now));
         *seconds_to_next = (int)SSH2_MIN(to_next, INT_MAX);
     }
 

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -37,15 +37,15 @@
 
 void libssh2_keepalive_config(LIBSSH2_SESSION *session,
                               int want_reply,
-                              unsigned int interval)
+                              unsigned int interval_s)
 {
     if(!session)
         return;
 
-    if(interval == 1)
+    if(interval_s == 1)
         session->keepalive_interval = ssh2_sec_to_timediff(2);
     else
-        session->keepalive_interval = ssh2_sec_to_timediff(interval);
+        session->keepalive_interval = ssh2_sec_to_timediff(interval_s);
     session->keepalive_want_reply = want_reply ? 1 : 0;
 }
 

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -52,7 +52,6 @@ void libssh2_keepalive_config(LIBSSH2_SESSION *session,
 int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 {
     ssh2_time_t now;
-    ssh2_timediff_t to_next;
 
     if(!session)
         return LIBSSH2_ERROR_BAD_USE;
@@ -85,15 +84,13 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
         }
 
         session->keepalive_last_sent = now;
-
-        to_next = ssh2_timediff_to_sec(session->keepalive_interval);
     }
-    else
-        to_next = ssh2_timediff_to_sec(session->keepalive_interval +
-            (ssh2_timediff_t)(session->keepalive_last_sent - now));
 
-    if(seconds_to_next)
+    if(seconds_to_next) {
+        ssh2_timediff_t to_next = ssh2_timediff_to_sec(
+            session->keepalive_interval + session->keepalive_last_sent - now);
         *seconds_to_next = (int)SSH2_MIN(to_next, INT_MAX);
+    }
 
     return LIBSSH2_ERROR_NONE;
 }

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -51,7 +51,7 @@ void libssh2_keepalive_config(LIBSSH2_SESSION *session,
 
 int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 {
-    time_t now;
+    ssh2_time_t now;
 
     if(!session)
         return LIBSSH2_ERROR_BAD_USE;
@@ -62,7 +62,7 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
         return LIBSSH2_ERROR_NONE;
     }
 
-    now = time(NULL);
+    now = ssh2_now();
 
     if(session->keepalive_last_sent + session->keepalive_interval <= now) {
         /* Format is

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -85,11 +85,12 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 
         session->keepalive_last_sent = now;
         if(seconds_to_next)
-            *seconds_to_next =
-                ssh2_timediff_to_sec(session->keepalive_interval);
+            *seconds_to_next = (int)ssh2_timediff_to_sec(
+                session->keepalive_interval);
     }
     else if(seconds_to_next)
-        *seconds_to_next = ssh2_timediff_to_sec(session->keepalive_interval +
+        *seconds_to_next = (int)ssh2_timediff_to_sec(
+            session->keepalive_interval +
             (ssh2_timediff_t)(session->keepalive_last_sent - now));
 
     return LIBSSH2_ERROR_NONE;

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -64,7 +64,7 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 
     now = ssh2_now();
 
-    if(session->keepalive_last_sent + session->keepalive_interval <= now) {
+    if(now >= session->keepalive_last_sent + session->keepalive_interval) {
         /* Format is
            "SSH_MSG_GLOBAL_REQUEST || 4-byte len || str || want-reply". */
         unsigned char keepalive_data[] =

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -52,6 +52,7 @@ void libssh2_keepalive_config(LIBSSH2_SESSION *session,
 int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 {
     ssh2_time_t now;
+    ssh2_timediff_t to_next;
 
     if(!session)
         return LIBSSH2_ERROR_BAD_USE;
@@ -84,14 +85,15 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
         }
 
         session->keepalive_last_sent = now;
-        if(seconds_to_next)
-            *seconds_to_next = (int)ssh2_timediff_to_sec(
-                session->keepalive_interval);
+
+        to_next = ssh2_timediff_to_sec(session->keepalive_interval);
     }
-    else if(seconds_to_next)
-        *seconds_to_next = (int)ssh2_timediff_to_sec(
-            session->keepalive_interval +
+    else
+        to_next = ssh2_timediff_to_sec(session->keepalive_interval +
             (ssh2_timediff_t)(session->keepalive_last_sent - now));
+
+    if(seconds_to_next)
+        *seconds_to_next = (int)SSH2_MIN(to_next, INT_MAX);
 
     return LIBSSH2_ERROR_NONE;
 }

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -89,7 +89,7 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
     if(seconds_to_next) {
         ssh2_timediff_t to_next = ssh2_timediff_to_sec(
             session->keepalive_interval +
-            (ssh2_timediff_t)(session->keepalive_last_sent - now));
+            (session->keepalive_last_sent - now));
         *seconds_to_next = (int)SSH2_MIN(to_next, INT_MAX);
     }
 

--- a/src/keepalive.c
+++ b/src/keepalive.c
@@ -43,9 +43,9 @@ void libssh2_keepalive_config(LIBSSH2_SESSION *session,
         return;
 
     if(interval == 1)
-        session->keepalive_interval = 2;
+        session->keepalive_interval = ssh2_sec_to_timediff(2);
     else
-        session->keepalive_interval = interval;
+        session->keepalive_interval = ssh2_sec_to_timediff(interval);
     session->keepalive_want_reply = want_reply ? 1 : 0;
 }
 
@@ -85,11 +85,12 @@ int libssh2_keepalive_send(LIBSSH2_SESSION *session, int *seconds_to_next)
 
         session->keepalive_last_sent = now;
         if(seconds_to_next)
-            *seconds_to_next = session->keepalive_interval;
+            *seconds_to_next =
+                ssh2_timediff_to_sec(session->keepalive_interval);
     }
     else if(seconds_to_next)
-        *seconds_to_next = (int)(session->keepalive_last_sent - now) +
-            session->keepalive_interval;
+        *seconds_to_next = ssh2_timediff_to_sec(session->keepalive_interval +
+            (ssh2_timediff_t)(session->keepalive_last_sent - now));
 
     return LIBSSH2_ERROR_NONE;
 }

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -305,7 +305,7 @@ typedef enum {
 #define ssh2_timediff_t           long
 #define ssh2_sec_to_timediff(sec) (sec)
 #define ssh2_timediff_to_sec(td)  (td)
-#define ssh2_ms_to_timediff(sec)  ((sec) / 1000)
+#define ssh2_ms_to_timediff(ms)   ((ms) / 1000)
 #define ssh2_timediff_to_ms(td)   ((td) * 1000)
 
 struct packet_require_state {

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -300,8 +300,11 @@ typedef enum {
     ssh2_NB_state_jumpauthagent
 } ssh2_NB_states;
 
-#define ssh2_time_t time_t
-#define ssh2_now()  time(NULL)
+#define ssh2_sec_to_timediff(sec) (sec)
+#define ssh2_timediff_to_sec(td)  (td)
+#define ssh2_timediff_t           long
+#define ssh2_time_t               time_t
+#define ssh2_now()                time(NULL)
 
 struct packet_require_state {
     ssh2_NB_states state;
@@ -716,7 +719,7 @@ struct _LIBSSH2_SESSION {
     int api_block_mode;
 
     /* Timeout used when blocking API behavior is active */
-    long api_timeout;
+    ssh2_timediff_t api_timeout;
 
     /* Server's public key */
     const struct hostkey_method *hostkey;
@@ -956,7 +959,7 @@ struct _LIBSSH2_SESSION {
     ssh2_time_t keepalive_last_sent;
 
     /* Configurable timeout for packets. Replaces LIBSSH2_READ_TIMEOUT */
-    long packet_read_timeout;
+    ssh2_timediff_t packet_read_timeout;
 };
 #if defined(__clang__) && __clang_major__ >= 13
 #pragma clang diagnostic pop

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -721,7 +721,7 @@ struct _LIBSSH2_SESSION {
     int api_block_mode;
 
     /* Timeout used when blocking API behavior is active */
-    long api_timeout;  /* FIXME: switch to ssh2_timediff_t */
+    long api_timeout_ms;
 
     /* Server's public key */
     const struct hostkey_method *hostkey;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -300,13 +300,13 @@ typedef enum {
     ssh2_NB_state_jumpauthagent
 } ssh2_NB_states;
 
-#define ssh2_time_t               time_t
-#define ssh2_now()                time(NULL)
-#define ssh2_timediff_t           long
-#define ssh2_sec_to_timediff(sec) (sec)
-#define ssh2_timediff_to_sec(td)  (td)
-#define ssh2_ms_to_timediff(ms)   ((ms) / 1000)
-#define ssh2_timediff_to_ms(td)   ((td) * 1000)
+#define ssh2_time_t               libssh2_uint64_t
+#define ssh2_now()                (time(NULL) * 1000)
+#define ssh2_timediff_t           libssh2_int64_t
+#define ssh2_sec_to_timediff(sec) ((sec) * 1000)
+#define ssh2_timediff_to_sec(td)  ((td) / 1000)
+#define ssh2_ms_to_timediff(ms)   (ms)
+#define ssh2_timediff_to_ms(td)   (td)
 
 struct packet_require_state {
     ssh2_NB_states state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -300,7 +300,7 @@ typedef enum {
     ssh2_NB_state_jumpauthagent
 } ssh2_NB_states;
 
-#define ssh2_time_t               libssh2_uint64_t
+#define ssh2_time_t               libssh2_int64_t
 #define ssh2_now()                ((ssh2_time_t)time(NULL) * 1000)
 #define ssh2_timediff_t           libssh2_int64_t
 #define ssh2_sec_to_timediff(sec) ((ssh2_time_t)(sec) * 1000)

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -305,6 +305,8 @@ typedef enum {
 #define ssh2_timediff_t           long
 #define ssh2_sec_to_timediff(sec) (sec)
 #define ssh2_timediff_to_sec(td)  (td)
+#define ssh2_ms_to_timediff(sec)  ((sec) / 1000)
+#define ssh2_timediff_to_ms(td)   ((td) * 1000)
 
 struct packet_require_state {
     ssh2_NB_states state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -307,6 +307,9 @@ typedef enum {
 #define ssh2_ms_to_timediff(ms)   ((ssh2_time_t)(ms))
 #define ssh2_timediff_to_ms(td)   (td)
 ssh2_time_t ssh2_now(void);
+#ifdef _WIN32
+int ssh2_now_init(void);
+#endif
 
 struct packet_require_state {
     ssh2_NB_states state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -300,11 +300,11 @@ typedef enum {
     ssh2_NB_state_jumpauthagent
 } ssh2_NB_states;
 
-#define ssh2_sec_to_timediff(sec) (sec)
-#define ssh2_timediff_to_sec(td)  (td)
-#define ssh2_timediff_t           long
 #define ssh2_time_t               time_t
 #define ssh2_now()                time(NULL)
+#define ssh2_timediff_t           long
+#define ssh2_sec_to_timediff(sec) (sec)
+#define ssh2_timediff_to_sec(td)  (td)
 
 struct packet_require_state {
     ssh2_NB_states state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -300,8 +300,8 @@ typedef enum {
     ssh2_NB_state_jumpauthagent
 } ssh2_NB_states;
 
-#define ssh2_time_t               libssh2_int64_t
-#define ssh2_timediff_t           libssh2_int64_t
+#define ssh2_time_t               libssh2_int64_t /* ms */
+#define ssh2_timediff_t           libssh2_int64_t /* ms */
 #define ssh2_sec_to_timediff(sec) ((ssh2_time_t)(sec) * 1000)
 #define ssh2_timediff_to_sec(td)  ((td) / 1000)
 #define ssh2_ms_to_timediff(ms)   ((ssh2_time_t)(ms))

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -307,9 +307,6 @@ typedef enum {
 #define ssh2_ms_to_timediff(ms)   ((ssh2_time_t)(ms))
 #define ssh2_timediff_to_ms(td)   (td)
 ssh2_time_t ssh2_now(void);
-#ifdef _WIN32
-int ssh2_now_init(void);
-#endif
 
 struct packet_require_state {
     ssh2_NB_states state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -954,7 +954,7 @@ struct _LIBSSH2_SESSION {
     LIBSSH2_CHANNEL *scpSend_channel;
 
     /* Keepalive variables used by keepalive.c. */
-    int keepalive_interval;
+    ssh2_timediff_t keepalive_interval;
     int keepalive_want_reply;
     ssh2_time_t keepalive_last_sent;
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -301,12 +301,12 @@ typedef enum {
 } ssh2_NB_states;
 
 #define ssh2_time_t               libssh2_int64_t
-#define ssh2_now()                ((ssh2_time_t)time(NULL) * 1000)
 #define ssh2_timediff_t           libssh2_int64_t
 #define ssh2_sec_to_timediff(sec) ((ssh2_time_t)(sec) * 1000)
 #define ssh2_timediff_to_sec(td)  ((td) / 1000)
 #define ssh2_ms_to_timediff(ms)   ((ssh2_time_t)(ms))
 #define ssh2_timediff_to_ms(td)   (td)
+ssh2_time_t ssh2_now(void);
 
 struct packet_require_state {
     ssh2_NB_states state;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -721,7 +721,7 @@ struct _LIBSSH2_SESSION {
     int api_block_mode;
 
     /* Timeout used when blocking API behavior is active */
-    ssh2_timediff_t api_timeout;
+    long api_timeout;  /* FIXME: switch to ssh2_timediff_t */
 
     /* Server's public key */
     const struct hostkey_method *hostkey;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -953,7 +953,7 @@ struct _LIBSSH2_SESSION {
     /* Keepalive variables used by keepalive.c. */
     int keepalive_interval;
     int keepalive_want_reply;
-    time_t keepalive_last_sent;
+    ssh2_time_t keepalive_last_sent;
 
     /* Configurable timeout for packets. Replaces LIBSSH2_READ_TIMEOUT */
     long packet_read_timeout;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -300,13 +300,16 @@ typedef enum {
     ssh2_NB_state_jumpauthagent
 } ssh2_NB_states;
 
+#define ssh2_time_t time_t
+#define ssh2_now()  time(NULL)
+
 struct packet_require_state {
     ssh2_NB_states state;
-    time_t start;
+    ssh2_time_t start;
 };
 
 struct packet_requirev_state {
-    time_t start;
+    ssh2_time_t start;
 };
 
 struct kmdhgGPshakex_state {

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -301,11 +301,11 @@ typedef enum {
 } ssh2_NB_states;
 
 #define ssh2_time_t               libssh2_uint64_t
-#define ssh2_now()                (time(NULL) * 1000)
+#define ssh2_now()                ((ssh2_time_t)time(NULL) * 1000)
 #define ssh2_timediff_t           libssh2_int64_t
-#define ssh2_sec_to_timediff(sec) ((sec) * 1000)
+#define ssh2_sec_to_timediff(sec) ((ssh2_time_t)(sec) * 1000)
 #define ssh2_timediff_to_sec(td)  ((td) / 1000)
-#define ssh2_ms_to_timediff(ms)   (ms)
+#define ssh2_ms_to_timediff(ms)   ((ssh2_time_t)(ms))
 #define ssh2_timediff_to_ms(td)   (td)
 
 struct packet_require_state {

--- a/src/misc.c
+++ b/src/misc.c
@@ -718,26 +718,19 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
 }
 #endif
 
-#ifdef _WIN32
-static LARGE_INTEGER s_time_freq;
-
-void ssh2_now_init(void)
-{
-    QueryPerformanceFrequency(&s_time_freq);
-}
-#endif
-
 ssh2_time_t ssh2_now(void) /* ms */
 {
 #ifdef _WIN32
-    LARGE_INTEGER count;
-    ssh2_time_t ms, sec, ns;
+    LARGE_INTEGER time_freq, count;
+    ssh2_time_t sec, ns;
 
+    /* These never fail on supported Windows versions */
+    QueryPerformanceFrequency(&time_freq);
     QueryPerformanceCounter(&count);
 
-    sec = (ssh2_time_t)(count.QuadPart / s_time_freq.QuadPart);
-    ns = (ssh2_time_t)(((count.QuadPart % s_time_freq.QuadPart) *
-        1000 * 1000 * 1000) / s_time_freq.QuadPart);
+    sec = (ssh2_time_t)(count.QuadPart / time_freq.QuadPart);
+    ns = (ssh2_time_t)(((count.QuadPart % time_freq.QuadPart) *
+        1000 * 1000 * 1000) / time_freq.QuadPart);
 
     return sec * 1000 + ns / 1000000;
 #else /* !_WIN32 */

--- a/src/misc.c
+++ b/src/misc.c
@@ -726,6 +726,7 @@ ssh2_time_t ssh2_now(void) /* ms */
     ssh2_time_t sec, ns;
 
     QueryPerformanceFrequency(&time_freq);
+    assert(time_freq.QuadPart);
     QueryPerformanceCounter(&count);
 
     sec = (ssh2_time_t)(count.QuadPart / time_freq.QuadPart);

--- a/src/misc.c
+++ b/src/misc.c
@@ -747,8 +747,7 @@ ssh2_time_t ssh2_now(void) /* ms */
 #elif defined(HAVE_GETTIMEOFDAY)
     struct timeval tv;
     if(!gettimeofday(&tv, NULL))
-        return (ssh2_time_t)tv.tv_sec * 1000 +
-            (ssh2_time_t)tv.tv_usec / 1000;
+        return (ssh2_time_t)tv.tv_sec * 1000 + (ssh2_time_t)tv.tv_usec / 1000;
 #endif
     {
         ssh2_time_t ms = (ssh2_time_t)time(NULL) * 1000;

--- a/src/misc.c
+++ b/src/misc.c
@@ -718,35 +718,46 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
 }
 #endif
 
+#ifdef _WIN32
+static LARGE_INTEGER s_time_freq;
+
+int ssh2_now_init(void)
+{
+    QueryPerformanceFrequency(&s_time_freq);
+    assert(s_time_freq.QuadPart);
+    return !!s_time_freq.QuadPart;
+}
+#endif
+
 ssh2_time_t ssh2_now(void) /* ms */
 {
 #ifdef _WIN32
-    /* Via https://stackoverflow.com/questions/5404277/porting-clock-gettime-to-windows */
-    LARGE_INTEGER time_freq, count;
+    LARGE_INTEGER count;
     ssh2_time_t sec, ns;
 
-    QueryPerformanceFrequency(&time_freq);
-    assert(time_freq.QuadPart);
     QueryPerformanceCounter(&count);
 
-    sec = (ssh2_time_t)(count.QuadPart / time_freq.QuadPart);
-    ns = (ssh2_time_t)(((count.QuadPart % time_freq.QuadPart) *
-        1000 * 1000 * 1000) / time_freq.QuadPart);
+    sec = (ssh2_time_t)(count.QuadPart / s_time_freq.QuadPart);
+    ns = (ssh2_time_t)(((count.QuadPart % s_time_freq.QuadPart) *
+        1000 * 1000 * 1000) / s_time_freq.QuadPart);
 
-    return sec * 1000 + ns / 1000 / 1000;
+    return sec * 1000 + ns / 1000000;
 #else /* !_WIN32 */
 #if defined(CLOCK_MONOTONIC_RAW) /* Apple/Linux */
     struct timespec ts;
     if(!clock_gettime(CLOCK_MONOTONIC_RAW, &ts))
-        return ts.tv_sec * 1000 + ts.tv_nsec / 1000 / 1000;
+        return (ssh2_time_t)ts.tv_sec * 1000 +
+            (ssh2_time_t)ts.tv_nsec / 1000000;
 #elif defined(CLOCK_MONOTONIC) /* POSIX */
     struct timespec ts;
     if(!clock_gettime(CLOCK_MONOTONIC, &ts))
-        return ts.tv_sec * 1000 + ts.tv_nsec / 1000 / 1000;
+        return (ssh2_time_t)ts.tv_sec * 1000 +
+            (ssh2_time_t)ts.tv_nsec / 1000000;
 #elif defined(HAVE_GETTIMEOFDAY)
-    struct timeval ts;
-    if(!gettimeofday(&ts, NULL))
-        return ts.tv_sec * 1000 + ts.tv_usec / 1000;
+    struct timeval tv;
+    if(!gettimeofday(&tv, NULL))
+        return (ssh2_time_t)tv.tv_sec * 1000 +
+            (ssh2_time_t)tv.tv_usec / 1000;
 #endif
     {
         ssh2_time_t now = (ssh2_time_t)time(NULL) * 1000;

--- a/src/misc.c
+++ b/src/misc.c
@@ -718,6 +718,39 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
 }
 #endif
 
+ssh2_time_t ssh2_now(void) /* ms */
+{
+#ifdef _WIN32
+    /* Via https://stackoverflow.com/questions/5404277/porting-clock-gettime-to-windows */
+    LARGE_INTEGER time_freq, count;
+    ssh2_time_t sec, ns;
+
+    QueryPerformanceFrequency(&time_freq);
+    QueryPerformanceCounter(&count);
+
+    sec = (ssh2_time_t)(count.QuadPart / time_freq.QuadPart);
+    ns = (ssh2_time_t)(((count.QuadPart % time_freq.QuadPart) *
+        1000 * 1000 * 1000) / time_freq.QuadPart);
+
+    return sec * 1000 + ns / 1000 / 1000;
+#else /* !_WIN32 */
+#if defined(CLOCK_MONOTONIC_RAW) /* Apple/Linux */
+    struct timespec ts;
+    if(!clock_gettime(CLOCK_MONOTONIC_RAW, &ts))
+        return ts.tv_sec * 1000 + ts.tv_nsec / 1000 / 1000;
+#elif defined(CLOCK_MONOTONIC) /* POSIX */
+    struct timespec ts;
+    if(!clock_gettime(CLOCK_MONOTONIC, &ts))
+        return ts.tv_sec * 1000 + ts.tv_nsec / 1000 / 1000;
+#elif defiend(HAVE_GETTIMEOFDAY)
+    struct timeval ts;
+    if(!gettimeofday(&ts, NULL))
+        return ts.tv_sec * 1000 + ts.tv_usec / 1000;
+#endif
+    return (ssh2_time_t)time(NULL) * 1000; /* fallback */
+#endif /* _WIN32 */
+}
+
 #ifndef HAVE_GETTIMEOFDAY
 /*
  * Implementation according to:

--- a/src/misc.c
+++ b/src/misc.c
@@ -742,7 +742,7 @@ ssh2_time_t ssh2_now(void) /* ms */
     struct timespec ts;
     if(!clock_gettime(CLOCK_MONOTONIC, &ts))
         return ts.tv_sec * 1000 + ts.tv_nsec / 1000 / 1000;
-#elif defiend(HAVE_GETTIMEOFDAY)
+#elif defined(HAVE_GETTIMEOFDAY)
     struct timeval ts;
     if(!gettimeofday(&ts, NULL))
         return ts.tv_sec * 1000 + ts.tv_usec / 1000;

--- a/src/misc.c
+++ b/src/misc.c
@@ -721,17 +721,14 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
 ssh2_time_t ssh2_now(void) /* ms */
 {
 #ifdef _WIN32
-    LARGE_INTEGER time_freq, count;
     ssh2_time_t sec, ns;
-
+    LARGE_INTEGER freq, count;
     /* These never fail on supported Windows versions */
-    QueryPerformanceFrequency(&time_freq);
+    QueryPerformanceFrequency(&freq);
     QueryPerformanceCounter(&count);
-
-    sec = (ssh2_time_t)(count.QuadPart / time_freq.QuadPart);
-    ns = (ssh2_time_t)(((count.QuadPart % time_freq.QuadPart) *
-        1000 * 1000 * 1000) / time_freq.QuadPart);
-
+    sec = (ssh2_time_t)(count.QuadPart / freq.QuadPart);
+    ns = (ssh2_time_t)(((count.QuadPart % freq.QuadPart) *
+        1000000000) / freq.QuadPart);
     return sec * 1000 + ns / 1000000;
 #else /* !_WIN32 */
 #if defined(CLOCK_MONOTONIC_RAW) /* Apple/Linux */

--- a/src/misc.c
+++ b/src/misc.c
@@ -748,7 +748,10 @@ ssh2_time_t ssh2_now(void) /* ms */
     if(!gettimeofday(&ts, NULL))
         return ts.tv_sec * 1000 + ts.tv_usec / 1000;
 #endif
-    return (ssh2_time_t)time(NULL) * 1000; /* fallback */
+    {
+        ssh2_time_t now = (ssh2_time_t)time(NULL) * 1000;
+        return now ? now : 1;
+    }
 #endif /* _WIN32 */
 }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -721,11 +721,9 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
 #ifdef _WIN32
 static LARGE_INTEGER s_time_freq;
 
-int ssh2_now_init(void)
+void ssh2_now_init(void)
 {
     QueryPerformanceFrequency(&s_time_freq);
-    assert(s_time_freq.QuadPart);
-    return !!s_time_freq.QuadPart;
 }
 #endif
 
@@ -740,9 +738,8 @@ ssh2_time_t ssh2_now(void) /* ms */
     sec = (ssh2_time_t)(count.QuadPart / s_time_freq.QuadPart);
     ns = (ssh2_time_t)(((count.QuadPart % s_time_freq.QuadPart) *
         1000 * 1000 * 1000) / s_time_freq.QuadPart);
-    ms = sec * 1000 + ns / 1000000
 
-    return ms ? ms : 1;
+    return sec * 1000 + ns / 1000000;
 #else /* !_WIN32 */
 #if defined(CLOCK_MONOTONIC_RAW) /* Apple/Linux */
     struct timespec ts;

--- a/src/misc.c
+++ b/src/misc.c
@@ -733,15 +733,16 @@ ssh2_time_t ssh2_now(void) /* ms */
 {
 #ifdef _WIN32
     LARGE_INTEGER count;
-    ssh2_time_t sec, ns;
+    ssh2_time_t ms, sec, ns;
 
     QueryPerformanceCounter(&count);
 
     sec = (ssh2_time_t)(count.QuadPart / s_time_freq.QuadPart);
     ns = (ssh2_time_t)(((count.QuadPart % s_time_freq.QuadPart) *
         1000 * 1000 * 1000) / s_time_freq.QuadPart);
+    ms = sec * 1000 + ns / 1000000
 
-    return sec * 1000 + ns / 1000000;
+    return ms ? ms : 1;
 #else /* !_WIN32 */
 #if defined(CLOCK_MONOTONIC_RAW) /* Apple/Linux */
     struct timespec ts;
@@ -760,8 +761,8 @@ ssh2_time_t ssh2_now(void) /* ms */
             (ssh2_time_t)tv.tv_usec / 1000;
 #endif
     {
-        ssh2_time_t now = (ssh2_time_t)time(NULL) * 1000;
-        return now ? now : 1;
+        ssh2_time_t ms = (ssh2_time_t)time(NULL) * 1000;
+        return ms ? ms : 1;
     }
 #endif /* _WIN32 */
 }

--- a/src/packet.c
+++ b/src/packet.c
@@ -1461,7 +1461,7 @@ int ssh2_packet_require(LIBSSH2_SESSION *session,
                            match_len) == 0)
             return 0;  /* A packet was available in the packet brigade */
 
-        state->start = time(NULL);
+        state->start = ssh2_now();
     }
 
     while(session->socket_state == SSH2_SOCKET_CONNECTED) {
@@ -1485,7 +1485,7 @@ int ssh2_packet_require(LIBSSH2_SESSION *session,
         }
         else if(ret == 0) {
             /* nothing available, wait until data arrives or we time out */
-            long left = session->packet_read_timeout - (long)(time(NULL) -
+            long left = session->packet_read_timeout - (long)(ssh2_now() -
                                                               state->start);
 
             if(left <= 0) {
@@ -1575,7 +1575,7 @@ int ssh2_packet_requirev(LIBSSH2_SESSION *session,
     }
 
     if(state->start == 0)
-        state->start = time(NULL);
+        state->start = ssh2_now();
 
     while(session->socket_state != SSH2_SOCKET_DISCONNECTED) {
         int ret = ssh2_transport_read(session);
@@ -1585,7 +1585,7 @@ int ssh2_packet_requirev(LIBSSH2_SESSION *session,
         }
         if(ret <= 0) {
             long left = session->packet_read_timeout -
-                (long)(time(NULL) - state->start);
+                (long)(ssh2_now() - state->start);
 
             if(left <= 0) {
                 state->start = 0;

--- a/src/packet.c
+++ b/src/packet.c
@@ -1486,7 +1486,7 @@ int ssh2_packet_require(LIBSSH2_SESSION *session,
         else if(ret == 0) {
             /* nothing available, wait until data arrives or we time out */
             ssh2_timediff_t left = session->packet_read_timeout -
-                (ssh2_now() - state->start);
+                (ssh2_timediff_t)(ssh2_now() - state->start);
 
             if(left <= 0) {
                 state->start = 0;
@@ -1585,7 +1585,7 @@ int ssh2_packet_requirev(LIBSSH2_SESSION *session,
         }
         if(ret <= 0) {
             ssh2_timediff_t left = session->packet_read_timeout -
-                (ssh2_now() - state->start);
+                (ssh2_timediff_t)(ssh2_now() - state->start);
 
             if(left <= 0) {
                 state->start = 0;

--- a/src/packet.c
+++ b/src/packet.c
@@ -1486,7 +1486,7 @@ int ssh2_packet_require(LIBSSH2_SESSION *session,
         else if(ret == 0) {
             /* nothing available, wait until data arrives or we time out */
             ssh2_timediff_t left = session->packet_read_timeout -
-                (ssh2_timediff_t)(ssh2_now() - state->start);
+                (ssh2_now() - state->start);
 
             if(left <= 0) {
                 state->start = 0;
@@ -1585,7 +1585,7 @@ int ssh2_packet_requirev(LIBSSH2_SESSION *session,
         }
         if(ret <= 0) {
             ssh2_timediff_t left = session->packet_read_timeout -
-                (ssh2_timediff_t)(ssh2_now() - state->start);
+                (ssh2_now() - state->start);
 
             if(left <= 0) {
                 state->start = 0;

--- a/src/packet.c
+++ b/src/packet.c
@@ -1485,8 +1485,8 @@ int ssh2_packet_require(LIBSSH2_SESSION *session,
         }
         else if(ret == 0) {
             /* nothing available, wait until data arrives or we time out */
-            long left = session->packet_read_timeout - (long)(ssh2_now() -
-                                                              state->start);
+            ssh2_timediff_t left = session->packet_read_timeout -
+                (ssh2_timediff_t)(ssh2_now() - state->start);
 
             if(left <= 0) {
                 state->start = 0;
@@ -1584,8 +1584,8 @@ int ssh2_packet_requirev(LIBSSH2_SESSION *session,
             return ret;
         }
         if(ret <= 0) {
-            long left = session->packet_read_timeout -
-                (long)(ssh2_now() - state->start);
+            ssh2_timediff_t left = session->packet_read_timeout -
+                (ssh2_timediff_t)(ssh2_now() - state->start);
 
             if(left <= 0) {
                 state->start = 0;

--- a/src/session.c
+++ b/src/session.c
@@ -575,7 +575,8 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     if(api_timeout > 0 &&
        (seconds_to_next == 0 || time_to_next > api_timeout)) {
         ssh2_time_t now = ssh2_now();
-        elapsed_time = now > start_time ? (now - start_time) : 0;
+        elapsed_time = now > start_time ? (ssh2_timediff_t)(now - start_time)
+                                        : 0;
         if(elapsed_time > api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");

--- a/src/session.c
+++ b/src/session.c
@@ -1663,10 +1663,10 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
         {
             ssh2_timediff_t timeout_remaining_ms =
                 ssh2_timediff_to_ms(timeout_remaining);
-            ssh2_time_t being = ssh2_now();
+            ssh2_time_t begin = ssh2_now();
             sysret = poll(sockets, nfds,
                           (int)SSH2_MIN(timeout_remaining_ms, INT_MAX));
-            timeout_remaining -= ssh2_now() - start;
+            timeout_remaining -= ssh2_now() - begin;
         }
 
         if(sysret > 0) {
@@ -1717,9 +1717,9 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
         tv.tv_usec = (timeout_remaining % 1000) * 1000;
 #endif
         {
-            ssh2_time_t being = ssh2_now();
+            ssh2_time_t begin = ssh2_now();
             sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
-            timeout_remaining -= ssh2_now() - start;
+            timeout_remaining -= ssh2_now() - begin;
         }
 
         if(sysret > 0) {

--- a/src/session.c
+++ b/src/session.c
@@ -1454,7 +1454,7 @@ static SSH2_INLINE int session_poll_listener_queued(LIBSSH2_LISTENER *listener)
  */
 int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
 {
-    long timeout_remaining;
+    ssh2_timediff_t timeout_remaining;
     unsigned int i, active_fds;
 #ifdef HAVE_POLL
     LIBSSH2_SESSION *session = NULL;
@@ -1584,7 +1584,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
     timeout_ms = 0;  /* no sockets structure to setup */
 #endif /* HAVE_POLL || HAVE_SELECT */
 
-    timeout_remaining = timeout_ms;
+    timeout_remaining = ssh2_ms_to_timediff(timeout_ms);
     do {
 #if defined(HAVE_POLL) || defined(HAVE_SELECT)
         int sysret;
@@ -1661,12 +1661,12 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
 
 #ifdef HAVE_POLL
         {
-            struct timeval tv_begin, tv_end;
-            ssh2_gettimeofday(&tv_begin, NULL);
-            sysret = poll(sockets, nfds, (int)timeout_remaining);
-            ssh2_gettimeofday(&tv_end, NULL);
-            timeout_remaining -= (tv_end.tv_sec - tv_begin.tv_sec) * 1000;
-            timeout_remaining -= (tv_end.tv_usec - tv_begin.tv_usec) / 1000;
+            ssh2_timediff_t timeout_remaining_ms =
+                ssh2_timediff_to_ms(timeout_remaining);
+            ssh2_time_t being = ssh2_now();
+            sysret = poll(sockets, nfds,
+                          (int)SSH2_MIN(timeout_remaining_ms, INT_MAX));
+            timeout_remaining -= ssh2_now() - start;
         }
 
         if(sysret > 0) {
@@ -1717,12 +1717,9 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
         tv.tv_usec = (timeout_remaining % 1000) * 1000;
 #endif
         {
-            struct timeval tv_begin, tv_end;
-            ssh2_gettimeofday(&tv_begin, NULL);
+            ssh2_time_t being = ssh2_now();
             sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
-            ssh2_gettimeofday(&tv_end, NULL);
-            timeout_remaining -= (tv_end.tv_sec - tv_begin.tv_sec) * 1000;
-            timeout_remaining -= (tv_end.tv_usec - tv_begin.tv_usec) / 1000;
+            timeout_remaining -= ssh2_now() - start;
         }
 
         if(sysret > 0) {

--- a/src/session.c
+++ b/src/session.c
@@ -1763,7 +1763,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
             }
         }
 #endif /* !HAVE_POLL && !HAVE_SELECT -- timeout_ms (and by extension
-        * timeout_remaining) is equal to 0 */
+          timeout_remaining) is equal to 0 */
     } while(timeout_remaining > 0 && !active_fds);
 
 #ifdef HAVE_POLL

--- a/src/session.c
+++ b/src/session.c
@@ -412,7 +412,7 @@ LIBSSH2_SESSION *libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
         session->send = ssh2_send;
         session->recv = ssh2_recv;
         session->abstract = abstract;
-        session->api_timeout = 0; /* timeout-free API by default */
+        session->api_timeout_ms = 0; /* timeout-free API by default */
         session->api_block_mode = 1; /* blocking API by default */
         session->state = SSH2_STATE_INITIAL_KEX;
         session->fullpacket_required_type = 0;
@@ -547,7 +547,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     int has_timeout;
     ssh2_timediff_t time_to_next = 0;
     ssh2_timediff_t elapsed_time;
-    ssh2_timediff_t api_timediff_t = ssh2_ms_to_timediff(session->api_timeout);
+    ssh2_timediff_t api_timeout = ssh2_ms_to_timediff(session->api_timeout_ms);
 
     /* since libssh2 often sets EAGAIN internally before this function is
        called, we can decrease some amount of confusion in user programs by
@@ -572,16 +572,16 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         time_to_next = ssh2_sec_to_timediff(1);
     }
 
-    if(api_timediff_t > 0 &&
-       (seconds_to_next == 0 || time_to_next > api_timediff_t)) {
+    if(api_timeout > 0 &&
+       (seconds_to_next == 0 || time_to_next > api_timeout)) {
         ssh2_time_t now = ssh2_now();
         elapsed_time = now > start_time ? (ssh2_timediff_t)(now - start_time)
                                         : 0;
-        if(elapsed_time > api_timediff_t)
+        if(elapsed_time > api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");
 
-        time_to_next = api_timediff_t - elapsed_time;
+        time_to_next = api_timeout - elapsed_time;
         has_timeout = 1;
     }
     else if(time_to_next > 0)
@@ -1346,7 +1346,7 @@ void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
     if(!session)
         return;
 
-    session->api_timeout = timeout;
+    session->api_timeout_ms = timeout;
 }
 
 /*
@@ -1357,7 +1357,7 @@ long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
     if(!session)
         return 0;
 
-    return session->api_timeout;
+    return session->api_timeout_ms;
 }
 
 /*

--- a/src/session.c
+++ b/src/session.c
@@ -591,6 +591,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
 
 #ifdef HAVE_POLL
     {
+        ssh2_timediff_t time_to_next_ms = ssh2_timediff_to_ms(time_to_next);
         struct pollfd sockets[1];
 
         sockets[0].fd = session->socket_fd;
@@ -604,7 +605,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
             sockets[0].events |= POLLOUT;
 
         rc = poll(sockets, 1,
-                  has_timeout ? (int)ssh2_timediff_to_ms(time_to_next) : -1);
+                  has_timeout ? (int)SSH2_MIN(time_to_next_ms, INT_MAX) : -1);
     }
 #else
     {

--- a/src/session.c
+++ b/src/session.c
@@ -558,7 +558,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     if(rc)
         return rc;
 
-    ms_to_next = seconds_to_next * 1000;
+    ms_to_next = ssh2_sec_to_timediff(seconds_to_next);
 
     /* figure out what to wait for */
     dir = libssh2_session_block_directions(session);
@@ -568,13 +568,13 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         /* To avoid that we hang below because there is nothing set to
            wait for, we timeout on 1 second to also avoid busy-looping
            during this condition */
-        ms_to_next = 1000;
+        ms_to_next = ssh2_sec_to_timediff(1);
     }
 
     if(session->api_timeout > 0 &&
        (seconds_to_next == 0 || ms_to_next > session->api_timeout)) {
         ssh2_time_t now = ssh2_now();
-        elapsed_ms = (long)(1000 * difftime(now, start_time));
+        elapsed_ms = now > start_time ? (ssh2_time_t)(now - start_time) : 0;
         if(elapsed_ms > session->api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");
@@ -1342,7 +1342,7 @@ void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
     if(!session)
         return;
 
-    session->api_timeout = ssh2_sec_to_timediff(timeout);
+    session->api_timeout = ssh2_ms_to_timediff(timeout);
 }
 
 /*
@@ -1353,7 +1353,7 @@ long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
     if(!session)
         return 0;
 
-    return ssh2_timediff_to_sec(session->api_timeout);
+    return ssh2_timediff_to_ms(session->api_timeout);
 }
 
 /*

--- a/src/session.c
+++ b/src/session.c
@@ -545,8 +545,8 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     int seconds_to_next;
     int dir;
     int has_timeout;
-    long ms_to_next = 0;
-    long elapsed_ms;
+    ssh2_timediff_t ms_to_next = 0;
+    ssh2_timediff_t elapsed_ms;
 
     /* since libssh2 often sets EAGAIN internally before this function is
        called, we can decrease some amount of confusion in user programs by
@@ -1342,7 +1342,7 @@ void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
     if(!session)
         return;
 
-    session->api_timeout = timeout;
+    session->api_timeout = ssh2_sec_to_timediff(timeout);
 }
 
 /*
@@ -1353,7 +1353,7 @@ long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
     if(!session)
         return 0;
 
-    return session->api_timeout;
+    return ssh2_timediff_to_sec(session->api_timeout);
 }
 
 /*
@@ -1368,7 +1368,7 @@ void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
     if(timeout <= 0)
         timeout = SSH2_DEFAULT_READ_TIMEOUT;
 
-    session->packet_read_timeout = timeout;
+    session->packet_read_timeout = ssh2_sec_to_timediff(timeout);
 }
 
 /*
@@ -1379,7 +1379,7 @@ long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
     if(!session)
         return 0;
 
-    return session->packet_read_timeout;
+    return ssh2_timediff_to_sec(session->packet_read_timeout);
 }
 
 #ifndef LIBSSH2_NO_DEPRECATED

--- a/src/session.c
+++ b/src/session.c
@@ -1385,7 +1385,7 @@ long libssh2_session_get_read_timeout(LIBSSH2_SESSION *session)
     if(!session)
         return 0;
 
-    return ssh2_timediff_to_sec(session->packet_read_timeout);
+    return (long)ssh2_timediff_to_sec(session->packet_read_timeout);
 }
 
 #ifndef LIBSSH2_NO_DEPRECATED

--- a/src/session.c
+++ b/src/session.c
@@ -1661,10 +1661,11 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
         {
             ssh2_timediff_t timeout_remaining_ms =
                 ssh2_timediff_to_ms(timeout_remaining);
-            ssh2_time_t begin = ssh2_now();
+            ssh2_time_t start_time = ssh2_now(), now;
             sysret = poll(sockets, nfds,
                           (int)SSH2_MIN(timeout_remaining_ms, INT_MAX));
-            timeout_remaining -= ssh2_now() - begin;
+            now = ssh2_now();
+            timeout_remaining -= now > start_time ? (now - start_time) : 0;
         }
 
         if(sysret > 0) {
@@ -1709,7 +1710,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
 #elif defined(HAVE_SELECT)
 
         {
-            ssh2_time_t begin;
+            ssh2_time_t start_time, now;
             struct timeval tv;
             tv.tv_sec = (long)(timeout_remaining / 1000);
 #ifdef libssh2_usec_t
@@ -1717,9 +1718,10 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
 #else
             tv.tv_usec = (timeout_remaining % 1000) * 1000;
 #endif
-            begin = ssh2_now();
+            start_time = ssh2_now();
             sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
-            timeout_remaining -= ssh2_now() - begin;
+            now = ssh2_now();
+            timeout_remaining -= now > start_time ? (now - start_time) : 0;
         }
 
         if(sysret > 0) {

--- a/src/session.c
+++ b/src/session.c
@@ -1509,7 +1509,6 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
     LIBSSH2_SESSION *session = NULL;
     libssh2_socket_t maxfd = 0;
     fd_set rfds, wfds;
-    struct timeval tv;
 
     FD_ZERO(&rfds);
     FD_ZERO(&wfds);
@@ -1710,14 +1709,16 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
 
 #elif defined(HAVE_SELECT)
 
-        tv.tv_sec = (long)(timeout_remaining / 1000);
-#ifdef libssh2_usec_t
-        tv.tv_usec = (libssh2_usec_t)((timeout_remaining % 1000) * 1000);
-#else
-        tv.tv_usec = (timeout_remaining % 1000) * 1000;
-#endif
         {
-            ssh2_time_t begin = ssh2_now();
+            ssh2_time_t begin;
+            struct timeval tv;
+            tv.tv_sec = (long)(timeout_remaining / 1000);
+#ifdef libssh2_usec_t
+            tv.tv_usec = (libssh2_usec_t)((timeout_remaining % 1000) * 1000);
+#else
+            tv.tv_usec = (timeout_remaining % 1000) * 1000;
+#endif
+            begin = ssh2_now();
             sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
             timeout_remaining -= ssh2_now() - begin;
         }

--- a/src/session.c
+++ b/src/session.c
@@ -575,8 +575,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     if(api_timeout > 0 &&
        (seconds_to_next == 0 || time_to_next > api_timeout)) {
         ssh2_time_t now = ssh2_now();
-        elapsed_time = now > start_time ? (ssh2_timediff_t)(now - start_time)
-                                        : 0;
+        elapsed_time = now > start_time ? (now - start_time) : 0;
         if(elapsed_time > api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");

--- a/src/session.c
+++ b/src/session.c
@@ -539,7 +539,7 @@ void *libssh2_session_callback_set(LIBSSH2_SESSION *session,
  * Utility function that waits for action on the socket. Returns 0 when ready
  * to run again or error on timeout.
  */
-int ssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
+int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
 {
     int rc;
     int seconds_to_next;
@@ -573,7 +573,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time)
 
     if(session->api_timeout > 0 &&
        (seconds_to_next == 0 || ms_to_next > session->api_timeout)) {
-        time_t now = time(NULL);
+        ssh2_time_t now = ssh2_now();
         elapsed_ms = (long)(1000 * difftime(now, start_time));
         if(elapsed_ms > session->api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,

--- a/src/session.c
+++ b/src/session.c
@@ -570,7 +570,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         /* To avoid that we hang below because there is nothing set to
            wait for, we timeout on 1 second to also avoid busy-looping
            during this condition */
-        time_to_next = ssh2_sec_to_timediff(1);
+        time_to_next = ssh2_ms_to_timediff(1000);
     }
 
     if(api_timeout > 0 &&

--- a/src/session.c
+++ b/src/session.c
@@ -1710,7 +1710,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
 
 #elif defined(HAVE_SELECT)
 
-        tv.tv_sec = timeout_remaining / 1000;
+        tv.tv_sec = (long)(timeout_remaining / 1000);
 #ifdef libssh2_usec_t
         tv.tv_usec = (libssh2_usec_t)((timeout_remaining % 1000) * 1000);
 #else

--- a/src/session.c
+++ b/src/session.c
@@ -547,6 +547,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     int has_timeout;
     ssh2_timediff_t time_to_next = 0;
     ssh2_timediff_t elapsed_time;
+    ssh2_timediff_t api_timediff_t = ssh2_ms_to_timediff(session->api_timeout);
 
     /* since libssh2 often sets EAGAIN internally before this function is
        called, we can decrease some amount of confusion in user programs by
@@ -571,16 +572,16 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         time_to_next = ssh2_sec_to_timediff(1);
     }
 
-    if(session->api_timeout > 0 &&
-       (seconds_to_next == 0 || time_to_next > session->api_timeout)) {
+    if(api_timediff_t > 0 &&
+       (seconds_to_next == 0 || time_to_next > api_timediff_t)) {
         ssh2_time_t now = ssh2_now();
         elapsed_time = now > start_time ? (ssh2_timediff_t)(now - start_time)
                                         : 0;
-        if(elapsed_time > session->api_timeout)
+        if(elapsed_time > api_timediff_t)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");
 
-        time_to_next = session->api_timeout - elapsed_time;
+        time_to_next = api_timediff_t - elapsed_time;
         has_timeout = 1;
     }
     else if(time_to_next > 0)
@@ -1345,7 +1346,7 @@ void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
     if(!session)
         return;
 
-    session->api_timeout = ssh2_ms_to_timediff(timeout);
+    session->api_timeout = timeout;
 }
 
 /*
@@ -1356,7 +1357,7 @@ long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
     if(!session)
         return 0;
 
-    return ssh2_timediff_to_ms(session->api_timeout);
+    return session->api_timeout;
 }
 
 /*

--- a/src/session.c
+++ b/src/session.c
@@ -574,7 +574,8 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     if(session->api_timeout > 0 &&
        (seconds_to_next == 0 || time_to_next > session->api_timeout)) {
         ssh2_time_t now = ssh2_now();
-        elapsed_time = now > start_time ? (ssh2_time_t)(now - start_time) : 0;
+        elapsed_time = now > start_time ? (ssh2_timediff_t)(now - start_time)
+                                        : 0;
         if(elapsed_time > session->api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");

--- a/src/session.c
+++ b/src/session.c
@@ -416,7 +416,8 @@ LIBSSH2_SESSION *libssh2_session_init_ex(LIBSSH2_ALLOC_FUNC(*my_alloc),
         session->api_block_mode = 1; /* blocking API by default */
         session->state = SSH2_STATE_INITIAL_KEX;
         session->fullpacket_required_type = 0;
-        session->packet_read_timeout = SSH2_DEFAULT_READ_TIMEOUT;
+        session->packet_read_timeout =
+            ssh2_sec_to_timediff(SSH2_DEFAULT_READ_TIMEOUT);
         session->flag.quote_paths = 1; /* default behavior is to quote paths
                                           for the scp subsystem */
         session->kex = NULL;

--- a/src/session.c
+++ b/src/session.c
@@ -576,8 +576,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     if(api_timeout > 0 &&
        (seconds_to_next == 0 || time_to_next > api_timeout)) {
         ssh2_time_t now = ssh2_now();
-        elapsed_time = now > start_time ? (ssh2_timediff_t)(now - start_time)
-                                        : 0;
+        elapsed_time = now > start_time ? (now - start_time) : 0;
         if(elapsed_time > api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");

--- a/src/session.c
+++ b/src/session.c
@@ -545,7 +545,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     int seconds_to_next;
     int dir;
     int has_timeout;
-    ssh2_timediff_t ms_to_next = 0;
+    ssh2_timediff_t time_to_next = 0;
     ssh2_timediff_t elapsed_ms;
 
     /* since libssh2 often sets EAGAIN internally before this function is
@@ -558,7 +558,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     if(rc)
         return rc;
 
-    ms_to_next = ssh2_sec_to_timediff(seconds_to_next);
+    time_to_next = ssh2_sec_to_timediff(seconds_to_next);
 
     /* figure out what to wait for */
     dir = libssh2_session_block_directions(session);
@@ -568,21 +568,21 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         /* To avoid that we hang below because there is nothing set to
            wait for, we timeout on 1 second to also avoid busy-looping
            during this condition */
-        ms_to_next = ssh2_sec_to_timediff(1);
+        time_to_next = ssh2_sec_to_timediff(1);
     }
 
     if(session->api_timeout > 0 &&
-       (seconds_to_next == 0 || ms_to_next > session->api_timeout)) {
+       (seconds_to_next == 0 || time_to_next > session->api_timeout)) {
         ssh2_time_t now = ssh2_now();
         elapsed_ms = now > start_time ? (ssh2_time_t)(now - start_time) : 0;
         if(elapsed_ms > session->api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");
 
-        ms_to_next = session->api_timeout - elapsed_ms;
+        time_to_next = session->api_timeout - elapsed_ms;
         has_timeout = 1;
     }
-    else if(ms_to_next > 0)
+    else if(time_to_next > 0)
         has_timeout = 1;
     else
         has_timeout = 0;
@@ -601,7 +601,8 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         if(dir & LIBSSH2_SESSION_BLOCK_OUTBOUND)
             sockets[0].events |= POLLOUT;
 
-        rc = poll(sockets, 1, has_timeout ? (int)ms_to_next : -1);
+        rc = poll(sockets, 1,
+                  has_timeout ? (int)ssh2_timediff_to_ms(time_to_next) : -1);
     }
 #else
     {
@@ -610,6 +611,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         fd_set *writefd = NULL;
         fd_set *readfd = NULL;
         struct timeval tv;
+        long ms_to_next = ssh2_timediff_to_ms(time_to_next);
 
         tv.tv_sec = ms_to_next / 1000;
 #ifdef libssh2_usec_t

--- a/src/session.c
+++ b/src/session.c
@@ -614,9 +614,9 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         fd_set *writefd = NULL;
         fd_set *readfd = NULL;
         struct timeval tv;
-        long ms_to_next = ssh2_timediff_to_ms(time_to_next);
+        ssh2_timediff_t ms_to_next = ssh2_timediff_to_ms(time_to_next);
 
-        tv.tv_sec = ms_to_next / 1000;
+        tv.tv_sec = (long)(ms_to_next / 1000);
 #ifdef libssh2_usec_t
         tv.tv_usec = (libssh2_usec_t)((ms_to_next - tv.tv_sec * 1000) * 1000);
 #else

--- a/src/session.c
+++ b/src/session.c
@@ -546,7 +546,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     int dir;
     int has_timeout;
     ssh2_timediff_t time_to_next = 0;
-    ssh2_timediff_t elapsed_ms;
+    ssh2_timediff_t elapsed_time;
 
     /* since libssh2 often sets EAGAIN internally before this function is
        called, we can decrease some amount of confusion in user programs by
@@ -574,12 +574,12 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
     if(session->api_timeout > 0 &&
        (seconds_to_next == 0 || time_to_next > session->api_timeout)) {
         ssh2_time_t now = ssh2_now();
-        elapsed_ms = now > start_time ? (ssh2_time_t)(now - start_time) : 0;
-        if(elapsed_ms > session->api_timeout)
+        elapsed_time = now > start_time ? (ssh2_time_t)(now - start_time) : 0;
+        if(elapsed_time > session->api_timeout)
             return ssh2_err(session, LIBSSH2_ERROR_TIMEOUT,
                             "API timeout expired");
 
-        time_to_next = session->api_timeout - elapsed_ms;
+        time_to_next = session->api_timeout - elapsed_time;
         has_timeout = 1;
     }
     else if(time_to_next > 0)

--- a/src/session.c
+++ b/src/session.c
@@ -1343,12 +1343,12 @@ int libssh2_session_get_blocking(LIBSSH2_SESSION *session)
  * Set a session's timeout (in msec) for blocking mode,
  * or 0 to disable timeouts.
  */
-void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout)
+void libssh2_session_set_timeout(LIBSSH2_SESSION *session, long timeout_ms)
 {
     if(!session)
         return;
 
-    session->api_timeout_ms = timeout;
+    session->api_timeout_ms = timeout_ms;
 }
 
 /*
@@ -1366,15 +1366,15 @@ long libssh2_session_get_timeout(LIBSSH2_SESSION *session)
  * Set a session's timeout (in sec) when reading packets,
  * or 0 to use default of 60 seconds.
  */
-void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout)
+void libssh2_session_set_read_timeout(LIBSSH2_SESSION *session, long timeout_s)
 {
     if(!session)
         return;
 
-    if(timeout <= 0)
-        timeout = SSH2_DEFAULT_READ_TIMEOUT;
+    if(timeout_s <= 0)
+        timeout_s = SSH2_DEFAULT_READ_TIMEOUT;
 
-    session->packet_read_timeout = ssh2_sec_to_timediff(timeout);
+    session->packet_read_timeout = ssh2_sec_to_timediff(timeout_s);
 }
 
 /*
@@ -1452,7 +1452,7 @@ static SSH2_INLINE int session_poll_listener_queued(LIBSSH2_LISTENER *listener)
  *
  * Poll sockets, channels, and listeners for activity
  */
-int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
+int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
 {
     long timeout_remaining;
     unsigned int i, active_fds;
@@ -1581,10 +1581,10 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
         }
     }
 #else /* !HAVE_POLL && !HAVE_SELECT */
-    timeout = 0;  /* no sockets structure to setup */
+    timeout_ms = 0;  /* no sockets structure to setup */
 #endif /* HAVE_POLL || HAVE_SELECT */
 
-    timeout_remaining = timeout;
+    timeout_remaining = timeout_ms;
     do {
 #if defined(HAVE_POLL) || defined(HAVE_SELECT)
         int sysret;
@@ -1764,7 +1764,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout)
                 }
             }
         }
-#endif /* !HAVE_POLL && !HAVE_SELECT -- timeout (and by extension
+#endif /* !HAVE_POLL && !HAVE_SELECT -- timeout_ms (and by extension
         * timeout_remaining) is equal to 0 */
     } while(timeout_remaining > 0 && !active_fds);
 

--- a/src/session.h
+++ b/src/session.h
@@ -46,7 +46,7 @@
  */
 #define BLOCK_ADJUST(rc, session, x)                                 \
     do {                                                             \
-        time_t entry_time = time(NULL);                              \
+        ssh2_time_t entry_time = ssh2_now();                         \
         do {                                                         \
             (rc) = (x);                                              \
             /* the order of the check below is important to properly \
@@ -66,7 +66,7 @@
  */
 #define BLOCK_ADJUST_ERRNO(ptr, session, x)                                 \
     do {                                                                    \
-        time_t entry_time = time(NULL);                                     \
+        ssh2_time_t entry_time = ssh2_now();                                \
         int rc;                                                             \
         do {                                                                \
             (ptr) = (x);                                                    \
@@ -77,7 +77,7 @@
         } while(!(rc));                                                     \
     } while(0)
 
-int ssh2_wait_socket(LIBSSH2_SESSION *session, time_t start_time);
+int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time);
 
 /* this is the lib-internal set blocking function */
 int ssh2_session_set_blocking(LIBSSH2_SESSION *session, int blocking);

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -538,7 +538,7 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
             /* prevent busy-looping */
             ssh2_timediff_t left =
                 sftp->channel->session->packet_read_timeout -
-                (ssh2_timediff_t)(ssh2_now() - sftp->requirev_start);
+                (ssh2_now() - sftp->requirev_start);
 
             if(left <= 0) {
                 sftp->requirev_start = 0;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -510,7 +510,7 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
 
     /* If no timeout is active, start a new one */
     if(sftp->requirev_start == 0)
-        sftp->requirev_start = time(NULL);
+        sftp->requirev_start = ssh2_now();
 
     while(sftp->channel->session->socket_state == SSH2_SOCKET_CONNECTED) {
         for(i = 0; i < num_valid_responses; i++) {
@@ -538,7 +538,7 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
             /* prevent busy-looping */
             long left =
                 sftp->channel->session->packet_read_timeout -
-                (long)(time(NULL) - sftp->requirev_start);
+                (long)(ssh2_now() - sftp->requirev_start);
 
             if(left <= 0) {
                 sftp->requirev_start = 0;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -538,7 +538,7 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
             /* prevent busy-looping */
             ssh2_timediff_t left =
                 sftp->channel->session->packet_read_timeout -
-                (ssh2_now() - sftp->requirev_start);
+                (ssh2_timediff_t)(ssh2_now() - sftp->requirev_start);
 
             if(left <= 0) {
                 sftp->requirev_start = 0;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -536,9 +536,9 @@ static int sftp_packet_requirev(LIBSSH2_SFTP *sftp, int num_valid_responses,
         }
         else if(rc <= 0) {
             /* prevent busy-looping */
-            long left =
+            ssh2_timediff_t left =
                 sftp->channel->session->packet_read_timeout -
-                (long)(ssh2_now() - sftp->requirev_start);
+                (ssh2_timediff_t)(ssh2_now() - sftp->requirev_start);
 
             if(left <= 0) {
                 sftp->requirev_start = 0;

--- a/src/sftp.h
+++ b/src/sftp.h
@@ -143,7 +143,7 @@ struct _LIBSSH2_SFTP {
     size_t partial_received;            /* Bytes received so far   */
 
     /* Time that sftp_packet_requirev() started reading */
-    time_t requirev_start;
+    ssh2_time_t requirev_start;
 
     /* State variables used in libssh2_sftp_open_ex() */
     ssh2_NB_states open_state;


### PR DESCRIPTION
To honor the actual millisecond timeout set via
`libssh2_session_set_timeout()`, to open the possibility for the same in
other APIs, and to use monotonic time if available.

- add internal abstract time types and macros for handling point in time
  and time intervals, and use them throughout the codebase.
- bump internal abstract time resolution to milliseconds (from seconds).
  Use signed 64-bit integers.
- replace existing millisecond-resolution code in `libssh2_poll()` with
  the internal abstract time interface.
- bump 'now' function to retrieve millisecond-resolution monotonic time
  from the system, if available.

Also:
- append `_s` or `_ms` to public API arguments to tell the time unit.
- keepalive: minor tidy-ups.
- make `ssh2_now()` return at least 1 in the fallback, 
  `time(NULL)`-based codepath to not confuse a zero value with unset
  time.
  Credits: Stefan Eissing
  Ref: https://github.com/curl/curl/commit/5649b212979de21f52424bd22c45c3e8dcbb7448
  Ref: https://github.com/curl/curl/pull/21034
- this leaves existing `ssh2_gettimeofday()` (together with its
  Windows-specific local implementation) with a single caller,
  `ssh2_deb_low()`.

Refs:
https://pubs.opengroup.org/onlinepubs/9699919799/functions/clock_gettime.html
https://www.man7.org/linux/man-pages/man3/clock_gettime.3.html
https://pubs.opengroup.org/onlinepubs/009604599/functions/gettimeofday.html
https://www.man7.org/linux/man-pages/man2/gettimeofday.2.html
https://learn.microsoft.com/windows/win32/api/profileapi/nf-profileapi-queryperformancefrequency
https://learn.microsoft.com/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
https://stackoverflow.com/questions/5404277/porting-clock-gettime-to-windows

Reported-and-patch-proposal-by: Trzik on github
Based-on-patch-proposals-by: Ryan Kelley
Fixes #1497
Ref: #1818
Closes #1893
Follow-up to 772abc7a85540c55a7e0e02cbbac8b1e5a60c8ce #1919
