### PR TITLE
src: make internal passphrase type `const char *` to match public API

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -484,7 +484,7 @@ support the private key and the other parameters here.
 int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase);
+                         const char *passphrase);
 ```
 Reads an RSA private key from file `filename` into a new RSA context.
 Must call `ssh2_init_if_needed()`.
@@ -495,7 +495,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase);
+                                    const char *passphrase);
 ```
 Gets an RSA private key from `blob` into a new RSA context.
 Must call `ssh2_init_if_needed()`.
@@ -624,7 +624,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase);
+                         const char *passphrase);
 ```
 Gets a DSA private key from file `filename` into a new DSA context.
 Must call `ssh2_init_if_needed()`.
@@ -635,7 +635,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase);
+                                    const char *passphrase);
 ```
 Gets a DSA private key from the `blob_len`-bytes `blob` into a new DSA context.
 Must call `ssh2_init_if_needed()`.
@@ -700,7 +700,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                            LIBSSH2_SESSION *session,
                            const char *filename,
-                           const unsigned char *passphrase);
+                           const char *passphrase);
 ```
 Reads an ECDSA private key from PEM file `filename` into a new ECDSA context.
 Must call `ssh2_init_if_needed()`.
@@ -711,7 +711,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                       LIBSSH2_SESSION *session,
                                       const char *blob, size_t blob_len,
-                                      const unsigned char *passphrase);
+                                      const char *passphrase);
 ```
 Builds an ECDSA private key from PEM data at `blob` of length `blob_len`
 into a new ECDSA context stored at `ec_ctx`.
@@ -734,7 +734,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_ecdsa_new_openssh_private(ssh2_ecdsa_ctx **ec_ctx,
                                    LIBSSH2_SESSION *session,
                                    const char *filename,
-                                   const unsigned char *passphrase);
+                                   const char *passphrase);
 ```
 Reads a PEM-encoded ECDSA private key from file `filename` encrypted with
 `passphrase` and stores at `ec_ctx` a new ECDSA context for it.
@@ -804,7 +804,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename,
-                             const uint8_t *passphrase);
+                             const char *passphrase);
 ```
 Reads an ED25519 private key from PEM file `filename` into a new ED25519
 context.
@@ -827,7 +827,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         LIBSSH2_SESSION *session,
                                         const char *blob, size_t blob_len,
-                                        const unsigned char *passphrase);
+                                        const char *passphrase);
 ```
 Builds an ED25519 private key from PEM data at `blob` of length `blob_len`
 into a new ED25519 context stored at `ed_ctx`.

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -419,7 +419,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const unsigned char *passphrase);
+                          const char *passphrase);
 ```
 Reads a private key from file privatekey and extract the public key -->
 (`pubkeydata`, `pubkeydata_len`). Store the associated method (ssh-rsa or
@@ -435,7 +435,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const unsigned char *passphrase);
+                                const char *passphrase);
 ```
 Gets a private key from bytes at (`privatekeydata`, `privatekeydata_len`) and
 extract the public key --> (`pubkeydata`, `pubkeydata_len`). Store the
@@ -804,7 +804,7 @@ This procedure is already prototyped in `crypto.h`.
 int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename,
-                             const unsigned char *passphrase);
+                             const uint8_t *passphrase);
 ```
 Reads an ED25519 private key from PEM file `filename` into a new ED25519
 context.

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -250,7 +250,7 @@ int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,
 int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename,
-                             const unsigned char *passphrase);
+                             const uint8_t *passphrase);
 
 int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         LIBSSH2_SESSION *session,
@@ -291,7 +291,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const unsigned char *passphrase);
+                          const char *passphrase);
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 unsigned char **method, size_t *method_len,
@@ -299,7 +299,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const unsigned char *passphrase);
+                                const char *passphrase);
 
 int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               unsigned char **method, size_t *method_len,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -136,11 +136,11 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase);
+                         const char *passphrase);
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase);
+                                    const char *passphrase);
 #if LIBSSH2_RSA_SHA1
 int ssh2_rsa_sha1_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash, size_t hash_len,
@@ -172,11 +172,11 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
 int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase);
+                         const char *passphrase);
 int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase);
+                                    const char *passphrase);
 int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
                        const unsigned char *hash, size_t hash_len,
                        unsigned char *signature);
@@ -213,12 +213,12 @@ int ssh2_ecdsa_curve_name_with_octal_new(
 int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                            LIBSSH2_SESSION *session,
                            const char *filename,
-                           const unsigned char *passphrase);
+                           const char *passphrase);
 
 int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                       LIBSSH2_SESSION *session,
                                       const char *blob, size_t blob_len,
-                                      const unsigned char *passphrase);
+                                      const char *passphrase);
 
 int ssh2_ecdsa_sign(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                     const unsigned char *hash, size_t hash_len,
@@ -250,12 +250,12 @@ int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,
 int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename,
-                             const uint8_t *passphrase);
+                             const char *passphrase);
 
 int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         LIBSSH2_SESSION *session,
                                         const char *blob, size_t blob_len,
-                                        const unsigned char *passphrase);
+                                        const char *passphrase);
 
 int ssh2_ed25519_sign(ssh2_ed25519_ctx *ed_ctx, LIBSSH2_SESSION *session,
                       uint8_t **out_sig, size_t *out_sig_len,
@@ -312,7 +312,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               size_t *handle_len,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
-                              const unsigned char *passphrase);
+                              const char *passphrase);
 
 #ifndef ssh2_bn_ctx
 #define ssh2_bn_ctx              int

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -131,7 +131,7 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
  */
 static int hostkey_method_ssh_rsa_initPEM(LIBSSH2_SESSION *session,
                                           const char *privkeyfile,
-                                          const unsigned char *passphrase,
+                                          const char *passphrase,
                                           void **abstract)
 {
     ssh2_rsa_ctx *rsa;
@@ -156,7 +156,7 @@ static int hostkey_method_ssh_rsa_initPEMFromMemory(
     LIBSSH2_SESSION *session,
     const char *privkeyfiledata,
     size_t privkeyfiledata_len,
-    const unsigned char *passphrase,
+    const char *passphrase,
     void **abstract)
 {
     ssh2_rsa_ctx *rsa;
@@ -511,7 +511,7 @@ static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
  */
 static int hostkey_method_ssh_dss_initPEM(LIBSSH2_SESSION *session,
                                           const char *privkeyfile,
-                                          const unsigned char *passphrase,
+                                          const char *passphrase,
                                           void **abstract)
 {
     ssh2_dsa_ctx *dsa;
@@ -536,7 +536,7 @@ static int hostkey_method_ssh_dss_initPEMFromMemory(
     LIBSSH2_SESSION *session,
     const char *privkeyfiledata,
     size_t privkeyfiledata_len,
-    const unsigned char *passphrase,
+    const char *passphrase,
     void **abstract)
 {
     ssh2_dsa_ctx *dsa;
@@ -735,7 +735,7 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
  */
 static int hostkey_method_ssh_ecdsa_initPEM(LIBSSH2_SESSION *session,
                                             const char *privkeyfile,
-                                            const unsigned char *passphrase,
+                                            const char *passphrase,
                                             void **abstract)
 {
     ssh2_ecdsa_ctx *ec_ctx = NULL;
@@ -761,7 +761,7 @@ static int hostkey_method_ssh_ecdsa_initPEMFromMemory(
     LIBSSH2_SESSION *session,
     const char *privkeyfiledata,
     size_t privkeyfiledata_len,
-    const unsigned char *passphrase,
+    const char *passphrase,
     void **abstract)
 {
     ssh2_ecdsa_ctx *ec_ctx = NULL;
@@ -1073,7 +1073,7 @@ static int hostkey_method_ssh_ed25519_init_cert(
  */
 static int hostkey_method_ssh_ed25519_initPEM(LIBSSH2_SESSION *session,
                                               const char *privkeyfile,
-                                              const unsigned char *passphrase,
+                                              const char *passphrase,
                                               void **abstract)
 {
     ssh2_ed25519_ctx *ed_ctx = NULL;
@@ -1098,7 +1098,7 @@ static int hostkey_method_ssh_ed25519_initPEMFromMemory(
     LIBSSH2_SESSION *session,
     const char *privkeyfiledata,
     size_t privkeyfiledata_len,
-    const unsigned char *passphrase,
+    const char *passphrase,
     void **abstract)
 {
     ssh2_ed25519_ctx *ed_ctx = NULL;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -241,7 +241,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase)
+                                    const char *passphrase)
 {
     (void)rsa;
     (void)blob;
@@ -256,7 +256,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase)
+                         const char *passphrase)
 {
     FILE *fp;
     unsigned char *data, *save_data;
@@ -355,7 +355,7 @@ fail:
 int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase)
+                                    const char *passphrase)
 {
     (void)dsa;
     (void)blob;
@@ -370,7 +370,7 @@ int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
 int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase)
+                         const char *passphrase)
 {
     FILE *fp;
     unsigned char *data, *save_data;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -702,7 +702,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const unsigned char *passphrase)
+                                const char *passphrase)
 {
     (void)method;
     (void)method_len;
@@ -722,7 +722,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const unsigned char *passphrase)
+                          const char *passphrase)
 {
     (void)method;
     (void)method_len;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1012,11 +1012,11 @@ struct hostkey_method {
     int (*init)(LIBSSH2_SESSION *session, const unsigned char *hostkey_data,
                 size_t hostkey_data_len, void **abstract);
     int (*initPEM)(LIBSSH2_SESSION *session, const char *privkeyfile,
-                   const unsigned char *passphrase, void **abstract);
+                   const char *passphrase, void **abstract);
     int (*initPEMFromMemory)(LIBSSH2_SESSION *session,
                              const char *privkeyfiledata,
                              size_t privkeyfiledata_len,
-                             const unsigned char *passphrase,
+                             const char *passphrase,
                              void **abstract);
     int (*sig_verify)(LIBSSH2_SESSION *session, const unsigned char *sig,
                       size_t sig_len, const unsigned char *m,
@@ -1230,20 +1230,20 @@ int ssh2_bcrypt_pbkdf(const char *pass,
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
-                   const unsigned char *passphrase,
+                   const char *passphrase,
                    FILE *fp, unsigned char **data, size_t *datalen);
 int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
                           const char *headerbegin,
                           const char *headerend,
-                          const unsigned char *passphrase,
+                          const char *passphrase,
                           const char *filedata, size_t filedata_len,
                           unsigned char **data, size_t *datalen);
 /* OpenSSL keys */
 int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
-                           const unsigned char *passphrase,
+                           const char *passphrase,
                            FILE *fp, struct string_buf **decrypted_buf);
 int ssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
-                                  const unsigned char *passphrase,
+                                  const char *passphrase,
                                   const char *filedata,
                                   size_t filedata_len,
                                   struct string_buf **decrypted_buf);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -650,14 +650,14 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const unsigned char *passphrase)
+                          const char *passphrase)
 {
     mbedtls_pk_context pkey;
     char buf[1024];
     int ret;
 
     mbedtls_pk_init(&pkey);
-    ret = mbedtls_pk_parse_keyfile(&pkey, privatekey, (const char *)passphrase,
+    ret = mbedtls_pk_parse_keyfile(&pkey, privatekey, passphrase,
                                    mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     if(ret) {
         mbedtls_strerror(ret, (char *)buf, sizeof(buf));
@@ -680,7 +680,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const unsigned char *passphrase)
+                                const char *passphrase)
 {
     mbedtls_pk_context pkey;
     char buf[1024];

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -357,7 +357,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase)
+                         const char *passphrase)
 {
     int ret;
     mbedtls_pk_context pkey;
@@ -372,7 +372,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
     mbedtls_rsa_init(*rsa);
     mbedtls_pk_init(&pkey);
 
-    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase,
+    ret = mbedtls_pk_parse_keyfile(&pkey, filename, passphrase,
                                    mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);
@@ -391,13 +391,13 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase)
+                                    const char *passphrase)
 {
     int ret;
     mbedtls_pk_context pkey;
     mbedtls_rsa_context *pk_rsa;
     unsigned char *data_nullterm;
-    size_t pwd_len;
+    size_t passphrase_len;
 
     (void)session;
 
@@ -421,9 +421,10 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 
     mbedtls_pk_init(&pkey);
 
-    pwd_len = passphrase ? strlen((const char *)passphrase) : 0;
+    passphrase_len = passphrase ? strlen(passphrase) : 0;
     ret = mbedtls_pk_parse_key(&pkey, data_nullterm, blob_len + 1,
-                               passphrase, pwd_len,
+                               (const unsigned char *)passphrase,
+                               passphrase_len,
                                mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     mbed_zero_free(data_nullterm, blob_len + 1);
 
@@ -686,7 +687,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     char buf[1024];
     int ret;
     unsigned char *data_nullterm;
-    size_t pwd_len;
+    size_t passphrase_len;
 
     /* mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
        private-key from memory fails if the last byte is not a null byte */
@@ -699,9 +700,10 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 
     mbedtls_pk_init(&pkey);
 
-    pwd_len = passphrase ? strlen((const char *)passphrase) : 0;
+    passphrase_len = passphrase ? strlen(passphrase) : 0;
     ret = mbedtls_pk_parse_key(&pkey, data_nullterm, privatekeydata_len + 1,
-                               passphrase, pwd_len,
+                               (const unsigned char *)passphrase,
+                               passphrase_len,
                                mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     mbed_zero_free(data_nullterm, privatekeydata_len + 1);
 
@@ -1002,13 +1004,13 @@ cleanup:
 
 static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx, mbedtls_pk_context *pkey,
                             const unsigned char *data, size_t data_len,
-                            const unsigned char *pwd)
+                            const unsigned char *passphrase)
 {
-    size_t pwd_len;
+    size_t passphrase_len;
 
-    pwd_len = pwd ? strlen((const char *)pwd) : 0;
+    passphrase_len = passphrase ? strlen(passphrase) : 0;
 
-    if(mbedtls_pk_parse_key(pkey, data, data_len, pwd, pwd_len,
+    if(mbedtls_pk_parse_key(pkey, data, data_len, passphrase, passphrase_len,
                             mbedtls_ctr_drbg_random, &mbed_ctr_drbg))
         goto failed;
 
@@ -1070,7 +1072,7 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
                                   LIBSSH2_SESSION *session,
                                   const unsigned char *data,
                                   size_t data_len,
-                                  const unsigned char *pwd)
+                                  const char *passphrase)
 {
     ssh2_curve_type type;
     unsigned char *name = NULL;
@@ -1078,7 +1080,7 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
     size_t curvelen, exponentlen, pointlen;
     unsigned char *curve, *exponent, *point_buf;
 
-    if(ssh2_openssh_pem_parse_memory(session, pwd,
+    if(ssh2_openssh_pem_parse_memory(session, passphrase,
                                      (const char *)data, data_len,
                                      &decrypted))
         goto failed;
@@ -1142,7 +1144,7 @@ cleanup:
 int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                            LIBSSH2_SESSION *session,
                            const char *filename,
-                           const unsigned char *passphrase)
+                           const char *passphrase)
 {
     mbedtls_pk_context pkey;
     unsigned char *data = NULL;
@@ -1172,7 +1174,8 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
         goto cleanup;
 
     data[data_len] = 0;  /* for mbedtls_pk_parse_key() */
-    if(mbed_parse_eckey(ec_ctx, &pkey, data, data_len + 1, passphrase) == 0)
+    if(mbed_parse_eckey(ec_ctx, &pkey, data, data_len + 1,
+                        (const unsigned char *)passphrase) == 0)
         goto cleanup;
 
     mbed_parse_openssh_key(ec_ctx, session, data, data_len, passphrase);
@@ -1197,7 +1200,7 @@ cleanup:
 int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                       LIBSSH2_SESSION *session,
                                       const char *blob, size_t blob_len,
-                                      const unsigned char *passphrase)
+                                      const char *passphrase)
 {
     unsigned char *data_nullterm;
     mbedtls_pk_context pkey;
@@ -1214,7 +1217,7 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
     data_nullterm[blob_len] = 0;
 
     if(mbed_parse_eckey(ec_ctx, &pkey, data_nullterm, blob_len + 1,
-                        passphrase) == 0)
+                        (const unsigned char *)passphrase) == 0)
         goto cleanup;
 
     mbed_parse_openssh_key(ec_ctx, session, data_nullterm, blob_len + 1,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -397,7 +397,6 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
     mbedtls_pk_context pkey;
     mbedtls_rsa_context *pk_rsa;
     unsigned char *data_nullterm;
-    size_t passphrase_len;
 
     (void)session;
 
@@ -421,10 +420,9 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 
     mbedtls_pk_init(&pkey);
 
-    passphrase_len = passphrase ? strlen(passphrase) : 0;
     ret = mbedtls_pk_parse_key(&pkey, data_nullterm, blob_len + 1,
                                (const unsigned char *)passphrase,
-                               passphrase_len,
+                               passphrase ? strlen(passphrase) : 0,
                                mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     mbed_zero_free(data_nullterm, blob_len + 1);
 
@@ -687,7 +685,6 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
     char buf[1024];
     int ret;
     unsigned char *data_nullterm;
-    size_t passphrase_len;
 
     /* mbedtls checks in "mbedtls/pkparse.c:1184" if "key[keylen - 1] != '\0'"
        private-key from memory fails if the last byte is not a null byte */
@@ -700,10 +697,9 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 
     mbedtls_pk_init(&pkey);
 
-    passphrase_len = passphrase ? strlen(passphrase) : 0;
     ret = mbedtls_pk_parse_key(&pkey, data_nullterm, privatekeydata_len + 1,
                                (const unsigned char *)passphrase,
-                               passphrase_len,
+                               passphrase ? strlen(passphrase) : 0,
                                mbedtls_ctr_drbg_random, &mbed_ctr_drbg);
     mbed_zero_free(data_nullterm, privatekeydata_len + 1);
 
@@ -1004,13 +1000,11 @@ cleanup:
 
 static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx, mbedtls_pk_context *pkey,
                             const unsigned char *data, size_t data_len,
-                            const unsigned char *passphrase)
+                            const char *passphrase)
 {
-    size_t passphrase_len;
-
-    passphrase_len = passphrase ? strlen(passphrase) : 0;
-
-    if(mbedtls_pk_parse_key(pkey, data, data_len, passphrase, passphrase_len,
+    if(mbedtls_pk_parse_key(pkey, data, data_len,
+                            (const unsigned char *)passphrase,
+                            passphrase ? strlen(passphrase) : 0,
                             mbedtls_ctr_drbg_random, &mbed_ctr_drbg))
         goto failed;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1168,8 +1168,7 @@ int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
         goto cleanup;
 
     data[data_len] = 0;  /* for mbedtls_pk_parse_key() */
-    if(mbed_parse_eckey(ec_ctx, &pkey, data, data_len + 1,
-                        (const unsigned char *)passphrase) == 0)
+    if(mbed_parse_eckey(ec_ctx, &pkey, data, data_len + 1, passphrase) == 0)
         goto cleanup;
 
     mbed_parse_openssh_key(ec_ctx, session, data, data_len, passphrase);
@@ -1211,7 +1210,7 @@ int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
     data_nullterm[blob_len] = 0;
 
     if(mbed_parse_eckey(ec_ctx, &pkey, data_nullterm, blob_len + 1,
-                        (const unsigned char *)passphrase) == 0)
+                        passphrase) == 0)
         goto cleanup;
 
     mbed_parse_openssh_key(ec_ctx, session, data_nullterm, blob_len + 1,

--- a/src/misc.c
+++ b/src/misc.c
@@ -1011,7 +1011,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               size_t *handle_len,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
-                              const unsigned char *passphrase)
+                              const char *passphrase)
 {
     (void)method;
     (void)method_len;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -156,7 +156,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                       size_t *pubkeydata_len,
                                       const char *privatekeydata,
                                       size_t privatekeydata_len,
-                                      const unsigned char *passphrase);
+                                      const char *passphrase);
 
 #if LIBSSH2_RSA || LIBSSH2_DSA || LIBSSH2_ECDSA
 static unsigned char *ossl_write_bn(unsigned char *buf,
@@ -1052,7 +1052,7 @@ static int ossl_passphrase_cb(char *buf, int size, int rwflag,
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase)
+                                    const char *passphrase)
 {
     int rc = 0;
     BIO *bp;
@@ -1353,7 +1353,7 @@ fail:
 static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
                                      LIBSSH2_SESSION *session,
                                      const char *filename,
-                                     const unsigned char *passphrase)
+                                     const char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -1403,7 +1403,7 @@ cleanup:
 int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase)
+                         const char *passphrase)
 {
     int rc = 0;
     BIO *bp;
@@ -1432,7 +1432,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
 int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase)
+                                    const char *passphrase)
 {
     int rc = 0;
     BIO *bp;
@@ -1665,7 +1665,7 @@ fail:
 static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
                                      LIBSSH2_SESSION *session,
                                      const char *filename,
-                                     const unsigned char *passphrase)
+                                     const char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -1715,7 +1715,7 @@ cleanup:
 int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase)
+                         const char *passphrase)
 {
     int rc = 0;
     BIO *bp;
@@ -1744,7 +1744,7 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
 int ssh2_ecdsa_new_private_frommemory(ssh2_ecdsa_ctx **ec_ctx,
                                       LIBSSH2_SESSION *session,
                                       const char *blob, size_t blob_len,
-                                      const unsigned char *passphrase)
+                                      const char *passphrase)
 {
     int rc = 0;
     BIO *bp;
@@ -2178,7 +2178,7 @@ clean_exit:
 int ssh2_ed25519_new_private(ssh2_ed25519_ctx **ed_ctx,
                              LIBSSH2_SESSION *session,
                              const char *filename,
-                             const unsigned char *passphrase)
+                             const char *passphrase)
 {
     int rc;
     FILE *fp;
@@ -2236,7 +2236,7 @@ cleanup:
 int ssh2_ed25519_new_private_frommemory(ssh2_ed25519_ctx **ed_ctx,
                                         LIBSSH2_SESSION *session,
                                         const char *blob, size_t blob_len,
-                                        const unsigned char *passphrase)
+                                        const char *passphrase)
 {
     ssh2_ed25519_ctx *ctx = NULL;
     BIO *bp;
@@ -3126,7 +3126,7 @@ fail:
 static int ossl_ecdsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
                                        LIBSSH2_SESSION *session,
                                        const char *filename,
-                                       const unsigned char *passphrase)
+                                       const char *passphrase)
 {
     FILE *fp;
     int rc;
@@ -3179,7 +3179,7 @@ cleanup:
 int ssh2_ecdsa_new_private(ssh2_ecdsa_ctx **ec_ctx,
                            LIBSSH2_SESSION *session,
                            const char *filename,
-                           const unsigned char *passphrase)
+                           const char *passphrase)
 {
     int rc = 0;
     BIO *bp;
@@ -3647,7 +3647,7 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       const char *privatekey,
-                                      const unsigned char *passphrase)
+                                      const char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;
@@ -3819,7 +3819,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                       size_t *pubkeydata_len,
                                       const char *privatekeydata,
                                       size_t privatekeydata_len,
-                                      const unsigned char *passphrase)
+                                      const char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;
@@ -3932,7 +3932,7 @@ int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
                               size_t *handle_len,
                               const char *privatekeydata,
                               size_t privatekeydata_len,
-                              const unsigned char *passphrase)
+                              const char *passphrase)
 {
     int rc;
     unsigned char *buf = NULL;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3738,7 +3738,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const unsigned char *passphrase)
+                          const char *passphrase)
 {
     BIO *bp;
     EVP_PKEY *pk;
@@ -4020,7 +4020,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const unsigned char *passphrase)
+                                const char *passphrase)
 {
     int rc;
     BIO *bp;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2094,7 +2094,8 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method, size_t *method_len,
+                          unsigned char **method,
+                          size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
@@ -2207,7 +2208,8 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method, size_t *method_len,
+                                unsigned char **method,
+                                size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2011,7 +2011,7 @@ static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
 
 static int load_rsa_private_file(LIBSSH2_SESSION *session,
                                  const char *filename,
-                                 unsigned const char *passphrase,
+                                 const char *passphrase,
                                  loadkeyproc proc1, loadkeyproc proc8,
                                  void *loadkeydata)
 {
@@ -2075,7 +2075,7 @@ static int load_rsa_private_file(LIBSSH2_SESSION *session,
 
 int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                          const char *filename,
-                         unsigned const char *passphrase)
+                         const char *passphrase)
 {
     ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL);
     int ret;
@@ -2136,7 +2136,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    unsigned const char *passphrase)
+                                    const char *passphrase)
 {
     ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL);
     unsigned char *data = NULL;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2094,12 +2094,10 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method,
-                          size_t *method_len,
+                          unsigned char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
-                          const char *privatekey,
-                          const unsigned char *passphrase)
+                          const char *privatekey, const char *passphrase)
 {
     struct loadpubkeydata p;
     int ret;
@@ -2208,13 +2206,12 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method,
-                                size_t *method_len,
+                                unsigned char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const unsigned char *passphrase)
+                                const char *passphrase)
 {
     struct loadpubkeydata p;
     unsigned char *data = NULL;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -57,7 +57,7 @@ struct valiststr {
 
 typedef int (*loadkeyproc)(LIBSSH2_SESSION *session,
                            const unsigned char *data, unsigned int datalen,
-                           const unsigned char *passphrase, void *loadkeydata);
+                           const char *passphrase, void *loadkeydata);
 
 /* Public key extraction data. */
 struct loadpubkeydata {
@@ -117,7 +117,7 @@ struct pkcs5params {
     char padopt;           /* Pad option. */
     char padchar;          /* Pad character. */
     int (*kdf)(LIBSSH2_SESSION *session, char **dk,
-               const unsigned char *passphrase,
+               const char *passphrase,
                struct pkcs5params *pkcs5);
     int hash;              /* KDF hash algorithm. */
     size_t hashlen;        /* KDF hash digest length. */
@@ -1334,7 +1334,7 @@ static int asn1getword(struct asn1Element *e, unsigned long *v)
 }
 
 static int pbkdf1(LIBSSH2_SESSION *session, char **dk,
-                  const unsigned char *passphrase, struct pkcs5params *pkcs5)
+                  const char *passphrase, struct pkcs5params *pkcs5)
 {
     int i;
     Qc3_Format_ALGD0100_T hctx;
@@ -1388,7 +1388,7 @@ static int pbkdf1(LIBSSH2_SESSION *session, char **dk,
 }
 
 static int pbkdf2(LIBSSH2_SESSION *session, char **dk,
-                  const unsigned char *passphrase, struct pkcs5params *pkcs5)
+                  const char *passphrase, struct pkcs5params *pkcs5)
 {
     size_t i;
     size_t k;
@@ -1663,7 +1663,7 @@ static int parse_pbes1(LIBSSH2_SESSION *session, struct pkcs5params *pkcs5,
 
 static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
                     const unsigned char *data, unsigned int datalen,
-                    const unsigned char *passphrase,
+                    const char *passphrase,
                     struct asn1Element *privkeyinfo)
 {
     struct asn1Element encprivkeyinfo;
@@ -1764,7 +1764,7 @@ static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
 
 static int rsapkcs8privkey(LIBSSH2_SESSION *session,
                            const unsigned char *data, unsigned int datalen,
-                           const unsigned char *passphrase, void *loadkeydata)
+                           const char *passphrase, void *loadkeydata)
 {
     ssh2_rsa_ctx *ctx = (ssh2_rsa_ctx *)loadkeydata;
     char keyform = Qc3_Clear;
@@ -1841,7 +1841,7 @@ static int sshrsapubkey(LIBSSH2_SESSION *session, char **sshpubkey,
 
 static int rsapkcs8pubkey(LIBSSH2_SESSION *session,
                           const unsigned char *data, unsigned int datalen,
-                          const unsigned char *passphrase, void *loadkeydata)
+                          const char *passphrase, void *loadkeydata)
 {
     struct loadpubkeydata *p = (struct loadpubkeydata *)loadkeydata;
     char *buf;
@@ -1947,7 +1947,7 @@ static int pkcs1topkcs8(LIBSSH2_SESSION *session,
 
 static int rsapkcs1privkey(LIBSSH2_SESSION *session,
                            const unsigned char *data, unsigned int datalen,
-                           const unsigned char *passphrase, void *loadkeydata)
+                           const char *passphrase, void *loadkeydata)
 {
     const unsigned char *data8;
     unsigned int datalen8;
@@ -1962,7 +1962,7 @@ static int rsapkcs1privkey(LIBSSH2_SESSION *session,
 
 static int rsapkcs1pubkey(LIBSSH2_SESSION *session,
                           const unsigned char *data, unsigned int datalen,
-                          const unsigned char *passphrase, void *loadkeydata)
+                          const char *passphrase, void *loadkeydata)
 {
     const unsigned char *data8;
     unsigned int datalen8;
@@ -1976,7 +1976,7 @@ static int rsapkcs1pubkey(LIBSSH2_SESSION *session,
 }
 
 static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
-                        const unsigned char *passphrase,
+                        const char *passphrase,
                         const char *header, const char *trailer,
                         loadkeyproc proc, void *loadkeydata)
 {

--- a/src/pem.c
+++ b/src/pem.c
@@ -280,8 +280,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
         /* Perform key derivation (PBKDF1/MD5) */
         hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
         if(hok) {
-            hok &= ssh2_hash_update(&ctx, passphrase,
-                                    strlen((const char *)passphrase));
+            hok &= ssh2_hash_update(&ctx, passphrase, strlen(passphrase));
             hok &= ssh2_hash_update(&ctx, iv, 8);
             hok &= ssh2_hash_final(&ctx, secret, SSH2_MD5_DIG_LEN);
         }
@@ -293,8 +292,7 @@ int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
             hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
             if(hok) {
                 hok &= ssh2_hash_update(&ctx, secret, SSH2_MD5_DIG_LEN);
-                hok &= ssh2_hash_update(&ctx, passphrase,
-                                        strlen((const char *)passphrase));
+                hok &= ssh2_hash_update(&ctx, passphrase, strlen(passphrase));
                 hok &= ssh2_hash_update(&ctx, iv, 8);
                 hok &= ssh2_hash_final(&ctx, secret + SSH2_MD5_DIG_LEN,
                                        SSH2_MD5_DIG_LEN);
@@ -468,7 +466,7 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
         kdf_buf.len = kdf_len;
     }
 
-    if((!passphrase || strlen((const char *)passphrase) == 0) &&
+    if((!passphrase || strlen(passphrase) == 0) &&
        strcmp((const char *)ciphername, "none")) {
         /* passphrase required */
         ret = LIBSSH2_ERROR_KEYFILE_AUTH_FAILED;
@@ -556,8 +554,7 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
                 goto out;
             }
 
-            if(ssh2_bcrypt_pbkdf((const char *)passphrase,
-                                 strlen((const char *)passphrase),
+            if(ssh2_bcrypt_pbkdf(passphrase, strlen(passphrase),
                                  salt, salt_len, key,
                                  keylen + ivlen, rounds) < 0) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_DECRYPT,

--- a/src/pem.c
+++ b/src/pem.c
@@ -99,7 +99,7 @@ static unsigned char pem_hex_decode(char digit)
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
-                   const unsigned char *passphrase,
+                   const char *passphrase,
                    FILE *fp, unsigned char **data, size_t *datalen)
 {
     int ret = -1;
@@ -159,7 +159,7 @@ out:
 int ssh2_pem_parse_memory(LIBSSH2_SESSION *session,
                           const char *headerbegin,
                           const char *headerend,
-                          const unsigned char *passphrase,
+                          const char *passphrase,
                           const char *filedata, size_t filedata_len,
                           unsigned char **data, size_t *datalen)
 {
@@ -399,7 +399,7 @@ out:
 #define OPENSSH_PRIVKEY_AUTH_MAGIC "openssh-key-v1"
 
 static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
-                                  const unsigned char *passphrase,
+                                  const char *passphrase,
                                   const char *b64data, size_t b64datalen,
                                   struct string_buf **decrypted_buf)
 {
@@ -717,7 +717,7 @@ out:
 }
 
 int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
-                           const unsigned char *passphrase,
+                           const char *passphrase,
                            FILE *fp, struct string_buf **decrypted_buf)
 {
     char line[LINE_SIZE];
@@ -780,7 +780,7 @@ out:
 }
 
 int ssh2_openssh_pem_parse_memory(LIBSSH2_SESSION *session,
-                                  const unsigned char *passphrase,
+                                  const char *passphrase,
                                   const char *filedata,
                                   size_t filedata_len,
                                   struct string_buf **decrypted_buf)

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -491,8 +491,7 @@ password_response:
                                        sizeof("ssh-connection") - 1);
                         ssh2_store_str(&s, "password", sizeof("password") - 1);
                         *s++ = 0x01;
-                        ssh2_store_str(&s, (const char *)password,
-                                       password_len);
+                        ssh2_store_str(&s, password, password_len);
                         ssh2_store_u32(&s, session->userauth_pswd_newpw_len);
                         /* send session->userauth_pswd_newpw separately */
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -734,7 +734,7 @@ static int userauth_read_blob_privkey(
     const struct hostkey_method **hostkey_method, void **hostkey_abstract,
     const unsigned char *method, size_t method_len,
     const char *privkeyfiledata, size_t privkeyfiledata_len,
-    const unsigned char *passphrase)
+    const char *passphrase)
 {
     const struct hostkey_method **hostkey_methods_avail =
         ssh2_hostkey_methods();
@@ -772,7 +772,7 @@ static int userauth_read_file_privkey(
     const struct hostkey_method **hostkey_method, void **hostkey_abstract,
     const unsigned char *method, size_t method_len,
     const char *privkeyfile,
-    const unsigned char *passphrase)
+    const char *passphrase)
 {
     const struct hostkey_method **hostkey_methods_avail =
         ssh2_hostkey_methods();
@@ -804,11 +804,11 @@ static int userauth_read_file_privkey(
 
 struct privkey_file {
     const char *filename;
-    const unsigned char *passphrase;
+    const char *passphrase;
 };
 
 struct privkey_mem {
-    const unsigned char *passphrase;
+    const char *passphrase;
     const char *data;
     size_t data_len;
 };
@@ -1003,7 +1003,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                                        size_t username_len,
                                        const char *publickey,
                                        const char *privatekey,
-                                       const unsigned char *passphrase,
+                                       const char *passphrase,
                                        const char *hostname,
                                        size_t hostname_len,
                                        const char *local_username,
@@ -1244,7 +1244,7 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
                  userauth_hostbased_fromfile(session,
                                              username, username_len,
                                              publickey, privatekey,
-                                             (const unsigned char *)passphrase,
+                                             passphrase,
                                              hostname, hostname_len,
                                              local_username,
                                              local_username_len));
@@ -1894,7 +1894,7 @@ static int userauth_publickey_frommemory(LIBSSH2_SESSION *session,
                                          size_t publickeydata_len,
                                          const char *privatekeydata,
                                          size_t privatekeydata_len,
-                                         const unsigned char *passphrase)
+                                         const char *passphrase)
 {
     unsigned char *pubkeydata = NULL;
     size_t pubkeydata_len = 0;
@@ -1949,7 +1949,7 @@ static int userauth_publickey_fromfile(LIBSSH2_SESSION *session,
                                        size_t username_len,
                                        const char *publickey,
                                        const char *privatekey,
-                                       const unsigned char *passphrase)
+                                       const char *passphrase)
 {
     unsigned char *pubkeydata = NULL;
     size_t pubkeydata_len = 0;
@@ -2022,7 +2022,7 @@ int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
                                                publickeyfiledata_len,
                                                privatekeyfiledata,
                                                privatekeyfiledata_len,
-                                           (const unsigned char *)passphrase));
+                                               passphrase));
     return rc;
 }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -295,7 +295,7 @@ int libssh2_userauth_authenticated(LIBSSH2_SESSION *session)
 static int userauth_password(LIBSSH2_SESSION *session,
                              const char *username,
                              unsigned int username_len,
-                             const unsigned char *password,
+                             const char *password,
                              unsigned int password_len,
                              LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb))
 {
@@ -357,7 +357,8 @@ static int userauth_password(LIBSSH2_SESSION *session,
     if(session->userauth_pswd_state == ssh2_NB_state_created) {
         rc = ssh2_transport_send(session, session->userauth_pswd_data,
                                  session->userauth_pswd_data_len,
-                                 password, password_len);
+                                 (const unsigned char *)password,
+                                 password_len);
         if(rc == LIBSSH2_ERROR_EAGAIN)
             return ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
                             "Would block writing password request");
@@ -559,8 +560,7 @@ int libssh2_userauth_password_ex(
 
     BLOCK_ADJUST(rc, session,
                  userauth_password(session, username, username_len,
-                                   (const unsigned char *)password,
-                                   password_len,
+                                   password, password_len,
                                    passwd_change_cb));
     return rc;
 }
@@ -2050,7 +2050,7 @@ int libssh2_userauth_publickey_fromfile_ex(LIBSSH2_SESSION *session,
                  userauth_publickey_fromfile(session,
                                              username, username_len,
                                              publickey, privatekey,
-                                           (const unsigned char *)passphrase));
+                                             passphrase));
     return rc;
 }
 
@@ -2380,7 +2380,7 @@ int libssh2_userauth_publickey_sk(
                                      &sk_info.key_handle,
                                      &sk_info.handle_len,
                                      privatekeydata, privatekeydata_len,
-                                     (const unsigned char *)passphrase))
+                                     passphrase))
             return ssh2_err(session, LIBSSH2_ERROR_FILE,
                             "Unable to extract public key from private key.");
         else if(publickeydata_len == 0 || !publickeydata) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -901,7 +901,7 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx, ULONG hash_len,
 
 static int wcng_load_private(LIBSSH2_SESSION *session,
                              const char *filename,
-                             const unsigned char *passphrase,
+                             const char *passphrase,
                              unsigned char **ppbEncoded,
                              size_t *pcbEncoded,
                              int tryLoadRSA, int tryLoadDSA)
@@ -944,7 +944,7 @@ static int wcng_load_private(LIBSSH2_SESSION *session,
 static int wcng_load_private_memory(LIBSSH2_SESSION *session,
                                     const char *privatekeydata,
                                     size_t privatekeydata_len,
-                                    const unsigned char *passphrase,
+                                    const char *passphrase,
                                     unsigned char **ppbEncoded,
                                     size_t *pcbEncoded,
                                     int tryLoadRSA, int tryLoadDSA)
@@ -1333,7 +1333,7 @@ static int wcng_rsa_new_private_parse(ssh2_rsa_ctx **rsa,
 int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase)
+                         const char *passphrase)
 {
     unsigned char *pbEncoded;
     size_t cbEncoded;
@@ -1350,7 +1350,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa,
 int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase)
+                                    const char *passphrase)
 {
     unsigned char *pbEncoded;
     size_t cbEncoded;
@@ -1620,7 +1620,7 @@ static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
 int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
                          LIBSSH2_SESSION *session,
                          const char *filename,
-                         const unsigned char *passphrase)
+                         const char *passphrase)
 {
     unsigned char *pbEncoded;
     size_t cbEncoded;
@@ -1637,7 +1637,7 @@ int ssh2_dsa_new_private(ssh2_dsa_ctx **dsa,
 int ssh2_dsa_new_private_frommemory(ssh2_dsa_ctx **dsa,
                                     LIBSSH2_SESSION *session,
                                     const char *blob, size_t blob_len,
-                                    const unsigned char *passphrase)
+                                    const char *passphrase)
 {
     unsigned char *pbEncoded;
     size_t cbEncoded;
@@ -2522,7 +2522,7 @@ cleanup:
 int ssh2_ecdsa_new_private(OUT ssh2_ecdsa_ctx **ec_ctx,
                            IN LIBSSH2_SESSION *session,
                            IN const char *filename,
-                           IN const unsigned char *passphrase)
+                           IN const char *passphrase)
 {
     int result;
 
@@ -2567,7 +2567,7 @@ cleanup:
 int ssh2_ecdsa_new_private_frommemory(OUT ssh2_ecdsa_ctx **ec_ctx,
                                       IN LIBSSH2_SESSION *session,
                                       IN const char *blob, IN size_t blob_len,
-                                      IN const unsigned char *passphrase)
+                                      IN const char *passphrase)
 {
     int result;
     struct string_buf *decrypted = NULL;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2832,7 +2832,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
-                          const unsigned char *passphrase)
+                          const char *passphrase)
 {
     unsigned char *pbEncoded;
     size_t cbEncoded;
@@ -2854,7 +2854,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
                                 size_t privatekeydata_len,
-                                const unsigned char *passphrase)
+                                const char *passphrase)
 {
     unsigned char *pbEncoded;
     size_t cbEncoded;


### PR DESCRIPTION
Public interface used `const char *` since the beginning, internally
vastly `const unsigned char *`, with the outliers fixed recently.

To avoid the inconsistency (and casts) between public and internal
types, make `passphrase` a `const char *` internally too.

Use casts when interacing with crypto backends where necessary
(mbedtls).

Also:
- userauth: do the same for the `password` type.
- mbedtls: rename vars to `passphrase` where missing.
- mbedtls: drop passphrase length interim variables.

Follow-up to 17aa8b04f6afa30285cbf88ee60de4fa4a6cdedf #2349
