### PR TITLE
publickey: honor key type length in traces

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -569,8 +569,8 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
     if(pkey->add_state == ssh2_NB_state_idle) {
         pkey->add_packet = NULL;
 
-        ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY, "Adding %s publickey",
-                  name));
+        ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY,
+                  "Adding %.*s publickey", (int)name_len, name));
 
         if(pkey->version == 1) {
             for(i = 0; i < num_attrs; i++) {
@@ -666,8 +666,8 @@ int libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey,
 
         ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY,
                   "Sending publickey 'add' packet: "
-                  "type=%s blob_len=%lu num_attrs=%lu",
-                  name, blob_len, num_attrs));
+                  "type=%.*s blob_len=%lu num_attrs=%lu",
+                  (int)name_len, name, blob_len, num_attrs));
 
         pkey->add_state = ssh2_NB_state_created;
     }
@@ -756,7 +756,7 @@ int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
 
         ssh2_deb((session, LIBSSH2_TRACE_PUBLICKEY,
                   "Sending publickey 'remove' packet: "
-                  "type=%s blob_len=%lu", name, blob_len));
+                  "type=%.*s blob_len=%lu", (int)name_len, name, blob_len));
 
         pkey->remove_state = ssh2_NB_state_created;
     }


### PR DESCRIPTION
The publickey add/remove APIs accept a key type with an explicit `name_len`, but their trace messages formatted it as a null-terminated string. A caller using an exact-length buffer could therefore expose adjacent bytes in debug output.

Use the already validated length as the printf precision in all three publickey trace messages. The regression test places a sentinel suffix after the declared key type and verifies that the suffix never reaches the trace handler.

Verified with:
- debug static OpenSSL build under UBSan
- release static/shared OpenSSL build
- `test_simple` in both configurations
- `scripts/checksrc-all.pl`