### PR TITLE
knownhost: stop determining `keylen` if passed as zero in `libssh2_knownhost_add*()`

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -1093,9 +1093,6 @@ LIBSSH2_API LIBSSH2_KNOWNHOSTS *libssh2_knownhost_init(
  * The SHA-1 hash is what OpenSSH can be told to use in known_hosts files.  If
  * a custom type is used, salt is ignored and you must provide the host
  * pre-hashed when checking for it in the libssh2_knownhost_check() function.
- *
- * The keylen parameter may be omitted (zero) if the key is provided as a
- * null-terminated base64-encoded string.
  */
 
 /* host format (2 bits) */
@@ -1155,9 +1152,6 @@ LIBSSH2_API int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
  * The SHA-1 hash is what OpenSSH can be told to use in known_hosts files.
  * If a custom type is used, salt is ignored and you must provide the host
  * pre-hashed when checking for it in the libssh2_knownhost_check() function.
- *
- * The keylen parameter may be omitted (zero) if the key is provided as a
- * null-terminated base64-encoded string.
  */
 LIBSSH2_API int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
                                        const char *host,

--- a/os400/libssh2rpg/libssh2.rpgle.in
+++ b/os400/libssh2rpg/libssh2.rpgle.in
@@ -1490,9 +1490,6 @@
       * If a custom type is used, salt is ignored and you must provide the host
       * pre-hashed when checking for it in the libssh2_knownhost_check()
       * function.
-      *
-      * The keylen parameter may be omitted (zero) if the key is provided as a
-      * NULL-terminated base64-encoded string.
 
       * host format (2 bits).
      d LIBSSH2_KNOWNHOST_TYPE_MASK...
@@ -1569,9 +1566,6 @@
       * If a custom type is used, salt is ignored and you must provide the host
       * pre-hashed when checking for it in the libssh2_knownhost_check()
       * function.
-      *
-      * The keylen parameter may be omitted (zero) if the key is provided as a
-      * NULL-terminated base64-encoded string.
 
      d libssh2_knownhost_addc...
      d                 pr                  extproc('libssh2_knownhost_addc')

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -134,13 +134,10 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
     char *ptr = NULL;
     size_t ptrlen = 0;
 
-    if(!hosts || !host || !key)
+    if(!hosts || !host || !key || !keylen)
         return LIBSSH2_ERROR_BAD_USE;
 
     hostlen = strlen(host);
-
-    if((typemask & LIBSSH2_KNOWNHOST_KEYENC_BASE64) && !keylen)
-        keylen = strlen(key);
 
     if(hostlen > KNOWNHOST_MAX_LEN ||
        keylen > KNOWNHOST_MAX_LEN)
@@ -862,13 +859,6 @@ static int knownhost_line(LIBSSH2_KNOWNHOSTS *hosts,
         }
         break;
     }
-
-    /* The key is passed on as base64 with its length, and knownhost_add()
-       falls back to strlen() when the length is zero, so an empty key would
-       make it scan past the caller-supplied buffer. */
-    if(!keylen)
-        return ssh2_err(hosts->session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
-                        "Failed to parse known_hosts line (no key)");
 
     /* Figure out host format */
     if(hostlen < 3 || memcmp(host, "|1|", 3))

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -137,7 +137,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
     if(!hosts || !host || !key)
         return LIBSSH2_ERROR_BAD_USE;
 
-    /* keylen == 0 previously fell back to strlen(key) for base64-encoded keys.
+    /* keylen == 0 fell back to strlen(key) until libssh2 1.11.1.
        Require explicit length now. */
     if(!keylen)
         return ssh2_err(hosts->session, LIBSSH2_ERROR_BAD_USE,

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -134,8 +134,13 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
     char *ptr = NULL;
     size_t ptrlen = 0;
 
-    if(!hosts || !host || !key || !keylen)
+    if(!hosts || !host || !key)
         return LIBSSH2_ERROR_BAD_USE;
+
+    /* Set an error message because this was a breaking change. */
+    if(!keylen)
+        return ssh2_err(hosts->session, LIBSSH2_ERROR_BAD_USE,
+                        "Known-host key length required");
 
     hostlen = strlen(host);
 

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -137,8 +137,8 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
     if(!hosts || !host || !key)
         return LIBSSH2_ERROR_BAD_USE;
 
-    /* keylen == 0 previously fell back to strlen(key); require explicit
-       length. */
+    /* keylen == 0 previously fell back to strlen(key) for base64-encoded keys.
+       Require explicit length now. */
     if(!keylen)
         return ssh2_err(hosts->session, LIBSSH2_ERROR_BAD_USE,
                         "Known-host key length required");

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -321,9 +321,6 @@ error:
  * The SHA-1 hash is what OpenSSH can be told to use in known_hosts files.  If
  * a custom type is used, salt is ignored and you must provide the host
  * pre-hashed when checking for it in the libssh2_knownhost_check() function.
- *
- * The keylen parameter may be omitted (zero) if the key is provided as a
- * null-terminated base64-encoded string.
  */
 int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
                           const char *host, const char *salt,
@@ -355,9 +352,6 @@ int libssh2_knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
  * The SHA-1 hash is what OpenSSH can be told to use in known_hosts files.  If
  * a custom type is used, salt is ignored and you must provide the host
  * pre-hashed when checking for it in the libssh2_knownhost_check() function.
- *
- * The keylen parameter may be omitted (zero) if the key is provided as a
- * null-terminated base64-encoded string.
  */
 int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
                            const char *host, const char *salt,

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -137,7 +137,8 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
     if(!hosts || !host || !key)
         return LIBSSH2_ERROR_BAD_USE;
 
-    /* Set an error message because this was a breaking change. */
+    /* keylen == 0 previously fell back to strlen(key); require explicit
+       length. */
     if(!keylen)
         return ssh2_err(hosts->session, LIBSSH2_ERROR_BAD_USE,
                         "Known-host key length required");
@@ -864,6 +865,10 @@ static int knownhost_line(LIBSSH2_KNOWNHOSTS *hosts,
         }
         break;
     }
+
+    if(!keylen)
+        return ssh2_err(hosts->session, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
+                        "Failed to parse known_hosts line (no key)");
 
     /* Figure out host format */
     if(hostlen < 3 || memcmp(host, "|1|", 3))


### PR DESCRIPTION
To complement/replace similar fixes made earlier to
`ssh2_base64_encode()` and `knownhost_line()`, respectively.

Until libssh2 1.11.1, `libssh2_knownhost_add*()` public APIs had a
special behavior when they received `keylen == 0` argument. They
automatically determined the length of the `key` buffer via `strlen()`.
When passing zero length either on purpose or by accident, it could
result in an OOB read if the buffer's actual length was zero. (Such case
could also happen within libssh2's own code.)

This behavior was not documented on the man page, but the public
`libssh2.h` header mentioned it in comments.

Earlier patch #1641 dropped this behavior for one codepath, which was a
breaking change, arguably for the better. This patch fixes the remaining
codepath and removes this behavior from these functions completely. They
now return `LIBSSH2_ERROR_BAD_USE` when called with a zero `keylen`
argument, with an explanatory error string.

Recommended fix is passing `key` buffer length, or `strlen()` it at the
call site if the buffer is null-terminated, and making sure the buffer
is non-empty.

Refs:
https://github.com/libssh2/libssh2/pull/2363/files#diff-5182b571dc174e7b59106f0ea398a54784a0eb6c32eb95b9952cfa1aca893a71R866
https://github.com/curl/curl/commit/5e2d4d790575d4ad0381c4862f5e435a3b6532d1
https://github.com/curl/curl/pull/18617

Follow-up to 102e444846e99a6b7e36c7b02c9b6699d92dfb67 #2363
Follow-up to d1c0e14d2a7a82de83b9085299bcb9f715c57416 #1641
Follow-up to 4b991b232dc7df53a339c530055ca818467d6fb8

---

- [x] Turns out this behavior was documented in `libssh2.h`. Reconsider?

https://codesearch.debian.net/search?q=libssh2_knownhost_add&literal=1
https://github.com/search?q=libssh2_knownhost_add+language%3AC&type=code
