### PR TITLE
userauth: apply two OOB fixes to `userauth_read_blob_pubkey()`

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -572,7 +572,7 @@ static int userauth_read_blob_pubkey(
 {
     unsigned char *pubkey = NULL, *sp1, *sp2, *tmp;
     size_t pubkey_len = pubkeyfiledata_len;
-    size_t tmp_len;
+    size_t sp_len, tmp_len;
 
     if(pubkeyfiledata_len <= 1)
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
@@ -606,7 +606,8 @@ static int userauth_read_blob_pubkey(
 
     sp1++;
 
-    sp2 = memchr(sp1, ' ', pubkey_len - (sp1 - pubkey));
+    sp_len = sp1 > pubkey ? (sp1 - pubkey) : 0;
+    sp2 = memchr(sp1, ' ', pubkey_len - sp_len);
     if(!sp2)
         /* Assume that the id string is missing, but that it is okay */
         sp2 = pubkey + pubkey_len;
@@ -647,8 +648,8 @@ static int userauth_read_file_pubkey(
     FILE *fd;
     char c;
     unsigned char *pubkey = NULL, *sp1, *sp2, *tmp;
-    size_t pubkey_len = 0, sp_len;
-    size_t tmp_len;
+    size_t pubkey_len = 0;
+    size_t sp_len, tmp_len;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Loading public key file: %s",
               pubkeyfile));


### PR DESCRIPTION
- fix off by one error when loading public keys with no id.
- make sure that sp_len is positive and avoid overflows.

These were fixed in `userauth_read_file_pubkey()` earlier, but missed
from the sibling code loading pubkey from memory buffer (as opposed to
file). Sibling code made it into the codebase after the first fix, but
it was based code copy-pasted from a pre-fix revision.

Bug: https://github.com/libssh2/libssh2/pull/2354#issuecomment-5015775127
Follow-up to 482055695011fabb55f3cb7598356d47a0429068 #386
Follow-up to 18cfec8336e88ab7df8a4427b803b9a177053674
Follow-up to 3e47ca8a32042d0aff5dee0ec1b2914027253d75
