### PR TITLE
wincng: cap private key components in `wcng_pub_privkey_file_parse()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2760,6 +2760,10 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
             goto cleanup;
         memcpy(method_buf, "ssh-rsa", method_buf_len);
 
+        if(rcbDecoded[2] > (32 * 1024) ||
+           rcbDecoded[1] > (32 * 1024))
+            goto cleanup;
+
         keylen = 4 + method_buf_len +
                  4 + rcbDecoded[2] +
                  4 + rcbDecoded[1];
@@ -2778,6 +2782,12 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         if(!method_buf)
             goto cleanup;
         memcpy(method_buf, "ssh-dss", method_buf_len);
+
+        if(rcbDecoded[1] > (32 * 1024) ||
+           rcbDecoded[2] > (32 * 1024) ||
+           rcbDecoded[3] > (32 * 1024) ||
+           rcbDecoded[4] > (32 * 1024))
+            goto cleanup;
 
         keylen = 4 + method_buf_len +
                  4 + rcbDecoded[1] +


### PR DESCRIPTION
When parsing private key files/blobs. To avoid a corrupt/crafted RSA or 
DSA private file cause internal size overflows.

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2376#discussion_r3622147943
Bug: https://github.com/libssh2/libssh2/pull/2376#discussion_r3622147965

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
