### PR TITLE
transport: fix out-of-bounds write on short EtM packets

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -239,13 +239,20 @@ static int transport_fullpacket(LIBSSH2_SESSION *session,
 
                 first_block[0] = 0;
 
+                /* the encrypted portion (everything but the cleartext length
+                   field and the trailing MAC) must be at least one whole
+                   cipher block; a shorter value would make the block copies
+                   below read and write past their buffers */
+                decrypt_size = p->total_num - mac_len - 4;
+                if(decrypt_size < blocksize)
+                    return LIBSSH2_ERROR_PROTO;
+
                 rc = transport_decrypt(session, p->payload + 4,
                                        first_block, blocksize, FIRST_BLOCK);
                 if(rc)
                     return rc;
 
                 /* we need buffer for decrypt */
-                decrypt_size = p->total_num - mac_len - 4;
                 decrypt_buffer = SSH2_ALLOC(session, decrypt_size);
                 if(!decrypt_buffer)
                     return LIBSSH2_ERROR_ALLOC;


### PR DESCRIPTION
The EtM branch of transport_fullpacket copies blocksize-1 bytes of the decrypted first block into a heap buffer sized from decrypt_size, which is the server's packet_length field, and the read path only rejects that field when it is below 1. A server that negotiated an -etm@openssh.com MAC with a block cipher (AES-CTR/CBC, blocksize 16) can send a packet whose length is smaller than one cipher block, and since the MAC is verified first with a tag the peer can compute, the copy runs past the too-small allocation. This rejects packets whose encrypted portion is shorter than one block before the copy, matching the transport requirement that it be a whole number of cipher blocks. Confirmed with asan on the extracted arithmetic: length 1 with blocksize 16 and a 32-byte mac gives a 1-byte decrypt_buffer and a 15-byte write; clean reject after.