### PR TITLE
knownhost: fix out-of-bounds read in `knownhost_line_hashed()`

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -722,10 +722,10 @@ static int knownhost_line_hashed(LIBSSH2_KNOWNHOSTS *hosts,
     hostlen -= 3; /* deduct the marker */
 
     /* this is where the salt starts, find the end of it */
-    for(p = salt; *p && *p != '|'; p++)
+    for(p = salt; (size_t)(p - salt) < hostlen && *p && *p != '|'; p++)
         ;
 
-    if(*p == '|') {
+    if((size_t)(p - salt) < hostlen && *p == '|') {
         const char *hash = NULL;
         size_t saltlen = p - salt;
         if(saltlen >= (sizeof(saltbuf) - 1)) /* weird length */
@@ -862,6 +862,13 @@ static int knownhost_line(LIBSSH2_KNOWNHOSTS *hosts,
         }
         break;
     }
+
+    /* The key is passed on as base64 with its length, and knownhost_add()
+       falls back to strlen() when the length is zero, so an empty key would
+       make it scan past the caller-supplied buffer. */
+    if(!keylen)
+        return ssh2_err(hosts->session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
+                        "Failed to parse known_hosts line (no key)");
 
     /* Figure out host format */
     if(hostlen < 3 || memcmp(host, "|1|", 3))


### PR DESCRIPTION
The salt separator scan in `knownhost_line_hashed()` tested only `*p` and never consulted `hostlen`, so a `|1|` hashed-host line with no closing `|` walked off the end of a non-NUL-terminated span handed in by `libssh2_knownhost_readline()`. With an exact-length, unterminated buffer, `"|1|abc ssh-rsa AAAAB3NzaC1yc2E"` gives a heap-buffer-overflow read at knownhost.c:725. Bounding the scan by `hostlen` keeps it inside the buffer; valid plain and hashed lines still parse unchanged.

Narrowed to just this fix. The zero-`keylen` / `strlen()` fallback over-read that was originally in here is a separate issue, left for #2364 (or a standalone patch) to handle at the root.