### PR TITLE
transport: fix to translate low-level crypt result to LIBSSH2 error code

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -792,16 +792,14 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
         if(numdecrypt > 0) {
             /* now decrypt the lot */
             if(CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
-                rc = session->remote.crypt->crypt(session,
+                if(session->remote.crypt->crypt(session,
                                                session->remote.seqno,
                                                &p->buf[p->readidx],
                                                numdecrypt,
                                                &session->remote.crypt_abstract,
-                                               0);
-
-                if(rc != LIBSSH2_ERROR_NONE) {
+                                               0)) {
                     p->total_num = 0; /* no packet buffer available */
-                    return rc;
+                    return LIBSSH2_ERROR_DECRYPT;
                 }
 
                 memcpy(p->wptr, &p->buf[p->readidx], numbytes);


### PR DESCRIPTION
In `ssh2_transport_read()`.

Prior to this patch, `ssh2_transport_read()` propagated the low-level 
`crypt()` callback result code as-is to its callers, which do expect a
LIBSSH2 error code (errors negative, success is 0 and positive). The 
low-level error code however is 1. Callers interpreted this as success 
and continued looping, potentially forever in case of a low-level
failure. This happened in a single call site, the rest were correct.

Translate 1 to `LIBSSH2_ERROR_DECRYPT` to fix.

Reported-by: vnth4nhnt from CyStack
Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2389#discussion_r3630000680
Follow-up to 492bc543bbb6ee39df588e2bffdd3478aff2f7e5 #1426
