### PR TITLE
crypt: fix length underflow on short chacha20-poly1305 packets

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -434,7 +434,7 @@ static int crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
             /* buf is full packet including size and auth tag but buf_len
                does not include size */
             if(buf_len < 4)
-                return 1; /* too short to drop the size field below */
+                return 1; /* too short to fit the size field below */
 
             ret = chachapoly_crypt(&ctx->chachapoly_ctx, seqno, buf, buf,
                                    buf_len, 4, ctx->encrypt);

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -434,8 +434,7 @@ static int crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
             /* buf is full packet including size and auth tag but buf_len
                does not include size */
             if(buf_len < 4)
-                /* too short to drop the size field below */
-                return 1;
+                return 1; /* too short to drop the size field below */
 
             ret = chachapoly_crypt(&ctx->chachapoly_ctx, seqno, buf, buf,
                                    buf_len, 4, ctx->encrypt);

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -433,6 +433,10 @@ static int crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
         else {
             /* buf is full packet including size and auth tag but buf_len
                does not include size */
+            if(buf_len < 4)
+                /* too short to drop the size field below */
+                return 1;
+
             ret = chachapoly_crypt(&ctx->chachapoly_ctx, seqno, buf, buf,
                                    buf_len, 4, ctx->encrypt);
 


### PR DESCRIPTION
crypt_encrypt_chacha20_poly_buffer() strips the 4 byte size field with memmove(buf, buf + 4, buf_len - 4), where buf_len is the packet_length the server sent, and ssh2_transport_read() only rejects a packet_length of 0. A server that sends an authenticated chacha20-poly1305 packet with a length field of 1 to 3 therefore wraps that subtraction, and AddressSanitizer reports negative-size-param (size=-3) at the memmove; the poly1305 tag check ahead of it passes because the peer holds the negotiated keys. Checking the length in the decrypt branch keeps the guard next to the arithmetic that needs it; valid-length packets still round-trip byte for byte, and I did not find an open or closed PR already covering this.

Reported-by: Hananto Adi
Reported-by: vnth4nhnt from CyStack
Fixes GHSA-x4g5-mgfc-cxvv
