### PR TITLE
crypt: fix propagating `get_len()` error code in `ssh2_transport_read()`

### DIFF
--- a/src/cipher-chachapoly.c
+++ b/src/cipher-chachapoly.c
@@ -117,11 +117,11 @@ int chachapoly_get_length(struct chachapoly_ctx *ctx, unsigned int *plenp,
     unsigned char *ptr = NULL;
 
     if(len < 4)
-        return -1;
+        return -1;  /* fail */
     ptr = &seqbuf[0];
     ssh2_store_u64(&ptr, seqnr);
     chacha_ivsetup(&ctx->header_ctx, seqbuf, NULL);
     chacha_encrypt_bytes(&ctx->header_ctx, cp, buf, 4);
     *plenp = ssh2_ntohu32(buf);
-    return 0;
+    return 0;  /* success */
 }

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -97,12 +97,12 @@ static int crypt_init(LIBSSH2_SESSION *session,
     ctx->algo = method->algo;
     if(ssh2_cipher_init(&ctx->h, ctx->algo, iv, secret, encrypt)) {
         SSH2_FREE(session, ctx);
-        return -1;
+        return -1;  /* fail */
     }
     *abstract = ctx;
     *free_iv = 1;
     *free_secret = 1;
-    return 0;
+    return 0;  /* success */
 }
 
 static int crypt_encrypt(LIBSSH2_SESSION *session,
@@ -397,13 +397,13 @@ static int crypt_init_chacha20_poly(LIBSSH2_SESSION *session,
 
     if(chachapoly_init(&ctx->chachapoly_ctx, secret, method->secret_len)) {
         SSH2_FREE(session, ctx);
-        return -1;
+        return -1;  /* fail */
     }
 
     *abstract = ctx;
     *free_iv = 1;
     *free_secret = 1;
-    return 0;
+    return 0;  /* success */
 }
 
 static int crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
@@ -443,7 +443,7 @@ static int crypt_encrypt_chacha20_poly_buffer(LIBSSH2_SESSION *session,
         }
     }
 
-    return ret == 0 ? 0 : 1;
+    return ret == 0 ? 0 : 1;  /* success: 0, fail: 1 */
 }
 
 static int crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session,
@@ -453,11 +453,14 @@ static int crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session,
                                           unsigned int *len, void **abstract)
 {
     struct crypt_ctx *ctx = *(struct crypt_ctx **)abstract;
+    int ret;
 
     (void)session;
 
-    return chachapoly_get_length(&ctx->chachapoly_ctx, len, seqno, data,
-                                 data_size);
+    ret = chachapoly_get_length(&ctx->chachapoly_ctx, len, seqno, data,
+                                 data_size)
+
+    return ret == 0 ? 0 : 1;  /* success: 0, fail: 1 */
 }
 
 static int crypt_dtor_chacha20_poly(LIBSSH2_SESSION *session, void **abstract)

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -458,7 +458,7 @@ static int crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session,
     (void)session;
 
     ret = chachapoly_get_length(&ctx->chachapoly_ctx, len, seqno, data,
-                                 data_size)
+                                 data_size);
 
     return ret == 0 ? 0 : 1;  /* success: 0, fail: 1 */
 }

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -458,7 +458,7 @@ static int crypt_get_length_chacha20_poly(LIBSSH2_SESSION *session,
     (void)session;
 
     ret = chachapoly_get_length(&ctx->chachapoly_ctx, len, seqno, data,
-                                 data_size);
+                                data_size);
 
     return ret == 0 ? 0 : 1;  /* success: 0, fail: 1 */
 }

--- a/src/transport.c
+++ b/src/transport.c
@@ -556,18 +556,16 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 unsigned int len = 0;
                 unsigned char *ptr = NULL;
 
-                rc = session->remote.crypt->get_len(session,
+                if(session->remote.crypt->get_len(session,
                                             session->remote.seqno,
                                             &p->buf[p->readidx],
                                             numbytes,
                                             &len,
-                                            &session->remote.crypt_abstract);
-
-                if(rc != LIBSSH2_ERROR_NONE) {
+                                            &session->remote.crypt_abstract)) {
                     p->total_num = 0; /* no packet buffer available */
                     if(p->payload)
                         SSH2_SAFEFREE(session, p->payload);
-                    return rc;
+                    return LIBSSH2_ERROR_DECRYPT;
                 }
 
                 /* store size in buffers for use below */


### PR DESCRIPTION
Prior to this patch `get_len()` crypt callback returned the low-level
`chachapoly_get_length()` return code as-is. In case of failure, this
values was -1. `ssh2_transport_read()` interpreted it as LIBSSH2 code
and returned it to callers as-is. -1 is `LIBSSH2_ERROR_SOCKET_NONE`,
which is inaccurate and misleading in this case.

Fix by aligning the crypt `get_len()` error code with `crypt()` and
translating it to `LIBSSH2_ERROR_DECRYPT` in `ssh2_transport_read()`.

Also:
- make `get_len()` callback return 0/1 as its sibling `crypt()` does
  already.
- add comments to clarify which value means success/fail in which
  callback.

Ref: #2392
Follow-up to 492bc543bbb6ee39df588e2bffdd3478aff2f7e5 #1426
