### PR TITLE
transport: fix two memleaks on error paths in `transport_fullpacket()`

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -252,8 +252,10 @@ static int transport_fullpacket(LIBSSH2_SESSION *session,
 
                 /* we need buffer for decrypt */
                 decrypt_buffer = SSH2_ALLOC(session, decrypt_size);
-                if(!decrypt_buffer)
+                if(!decrypt_buffer) {
+                    SSH2_SAFEFREE(session, p->payload);
                     return LIBSSH2_ERROR_ALLOC;
+                }
 
                 /* grab padding length and copy anything else
                    into target buffer */
@@ -261,6 +263,7 @@ static int transport_fullpacket(LIBSSH2_SESSION *session,
 
                 if(p->padding_length > p->packet_length - 1) {
                     SSH2_FREE(session, decrypt_buffer);
+                    SSH2_SAFEFREE(session, p->payload);
                     return LIBSSH2_ERROR_PROTO;
                 }
 


### PR DESCRIPTION
Ref: https://github.com/libssh2/libssh2/pull/2198#discussion_r3521927583

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
