### PR TITLE
wincng: fix NULL derefs on OOM in `wcng_pub_privkey_file_parse()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2747,42 +2747,40 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
 
     ret = wcng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
                               &rpbDecoded, &rcbDecoded, &length);
-
     wcng_zero_free(pbEncoded, cbEncoded);
-
     if(ret)
-        return -1;
+        goto cleanup;
+
+    ret = -1;
 
     if(length == 9) { /* private RSA key */
         method_buf_len = sizeof("ssh-rsa") - 1;
         method_buf = SSH2_ALLOC(session, method_buf_len);
-        if(method_buf)
-            memcpy(method_buf, "ssh-rsa", method_buf_len);
-        else
-            ret = -1;
+        if(!method_buf)
+            goto cleanup;
+        memcpy(method_buf, "ssh-rsa", method_buf_len);
 
         keylen = 4 + method_buf_len +
                  4 + rcbDecoded[2] +
                  4 + rcbDecoded[1];
         key = SSH2_ALLOC(session, keylen);
-        if(key) {
-            offset = wcng_pub_priv_write(key, 0,
-                                         method_buf, method_buf_len);
-            offset = wcng_pub_priv_write(key, offset,
-                                         rpbDecoded[2], rcbDecoded[2]);
-            wcng_pub_priv_write(key, offset,
-                                rpbDecoded[1], rcbDecoded[1]);
-        }
-        else
-            ret = -1;
+        if(!key)
+            goto cleanup;
+
+        offset = wcng_pub_priv_write(key, 0,
+                                     method_buf, method_buf_len);
+        offset = wcng_pub_priv_write(key, offset,
+                                     rpbDecoded[2], rcbDecoded[2]);
+        wcng_pub_priv_write(key, offset,
+                            rpbDecoded[1], rcbDecoded[1]);
+        ret = 0; /* success */
     }
     else if(length == 6) { /* private DSA key */
         method_buf_len = sizeof("ssh-dss") - 1;
         method_buf = SSH2_ALLOC(session, method_buf_len);
-        if(method_buf)
-            memcpy(method_buf, "ssh-dss", method_buf_len);
-        else
-            ret = -1;
+        if(!method_buf)
+            goto cleanup;
+        memcpy(method_buf, "ssh-dss", method_buf_len);
 
         keylen = 4 + method_buf_len +
                  4 + rcbDecoded[1] +
@@ -2790,23 +2788,23 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
                  4 + rcbDecoded[3] +
                  4 + rcbDecoded[4];
         key = SSH2_ALLOC(session, keylen);
-        if(key) {
-            offset = wcng_pub_priv_write(key, 0,
-                                         method_buf, method_buf_len);
-            offset = wcng_pub_priv_write(key, offset,
-                                         rpbDecoded[1], rcbDecoded[1]);
-            offset = wcng_pub_priv_write(key, offset,
-                                         rpbDecoded[2], rcbDecoded[2]);
-            offset = wcng_pub_priv_write(key, offset,
-                                         rpbDecoded[3], rcbDecoded[3]);
-            wcng_pub_priv_write(key, offset,
-                                rpbDecoded[4], rcbDecoded[4]);
-        }
-        else
-            ret = -1;
+        if(!key)
+            goto cleanup;
+
+        offset = wcng_pub_priv_write(key, 0,
+                                     method_buf, method_buf_len);
+        offset = wcng_pub_priv_write(key, offset,
+                                     rpbDecoded[1], rcbDecoded[1]);
+        offset = wcng_pub_priv_write(key, offset,
+                                     rpbDecoded[2], rcbDecoded[2]);
+        offset = wcng_pub_priv_write(key, offset,
+                                     rpbDecoded[3], rcbDecoded[3]);
+        wcng_pub_priv_write(key, offset,
+                            rpbDecoded[4], rcbDecoded[4]);
+        ret = 0; /* success */
     }
-    else
-        ret = -1;
+
+cleanup:
 
     for(index = 0; index < length; index++) {
         wcng_zero_free(rpbDecoded[index], rcbDecoded[index]);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2742,7 +2742,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
     char *method_buf = NULL;
     unsigned char *key = NULL;
     DWORD keylen = 0, method_buf_len = 0;
-    DWORD index, offset, length = 0;
+    DWORD index, offs, length = 0;
     int ret;
 
     ret = wcng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
@@ -2767,12 +2767,9 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         if(!key)
             goto cleanup;
 
-        offset = wcng_pub_priv_write(key, 0,
-                                     method_buf, method_buf_len);
-        offset = wcng_pub_priv_write(key, offset,
-                                     rpbDecoded[2], rcbDecoded[2]);
-        wcng_pub_priv_write(key, offset,
-                            rpbDecoded[1], rcbDecoded[1]);
+        offs = wcng_pub_priv_write(key, 0, method_buf, method_buf_len);
+        offs = wcng_pub_priv_write(key, offs, rpbDecoded[2], rcbDecoded[2]);
+        wcng_pub_priv_write(key, offs, rpbDecoded[1], rcbDecoded[1]);
         ret = 0; /* success */
     }
     else if(length == 6) { /* private DSA key */
@@ -2791,16 +2788,11 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         if(!key)
             goto cleanup;
 
-        offset = wcng_pub_priv_write(key, 0,
-                                     method_buf, method_buf_len);
-        offset = wcng_pub_priv_write(key, offset,
-                                     rpbDecoded[1], rcbDecoded[1]);
-        offset = wcng_pub_priv_write(key, offset,
-                                     rpbDecoded[2], rcbDecoded[2]);
-        offset = wcng_pub_priv_write(key, offset,
-                                     rpbDecoded[3], rcbDecoded[3]);
-        wcng_pub_priv_write(key, offset,
-                            rpbDecoded[4], rcbDecoded[4]);
+        offs = wcng_pub_priv_write(key, 0, method_buf, method_buf_len);
+        offs = wcng_pub_priv_write(key, offs, rpbDecoded[1], rcbDecoded[1]);
+        offs = wcng_pub_priv_write(key, offs, rpbDecoded[2], rcbDecoded[2]);
+        offs = wcng_pub_priv_write(key, offs, rpbDecoded[3], rcbDecoded[3]);
+        wcng_pub_priv_write(key, offs, rpbDecoded[4], rcbDecoded[4]);
         ret = 0; /* success */
     }
 


### PR DESCRIPTION
A failed `method_buf` allocation followed by a successful `key`
allocation could result in NULL derefs in both RSA and DSA codepaths.

Also:
- simplify control flow.
- shorten a variable name to avoid folding.

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2376#discussion_r3622095675
Bug: https://github.com/libssh2/libssh2/pull/2376#discussion_r3622095708
