### PR TITLE
src: make internal passphrase type consistent, where missing

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -415,12 +415,11 @@ Each item is preceded by its 32-bit byte length, MSB first.
 
 ```c
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
+                          unsigned char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const char *passphrase);
+                          const unsigned char *passphrase);
 ```
 Reads a private key from file privatekey and extract the public key -->
 (`pubkeydata`, `pubkeydata_len`). Store the associated method (ssh-rsa or
@@ -431,13 +430,12 @@ This procedure is already prototyped in `crypto.h`.
 
 ```c
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method,
-                                size_t *method_len,
+                                unsigned char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const char *passphrase);
+                                const unsigned char *passphrase);
 ```
 Gets a private key from bytes at (`privatekeydata`, `privatekeydata_len`) and
 extract the public key --> (`pubkeydata`, `pubkeydata_len`). Store the

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -287,25 +287,22 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
 #endif
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
+                          unsigned char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const char *passphrase);
+                          const unsigned char *passphrase);
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method,
-                                size_t *method_len,
+                                unsigned char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const char *passphrase);
+                                const unsigned char *passphrase);
 
 int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
-                              unsigned char **method,
-                              size_t *method_len,
+                              unsigned char **method, size_t *method_len,
                               unsigned char **pubkeydata,
                               size_t *pubkeydata_len,
                               int *algorithm,

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -697,13 +697,12 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method,
-                                size_t *method_len,
+                                unsigned char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const char *passphrase)
+                                const unsigned char *passphrase)
 {
     (void)method;
     (void)method_len;
@@ -719,12 +718,11 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
+                          unsigned char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const char *passphrase)
+                          const unsigned char *passphrase)
 {
     (void)method;
     (void)method_len;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -647,12 +647,11 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
+                          unsigned char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const char *passphrase)
+                          const unsigned char *passphrase)
 {
     mbedtls_pk_context pkey;
     char buf[1024];
@@ -677,8 +676,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method,
-                                size_t *method_len,
+                                unsigned char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -658,7 +658,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
     int ret;
 
     mbedtls_pk_init(&pkey);
-    ret = mbedtls_pk_parse_keyfile(&pkey, privatekey, passphrase,
+    ret = mbedtls_pk_parse_keyfile(&pkey, privatekey, (const char *)passphrase,
                                    mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     if(ret) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));
@@ -681,7 +681,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const char *passphrase)
+                                const unsigned char *passphrase)
 {
     mbedtls_pk_context pkey;
     char buf[1024];

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -702,7 +702,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 
     pwd_len = passphrase ? strlen((const char *)passphrase) : 0;
     ret = mbedtls_pk_parse_key(&pkey, data_nullterm, privatekeydata_len + 1,
-                               (const unsigned char *)passphrase, pwd_len,
+                               passphrase, pwd_len,
                                mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     mbed_zero_free(data_nullterm, privatekeydata_len + 1);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3725,12 +3725,11 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
+                          unsigned char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const char *passphrase)
+                          const unsigned char *passphrase)
 {
     BIO *bp;
     EVP_PKEY *pk;
@@ -3913,8 +3912,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
 }
 
 int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
-                              unsigned char **method,
-                              size_t *method_len,
+                              unsigned char **method, size_t *method_len,
                               unsigned char **pubkeydata,
                               size_t *pubkeydata_len,
                               int *algorithm,
@@ -4010,7 +4008,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const char *passphrase)
+                                const unsigned char *passphrase)
 {
     int rc;
     BIO *bp;
@@ -4040,7 +4038,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                         method, method_len,
                                         pubkeydata, pubkeydata_len,
                                         privatekeydata, privatekeydata_len,
-                                        (const unsigned char *)passphrase);
+                                        passphrase);
         if(rc == 0)
             return 0;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3639,7 +3639,7 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       const char *privatekey,
-                                      const char *passphrase)
+                                      const unsigned char *passphrase)
 {
     FILE *fp;
     unsigned char *buf = NULL;
@@ -3661,8 +3661,7 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_openssh_pem_parse(session, (const unsigned char *)passphrase,
-                                fp, &decrypted);
+    rc = ssh2_openssh_pem_parse(session, passphrase, fp, &decrypted);
     fclose(fp);
     if(rc) {
         ssh2_err(session, LIBSSH2_ERROR_FILE, "Not an OpenSSH key file");

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3751,8 +3751,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 
     if(!pk) {
         /* Try OpenSSH format */
-        rc = ossl_key_from_openssh_file(session,
-                                        method, method_len,
+        rc = ossl_key_from_openssh_file(session, method, method_len,
                                         pubkeydata, pubkeydata_len,
                                         privatekey, passphrase);
         if(rc)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2098,7 +2098,8 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
-                          const char *privatekey, const char *passphrase)
+                          const char *privatekey,
+                          const unsigned char *passphrase)
 {
     struct loadpubkeydata p;
     int ret;
@@ -2212,7 +2213,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const char *passphrase)
+                                const unsigned char *passphrase)
 {
     struct loadpubkeydata p;
     unsigned char *data = NULL;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -734,7 +734,7 @@ static int userauth_read_blob_privkey(
     const struct hostkey_method **hostkey_method, void **hostkey_abstract,
     const unsigned char *method, size_t method_len,
     const char *privkeyfiledata, size_t privkeyfiledata_len,
-    const char *passphrase)
+    const unsigned char *passphrase)
 {
     const struct hostkey_method **hostkey_methods_avail =
         ssh2_hostkey_methods();
@@ -754,10 +754,10 @@ static int userauth_read_blob_privkey(
         return ssh2_err(session, LIBSSH2_ERROR_METHOD_NONE,
                         "No handler for specified private key");
 
-    if((*hostkey_method)->initPEMFromMemory(session, privkeyfiledata,
+    if((*hostkey_method)->initPEMFromMemory(session,
+                                            privkeyfiledata,
                                             privkeyfiledata_len,
-                                            (const unsigned char *)passphrase,
-                                            hostkey_abstract))
+                                            passphrase, hostkey_abstract))
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Unable to initialize private key from memory");
 
@@ -772,7 +772,7 @@ static int userauth_read_file_privkey(
     const struct hostkey_method **hostkey_method, void **hostkey_abstract,
     const unsigned char *method, size_t method_len,
     const char *privkeyfile,
-    const char *passphrase)
+    const unsigned char *passphrase)
 {
     const struct hostkey_method **hostkey_methods_avail =
         ssh2_hostkey_methods();
@@ -795,8 +795,7 @@ static int userauth_read_file_privkey(
                         "No handler for specified private key");
 
     if((*hostkey_method)->initPEM(session, privkeyfile,
-                                  (const unsigned char *)passphrase,
-                                  hostkey_abstract))
+                                  passphrase, hostkey_abstract))
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Unable to initialize private key from file");
 
@@ -805,11 +804,11 @@ static int userauth_read_file_privkey(
 
 struct privkey_file {
     const char *filename;
-    const char *passphrase;
+    const unsigned char *passphrase;
 };
 
 struct privkey_mem {
-    const char *passphrase;
+    const unsigned char *passphrase;
     const char *data;
     size_t data_len;
 };
@@ -1004,7 +1003,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                        size_t username_len,
                                        const char *publickey,
                                        const char *privatekey,
-                                       const char *passphrase,
+                                       const unsigned char *passphrase,
                                        const char *hostname,
                                        size_t hostname_len,
                                        const char *local_username,
@@ -1247,7 +1246,7 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
                  userauth_hostbased_fromfile(session,
                                              username, username_len,
                                              publickey, privatekey,
-                                             passphrase,
+                                             (const unsigned char *)passphrase,
                                              hostname, hostname_len,
                                              local_username,
                                              local_username_len));
@@ -1897,7 +1896,7 @@ static int userauth_publickey_frommemory(LIBSSH2_SESSION *session,
                                          size_t publickeydata_len,
                                          const char *privatekeydata,
                                          size_t privatekeydata_len,
-                                         const char *passphrase)
+                                         const unsigned char *passphrase)
 {
     unsigned char *pubkeydata = NULL;
     size_t pubkeydata_len = 0;
@@ -1952,7 +1951,7 @@ static int userauth_publickey_fromfile(LIBSSH2_SESSION *session,
                                        size_t username_len,
                                        const char *publickey,
                                        const char *privatekey,
-                                       const char *passphrase)
+                                       const unsigned char *passphrase)
 {
     unsigned char *pubkeydata = NULL;
     size_t pubkeydata_len = 0;
@@ -2025,7 +2024,7 @@ int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
                                                publickeyfiledata_len,
                                                privatekeyfiledata,
                                                privatekeyfiledata_len,
-                                               passphrase));
+                                           (const unsigned char *)passphrase));
     return rc;
 }
 
@@ -2053,7 +2052,7 @@ int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
                  userauth_publickey_fromfile(session,
                                              username, username_len,
                                              publickey, privatekey,
-                                             passphrase));
+                                           (const unsigned char *)passphrase));
     return rc;
 }
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2911,19 +2911,17 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
+                          unsigned char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const char *passphrase)
+                          const unsigned char *passphrase)
 {
     unsigned char *pbEncoded;
     size_t cbEncoded;
     int ret;
 
-    ret = wcng_load_private(session, privatekey,
-                            (const unsigned char *)passphrase,
+    ret = wcng_load_private(session, privatekey, passphrase,
                             &pbEncoded, &cbEncoded, 1, 1);
     if(ret)
         return -1;
@@ -2934,22 +2932,19 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method,
-                                size_t *method_len,
+                                unsigned char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const char *passphrase)
+                                const unsigned char *passphrase)
 {
     unsigned char *pbEncoded;
     size_t cbEncoded;
     int ret;
 
-    ret = wcng_load_private_memory(session, privatekeydata,
-                                   privatekeydata_len,
-                                   (const unsigned char *)passphrase,
-                                   &pbEncoded, &cbEncoded, 1, 1);
+    ret = wcng_load_private_memory(session, privatekeydata, privatekeydata_len,
+                                   passphrase, &pbEncoded, &cbEncoded, 1, 1);
     if(ret)
         return -1;
 


### PR DESCRIPTION
passphrase is `const char *` in the public API, but internally it was 
`const unsigned char *` in most places. Sync outlier internal APIs to
use the latter, and cast close to the public API boundary.     

Also: reflow (formatting) in a few places.
