### PR TITLE
userauth: reset state machine to idle on fail in `userauth_password()`

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -459,6 +459,7 @@ password_response:
                            password_len > MAX_INPUT_LEN) {
                             SSH2_SAFEFREE(session,
                                           session->userauth_pswd_newpw);
+                            session->userauth_pswd_state = ssh2_NB_state_idle;
                             return ssh2_err(session,
                                             LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                             "Username or password too large");
@@ -472,6 +473,7 @@ password_response:
                         if(!session->userauth_pswd_data) {
                             SSH2_SAFEFREE(session,
                                           session->userauth_pswd_newpw);
+                            session->userauth_pswd_state = ssh2_NB_state_idle;
                             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                             "Unable to allocate memory "
                                             "for userauth password "

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -450,6 +450,7 @@ password_response:
                                          &session->abstract);
                         if(!session->userauth_pswd_newpw) {
                             session->userauth_pswd_state = ssh2_NB_state_idle;
+                            session->userauth_pswd_data_len = 0;
                             return ssh2_err(session,
                                             LIBSSH2_ERROR_PASSWORD_EXPIRED,
                                             "Password expired, and "

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -448,11 +448,13 @@ password_response:
                                          &session->userauth_pswd_newpw,
                                          &session->userauth_pswd_newpw_len,
                                          &session->abstract);
-                        if(!session->userauth_pswd_newpw)
+                        if(!session->userauth_pswd_newpw) {
+                            session->userauth_pswd_state = ssh2_NB_state_idle;
                             return ssh2_err(session,
                                             LIBSSH2_ERROR_PASSWORD_EXPIRED,
                                             "Password expired, and "
                                             "callback failed");
+                        }
 
                         session->userauth_pswd_data_len = 0;
                         if(username_len > MAX_INPUT_LEN ||

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -459,9 +459,9 @@ password_response:
                         session->userauth_pswd_data_len = 0;
                         if(username_len > MAX_INPUT_LEN ||
                            password_len > MAX_INPUT_LEN) {
+                            session->userauth_pswd_state = ssh2_NB_state_idle;
                             SSH2_SAFEFREE(session,
                                           session->userauth_pswd_newpw);
-                            session->userauth_pswd_state = ssh2_NB_state_idle;
                             return ssh2_err(session,
                                             LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                             "Username or password too large");
@@ -473,9 +473,9 @@ password_response:
                         session->userauth_pswd_data = s =
                             SSH2_ALLOC(session, data_len);
                         if(!session->userauth_pswd_data) {
+                            session->userauth_pswd_state = ssh2_NB_state_idle;
                             SSH2_SAFEFREE(session,
                                           session->userauth_pswd_newpw);
-                            session->userauth_pswd_state = ssh2_NB_state_idle;
                             return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                             "Unable to allocate memory "
                                             "for userauth password "


### PR DESCRIPTION
Also: reset buffer length if password change callback returned NULL.

"On the out-of-bounds early-return path, the function returns without
resetting `session->userauth_pswd_state` back to `ssh2_NB_state_idle`.
If the caller retries after this error, the state machine can continue
in `sent1` with `userauth_pswd_data_len == 0`, leading to a misleading
follow-up `LIBSSH2_ERROR_PROTO` ("Unexpected packet size"). Reset the
state before returning on this failure path."

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2224#discussion_r3525561967
