### PR TITLE
pem: merge file/blob codepaths

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -255,15 +255,12 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
         fp = ssh2_fopen(filename, "rb");
         if(!fp)
             return -1;
-        ret = ssh2_pem_parse_FILE(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                                  fp, passphrase,
-                                  &data, &datalen);
-        fclose(fp);
     }
-    else
-        ret = ssh2_pem_parse_blob(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                                  blob, blob_len, passphrase,
-                                  &data, &datalen);
+    ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
+                         fp, blob, blob_len, passphrase,
+                         &data, &datalen);
+    if(fp)
+        fclose(fp);
     if(ret)
         return -1;
 
@@ -361,16 +358,12 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
         fp = ssh2_fopen(filename, "rb");
         if(!fp)
             return -1;
-
-        ret = ssh2_pem_parse_FILE(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                                  fp, passphrase,
-                                  &data, &datalen);
-        fclose(fp);
     }
-    else
-        ret = ssh2_pem_parse_blob(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                                  blob, blob_len, passphrase,
-                                  &data, &datalen);
+    ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
+                         fp, blob, blob_len, passphrase,
+                         &data, &datalen);
+    if(fp)
+        fclose(fp);
     if(ret)
         return -1;
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -244,23 +244,15 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
                       const char *blob, size_t blob_len,
                       const char *passphrase)
 {
-    FILE *fp;
     unsigned char *data, *save_data;
     size_t datalen;
     int ret;
     unsigned char *n, *e, *d, *p, *q, *e1, *e2, *coeff;
     unsigned int nlen, elen, dlen, plen, qlen, e1len, e2len, coefflen;
 
-    if(filename) {
-        fp = ssh2_fopen(filename, "rb");
-        if(!fp)
-            return -1;
-    }
     ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                         fp, blob, blob_len, passphrase,
+                         filename, blob, blob_len, passphrase,
                          &data, &datalen);
-    if(fp)
-        fclose(fp);
     if(ret)
         return -1;
 
@@ -347,23 +339,15 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
                       const char *blob, size_t blob_len,
                       const char *passphrase)
 {
-    FILE *fp = NULL;
     unsigned char *data, *save_data;
     size_t datalen;
     int ret;
     unsigned char *p, *q, *g, *y, *x;
     unsigned int plen, qlen, glen, ylen, xlen;
 
-    if(filename) {
-        fp = ssh2_fopen(filename, "rb");
-        if(!fp)
-            return -1;
-    }
     ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                         fp, blob, blob_len, passphrase,
+                         filename, blob, blob_len, passphrase,
                          &data, &datalen);
-    if(fp)
-        fclose(fp);
     if(ret)
         return -1;
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -252,7 +252,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 
     ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
                          filename, blob, blob_len, passphrase,
-                         &data, &datalen);
+                         &data, &datalen, NULL);
     if(ret)
         return -1;
 
@@ -347,7 +347,7 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
 
     ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
                          filename, blob, blob_len, passphrase,
-                         &data, &datalen);
+                         &data, &datalen, NULL);
     if(ret)
         return -1;
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -347,7 +347,7 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
                       const char *blob, size_t blob_len,
                       const char *passphrase)
 {
-    FILE *fp;
+    FILE *fp = NULL;
     unsigned char *data, *save_data;
     size_t datalen;
     int ret;

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1232,7 +1232,8 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *filename,
                    const char *blob, size_t blob_len,
                    const char *passphrase,
-                   unsigned char **data, size_t *datalen);
+                   unsigned char **data, size_t *datalen,
+                   size_t *blob_offset);
 /* OpenSSL keys */
 int ssh2_openssh_pem_parse_FILE(LIBSSH2_SESSION *session,
                                 FILE *fp,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1222,8 +1222,6 @@ int ssh2_bcrypt_pbkdf(const char *pass,
                       unsigned int rounds);
 
 /* pem.c */
-int ssh2_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
-                      char **blob, size_t *blob_len);
 int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
                       char **blob, size_t *blob_len);
 int ssh2_pem_parse(LIBSSH2_SESSION *session,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1224,6 +1224,8 @@ int ssh2_bcrypt_pbkdf(const char *pass,
 /* pem.c */
 int ssh2_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
                       char **blob, size_t *blob_len);
+int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
+                      char **blob, size_t *blob_len);
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1222,18 +1222,13 @@ int ssh2_bcrypt_pbkdf(const char *pass,
                       unsigned int rounds);
 
 /* pem.c */
-int ssh2_pem_parse_FILE(LIBSSH2_SESSION *session,
-                        const char *headerbegin,
-                        const char *headerend,
-                        FILE *fp,
-                        const char *passphrase,
-                        unsigned char **data, size_t *datalen);
-int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
-                        const char *headerbegin,
-                        const char *headerend,
-                        const char *blob, size_t blob_len,
-                        const char *passphrase,
-                        unsigned char **data, size_t *datalen);
+int ssh2_pem_parse(LIBSSH2_SESSION *session,
+                   const char *headerbegin,
+                   const char *headerend,
+                   FILE *fp,
+                   const char *blob, size_t blob_len,
+                   const char *passphrase,
+                   unsigned char **data, size_t *datalen);
 /* OpenSSL keys */
 int ssh2_openssh_pem_parse_FILE(LIBSSH2_SESSION *session,
                                 FILE *fp,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1233,14 +1233,11 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    unsigned char **data, size_t *datalen,
                    size_t *blob_offset);
 /* OpenSSL keys */
-int ssh2_openssh_pem_parse_FILE(LIBSSH2_SESSION *session,
-                                FILE *fp,
-                                const char *passphrase,
-                                struct string_buf **decrypted_buf);
-int ssh2_openssh_pem_parse_blob(LIBSSH2_SESSION *session,
-                                const char *blob, size_t blob_len,
-                                const char *passphrase,
-                                struct string_buf **decrypted_buf);
+int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
+                           const char *filename,
+                           const char *blob, size_t blob_len,
+                           const char *passphrase,
+                           struct string_buf **decrypted_buf);
 
 int ssh2_pem_decode_sequence(unsigned char **data, size_t *datalen);
 int ssh2_pem_decode_integer(unsigned char **data, size_t *datalen,

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1229,7 +1229,7 @@ int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
-                   FILE *fp,
+                   const char *filename,
                    const char *blob, size_t blob_len,
                    const char *passphrase,
                    unsigned char **data, size_t *datalen);

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1222,6 +1222,8 @@ int ssh2_bcrypt_pbkdf(const char *pass,
                       unsigned int rounds);
 
 /* pem.c */
+int ssh2_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
+                      char **blob, size_t *blob_len);
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1026,8 +1026,8 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
     size_t curvelen, exponentlen, pointlen;
     unsigned char *curve, *exponent, *point_buf;
 
-    if(ssh2_openssh_pem_parse_blob(session, data, data_len,
-                                   passphrase, &decrypted))
+    if(ssh2_openssh_pem_parse(session, NULL, data, data_len,
+                              passphrase, &decrypted))
         goto failed;
 
     if(ssh2_get_string(decrypted, &name, NULL))

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1118,9 +1118,6 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
 
 cleanup:
 
-    if(fp)
-        fclose(fp);
-
     if(data_nullterm) {
         ssh2_explicit_zero(data_nullterm, data_len + 1);
         SSH2_FREE(session, data_nullterm);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1093,52 +1093,38 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
                         const char *passphrase)
 {
     mbedtls_pk_context pkey;
-    char *data = NULL;
+    char *data_nullterm = NULL;
     size_t data_len = 0;
-    FILE *fp = NULL;
 
     mbedtls_pk_init(&pkey);
 
     if(filename) {
-        long file_size;
-        fp = ssh2_fopen(filename, "rb");
-        if(!fp)
-            goto cleanup;
-        if(fseek(fp, 0, SEEK_END))
-            goto cleanup;
-        file_size = ftell(fp);
-        if(file_size < 0 || file_size > (1024 * 1024))
-            goto cleanup;
-        if(fseek(fp, 0, SEEK_SET))
-            goto cleanup;
-        data_len = (size_t)file_size;
-        if(data_len == 0)
-            goto cleanup;
-        data = mbedtls_calloc(1, data_len + 1);
-        if(!data)
-            goto cleanup;
-        if(fread(data, 1, data_len, fp) != data_len)
+        if(ssh2_file_to_blob(session, filename, &data_nullterm, &data_len))
             goto cleanup;
     }
     else {
         data_len = blob_len;
-        data = mbedtls_calloc(1, data_len + 1);
-        if(!data)
+        data_nullterm = SSH2_ALLOC(session, data_len + 1);
+        if(!data_nullterm)
             goto cleanup;
-        memcpy(data, blob, blob_len);
+        memcpy(data_nullterm, blob, blob_len);
+        data_nullterm[blob_len] = '\0';  /* for mbedtls_pk_parse_key() */
     }
 
-    data[data_len] = '\0';  /* for mbedtls_pk_parse_key() */
-    if(mbed_parse_eckey(ec_ctx, &pkey, data, data_len + 1, passphrase) == 0)
+    if(mbed_parse_eckey(ec_ctx, &pkey, data_nullterm, data_len + 1, passphrase) == 0)
         goto cleanup;
 
-    mbed_parse_openssh_key(ec_ctx, session, data, data_len, passphrase);
+    mbed_parse_openssh_key(ec_ctx, session, data_nullterm, data_len, passphrase);
 
 cleanup:
 
     if(fp)
         fclose(fp);
-    mbed_zero_free(data, data_len + 1);
+
+    if(data_nullterm) {
+        ssh2_explicit_zero(data_nullterm, data_len + 1);
+        SSH2_FREE(session, data_nullterm);
+    }
 
     mbedtls_pk_free(&pkey);
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1111,10 +1111,12 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
         data_nullterm[blob_len] = '\0';  /* for mbedtls_pk_parse_key() */
     }
 
-    if(mbed_parse_eckey(ec_ctx, &pkey, data_nullterm, data_len + 1, passphrase) == 0)
+    if(mbed_parse_eckey(ec_ctx, &pkey, data_nullterm, data_len + 1,
+                        passphrase) == 0)
         goto cleanup;
 
-    mbed_parse_openssh_key(ec_ctx, session, data_nullterm, data_len, passphrase);
+    mbed_parse_openssh_key(ec_ctx, session, data_nullterm, data_len,
+                           passphrase);
 
 cleanup:
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3531,10 +3531,8 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session, char **method,
 
     rc = ssh2_openssh_pem_parse(session, privatekey, NULL, 0, passphrase,
                                 &decrypted);
-    if(rc) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE, "Not an OpenSSH key file");
+    if(rc)
         return rc;
-    }
 
     /* We have a new key file, now try and parse it using supported types */
     rc = ssh2_get_string(decrypted, &buf, NULL);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3837,19 +3837,12 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
 
     if(!pk) {
         /* Try OpenSSH format */
-        if(privatekey)
-            rc = ossl_key_from_openssh_file(session, NULL, NULL,
-                                            method,
-                                            pubkeydata, pubkeydata_len,
-                                            privatekey,
-                                            passphrase);
-        else
-            rc = ossl_key_from_openssh_blob(session, NULL, NULL,
-                                            method,
-                                            pubkeydata, pubkeydata_len,
-                                            privkeyblob, privkeyblob_len,
-                                            passphrase);
-        if(rc == 0)
+        if(!ossl_key_from_openssh(session, NULL, NULL,
+                                  method,
+                                  pubkeydata, pubkeydata_len,
+                                  privatekey,
+                                  privkeyblob, privkeyblob_len,
+                                  passphrase))
             return 0;
 
 #ifdef HAVE_SSLERROR_BAD_DECRYPT

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1314,7 +1314,6 @@ static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
                                      const char *filename,
                                      const char *passphrase)
 {
-    FILE *fp;
     int rc;
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
@@ -1324,15 +1323,8 @@ static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
 
     OSSL_INIT_IF_NEEDED();
 
-    fp = ssh2_fopen(filename, "r");
-    if(!fp) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Unable to open OpenSSH RSA private key file");
-        return -1;
-    }
-
-    rc = ssh2_openssh_pem_parse_FILE(session, fp, passphrase, &decrypted);
-    fclose(fp);
+    rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
+                                &decrypted);
     if(rc)
         return rc;
 
@@ -1600,7 +1592,6 @@ static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
                                      const char *filename,
                                      const char *passphrase)
 {
-    FILE *fp;
     int rc;
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
@@ -1610,15 +1601,8 @@ static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
 
     OSSL_INIT_IF_NEEDED();
 
-    fp = ssh2_fopen(filename, "r");
-    if(!fp) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Unable to open OpenSSH DSA private key file");
-        return -1;
-    }
-
-    rc = ssh2_openssh_pem_parse_FILE(session, fp, passphrase, &decrypted);
-    fclose(fp);
+    rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
+                                &decrypted);
     if(rc)
         return rc;
 
@@ -2087,19 +2071,11 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
 
     if(filename) {
         int rc;
-        FILE *fp;
         unsigned char *buf;
         struct string_buf *decrypted = NULL;
 
-        fp = ssh2_fopen(filename, "r");
-        if(!fp) {
-            ssh2_err(session, LIBSSH2_ERROR_FILE,
-                     "Unable to open ED25519 private key file");
-            return -1;
-        }
-
-        rc = ssh2_openssh_pem_parse_FILE(session, fp, passphrase, &decrypted);
-        fclose(fp);
+        rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
+                                    &decrypted);
         if(rc)
             return rc;
 
@@ -3017,7 +2993,6 @@ static int ossl_ecdsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
                                        const char *filename,
                                        const char *passphrase)
 {
-    FILE *fp;
     int rc;
     unsigned char *buf = NULL;
     struct string_buf *decrypted = NULL;
@@ -3028,15 +3003,8 @@ static int ossl_ecdsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
 
     OSSL_INIT_IF_NEEDED();
 
-    fp = ssh2_fopen(filename, "r");
-    if(!fp) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Unable to open OpenSSH ECDSA private key file");
-        return -1;
-    }
-
-    rc = ssh2_openssh_pem_parse_FILE(session, fp, passphrase, &decrypted);
-    fclose(fp);
+    rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
+                                &decrypted);
     if(rc)
         return rc;
 
@@ -3555,22 +3523,14 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session, char **method,
 #if LIBSSH2_ECDSA
     ssh2_curve_type type;
 #endif
-    FILE *fp;
 
     if(!session)
         return -1;
 
     OSSL_INIT_IF_NEEDED();
 
-    fp = ssh2_fopen(privatekey, "r");
-    if(!fp) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Unable to open private key file");
-        return -1;
-    }
-
-    rc = ssh2_openssh_pem_parse_FILE(session, fp, passphrase, &decrypted);
-    fclose(fp);
+    rc = ssh2_openssh_pem_parse(session, privatekey, NULL, 0, passphrase,
+                                &decrypted);
     if(rc) {
         ssh2_err(session, LIBSSH2_ERROR_FILE, "Not an OpenSSH key file");
         return rc;
@@ -3660,9 +3620,8 @@ static int ossl_key_from_openssh_blob(LIBSSH2_SESSION *session,
 
     OSSL_INIT_IF_NEEDED();
 
-    rc = ssh2_openssh_pem_parse_blob(session, privkeyblob, privkeyblob_len,
-                                     passphrase,
-                                     &decrypted);
+    rc = ssh2_openssh_pem_parse(session, NULL, privkeyblob, privkeyblob_len,
+                                passphrase, &decrypted);
     if(rc)
         return rc;
 
@@ -3762,18 +3721,9 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
 
     OSSL_INIT_IF_NEEDED();
 
-    if(privatekey) {
-        FILE *fp = ssh2_fopen(privatekey, "rb");
-        if(!fp)
-            return ssh2_err(session, LIBSSH2_ERROR_FILE,
-                            "Opening the private key failed");
-        rc = ssh2_openssh_pem_parse_FILE(session, fp, passphrase, &decrypted);
-        fclose(fp);
-    }
-    else
-        rc = ssh2_openssh_pem_parse_blob(session, privkeyblob, privkeyblob_len,
-                                         passphrase,
-                                         &decrypted);
+    rc = ssh2_openssh_pem_parse(session,
+                                privatekey, privkeyblob, privkeyblob_len,
+                                passphrase, &decrypted);
     if(rc)
         return rc;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3511,7 +3511,10 @@ clean_exit:
 
 #endif /* LIBSSH2_ED25519 */
 
-static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session, char **method,
+static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
+                                      void **key_ctx,
+                                      const char *want_method,
+                                      char **method,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
                                       const char *privatekey,
@@ -3523,6 +3526,8 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session, char **method,
 #if LIBSSH2_ECDSA
     ssh2_curve_type type;
 #endif
+    (void)key_ctx;
+    (void)want_method;
 
     if(!session)
         return -1;
@@ -3833,7 +3838,7 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
     if(!pk) {
         /* Try OpenSSH format */
         if(privatekey)
-            rc = ossl_key_from_openssh_file(session,
+            rc = ossl_key_from_openssh_file(session, NULL, NULL,
                                             method,
                                             pubkeydata, pubkeydata_len,
                                             privatekey,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3837,12 +3837,19 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
 
     if(!pk) {
         /* Try OpenSSH format */
-        if(!ossl_key_from_openssh(session, NULL, NULL,
-                                  method,
-                                  pubkeydata, pubkeydata_len,
-                                  privatekey,
-                                  privkeyblob, privkeyblob_len,
-                                  passphrase))
+        if(privatekey)
+            rc = ossl_key_from_openssh_file(session, NULL, NULL,
+                                            method,
+                                            pubkeydata, pubkeydata_len,
+                                            privatekey,
+                                            passphrase);
+        else
+            rc = ossl_key_from_openssh_blob(session, NULL, NULL,
+                                            method,
+                                            pubkeydata, pubkeydata_len,
+                                            privkeyblob, privkeyblob_len,
+                                            passphrase);
+        if(rc == 0)
             return 0;
 
 #ifdef HAVE_SSLERROR_BAD_DECRYPT

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1975,9 +1975,10 @@ static int rsapkcs1pubkey(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
-                        const char *passphrase,
+static int try_pem_load(LIBSSH2_SESSION *session,
                         const char *header, const char *trailer,
+                        const char *blob, size_t blob_len,
+                        const char *passphrase,
                         loadkeyproc proc, void *loadkeydata)
 {
     unsigned char *data = NULL;
@@ -1985,10 +1986,10 @@ static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
     int c;
     int ret;
 
-    fseek(fp, 0L, SEEK_SET);
     for(;;) {
         ret = ssh2_pem_parse(session, header, trailer,
-                             fp, NULL, 0, passphrase, &data, &datalen);
+                             NULL, blob, blob_len, passphrase,
+                             &data, &datalen);
 
         if(!ret) {
             ret = (*proc)(session, data, datalen, passphrase, loadkeydata);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1990,7 +1990,7 @@ static int try_pem_load(LIBSSH2_SESSION *session,
 
     while(blob_left > 0) {
         ret = ssh2_pem_parse(session, header, trailer,
-                             NULL, blob_pos, blob_remain,
+                             NULL, blob_pos, blob_left,
                              passphrase,
                              &data, &datalen, &blob_offset);
         if(!ret) {
@@ -2002,7 +2002,7 @@ static int try_pem_load(LIBSSH2_SESSION *session,
         }
 
         blob_pos += blob_offset;
-        blob_remain -= blob_offset;
+        blob_left -= blob_offset;
 
         if(data)
             SSH2_SAFEFREE(session, data);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1987,8 +1987,8 @@ static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
 
     fseek(fp, 0L, SEEK_SET);
     for(;;) {
-        ret = ssh2_pem_parse_FILE(session, header, trailer,
-                                  fp, passphrase, &data, &datalen);
+        ret = ssh2_pem_parse(session, header, trailer,
+                             fp, NULL, 0, passphrase, &data, &datalen);
 
         if(!ret) {
             ret = (*proc)(session, data, datalen, passphrase, loadkeydata);
@@ -2131,20 +2131,18 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session, char **method,
 
     /* Try with "ENCRYPTED PRIVATE KEY" PEM armor.
        --> PKCS#8 EncryptedPrivateKeyInfo */
-    ret = ssh2_pem_parse_blob(session,
-                              beginencprivkeyhdr, endencprivkeyhdr,
-                              privkeyblob, privkeyblob_len,
-                              passphrase,
-                              &data, &datalen);
+    ret = ssh2_pem_parse(session, beginencprivkeyhdr, endencprivkeyhdr,
+                         NULL, privkeyblob, privkeyblob_len,
+                         passphrase,
+                         &data, &datalen);
 
     /* Try with "PRIVATE KEY" PEM armor.
        --> PKCS#8 PrivateKeyInfo or EncryptedPrivateKeyInfo */
     if(ret)
-        ret = ssh2_pem_parse_blob(session,
-                                  beginprivkeyhdr, endprivkeyhdr,
-                                  privkeyblob, privkeyblob_len,
-                                  passphrase,
-                                  &data, &datalen);
+        ret = ssh2_pem_parse(session, beginprivkeyhdr, endprivkeyhdr,
+                             NULL, privkeyblob, privkeyblob_len,
+                             passphrase,
+                             &data, &datalen);
 
     if(!ret) {
         /* Process PKCS#8. */
@@ -2153,11 +2151,10 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session, char **method,
     else {
         /* Try with "RSA PRIVATE KEY" PEM armor.
            --> PKCS#1 RSAPrivateKey */
-        ret = ssh2_pem_parse_blob(session,
-                                  beginrsaprivkeyhdr, endrsaprivkeyhdr,
-                                  privkeyblob, privkeyblob_len,
-                                  passphrase,
-                                  &data, &datalen);
+        ret = ssh2_pem_parse(session, beginrsaprivkeyhdr, endrsaprivkeyhdr,
+                             NULL, privkeyblob, privkeyblob_len,
+                             passphrase,
+                             &data, &datalen);
         if(!ret)
             ret = rsapkcs1pubkey(session,
                                  data, datalen, passphrase, (void *)&p);
@@ -2256,20 +2253,18 @@ static int os400_rsa_new_priv_from_blob(ssh2_rsa_ctx **rsa,
 
     /* Try with "ENCRYPTED PRIVATE KEY" PEM armor.
        --> PKCS#8 EncryptedPrivateKeyInfo */
-    ret = ssh2_pem_parse_blob(session,
-                              beginencprivkeyhdr, endencprivkeyhdr,
-                              blob, blob_len,
-                              passphrase,
-                              &data, &datalen);
+    ret = ssh2_pem_parse(session, beginencprivkeyhdr, endencprivkeyhdr,
+                         NULL, blob, blob_len,
+                         passphrase,
+                         &data, &datalen);
 
     /* Try with "PRIVATE KEY" PEM armor.
        --> PKCS#8 PrivateKeyInfo or EncryptedPrivateKeyInfo */
     if(ret)
-        ret = ssh2_pem_parse_blob(session,
-                                  beginprivkeyhdr, endprivkeyhdr,
-                                  blob, blob_len,
-                                  passphrase,
-                                  &data, &datalen);
+        ret = ssh2_pem_parse(session, beginprivkeyhdr, endprivkeyhdr,
+                             NULL, blob, blob_len,
+                             passphrase,
+                             &data, &datalen);
 
     if(!ret) {
         /* Process PKCS#8. */
@@ -2279,11 +2274,10 @@ static int os400_rsa_new_priv_from_blob(ssh2_rsa_ctx **rsa,
     else {
         /* Try with "RSA PRIVATE KEY" PEM armor.
            --> PKCS#1 RSAPrivateKey */
-        ret = ssh2_pem_parse_blob(session,
-                                  beginrsaprivkeyhdr, endrsaprivkeyhdr,
-                                  blob, blob_len,
-                                  passphrase,
-                                  &data, &datalen);
+        ret = ssh2_pem_parse(session, beginrsaprivkeyhdr, endrsaprivkeyhdr,
+                             NULL, blob, blob_len,
+                             passphrase,
+                             &data, &datalen);
         if(!ret)
             ret = rsapkcs1privkey(session,
                                   data, datalen, passphrase, (void *)&ctx);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1997,7 +1997,10 @@ static int try_pem_load(LIBSSH2_SESSION *session,
             ret = (*proc)(session, (const unsigned char *)data, datalen,
                           passphrase, loadkeydata);
             if(!ret) {
-                SSH2_FREE(session, data);
+                if(data) {
+                    ssh2_explicit_zero(data, datalen);
+                    SSH2_FREE(session, data);
+                }
                 return 0; /* success */
             }
         }
@@ -2005,8 +2008,10 @@ static int try_pem_load(LIBSSH2_SESSION *session,
         blob_pos += blob_offset;
         blob_left -= blob_offset;
 
-        if(data)
+        if(data) {
+            ssh2_explicit_zero(data, datalen);
             SSH2_SAFEFREE(session, data);
+        }
     }
 
     return -1;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2064,7 +2064,10 @@ static int load_rsa_private_file(LIBSSH2_SESSION *session,
                            passphrase, loadkeydata);
     }
 
-    SSH2_FREE(session, blob);
+    if(blob) {
+        ssh2_explicit_zero(blob, blob_len + 1);
+        SSH2_FREE(session, blob);
+    }
 
     return ret;
 }

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1983,14 +1983,14 @@ static int try_pem_load(LIBSSH2_SESSION *session,
 {
     unsigned char *data = NULL;
     size_t datalen = 0;
-    int c;
+    size_t blob_offset = 0;
     int ret;
 
-    for(;;) {
+    while(blob_offset < blob_len) {
         ret = ssh2_pem_parse(session, header, trailer,
-                             NULL, blob, blob_len, passphrase,
-                             &data, &datalen);
-
+                             NULL, blob + blob_offset, blob_len - blob_offset,
+                             passphrase,
+                             &data, &datalen, &blob_offset);
         if(!ret) {
             ret = (*proc)(session, data, datalen, passphrase, loadkeydata);
             if(!ret) {
@@ -2001,12 +2001,6 @@ static int try_pem_load(LIBSSH2_SESSION *session,
 
         if(data)
             SSH2_SAFEFREE(session, data);
-        c = getc(fp);
-
-        if(c == EOF)
-            break;
-
-        ungetc(c, fp);
     }
 
     return -1;
@@ -2018,60 +2012,48 @@ static int load_rsa_private_file(LIBSSH2_SESSION *session,
                                  loadkeyproc proc1, loadkeyproc proc8,
                                  void *loadkeydata)
 {
-    FILE *fp = ssh2_fopen(filename, fopenrbmode);
-    unsigned char *data = NULL;
-    size_t datalen = 0;
     int ret;
-    long filesize;
+    char *blob = NULL;
+    size_t blob_len = 0;
 
-    if(!fp)
+    if(ssh2_file_to_blob(session, filename, &blob, &blob_len))
         return -1;
 
     /* Try with "ENCRYPTED PRIVATE KEY" PEM armor.
        --> PKCS#8 EncryptedPrivateKeyInfo */
-    ret = try_pem_load(session, fp, passphrase, beginencprivkeyhdr,
-                       endencprivkeyhdr, proc8, loadkeydata);
+    ret = try_pem_load(session, beginencprivkeyhdr, endencprivkeyhdr,
+                       blob, blob_len, passphrase,
+                       proc8, loadkeydata);
 
     /* Try with "PRIVATE KEY" PEM armor.
        --> PKCS#8 PrivateKeyInfo or EncryptedPrivateKeyInfo */
     if(ret)
-        ret = try_pem_load(session, fp, passphrase, beginprivkeyhdr,
-                           endprivkeyhdr, proc8, loadkeydata);
+        ret = try_pem_load(session, beginprivkeyhdr, endprivkeyhdr,
+                           blob, blob_len, passphrase,
+                           proc8, loadkeydata);
 
     /* Try with "RSA PRIVATE KEY" PEM armor.
        --> PKCS#1 RSAPrivateKey */
     if(ret)
-        ret = try_pem_load(session, fp, passphrase, beginrsaprivkeyhdr,
-                           endrsaprivkeyhdr, proc1, loadkeydata);
+        ret = try_pem_load(session, beginrsaprivkeyhdr, endrsaprivkeyhdr,
+                           blob, blob_len, passphrase,
+                           proc1, loadkeydata);
 
     /* Try DER encoding. */
     if(ret) {
-        fseek(fp, 0L, SEEK_END);
-        filesize = ftell(fp);
+        /* Try as PKCS#8 DER data.
+           --> PKCS#8 PrivateKeyInfo or EncryptedPrivateKeyInfo */
+        ret = (*proc8)(session, blob, blob_len, passphrase,
+                       loadkeydata);
 
-        if(filesize > 0 &&
-           filesize <= 32768) { /* Limit to a reasonable size. */
-            datalen = filesize;
-            data = (unsigned char *)alloca(datalen);
-            if(data) {
-                fseek(fp, 0L, SEEK_SET);
-                fread(data, datalen, 1, fp);
-
-                /* Try as PKCS#8 DER data.
-                   --> PKCS#8 PrivateKeyInfo or EncryptedPrivateKeyInfo */
-                ret = (*proc8)(session, data, datalen, passphrase,
-                               loadkeydata);
-
-                /* Try as PKCS#1 DER data.
-                   --> PKCS#1 RSAPrivateKey */
-                if(ret)
-                    ret = (*proc1)(session, data, datalen, passphrase,
-                                   loadkeydata);
-            }
-        }
+        /* Try as PKCS#1 DER data.
+           --> PKCS#1 RSAPrivateKey */
+        if(ret)
+            ret = (*proc1)(session, blob, blob_len, passphrase,
+                           loadkeydata);
     }
 
-    fclose(fp);
+    SSH2_FREE(session, blob);
 
     return ret;
 }

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2117,7 +2117,7 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session, char **method,
     ret = ssh2_pem_parse(session, beginencprivkeyhdr, endencprivkeyhdr,
                          NULL, privkeyblob, privkeyblob_len,
                          passphrase,
-                         &data, &datalen);
+                         &data, &datalen, NULL);
 
     /* Try with "PRIVATE KEY" PEM armor.
        --> PKCS#8 PrivateKeyInfo or EncryptedPrivateKeyInfo */
@@ -2125,7 +2125,7 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session, char **method,
         ret = ssh2_pem_parse(session, beginprivkeyhdr, endprivkeyhdr,
                              NULL, privkeyblob, privkeyblob_len,
                              passphrase,
-                             &data, &datalen);
+                             &data, &datalen, NULL);
 
     if(!ret) {
         /* Process PKCS#8. */
@@ -2137,7 +2137,7 @@ static int os400_pub_privkey_blob(LIBSSH2_SESSION *session, char **method,
         ret = ssh2_pem_parse(session, beginrsaprivkeyhdr, endrsaprivkeyhdr,
                              NULL, privkeyblob, privkeyblob_len,
                              passphrase,
-                             &data, &datalen);
+                             &data, &datalen, NULL);
         if(!ret)
             ret = rsapkcs1pubkey(session,
                                  data, datalen, passphrase, (void *)&p);
@@ -2239,7 +2239,7 @@ static int os400_rsa_new_priv_from_blob(ssh2_rsa_ctx **rsa,
     ret = ssh2_pem_parse(session, beginencprivkeyhdr, endencprivkeyhdr,
                          NULL, blob, blob_len,
                          passphrase,
-                         &data, &datalen);
+                         &data, &datalen, NULL);
 
     /* Try with "PRIVATE KEY" PEM armor.
        --> PKCS#8 PrivateKeyInfo or EncryptedPrivateKeyInfo */
@@ -2247,7 +2247,7 @@ static int os400_rsa_new_priv_from_blob(ssh2_rsa_ctx **rsa,
         ret = ssh2_pem_parse(session, beginprivkeyhdr, endprivkeyhdr,
                              NULL, blob, blob_len,
                              passphrase,
-                             &data, &datalen);
+                             &data, &datalen, NULL);
 
     if(!ret) {
         /* Process PKCS#8. */
@@ -2260,7 +2260,7 @@ static int os400_rsa_new_priv_from_blob(ssh2_rsa_ctx **rsa,
         ret = ssh2_pem_parse(session, beginrsaprivkeyhdr, endrsaprivkeyhdr,
                              NULL, blob, blob_len,
                              passphrase,
-                             &data, &datalen);
+                             &data, &datalen, NULL);
         if(!ret)
             ret = rsapkcs1privkey(session,
                                   data, datalen, passphrase, (void *)&ctx);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1984,11 +1984,13 @@ static int try_pem_load(LIBSSH2_SESSION *session,
     unsigned char *data = NULL;
     size_t datalen = 0;
     size_t blob_offset = 0;
+    const char *blob_pos = blob;
+    size_t blob_left = blob_len;
     int ret;
 
-    while(blob_offset < blob_len) {
+    while(blob_left > 0) {
         ret = ssh2_pem_parse(session, header, trailer,
-                             NULL, blob + blob_offset, blob_len - blob_offset,
+                             NULL, blob_pos, blob_remain,
                              passphrase,
                              &data, &datalen, &blob_offset);
         if(!ret) {
@@ -1998,6 +2000,9 @@ static int try_pem_load(LIBSSH2_SESSION *session,
                 return 0; /* success */
             }
         }
+
+        blob_pos += blob_offset;
+        blob_remain -= blob_offset;
 
         if(data)
             SSH2_SAFEFREE(session, data);

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1994,7 +1994,8 @@ static int try_pem_load(LIBSSH2_SESSION *session,
                              passphrase,
                              &data, &datalen, &blob_offset);
         if(!ret) {
-            ret = (*proc)(session, data, datalen, passphrase, loadkeydata);
+            ret = (*proc)(session, (const unsigned char *)data, datalen,
+                          passphrase, loadkeydata);
             if(!ret) {
                 SSH2_FREE(session, data);
                 return 0; /* success */
@@ -2048,14 +2049,14 @@ static int load_rsa_private_file(LIBSSH2_SESSION *session,
     if(ret) {
         /* Try as PKCS#8 DER data.
            --> PKCS#8 PrivateKeyInfo or EncryptedPrivateKeyInfo */
-        ret = (*proc8)(session, blob, blob_len, passphrase,
-                       loadkeydata);
+        ret = (*proc8)(session, (const unsigned char *)blob, blob_len,
+                       passphrase, loadkeydata);
 
         /* Try as PKCS#1 DER data.
            --> PKCS#1 RSAPrivateKey */
         if(ret)
-            ret = (*proc1)(session, blob, blob_len, passphrase,
-                           loadkeydata);
+            ret = (*proc1)(session, (const unsigned char *)blob, blob_len,
+                           passphrase, loadkeydata);
     }
 
     SSH2_FREE(session, blob);

--- a/src/pem.c
+++ b/src/pem.c
@@ -80,6 +80,9 @@ int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
     size_t filedata_len = 0;
     FILE *fp = NULL;
 
+    *blob = NULL;
+    *blob_len = 0;
+
     fp = ssh2_fopen(filename, "rb");
     if(!fp) {
         ret = ssh2_err(session, LIBSSH2_ERROR_FILE,

--- a/src/pem.c
+++ b/src/pem.c
@@ -350,9 +350,6 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
 
     ret = 0;
 
-    if(blob_offset)
-        *blob_offset = off;
-
 out:
 
     if(ret && *data) {
@@ -368,6 +365,9 @@ out:
         ssh2_explicit_zero(b64data, b64datalen);
         SSH2_FREE(session, b64data);
     }
+
+    if(blob_offset)
+        *blob_offset = off;
 
     return ret;
 }
@@ -705,22 +705,36 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
     char *b64data = NULL;
     size_t b64datalen = 0;
     size_t off = 0;
+    char *filedata = NULL;
+    size_t filedata_len = 0;
     int ret;
 
     if(!filename && (!blob || !blob_len))
         return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                         "Error parsing PEM: filename/blob missing");
 
+    if(filename) {
+        ret = ssh2_file_to_blob(session, filename, &filedata, &filedata_len);
+        if(ret)
+            goto out;
+        blob = filedata;
+        blob_len = filedata_len;
+    }
+
     do {
 
         *line = '\0';
 
-        if(off >= blob_len)
-            return ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                            "Error parsing PEM: OpenSSH header not found");
+        if(off >= blob_len) {
+            ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
+                           "Error parsing PEM: OpenSSH header not found");
+            goto out;
+        }
 
-        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
-            return -1;
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off)) {
+            ret = -1;
+            goto out;
+        }
     } while(strcmp(line, OPENSSH_PRIVKEY_HEADER));
 
     *line = '\0';
@@ -756,18 +770,25 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
         }
     } while(strcmp(line, OPENSSH_PRIVKEY_FOOTER));
 
-    if(!b64data)
-        return ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                        "Error parsing PEM: base 64 data missing");
+    if(!b64data) {
+        ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
+                       "Error parsing PEM: base 64 data missing");
+        goto out;
+    }
 
     ret = pem_parse_data_openssh(session, passphrase,
                                  b64data, b64datalen, decrypted_buf);
 
 out:
+
+    if(filedata)
+        SSH2_FREE(session, filedata);
+
     if(b64data) {
         ssh2_explicit_zero(b64data, b64datalen);
         SSH2_FREE(session, b64data);
     }
+
     return ret;
 }
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -720,74 +720,11 @@ out:
     return ret;
 }
 
-int ssh2_openssh_pem_parse_FILE(LIBSSH2_SESSION *session,
-                                FILE *fp,
-                                const char *passphrase,
-                                struct string_buf **decrypted_buf)
-{
-    char line[LINE_SIZE];
-    char *b64data = NULL;
-    size_t b64datalen = 0;
-    int ret = 0;
-
-    /* read file */
-
-    do {
-        *line = '\0';
-
-        if(pem_readline_file(line, LINE_SIZE, fp))
-            return -1;
-    } while(strcmp(line, OPENSSH_PRIVKEY_HEADER));
-
-    if(pem_readline_file(line, LINE_SIZE, fp))
-        return -1;
-
-    do {
-        if(*line) {
-            char *tmp;
-            size_t linelen;
-
-            linelen = strlen(line);
-            tmp = SSH2_REALLOC(session, b64data, b64datalen + linelen);
-            if(!tmp) {
-                ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                         "Unable to allocate memory for PEM parsing");
-                ret = -1;
-                goto out;
-            }
-            memcpy(tmp + b64datalen, line, linelen);
-            b64data = tmp;
-            b64datalen += linelen;
-        }
-
-        *line = '\0';
-
-        if(pem_readline_file(line, LINE_SIZE, fp)) {
-            ret = -1;
-            goto out;
-        }
-    } while(strcmp(line, OPENSSH_PRIVKEY_FOOTER));
-
-    if(!b64data)
-        return -1;
-
-    ret = pem_parse_data_openssh(session, passphrase,
-                                 b64data, b64datalen, decrypted_buf);
-
-    if(b64data) {
-        ssh2_explicit_zero(b64data, b64datalen);
-        SSH2_FREE(session, b64data);
-    }
-
-out:
-
-    return ret;
-}
-
-int ssh2_openssh_pem_parse_blob(LIBSSH2_SESSION *session,
-                                const char *blob, size_t blob_len,
-                                const char *passphrase,
-                                struct string_buf **decrypted_buf)
+int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
+                           const char *filename,
+                           const char *blob, size_t blob_len,
+                           const char *passphrase,
+                           struct string_buf **decrypted_buf)
 {
     char line[LINE_SIZE];
     char *b64data = NULL;
@@ -795,9 +732,9 @@ int ssh2_openssh_pem_parse_blob(LIBSSH2_SESSION *session,
     size_t off = 0;
     int ret;
 
-    if(!blob || blob_len == 0)
+    if(!filename && (!blob || !blob_len))
         return ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                        "Error parsing PEM: blob missing");
+                        "Error parsing PEM: filename/blob missing");
 
     do {
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -96,65 +96,63 @@ static unsigned char pem_hex_decode(char digit)
         ((digit >= 'A') ? (0xA + (digit - 'A')) : (digit - '0'));
 }
 
-int ssh2_pem_parse_FILE(LIBSSH2_SESSION *session,
-                        const char *headerbegin,
-                        const char *headerend,
-                        FILE *fp,
-                        const char *passphrase,
-                        unsigned char **data, size_t *datalen)
+static int pem_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
+                            unsigned char **blob, size_t **blob_len)
 {
-    int ret = -1;
+    int ret = 0;
     char *filedata = NULL;
     long file_size;
     size_t filedata_len;
 
     if(fseek(fp, 0L, SEEK_END)) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Bad seek to file end in PEM parsing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
+                       "Bad seek to file end in PEM parsing");
         goto out;
     }
     file_size = ftell(fp);
     if(file_size < 0) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Error determining size in PEM parsing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
+                       "Error determining size in PEM parsing");
         goto out;
     }
     if(file_size == 0) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Zero-length file in PEM parsing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
+                       "Zero-length file in PEM parsing");
         goto out;
     }
     if(file_size > (1024 * 1024)) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE,
-                 "Input too large in PEM parsing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
+                       "Input too large in PEM parsing");
         goto out;
     }
     if(fseek(fp, 0L, SEEK_SET)) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE, "Bad seek to 0 in PEM parsing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_FILE, "Bad seek to 0 in PEM parsing");
         goto out;
     }
 
     filedata_len = (size_t)file_size;
     filedata = SSH2_ALLOC(session, filedata_len);
     if(!filedata) {
-        ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                 "Unable to allocate memory for PEM parsing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
+                       "Unable to allocate memory for PEM parsing");
         goto out;
     }
 
     if(fread(filedata, 1, filedata_len, fp) != filedata_len) {
-        ssh2_err(session, LIBSSH2_ERROR_FILE, "Bad read in PEM parsing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_FILE, "Bad read in PEM parsing");
         goto out;
     }
 
-    ret = ssh2_pem_parse_blob(session, headerbegin, headerend,
-                              filedata, filedata_len,
-                              passphrase,
-                              data, datalen);
+finish:
 
-out:
+    *blob = filedata;
+    *blob_len = filedata_len;
+
+    return ret;
+
     if(filedata)
         SSH2_FREE(session, filedata);
+
     return ret;
 }
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -96,13 +96,18 @@ static unsigned char pem_hex_decode(char digit)
         ((digit >= 'A') ? (0xA + (digit - 'A')) : (digit - '0'));
 }
 
-int ssh2_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
+int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
                       char **blob, size_t *blob_len)
 {
     int ret = -1;
     long file_size;
     char *filedata = NULL;
     size_t filedata_len = 0;
+    FILE *fp = NULL;
+
+    fp = ssh2_fopen(filename, "rb");
+    if(!fp)
+        goto out;
 
     if(fseek(fp, 0L, SEEK_END)) {
         ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
@@ -153,23 +158,6 @@ out:
     }
     else if(filedata)
         SSH2_FREE(session, filedata);
-
-    return ret;
-}
-
-int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
-                      char **blob, size_t *blob_len)
-{
-    int ret;
-    FILE *fp = NULL;
-
-    if(filename) {
-        fp = ssh2_fopen(filename, "rb");
-        if(!fp)
-            return -1;
-    }
-
-    ret = ssh2_FILE_to_blob(session, fp, blob, blob_len);
 
     if(fp)
         fclose(fp);

--- a/src/pem.c
+++ b/src/pem.c
@@ -81,8 +81,11 @@ int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
     FILE *fp = NULL;
 
     fp = ssh2_fopen(filename, "rb");
-    if(!fp)
+    if(!fp) {
+        ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
+                       "Unable to open file for PEM parsing");
         goto out;
+    }
 
     if(fseek(fp, 0L, SEEK_END)) {
         ret = ssh2_err(session, LIBSSH2_ERROR_FILE,

--- a/src/pem.c
+++ b/src/pem.c
@@ -177,14 +177,14 @@ int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
     return ret;
 }
 
-/* TODO: replace 'fp' with 'filename', or drop */
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
                    const char *filename,
                    const char *blob, size_t blob_len,
                    const char *passphrase,
-                   unsigned char **data, size_t *datalen)
+                   unsigned char **data, size_t *datalen,
+                   size_t *blob_offset)
 {
     char line[LINE_SIZE];
     unsigned char iv[LINE_SIZE];
@@ -386,6 +386,9 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     }
 
     ret = 0;
+
+    if(blob_offset)
+        *blob_offset = off;
 
 out:
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -716,6 +716,9 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
     size_t filedata_len = 0;
     int ret;
 
+    if(decrypted_buf)
+        *decrypted_buf = NULL;
+
     if(!filename && (!blob || !blob_len))
         return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                         "Error parsing PEM: filename/blob missing");

--- a/src/pem.c
+++ b/src/pem.c
@@ -157,11 +157,31 @@ out:
     return ret;
 }
 
+int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
+                      char **blob, size_t *blob_len)
+{
+    int ret;
+    FILE *fp = NULL;
+
+    if(filename) {
+        fp = ssh2_fopen(filename, "rb");
+        if(!fp)
+            return -1;
+    }
+
+    ret = ssh2_FILE_to_blob(session, fp, blob, blob_len);
+
+    if(fp)
+        fclose(fp);
+
+    return ret;
+}
+
 /* TODO: replace 'fp' with 'filename', or drop */
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
-                   FILE *fp,
+                   const char *filename,
                    const char *blob, size_t blob_len,
                    const char *passphrase,
                    unsigned char **data, size_t *datalen)
@@ -179,8 +199,8 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     *data = NULL;
     *datalen = 0;
 
-    if(fp) {
-        ret = ssh2_FILE_to_blob(session, fp, &filedata, &filedata_len);
+    if(filename) {
+        ret = ssh2_file_to_blob(session, filename, &filedata, &filedata_len);
         if(ret)
             goto out;
         blob = filedata;

--- a/src/pem.c
+++ b/src/pem.c
@@ -172,14 +172,18 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     size_t off = 0;
     int ret = -1;
     const struct crypt_method *method = NULL;
+    char *filedata = NULL;
+    size_t filedata_len = 0;
 
     *data = NULL;
     *datalen = 0;
 
     if(fp) {
-        ret = pem_FILE_to_blob(session, fp, &blob, &blob_len);
+        ret = pem_FILE_to_blob(session, fp, &filedata, &filedata_len);
         if(ret)
             goto out;
+        blob = filedata;
+        blob_len = filedata_len;
     }
 
     do {
@@ -370,8 +374,8 @@ out:
         *datalen = 0;
     }
 
-    if(blob)
-        SSH2_FREE(session, blob)
+    if(filedata)
+        SSH2_FREE(session, filedata);
 
     if(b64data) {
         ssh2_explicit_zero(b64data, b64datalen);

--- a/src/pem.c
+++ b/src/pem.c
@@ -96,6 +96,7 @@ static unsigned char pem_hex_decode(char digit)
         ((digit >= 'A') ? (0xA + (digit - 'A')) : (digit - '0'));
 }
 
+/* TODO: make this an internal API */
 static int pem_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
                             char **blob, size_t *blob_len)
 {
@@ -157,6 +158,7 @@ out:
     return ret;
 }
 
+/* TODO: replace 'fp' with 'filename', or drop */
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,

--- a/src/pem.c
+++ b/src/pem.c
@@ -97,12 +97,12 @@ static unsigned char pem_hex_decode(char digit)
 }
 
 static int pem_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
-                            unsigned char **blob, size_t **blob_len)
+                            char **blob, size_t *blob_len)
 {
-    int ret = 0;
-    char *filedata = NULL;
+    int ret = -1;
     long file_size;
-    size_t filedata_len;
+    char *filedata = NULL;
+    size_t filedata_len = 0;
 
     if(fseek(fp, 0L, SEEK_END)) {
         ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
@@ -143,56 +143,62 @@ static int pem_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
         goto out;
     }
 
-finish:
+    ret = 0;
 
-    *blob = filedata;
-    *blob_len = filedata_len;
+out:
 
-    return ret;
-
-    if(filedata)
+    if(!ret) {
+        *blob = filedata;
+        *blob_len = filedata_len;
+    }
+    else if(filedata)
         SSH2_FREE(session, filedata);
 
     return ret;
 }
 
-int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
-                        const char *headerbegin,
-                        const char *headerend,
-                        const char *blob, size_t blob_len,
-                        const char *passphrase,
-                        unsigned char **data, size_t *datalen)
+int ssh2_pem_parse(LIBSSH2_SESSION *session,
+                   const char *headerbegin,
+                   const char *headerend,
+                   FILE *fp,
+                   const char *blob, size_t blob_len,
+                   const char *passphrase,
+                   unsigned char **data, size_t *datalen)
 {
     char line[LINE_SIZE];
     unsigned char iv[LINE_SIZE];
     char *b64data = NULL;
     size_t b64datalen = 0;
     size_t off = 0;
-    int ret;
+    int ret = -1;
     const struct crypt_method *method = NULL;
 
     *data = NULL;
     *datalen = 0;
 
+    if(fp) {
+        ret = pem_FILE_to_blob(session, fp, &blob, &blob_len);
+        if(ret)
+            goto out;
+    }
+
     do {
         *line = '\0';
 
         if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
-            return -1;
+            goto out;
     } while(strcmp(line, headerbegin));
 
     if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
-        return -1;
+        goto out;
 
     if(passphrase &&
        !memcmp(line, crypt_annotation, strlen(crypt_annotation))) {
         const struct crypt_method **all_methods, *cur_method;
         int i;
 
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off)) {
-            ret = -1;
+        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
-        }
 
         all_methods = ssh2_crypt_methods();
         /* !checksrc! disable EQUALSNULL 1 */
@@ -208,9 +214,8 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
 
         /* None of the available crypt methods were able to decrypt the key */
         if(!method) {
-            ssh2_err(session, LIBSSH2_ERROR_ALGO_UNSUPPORTED,
-                     "Unable to decrypt PEM, unsupported algorithm");
-            ret = -1;
+            ret = ssh2_err(session, LIBSSH2_ERROR_ALGO_UNSUPPORTED,
+                           "Unable to decrypt PEM, unsupported algorithm");
             goto out;
         }
 
@@ -221,10 +226,8 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
         }
 
         /* skip to the next line */
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off)) {
-            ret = -1;
+        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
-        }
     }
 
     do {
@@ -235,9 +238,8 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
             linelen = strlen(line);
             tmp = SSH2_REALLOC(session, b64data, b64datalen + linelen);
             if(!tmp) {
-                ssh2_err(session, LIBSSH2_ERROR_ALLOC,
-                         "Unable to allocate memory for PEM parsing");
-                ret = -1;
+                ret = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
+                               "Unable to allocate memory for PEM parsing");
                 goto out;
             }
             memcpy(tmp + b64datalen, line, linelen);
@@ -247,25 +249,19 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
 
         *line = '\0';
 
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off)) {
-            ret = -1;
+        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
-        }
     } while(strcmp(line, headerend));
 
     if(!b64data)
-        return -1;
+        goto out;
 
     if(ssh2_base64_decode(session, (char **)data, datalen,
-                          b64data, b64datalen)) {
-        ret = -1;
+                          b64data, b64datalen))
         goto out;
-    }
 
-    if(*datalen == 0) {
-        ret = -1; /* Invalid decode */
-        goto out;
-    }
+    if(*datalen == 0)
+        goto out; /* Invalid decode */
 
     if(method) {
 #if LIBSSH2_MD5_PEM
@@ -285,10 +281,8 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
             hok &= ssh2_hash_update(&ctx, iv, 8);
             hok &= ssh2_hash_final(&ctx, secret, SSH2_MD5_DIG_LEN);
         }
-        if(!hok) {
-            ret = -1;
+        if(!hok)
             goto out;
-        }
         if(method->secret_len > SSH2_MD5_DIG_LEN) {
             hok = ssh2_hash_init(&ctx, SSH2_MD5_ALG);
             if(hok) {
@@ -298,17 +292,14 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
                 hok &= ssh2_hash_final(&ctx, secret + SSH2_MD5_DIG_LEN,
                                        SSH2_MD5_DIG_LEN);
             }
-            if(!hok) {
-                ret = -1;
+            if(!hok)
                 goto out;
-            }
         }
 
         /* Initialize the decryption */
         if(method->init(session, method, iv, &free_iv, secret, &free_secret, 0,
                         &abstract)) {
             ssh2_explicit_zero(secret, sizeof(secret));
-            ret = -1;
             goto out;
         }
 
@@ -319,7 +310,6 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
         if((*datalen % blocksize) != 0) {
             ssh2_explicit_zero(secret, sizeof(secret));
             method->dtor(session, &abstract);
-            ret = -1;
             goto out;
         }
 
@@ -354,8 +344,7 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
         /* Account for padding */
         padding = (*data)[*datalen - 1];
         if(padding > *datalen) {
-            /* Invalid padding len */
-            ret = LIBSSH2_ERROR_DECRYPT;
+            ret = LIBSSH2_ERROR_DECRYPT;  /* Invalid padding len */
             goto out;
         }
         memset(&(*data)[*datalen - padding], 0, padding);
@@ -367,7 +356,6 @@ int ssh2_pem_parse_blob(LIBSSH2_SESSION *session,
 #else
         ssh2_err(session, LIBSSH2_ERROR_ALGO_UNSUPPORTED,
                  "Unable to decrypt PEM, MD5 not enabled");
-        ret = -1;
         goto out;
 #endif
     }
@@ -381,6 +369,9 @@ out:
         SSH2_SAFEFREE(session, *data);
         *datalen = 0;
     }
+
+    if(blob)
+        SSH2_FREE(session, blob)
 
     if(b64data) {
         ssh2_explicit_zero(b64data, b64datalen);

--- a/src/pem.c
+++ b/src/pem.c
@@ -351,8 +351,8 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
         ssh2_explicit_zero(secret, sizeof(secret));
         method->dtor(session, &abstract);
 #else
-        ssh2_err(session, LIBSSH2_ERROR_ALGO_UNSUPPORTED,
-                 "Unable to decrypt PEM, MD5 not enabled");
+        ret = ssh2_err(session, LIBSSH2_ERROR_ALGO_UNSUPPORTED,
+                       "Unable to decrypt PEM, MD5 not enabled");
         goto out;
 #endif
     }

--- a/src/pem.c
+++ b/src/pem.c
@@ -118,7 +118,7 @@ int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
     }
 
     filedata_len = (size_t)file_size;
-    filedata = SSH2_ALLOC(session, filedata_len);
+    filedata = SSH2_ALLOC(session, filedata_len + 1);
     if(!filedata) {
         ret = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                        "Unable to allocate memory for PEM parsing");
@@ -129,6 +129,8 @@ int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
         ret = ssh2_err(session, LIBSSH2_ERROR_FILE, "Bad read in PEM parsing");
         goto out;
     }
+
+    filedata[filedata_len] = '\0'; /* some parsers require a null-terminator */
 
     ret = 0;
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -96,9 +96,8 @@ static unsigned char pem_hex_decode(char digit)
         ((digit >= 'A') ? (0xA + (digit - 'A')) : (digit - '0'));
 }
 
-/* TODO: make this an internal API */
-static int pem_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
-                            char **blob, size_t *blob_len)
+int ssh2_FILE_to_blob(LIBSSH2_SESSION *session, FILE *fp,
+                      char **blob, size_t *blob_len)
 {
     int ret = -1;
     long file_size;
@@ -181,7 +180,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     *datalen = 0;
 
     if(fp) {
-        ret = pem_FILE_to_blob(session, fp, &filedata, &filedata_len);
+        ret = ssh2_FILE_to_blob(session, fp, &filedata, &filedata_len);
         if(ret)
             goto out;
         blob = filedata;

--- a/src/pem.c
+++ b/src/pem.c
@@ -140,8 +140,10 @@ out:
         *blob = filedata;
         *blob_len = filedata_len;
     }
-    else if(filedata)
+    else if(filedata) {
+        ssh2_explicit_zero(filedata, filedata_len + 1);
         SSH2_FREE(session, filedata);
+    }
 
     if(fp)
         fclose(fp);
@@ -367,8 +369,10 @@ out:
         *datalen = 0;
     }
 
-    if(filedata)
+    if(filedata) {
+        ssh2_explicit_zero(filedata, filedata_len + 1);
         SSH2_FREE(session, filedata);
+    }
 
     if(b64data) {
         ssh2_explicit_zero(b64data, b64datalen);
@@ -793,8 +797,10 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
 
 out:
 
-    if(filedata)
+    if(filedata) {
+        ssh2_explicit_zero(filedata, filedata_len + 1);
         SSH2_FREE(session, filedata);
+    }
 
     if(b64data) {
         ssh2_explicit_zero(b64data, b64datalen);

--- a/src/pem.c
+++ b/src/pem.c
@@ -106,7 +106,8 @@ int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
         goto out;
     }
     if(fseek(fp, 0L, SEEK_SET)) {
-        ret = ssh2_err(session, LIBSSH2_ERROR_FILE, "Bad seek to 0 in PEM parsing");
+        ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
+                       "Bad seek to 0 in PEM parsing");
         goto out;
     }
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -33,9 +33,8 @@
 
 #include "libssh2_priv.h"
 
-static int pem_readline_blob(char *line, size_t line_size,
-                             const char *blob, size_t blob_len,
-                             size_t *blob_offset)
+static int pem_readline(char *line, size_t line_size,
+                        const char *blob, size_t blob_len, size_t *blob_offset)
 {
     size_t off, len;
 
@@ -174,11 +173,11 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     do {
         *line = '\0';
 
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
     } while(strcmp(line, headerbegin));
 
-    if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
+    if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
         goto out;
 
     if(passphrase &&
@@ -186,7 +185,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
         const struct crypt_method **all_methods, *cur_method;
         int i;
 
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
 
         all_methods = ssh2_crypt_methods();
@@ -215,7 +214,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
         }
 
         /* skip to the next line */
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
     }
 
@@ -238,7 +237,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
 
         *line = '\0';
 
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
     } while(strcmp(line, headerend));
 
@@ -720,7 +719,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
             return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                             "Error parsing PEM: OpenSSH header not found");
 
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             return -1;
     } while(strcmp(line, OPENSSH_PRIVKEY_HEADER));
 
@@ -751,7 +750,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(pem_readline_blob(line, LINE_SIZE, blob, blob_len, &off)) {
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off)) {
             ret = -1;
             goto out;
         }

--- a/src/pem.c
+++ b/src/pem.c
@@ -33,30 +33,6 @@
 
 #include "libssh2_priv.h"
 
-static int pem_readline_file(char *line, int line_size, FILE *fp)
-{
-    size_t len;
-
-    if(!line)
-        return -1;
-    if(!fgets(line, line_size, fp))
-        return -1;
-
-    if(*line) {
-        len = strlen(line);
-        if(len > 0 && line[len - 1] == '\n')
-            line[len - 1] = '\0';
-    }
-
-    if(*line) {
-        len = strlen(line);
-        if(len > 0 && line[len - 1] == '\r')
-            line[len - 1] = '\0';
-    }
-
-    return 0;
-}
-
 static int pem_readline_blob(char *line, size_t line_size,
                              const char *blob, size_t blob_len,
                              size_t *blob_offset)

--- a/src/pem.c
+++ b/src/pem.c
@@ -104,7 +104,7 @@ int ssh2_file_to_blob(LIBSSH2_SESSION *session, const char *filename,
         goto out;
     }
     if(file_size > (1024 * 1024)) {
-        ret = ssh2_err(session, LIBSSH2_ERROR_FILE,
+        ret = ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                        "Input too large in PEM parsing");
         goto out;
     }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -898,11 +898,9 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx, ULONG hash_len,
 
 static int wcng_load_priv(LIBSSH2_SESSION *session,
                           const char *filename,
-                          const char *privkeyblob,
-                          size_t privkeyblob_len,
+                          const char *privkeyblob, size_t privkeyblob_len,
                           const char *passphrase,
-                          unsigned char **ppbEncoded,
-                          size_t *pcbEncoded,
+                          unsigned char **ppbEncoded, size_t *pcbEncoded,
                           int tryLoadRSA, int tryLoadDSA)
 {
     int ret = -1;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -903,21 +903,26 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
                           unsigned char **ppbEncoded, size_t *pcbEncoded,
                           int tryLoadRSA, int tryLoadDSA)
 {
-    int ret = -1;
+    int ret;
     unsigned char *data = NULL;
     size_t datalen = 0;
-    FILE *fp = NULL;
+    char *blob = NULL;
+    size_t blob_len = 0;
 
     if(filename) {
-        fp = ssh2_fopen(filename, "rb");
-        if(!fp)
-            return -1;
+        ret = ssh2_file_to_blob(session, filename, &blob, &blob_len);
+        if(ret)
+            return ret;
+        privkeyblob = blob;
+        privkeyblob_len = blob_len;
     }
+
+    ret = -1;
 
 #if LIBSSH2_RSA
     if(ret && tryLoadRSA)
         ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                             fp, privkeyblob, privkeyblob_len, passphrase,
+                             NULL, privkeyblob, privkeyblob_len, passphrase,
                              &data, &datalen);
 #else
     (void)tryLoadRSA;
@@ -926,19 +931,19 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
 #if LIBSSH2_DSA
     if(ret && tryLoadDSA)
         ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                             fp, privkeyblob, privkeyblob_len, passphrase,
+                             NULL, privkeyblob, privkeyblob_len, passphrase,
                              &data, &datalen);
 #else
     (void)tryLoadDSA;
 #endif
 
-    if(fp)
-        fclose(fp);
-
     if(!ret) {
         *ppbEncoded = data;
         *pcbEncoded = datalen;
     }
+
+    if(blob)
+        SSH2_FREE(session, blob);
 
     return ret;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2441,7 +2441,6 @@ int ssh2_ecdsa_new_priv(OUT ssh2_ecdsa_ctx **ec_ctx,
 {
     int result;
     struct string_buf *decrypted = NULL;
-    FILE *fp = NULL;
 
     /* Validate parameters */
     if(!ec_ctx || !session || (!filename && !blob))
@@ -2449,21 +2448,8 @@ int ssh2_ecdsa_new_priv(OUT ssh2_ecdsa_ctx **ec_ctx,
 
     *ec_ctx = NULL;
 
-    if(filename) {
-        fp = ssh2_fopen(filename, "rb");
-        if(!fp) {
-            result = ssh2_err(session, LIBSSH2_ERROR_FILE,
-                              "Opening the private key file failed");
-            goto cleanup;
-        }
-
-        result = ssh2_openssh_pem_parse_FILE(session, fp,
-                                             passphrase, &decrypted);
-    }
-    else
-        result = ssh2_openssh_pem_parse_blob(session, blob, blob_len,
-                                             passphrase, &decrypted);
-
+    result = ssh2_openssh_pem_parse(session, filename, blob, blob_len,
+                                    passphrase, &decrypted);
     if(result)
         goto cleanup;
 
@@ -2473,9 +2459,6 @@ int ssh2_ecdsa_new_priv(OUT ssh2_ecdsa_ctx **ec_ctx,
 cleanup:
     if(decrypted)
         ssh2_string_buf_free(session, decrypted);
-
-    if(fp)
-        fclose(fp);
 
     return result;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -903,26 +903,14 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
                           unsigned char **ppbEncoded, size_t *pcbEncoded,
                           int tryLoadRSA, int tryLoadDSA)
 {
-    int ret;
+    int ret = -1;
     unsigned char *data = NULL;
     size_t datalen = 0;
-    char *blob = NULL;
-    size_t blob_len = 0;
-
-    if(filename) {
-        ret = ssh2_file_to_blob(session, filename, &blob, &blob_len);
-        if(ret)
-            return ret;
-        privkeyblob = blob;
-        privkeyblob_len = blob_len;
-    }
-
-    ret = -1;
 
 #if LIBSSH2_RSA
     if(ret && tryLoadRSA)
         ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                             NULL, privkeyblob, privkeyblob_len, passphrase,
+                             filename, privkeyblob, privkeyblob_len, passphrase,
                              &data, &datalen);
 #else
     (void)tryLoadRSA;
@@ -931,7 +919,7 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
 #if LIBSSH2_DSA
     if(ret && tryLoadDSA)
         ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                             NULL, privkeyblob, privkeyblob_len, passphrase,
+                             filename, privkeyblob, privkeyblob_len, passphrase,
                              &data, &datalen);
 #else
     (void)tryLoadDSA;
@@ -941,9 +929,6 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
         *ppbEncoded = data;
         *pcbEncoded = datalen;
     }
-
-    if(blob)
-        SSH2_FREE(session, blob);
 
     return ret;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -911,7 +911,7 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
     if(ret && tryLoadRSA)
         ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
                              filename, privkeyblob, privkeyblob_len, passphrase,
-                             &data, &datalen);
+                             &data, &datalen, NULL);
 #else
     (void)tryLoadRSA;
 #endif
@@ -920,7 +920,7 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
     if(ret && tryLoadDSA)
         ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
                              filename, privkeyblob, privkeyblob_len, passphrase,
-                             &data, &datalen);
+                             &data, &datalen, NULL);
 #else
     (void)tryLoadDSA;
 #endif

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -910,8 +910,8 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
 #if LIBSSH2_RSA
     if(ret && tryLoadRSA)
         ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                             filename, privkeyblob, privkeyblob_len, passphrase,
-                             &data, &datalen, NULL);
+                             filename, privkeyblob, privkeyblob_len,
+                             passphrase, &data, &datalen, NULL);
 #else
     (void)tryLoadRSA;
 #endif
@@ -919,8 +919,8 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
 #if LIBSSH2_DSA
     if(ret && tryLoadDSA)
         ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                             filename, privkeyblob, privkeyblob_len, passphrase,
-                             &data, &datalen, NULL);
+                             filename, privkeyblob, privkeyblob_len,
+                             passphrase, &data, &datalen, NULL);
 #else
     (void)tryLoadDSA;
 #endif

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -917,31 +917,19 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
     }
 
 #if LIBSSH2_RSA
-    if(ret && tryLoadRSA) {
-        if(filename)
-            ret = ssh2_pem_parse_FILE(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                                      fp, passphrase,
-                                      &data, &datalen);
-        else
-            ret = ssh2_pem_parse_blob(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
-                                      privkeyblob, privkeyblob_len, passphrase,
-                                      &data, &datalen);
-    }
+    if(ret && tryLoadRSA)
+        ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
+                             fp, privkeyblob, privkeyblob_len, passphrase,
+                             &data, &datalen);
 #else
     (void)tryLoadRSA;
 #endif
 
 #if LIBSSH2_DSA
-    if(ret && tryLoadDSA) {
-        if(filename)
-            ret = ssh2_pem_parse_FILE(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                                      fp, passphrase,
-                                      &data, &datalen);
-        else
-            ret = ssh2_pem_parse_blob(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
-                                      privkeyblob, privkeyblob_len, passphrase,
-                                      &data, &datalen);
-    }
+    if(ret && tryLoadDSA)
+        ret = ssh2_pem_parse(session, PEM_DSA_HEADER, PEM_DSA_FOOTER,
+                             fp, privkeyblob, privkeyblob_len, passphrase,
+                             &data, &datalen);
 #else
     (void)tryLoadDSA;
 #endif


### PR DESCRIPTION
To further merge file/blob codepaths/behavior, and to reduce branching
at callers.

Also:
- pem: add internal API `ssh2_file_to_blob()` to load a (PEM) file into
  memory. Use it internally.
  Make sure to null-terminate the returned blob, primarily for mbedTLS.
- mbedtls, os400qc3: use `ssh2_file_to_blob()`. 
- pem: fix to return `LIBSSH2_ERROR_ALGO_UNSUPPORTED` in
  `ssh2_pem_parse()` in no-MD5 builds (was: -1).
- os400qc3: fix to scrub data before free in `try_pem_load()`.

Note:
- os400qc3: `try_pem_load()` has unique behavior of allowing multiple
  instances of private keys within a single file, but only when loading
  from a file. I could not positively confirm this to be valid/standard
  private file format, nor find a comment or commit message explaining
  the behavior. I've added (untested) support for this using the blob
  codepath, because the `FILE *` method is now gone from `pem.c`. It
  also seems one contributing factor why the file (vs blob) tracks are 
  much different in this backend. After this patch, both could use
  `ssh2_pem_parse()` and possibly unify `os400_pub_privkey_file/blob()`
  and `os400_rsa_new_priv_from_file/blob()`.

Follow-up to b560cb4c7bf268ba4cbb1947a417facb676b9782 #2379
Follow-up to 6a951168ceecee100691754b51bc257f46b9d62a #2362
Follow-up to fe9442be4d13b14edb1d6699ed9a75afddbfebcc #2359
Follow-up to 5b94157f1c83967f369d22bf5d90bc456a5a55c2 #2354

---

- [x] openssl: try to untangle the different file/blob codepaths.
  e.g. in `ssh2_rsa_new_priv()`. → Separate PR.
