### PR TITLE
session: free kex buffers unconditionally in `libssh2_session_free()`

### DIFF
--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -52,7 +52,8 @@ static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
     ssh2_rsa_ctx *rsactx = (ssh2_rsa_ctx *)(*abstract);
     (void)session;
 
-    ssh2_rsa_free(rsactx);
+    if(rsactx)
+        ssh2_rsa_free(rsactx);
 
     *abstract = NULL;
 
@@ -454,7 +455,8 @@ static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
     ssh2_dsa_ctx *dsactx = (ssh2_dsa_ctx *)(*abstract);
     (void)session;
 
-    ssh2_dsa_free(dsactx);
+    if(dsactx)
+        ssh2_dsa_free(dsactx);
 
     *abstract = NULL;
 

--- a/src/session.c
+++ b/src/session.c
@@ -876,38 +876,31 @@ static int session_free(LIBSSH2_SESSION *session)
     if(session->hostkey && session->hostkey->dtor)
         session->hostkey->dtor(session, &session->server_hostkey_abstract);
 
-    if(session->state & SSH2_STATE_NEWKEYS) {
+    /* Client to Server */
+    /* crypt */
+    if(session->local.crypt && session->local.crypt->dtor)
+        session->local.crypt->dtor(session, &session->local.crypt_abstract);
+    /* comp */
+    if(session->local.comp && session->local.comp->dtor)
+        session->local.comp->dtor(session, 1, &session->local.comp_abstract);
+    /* mac */
+    if(session->local.mac && session->local.mac->dtor)
+        session->local.mac->dtor(session, &session->local.mac_abstract);
 
-        /* Client to Server */
-        /* crypt */
-        if(session->local.crypt && session->local.crypt->dtor)
-            session->local.crypt->dtor(session,
-                                       &session->local.crypt_abstract);
-        /* comp */
-        if(session->local.comp && session->local.comp->dtor)
-            session->local.comp->dtor(session, 1,
-                                      &session->local.comp_abstract);
-        /* mac */
-        if(session->local.mac && session->local.mac->dtor)
-            session->local.mac->dtor(session, &session->local.mac_abstract);
+    /* Server to Client */
+    /* crypt */
+    if(session->remote.crypt && session->remote.crypt->dtor)
+        session->remote.crypt->dtor(session, &session->remote.crypt_abstract);
+    /* comp */
+    if(session->remote.comp && session->remote.comp->dtor)
+        session->remote.comp->dtor(session, 0, &session->remote.comp_abstract);
+    /* mac */
+    if(session->remote.mac && session->remote.mac->dtor)
+        session->remote.mac->dtor(session, &session->remote.mac_abstract);
 
-        /* Server to Client */
-        /* crypt */
-        if(session->remote.crypt && session->remote.crypt->dtor)
-            session->remote.crypt->dtor(session,
-                                        &session->remote.crypt_abstract);
-        /* comp */
-        if(session->remote.comp && session->remote.comp->dtor)
-            session->remote.comp->dtor(session, 0,
-                                       &session->remote.comp_abstract);
-        /* mac */
-        if(session->remote.mac && session->remote.mac->dtor)
-            session->remote.mac->dtor(session, &session->remote.mac_abstract);
-
-        /* session_id */
-        if(session->session_id)
-            SSH2_FREE(session, session->session_id);
-    }
+    /* session_id */
+    if(session->session_id)
+        SSH2_FREE(session, session->session_id);
 
     /* Free banner(s) */
     if(session->remote.banner)


### PR DESCRIPTION
Prior to this patch certain buffers where only freed if the session had
the `SSH2_STATE_NEWKEYS` status flag. To avoid potentially leaking
buffers for incomplete sessions, drop this guard and free all non-NULL
buffers having a destructor.

Also:
- hostkey: guard for NULL context object in destructors, where missing.

Reported-by: Liu Xingyu
Fixes #1691
Ref: 7a5ffc8cee259bbde82ab92515cd8fea2166854b

---

https://github.com/libssh2/libssh2/pull/2347/files?w=1

- [x] check if the abstract pointers are all non-NULL and/or that all dtors can gracfully fail on a NULL object.