### PR TITLE
session: disable timeout when negative in `libssh2_poll()` `select` path

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1719,7 +1719,8 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
             tv.tv_usec = (timeout_remaining % 1000) * 1000;
 #endif
             start_time = ssh2_now();
-            sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL, &tv);
+            sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL,
+                            timeout_remaining >= 0 ? &tv : NULL);
             now = ssh2_now();
             timeout_remaining -= now > start_time ? (now - start_time) : 0;
         }


### PR DESCRIPTION
"`libssh2_poll()` says its calling semantics generally match `poll(2)`,
which uses a negative timeout for “infinite”. In the `HAVE_SELECT` path,
a negative `timeout_ms` produces a negative `timeval` (`tv_usec` in
particular) and passes it to `select()`, which is invalid/undefined.
Treat negative `timeout_remaining` as “no timeout” and pass a NULL
`timeval*` to `select()`."

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2341#discussion_r3608484393
