### PR TITLE
openssl: check pointer before deref in `ossl_ecdsa_sk_openssh_priv_to_pubkey()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3054,7 +3054,7 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
 #endif
     }
 
-    if(rc == 0 && pubkeydata) {
+    if(rc == 0 && pubkeydata && pubkeydata_len) {
         key_len = *pubkeydata_len + app_len + 4;
         key = p = SSH2_ALLOC(session, key_len);
         if(!key) {


### PR DESCRIPTION
A NULL here doesn't seem possible with current code, but check it for 
consistency with its buffer pointer counterpart `pubkeydata` anyway.

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2372#discussion_r3621570932

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
