### PR TITLE
userauth: keep the key method name null-terminated

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -862,9 +862,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     len -= method_len;
     s += method_len;
 
-    plain_len = ssh2_userauth_plain_method(
-        session->userauth_pblc_method,
-        session->userauth_pblc_method_len);
+    plain_len = ssh2_userauth_plain_method(session->userauth_pblc_method);
 
     /* check to see if we match requested */
     if((method_len != session->userauth_pblc_method_len &&
@@ -1240,12 +1238,13 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
         return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
 
     agent->session->userauth_pblc_method = SSH2_ALLOC(agent->session,
-                                                      method_len);
+                                                      method_len + 1);
     if(!agent->session->userauth_pblc_method)
         return LIBSSH2_ERROR_ALLOC;
 
     agent->session->userauth_pblc_method_len = method_len;
     memcpy(agent->session->userauth_pblc_method, method, method_len);
+    agent->session->userauth_pblc_method[method_len] = '\0';
 
     rc = agent_sign(agent->session, sig, s_len, data, d_len, &abstract);
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -617,9 +617,9 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
 
     /* write method */
     mthlen = 7;
-    mth = SSH2_ALLOC(session, mthlen);
+    mth = SSH2_ALLOC(session, mthlen + 1);
     if(mth)
-        memcpy(mth, "ssh-rsa", mthlen);
+        memcpy(mth, "ssh-rsa", mthlen + 1);
     else
         ret = -1;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1155,7 +1155,7 @@ static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
         /* Assume memory allocation error... what else could it be? */
         goto alloc_error;
 
-    method_buf = SSH2_ALLOC(session, 7); /* ssh-rsa. */
+    method_buf = SSH2_ALLOC(session, 7 + 1); /* ssh-rsa. */
     if(!method_buf)
         goto alloc_error;
 
@@ -1166,8 +1166,7 @@ static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     RSA_free(rsa);
 #endif
 
-    /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-    memcpy(method_buf, "ssh-rsa", 7);
+    memcpy(method_buf, "ssh-rsa", 7 + 1);
     *method = method_buf;
     if(method_len)
         *method_len = 7;
@@ -1545,7 +1544,7 @@ static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
         /* Assume memory allocation error... what else could it be ? */
         goto alloc_error;
 
-    method_buf = SSH2_ALLOC(session, 7); /* ssh-dss. */
+    method_buf = SSH2_ALLOC(session, 7 + 1); /* ssh-dss. */
     if(!method_buf)
         goto alloc_error;
 
@@ -1556,8 +1555,7 @@ static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     DSA_free(dsa);
 #endif
 
-    /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-    memcpy(method_buf, "ssh-dss", 7);
+    memcpy(method_buf, "ssh-dss", 7 + 1);
     *method = method_buf;
     if(method_len)
         *method_len = 7;
@@ -1855,13 +1853,13 @@ static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session,
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing public key from ED private key envelope"));
 
-    methodBuf = SSH2_ALLOC(session, sizeof(methodName) - 1);
+    methodBuf = SSH2_ALLOC(session, sizeof(methodName));
     if(!methodBuf) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to allocate memory for private key data");
         goto fail;
     }
-    memcpy(methodBuf, methodName, sizeof(methodName) - 1);
+    memcpy(methodBuf, methodName, sizeof(methodName));
 
     if(EVP_PKEY_get_raw_public_key(pk, NULL, &rawKeyLen) != 1) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -1966,7 +1964,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing public key from ED25519 private key envelope"));
 
-    method_buf = SSH2_ALLOC(session, 11); /* ssh-ed25519. */
+    method_buf = SSH2_ALLOC(session, 11 + 1); /* ssh-ed25519. */
     if(!method_buf) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to allocate memory for ED25519 key");
@@ -1988,8 +1986,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     ssh2_store_str(&p, "ssh-ed25519", 11);
     ssh2_store_str(&p, (const char *)pub_key, SSH2_ED25519_KEY_LEN);
 
-    /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-    memcpy(method_buf, "ssh-ed25519", 11);
+    memcpy(method_buf, "ssh-ed25519", 11 + 1);
 
     if(method)
         *method = method_buf;
@@ -2091,7 +2088,7 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
               "Computing public key from ED25519 private key envelope"));
 
     /* sk-ssh-ed25519@openssh.com. */
-    method_buf = SSH2_ALLOC(session, strlen(key_type));
+    method_buf = SSH2_ALLOC(session, strlen(key_type) + 1);
     if(!method_buf) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to allocate memory for ED25519 key");
@@ -2125,8 +2122,7 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
         memcpy(SSH2_UNCONST(*application), app, app_len);
     }
 
-    /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-    memcpy(method_buf, key_type, strlen(key_type));
+    memcpy(method_buf, key_type, strlen(key_type) + 1);
 
     if(method)
         *method = method_buf;
@@ -2749,19 +2745,19 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     else
         method_buf_len = 19;
 
-    method_buf = SSH2_ALLOC(session, method_buf_len);
+    method_buf = SSH2_ALLOC(session, method_buf_len + 1);
     if(!method_buf)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC, "out of memory");
 
     if(is_sk)
         memcpy(method_buf, "sk-ecdsa-sha2-nistp256@openssh.com",
-               method_buf_len);
+               method_buf_len + 1);
     else if(type == SSH2_EC_CURVE_NISTP256)
-        memcpy(method_buf, "ecdsa-sha2-nistp256", method_buf_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp256", method_buf_len + 1);
     else if(type == SSH2_EC_CURVE_NISTP384)
-        memcpy(method_buf, "ecdsa-sha2-nistp384", method_buf_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp384", method_buf_len + 1);
     else if(type == SSH2_EC_CURVE_NISTP521)
-        memcpy(method_buf, "ecdsa-sha2-nistp521", method_buf_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp521", method_buf_len + 1);
     else {
         ssh2_deb((session, LIBSSH2_TRACE_ERROR,
                   "Unsupported EC private key type"));

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2112,9 +2112,9 @@ int ssh2_pub_privkey_file(LIBSSH2_SESSION *session,
                                 rsapkcs1pubkey, rsapkcs8pubkey, (void *)&p);
     if(!ret) {
         *method_len = strlen(p.method);
-        *method = SSH2_ALLOC(session, *method_len);
+        *method = SSH2_ALLOC(session, *method_len + 1);
         if(*method)
-            memcpy((char *)*method, p.method, *method_len);
+            memcpy((char *)*method, p.method, *method_len + 1);
         else
             ret = -1;
     }
@@ -2276,9 +2276,9 @@ int ssh2_pub_privkey_blob(LIBSSH2_SESSION *session,
 
     if(!ret) {
         *method_len = strlen(p.method);
-        *method = SSH2_ALLOC(session, *method_len);
+        *method = SSH2_ALLOC(session, *method_len + 1);
         if(*method)
-            memcpy(*method, p.method, *method_len);
+            memcpy(*method, p.method, *method_len + 1);
         else
             ret = -1;
     }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -676,6 +676,8 @@ static int userauth_read_pubkey(
        it a wash */
     *method = (char *)pubkey;
     *method_len = sp1 - pubkey - 1;
+    /* keep the method name null-terminated, overwriting the separator */
+    pubkey[*method_len] = '\0';
 
     *pubkeydata = tmp;
     *pubkeydata_len = tmp_len;
@@ -1133,47 +1135,38 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
     return rc;
 }
 
-size_t ssh2_userauth_plain_method(char *method, size_t method_len)
+/* `method` is null-terminated, and the replacement names below are shorter
+   than the cert names they replace, so the in-place rewrites always fit */
+size_t ssh2_userauth_plain_method(char *method)
 {
-    if(!strncmp("ssh-rsa-cert-v01@openssh.com",
-                method, method_len))
+    if(!strcmp("ssh-rsa-cert-v01@openssh.com", method))
         return 7;
 
-    if(!strncmp("rsa-sha2-256-cert-v01@openssh.com",
-                method, method_len) ||
-       !strncmp("rsa-sha2-512-cert-v01@openssh.com",
-                method, method_len))
+    if(!strcmp("rsa-sha2-256-cert-v01@openssh.com", method) ||
+       !strcmp("rsa-sha2-512-cert-v01@openssh.com", method))
         return 12;
 
-    if(!strncmp("ecdsa-sha2-nistp256-cert-v01@openssh.com",
-                method, method_len) ||
-       !strncmp("ecdsa-sha2-nistp384-cert-v01@openssh.com",
-                method, method_len) ||
-       !strncmp("ecdsa-sha2-nistp521-cert-v01@openssh.com",
-                method, method_len))
+    if(!strcmp("ecdsa-sha2-nistp256-cert-v01@openssh.com", method) ||
+       !strcmp("ecdsa-sha2-nistp384-cert-v01@openssh.com", method) ||
+       !strcmp("ecdsa-sha2-nistp521-cert-v01@openssh.com", method))
         return 19;
 
-    if(!strncmp("ssh-ed25519-cert-v01@openssh.com",
-                method, method_len))
+    if(!strcmp("ssh-ed25519-cert-v01@openssh.com", method))
         return 11;
 
-    if(!strncmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com",
-                method, method_len)) {
+    if(!strcmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com", method)) {
         const char *new_method = "sk-ecdsa-sha2-nistp256@openssh.com";
-        /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-        memcpy(method, new_method, strlen(new_method));
+        memcpy(method, new_method, strlen(new_method) + 1);
         return strlen(new_method);
     }
 
-    if(!strncmp("sk-ssh-ed25519-cert-v01@openssh.com",
-                method, method_len)) {
+    if(!strcmp("sk-ssh-ed25519-cert-v01@openssh.com", method)) {
         const char *new_method = "sk-ssh-ed25519@openssh.com";
-        /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-        memcpy(method, new_method, strlen(new_method));
+        memcpy(method, new_method, strlen(new_method) + 1);
         return strlen(new_method);
     }
 
-    return method_len;
+    return strlen(method);
 }
 
 /* Function to check if the given version is less than pattern (OpenSSH 7.8)
@@ -1374,19 +1367,20 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
         if(*method && *method_len == rsa_method_len &&
            !memcmp(*method, rsa_method, rsa_method_len)) {
             SSH2_FREE(session, *method);
-            *method = SSH2_ALLOC(session, match_len + suffix_len);
+            *method = SSH2_ALLOC(session, match_len + suffix_len + 1);
             if(*method) {
                 memcpy(*method, match, match_len);
-                memcpy(*method + match_len, suffix, suffix_len);
+                memcpy(*method + match_len, suffix, suffix_len + 1);
                 *method_len = match_len + suffix_len;
             }
         }
         else {
             if(*method)
                 SSH2_FREE(session, *method);
-            *method = SSH2_ALLOC(session, match_len);
+            *method = SSH2_ALLOC(session, match_len + 1);
             if(*method) {
                 memcpy(*method, match, match_len);
+                (*method)[match_len] = '\0';
                 *method_len = match_len;
             }
         }
@@ -1466,13 +1460,15 @@ retry_auth:
                                 "Invalid public key");
 
             session->userauth_pblc_method_len = 0;
-            session->userauth_pblc_method = SSH2_ALLOC(session, method_len);
+            session->userauth_pblc_method = SSH2_ALLOC(session,
+                                                       method_len + 1);
             if(!session->userauth_pblc_method)
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Unable to allocate memory "
                                 "for public key data");
             session->userauth_pblc_method_len = method_len;
             memcpy(session->userauth_pblc_method, pubkeydata + 4, method_len);
+            session->userauth_pblc_method[method_len] = '\0';
         }
 
         /* upgrade key signing algo if it is supported and
@@ -1675,15 +1671,12 @@ retry_auth:
         session->userauth_pblc_b = NULL;
 
         session->userauth_pblc_method_len =
-            ssh2_userauth_plain_method(session->userauth_pblc_method,
-                                       session->userauth_pblc_method_len);
+            ssh2_userauth_plain_method(session->userauth_pblc_method);
 
-        if(!strncmp(session->userauth_pblc_method,
-                    "sk-ecdsa-sha2-nistp256@openssh.com",
-                    session->userauth_pblc_method_len) ||
-           !strncmp(session->userauth_pblc_method,
-                    "sk-ssh-ed25519@openssh.com",
-                    session->userauth_pblc_method_len)) {
+        if(!strcmp(session->userauth_pblc_method,
+                   "sk-ecdsa-sha2-nistp256@openssh.com") ||
+           !strcmp(session->userauth_pblc_method,
+                   "sk-ssh-ed25519@openssh.com")) {
             ssh2_store_u32(&s,
                            (uint32_t)(4 + session->userauth_pblc_method_len +
                                       sig_len));

--- a/src/userauth.h
+++ b/src/userauth.h
@@ -41,6 +41,6 @@ int ssh2_userauth_publickey(
     void *abstract);
 
 /* Utility function for certificate auth */
-size_t ssh2_userauth_plain_method(char *method, size_t method_len);
+size_t ssh2_userauth_plain_method(char *method);
 
 #endif /* LIBSSH2_USERAUTH_H */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2757,9 +2757,9 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
 
     if(length == 9) { /* private RSA key */
         mthlen = 7;
-        mth = SSH2_ALLOC(session, mthlen);
+        mth = SSH2_ALLOC(session, mthlen + 1);
         if(mth)
-            memcpy(mth, "ssh-rsa", mthlen);
+            memcpy(mth, "ssh-rsa", mthlen + 1);
         else
             ret = -1;
 
@@ -2778,9 +2778,9 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
     }
     else if(length == 6) { /* private DSA key */
         mthlen = 7;
-        mth = SSH2_ALLOC(session, mthlen);
+        mth = SSH2_ALLOC(session, mthlen + 1);
         if(mth)
-            memcpy(mth, "ssh-dss", mthlen);
+            memcpy(mth, "ssh-dss", mthlen + 1);
         else
             ret = -1;
 


### PR DESCRIPTION
`ssh2_userauth_plain_method()` compared with `strncmp(literal, method, method_len)`, which is a prefix match, but `session->userauth_pblc_method` was allocated at exactly `method_len` bytes and not null-terminated, so a truncated name matched a longer one. A public key blob whose leading type string is the 8 bytes `sk-ecdsa` reached the sk-ecdsa-sha2-nistp256 branch and the in-place `memcpy()` wrote 34 bytes into that 8-byte allocation; `sk-ssh` did the same through the sk-ssh-ed25519 branch. Shorter names also returned a length larger than the buffer (`s` returned 7), which the caller stores back into `userauth_pblc_method_len` and later passes to `ssh2_store_str()`. The blob is caller-supplied via `libssh2_userauth_publickey()`/`_frommemory()`, and comes from the agent identity list under `libssh2_agent_userauth()`.

Per review, the fix is to make the method name null-terminated rather than to fix up the comparisons in place. It is now allocated with one extra byte and terminated everywhere it is produced: the blob parse in `ssh2_userauth_publickey()`, the algo upgrade in `userauth_key_sign_algs()`, `userauth_read_pubkey()` (the separating space becomes the terminator), `libssh2_agent_sign()`, and the backend `method` buffers in openssl/mbedtls/wincng/os400qc3. That makes the comparisons plain `strcmp()`, makes the in-place rewrites fit by construction since the plain names are shorter than the cert names, and drops the four bugprone-not-null-terminated-result suppressions. The now-redundant length argument of `ssh2_userauth_plain_method()` is gone; `userauth_pblc_method_len` is kept for now since unwinding it reaches into `libssh2_agent_sign()`.

Confirmed with ASAN: `heap-buffer-overflow WRITE of size 34` at `ssh2_userauth_plain_method` on the `sk-ecdsa` input before, clean after, and every real cert name still maps to the same plain name and length. Picky `-Werror` build, checksrc-all.pl and spacecheck.pl are green locally.