### PR TITLE
tidy-up: fix variable names, improve consistency, other nits

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -343,12 +343,21 @@ int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
 void ssh2_dh_dtor(ssh2_dh_ctx *dhctx);
 
 #if LIBSSH2_RSA
-#define PEM_RSA_HEADER "-----BEGIN RSA PRIVATE KEY-----"
-#define PEM_RSA_FOOTER "-----END RSA PRIVATE KEY-----"
+#define PEM_RSA_HEADER          "-----BEGIN RSA PRIVATE KEY-----"
+#define PEM_RSA_FOOTER          "-----END RSA PRIVATE KEY-----"
 #endif
 #if LIBSSH2_DSA
-#define PEM_DSA_HEADER "-----BEGIN DSA PRIVATE KEY-----"
-#define PEM_DSA_FOOTER "-----END DSA PRIVATE KEY-----"
+#define PEM_DSA_HEADER          "-----BEGIN DSA PRIVATE KEY-----"
+#define PEM_DSA_FOOTER          "-----END DSA PRIVATE KEY-----"
 #endif
+#if LIBSSH2_ECDSA
+#define PEM_ECDSA_HEADER        "-----BEGIN EC PRIVATE KEY-----"
+#define PEM_ECDSA_FOOTER        "-----END EC PRIVATE KEY-----"
+#endif
+
+#define PKCS8_HEADER            "-----BEGIN PRIVATE KEY-----"
+#define PKCS8_FOOTER            "-----END PRIVATE KEY-----"
+#define PKCS8_ENCRYPTED_HEADER  "-----BEGIN ENCRYPTED PRIVATE KEY-----"
+#define PKCS8_ENCRYPTED_FOOTER  "-----END ENCRYPTED PRIVATE KEY-----"
 
 #endif /* LIBSSH2_CRYPTO_H */

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -1076,17 +1076,17 @@ static int hostkey_method_ssh_ed25519_initPEM(LIBSSH2_SESSION *session,
                                               const unsigned char *passphrase,
                                               void **abstract)
 {
-    ssh2_ed25519_ctx *ec_ctx = NULL;
+    ssh2_ed25519_ctx *ed_ctx = NULL;
 
     if(*abstract) {
         hostkey_method_ssh_ed25519_dtor(session, abstract);
         *abstract = NULL;
     }
 
-    if(ssh2_ed25519_new_private(&ec_ctx, session, privkeyfile, passphrase))
+    if(ssh2_ed25519_new_private(&ed_ctx, session, privkeyfile, passphrase))
         return -1;
 
-    *abstract = ec_ctx;
+    *abstract = ed_ctx;
 
     return 0;
 }

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -795,7 +795,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
     size_t r_len, s_len, name_len;
     uint32_t len;
     struct string_buf buf;
-    ssh2_ecdsa_ctx *ctx = (ssh2_ecdsa_ctx *)(*abstract);
+    ssh2_ecdsa_ctx *ec_ctx = (ssh2_ecdsa_ctx *)(*abstract);
 
     (void)session;
 
@@ -820,7 +820,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
     if(ssh2_get_string(&buf, &s, &s_len))
         return -1;
 
-    return ssh2_ecdsa_verify(ctx, r, r_len, s, s_len, m, m_len);
+    return ssh2_ecdsa_verify(ec_ctx, r, r_len, s, s_len, m, m_len);
 }
 
 /*
@@ -979,7 +979,7 @@ static int hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
 {
     size_t key_len;
     unsigned char *key;
-    ssh2_ed25519_ctx *ctx = NULL;
+    ssh2_ed25519_ctx *ed_ctx = NULL;
     struct string_buf buf;
 
     if(*abstract) {
@@ -1006,10 +1006,10 @@ static int hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION *session,
     if(!ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_ed25519_new_public(&ctx, session, key, key_len) != 0)
+    if(ssh2_ed25519_new_public(&ed_ctx, session, key, key_len) != 0)
         return -1;
 
-    *abstract = ctx;
+    *abstract = ed_ctx;
 
     return 0;
 }
@@ -1025,7 +1025,7 @@ static int hostkey_method_ssh_ed25519_init_cert(
 {
     size_t key_len, nonce_len;
     unsigned char *key;
-    ssh2_ed25519_ctx *ctx = NULL;
+    ssh2_ed25519_ctx *ed_ctx = NULL;
     struct string_buf buf;
     unsigned char *nonce;
 
@@ -1060,10 +1060,10 @@ static int hostkey_method_ssh_ed25519_init_cert(
      * have more meta data we do not read
      */
 
-    if(ssh2_ed25519_new_public(&ctx, session, key, key_len) != 0)
+    if(ssh2_ed25519_new_public(&ed_ctx, session, key, key_len) != 0)
         return -1;
 
-    *abstract = ctx;
+    *abstract = ed_ctx;
 
     return 0;
 }
@@ -1129,7 +1129,7 @@ static int hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION *session,
                                                  const unsigned char *m,
                                                  size_t m_len, void **abstract)
 {
-    ssh2_ed25519_ctx *ctx = (ssh2_ed25519_ctx *)(*abstract);
+    ssh2_ed25519_ctx *ed_ctx = (ssh2_ed25519_ctx *)(*abstract);
     (void)session;
 
     /* Skip past keyname_len(4) + keyname(11){"ssh-ed25519"} +
@@ -1143,7 +1143,7 @@ static int hostkey_method_ssh_ed25519_sig_verify(LIBSSH2_SESSION *session,
     if(sig_len != SSH2_ED25519_SIG_LEN)
         return -1;
 
-    return ssh2_ed25519_verify(ctx, session, sig, sig_len, m, m_len);
+    return ssh2_ed25519_verify(ed_ctx, session, sig, sig_len, m, m_len);
 }
 
 /*
@@ -1156,12 +1156,12 @@ static int hostkey_method_ssh_ed25519_signv(LIBSSH2_SESSION *session,
                                             const struct iovec datavec[],
                                             void **abstract)
 {
-    ssh2_ed25519_ctx *ctx = (ssh2_ed25519_ctx *)(*abstract);
+    ssh2_ed25519_ctx *ed_ctx = (ssh2_ed25519_ctx *)(*abstract);
 
     if(veccount != 1)
         return -1;
 
-    return ssh2_ed25519_sign(ctx, session, signature, signature_len,
+    return ssh2_ed25519_sign(ed_ctx, session, signature, signature_len,
                              (const uint8_t *)datavec[0].iov_base,
                              datavec[0].iov_len);
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -598,8 +598,7 @@ static unsigned char *mbed_gen_publickey_from_rsa(LIBSSH2_SESSION *session,
 }
 
 static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
-                             unsigned char **method,
-                             size_t *method_len,
+                             unsigned char **method, size_t *method_len,
                              unsigned char **pubkeydata,
                              size_t *pubkeydata_len,
                              mbedtls_pk_context *pkey)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1262,7 +1262,7 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     int rc = 0;
     size_t nlen, elen, dlen, plen, qlen, coefflen, commentlen;
     unsigned char *n, *e, *d, *p, *q, *coeff, *comment;
-    ssh2_rsa_ctx *rsa = NULL;
+    ssh2_rsa_ctx *rsa_key = NULL;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing RSA keys from private key data"));
@@ -1304,7 +1304,7 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_rsa_new(&rsa, e, elen, n, nlen, d, dlen,
+    rc = ssh2_rsa_new(&rsa_key, e, elen, n, nlen, d, dlen,
                       p, plen, q, qlen, NULL, 0, NULL, 0, coeff, coefflen);
     if(rc) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1313,16 +1313,16 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
 #ifndef USE_OPENSSL_3
-    if(rsa)
-        rc = ossl_rsa_additional_params_new(rsa);
+    if(rsa_key)
+        rc = ossl_rsa_additional_params_new(rsa_key);
 #endif
 
-    if(rsa && pubkeydata && method) {
+    if(rsa_key && pubkeydata && method) {
 #ifdef USE_OPENSSL_3
-        EVP_PKEY *pk = rsa;
+        EVP_PKEY *pk = rsa_key;
 #else
         EVP_PKEY *pk = EVP_PKEY_new();
-        EVP_PKEY_set1_RSA(pk, rsa);
+        EVP_PKEY_set1_RSA(pk, rsa_key);
 #endif
 
         rc = ossl_rsa_evp_to_pubkey(session, method, method_len,
@@ -1335,16 +1335,16 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
     if(rsa_ctx)
-        *rsa_ctx = rsa;
+        *rsa_ctx = rsa_key;
     else
-        ssh2_rsa_free(rsa);
+        ssh2_rsa_free(rsa_key);
 
     return rc;
 
 fail:
 
-    if(rsa)
-        ssh2_rsa_free(rsa);
+    if(rsa_key)
+        ssh2_rsa_free(rsa_key);
 
     return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                     "Unable to allocate memory for private key data");
@@ -1589,7 +1589,7 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     int rc = 0;
     size_t plen, qlen, glen, pub_len, priv_len;
     unsigned char *p, *q, *g, *pub_key, *priv_key;
-    ssh2_dsa_ctx *dsa = NULL;
+    ssh2_dsa_ctx *dsa_key = NULL;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing DSA keys from private key data"));
@@ -1619,7 +1619,7 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_dsa_new(&dsa, p, plen, q, qlen, g, glen,
+    rc = ssh2_dsa_new(&dsa_key, p, plen, q, qlen, g, glen,
                       pub_key, pub_len, priv_key, priv_len);
     if(rc) {
         ssh2_deb((session, LIBSSH2_ERROR_PROTO,
@@ -1627,12 +1627,12 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto fail;
     }
 
-    if(dsa && pubkeydata && method) {
+    if(dsa_key && pubkeydata && method) {
 #ifdef USE_OPENSSL_3
-        EVP_PKEY *pk = dsa;
+        EVP_PKEY *pk = dsa_key;
 #else
         EVP_PKEY *pk = EVP_PKEY_new();
-        EVP_PKEY_set1_DSA(pk, dsa);
+        EVP_PKEY_set1_DSA(pk, dsa_key);
 #endif
 
         rc = ossl_dsa_evp_to_pubkey(session, method, method_len,
@@ -1645,16 +1645,16 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
     if(dsa_ctx)
-        *dsa_ctx = dsa;
+        *dsa_ctx = dsa_key;
     else
-        ssh2_dsa_free(dsa);
+        ssh2_dsa_free(dsa_key);
 
     return rc;
 
 fail:
 
-    if(dsa)
-        ssh2_dsa_free(dsa);
+    if(dsa_key)
+        ssh2_dsa_free(dsa_key);
 
     return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                     "Unable to allocate memory for private key data");

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1262,7 +1262,7 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     int rc = 0;
     size_t nlen, elen, dlen, plen, qlen, coefflen, commentlen;
     unsigned char *n, *e, *d, *p, *q, *coeff, *comment;
-    ssh2_rsa_ctx *rsa_key = NULL;
+    ssh2_rsa_ctx *ctx = NULL;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing RSA keys from private key data"));
@@ -1304,7 +1304,7 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_rsa_new(&rsa_key, e, elen, n, nlen, d, dlen,
+    rc = ssh2_rsa_new(&ctx, e, elen, n, nlen, d, dlen,
                       p, plen, q, qlen, NULL, 0, NULL, 0, coeff, coefflen);
     if(rc) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1313,16 +1313,16 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
 #ifndef USE_OPENSSL_3
-    if(rsa_key)
-        rc = ossl_rsa_additional_params_new(rsa_key);
+    if(ctx)
+        rc = ossl_rsa_additional_params_new(ctx);
 #endif
 
-    if(rsa_key && pubkeydata && method) {
+    if(ctx && pubkeydata && method) {
 #ifdef USE_OPENSSL_3
-        EVP_PKEY *pk = rsa_key;
+        EVP_PKEY *pk = ctx;
 #else
         EVP_PKEY *pk = EVP_PKEY_new();
-        EVP_PKEY_set1_RSA(pk, rsa_key);
+        EVP_PKEY_set1_RSA(pk, ctx);
 #endif
 
         rc = ossl_rsa_evp_to_pubkey(session, method, method_len,
@@ -1335,16 +1335,16 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
     if(rsa)
-        *rsa = rsa_key;
+        *rsa = ctx;
     else
-        ssh2_rsa_free(rsa_key);
+        ssh2_rsa_free(ctx);
 
     return rc;
 
 fail:
 
-    if(rsa_key)
-        ssh2_rsa_free(rsa_key);
+    if(ctx)
+        ssh2_rsa_free(ctx);
 
     return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                     "Unable to allocate memory for private key data");
@@ -1589,7 +1589,7 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     int rc = 0;
     size_t plen, qlen, glen, pub_len, priv_len;
     unsigned char *p, *q, *g, *pub_key, *priv_key;
-    ssh2_dsa_ctx *dsa_key = NULL;
+    ssh2_dsa_ctx *ctx = NULL;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing DSA keys from private key data"));
@@ -1619,7 +1619,7 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_dsa_new(&dsa_key, p, plen, q, qlen, g, glen,
+    rc = ssh2_dsa_new(&ctx, p, plen, q, qlen, g, glen,
                       pub_key, pub_len, priv_key, priv_len);
     if(rc) {
         ssh2_deb((session, LIBSSH2_ERROR_PROTO,
@@ -1627,12 +1627,12 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto fail;
     }
 
-    if(dsa_key && pubkeydata && method) {
+    if(ctx && pubkeydata && method) {
 #ifdef USE_OPENSSL_3
-        EVP_PKEY *pk = dsa_key;
+        EVP_PKEY *pk = ctx;
 #else
         EVP_PKEY *pk = EVP_PKEY_new();
-        EVP_PKEY_set1_DSA(pk, dsa_key);
+        EVP_PKEY_set1_DSA(pk, ctx);
 #endif
 
         rc = ossl_dsa_evp_to_pubkey(session, method, method_len,
@@ -1645,16 +1645,16 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
     if(dsa)
-        *dsa = dsa_key;
+        *dsa = ctx;
     else
-        ssh2_dsa_free(dsa_key);
+        ssh2_dsa_free(ctx);
 
     return rc;
 
 fail:
 
-    if(dsa_key)
-        ssh2_dsa_free(dsa_key);
+    if(ctx)
+        ssh2_dsa_free(ctx);
 
     return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                     "Unable to allocate memory for private key data");

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3641,13 +3641,13 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
                                       const char *privatekey,
                                       const unsigned char *passphrase)
 {
-    FILE *fp;
+    int rc;
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
-    int rc = 0;
 #if LIBSSH2_ECDSA
     ssh2_curve_type type;
 #endif
+    FILE *fp;
 
     if(!session)
         return -1;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1257,7 +1257,7 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                            size_t *method_len,
                                            unsigned char **pubkeydata,
                                            size_t *pubkeydata_len,
-                                           ssh2_rsa_ctx **rsa_ctx)
+                                           ssh2_rsa_ctx **rsa)
 {
     int rc = 0;
     size_t nlen, elen, dlen, plen, qlen, coefflen, commentlen;
@@ -1334,8 +1334,8 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
 #endif
     }
 
-    if(rsa_ctx)
-        *rsa_ctx = rsa_key;
+    if(rsa)
+        *rsa = rsa_key;
     else
         ssh2_rsa_free(rsa_key);
 
@@ -1584,7 +1584,7 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                            size_t *method_len,
                                            unsigned char **pubkeydata,
                                            size_t *pubkeydata_len,
-                                           ssh2_dsa_ctx **dsa_ctx)
+                                           ssh2_dsa_ctx **dsa)
 {
     int rc = 0;
     size_t plen, qlen, glen, pub_len, priv_len;
@@ -1644,8 +1644,8 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
 #endif
     }
 
-    if(dsa_ctx)
-        *dsa_ctx = dsa_key;
+    if(dsa)
+        *dsa = dsa_key;
     else
         ssh2_dsa_free(dsa_key);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3670,7 +3670,6 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
 
     /* We have a new key file, now try and parse it using supported types  */
     rc = ssh2_get_string(decrypted, &buf, NULL);
-
     if(rc || !buf) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO,
                  "Public key type in decrypted key data not found");
@@ -3832,13 +3831,11 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
     rc = ssh2_openssh_pem_parse_memory(session, passphrase,
                                        privatekeydata,
                                        privatekeydata_len, &decrypted);
-
     if(rc)
         return rc;
 
     /* We have a new key file, now try and parse it using supported types  */
     rc = ssh2_get_string(decrypted, &buf, NULL);
-
     if(rc || !buf)
         return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                         "Public key type in decrypted key data not found");

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2857,7 +2857,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     int rc = 0;
     size_t curvelen, exponentlen, pointlen;
     unsigned char *curve, *exponent, *point_buf;
-    ssh2_ecdsa_ctx *ec_key = NULL;
+    ssh2_ecdsa_ctx *ctx = NULL;
 
 #ifdef USE_OPENSSL_3
     EVP_PKEY_CTX *fromdata_ctx = NULL;
@@ -2913,13 +2913,13 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     if(EVP_PKEY_fromdata_init(fromdata_ctx) <= 0)
         goto fail;
 
-    rc = EVP_PKEY_fromdata(fromdata_ctx, &ec_key, EVP_PKEY_KEYPAIR, params);
+    rc = EVP_PKEY_fromdata(fromdata_ctx, &ctx, EVP_PKEY_KEYPAIR, params);
     rc = rc != 1;
 
     if(group_name)
         OPENSSL_clear_free(group_name, strlen(n) + 1);
 #else
-    rc = ssh2_ecdsa_curve_name_with_octal_new(&ec_key, point_buf, pointlen,
+    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, point_buf, pointlen,
                                               curve_type);
     if(rc) {
         rc = -1;
@@ -2936,16 +2936,16 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
     BN_bin2bn(exponent, (int)exponentlen, bn_exponent);
-    rc = (EC_KEY_set_private_key(ec_key, bn_exponent) != 1);
+    rc = (EC_KEY_set_private_key(ctx, bn_exponent) != 1);
     BN_free(bn_exponent);
 #endif
 
-    if(rc == 0 && ec_key && pubkeydata && method) {
+    if(rc == 0 && ctx && pubkeydata && method) {
 #ifdef USE_OPENSSL_3
-        EVP_PKEY *pk = ec_key;
+        EVP_PKEY *pk = ctx;
 #else
         EVP_PKEY *pk = EVP_PKEY_new();
-        EVP_PKEY_set1_EC_KEY(pk, ec_key);
+        EVP_PKEY_set1_EC_KEY(pk, ctx);
 #endif
 
         rc = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
@@ -2963,9 +2963,9 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
 #endif
 
     if(ec_ctx)
-        *ec_ctx = ec_key;
+        *ec_ctx = ctx;
     else
-        ssh2_ecdsa_free(ec_key);
+        ssh2_ecdsa_free(ctx);
 
     return rc;
 
@@ -2975,8 +2975,8 @@ fail:
         EVP_PKEY_CTX_free(fromdata_ctx);
 #endif
 
-    if(ec_key)
-        ssh2_ecdsa_free(ec_key);
+    if(ctx)
+        ssh2_ecdsa_free(ctx);
 
     return rc;
 }
@@ -2997,7 +2997,7 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     int rc = 0;
     size_t curvelen, pointlen, key_len, app_len;
     unsigned char *curve, *point_buf, *p, *key = NULL, *app;
-    ssh2_ecdsa_ctx *ec_key = NULL;
+    ssh2_ecdsa_ctx *ctx = NULL;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Extracting ECDSA-SK public key"));
 
@@ -3011,7 +3011,7 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
         return -1;
     }
 
-    rc = ssh2_ecdsa_curve_name_with_octal_new(&ec_key, point_buf, pointlen,
+    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, point_buf, pointlen,
                                               SSH2_EC_CURVE_NISTP256);
     if(rc) {
         rc = -1;
@@ -3043,12 +3043,12 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
         }
     }
 
-    if(rc == 0 && ec_key && pubkeydata && method) {
+    if(rc == 0 && ctx && pubkeydata && method) {
 #ifdef USE_OPENSSL_3
-        EVP_PKEY *pk = ec_key;
+        EVP_PKEY *pk = ctx;
 #else
         EVP_PKEY *pk = EVP_PKEY_new();
-        EVP_PKEY_set1_EC_KEY(pk, ec_key);
+        EVP_PKEY_set1_EC_KEY(pk, ctx);
 #endif
 
         rc = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
@@ -3091,15 +3091,15 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     }
 
     if(ec_ctx)
-        *ec_ctx = ec_key;
+        *ec_ctx = ctx;
     else
-        ssh2_ecdsa_free(ec_key);
+        ssh2_ecdsa_free(ctx);
 
     return rc;
 
 fail:
-    if(ec_key)
-        ssh2_ecdsa_free(ec_key);
+    if(ctx)
+        ssh2_ecdsa_free(ctx);
 
     if(key)
         SSH2_FREE(session, key);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3895,13 +3895,13 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                                (ssh2_ecdsa_ctx **)key_ctx);
 #endif
 
+    if(decrypted)
+        ssh2_string_buf_free(session, decrypted);
+
     if(rc == LIBSSH2_ERROR_FILE)
         rc = ssh2_err(session, LIBSSH2_ERROR_FILE,
                       "Unable to extract public key from private key file: "
                       "invalid/unrecognized private key file format");
-
-    if(decrypted)
-        ssh2_string_buf_free(session, decrypted);
 
     return rc;
 }

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -304,11 +304,10 @@ static struct {
 };
 
 /* Define ASCII strings. */
-static const char beginencprivkeyhdr[] =
-    "-----BEGIN ENCRYPTED PRIVATE KEY-----";
-static const char endencprivkeyhdr[] = "-----END ENCRYPTED PRIVATE KEY-----";
-static const char beginprivkeyhdr[] = "-----BEGIN PRIVATE KEY-----";
-static const char endprivkeyhdr[] = "-----END PRIVATE KEY-----";
+static const char beginencprivkeyhdr[] = PKCS8_ENCRYPTED_HEADER;
+static const char endencprivkeyhdr[] = PKCS8_ENCRYPTED_FOOTER;
+static const char beginprivkeyhdr[] = PKCS8_HEADER;
+static const char endprivkeyhdr[] = PKCS8_FOOTER;
 static const char beginrsaprivkeyhdr[] = PEM_RSA_HEADER;
 static const char endrsaprivkeyhdr[] = PEM_RSA_FOOTER;
 static const char fopenrbmode[] = "rb";

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1032,8 +1032,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                            &pubkeydata, &pubkeydata_len,
                                            publickey);
             if(rc)
-                /* Note: userauth_read_file_pubkey() calls ssh2_err() */
-                return rc;
+                return rc; /* userauth_read_file_pubkey() calls ssh2_err() */
         }
         else {
             /* Compute public key from private key. */
@@ -1043,8 +1042,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                        &pubkeydata, &pubkeydata_len,
                                        privatekey, passphrase);
             if(rc)
-                /* ssh2_pub_priv_keyfile() calls ssh2_err() */
-                return rc;
+                return rc; /* ssh2_pub_priv_keyfile() calls ssh2_err() */
         }
 
         if(username_len > MAX_INPUT_LEN ||


### PR DESCRIPTION
Also:
- move `PKCS8_*` macros to `crypto.h` from os400qc3.
