### PR TITLE
knownhost: fix off-by-one read in `libssh2_knownhost_readline()`

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -950,7 +950,7 @@ int libssh2_knownhost_readline(LIBSSH2_KNOWNHOSTS *hosts,
         len--;
     }
 
-    if(!*cp || !len) /* illegal line */
+    if(!len || !*cp) /* illegal line */
         return ssh2_err(hosts->session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
                         "Failed to parse known_hosts line");
 


### PR DESCRIPTION
Fixing:
```
==254==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b1f105e02f1 at pc 0x5621889c09ae bp 0x7fff81a77560 sp 0x7fff81a77558
READ of size 1 at 0x7b1f105e02f1 thread T0
SCARINESS: 12 (1-byte-read-heap-buffer-overflow)
    #0 0x5621889c09ad in libssh2_knownhost_readline /src/libssh2/src/knownhost.c:953:9
```
Ref: https://github.com/libssh2/libssh2/actions/runs/29662726134/job/88128001261?pr=1953#step:4:1190
