### PR TITLE
src: drop method length

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -423,7 +423,7 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
 Gets a private key from file `privatekey`, or bytes at (`privkeyblob`,
 `privkeyblob_len`) and extracts the public key --> (`pubkeydata`,
 `pubkeydata_len`). Store the associated method (e.g., `ssh-rsa`, `ssh-ed25519`)
-into `method`.
+into `*method`.
 Both buffers have to be allocated using `SSH2_ALLOC()`.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in `crypto.h`.

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -414,8 +414,7 @@ Format of an ED25519 public key:
 Each item is preceded by its 32-bit byte length, MSB first.
 
 ```c
-int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method,
+int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -415,7 +415,7 @@ Each item is preceded by its 32-bit byte length, MSB first.
 
 ```c
 int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method, size_t *method_len,
+                     char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,
@@ -424,7 +424,7 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session,
 Gets a private key from file `privatekey`, or bytes at (`privkeyblob`,
 `privkeyblob_len`) and extracts the public key --> (`pubkeydata`,
 `pubkeydata_len`). Store the associated method (e.g., `ssh-rsa`, `ssh-ed25519`)
-into (`method`, `method_len`).
+into `method`.
 Both buffers have to be allocated using `SSH2_ALLOC()`.
 Returns 0 if OK, else -1.
 This procedure is already prototyped in `crypto.h`.

--- a/src/agent.c
+++ b/src/agent.c
@@ -862,6 +862,13 @@ static int agent_sign(LIBSSH2_SESSION *session,
 
     ssh2_userauth_plain_method(session->userauth_pblc_method);
 
+    if(method_len != strlen(method_name)) {
+        ssh2_deb((session, LIBSSH2_TRACE_KEX,
+                  "Agent sign method contains null byte"));
+        rc = LIBSSH2_ERROR_INVAL;
+        goto error;
+    }
+
     /* check to see if we match requested */
     if(strcmp(method_name, session->userauth_pblc_method)) {
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Agent sign method %.*s",

--- a/src/agent.c
+++ b/src/agent.c
@@ -1249,7 +1249,7 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
 
     if(method_len != strlen(agent->session->userauth_pblc_method)) {
         rc = ssh2_err(agent->session, LIBSSH2_ERROR_INVAL,
-                      "Method contains null byte");
+                      "Identity method contains null byte");
         goto cleanup;
     }
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -758,7 +758,7 @@ static int agent_sign(LIBSSH2_SESSION *session,
     LIBSSH2_AGENT *agent = (LIBSSH2_AGENT *)(*abstract);
     struct agent_transaction_ctx *transctx = &agent->transctx;
     struct agent_publickey *identity = agent->identity;
-    size_t len, method_len, plain_len;
+    size_t len, method_len;
     unsigned char *s;
     int rc;
     char *method_name = NULL;
@@ -785,13 +785,10 @@ static int agent_sign(LIBSSH2_SESSION *session,
         ssh2_store_str(&s, (const char *)data, data_len);
 
         /* flags */
-        if(session->userauth_pblc_method_len > 0 &&
-           session->userauth_pblc_method) {
-            if(session->userauth_pblc_method_len == 12 &&
-               !memcmp(session->userauth_pblc_method, "rsa-sha2-512", 12))
+        if(session->userauth_pblc_method && *session->userauth_pblc_method) {
+            if(!strcmp(session->userauth_pblc_method, "rsa-sha2-512"))
                 sign_flags = SSH_AGENT_RSA_SHA2_512;
-            else if(session->userauth_pblc_method_len == 12 &&
-                    !memcmp(session->userauth_pblc_method, "rsa-sha2-256", 12))
+            else if(!strcmp(session->userauth_pblc_method, "rsa-sha2-256"))
                 sign_flags = SSH_AGENT_RSA_SHA2_256;
         }
         ssh2_store_u32(&s, sign_flags);
@@ -863,17 +860,12 @@ static int agent_sign(LIBSSH2_SESSION *session,
     len -= method_len;
     s += method_len;
 
-    plain_len = ssh2_userauth_plain_method(
-        session->userauth_pblc_method,
-        session->userauth_pblc_method_len);
+    ssh2_userauth_plain_method(session->userauth_pblc_method);
 
     /* check to see if we match requested */
-    if((method_len != session->userauth_pblc_method_len &&
-        method_len != plain_len) ||
-       memcmp(method_name, session->userauth_pblc_method, method_len)) {
+    if(strcmp(method_name, session->userauth_pblc_method)) {
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Agent sign method %.*s",
                   (int)method_len, method_name));
-
         rc = LIBSSH2_ERROR_ALGO_UNSUPPORTED;
         goto error;
     }
@@ -1245,14 +1237,12 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
     if(!agent->session->userauth_pblc_method)
         return LIBSSH2_ERROR_ALLOC;
 
-    agent->session->userauth_pblc_method_len = method_len;
     memcpy(agent->session->userauth_pblc_method, method, method_len);
     agent->session->userauth_pblc_method[method_len] = '\0';
 
     rc = agent_sign(agent->session, sig, s_len, data, d_len, &abstract);
 
     SSH2_SAFEFREE(agent->session, agent->session->userauth_pblc_method);
-    agent->session->userauth_pblc_method_len = 0;
 
     return rc;
 }

--- a/src/agent.c
+++ b/src/agent.c
@@ -1247,7 +1247,15 @@ int libssh2_agent_sign(LIBSSH2_AGENT *agent,
     memcpy(agent->session->userauth_pblc_method, method, method_len);
     agent->session->userauth_pblc_method[method_len] = '\0';
 
+    if(method_len != strlen(agent->session->userauth_pblc_method)) {
+        rc = ssh2_err(agent->session, LIBSSH2_ERROR_INVAL,
+                      "Method contains null byte");
+        goto cleanup;
+    }
+
     rc = agent_sign(agent->session, sig, s_len, data, d_len, &abstract);
+
+cleanup:
 
     SSH2_SAFEFREE(agent->session, agent->session->userauth_pblc_method);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -272,15 +272,13 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
 #endif
 
-int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method,
+int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,
                      const char *passphrase);
 
-int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
-                   char **method,
+int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
                    unsigned char **pubkeydata, size_t *pubkeydata_len,
                    int *algorithm, unsigned char *flags,
                    const char **application,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -273,14 +273,14 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx);
 #endif
 
 int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method, size_t *method_len,
+                     char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,
                      const char *passphrase);
 
 int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
-                   char **method, size_t *method_len,
+                   char **method,
                    unsigned char **pubkeydata, size_t *pubkeydata_len,
                    int *algorithm, unsigned char *flags,
                    const char **application,

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -682,14 +682,13 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx,
 }
 
 int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method, size_t *method_len,
+                     char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,
                      const char *passphrase)
 {
     (void)method;
-    (void)method_len;
     (void)pubkeydata;
     (void)pubkeydata_len;
     (void)privatekey;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -681,8 +681,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx,
     return ret;
 }
 
-int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method,
+int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -845,7 +845,6 @@ struct _LIBSSH2_SESSION {
     unsigned char *userauth_host_packet;
     size_t userauth_host_packet_len;
     char *userauth_host_method;
-    size_t userauth_host_method_len;
     unsigned char *userauth_host_s;
     struct packet_requirev_state userauth_host_packet_requirev_state;
 
@@ -856,7 +855,6 @@ struct _LIBSSH2_SESSION {
     unsigned char *userauth_pblc_packet;
     size_t userauth_pblc_packet_len;
     char *userauth_pblc_method;
-    size_t userauth_pblc_method_len;
     unsigned char *userauth_pblc_s;
     unsigned char *userauth_pblc_b;
     struct packet_requirev_state userauth_pblc_packet_requirev_state;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -571,8 +571,7 @@ static unsigned char *mbed_gen_publickey_from_rsa(LIBSSH2_SESSION *session,
     return key;
 }
 
-static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
-                             char **method,
+static int mbed_pub_priv_key(LIBSSH2_SESSION *session, char **method,
                              unsigned char **pubkeydata,
                              size_t *pubkeydata_len,
                              mbedtls_pk_context *pkey)
@@ -619,8 +618,7 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
     return ret;
 }
 
-int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method,
+int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -572,7 +572,7 @@ static unsigned char *mbed_gen_publickey_from_rsa(LIBSSH2_SESSION *session,
 }
 
 static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
-                             char **method, size_t *method_len,
+                             char **method,
                              unsigned char **pubkeydata,
                              size_t *pubkeydata_len,
                              mbedtls_pk_context *pkey)
@@ -612,7 +612,6 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
     }
     else {
         *method = method_buf;
-        *method_len = method_buf_len;
         *pubkeydata = key;
         *pubkeydata_len = keylen;
     }
@@ -621,7 +620,7 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session,
 }
 
 int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method, size_t *method_len,
+                     char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,
@@ -665,7 +664,7 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session,
                               SSH2_ERR_FLAG_DUP);
     }
 
-    ret = mbed_pub_priv_key(session, method, method_len,
+    ret = mbed_pub_priv_key(session, method,
                             pubkeydata, pubkeydata_len, &pkey);
 
     mbedtls_pk_free(&pkey);

--- a/src/misc.c
+++ b/src/misc.c
@@ -1010,7 +1010,6 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
                    const char *passphrase)
 {
     (void)method;
-    (void)method_len;
     (void)pubkeydata;
     (void)pubkeydata_len;
     (void)algorithm;

--- a/src/misc.c
+++ b/src/misc.c
@@ -999,8 +999,7 @@ int ssh2_timingsafe_bcmp(const void *b1, const void *b2, size_t n)
 }
 
 #ifndef LIBSSH2_KEY_SK
-int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
-                   char **method,
+int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
                    unsigned char **pubkeydata, size_t *pubkeydata_len,
                    int *algorithm, unsigned char *flags,
                    const char **application,

--- a/src/misc.c
+++ b/src/misc.c
@@ -1000,7 +1000,7 @@ int ssh2_timingsafe_bcmp(const void *b1, const void *b2, size_t n)
 
 #ifndef LIBSSH2_KEY_SK
 int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
-                   char **method, size_t *method_len,
+                   char **method,
                    unsigned char **pubkeydata, size_t *pubkeydata_len,
                    int *algorithm, unsigned char *flags,
                    const char **application,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1096,8 +1096,7 @@ fail:
     return key;
 }
 
-static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                  char **method,
+static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
                                   EVP_PKEY *pk)
@@ -1461,8 +1460,7 @@ fail:
     return key;
 }
 
-static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                  char **method,
+static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
                                   EVP_PKEY *pk)
@@ -1755,8 +1753,7 @@ clean_exit:
     return rc;
 }
 
-static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                      char **method,
+static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       EVP_PKEY *pk)
@@ -2596,8 +2593,7 @@ clean_exit:
     return rc;
 }
 
-static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
-                                    char **method,
+static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
                                     unsigned char **pubkeydata,
                                     size_t *pubkeydata_len,
                                     int is_sk,
@@ -3547,8 +3543,7 @@ clean_exit:
 
 #endif /* LIBSSH2_ED25519 */
 
-static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
-                                      char **method,
+static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session, char **method,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       const char *privatekey,
@@ -3746,8 +3741,7 @@ cleanup:
     return rc;
 }
 
-int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
-                   char **method,
+int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
                    unsigned char **pubkeydata, size_t *pubkeydata_len,
                    int *algorithm, unsigned char *flags,
                    const char **application,
@@ -3844,8 +3838,7 @@ cleanup:
 #define HAVE_SSLERROR_BAD_DECRYPT
 #endif
 
-int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method,
+int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -151,7 +151,6 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                       void **key_ctx,
                                       const char *want_method,
                                       char **method,
-                                      size_t *method_len,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       const char *privkeyblob,
@@ -1099,7 +1098,6 @@ fail:
 
 static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
                                   char **method,
-                                  size_t *method_len,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
                                   EVP_PKEY *pk)
@@ -1134,8 +1132,6 @@ static int ossl_rsa_evp_to_pubkey(LIBSSH2_SESSION *session,
 
     memcpy(method_buf, "ssh-rsa", sizeof("ssh-rsa"));
     *method = method_buf;
-    if(method_len)
-        *method_len = sizeof("ssh-rsa") - 1;
 
     *pubkeydata = key;
     if(pubkeydata_len)
@@ -1219,7 +1215,6 @@ out:
 static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                            struct string_buf *decrypted,
                                            char **method,
-                                           size_t *method_len,
                                            unsigned char **pubkeydata,
                                            size_t *pubkeydata_len,
                                            ssh2_rsa_ctx **rsa)
@@ -1290,7 +1285,7 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         EVP_PKEY_set1_RSA(pk, ctx);
 #endif
 
-        rc = ossl_rsa_evp_to_pubkey(session, method, method_len,
+        rc = ossl_rsa_evp_to_pubkey(session, method,
                                     pubkeydata, pubkeydata_len, pk);
 
 #ifndef USE_OPENSSL_3
@@ -1353,7 +1348,7 @@ static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
 
     if(!strcmp("ssh-rsa", (const char *)buf))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
-                                             NULL, NULL, NULL, NULL, rsa);
+                                             NULL, NULL, NULL, rsa);
     else
         rc = -1;
 
@@ -1397,7 +1392,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
             rc = ossl_rsa_openssh_priv_new(rsa, session, filename, passphrase);
         else
             rc = ossl_key_from_openssh_blob(session, (void **)rsa, "ssh-rsa",
-                                            NULL, NULL, NULL, NULL,
+                                            NULL, NULL, NULL,
                                             blob, blob_len, passphrase);
     }
 
@@ -1468,7 +1463,6 @@ fail:
 
 static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
                                   char **method,
-                                  size_t *method_len,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
                                   EVP_PKEY *pk)
@@ -1503,8 +1497,6 @@ static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session,
 
     memcpy(method_buf, "ssh-dss", sizeof("ssh-dss"));
     *method = method_buf;
-    if(method_len)
-        *method_len = sizeof("ssh-dss") - 1;
 
     *pubkeydata = key;
     if(pubkeydata_len)
@@ -1527,7 +1519,6 @@ alloc_error:
 static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                            struct string_buf *decrypted,
                                            char **method,
-                                           size_t *method_len,
                                            unsigned char **pubkeydata,
                                            size_t *pubkeydata_len,
                                            ssh2_dsa_ctx **dsa)
@@ -1581,7 +1572,7 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         EVP_PKEY_set1_DSA(pk, ctx);
 #endif
 
-        rc = ossl_dsa_evp_to_pubkey(session, method, method_len,
+        rc = ossl_dsa_evp_to_pubkey(session, method,
                                     pubkeydata, pubkeydata_len, pk);
 
 #ifndef USE_OPENSSL_3
@@ -1644,7 +1635,7 @@ static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
 
     if(!strcmp("ssh-dss", (const char *)buf))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
-                                             NULL, NULL, NULL, NULL, dsa);
+                                             NULL, NULL, NULL, dsa);
     else
         rc = -1;
 
@@ -1688,7 +1679,7 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
             rc = ossl_dsa_openssh_priv_new(dsa, session, filename, passphrase);
         else
             rc = ossl_key_from_openssh_blob(session, (void **)dsa, "ssh-dsa",
-                                            NULL, NULL, NULL, NULL,
+                                            NULL, NULL, NULL,
                                             blob, blob_len, passphrase);
     }
 
@@ -1766,7 +1757,6 @@ clean_exit:
 
 static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session,
                                       char **method,
-                                      size_t *method_len,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       EVP_PKEY *pk)
@@ -1814,8 +1804,6 @@ static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session,
     }
 
     *method = method_buf;
-    if(method_len)
-        *method_len = sizeof(method_name) - 1;
 
     *pubkeydata = pub_key;
     if(pubkeydata_len)
@@ -1834,7 +1822,6 @@ fail:
 static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                                struct string_buf *decrypted,
                                                char **method,
-                                               size_t *method_len,
                                                unsigned char **pubkeydata,
                                                size_t *pubkeydata_len,
                                                ssh2_ed25519_ctx **ed_ctx)
@@ -1919,9 +1906,6 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     else
         SSH2_FREE(session, method_buf);
 
-    if(method_len)
-        *method_len = sizeof(method_name) - 1;
-
     if(pubkeydata)
         *pubkeydata = key;
     else
@@ -1955,7 +1939,6 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
     LIBSSH2_SESSION *session,
     struct string_buf *decrypted,
     char **method,
-    size_t *method_len,
     unsigned char **pubkeydata,
     size_t *pubkeydata_len,
     unsigned char *flags,
@@ -2053,9 +2036,6 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
     else
         SSH2_FREE(session, method_buf);
 
-    if(method_len)
-        *method_len = sizeof(method_name) - 1;
-
     if(pubkeydata)
         *pubkeydata = key;
     else
@@ -2138,8 +2118,7 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
 
         if(!strcmp("ssh-ed25519", (const char *)buf))
             rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
-                                                     NULL, NULL, NULL, NULL,
-                                                     &ctx);
+                                                     NULL, NULL, NULL, &ctx);
         else
             rc = -1;
 
@@ -2180,7 +2159,7 @@ cleanup:
 
         return ossl_key_from_openssh_blob(session,
                                           (void **)ed_ctx, "ssh-ed25519",
-                                          NULL, NULL, NULL, NULL,
+                                          NULL, NULL, NULL,
                                           blob, blob_len, passphrase);
     }
 }
@@ -2619,7 +2598,6 @@ clean_exit:
 
 static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
                                     char **method,
-                                    size_t *method_len,
                                     unsigned char **pubkeydata,
                                     size_t *pubkeydata_len,
                                     int is_sk,
@@ -2742,8 +2720,6 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     ssh2_store_str(&p, (const char *)octal_value, octal_len);
 
     *method = method_buf;
-    if(method_len)
-        *method_len = method_buf_len;
 
     *pubkeydata = key;
     if(pubkeydata_len)
@@ -2775,7 +2751,6 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                              ssh2_curve_type curve_type,
                                              struct string_buf *decrypted,
                                              char **method,
-                                             size_t *method_len,
                                              unsigned char **pubkeydata,
                                              size_t *pubkeydata_len,
                                              ssh2_ecdsa_ctx **ec_ctx)
@@ -2873,7 +2848,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         EVP_PKEY_set1_EC_KEY(pk, ctx);
 #endif
 
-        rc = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
+        rc = ossl_ecdsa_evp_to_pubkey(session, method,
                                       pubkeydata, pubkeydata_len, 0, pk);
 
 #ifndef USE_OPENSSL_3
@@ -2910,7 +2885,6 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     LIBSSH2_SESSION *session,
     struct string_buf *decrypted,
     char **method,
-    size_t *method_len,
     unsigned char **pubkeydata,
     size_t *pubkeydata_len,
     unsigned char *flags,
@@ -2976,7 +2950,7 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
         EVP_PKEY_set1_EC_KEY(pk, ctx);
 #endif
 
-        rc = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
+        rc = ossl_ecdsa_evp_to_pubkey(session, method,
                                       pubkeydata, pubkeydata_len, 1, pk);
 
 #ifndef USE_OPENSSL_3
@@ -3083,7 +3057,7 @@ static int ossl_ecdsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
 
     if(rc == 0)
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
-                                               NULL, NULL, NULL, NULL, ec_ctx);
+                                               NULL, NULL, NULL, ec_ctx);
     else
         rc = -1;
 
@@ -3129,7 +3103,7 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
         else
             rc = ossl_key_from_openssh_blob(session,
                                             (void **)ec_ctx, "ssh-ecdsa",
-                                            NULL, NULL, NULL, NULL,
+                                            NULL, NULL, NULL,
                                             blob, blob_len, passphrase);
     }
     return rc;
@@ -3575,7 +3549,6 @@ clean_exit:
 
 static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
                                       char **method,
-                                      size_t *method_len,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       const char *privatekey,
@@ -3621,35 +3594,34 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
 
     /* Avoid unused variable warnings when all branches below are disabled */
     (void)method;
-    (void)method_len;
     (void)pubkeydata;
     (void)pubkeydata_len;
 
 #if LIBSSH2_ED25519
     if(!strcmp("ssh-ed25519", (const char *)buf))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
-                                                 method, method_len,
+                                                 method,
                                                  pubkeydata, pubkeydata_len,
                                                  NULL);
 #endif
 #if LIBSSH2_RSA
     if(!strcmp("ssh-rsa", (const char *)buf))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
-                                             method, method_len,
+                                             method,
                                              pubkeydata, pubkeydata_len,
                                              NULL);
 #endif
 #if LIBSSH2_DSA
     if(!strcmp("ssh-dss", (const char *)buf))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
-                                             method, method_len,
+                                             method,
                                              pubkeydata, pubkeydata_len,
                                              NULL);
 #endif
 #if LIBSSH2_ECDSA
     if(ossl_ecdsa_curve_type_from_name((const char *)buf, &type) == 0)
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
-                                               method, method_len,
+                                               method,
                                                pubkeydata, pubkeydata_len,
                                                NULL);
 #endif
@@ -3668,7 +3640,7 @@ cleanup:
 static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
                                       void **key_ctx,
                                       const char *want_method,
-                                      char **method, size_t *method_len,
+                                      char **method,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       const char *privkeyblob,
@@ -3711,7 +3683,6 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
 
     /* Avoid unused variable warnings when all branches below are disabled */
     (void)method;
-    (void)method_len;
     (void)pubkeydata;
     (void)pubkeydata_len;
 
@@ -3719,14 +3690,14 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
     if(!strcmp("ssh-ed25519", (const char *)buf) &&
        (!want_method || !strcmp("ssh-ed25519", want_method)))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
-                                                 method, method_len,
+                                                 method,
                                                  pubkeydata, pubkeydata_len,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 
     if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) &&
        (!want_method || !strcmp("sk-ssh-ed25519@openssh.com", want_method)))
         rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                    method, method_len,
+                                                    method,
                                                     pubkeydata, pubkeydata_len,
                                                     NULL, NULL, NULL, NULL,
                                                  (ssh2_ed25519_ctx **)key_ctx);
@@ -3735,7 +3706,7 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
     if(!strcmp("ssh-rsa", (const char *)buf) &&
        (!want_method || !strcmp("ssh-rsa", want_method)))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
-                                             method, method_len,
+                                             method,
                                              pubkeydata, pubkeydata_len,
                                              (ssh2_rsa_ctx **)key_ctx);
 #endif
@@ -3743,21 +3714,21 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
     if(!strcmp("ssh-dss", (const char *)buf) &&
        (!want_method || !strcmp("ssh-dss", want_method)))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
-                                             method, method_len,
+                                             method,
                                              pubkeydata, pubkeydata_len,
                                              (ssh2_dsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_ECDSA
     if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf))
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                  method, method_len,
+                                                  method,
                                                   pubkeydata, pubkeydata_len,
                                                   NULL, NULL, NULL, NULL,
                                                   (ssh2_ecdsa_ctx **)key_ctx);
     else if(ossl_ecdsa_curve_type_from_name((const char *)buf, &type) == 0 &&
             (!want_method || !strcmp("ssh-ecdsa", want_method)))
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
-                                               method, method_len,
+                                               method,
                                                pubkeydata, pubkeydata_len,
                                                (ssh2_ecdsa_ctx **)key_ctx);
 #endif
@@ -3776,7 +3747,7 @@ cleanup:
 }
 
 int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
-                   char **method, size_t *method_len,
+                   char **method,
                    unsigned char **pubkeydata, size_t *pubkeydata_len,
                    int *algorithm, unsigned char *flags,
                    const char **application,
@@ -3824,7 +3795,6 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
 
     /* Avoid unused variable warnings when all branches below are disabled */
     (void)method;
-    (void)method_len;
     (void)pubkeydata;
     (void)pubkeydata_len;
     (void)algorithm;
@@ -3837,7 +3807,7 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
     if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf)) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ED25519;
         rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                    method, method_len,
+                                                    method,
                                                     pubkeydata,
                                                     pubkeydata_len,
                                                     flags, application,
@@ -3849,7 +3819,7 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session,
     if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf)) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ECDSA_256;
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                  method, method_len,
+                                                  method,
                                                   pubkeydata, pubkeydata_len,
                                                   flags, application,
                                                   key_handle, handle_len,
@@ -3875,7 +3845,7 @@ cleanup:
 #endif
 
 int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method, size_t *method_len,
+                     char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,
@@ -3923,13 +3893,13 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session,
         /* Try OpenSSH format */
         if(privatekey)
             rc = ossl_key_from_openssh_file(session,
-                                            method, method_len,
+                                            method,
                                             pubkeydata, pubkeydata_len,
                                             privatekey,
                                             passphrase);
         else
             rc = ossl_key_from_openssh_blob(session, NULL, NULL,
-                                            method, method_len,
+                                            method,
                                             pubkeydata, pubkeydata_len,
                                             privkeyblob, privkeyblob_len,
                                             passphrase);
@@ -3954,25 +3924,25 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session,
     switch(pktype) {
 #if LIBSSH2_ED25519
     case EVP_PKEY_ED25519:
-        rc = ossl_ed25519_evp_to_pubkey(session, method, method_len,
+        rc = ossl_ed25519_evp_to_pubkey(session, method,
                                         pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_ED25519 */
 #if LIBSSH2_RSA
     case EVP_PKEY_RSA:
-        rc = ossl_rsa_evp_to_pubkey(session, method, method_len,
+        rc = ossl_rsa_evp_to_pubkey(session, method,
                                     pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_RSA */
 #if LIBSSH2_DSA
     case EVP_PKEY_DSA:
-        rc = ossl_dsa_evp_to_pubkey(session, method, method_len,
+        rc = ossl_dsa_evp_to_pubkey(session, method,
                                     pubkeydata, pubkeydata_len, pk);
         break;
 #endif /* LIBSSH2_DSA */
 #if LIBSSH2_ECDSA
     case EVP_PKEY_EC:
-        rc = ossl_ecdsa_evp_to_pubkey(session, method, method_len,
+        rc = ossl_ecdsa_evp_to_pubkey(session, method,
                                       pubkeydata, pubkeydata_len, 0, pk);
         break;
 #endif /* LIBSSH2_ECDSA */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2645,7 +2645,7 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     if(is_sk)
         method_buf_len = sizeof("sk-ecdsa-sha2-nistp256@openssh.com") - 1;
     else
-        method_buf_len = sizeof("ecdsa-sha2-nistp999") - 1;
+        method_buf_len = sizeof("ecdsa-sha2-nistp256") - 1;
 
     method_buf = SSH2_ALLOC(session, method_buf_len + 1);
     if(!method_buf)
@@ -2714,7 +2714,7 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session,
     else
         ssh2_store_str(&p,
            (const char *)method_buf + sizeof("ecdsa-sha2-") - 1,
-           sizeof("nistp999") - 1);
+           sizeof("nistp256") - 1);
 
     /* Public key */
     ssh2_store_str(&p, (const char *)octal_value, octal_len);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2074,7 +2074,7 @@ static int load_rsa_private_file(LIBSSH2_SESSION *session,
 }
 
 static int os400_pub_privkey_file(LIBSSH2_SESSION *session,
-                                  char **method, size_t *method_len,
+                                  char **method,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
                                   const char *privatekey,
@@ -2084,17 +2084,16 @@ static int os400_pub_privkey_file(LIBSSH2_SESSION *session,
     int ret;
 
     *method = NULL;
-    *method_len = 0;
     *pubkeydata = NULL;
     *pubkeydata_len = 0;
 
     ret = load_rsa_private_file(session, privatekey, passphrase,
                                 rsapkcs1pubkey, rsapkcs8pubkey, (void *)&p);
     if(!ret) {
-        *method_len = strlen(p.method);
-        *method = SSH2_ALLOC(session, *method_len + 1);
+        size_t method_len = strlen(p.method);
+        *method = SSH2_ALLOC(session, method_len + 1);
         if(*method)
-            memcpy(*method, p.method, *method_len + 1);
+            memcpy(*method, p.method, method_len + 1);
         else
             ret = -1;
     }
@@ -2102,7 +2101,6 @@ static int os400_pub_privkey_file(LIBSSH2_SESSION *session,
     if(ret) {
         if(*method)
             SSH2_SAFEFREE(session, *method);
-        *method_len = 0;
         if(p.data)
             SSH2_FREE(session, (void *)p.data);
     }
@@ -2115,7 +2113,7 @@ static int os400_pub_privkey_file(LIBSSH2_SESSION *session,
 }
 
 static int os400_pub_privkey_blob(LIBSSH2_SESSION *session,
-                                  char **method, size_t *method_len,
+                                  char **method,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
                                   const char *privkeyblob,
@@ -2128,7 +2126,6 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session,
     int ret;
 
     *method = NULL;
-    *method_len = 0;
     *pubkeydata = NULL;
     *pubkeydata_len = 0;
 
@@ -2183,17 +2180,16 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session,
         SSH2_FREE(session, data);
 
     if(!ret) {
-        *method_len = strlen(p.method);
-        *method = SSH2_ALLOC(session, *method_len + 1);
+        size_t method_len = strlen(p.method);
+        *method = SSH2_ALLOC(session, method_len + 1);
         if(*method)
-            memcpy(*method, p.method, *method_len + 1);
+            memcpy(*method, p.method, method_len + 1);
         else
             ret = -1;
     }
     if(ret) {
         if(*method)
             SSH2_SAFEFREE(session, *method);
-        *method_len = 0;
         if(p.data)
             SSH2_FREE(session, (void *)p.data);
     }
@@ -2207,19 +2203,19 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session,
 
 /* TODO: merge the two callees into one. */
 int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method, size_t *method_len,
+                     char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,
                      const char *passphrase)
 {
     if(privatekey)
-        return os400_pub_privkey_file(session, method, method_len,
+        return os400_pub_privkey_file(session, method,
                                       pubkeydata, pubkeydata_len,
                                       privatekey,
                                       passphrase);
     else
-        return os400_pub_privkey_blob(session, method, method_len,
+        return os400_pub_privkey_blob(session, method,
                                       pubkeydata, pubkeydata_len,
                                       privkeyblob,  privkeyblob_len,
                                       passphrase);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2073,8 +2073,7 @@ static int load_rsa_private_file(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int os400_pub_privkey_file(LIBSSH2_SESSION *session,
-                                  char **method,
+static int os400_pub_privkey_file(LIBSSH2_SESSION *session, char **method,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
                                   const char *privatekey,
@@ -2112,8 +2111,7 @@ static int os400_pub_privkey_file(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int os400_pub_privkey_blob(LIBSSH2_SESSION *session,
-                                  char **method,
+static int os400_pub_privkey_blob(LIBSSH2_SESSION *session, char **method,
                                   unsigned char **pubkeydata,
                                   size_t *pubkeydata_len,
                                   const char *privkeyblob,
@@ -2202,8 +2200,7 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session,
 }
 
 /* TODO: merge the two callees into one. */
-int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method,
+int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -689,7 +689,7 @@ static int userauth_read_pubkey(
 static int userauth_read_privkey(
     LIBSSH2_SESSION *session,
     const struct hostkey_method **hostkey_method, void **hostkey_abstract,
-    const char *method, size_t method_len,
+    const char *method,
     const char *privkeyfile,
     const char *privkeyblob, size_t privkeyblob_len,
     const char *passphrase)
@@ -709,7 +709,7 @@ static int userauth_read_privkey(
 
     while(*hostkey_methods_avail && (*hostkey_methods_avail)->name) {
         if((*hostkey_methods_avail)->initPEM &&
-           !strncmp((*hostkey_methods_avail)->name, method, method_len)) {
+           !strcmp((*hostkey_methods_avail)->name, method)) {
             *hostkey_method = *hostkey_methods_avail;
             break;
         }
@@ -750,7 +750,6 @@ static int userauth_sign(LIBSSH2_SESSION *session,
 
     rc = userauth_read_privkey(session, &privkeyobj, &hostkey_abstract,
                                session->userauth_pblc_method,
-                               session->userauth_pblc_method_len,
                                pk_info->filename,
                                pk_info->data, pk_info->data_len,
                                pk_info->passphrase);
@@ -903,6 +902,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         unsigned char *sig = NULL;
         size_t pubkeydata_len = 0;
         size_t sig_len = 0;
+        size_t host_method_len;
         void *abstract;
         unsigned char buf[5];
         struct iovec datavec[4];
@@ -925,8 +925,10 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         if(rc)
             return rc; /* low-level functions called ssh2_err() */
 
+        host_method_len = strlen(session->userauth_host_method);
+
         if(username_len > MAX_INPUT_LEN ||
-           session->userauth_host_method_len > MAX_INPUT_LEN ||
+           host_method_len > MAX_INPUT_LEN ||
            hostname_len > MAX_INPUT_LEN ||
            local_username_len > MAX_INPUT_LEN ||
            pubkeydata_len > MAX_INPUT_LEN) {
@@ -943,7 +945,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
          * hostname_len(4) + local_username_len(4)
          */
         session->userauth_host_packet_len =
-            username_len + session->userauth_host_method_len + hostname_len +
+            username_len + host_method_len + hostname_len +
             local_username_len + pubkeydata_len + 52;
 
         /*
@@ -952,10 +954,9 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
          * the publickeydata itself
          */
         session->userauth_host_s = session->userauth_host_packet =
-            SSH2_ALLOC(session,
-                       4 + session->userauth_host_packet_len +
-                       4 + session->userauth_host_method_len +
-                       4 + pubkeydata_len);
+            SSH2_ALLOC(session, 4 + session->userauth_host_packet_len +
+                                4 + host_method_len +
+                                4 + pubkeydata_len);
         if(!session->userauth_host_packet) {
             SSH2_SAFEFREE(session, session->userauth_host_method);
             SSH2_FREE(session, pubkeydata);
@@ -967,8 +968,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         ssh2_store_str(&session->userauth_host_s, "ssh-connection", 14);
         ssh2_store_str(&session->userauth_host_s, "hostbased", 9);
         ssh2_store_str(&session->userauth_host_s,
-                       session->userauth_host_method,
-                       session->userauth_host_method_len);
+                       session->userauth_host_method, host_method_len);
         ssh2_store_str(&session->userauth_host_s, (const char *)pubkeydata,
                        pubkeydata_len);
         SSH2_FREE(session, pubkeydata);
@@ -978,7 +978,6 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
 
         rc = userauth_read_privkey(session, &privkeyobj, &abstract,
                                    session->userauth_host_method,
-                                   session->userauth_host_method_len,
                                    privatekey, NULL, 0, passphrase);
         if(rc) {
             /* userauth_read_privkey() calls ssh2_err() */
@@ -1013,7 +1012,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
             /* Should *NEVER* happen, but...well.. better safe than sorry */
             newpacket = SSH2_REALLOC(session, session->userauth_host_packet,
                                      4 + session->userauth_host_packet_len +
-                                     4 + session->userauth_host_method_len +
+                                     4 + host_method_len +
                                      4 + sig_len); /* PK sigblob */
             if(!newpacket) {
                 SSH2_FREE(session, sig);
@@ -1030,11 +1029,10 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
             session->userauth_host_packet + session->userauth_host_packet_len;
 
         ssh2_store_u32(&session->userauth_host_s,
-                       (uint32_t)(4 + session->userauth_host_method_len + 4 +
-                                  sig_len));
+                       (uint32_t)(4 + host_method_len +
+                                  4 + sig_len));
         ssh2_store_str(&session->userauth_host_s,
-                       session->userauth_host_method,
-                       session->userauth_host_method_len);
+                       session->userauth_host_method, host_method_len);
         SSH2_SAFEFREE(session, session->userauth_host_method);
 
         ssh2_store_str(&session->userauth_host_s, (const char *)sig, sig_len);
@@ -1131,45 +1129,34 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
     return rc;
 }
 
-size_t ssh2_userauth_plain_method(char *method, size_t method_len)
+void ssh2_userauth_plain_method(char *method)
 {
-    if(!strncmp("ssh-rsa-cert-v01@openssh.com",
-                method, method_len))
-        return 7;
+    if(!strcmp("ssh-rsa-cert-v01@openssh.com", method))
+        return;
 
-    if(!strncmp("rsa-sha2-256-cert-v01@openssh.com",
-                method, method_len) ||
-       !strncmp("rsa-sha2-512-cert-v01@openssh.com",
-                method, method_len))
-        return 12;
+    if(!strcmp("rsa-sha2-256-cert-v01@openssh.com", method) ||
+       !strcmp("rsa-sha2-512-cert-v01@openssh.com", method))
+        return;
 
-    if(!strncmp("ecdsa-sha2-nistp256-cert-v01@openssh.com",
-                method, method_len) ||
-       !strncmp("ecdsa-sha2-nistp384-cert-v01@openssh.com",
-                method, method_len) ||
-       !strncmp("ecdsa-sha2-nistp521-cert-v01@openssh.com",
-                method, method_len))
-        return 19;
+    if(!strcmp("ecdsa-sha2-nistp256-cert-v01@openssh.com", method) ||
+       !strcmp("ecdsa-sha2-nistp384-cert-v01@openssh.com", method) ||
+       !strcmp("ecdsa-sha2-nistp521-cert-v01@openssh.com", method))
+        return;
 
-    if(!strncmp("ssh-ed25519-cert-v01@openssh.com",
-                method, method_len))
-        return 11;
+    if(!strcmp("ssh-ed25519-cert-v01@openssh.com", method))
+        return;
 
-    if(!strncmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com",
-                method, method_len)) {
+    if(!strcmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com", method)) {
         const char new_method[] = "sk-ecdsa-sha2-nistp256@openssh.com";
         memcpy(method, new_method, sizeof(new_method));
-        return sizeof(new_method) - 1;
+        return;
     }
 
-    if(!strncmp("sk-ssh-ed25519-cert-v01@openssh.com",
-                method, method_len)) {
+    if(!strcmp("sk-ssh-ed25519-cert-v01@openssh.com", method)) {
         const char new_method[] = "sk-ssh-ed25519@openssh.com";
         memcpy(method, new_method, sizeof(new_method));
-        return sizeof(new_method) - 1;
+        return;
     }
-
-    return method_len;
 }
 
 /* Function to check if the given version is less than pattern (OpenSSH 7.8)
@@ -1215,17 +1202,14 @@ static int userauth_is_version_less_than_78(const char *version)
  * there is no upgrade option return NULL
  */
 static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
-                                                    const char *method,
-                                                    size_t method_len)
+                                                    const char *method)
 {
     (void)session;
 
 #if LIBSSH2_RSA_SHA2
-    if((method_len == 7 &&
-        !memcmp(method, "ssh-rsa", method_len))
+    if((!strcmp(method, "ssh-rsa"))
 #if defined(LIBSSH2_OPENSSL) || defined(LIBSSH2_WOLFSSL)
-       || (method_len == 28 &&
-           !memcmp(method, "ssh-rsa-cert-v01@openssh.com", method_len))
+       || !strcmp(method, "ssh-rsa-cert-v01@openssh.com")
 #endif
       ) {
         return "rsa-sha2-512,rsa-sha2-256"
@@ -1236,7 +1220,6 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
     }
 #else
     (void)method;
-    (void)method_len;
 #endif
 
     return NULL;
@@ -1249,11 +1232,9 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
  * server support algos and crypto backend support
  * @related userauth_supported_key_sign_algs()
  * @param method current key method, usually the default key sig method
- * @param method_len length of the key method buffer
  * @result error code or zero on success
  */
-static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
-                                  char **method, size_t *method_len)
+static int userauth_key_sign_algs(LIBSSH2_SESSION *session, char **method)
 {
     const char *s = NULL;
     const char *a = NULL;
@@ -1269,13 +1250,11 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
     const char * const suffix = "-cert-v01@openssh.com";
     const size_t suffix_len = sizeof("-cert-v01@openssh.com") - 1;
     const char * const rsa_method = "ssh-rsa-cert-v01@openssh.com";
-    const size_t rsa_method_len = sizeof("ssh-rsa-cert-v01@openssh.com") - 1;
     const char *remote_banner = NULL;
     const char * const remote_ver_pre = "OpenSSH_";
 
     const char *supported_algs = userauth_supported_key_sign_algs(session,
-                                                                  *method,
-                                                                  *method_len);
+                                                                  *method);
 
     if(!supported_algs || !session->server_sign_algorithms)
         /* no upgrading key algorithm supported, do nothing */
@@ -1292,8 +1271,7 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
         if(remote_ver_start) {
             const char *remote_ver = remote_ver_start + strlen(remote_ver_pre);
             int SSH_BUG_SIGTYPE = userauth_is_version_less_than_78(remote_ver);
-            if(SSH_BUG_SIGTYPE && *method && *method_len == rsa_method_len &&
-               !memcmp(*method, rsa_method, rsa_method_len))
+            if(SSH_BUG_SIGTYPE && *method && !strcmp(*method, rsa_method))
                 return LIBSSH2_ERROR_NONE;
         }
     }
@@ -1367,14 +1345,12 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
     }
 
     if(match) {
-        if(*method && *method_len == rsa_method_len &&
-           !memcmp(*method, rsa_method, rsa_method_len)) {
+        if(*method && !strcmp(*method, rsa_method)) {
             SSH2_FREE(session, *method);
             *method = SSH2_ALLOC(session, match_len + suffix_len + 1);
             if(*method) {
                 memcpy(*method, match, match_len);
                 memcpy(*method + match_len, suffix, suffix_len + 1);
-                *method_len = match_len + suffix_len;
             }
         }
         else {
@@ -1384,14 +1360,11 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session,
             if(*method) {
                 memcpy(*method, match, match_len);
                 (*method)[match_len] = '\0';
-                *method_len = match_len;
             }
         }
-        if(!*method) {
-            *method_len = 0;
+        if(!*method)
             rc = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                           "Unable to allocate key method upgrade");
-        }
     }
     else /* no match was found */
         rc = ssh2_err(session, LIBSSH2_ERROR_METHOD_NONE,
@@ -1423,6 +1396,7 @@ retry_auth:
     auth_attempts++;
 
     if(session->userauth_pblc_state == ssh2_NB_state_idle) {
+        size_t method_len;
 
         /*
          * The call to ssh2_ntohu32() later relies on pubkeydata having at
@@ -1452,7 +1426,7 @@ retry_auth:
          * For other uses, we allocate and populate it here.
          */
         if(!session->userauth_pblc_method) {
-            size_t method_len = ssh2_ntohu32(pubkeydata);
+            method_len = ssh2_ntohu32(pubkeydata);
 
             if(method_len == 0 ||
                method_len > MAX_INPUT_LEN ||
@@ -1462,14 +1436,12 @@ retry_auth:
                 return ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                                 "Invalid public key");
 
-            session->userauth_pblc_method_len = 0;
             session->userauth_pblc_method = SSH2_ALLOC(session,
                                                        method_len + 1);
             if(!session->userauth_pblc_method)
                 return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                 "Unable to allocate memory "
                                 "for public key data");
-            session->userauth_pblc_method_len = method_len;
             memcpy(session->userauth_pblc_method, pubkeydata + 4, method_len);
             session->userauth_pblc_method[method_len] = '\0';
         }
@@ -1479,25 +1451,23 @@ retry_auth:
          * the key default algo */
         if(auth_attempts == 1) {
             rc = userauth_key_sign_algs(session,
-                                        &session->userauth_pblc_method,
-                                        &session->userauth_pblc_method_len);
+                                        &session->userauth_pblc_method);
             if(rc)
                 return rc;
         }
 
-        if(session->userauth_pblc_method_len &&
-           session->userauth_pblc_method)
-            ssh2_deb((session, LIBSSH2_TRACE_KEX, "Signing using %.*s",
-                      (int)session->userauth_pblc_method_len,
+        if(session->userauth_pblc_method && *session->userauth_pblc_method)
+            ssh2_deb((session, LIBSSH2_TRACE_KEX, "Signing using %s",
                       session->userauth_pblc_method));
+
+        method_len = strlen(session->userauth_pblc_method);
 
         /* 45 = packet_type(1) + username_len(4) + servicename_len(4) +
            service_name(14)"ssh-connection" + authmethod_len(4) +
            authmethod(9)"publickey" + sig_included(1)'\0' + algmethod_len(4) +
            publickey_len(4) */
-        session->userauth_pblc_packet_len =
-            username_len + session->userauth_pblc_method_len + pubkeydata_len +
-            45;
+        session->userauth_pblc_packet_len = username_len + method_len +
+            pubkeydata_len + 45;
 
         /*
          * Preallocate space for an overall length, method name again, and the
@@ -1511,7 +1481,7 @@ retry_auth:
         session->userauth_pblc_packet = s =
             SSH2_ALLOC(session,
                        4 + session->userauth_pblc_packet_len +
-                       4 + session->userauth_pblc_method_len +
+                       4 + method_len +
                        4 + pubkeydata_len);
         if(!session->userauth_pblc_packet) {
             SSH2_SAFEFREE(session, session->userauth_pblc_method);
@@ -1527,8 +1497,7 @@ retry_auth:
         /* Not sending signature with *this* packet */
         *s++ = 0;
 
-        ssh2_store_str(&s, session->userauth_pblc_method,
-                           session->userauth_pblc_method_len);
+        ssh2_store_str(&s, session->userauth_pblc_method, method_len);
         ssh2_store_str(&s, (const char *)pubkeydata, pubkeydata_len);
 
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1651,14 +1620,14 @@ retry_auth:
          * which causes an unnecessary but harmless realloc here.
          */
         if(sig_len > pubkeydata_len) {
-            unsigned char *newpacket;
+            unsigned char *newpckt;
             /* Should *NEVER* happen, but...well.. better safe than sorry */
-            newpacket = SSH2_REALLOC(session,
-                                     session->userauth_pblc_packet,
-                                     4 + session->userauth_pblc_packet_len +
-                                     4 + session->userauth_pblc_method_len +
-                                     4 + sig_len); /* PK sigblob */
-            if(!newpacket) {
+            newpckt = SSH2_REALLOC(session,
+                                   session->userauth_pblc_packet,
+                                   4 + session->userauth_pblc_packet_len +
+                                   4 + strlen(session->userauth_pblc_method) +
+                                   4 + sig_len); /* PK sigblob */
+            if(!newpckt) {
                 SSH2_FREE(session, sig);
                 SSH2_SAFEFREE(session, session->userauth_pblc_packet);
                 SSH2_SAFEFREE(session, session->userauth_pblc_method);
@@ -1667,36 +1636,32 @@ retry_auth:
                                 "Failed allocating additional space for "
                                 "userauth-publickey packet");
             }
-            session->userauth_pblc_packet = newpacket;
+            session->userauth_pblc_packet = newpckt;
         }
 
         s = session->userauth_pblc_packet + session->userauth_pblc_packet_len;
         session->userauth_pblc_b = NULL;
 
-        session->userauth_pblc_method_len =
-            ssh2_userauth_plain_method(session->userauth_pblc_method,
-                                       session->userauth_pblc_method_len);
+        ssh2_userauth_plain_method(session->userauth_pblc_method);
 
-        if(!strncmp(session->userauth_pblc_method,
-                    "sk-ecdsa-sha2-nistp256@openssh.com",
-                    session->userauth_pblc_method_len) ||
-           !strncmp(session->userauth_pblc_method,
-                    "sk-ssh-ed25519@openssh.com",
-                    session->userauth_pblc_method_len)) {
+        if(!strcmp(session->userauth_pblc_method,
+                   "sk-ecdsa-sha2-nistp256@openssh.com") ||
+           !strcmp(session->userauth_pblc_method,
+                   "sk-ssh-ed25519@openssh.com")) {
             ssh2_store_u32(&s,
-                           (uint32_t)(4 + session->userauth_pblc_method_len +
-                                      sig_len));
+                         (uint32_t)(4 + strlen(session->userauth_pblc_method) +
+                                    sig_len));
             ssh2_store_str(&s, session->userauth_pblc_method,
-                               session->userauth_pblc_method_len);
+                               strlen(session->userauth_pblc_method));
             memcpy(s, sig, sig_len);
             s += sig_len;
         }
         else {
             ssh2_store_u32(&s,
-                           (uint32_t)(4 + session->userauth_pblc_method_len +
-                                      4 + sig_len));
+                         (uint32_t)(4 + strlen(session->userauth_pblc_method) +
+                                    4 + sig_len));
             ssh2_store_str(&s, session->userauth_pblc_method,
-                               session->userauth_pblc_method_len);
+                               strlen(session->userauth_pblc_method));
             ssh2_store_str(&s, (const char *)sig, sig_len);
         }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1136,6 +1136,9 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
 
 void ssh2_userauth_plain_method(char *method)
 {
+    static const char method_sk_ec[] = "sk-ecdsa-sha2-nistp256@openssh.com";
+    static const char method_sk_ed[] = "sk-ssh-ed25519@openssh.com";
+
     if(!strcmp("ssh-rsa-cert-v01@openssh.com", method))
         method[sizeof("ssh-rsa") - 1] = '\0';
     else if(!strcmp("rsa-sha2-256-cert-v01@openssh.com", method) ||
@@ -1147,14 +1150,10 @@ void ssh2_userauth_plain_method(char *method)
         method[sizeof("ecdsa-sha2-nistp256") - 1] = '\0';
     else if(!strcmp("ssh-ed25519-cert-v01@openssh.com", method))
         method[sizeof("ssh-ed25519") - 1] = '\0';
-    else if(!strcmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com", method)) {
-        const char new_method[] = "sk-ecdsa-sha2-nistp256@openssh.com";
-        memcpy(method, new_method, sizeof(new_method));
-    }
-    else if(!strcmp("sk-ssh-ed25519-cert-v01@openssh.com", method)) {
-        const char new_method[] = "sk-ssh-ed25519@openssh.com";
-        memcpy(method, new_method, sizeof(new_method));
-    }
+    else if(!strcmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com", method))
+        memcpy(method, method_sk_ec, sizeof(method_sk_ec));
+    else if(!strcmp("sk-ssh-ed25519-cert-v01@openssh.com", method))
+        memcpy(method, method_sk_ed, sizeof(method_sk_ed));
 }
 
 /* Function to check if the given version is less than pattern (OpenSSH 7.8)

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1131,20 +1131,28 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
 
 void ssh2_userauth_plain_method(char *method)
 {
-    if(!strcmp("ssh-rsa-cert-v01@openssh.com", method))
+    if(!strcmp("ssh-rsa-cert-v01@openssh.com", method)) {
+        method[sizeof("ssh-rsa") - 1] = '\0';
         return;
+    }
 
     if(!strcmp("rsa-sha2-256-cert-v01@openssh.com", method) ||
-       !strcmp("rsa-sha2-512-cert-v01@openssh.com", method))
+       !strcmp("rsa-sha2-512-cert-v01@openssh.com", method)) {
+        method[sizeof("rsa-sha2-999") - 1] = '\0';
         return;
+    }
 
     if(!strcmp("ecdsa-sha2-nistp256-cert-v01@openssh.com", method) ||
        !strcmp("ecdsa-sha2-nistp384-cert-v01@openssh.com", method) ||
-       !strcmp("ecdsa-sha2-nistp521-cert-v01@openssh.com", method))
+       !strcmp("ecdsa-sha2-nistp521-cert-v01@openssh.com", method)) {
+        method[sizeof("ecdsa-sha2-nistp999") - 1] = '\0';
         return;
+    }
 
-    if(!strcmp("ssh-ed25519-cert-v01@openssh.com", method))
+    if(!strcmp("ssh-ed25519-cert-v01@openssh.com", method)) {
+        method[sizeof("ssh-ed25519") - 1] = '\0';
         return;
+    }
 
     if(!strcmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com", method)) {
         const char new_method[] = "sk-ecdsa-sha2-nistp256@openssh.com";

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -574,7 +574,7 @@ int libssh2_userauth_password_ex(
  */
 static int userauth_read_pubkey(
     LIBSSH2_SESSION *session,
-    char **method, size_t *method_len,
+    char **method,
     unsigned char **pubkeydata, size_t *pubkeydata_len,
     const char *pubkeyfile,
     const char *pubkeyblob, size_t pubkeyblob_len)
@@ -675,8 +675,7 @@ static int userauth_read_pubkey(
        to be freed soon anyway, we avoid the extra free/alloc and call
        it a wash */
     *method = (char *)pubkey;
-    *method_len = sp1 - pubkey - 1;
-    (*method)[*method_len] = '\0';
+    (*method)[sp1 - pubkey - 1] = '\0';
 
     *pubkeydata = tmp;
     *pubkeydata_len = tmp_len;
@@ -915,13 +914,11 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         if(publickey)
             rc = userauth_read_pubkey(session,
                                       &session->userauth_host_method,
-                                      &session->userauth_host_method_len,
                                       &pubkeydata, &pubkeydata_len,
                                       publickey, NULL, 0);
         else /* Compute public key from private key. */
             rc = ssh2_pub_privkey(session,
                                   &session->userauth_host_method,
-                                  &session->userauth_host_method_len,
                                   &pubkeydata, &pubkeydata_len,
                                   privatekey, NULL, 0, passphrase);
 
@@ -1791,14 +1788,12 @@ static int userauth_publickey(LIBSSH2_SESSION *session,
         if(pubkeyfile || (pubkeyblob && pubkeyblob_len))
             rc = userauth_read_pubkey(session,
                                       &session->userauth_pblc_method,
-                                      &session->userauth_pblc_method_len,
                                       &pubkeydata, &pubkeydata_len,
                                       pubkeyfile, pubkeyblob, pubkeyblob_len);
         /* Compute public key from private key. */
         else if(privkeyfile || (privkeyblob && privkeyblob_len))
             rc = ssh2_pub_privkey(session,
                                   &session->userauth_pblc_method,
-                                  &session->userauth_pblc_method_len,
                                   &pubkeydata, &pubkeydata_len,
                                   privkeyfile, privkeyblob, privkeyblob_len,
                                   passphrase);
@@ -2175,7 +2170,6 @@ int libssh2_userauth_publickey_sk(
     int rc = LIBSSH2_ERROR_NONE;
 
     char *tmp_method = NULL;
-    size_t tmp_method_len = 0;
 
     unsigned char *tmp_publickeydata = NULL;
     size_t tmp_publickeydata_len = 0;
@@ -2196,7 +2190,6 @@ int libssh2_userauth_publickey_sk(
 
         if(ssh2_sk_pubkey(session,
                           &tmp_method,
-                          &tmp_method_len,
                           &tmp_publickeydata,
                           &tmp_publickeydata_len,
                           &sk_info.algorithm,
@@ -2210,7 +2203,6 @@ int libssh2_userauth_publickey_sk(
                             "Unable to extract public key from private key.");
         else if(publickeydata_len == 0 || !publickeydata) {
             session->userauth_pblc_method = tmp_method;
-            session->userauth_pblc_method_len = tmp_method_len;
 
             pubkeydata_len = tmp_publickeydata_len;
             pubkeydata = tmp_publickeydata;
@@ -2221,7 +2213,6 @@ int libssh2_userauth_publickey_sk(
 
             rc = userauth_read_pubkey(session,
                                       &session->userauth_pblc_method,
-                                      &session->userauth_pblc_method_len,
                                       &pubkeydata, &pubkeydata_len,
                                       NULL,
                                       (const char *)publickeydata,

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1450,6 +1450,12 @@ retry_auth:
                                 "for public key data");
             memcpy(session->userauth_pblc_method, pubkeydata + 4, method_len);
             session->userauth_pblc_method[method_len] = '\0';
+
+            if(method_len != strlen(session->userauth_pblc_method)) {
+                SSH2_SAFEFREE(session, session->userauth_pblc_method);
+                return ssh2_err(session, LIBSSH2_ERROR_INVAL,
+                                "Public key method contains null byte");
+            }
         }
 
         /* upgrade key signing algo if it is supported and

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1136,39 +1136,24 @@ int libssh2_userauth_hostbased_fromfile_ex(LIBSSH2_SESSION *session,
 
 void ssh2_userauth_plain_method(char *method)
 {
-    if(!strcmp("ssh-rsa-cert-v01@openssh.com", method)) {
+    if(!strcmp("ssh-rsa-cert-v01@openssh.com", method))
         method[sizeof("ssh-rsa") - 1] = '\0';
-        return;
-    }
-
-    if(!strcmp("rsa-sha2-256-cert-v01@openssh.com", method) ||
-       !strcmp("rsa-sha2-512-cert-v01@openssh.com", method)) {
+    else if(!strcmp("rsa-sha2-256-cert-v01@openssh.com", method) ||
+            !strcmp("rsa-sha2-512-cert-v01@openssh.com", method))
         method[sizeof("rsa-sha2-256") - 1] = '\0';
-        return;
-    }
-
-    if(!strcmp("ecdsa-sha2-nistp256-cert-v01@openssh.com", method) ||
-       !strcmp("ecdsa-sha2-nistp384-cert-v01@openssh.com", method) ||
-       !strcmp("ecdsa-sha2-nistp521-cert-v01@openssh.com", method)) {
+    else if(!strcmp("ecdsa-sha2-nistp256-cert-v01@openssh.com", method) ||
+            !strcmp("ecdsa-sha2-nistp384-cert-v01@openssh.com", method) ||
+            !strcmp("ecdsa-sha2-nistp521-cert-v01@openssh.com", method))
         method[sizeof("ecdsa-sha2-nistp256") - 1] = '\0';
-        return;
-    }
-
-    if(!strcmp("ssh-ed25519-cert-v01@openssh.com", method)) {
+    else if(!strcmp("ssh-ed25519-cert-v01@openssh.com", method))
         method[sizeof("ssh-ed25519") - 1] = '\0';
-        return;
-    }
-
-    if(!strcmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com", method)) {
+    else if(!strcmp("sk-ecdsa-sha2-nistp256-cert-v01@openssh.com", method)) {
         const char new_method[] = "sk-ecdsa-sha2-nistp256@openssh.com";
         memcpy(method, new_method, sizeof(new_method));
-        return;
     }
-
-    if(!strcmp("sk-ssh-ed25519-cert-v01@openssh.com", method)) {
+    else if(!strcmp("sk-ssh-ed25519-cert-v01@openssh.com", method)) {
         const char new_method[] = "sk-ssh-ed25519@openssh.com";
         memcpy(method, new_method, sizeof(new_method));
-        return;
     }
 }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -639,7 +639,7 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
     /*
      * Remove trailing whitespace
      */
-    while(pubkey_len && isspace(pubkey[pubkey_len - 1]))
+    while(pubkey_len && isspace((unsigned char)pubkey[pubkey_len - 1]))
         pubkey_len--;
 
     if(!pubkey_len) {

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1456,11 +1456,13 @@ retry_auth:
                 return rc;
         }
 
-        if(session->userauth_pblc_method && *session->userauth_pblc_method)
+        if(session->userauth_pblc_method && *session->userauth_pblc_method) {
             ssh2_deb((session, LIBSSH2_TRACE_KEX, "Signing using %s",
                       session->userauth_pblc_method));
-
-        method_len = strlen(session->userauth_pblc_method);
+            method_len = strlen(session->userauth_pblc_method);
+        }
+        else
+            method_len = 0;
 
         /* 45 = packet_type(1) + username_len(4) + servicename_len(4) +
            service_name(14)"ssh-connection" + authmethod_len(4) +

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -579,7 +579,7 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
                                 const char *pubkeyblob, size_t pubkeyblob_len)
 {
     unsigned char *pubkey = NULL, *sp1, *sp2, *tmp;
-    size_t pubkey_len;
+    size_t pubkey_len, method_len;
     size_t sp_len, tmp_len;
 
     if(pubkeyfile) {
@@ -670,11 +670,18 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
                         "Invalid key data, not base64 encoded");
     }
 
+    method_len = sp1 - pubkey - 1;
+    if(method_len != strlen(pubkey)) {
+        SSH2_FREE(session, pubkey);
+        return ssh2_err(session, LIBSSH2_ERROR_FILE,
+                        "Invalid key data, method contains null byte");
+    }
+
     /* Wasting some bytes here (okay, more than some), but since it is likely
        to be freed soon anyway, we avoid the extra free/alloc and call
        it a wash */
     *method = (char *)pubkey;
-    (*method)[sp1 - pubkey - 1] = '\0';
+    (*method)[method_len] = '\0';
 
     *pubkeydata = tmp;
     *pubkeydata_len = tmp_len;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -671,7 +671,7 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
     }
 
     method_len = sp1 - pubkey - 1;
-    if(method_len != strlen(pubkey)) {
+    if(method_len != strlen((const char *)pubkey)) {
         SSH2_FREE(session, pubkey);
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Invalid key data, method contains null byte");

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -578,7 +578,7 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
                                 const char *pubkeyfile,
                                 const char *pubkeyblob, size_t pubkeyblob_len)
 {
-    unsigned char *pubkey = NULL, *sp1, *sp2, *tmp;
+    char *pubkey = NULL, *sp1, *sp2, *tmp;
     size_t pubkey_len, method_len;
     size_t sp_len, tmp_len;
 
@@ -663,15 +663,14 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
         /* Assume that the id string is missing, but that it is okay */
         sp2 = pubkey + pubkey_len;
 
-    if(ssh2_base64_decode(session, (char **)&tmp, &tmp_len, (const char *)sp1,
-                          sp2 - sp1)) {
+    if(ssh2_base64_decode(session, &tmp, &tmp_len, sp1, sp2 - sp1)) {
         SSH2_FREE(session, pubkey);
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Invalid key data, not base64 encoded");
     }
 
     method_len = sp1 - pubkey - 1;
-    if(method_len != strlen((const char *)pubkey)) {
+    if(method_len != strlen(pubkey)) {
         SSH2_FREE(session, pubkey);
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Invalid key data, method contains null byte");
@@ -680,10 +679,10 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
     /* Wasting some bytes here (okay, more than some), but since it is likely
        to be freed soon anyway, we avoid the extra free/alloc and call
        it a wash */
-    *method = (char *)pubkey;
+    *method = pubkey;
     (*method)[method_len] = '\0';
 
-    *pubkeydata = tmp;
+    *pubkeydata = (unsigned char *)tmp;
     *pubkeydata_len = tmp_len;
 
     return 0;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -679,6 +679,7 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
     if(method_len != strlen(*method)) {
         *method = NULL;
         SSH2_FREE(session, pubkey);
+        SSH2_FREE(session, tmp);
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Invalid key data, method contains null byte");
     }

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -669,18 +669,18 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
                         "Invalid key data, not base64 encoded");
     }
 
+    /* Wasting some bytes here (okay, more than some), but since it is likely
+       to be freed soon anyway, we avoid the extra free/alloc and call
+       it a wash */
+    *method = pubkey;
     method_len = sp1 - pubkey - 1;
+    (*method)[method_len] = '\0';
+
     if(method_len != strlen(pubkey)) {
         SSH2_FREE(session, pubkey);
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Invalid key data, method contains null byte");
     }
-
-    /* Wasting some bytes here (okay, more than some), but since it is likely
-       to be freed soon anyway, we avoid the extra free/alloc and call
-       it a wash */
-    *method = pubkey;
-    (*method)[method_len] = '\0';
 
     *pubkeydata = (unsigned char *)tmp;
     *pubkeydata_len = tmp_len;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1398,13 +1398,12 @@ int ssh2_userauth_publickey(
     int rc;
     unsigned char *s;
     int auth_attempts = 0;
+    size_t method_len;
 
 retry_auth:
     auth_attempts++;
 
     if(session->userauth_pblc_state == ssh2_NB_state_idle) {
-        size_t method_len;
-
         /*
          * The call to ssh2_ntohu32() later relies on pubkeydata having at
          * least 4 valid bytes containing the length of the method name.
@@ -1653,24 +1652,22 @@ retry_auth:
 
         ssh2_userauth_plain_method(session->userauth_pblc_method);
 
+        method_len = strlen(session->userauth_pblc_method);
+
         if(!strcmp(session->userauth_pblc_method,
                    "sk-ecdsa-sha2-nistp256@openssh.com") ||
            !strcmp(session->userauth_pblc_method,
                    "sk-ssh-ed25519@openssh.com")) {
-            ssh2_store_u32(&s,
-                         (uint32_t)(4 + strlen(session->userauth_pblc_method) +
-                                    sig_len));  /* FIXME: '4 +' missing? */
-            ssh2_store_str(&s, session->userauth_pblc_method,
-                               strlen(session->userauth_pblc_method));
+            ssh2_store_u32(&s, (uint32_t)(4 + method_len +
+                                          sig_len));
+            ssh2_store_str(&s, session->userauth_pblc_method, method_len);
             memcpy(s, sig, sig_len);
             s += sig_len;
         }
         else {
-            ssh2_store_u32(&s,
-                         (uint32_t)(4 + strlen(session->userauth_pblc_method) +
-                                    4 + sig_len));
-            ssh2_store_str(&s, session->userauth_pblc_method,
-                               strlen(session->userauth_pblc_method));
+            ssh2_store_u32(&s, (uint32_t)(4 + method_len +
+                                          4 + sig_len));
+            ssh2_store_str(&s, session->userauth_pblc_method, method_len);
             ssh2_store_str(&s, (const char *)sig, sig_len);
         }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -676,7 +676,8 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
     method_len = sp1 - pubkey - 1;
     (*method)[method_len] = '\0';
 
-    if(method_len != strlen(pubkey)) {
+    if(method_len != strlen(*method)) {
+        *method = NULL;
         SSH2_FREE(session, pubkey);
         return ssh2_err(session, LIBSSH2_ERROR_FILE,
                         "Invalid key data, method contains null byte");

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1650,7 +1650,7 @@ retry_auth:
                    "sk-ssh-ed25519@openssh.com")) {
             ssh2_store_u32(&s,
                          (uint32_t)(4 + strlen(session->userauth_pblc_method) +
-                                    sig_len));
+                                    sig_len));  /* FIXME: '4 +' missing? */
             ssh2_store_str(&s, session->userauth_pblc_method,
                                strlen(session->userauth_pblc_method));
             memcpy(s, sig, sig_len);

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1138,14 +1138,14 @@ void ssh2_userauth_plain_method(char *method)
 
     if(!strcmp("rsa-sha2-256-cert-v01@openssh.com", method) ||
        !strcmp("rsa-sha2-512-cert-v01@openssh.com", method)) {
-        method[sizeof("rsa-sha2-999") - 1] = '\0';
+        method[sizeof("rsa-sha2-256") - 1] = '\0';
         return;
     }
 
     if(!strcmp("ecdsa-sha2-nistp256-cert-v01@openssh.com", method) ||
        !strcmp("ecdsa-sha2-nistp384-cert-v01@openssh.com", method) ||
        !strcmp("ecdsa-sha2-nistp521-cert-v01@openssh.com", method)) {
-        method[sizeof("ecdsa-sha2-nistp999") - 1] = '\0';
+        method[sizeof("ecdsa-sha2-nistp256") - 1] = '\0';
         return;
     }
 

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1197,7 +1197,6 @@ static int userauth_is_version_less_than_78(const char *version)
  * @discussion Based on the incoming 'method' value, this function
  * returns supported algorithms that can upgrade the key method
  * @param method current key method, usually the default key sig method
- * @param method_len length of the key method buffer
  * @result comma separated list of supported upgrade options per RFC 8332, if
  * there is no upgrade option return NULL
  */

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -572,12 +572,11 @@ int libssh2_userauth_password_ex(
  * Returns an allocated string containing the key method (e.g. "ssh-dss")
  * in method on success.
  */
-static int userauth_read_pubkey(
-    LIBSSH2_SESSION *session,
-    char **method,
-    unsigned char **pubkeydata, size_t *pubkeydata_len,
-    const char *pubkeyfile,
-    const char *pubkeyblob, size_t pubkeyblob_len)
+static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
+                                unsigned char **pubkeydata,
+                                size_t *pubkeydata_len,
+                                const char *pubkeyfile,
+                                const char *pubkeyblob, size_t pubkeyblob_len)
 {
     unsigned char *pubkey = NULL, *sp1, *sp2, *tmp;
     size_t pubkey_len;
@@ -912,13 +911,11 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                sizeof(session->userauth_host_packet_requirev_state));
 
         if(publickey)
-            rc = userauth_read_pubkey(session,
-                                      &session->userauth_host_method,
+            rc = userauth_read_pubkey(session, &session->userauth_host_method,
                                       &pubkeydata, &pubkeydata_len,
                                       publickey, NULL, 0);
         else /* Compute public key from private key. */
-            rc = ssh2_pub_privkey(session,
-                                  &session->userauth_host_method,
+            rc = ssh2_pub_privkey(session, &session->userauth_host_method,
                                   &pubkeydata, &pubkeydata_len,
                                   privatekey, NULL, 0, passphrase);
 
@@ -1763,14 +1760,12 @@ static int userauth_publickey(LIBSSH2_SESSION *session,
 
     if(session->userauth_pblc_state == ssh2_NB_state_idle) {
         if(pubkeyfile || (pubkeyblob && pubkeyblob_len))
-            rc = userauth_read_pubkey(session,
-                                      &session->userauth_pblc_method,
+            rc = userauth_read_pubkey(session, &session->userauth_pblc_method,
                                       &pubkeydata, &pubkeydata_len,
                                       pubkeyfile, pubkeyblob, pubkeyblob_len);
         /* Compute public key from private key. */
         else if(privkeyfile || (privkeyblob && privkeyblob_len))
-            rc = ssh2_pub_privkey(session,
-                                  &session->userauth_pblc_method,
+            rc = ssh2_pub_privkey(session, &session->userauth_pblc_method,
                                   &pubkeydata, &pubkeydata_len,
                                   privkeyfile, privkeyblob, privkeyblob_len,
                                   passphrase);
@@ -2188,8 +2183,7 @@ int libssh2_userauth_publickey_sk(
             if(tmp_method)
                 SSH2_FREE(session, tmp_method);
 
-            rc = userauth_read_pubkey(session,
-                                      &session->userauth_pblc_method,
+            rc = userauth_read_pubkey(session, &session->userauth_pblc_method,
                                       &pubkeydata, &pubkeydata_len,
                                       NULL,
                                       (const char *)publickeydata,

--- a/src/userauth.h
+++ b/src/userauth.h
@@ -41,6 +41,6 @@ int ssh2_userauth_publickey(
     void *abstract);
 
 /* Utility function for certificate auth */
-size_t ssh2_userauth_plain_method(char *method, size_t method_len);
+void ssh2_userauth_plain_method(char *method);
 
 #endif /* LIBSSH2_USERAUTH_H */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2642,7 +2642,6 @@ static DWORD wcng_pub_priv_write(unsigned char *key, DWORD offset,
 
 static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
                                        char **method,
-                                       size_t *method_len,
                                        unsigned char **pubkeydata,
                                        size_t *pubkeydata_len,
                                        unsigned char *pbEncoded,
@@ -2652,7 +2651,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
     DWORD *rcbDecoded = NULL;
     char *method_buf = NULL;
     unsigned char *key = NULL;
-    DWORD keylen = 0, method_buf_len = 0;
+    DWORD keylen = 0;
     DWORD index, offs, length = 0;
     int ret;
 
@@ -2665,34 +2664,34 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
     ret = -1;
 
     if(length == 9) { /* private RSA key */
-        method_buf_len = sizeof("ssh-rsa") - 1;
-        method_buf = SSH2_ALLOC(session, method_buf_len + 1);
+        static const char method_name[] = "ssh-rsa";
+        method_buf = SSH2_ALLOC(session, sizeof(method_name));
         if(!method_buf)
             goto cleanup;
-        memcpy(method_buf, "ssh-rsa", method_buf_len + 1);
+        memcpy(method_buf, method_name, sizeof(method_name));
 
         if(rcbDecoded[2] > (32 * 1024) ||
            rcbDecoded[1] > (32 * 1024))
             goto cleanup;
 
-        keylen = 4 + method_buf_len +
+        keylen = 4 + sizeof(method_name) - 1 +
                  4 + rcbDecoded[2] +
                  4 + rcbDecoded[1];
         key = SSH2_ALLOC(session, keylen);
         if(!key)
             goto cleanup;
 
-        offs = wcng_pub_priv_write(key, 0, method_buf, method_buf_len);
+        offs = wcng_pub_priv_write(key, 0, method_buf, sizeof(method_name) - 1);
         offs = wcng_pub_priv_write(key, offs, rpbDecoded[2], rcbDecoded[2]);
         wcng_pub_priv_write(key, offs, rpbDecoded[1], rcbDecoded[1]);
         ret = 0; /* success */
     }
     else if(length == 6) { /* private DSA key */
-        method_buf_len = sizeof("ssh-dss") - 1;
-        method_buf = SSH2_ALLOC(session, method_buf_len + 1);
+        static const char method_name[] = "ssh-dss";
+        method_buf = SSH2_ALLOC(session, sizeof(method_name));
         if(!method_buf)
             goto cleanup;
-        memcpy(method_buf, "ssh-dss", method_buf_len + 1);
+        memcpy(method_buf, method_name, sizeof(method_name));
 
         if(rcbDecoded[1] > (32 * 1024) ||
            rcbDecoded[2] > (32 * 1024) ||
@@ -2700,7 +2699,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
            rcbDecoded[4] > (32 * 1024))
             goto cleanup;
 
-        keylen = 4 + method_buf_len +
+        keylen = 4 + sizeof(method_name) - 1 +
                  4 + rcbDecoded[1] +
                  4 + rcbDecoded[2] +
                  4 + rcbDecoded[3] +
@@ -2709,7 +2708,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         if(!key)
             goto cleanup;
 
-        offs = wcng_pub_priv_write(key, 0, method_buf, method_buf_len);
+        offs = wcng_pub_priv_write(key, 0, method_buf, sizeof(method_name) - 1);
         offs = wcng_pub_priv_write(key, offs, rpbDecoded[1], rcbDecoded[1]);
         offs = wcng_pub_priv_write(key, offs, rpbDecoded[2], rcbDecoded[2]);
         offs = wcng_pub_priv_write(key, offs, rpbDecoded[3], rcbDecoded[3]);
@@ -2736,7 +2735,6 @@ cleanup:
     }
     else {
         *method = method_buf;
-        *method_len = method_buf_len;
         *pubkeydata = key;
         *pubkeydata_len = keylen;
     }
@@ -2745,7 +2743,7 @@ cleanup:
 }
 
 int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method, size_t *method_len,
+                     char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,
@@ -2759,7 +2757,7 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session,
                       &pbEncoded, &cbEncoded, 1, 1))
         return -1;
 
-    return wcng_pub_privkey_file_parse(session, method, method_len,
+    return wcng_pub_privkey_file_parse(session, method,
                                        pubkeydata, pubkeydata_len,
                                        pbEncoded, cbEncoded);
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2640,8 +2640,7 @@ static DWORD wcng_pub_priv_write(unsigned char *key, DWORD offset,
     return offset;
 }
 
-static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
-                                       char **method,
+static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session, char **method,
                                        unsigned char **pubkeydata,
                                        size_t *pubkeydata_len,
                                        unsigned char *pbEncoded,
@@ -2742,8 +2741,7 @@ cleanup:
     return ret;
 }
 
-int ssh2_pub_privkey(LIBSSH2_SESSION *session,
-                     char **method,
+int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
                      const char *privatekey,
                      const char *privkeyblob, size_t privkeyblob_len,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2674,7 +2674,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
            rcbDecoded[1] > (32 * 1024))
             goto cleanup;
 
-        keylen = 4 + sizeof(method_name) - 1 +
+        keylen = 4 + (DWORD)sizeof(method_name) - 1 +
                  4 + rcbDecoded[2] +
                  4 + rcbDecoded[1];
         key = SSH2_ALLOC(session, keylen);
@@ -2699,7 +2699,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
            rcbDecoded[4] > (32 * 1024))
             goto cleanup;
 
-        keylen = 4 + sizeof(method_name) - 1 +
+        keylen = 4 + (DWORD)sizeof(method_name) - 1 +
                  4 + rcbDecoded[1] +
                  4 + rcbDecoded[2] +
                  4 + rcbDecoded[3] +

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2652,7 +2652,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
     char *method_buf = NULL;
     unsigned char *key = NULL;
     DWORD keylen = 0;
-    DWORD index, offs, length = 0;
+    DWORD index, off, length = 0;
     int ret;
 
     ret = wcng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
@@ -2681,9 +2681,9 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         if(!key)
             goto cleanup;
 
-        offs = wcng_pub_priv_write(key, 0, method_buf, sizeof(method_name) - 1);
-        offs = wcng_pub_priv_write(key, offs, rpbDecoded[2], rcbDecoded[2]);
-        wcng_pub_priv_write(key, offs, rpbDecoded[1], rcbDecoded[1]);
+        off = wcng_pub_priv_write(key, 0, method_buf, sizeof(method_name) - 1);
+        off = wcng_pub_priv_write(key, off, rpbDecoded[2], rcbDecoded[2]);
+        wcng_pub_priv_write(key, off, rpbDecoded[1], rcbDecoded[1]);
         ret = 0; /* success */
     }
     else if(length == 6) { /* private DSA key */
@@ -2708,11 +2708,11 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session,
         if(!key)
             goto cleanup;
 
-        offs = wcng_pub_priv_write(key, 0, method_buf, sizeof(method_name) - 1);
-        offs = wcng_pub_priv_write(key, offs, rpbDecoded[1], rcbDecoded[1]);
-        offs = wcng_pub_priv_write(key, offs, rpbDecoded[2], rcbDecoded[2]);
-        offs = wcng_pub_priv_write(key, offs, rpbDecoded[3], rcbDecoded[3]);
-        wcng_pub_priv_write(key, offs, rpbDecoded[4], rcbDecoded[4]);
+        off = wcng_pub_priv_write(key, 0, method_buf, sizeof(method_name) - 1);
+        off = wcng_pub_priv_write(key, off, rpbDecoded[1], rcbDecoded[1]);
+        off = wcng_pub_priv_write(key, off, rpbDecoded[2], rcbDecoded[2]);
+        off = wcng_pub_priv_write(key, off, rpbDecoded[3], rcbDecoded[3]);
+        wcng_pub_priv_write(key, off, rpbDecoded[4], rcbDecoded[4]);
         ret = 0; /* success */
     }
 


### PR DESCRIPTION
`method` is now null-terminated in internal structures and APIs.

Also:
- replace `strncmp()` and `memcmp()` with `strcmp()` where applicable.
- agent, userauth: verify if method names originating from the outside
  does not contain a null byte before using them. Report an error
  otherwise.
- userauth: simplify casts in `userauth_read_pubkey()`.

Bug: https://github.com/libssh2/libssh2/pull/2369#discussion_r3620847307
Follow-up to 84485961335066565344107bdb8b578b1d4e3787 #2381
