### PR TITLE
publickey: fix `attr` memleak on error in `libssh2_publickey_list_fetch()`

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1116,6 +1116,9 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                                  "publickey attributes");
                         goto err_exit;
                     }
+                    memset(list[keys].attrs, 0,
+                           list[keys].num_attrs *
+                               sizeof(libssh2_publickey_attribute));
                     for(i = 0; i < list[keys].num_attrs; i++) {
                         if(pkey->listFetch_data_len <
                            (size_t)(pkey->listFetch_s - pkey->listFetch_data) +

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -941,7 +941,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                     goto err_exit;
                 }
                 list = newlist;
-                memset(&list[keys], 0, sizeof(list[keys]));
+                memset(&list[keys], 0, (max_keys - keys) * sizeof(list[keys]));
             }
             if(pkey->version == 1) {
                 unsigned long comment_len;
@@ -1116,9 +1116,6 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                                  "publickey attributes");
                         goto err_exit;
                     }
-                    memset(list[keys].attrs, 0,
-                           list[keys].num_attrs *
-                               sizeof(libssh2_publickey_attribute));
                     for(i = 0; i < list[keys].num_attrs; i++) {
                         if(pkey->listFetch_data_len <
                            (size_t)(pkey->listFetch_s - pkey->listFetch_data) +

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1180,10 +1180,10 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
             }
             /* To be FREEd in libssh2_publickey_list_free() */
             list[keys].packet = pkey->listFetch_data;
-            keys++;
-
-            list[keys].packet = NULL; /* Terminate the list */
             pkey->listFetch_data = NULL;
+
+            keys++;
+            memset(&list[keys], 0, sizeof(list[keys]));
             break;
         default:
             /* Unknown/Unexpected */
@@ -1217,10 +1217,11 @@ void libssh2_publickey_list_free(LIBSSH2_PUBLICKEY *pkey,
 
     session = pkey->channel->session;
 
-    while(p->packet) {
+    while(p->attrs || p->packet) {
         if(p->attrs)
             SSH2_FREE(session, p->attrs);
-        SSH2_FREE(session, p->packet);
+        if(p->packet)
+            SSH2_FREE(session, p->packet);
         p++;
     }
 

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -1186,7 +1186,6 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
             pkey->listFetch_data = NULL;
 
             keys++;
-            memset(&list[keys], 0, sizeof(list[keys]));
             break;
         default:
             /* Unknown/Unexpected */


### PR DESCRIPTION
In case of error, the last touched list entry could have the `attr`
field assigned to an allocated buffer, while still having NULL `packet`.
This made the destructore skip this entry and leak `attr`.

Fix by initializing all new list entries to zero and freeing entries
with either `attr` or `packet` set, up to entry where both are NULL.

Reported-by: hyunjiHong on github
Fixes #2368

---

/cc @hyunjiHong

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
