### PR TITLE
src: make sure `method` buffers are null-terminated

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -859,7 +859,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
         goto error;
     }
     memcpy(method_name, s, method_len);
-    method_name[method_len] = 0;
+    method_name[method_len] = '\0';
     len -= method_len;
     s += method_len;
 
@@ -1247,7 +1247,7 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
 
     agent->session->userauth_pblc_method_len = method_len;
     memcpy(agent->session->userauth_pblc_method, method, method_len);
-    agent->session->userauth_pblc_method[method_len] = 0;
+    agent->session->userauth_pblc_method[method_len] = '\0';
 
     rc = agent_sign(agent->session, sig, s_len, data, d_len, &abstract);
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -1241,12 +1241,13 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
         return LIBSSH2_ERROR_BUFFER_TOO_SMALL;
 
     agent->session->userauth_pblc_method = SSH2_ALLOC(agent->session,
-                                                      method_len);
+                                                      method_len + 1);
     if(!agent->session->userauth_pblc_method)
         return LIBSSH2_ERROR_ALLOC;
 
     agent->session->userauth_pblc_method_len = method_len;
     memcpy(agent->session->userauth_pblc_method, method, method_len);
+    agent->session->userauth_pblc_method[method_len] = 0;
 
     rc = agent_sign(agent->session, sig, s_len, data, d_len, &abstract);
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -853,12 +853,13 @@ static int agent_sign(LIBSSH2_SESSION *session,
     }
 
     /* method name */
-    method_name = SSH2_ALLOC(session, method_len);
+    method_name = SSH2_ALLOC(session, method_len + 1);
     if(!method_name) {
         rc = LIBSSH2_ERROR_ALLOC;
         goto error;
     }
     memcpy(method_name, s, method_len);
+    method_name[method_len] = 0;
     len -= method_len;
     s += method_len;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -593,9 +593,9 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
 
     /* write method */
     method_buf_len = sizeof("ssh-rsa") - 1;
-    method_buf = SSH2_ALLOC(session, method_buf_len);
+    method_buf = SSH2_ALLOC(session, method_buf_len + 1);
     if(method_buf)
-        memcpy(method_buf, "ssh-rsa", method_buf_len);
+        memcpy(method_buf, "ssh-rsa", method_buf_len + 1);
     else
         ret = -1;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1784,13 +1784,13 @@ static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session,
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing public key from ED private key envelope"));
 
-    method_buf = SSH2_ALLOC(session, sizeof(method_name) - 1);
+    method_buf = SSH2_ALLOC(session, sizeof(method_name));
     if(!method_buf) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to allocate memory for private key data");
         goto fail;
     }
-    memcpy(method_buf, method_name, sizeof(method_name) - 1);
+    memcpy(method_buf, method_name, sizeof(method_name));
 
     if(EVP_PKEY_get_raw_public_key(pk, NULL, &rawKeyLen) != 1) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -1896,7 +1896,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing public key from ED25519 private key envelope"));
 
-    method_buf = SSH2_ALLOC(session, sizeof(method_name) - 1);
+    method_buf = SSH2_ALLOC(session, sizeof(method_name));
     if(!method_buf) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to allocate memory for ED25519 key");
@@ -1915,8 +1915,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     ssh2_store_str(&p, method_name, sizeof(method_name) - 1);
     ssh2_store_str(&p, (const char *)pub_key, SSH2_ED25519_KEY_LEN);
 
-    /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-    memcpy(method_buf, method_name, sizeof(method_name) - 1);
+    memcpy(method_buf, method_name, sizeof(method_name));
 
     if(method)
         *method = method_buf;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1123,7 +1123,7 @@ static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
         /* Assume memory allocation error... what else could it be? */
         goto alloc_error;
 
-    method_buf = SSH2_ALLOC(session, 7); /* ssh-rsa. */
+    method_buf = SSH2_ALLOC(session, sizeof("ssh-rsa"));
     if(!method_buf)
         goto alloc_error;
 
@@ -1134,11 +1134,10 @@ static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     RSA_free(rsa);
 #endif
 
-    /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-    memcpy(method_buf, "ssh-rsa", 7);
+    memcpy(method_buf, "ssh-rsa", sizeof("ssh-rsa"));
     *method = method_buf;
     if(method_len)
-        *method_len = 7;
+        *method_len = sizeof("ssh-rsa") - 1;
 
     *pubkeydata = key;
     if(pubkeydata_len)
@@ -1494,7 +1493,7 @@ static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
         /* Assume memory allocation error... what else could it be ? */
         goto alloc_error;
 
-    method_buf = SSH2_ALLOC(session, 7); /* ssh-dss. */
+    method_buf = SSH2_ALLOC(session, sizeof("ssh-dss"));
     if(!method_buf)
         goto alloc_error;
 
@@ -1505,11 +1504,10 @@ static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     DSA_free(dsa);
 #endif
 
-    /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-    memcpy(method_buf, "ssh-dss", 7);
+    memcpy(method_buf, "ssh-dss", sizeof("ssh-dss"));
     *method = method_buf;
     if(method_len)
-        *method_len = 7;
+        *method_len = sizeof("ssh-dss") - 1;
 
     *pubkeydata = key;
     if(pubkeydata_len)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2672,19 +2672,19 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     else
         method_buf_len = sizeof("ecdsa-sha2-nistp999") - 1;
 
-    method_buf = SSH2_ALLOC(session, method_buf_len);
+    method_buf = SSH2_ALLOC(session, method_buf_len + 1);
     if(!method_buf)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC, "out of memory");
 
     if(is_sk)
         memcpy(method_buf, "sk-ecdsa-sha2-nistp256@openssh.com",
-               method_buf_len);
+               method_buf_len + 1);
     else if(type == SSH2_EC_CURVE_NISTP256)
-        memcpy(method_buf, "ecdsa-sha2-nistp256", method_buf_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp256", method_buf_len + 1);
     else if(type == SSH2_EC_CURVE_NISTP384)
-        memcpy(method_buf, "ecdsa-sha2-nistp384", method_buf_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp384", method_buf_len + 1);
     else if(type == SSH2_EC_CURVE_NISTP521)
-        memcpy(method_buf, "ecdsa-sha2-nistp521", method_buf_len);
+        memcpy(method_buf, "ecdsa-sha2-nistp521", method_buf_len + 1);
     else {
         ssh2_deb((session, LIBSSH2_TRACE_ERROR,
                   "Unsupported EC private key type"));

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2017,7 +2017,7 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
               "Computing public key from ED25519 private key envelope"));
 
     /* sk-ssh-ed25519@openssh.com. */
-    method_buf = SSH2_ALLOC(session, sizeof(method_name) - 1);
+    method_buf = SSH2_ALLOC(session, sizeof(method_name));
     if(!method_buf) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to allocate memory for ED25519 key");
@@ -2049,8 +2049,7 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
         memcpy(SSH2_UNCONST(*application), app, app_len);
     }
 
-    /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-    memcpy(method_buf, method_name, sizeof(method_name) - 1);
+    memcpy(method_buf, method_name, sizeof(method_name));
 
     if(method)
         *method = method_buf;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2092,9 +2092,9 @@ static int os400_pub_privkey_file(LIBSSH2_SESSION *session,
                                 rsapkcs1pubkey, rsapkcs8pubkey, (void *)&p);
     if(!ret) {
         *method_len = strlen(p.method);
-        *method = SSH2_ALLOC(session, *method_len);
+        *method = SSH2_ALLOC(session, *method_len + 1);
         if(*method)
-            memcpy((char *)*method, p.method, *method_len);
+            memcpy(*method, p.method, *method_len + 1);
         else
             ret = -1;
     }
@@ -2184,9 +2184,9 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session,
 
     if(!ret) {
         *method_len = strlen(p.method);
-        *method = SSH2_ALLOC(session, *method_len);
+        *method = SSH2_ALLOC(session, *method_len + 1);
         if(*method)
-            memcpy(*method, p.method, *method_len);
+            memcpy(*method, p.method, *method_len + 1);
         else
             ret = -1;
     }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1377,7 +1377,7 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
             if(*method) {
                 memcpy(*method, match, match_len);
                 memcpy(*method + match_len, suffix, suffix_len);
-                method[match_len + suffix_len] = 0;
+                (*method)[match_len + suffix_len] = 0;
                 *method_len = match_len + suffix_len;
             }
         }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -676,6 +676,7 @@ static int userauth_read_pubkey(
        it a wash */
     *method = (char *)pubkey;
     *method_len = sp1 - pubkey - 1;
+    method[*method_len] = 0;
 
     *pubkeydata = tmp;
     *pubkeydata_len = tmp_len;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -676,7 +676,7 @@ static int userauth_read_pubkey(
        it a wash */
     *method = (char *)pubkey;
     *method_len = sp1 - pubkey - 1;
-    method[*method_len] = 0;
+    (*method)[*method_len] = 0;
 
     *pubkeydata = tmp;
     *pubkeydata_len = tmp_len;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1269,10 +1269,10 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
     int rc = 0;
     size_t match_len = 0;
     char *filtered_algs = NULL;
-    const size_t suffix_len = sizeof("-cert-v01@openssh.com") - 1;
     const char * const suffix = "-cert-v01@openssh.com";
-    const size_t rsa_method_len = sizeof("ssh-rsa-cert-v01@openssh.com") - 1;
+    const size_t suffix_len = sizeof("-cert-v01@openssh.com") - 1;
     const char * const rsa_method = "ssh-rsa-cert-v01@openssh.com";
+    const size_t rsa_method_len = sizeof("ssh-rsa-cert-v01@openssh.com") - 1;
     const char *remote_banner = NULL;
     const char * const remote_ver_pre = "OpenSSH_";
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1376,8 +1376,7 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
             *method = SSH2_ALLOC(session, match_len + suffix_len + 1);
             if(*method) {
                 memcpy(*method, match, match_len);
-                memcpy(*method + match_len, suffix, suffix_len);
-                (*method)[match_len + suffix_len] = 0;
+                memcpy(*method + match_len, suffix, suffix_len + 1);
                 *method_len = match_len + suffix_len;
             }
         }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1159,18 +1159,16 @@ size_t ssh2_userauth_plain_method(char *method, size_t method_len)
 
     if(!strncmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com",
                 method, method_len)) {
-        const char *new_method = "sk-ecdsa-sha2-nistp256@openssh.com";
-        /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-        memcpy(method, new_method, strlen(new_method));
-        return strlen(new_method);
+        const char new_method[] = "sk-ecdsa-sha2-nistp256@openssh.com";
+        memcpy(method, new_method, sizeof(new_method));
+        return sizeof(new_method) - 1;
     }
 
     if(!strncmp("sk-ssh-ed25519-cert-v01@openssh.com",
                 method, method_len)) {
-        const char *new_method = "sk-ssh-ed25519@openssh.com";
-        /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-        memcpy(method, new_method, strlen(new_method));
-        return strlen(new_method);
+        const char new_method[] = "sk-ssh-ed25519@openssh.com";
+        memcpy(method, new_method, sizeof(new_method));
+        return sizeof(new_method) - 1;
     }
 
     return method_len;
@@ -1466,13 +1464,14 @@ retry_auth:
                                 "Invalid public key");
 
             session->userauth_pblc_method_len = 0;
-            session->userauth_pblc_method = SSH2_ALLOC(session, method_len);
+            session->userauth_pblc_method = SSH2_ALLOC(session,  + 1);
             if(!session->userauth_pblc_method)
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Unable to allocate memory "
                                 "for public key data");
             session->userauth_pblc_method_len = method_len;
             memcpy(session->userauth_pblc_method, pubkeydata + 4, method_len);
+            session->userauth_pblc_method[method_len] = 0;
         }
 
         /* upgrade key signing algo if it is supported and

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -676,7 +676,7 @@ static int userauth_read_pubkey(
        it a wash */
     *method = (char *)pubkey;
     *method_len = sp1 - pubkey - 1;
-    (*method)[*method_len] = 0;
+    (*method)[*method_len] = '\0';
 
     *pubkeydata = tmp;
     *pubkeydata_len = tmp_len;
@@ -1386,7 +1386,7 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
             *method = SSH2_ALLOC(session, match_len + 1);
             if(*method) {
                 memcpy(*method, match, match_len);
-                (*method)[match_len] = 0;
+                (*method)[match_len] = '\0';
                 *method_len = match_len;
             }
         }
@@ -1474,7 +1474,7 @@ retry_auth:
                                 "for public key data");
             session->userauth_pblc_method_len = method_len;
             memcpy(session->userauth_pblc_method, pubkeydata + 4, method_len);
-            session->userauth_pblc_method[method_len] = 0;
+            session->userauth_pblc_method[method_len] = '\0';
         }
 
         /* upgrade key signing algo if it is supported and

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1372,19 +1372,21 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
         if(*method && *method_len == rsa_method_len &&
            !memcmp(*method, rsa_method, rsa_method_len)) {
             SSH2_FREE(session, *method);
-            *method = SSH2_ALLOC(session, match_len + suffix_len);
+            *method = SSH2_ALLOC(session, match_len + suffix_len + 1);
             if(*method) {
                 memcpy(*method, match, match_len);
                 memcpy(*method + match_len, suffix, suffix_len);
+                method[match_len + suffix_len] = 0;
                 *method_len = match_len + suffix_len;
             }
         }
         else {
             if(*method)
                 SSH2_FREE(session, *method);
-            *method = SSH2_ALLOC(session, match_len);
+            *method = SSH2_ALLOC(session, match_len + 1);
             if(*method) {
                 memcpy(*method, match, match_len);
+                method[match_len] = 0;
                 *method_len = match_len;
             }
         }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1466,8 +1466,8 @@ retry_auth:
                                 "Invalid public key");
 
             session->userauth_pblc_method_len = 0;
-            session->userauth_pblc_method =
-                SSH2_ALLOC(session, method_len + 1);
+            session->userauth_pblc_method = SSH2_ALLOC(session,
+                                                       method_len + 1);
             if(!session->userauth_pblc_method)
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Unable to allocate memory "

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1467,7 +1467,8 @@ retry_auth:
                                 "Invalid public key");
 
             session->userauth_pblc_method_len = 0;
-            session->userauth_pblc_method = SSH2_ALLOC(session,  + 1);
+            session->userauth_pblc_method =
+                SSH2_ALLOC(session, method_len + 1);
             if(!session->userauth_pblc_method)
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Unable to allocate memory "

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1387,7 +1387,7 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
             *method = SSH2_ALLOC(session, match_len + 1);
             if(*method) {
                 memcpy(*method, match, match_len);
-                method[match_len] = 0;
+                (*method)[match_len] = 0;
                 *method_len = match_len;
             }
         }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2673,10 +2673,10 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
 
     if(length == 9) { /* private RSA key */
         method_buf_len = sizeof("ssh-rsa") - 1;
-        method_buf = SSH2_ALLOC(session, method_buf_len);
+        method_buf = SSH2_ALLOC(session, method_buf_len + 1);
         if(!method_buf)
             goto cleanup;
-        memcpy(method_buf, "ssh-rsa", method_buf_len);
+        memcpy(method_buf, "ssh-rsa", method_buf_len + 1);
 
         if(rcbDecoded[2] > (32 * 1024) ||
            rcbDecoded[1] > (32 * 1024))
@@ -2696,10 +2696,10 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
     }
     else if(length == 6) { /* private DSA key */
         method_buf_len = sizeof("ssh-dss") - 1;
-        method_buf = SSH2_ALLOC(session, method_buf_len);
+        method_buf = SSH2_ALLOC(session, method_buf_len + 1);
         if(!method_buf)
             goto cleanup;
-        memcpy(method_buf, "ssh-dss", method_buf_len);
+        memcpy(method_buf, "ssh-dss", method_buf_len + 1);
 
         if(rcbDecoded[1] > (32 * 1024) ||
            rcbDecoded[2] > (32 * 1024) ||


### PR DESCRIPTION
Method (as in for example `ssh-rsa`, `ssh-rsa-cert-v01@openssh.com`) is
always a string and expected to remain so. Prior to this patch it was
kept in memory buffers without a null-terminator, and passed around with
its length. This caused potential issues when making comparisons using
`strncmp()`, and in general a code smell, also often flagged by LLMs and
static analyizers alike.

To fix this patch makes sure to allocate + 1 byte for the method string 
and ensure to set or copy the null-terminator.

Also:
- drop related `NOLINT` clang-tidy warning suppressions no longer
  necessary after this.

Bug: https://github.com/libssh2/libssh2/pull/2369#discussion_r3620847307

Assisted-by: Syed Abdul Khaliq
Ref: #2369
