### PR TITLE
os400qc3: fix `data` memleak on success in `try_pem_load()`

### DIFF
--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1992,8 +1992,10 @@ static int try_pem_load(LIBSSH2_SESSION *session, FILE *fp,
 
         if(!ret) {
             ret = (*proc)(session, data, datalen, passphrase, loadkeydata);
-            if(!ret)
-                return 0;
+            if(!ret) {
+                SSH2_FREE(session, data);
+                return 0; /* success */
+            }
         }
 
         if(data)


### PR DESCRIPTION
Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2388#discussion_r3629035897

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
