### PR TITLE
openssl: fix `key_type` check in `ossl_key_from_openssh_blob()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3824,7 +3824,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
     if(!session)
         return LIBSSH2_ERROR_BAD_USE;
 
-    if(key_type && (strlen(key_type) > 11 || strlen(key_type) < 7))
+    if(key_type && strlen(key_type) < 7)
         return ssh2_err(session, LIBSSH2_ERROR_PROTO, "type is invalid");
 
     OSSL_INIT_IF_NEEDED();


### PR DESCRIPTION
To actually allow loading the longer key types added to this function
after the check has been put in place.

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698
Follow-up to 03092292597ac601c3f9f0c267ecb145dda75e4e #248

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
