### PR TITLE
src: make `method` string a signed `char *`

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -415,7 +415,7 @@ Each item is preceded by its 32-bit byte length, MSB first.
 
 ```c
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method, size_t *method_len,
+                          char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
@@ -430,7 +430,7 @@ This procedure is already prototyped in `crypto.h`.
 
 ```c
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method, size_t *method_len,
+                                char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -886,15 +886,3 @@ int ssh2_random(unsigned char *buf, size_t len);
 ```
 Store len random bytes at buf.
 Returns 0 if OK, else -1.
-
-```c
-const char *ssh2_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                         unsigned char *key_method,
-                                         size_t key_method_len);
-```
-This function is for implementing key hash upgrading as defined in RFC 8332.
-
-Based on the incoming key_method value, this function returns a list of
-supported algorithms that can upgrade the original key method algorithm as a
-comma separated list, if there is no upgrade option this function should
-return NULL.

--- a/src/agent.c
+++ b/src/agent.c
@@ -761,7 +761,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     size_t len, method_len, plain_len;
     unsigned char *s;
     int rc;
-    unsigned char *method_name = NULL;
+    char *method_name = NULL;
     uint32_t sign_flags = 0;
 
     len = 1 + 4 + 4 + 4;  /* fixed parts */
@@ -863,7 +863,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     s += method_len;
 
     plain_len = ssh2_userauth_plain_method(
-        (char *)session->userauth_pblc_method,
+        session->userauth_pblc_method,
         session->userauth_pblc_method_len);
 
     /* check to see if we match requested */

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -287,14 +287,14 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
 #endif
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method, size_t *method_len,
+                          char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
                           const char *passphrase);
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method, size_t *method_len,
+                                char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
@@ -302,7 +302,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
                                 const char *passphrase);
 
 int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
-                              unsigned char **method, size_t *method_len,
+                              char **method, size_t *method_len,
                               unsigned char **pubkeydata,
                               size_t *pubkeydata_len,
                               int *algorithm,

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -697,7 +697,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method, size_t *method_len,
+                                char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
@@ -718,7 +718,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method, size_t *method_len,
+                          char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -844,7 +844,7 @@ struct _LIBSSH2_SESSION {
     size_t userauth_host_data_len;
     unsigned char *userauth_host_packet;
     size_t userauth_host_packet_len;
-    unsigned char *userauth_host_method;
+    char *userauth_host_method;
     size_t userauth_host_method_len;
     unsigned char *userauth_host_s;
     struct packet_requirev_state userauth_host_packet_requirev_state;
@@ -855,7 +855,7 @@ struct _LIBSSH2_SESSION {
     size_t userauth_pblc_data_len;
     unsigned char *userauth_pblc_packet;
     size_t userauth_pblc_packet_len;
-    unsigned char *userauth_pblc_method;
+    char *userauth_pblc_method;
     size_t userauth_pblc_method_len;
     unsigned char *userauth_pblc_s;
     unsigned char *userauth_pblc_b;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -597,12 +597,13 @@ static unsigned char *mbed_gen_publickey_from_rsa(LIBSSH2_SESSION *session,
 }
 
 static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
-                             unsigned char **method, size_t *method_len,
+                             char **method, size_t *method_len,
                              unsigned char **pubkeydata,
                              size_t *pubkeydata_len,
                              mbedtls_pk_context *pkey)
 {
-    unsigned char *key = NULL, *mth = NULL;
+    char *mth = NULL;
+    unsigned char *key = NULL;
     size_t keylen = 0, mthlen = 0;
     int ret;
     mbedtls_rsa_context *rsa;
@@ -645,7 +646,7 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method, size_t *method_len,
+                          char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
@@ -674,7 +675,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method, size_t *method_len,
+                                char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,

--- a/src/misc.c
+++ b/src/misc.c
@@ -1000,7 +1000,7 @@ int ssh2_timingsafe_bcmp(const void *b1, const void *b2, size_t n)
 
 #ifndef LIBSSH2_KEY_SK
 int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
-                              unsigned char **method,
+                              char **method,
                               size_t *method_len,
                               unsigned char **pubkeydata,
                               size_t *pubkeydata_len,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -150,7 +150,7 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                       void **key_ctx,
                                       const char *key_type,
-                                      unsigned char **method,
+                                      char **method,
                                       size_t *method_len,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
@@ -1132,7 +1132,7 @@ fail:
 }
 
 static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                  unsigned char **method,
+                                  char **method,
                                   size_t *method_len,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
@@ -1140,7 +1140,7 @@ static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
 {
     ssh2_rsa_ctx *rsa = NULL;
     unsigned char *key;
-    unsigned char *method_buf = NULL;
+    char *method_buf = NULL;
     size_t key_len;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1253,7 +1253,7 @@ out:
 
 static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                            struct string_buf *decrypted,
-                                           unsigned char **method,
+                                           char **method,
                                            size_t *method_len,
                                            unsigned char **pubkeydata,
                                            size_t *pubkeydata_len,
@@ -1522,7 +1522,7 @@ fail:
 }
 
 static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                  unsigned char **method,
+                                  char **method,
                                   size_t *method_len,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
@@ -1530,7 +1530,7 @@ static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
 {
     ssh2_dsa_ctx *dsa = NULL;
     unsigned char *key;
-    unsigned char *method_buf = NULL;
+    char *method_buf = NULL;
     size_t key_len;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1582,7 +1582,7 @@ alloc_error:
 
 static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                            struct string_buf *decrypted,
-                                           unsigned char **method,
+                                           char **method,
                                            size_t *method_len,
                                            unsigned char **pubkeydata,
                                            size_t *pubkeydata_len,
@@ -1839,14 +1839,14 @@ clean_exit:
 }
 
 static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                      unsigned char **method,
+                                      char **method,
                                       size_t *method_len,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       EVP_PKEY *pk)
 {
     const char methodName[] = "ssh-ed25519";
-    unsigned char *methodBuf = NULL;
+    char *methodBuf = NULL;
     size_t rawKeyLen = 0;
     unsigned char *keyBuf = NULL;
     size_t bufLen = 0;
@@ -1907,14 +1907,14 @@ fail:
 
 static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                                struct string_buf *decrypted,
-                                               unsigned char **method,
+                                               char **method,
                                                size_t *method_len,
                                                unsigned char **pubkeydata,
                                                size_t *pubkeydata_len,
                                                ssh2_ed25519_ctx **ed_ctx)
 {
     ssh2_ed25519_ctx *ctx = NULL;
-    unsigned char *method_buf = NULL;
+    char *method_buf = NULL;
     unsigned char *key = NULL;
     int i;
     unsigned char *pub_key, *priv_key, *buf;
@@ -2031,7 +2031,7 @@ clean_exit:
 static int ossl_ed25519_sk_openssh_priv_to_pubkey(
     LIBSSH2_SESSION *session,
     struct string_buf *decrypted,
-    unsigned char **method,
+    char **method,
     size_t *method_len,
     unsigned char **pubkeydata,
     size_t *pubkeydata_len,
@@ -2044,7 +2044,7 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
     const char *key_type = "sk-ssh-ed25519@openssh.com";
 
     ssh2_ed25519_ctx *ctx = NULL;
-    unsigned char *method_buf = NULL;
+    char *method_buf = NULL;
     unsigned char *key = NULL;
     unsigned char *pub_key, *app;
     size_t key_len = 0, app_len = 0, tmp_len = 0;
@@ -2698,15 +2698,15 @@ clean_exit:
 }
 
 static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                    unsigned char **method, size_t *method_len,
+                                    char **method, size_t *method_len,
                                     unsigned char **pubkeydata,
                                     size_t *pubkeydata_len,
                                     int is_sk,
                                     EVP_PKEY *pk)
 {
     int rc = 0;
+    char *method_buf = NULL;
     unsigned char *p;
-    unsigned char *method_buf = NULL;
     unsigned char *key;
     size_t method_buf_len = 0;
     size_t key_len = 0;
@@ -2854,7 +2854,7 @@ clean_exit:
 static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                              ssh2_curve_type curve_type,
                                              struct string_buf *decrypted,
-                                             unsigned char **method,
+                                             char **method,
                                              size_t *method_len,
                                              unsigned char **pubkeydata,
                                              size_t *pubkeydata_len,
@@ -2990,7 +2990,7 @@ fail:
 static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     LIBSSH2_SESSION *session,
     struct string_buf *decrypted,
-    unsigned char **method,
+    char **method,
     size_t *method_len,
     unsigned char **pubkeydata,
     size_t *pubkeydata_len,
@@ -3642,7 +3642,7 @@ clean_exit:
 #endif /* LIBSSH2_ED25519 */
 
 static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
-                                      unsigned char **method,
+                                      char **method,
                                       size_t *method_len,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
@@ -3734,7 +3734,7 @@ cleanup:
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method, size_t *method_len,
+                          char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
@@ -3813,7 +3813,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                       void **key_ctx,
                                       const char *key_type,
-                                      unsigned char **method,
+                                      char **method,
                                       size_t *method_len,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
@@ -3922,7 +3922,7 @@ cleanup:
 }
 
 int ssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
-                              unsigned char **method, size_t *method_len,
+                              char **method, size_t *method_len,
                               unsigned char **pubkeydata,
                               size_t *pubkeydata_len,
                               int *algorithm,
@@ -4015,7 +4015,7 @@ cleanup:
 #endif
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method, size_t *method_len,
+                                char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2094,7 +2094,7 @@ int ssh2_rsa_new_private(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method, size_t *method_len,
+                          char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey, const char *passphrase)
@@ -2206,7 +2206,7 @@ int ssh2_rsa_new_private_frommemory(ssh2_rsa_ctx **rsa,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method, size_t *method_len,
+                                char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,
@@ -2278,7 +2278,7 @@ int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
         *method_len = strlen(p.method);
         *method = SSH2_ALLOC(session, *method_len);
         if(*method)
-            memcpy((char *)*method, p.method, *method_len);
+            memcpy(*method, p.method, *method_len);
         else
             ret = -1;
     }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1223,7 +1223,7 @@ static int userauth_is_version_less_than_78(const char *version)
  * there is no upgrade option return NULL
  */
 static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                                    char *key_method,
+                                                    const char *key_method,
                                                     size_t key_method_len)
 {
     (void)session;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -574,7 +574,7 @@ int libssh2_userauth_password_ex(
  */
 static int userauth_read_pubkey(
     LIBSSH2_SESSION *session,
-    unsigned char **method, size_t *method_len,
+    char **method, size_t *method_len,
     unsigned char **pubkeydata, size_t *pubkeydata_len,
     const char *pubkeyfile,
     const char *pubkeyblob, size_t pubkeyblob_len)
@@ -674,7 +674,7 @@ static int userauth_read_pubkey(
     /* Wasting some bytes here (okay, more than some), but since it is likely
        to be freed soon anyway, we avoid the extra free/alloc and call
        it a wash */
-    *method = pubkey;
+    *method = (char *)pubkey;
     *method_len = sp1 - pubkey - 1;
 
     *pubkeydata = tmp;
@@ -689,7 +689,7 @@ static int userauth_read_pubkey(
 static int userauth_read_privkey(
     LIBSSH2_SESSION *session,
     const struct hostkey_method **hostkey_method, void **hostkey_abstract,
-    const unsigned char *method, size_t method_len,
+    const char *method, size_t method_len,
     const char *privkeyfile,
     const char *privkeyblob, size_t privkeyblob_len,
     const char *passphrase)
@@ -709,8 +709,7 @@ static int userauth_read_privkey(
 
     while(*hostkey_methods_avail && (*hostkey_methods_avail)->name) {
         if((*hostkey_methods_avail)->initPEM &&
-           !strncmp((*hostkey_methods_avail)->name, (const char *)method,
-                    method_len)) {
+           !strncmp((*hostkey_methods_avail)->name, method, method_len)) {
             *hostkey_method = *hostkey_methods_avail;
             break;
         }
@@ -1224,7 +1223,7 @@ static int userauth_is_version_less_than_78(const char *version)
  * there is no upgrade option return NULL
  */
 static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                                    unsigned char *key_method,
+                                                    char *key_method,
                                                     size_t key_method_len)
 {
     (void)session;
@@ -1262,8 +1261,7 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
  * @result error code or zero on success
  */
 static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
-                                  unsigned char **key_method,
-                                  size_t *key_method_len)
+                                  char **key_method, size_t *key_method_len)
 {
     const char *s = NULL;
     const char *a = NULL;
@@ -2237,7 +2235,7 @@ int libssh2_userauth_publickey_sk(
 {
     int rc = LIBSSH2_ERROR_NONE;
 
-    unsigned char *tmp_method = NULL;
+    char *tmp_method = NULL;
     size_t tmp_method_len = 0;
 
     unsigned char *tmp_publickeydata = NULL;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2732,7 +2732,7 @@ static DWORD wcng_pub_priv_write(unsigned char *key,
 }
 
 static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
-                                       unsigned char **method,
+                                       char **method,
                                        size_t *method_len,
                                        unsigned char **pubkeydata,
                                        size_t *pubkeydata_len,
@@ -2741,7 +2741,8 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
 {
     unsigned char **rpbDecoded = NULL;
     DWORD *rcbDecoded = NULL;
-    unsigned char *key = NULL, *mth = NULL;
+    char *mth = NULL;
+    unsigned char *key = NULL;
     DWORD keylen = 0, mthlen = 0;
     DWORD index, offset, length = 0;
     int ret;
@@ -2765,7 +2766,8 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
         keylen = 4 + mthlen + 4 + rcbDecoded[2] + 4 + rcbDecoded[1];
         key = SSH2_ALLOC(session, keylen);
         if(key) {
-            offset = wcng_pub_priv_write(key, 0, mth, mthlen);
+            offset = wcng_pub_priv_write(key, 0,
+                                         (const unsigned char *)mth, mthlen);
             offset = wcng_pub_priv_write(key, offset,
                                          rpbDecoded[2], rcbDecoded[2]);
             wcng_pub_priv_write(key, offset,
@@ -2786,7 +2788,8 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
                             + 4 + rcbDecoded[3] + 4 + rcbDecoded[4];
         key = SSH2_ALLOC(session, keylen);
         if(key) {
-            offset = wcng_pub_priv_write(key, 0, mth, mthlen);
+            offset = wcng_pub_priv_write(key, 0,
+                                         (const unsigned char *)mth, mthlen);
             offset = wcng_pub_priv_write(key, offset,
                                          rpbDecoded[1], rcbDecoded[1]);
             offset = wcng_pub_priv_write(key, offset,
@@ -2828,7 +2831,7 @@ static int wcng_pub_priv_keyfile_parse(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
-                          unsigned char **method, size_t *method_len,
+                          char **method, size_t *method_len,
                           unsigned char **pubkeydata,
                           size_t *pubkeydata_len,
                           const char *privatekey,
@@ -2849,7 +2852,7 @@ int ssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
-                                unsigned char **method, size_t *method_len,
+                                char **method, size_t *method_len,
                                 unsigned char **pubkeydata,
                                 size_t *pubkeydata_len,
                                 const char *privatekeydata,


### PR DESCRIPTION
There is no reason for it to be unsigned.

Also:
- HACKING_CRYPTO.md: drop obsolete function.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
