### PR TITLE
mbedtls, wincng: make var names consistent, drop magic numbers

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -602,7 +602,7 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
                              size_t *pubkeydata_len,
                              mbedtls_pk_context *pkey)
 {
-    char *mth = NULL;
+    char *method_buf = NULL;
     unsigned char *key = NULL;
     size_t keylen = 0, mthlen = 0;
     int ret;
@@ -617,9 +617,9 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
 
     /* write method */
     mthlen = sizeof("ssh-rsa") - 1;
-    mth = SSH2_ALLOC(session, mthlen);
-    if(mth)
-        memcpy(mth, "ssh-rsa", mthlen);
+    method_buf = SSH2_ALLOC(session, mthlen);
+    if(method_buf)
+        memcpy(method_buf, "ssh-rsa", mthlen);
     else
         ret = -1;
 
@@ -630,13 +630,13 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
 
     /* write output */
     if(ret) {
-        if(mth)
-            SSH2_FREE(session, mth);
+        if(method_buf)
+            SSH2_FREE(session, method_buf);
         if(key)
             SSH2_FREE(session, key);
     }
     else {
-        *method = mth;
+        *method = method_buf;
         *method_len = mthlen;
         *pubkeydata = key;
         *pubkeydata_len = keylen;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -604,7 +604,7 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
 {
     char *method_buf = NULL;
     unsigned char *key = NULL;
-    size_t keylen = 0, mthlen = 0;
+    size_t keylen = 0, method_buf_len = 0;
     int ret;
     mbedtls_rsa_context *rsa;
 
@@ -616,10 +616,10 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
     ret = 0;
 
     /* write method */
-    mthlen = sizeof("ssh-rsa") - 1;
-    method_buf = SSH2_ALLOC(session, mthlen);
+    method_buf_len = sizeof("ssh-rsa") - 1;
+    method_buf = SSH2_ALLOC(session, method_buf_len);
     if(method_buf)
-        memcpy(method_buf, "ssh-rsa", mthlen);
+        memcpy(method_buf, "ssh-rsa", method_buf_len);
     else
         ret = -1;
 
@@ -637,7 +637,7 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
     }
     else {
         *method = method_buf;
-        *method_len = mthlen;
+        *method_len = method_buf_len;
         *pubkeydata = key;
         *pubkeydata_len = keylen;
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2741,9 +2741,9 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
 {
     unsigned char **rpbDecoded = NULL;
     DWORD *rcbDecoded = NULL;
-    char *mth = NULL;
+    char *method_buf = NULL;
     unsigned char *key = NULL;
-    DWORD keylen = 0, mthlen = 0;
+    DWORD keylen = 0, method_buf_len = 0;
     DWORD index, offset, length = 0;
     int ret;
 
@@ -2756,18 +2756,19 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         return -1;
 
     if(length == 9) { /* private RSA key */
-        mthlen = 7;
-        mth = SSH2_ALLOC(session, mthlen);
-        if(mth)
-            memcpy(mth, "ssh-rsa", mthlen);
+        method_buf_len = sizeof("ssh-rsa") - 1;
+        method_buf = SSH2_ALLOC(session, method_buf_len);
+        if(method_buf)
+            memcpy(method_buf, "ssh-rsa", method_buf_len);
         else
             ret = -1;
 
-        keylen = 4 + mthlen + 4 + rcbDecoded[2] + 4 + rcbDecoded[1];
+        keylen = 4 + method_buf_len + 4 + rcbDecoded[2] + 4 + rcbDecoded[1];
         key = SSH2_ALLOC(session, keylen);
         if(key) {
             offset = wcng_pub_priv_write(key, 0,
-                                         (const unsigned char *)mth, mthlen);
+                                         (const unsigned char *)method_buf,
+                                         method_buf_len);
             offset = wcng_pub_priv_write(key, offset,
                                          rpbDecoded[2], rcbDecoded[2]);
             wcng_pub_priv_write(key, offset,
@@ -2777,19 +2778,20 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
             ret = -1;
     }
     else if(length == 6) { /* private DSA key */
-        mthlen = 7;
-        mth = SSH2_ALLOC(session, mthlen);
-        if(mth)
-            memcpy(mth, "ssh-dss", mthlen);
+        method_buf_len = sizeof("ssh-dss") - 1;
+        method_buf = SSH2_ALLOC(session, method_buf_len);
+        if(method_buf)
+            memcpy(method_buf, "ssh-dss", method_buf_len);
         else
             ret = -1;
 
-        keylen = 4 + mthlen + 4 + rcbDecoded[1] + 4 + rcbDecoded[2]
-                            + 4 + rcbDecoded[3] + 4 + rcbDecoded[4];
+        keylen = 4 + method_buf_len + 4 + rcbDecoded[1] + 4 + rcbDecoded[2] +
+                 4 + rcbDecoded[3] + 4 + rcbDecoded[4];
         key = SSH2_ALLOC(session, keylen);
         if(key) {
             offset = wcng_pub_priv_write(key, 0,
-                                         (const unsigned char *)mth, mthlen);
+                                         (const unsigned char *)method_buf,
+                                         method_buf_len);
             offset = wcng_pub_priv_write(key, offset,
                                          rpbDecoded[1], rcbDecoded[1]);
             offset = wcng_pub_priv_write(key, offset,
@@ -2815,14 +2817,14 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
     free(rcbDecoded);
 
     if(ret) {
-        if(mth)
-            SSH2_FREE(session, mth);
+        if(method_buf)
+            SSH2_FREE(session, method_buf);
         if(key)
             SSH2_FREE(session, key);
     }
     else {
-        *method = mth;
-        *method_len = mthlen;
+        *method = method_buf;
+        *method_len = method_buf_len;
         *pubkeydata = key;
         *pubkeydata_len = keylen;
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2717,10 +2717,8 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(IN ssh2_ecdsa_ctx *ec_ctx)
  */
 
 #if LIBSSH2_RSA || LIBSSH2_DSA
-static DWORD wcng_pub_priv_write(unsigned char *key,
-                                 DWORD offset,
-                                 const unsigned char *buf,
-                                 const DWORD length)
+static DWORD wcng_pub_priv_write(unsigned char *key, DWORD offset,
+                                 const void *buf, const DWORD length)
 {
     ssh2_htonu32(key + offset, length);
     offset += 4;
@@ -2769,8 +2767,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         key = SSH2_ALLOC(session, keylen);
         if(key) {
             offset = wcng_pub_priv_write(key, 0,
-                                         (const unsigned char *)method_buf,
-                                         method_buf_len);
+                                         method_buf, method_buf_len);
             offset = wcng_pub_priv_write(key, offset,
                                          rpbDecoded[2], rcbDecoded[2]);
             wcng_pub_priv_write(key, offset,
@@ -2795,8 +2792,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         key = SSH2_ALLOC(session, keylen);
         if(key) {
             offset = wcng_pub_priv_write(key, 0,
-                                         (const unsigned char *)method_buf,
-                                         method_buf_len);
+                                         method_buf, method_buf_len);
             offset = wcng_pub_priv_write(key, offset,
                                          rpbDecoded[1], rcbDecoded[1]);
             offset = wcng_pub_priv_write(key, offset,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2763,7 +2763,9 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         else
             ret = -1;
 
-        keylen = 4 + method_buf_len + 4 + rcbDecoded[2] + 4 + rcbDecoded[1];
+        keylen = 4 + method_buf_len +
+                 4 + rcbDecoded[2] +
+                 4 + rcbDecoded[1];
         key = SSH2_ALLOC(session, keylen);
         if(key) {
             offset = wcng_pub_priv_write(key, 0,
@@ -2785,8 +2787,11 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         else
             ret = -1;
 
-        keylen = 4 + method_buf_len + 4 + rcbDecoded[1] + 4 + rcbDecoded[2] +
-                 4 + rcbDecoded[3] + 4 + rcbDecoded[4];
+        keylen = 4 + method_buf_len +
+                 4 + rcbDecoded[1] +
+                 4 + rcbDecoded[2] +
+                 4 + rcbDecoded[3] +
+                 4 + rcbDecoded[4];
         key = SSH2_ALLOC(session, keylen);
         if(key) {
             offset = wcng_pub_priv_write(key, 0,


### PR DESCRIPTION
Use `method_buf*` where missing.

Also:
- wincng: make raw buffer type `void *` to avoid casts.
- wincng: avoid magic numbers.
