### PR TITLE
openssl: replace `ossl_*_openssh_priv_new()` functions with `ossl_key_from_openssh()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1987,7 +1987,7 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
                                           SSH2_UNCONST(passphrase));
     BIO_free(bp);
 
-    if(EVP_PKEY_id(*ed_ctx) != EVP_PKEY_ED25519) {
+    if(*ed_ctx && EVP_PKEY_id(*ed_ctx) != EVP_PKEY_ED25519) {
         ssh2_ed25519_free(*ed_ctx);
         *ed_ctx = NULL;
         return ssh2_err(session, LIBSSH2_ERROR_PROTO,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3376,7 +3376,7 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
                                       char **method,
                                       unsigned char **pubkeydata,
                                       size_t *pubkeydata_len,
-                                      const char *filename,
+                                      const char *privatekey,
                                       const char *privkeyblob,
                                       size_t privkeyblob_len,
                                       const char *passphrase)
@@ -3400,7 +3400,7 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
     OSSL_INIT_IF_NEEDED();
 
     rc = ssh2_openssh_pem_parse(session,
-                                filename, NULL, 0,
+                                privatekey, privkeyblob, privkeyblob_len,
                                 passphrase, &decrypted);
     if(rc)
         return rc;
@@ -3424,21 +3424,32 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
     if(!strcmp("ssh-ed25519", (const char *)buf) &&
        (!want_method || !strcmp("ssh-ed25519", want_method)))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
-                                                 NULL, NULL, NULL,
+                                                 method,
+                                                 pubkeydata, pubkeydata_len,
+                                                 (ssh2_ed25519_ctx **)key_ctx);
+
+    if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) &&
+       (!want_method || !strcmp("sk-ssh-ed25519@openssh.com", want_method)))
+        rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
+                                                    method,
+                                                    pubkeydata, pubkeydata_len,
+                                                    NULL, NULL, NULL, NULL,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 #endif
 #if LIBSSH2_RSA
     if(!strcmp("ssh-rsa", (const char *)buf) &&
        (!want_method || !strcmp("ssh-rsa", want_method)))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
-                                             NULL, NULL, NULL,
+                                             method,
+                                             pubkeydata, pubkeydata_len,
                                              (ssh2_rsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_DSA
     if(!strcmp("ssh-dss", (const char *)buf) &&
        (!want_method || !strcmp("ssh-dss", want_method)))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
-                                             NULL, NULL, NULL,
+                                             method,
+                                             pubkeydata, pubkeydata_len,
                                              (ssh2_dsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_ECDSA
@@ -3451,7 +3462,8 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
     else if(ossl_ecdsa_curve_type_from_name((const char *)buf, &type) == 0 &&
             (!want_method || !strcmp("ssh-ecdsa", want_method)))
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
-                                               NULL, NULL, NULL,
+                                               method,
+                                               pubkeydata, pubkeydata_len,
                                                (ssh2_ecdsa_ctx **)key_ctx);
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -147,6 +147,12 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 #endif
 }
 
+static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
+                                      void **key_ctx,
+                                      const char *want_method,
+                                      const char *filename,
+                                      const char *passphrase);
+
 static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                  void **key_ctx,
                                  const char *want_method,
@@ -1310,48 +1316,6 @@ fail:
                     "Unable to allocate memory for private key data");
 }
 
-static int ossl_rsa_openssh_priv_new(ssh2_rsa_ctx **rsa,
-                                     LIBSSH2_SESSION *session,
-                                     const char *filename,
-                                     const char *passphrase)
-{
-    int rc;
-    unsigned char *buf = NULL;
-    struct string_buf *decrypted = NULL;
-
-    if(!session)
-        return -1;
-
-    OSSL_INIT_IF_NEEDED();
-
-    rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
-                                &decrypted);
-    if(rc)
-        return rc;
-
-    /* We have a new key file, now try and parse it using supported types */
-    rc = ssh2_get_string(decrypted, &buf, NULL);
-    if(rc || !buf) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                 "Public key type in decrypted key data not found");
-        rc = -1;
-        goto cleanup;
-    }
-
-    if(!strcmp("ssh-rsa", (const char *)buf))
-        rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
-                                             NULL, NULL, NULL, rsa);
-    else
-        rc = -1;
-
-cleanup:
-
-    if(decrypted)
-        ssh2_string_buf_free(session, decrypted);
-
-    return rc;
-}
-
 int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
                       LIBSSH2_SESSION *session,
                       const char *filename,
@@ -1381,7 +1345,8 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 
     if(!*rsa) {
         if(filename)
-            rc = ossl_rsa_openssh_priv_new(rsa, session, filename, passphrase);
+            rc = ossl_key_from_openssh_file(session, (void **)rsa, "ssh-rsa",
+                                            filename, passphrase);
         else
             rc = ossl_key_from_openssh(session, (void **)rsa, "ssh-rsa",
                                        NULL, NULL, NULL,
@@ -1588,48 +1553,6 @@ fail:
                     "Unable to allocate memory for private key data");
 }
 
-static int ossl_dsa_openssh_priv_new(ssh2_dsa_ctx **dsa,
-                                     LIBSSH2_SESSION *session,
-                                     const char *filename,
-                                     const char *passphrase)
-{
-    int rc;
-    unsigned char *buf = NULL;
-    struct string_buf *decrypted = NULL;
-
-    if(!session)
-        return -1;
-
-    OSSL_INIT_IF_NEEDED();
-
-    rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
-                                &decrypted);
-    if(rc)
-        return rc;
-
-    /* We have a new key file, now try and parse it using supported types */
-    rc = ssh2_get_string(decrypted, &buf, NULL);
-    if(rc || !buf) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                 "Public key type in decrypted key data not found");
-        rc = -1;
-        goto cleanup;
-    }
-
-    if(!strcmp("ssh-dss", (const char *)buf))
-        rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
-                                             NULL, NULL, NULL, dsa);
-    else
-        rc = -1;
-
-cleanup:
-
-    if(decrypted)
-        ssh2_string_buf_free(session, decrypted);
-
-    return rc;
-}
-
 int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
                       LIBSSH2_SESSION *session,
                       const char *filename,
@@ -1659,7 +1582,8 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
 
     if(!*dsa) {
         if(filename)
-            rc = ossl_dsa_openssh_priv_new(dsa, session, filename, passphrase);
+            rc = ossl_key_from_openssh_file(session, (void **)dsa, "ssh-dss",
+                                            filename, passphrase);
         else
             rc = ossl_key_from_openssh(session, (void **)dsa, "ssh-dss",
                                        NULL, NULL, NULL,
@@ -2064,54 +1988,20 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
                           const char *passphrase)
 {
     ssh2_ed25519_ctx *ctx = NULL;
+    int rc;
 
-    if(!session)
-        return -1;
-
-    OSSL_INIT_IF_NEEDED();
-
-    if(filename) {
-        int rc;
-        unsigned char *buf;
-        struct string_buf *decrypted = NULL;
-
-        rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
-                                    &decrypted);
-        if(rc)
-            return rc;
-
-        /* We have a new key file, now try and parse it using supported
-           types */
-        rc = ssh2_get_string(decrypted, &buf, NULL);
-        if(rc || !buf) {
-            ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                     "Public key type in decrypted key data not found");
-            rc = -1;
-            goto cleanup;
-        }
-
-        if(!strcmp("ssh-ed25519", (const char *)buf))
-            rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
-                                                     NULL, NULL, NULL, &ctx);
-        else
-            rc = -1;
-
-        if(rc == 0) {
-            if(ed_ctx)
-                *ed_ctx = ctx;
-            else if(ctx)
-                ssh2_ed25519_free(ctx);
-        }
-
-cleanup:
-
-        if(decrypted)
-            ssh2_string_buf_free(session, decrypted);
-
-        return rc;
-    }
+    if(filename)
+        rc = ossl_key_from_openssh_file(session, (void **)ctx, "ssh-ed25519",
+                                        filename, passphrase);
     else {
-        BIO *bp = BIO_new_mem_buf(blob, (int)blob_len);
+        BIO *bp;
+
+        if(!session)
+            return -1;
+
+        OSSL_INIT_IF_NEEDED();
+
+        bp = BIO_new_mem_buf(blob, (int)blob_len);
         if(bp) {
             ctx = PEM_read_bio_PrivateKey(bp, NULL, ossl_passphrase_cb,
                                           SSH2_UNCONST(passphrase));
@@ -2122,19 +2012,24 @@ cleanup:
                     return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                     "Private key is not an ED25519 key");
                 }
-
-                if(ed_ctx)
-                    *ed_ctx = ctx;
-                else
-                    ssh2_ed25519_free(ctx);
-                return 0;
+                rc = 0;
+                goto cleanup;
             }
         }
 
-        return ossl_key_from_openssh(session, (void **)ed_ctx, "ssh-ed25519",
-                                     NULL, NULL, NULL,
-                                     NULL, blob, blob_len, passphrase);
+        rc = ossl_key_from_openssh(session, (void **)ed_ctx, "ssh-ed25519",
+                                   NULL, NULL, NULL,
+                                   NULL, blob, blob_len, passphrase);
     }
+
+cleanup:
+
+    if(ed_ctx)
+        *ed_ctx = ctx;
+    else
+        ssh2_ed25519_free(ctx);
+
+    return rc;
 }
 
 int ssh2_ed25519_new_public(ssh2_ed25519_ctx **ed_ctx,
@@ -2988,51 +2883,6 @@ fail:
     return rc;
 }
 
-static int ossl_ecdsa_openssh_priv_new(ssh2_ecdsa_ctx **ec_ctx,
-                                       LIBSSH2_SESSION *session,
-                                       const char *filename,
-                                       const char *passphrase)
-{
-    int rc;
-    unsigned char *buf = NULL;
-    struct string_buf *decrypted = NULL;
-    ssh2_curve_type type;
-
-    if(!session)
-        return -1;
-
-    OSSL_INIT_IF_NEEDED();
-
-    rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
-                                &decrypted);
-    if(rc)
-        return rc;
-
-    /* We have a new key file, now try and parse it using supported types */
-    rc = ssh2_get_string(decrypted, &buf, NULL);
-    if(rc || !buf) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                 "Public key type in decrypted key data not found");
-        rc = -1;
-        goto cleanup;
-    }
-
-    rc = ossl_ecdsa_curve_type_from_name((const char *)buf, &type);
-
-    if(rc == 0)
-        rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
-                                               NULL, NULL, NULL, ec_ctx);
-    else
-        rc = -1;
-
-cleanup:
-
-    if(decrypted)
-        ssh2_string_buf_free(session, decrypted);
-
-    return rc;
-}
-
 int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
                         LIBSSH2_SESSION *session,
                         const char *filename,
@@ -3062,8 +2912,9 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
 
     if(!*ec_ctx) {
         if(filename)
-            rc = ossl_ecdsa_openssh_priv_new(ec_ctx, session, filename,
-                                             passphrase);
+            rc = ossl_key_from_openssh_file(session,
+                                            (void **)ec_ctx, "ssh-ecdsa",
+                                            filename, passphrase);
         else
             rc = ossl_key_from_openssh(session, (void **)ec_ctx, "ssh-ecdsa",
                                        NULL, NULL, NULL,
@@ -3509,6 +3360,72 @@ clean_exit:
 }
 
 #endif /* LIBSSH2_ED25519 */
+
+static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
+                                      void **key_ctx,
+                                      const char *want_method,
+                                      const char *filename,
+                                      const char *passphrase)
+{
+    int rc;
+    unsigned char *buf = NULL;
+    struct string_buf *decrypted = NULL;
+#if LIBSSH2_ECDSA
+    ssh2_curve_type type;
+#endif
+    (void)want_method;
+
+    if(!session)
+        return -1;
+
+    OSSL_INIT_IF_NEEDED();
+
+    rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
+                                &decrypted);
+    if(rc)
+        return rc;
+
+    /* We have a new key file, now try and parse it using supported types */
+    rc = ssh2_get_string(decrypted, &buf, NULL);
+    if(rc || !buf) {
+        ssh2_err(session, LIBSSH2_ERROR_PROTO,
+                 "Public key type in decrypted key data not found");
+        rc = -1;
+        goto cleanup;
+    }
+
+#if LIBSSH2_ED25519
+    if(!strcmp("ssh-ed25519", (const char *)buf))
+        rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
+                                                 NULL, NULL, NULL,
+                                                 (ssh2_ed25519_ctx **)key_ctx);
+#endif
+#if LIBSSH2_RSA
+    if(!strcmp("ssh-rsa", (const char *)buf))
+        rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
+                                             NULL, NULL, NULL,
+                                             (ssh2_rsa_ctx **)key_ctx);
+#endif
+#if LIBSSH2_DSA
+    if(!strcmp("ssh-dss", (const char *)buf))
+        rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
+                                             NULL, NULL, NULL,
+                                             (ssh2_dsa_ctx **)key_ctx);
+#endif
+#if LIBSSH2_ECDSA
+    if(ossl_ecdsa_curve_type_from_name((const char *)buf, &type) == 0)
+        rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
+                                               NULL, NULL, NULL,
+                                               (ssh2_ecdsa_ctx **)key_ctx);
+#endif
+
+cleanup:
+
+    if(decrypted)
+        ssh2_string_buf_free(session, decrypted);
+
+    return rc;
+}
 
 static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                  void **key_ctx,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -147,17 +147,6 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 #endif
 }
 
-static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
-                                      void **key_ctx,
-                                      const char *want_method,
-                                      char **method,
-                                      unsigned char **pubkeydata,
-                                      size_t *pubkeydata_len,
-                                      const char *filename,
-                                      const char *privkeyblob,
-                                      size_t privkeyblob_len,
-                                      const char *passphrase);
-
 static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                  void **key_ctx,
                                  const char *want_method,
@@ -1348,16 +1337,10 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 #endif
     BIO_free(bp);
 
-    if(!*rsa) {
-        if(filename)
-            rc = ossl_key_from_openssh_file(session, (void **)rsa, "ssh-rsa",
-                                            NULL, NULL, NULL,
-                                            filename, NULL, 0, passphrase);
-        else
-            rc = ossl_key_from_openssh(session, (void **)rsa, "ssh-rsa",
-                                       NULL, NULL, NULL,
-                                       NULL, blob, blob_len, passphrase);
-    }
+    if(!*rsa)
+        rc = ossl_key_from_openssh(session, (void **)rsa, "ssh-rsa",
+                                   NULL, NULL, NULL,
+                                   filename, blob, blob_len, passphrase);
 
     return rc;
 }
@@ -1586,16 +1569,10 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
 #endif
     BIO_free(bp);
 
-    if(!*dsa) {
-        if(filename)
-            rc = ossl_key_from_openssh_file(session, (void **)dsa, "ssh-dss",
-                                            NULL, NULL, NULL,
-                                            filename, NULL, 0, passphrase);
-        else
-            rc = ossl_key_from_openssh(session, (void **)dsa, "ssh-dss",
-                                       NULL, NULL, NULL,
-                                       NULL, blob, blob_len, passphrase);
-    }
+    if(!*dsa)
+        rc = ossl_key_from_openssh(session, (void **)dsa, "ssh-dss",
+                                   NULL, NULL, NULL,
+                                   filename, blob, blob_len, passphrase);
 
     return rc;
 }
@@ -1998,9 +1975,9 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
     int rc;
 
     if(filename)
-        rc = ossl_key_from_openssh_file(session, (void **)ctx, "ssh-ed25519",
-                                        NULL, NULL, NULL,
-                                        filename, NULL, 0, passphrase);
+        rc = ossl_key_from_openssh(session, (void **)ctx, "ssh-ed25519",
+                                   NULL, NULL, NULL,
+                                   filename, NULL, 0, passphrase);
     else {
         BIO *bp;
 
@@ -2918,17 +2895,11 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
 #endif
     BIO_free(bp);
 
-    if(!*ec_ctx) {
-        if(filename)
-            rc = ossl_key_from_openssh_file(session,
-                                            (void **)ec_ctx, "ssh-ecdsa",
-                                            NULL, NULL, NULL,
-                                            filename, NULL, 0, passphrase);
-        else
-            rc = ossl_key_from_openssh(session, (void **)ec_ctx, "ssh-ecdsa",
-                                       NULL, NULL, NULL,
-                                       NULL, blob, blob_len, passphrase);
-    }
+    if(!*ec_ctx)
+        rc = ossl_key_from_openssh(session, (void **)ec_ctx, "ssh-ecdsa",
+                                   NULL, NULL, NULL,
+                                   filename, blob, blob_len, passphrase);
+
     return rc;
 }
 
@@ -3369,116 +3340,6 @@ clean_exit:
 }
 
 #endif /* LIBSSH2_ED25519 */
-
-static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
-                                      void **key_ctx,
-                                      const char *want_method,
-                                      char **method,
-                                      unsigned char **pubkeydata,
-                                      size_t *pubkeydata_len,
-                                      const char *privatekey,
-                                      const char *privkeyblob,
-                                      size_t privkeyblob_len,
-                                      const char *passphrase)
-{
-    int rc;
-    unsigned char *buf = NULL;
-    struct string_buf *decrypted = NULL;
-#if LIBSSH2_ECDSA
-    ssh2_curve_type type;
-#endif
-
-    if(key_ctx)
-        *key_ctx = NULL;
-
-    if(!session)
-        return LIBSSH2_ERROR_BAD_USE;
-
-    if(want_method && strlen(want_method) < 7)
-        return ssh2_err(session, LIBSSH2_ERROR_PROTO, "type is invalid");
-
-    OSSL_INIT_IF_NEEDED();
-
-    rc = ssh2_openssh_pem_parse(session,
-                                privatekey, privkeyblob, privkeyblob_len,
-                                passphrase, &decrypted);
-    if(rc)
-        return rc;
-
-    /* We have a new key file, now try and parse it using supported types */
-    rc = ssh2_get_string(decrypted, &buf, NULL);
-    if(rc || !buf) {
-        rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                      "Public key type in decrypted key data not found");
-        goto cleanup;
-    }
-
-    rc = LIBSSH2_ERROR_FILE;
-
-    /* Avoid unused variable warnings when all branches below are disabled */
-    (void)method;
-    (void)pubkeydata;
-    (void)pubkeydata_len;
-
-#if LIBSSH2_ED25519
-    if(!strcmp("ssh-ed25519", (const char *)buf) &&
-       (!want_method || !strcmp("ssh-ed25519", want_method)))
-        rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
-                                                 method,
-                                                 pubkeydata, pubkeydata_len,
-                                                 (ssh2_ed25519_ctx **)key_ctx);
-
-    if(!strcmp("sk-ssh-ed25519@openssh.com", (const char *)buf) &&
-       (!want_method || !strcmp("sk-ssh-ed25519@openssh.com", want_method)))
-        rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                    method,
-                                                    pubkeydata, pubkeydata_len,
-                                                    NULL, NULL, NULL, NULL,
-                                                 (ssh2_ed25519_ctx **)key_ctx);
-#endif
-#if LIBSSH2_RSA
-    if(!strcmp("ssh-rsa", (const char *)buf) &&
-       (!want_method || !strcmp("ssh-rsa", want_method)))
-        rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
-                                             method,
-                                             pubkeydata, pubkeydata_len,
-                                             (ssh2_rsa_ctx **)key_ctx);
-#endif
-#if LIBSSH2_DSA
-    if(!strcmp("ssh-dss", (const char *)buf) &&
-       (!want_method || !strcmp("ssh-dss", want_method)))
-        rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
-                                             method,
-                                             pubkeydata, pubkeydata_len,
-                                             (ssh2_dsa_ctx **)key_ctx);
-#endif
-#if LIBSSH2_ECDSA
-    if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf))
-        rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
-                                                  method,
-                                                  pubkeydata, pubkeydata_len,
-                                                  NULL, NULL, NULL, NULL,
-                                                  (ssh2_ecdsa_ctx **)key_ctx);
-    else if(ossl_ecdsa_curve_type_from_name((const char *)buf, &type) == 0 &&
-            (!want_method || !strcmp("ssh-ecdsa", want_method)))
-        rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
-                                               method,
-                                               pubkeydata, pubkeydata_len,
-                                               (ssh2_ecdsa_ctx **)key_ctx);
-#endif
-
-    if(rc == LIBSSH2_ERROR_FILE)
-        rc = ssh2_err(session, LIBSSH2_ERROR_FILE,
-                      "Unable to extract public key from private key: "
-                      "invalid/unrecognized private key format");
-
-cleanup:
-
-    if(decrypted)
-        ssh2_string_buf_free(session, decrypted);
-
-    return rc;
-}
 
 static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                  void **key_ctx,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1971,48 +1971,33 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
                           const char *blob, size_t blob_len,
                           const char *passphrase)
 {
-    int rc;
+    int rc = 0;
+    BIO *bp = NULL;
+
+    OSSL_INIT_IF_NEEDED();
+
+    *ed_ctx = NULL;
 
     if(filename)
-        rc = ossl_key_from_openssh(session, (void **)ed_ctx, "ssh-ed25519",
-                                   NULL, NULL, NULL,
-                                   filename, NULL, 0, passphrase);
-    else {
-        ssh2_ed25519_ctx *ctx = NULL;
-        BIO *bp;
-
-        if(!session)
-            return -1;
-
-        OSSL_INIT_IF_NEEDED();
-
+        bp = BIO_new_file(filename, "r");
+    else
         bp = BIO_new_mem_buf(blob, (int)blob_len);
-        if(bp) {
-            ctx = PEM_read_bio_PrivateKey(bp, NULL, ossl_passphrase_cb,
+    if(bp)
+        *ed_ctx = PEM_read_bio_PrivateKey(bp, NULL, ossl_passphrase_cb,
                                           SSH2_UNCONST(passphrase));
-            BIO_free(bp);
-            if(ctx) {
-                if(EVP_PKEY_id(ctx) != EVP_PKEY_ED25519) {
-                    ssh2_ed25519_free(ctx);
-                    return ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                                    "Private key is not an ED25519 key");
-                }
-                rc = 0;
-                goto cleanup;
-            }
-        }
+    BIO_free(bp);
 
+    if(EVP_PKEY_id(*ed_ctx) != EVP_PKEY_ED25519) {
+        ssh2_ed25519_free(*ed_ctx);
+        *ed_ctx = NULL;
+        return ssh2_err(session, LIBSSH2_ERROR_PROTO,
+                        "Private key is not an ED25519 key");
+    }
+
+    if(!*ed_ctx)
         rc = ossl_key_from_openssh(session, (void **)ed_ctx, "ssh-ed25519",
                                    NULL, NULL, NULL,
-                                   NULL, blob, blob_len, passphrase);
-
-cleanup:
-
-        if(ed_ctx)
-            *ed_ctx = ctx;
-        else
-            ssh2_ed25519_free(ctx);
-    }
+                                   filename, blob, blob_len, passphrase);
 
     return rc;
 }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -150,7 +150,12 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
                                       void **key_ctx,
                                       const char *want_method,
+                                      char **method,
+                                      unsigned char **pubkeydata,
+                                      size_t *pubkeydata_len,
                                       const char *filename,
+                                      const char *privkeyblob,
+                                      size_t privkeyblob_len,
                                       const char *passphrase);
 
 static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
@@ -1346,7 +1351,8 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
     if(!*rsa) {
         if(filename)
             rc = ossl_key_from_openssh_file(session, (void **)rsa, "ssh-rsa",
-                                            filename, passphrase);
+                                            NULL, NULL, NULL,
+                                            filename, NULL, 0, passphrase);
         else
             rc = ossl_key_from_openssh(session, (void **)rsa, "ssh-rsa",
                                        NULL, NULL, NULL,
@@ -1583,7 +1589,8 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
     if(!*dsa) {
         if(filename)
             rc = ossl_key_from_openssh_file(session, (void **)dsa, "ssh-dss",
-                                            filename, passphrase);
+                                            NULL, NULL, NULL,
+                                            filename, NULL, 0, passphrase);
         else
             rc = ossl_key_from_openssh(session, (void **)dsa, "ssh-dss",
                                        NULL, NULL, NULL,
@@ -1992,7 +1999,8 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
 
     if(filename)
         rc = ossl_key_from_openssh_file(session, (void **)ctx, "ssh-ed25519",
-                                        filename, passphrase);
+                                        NULL, NULL, NULL,
+                                        filename, NULL, 0, passphrase);
     else {
         BIO *bp;
 
@@ -2914,7 +2922,8 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
         if(filename)
             rc = ossl_key_from_openssh_file(session,
                                             (void **)ec_ctx, "ssh-ecdsa",
-                                            filename, passphrase);
+                                            NULL, NULL, NULL,
+                                            filename, NULL, 0, passphrase);
         else
             rc = ossl_key_from_openssh(session, (void **)ec_ctx, "ssh-ecdsa",
                                        NULL, NULL, NULL,
@@ -3364,7 +3373,12 @@ clean_exit:
 static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
                                       void **key_ctx,
                                       const char *want_method,
+                                      char **method,
+                                      unsigned char **pubkeydata,
+                                      size_t *pubkeydata_len,
                                       const char *filename,
+                                      const char *privkeyblob,
+                                      size_t privkeyblob_len,
                                       const char *passphrase)
 {
     int rc;
@@ -3373,51 +3387,78 @@ static int ossl_key_from_openssh_file(LIBSSH2_SESSION *session,
 #if LIBSSH2_ECDSA
     ssh2_curve_type type;
 #endif
-    (void)want_method;
+
+    if(key_ctx)
+        *key_ctx = NULL;
 
     if(!session)
-        return -1;
+        return LIBSSH2_ERROR_BAD_USE;
+
+    if(want_method && strlen(want_method) < 7)
+        return ssh2_err(session, LIBSSH2_ERROR_PROTO, "type is invalid");
 
     OSSL_INIT_IF_NEEDED();
 
-    rc = ssh2_openssh_pem_parse(session, filename, NULL, 0, passphrase,
-                                &decrypted);
+    rc = ssh2_openssh_pem_parse(session,
+                                filename, NULL, 0,
+                                passphrase, &decrypted);
     if(rc)
         return rc;
 
     /* We have a new key file, now try and parse it using supported types */
     rc = ssh2_get_string(decrypted, &buf, NULL);
     if(rc || !buf) {
-        ssh2_err(session, LIBSSH2_ERROR_PROTO,
-                 "Public key type in decrypted key data not found");
-        rc = -1;
+        rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
+                      "Public key type in decrypted key data not found");
         goto cleanup;
     }
 
+    rc = LIBSSH2_ERROR_FILE;
+
+    /* Avoid unused variable warnings when all branches below are disabled */
+    (void)method;
+    (void)pubkeydata;
+    (void)pubkeydata_len;
+
 #if LIBSSH2_ED25519
-    if(!strcmp("ssh-ed25519", (const char *)buf))
+    if(!strcmp("ssh-ed25519", (const char *)buf) &&
+       (!want_method || !strcmp("ssh-ed25519", want_method)))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
                                                  NULL, NULL, NULL,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 #endif
 #if LIBSSH2_RSA
-    if(!strcmp("ssh-rsa", (const char *)buf))
+    if(!strcmp("ssh-rsa", (const char *)buf) &&
+       (!want_method || !strcmp("ssh-rsa", want_method)))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
                                              NULL, NULL, NULL,
                                              (ssh2_rsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_DSA
-    if(!strcmp("ssh-dss", (const char *)buf))
+    if(!strcmp("ssh-dss", (const char *)buf) &&
+       (!want_method || !strcmp("ssh-dss", want_method)))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
                                              NULL, NULL, NULL,
                                              (ssh2_dsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_ECDSA
-    if(ossl_ecdsa_curve_type_from_name((const char *)buf, &type) == 0)
+    if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", (const char *)buf))
+        rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
+                                                  method,
+                                                  pubkeydata, pubkeydata_len,
+                                                  NULL, NULL, NULL, NULL,
+                                                  (ssh2_ecdsa_ctx **)key_ctx);
+    else if(ossl_ecdsa_curve_type_from_name((const char *)buf, &type) == 0 &&
+            (!want_method || !strcmp("ssh-ecdsa", want_method)))
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
                                                NULL, NULL, NULL,
                                                (ssh2_ecdsa_ctx **)key_ctx);
 #endif
+
+    if(rc == LIBSSH2_ERROR_FILE)
+        rc = ssh2_err(session, LIBSSH2_ERROR_FILE,
+                      "Unable to extract public key from private key: "
+                      "invalid/unrecognized private key format");
 
 cleanup:
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1971,14 +1971,14 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
                           const char *blob, size_t blob_len,
                           const char *passphrase)
 {
-    ssh2_ed25519_ctx *ctx = NULL;
     int rc;
 
     if(filename)
-        rc = ossl_key_from_openssh(session, (void **)ctx, "ssh-ed25519",
+        rc = ossl_key_from_openssh(session, (void **)ed_ctx, "ssh-ed25519",
                                    NULL, NULL, NULL,
                                    filename, NULL, 0, passphrase);
     else {
+        ssh2_ed25519_ctx *ctx = NULL;
         BIO *bp;
 
         if(!session)
@@ -2005,14 +2005,14 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
         rc = ossl_key_from_openssh(session, (void **)ed_ctx, "ssh-ed25519",
                                    NULL, NULL, NULL,
                                    NULL, blob, blob_len, passphrase);
-    }
 
 cleanup:
 
-    if(ed_ctx)
-        *ed_ctx = ctx;
-    else
-        ssh2_ed25519_free(ctx);
+        if(ed_ctx)
+            *ed_ctx = ctx;
+        else
+            ssh2_ed25519_free(ctx);
+    }
 
     return rc;
 }


### PR DESCRIPTION
Merging `ossl_*_openssh_priv_new()` functions and syncing the result up
with `ossl_key_from_openssh()` ends up with an almost identical function
(with the newly merged ones supporting filenames, not blobs). Therefore
replace these calls with the latter, and drop the redundant code.

This also syncs up recognized keys loaded from filenames with those 
loaded from memory buffers.

Also:
- sync `ssh2_ed25519_new_priv()` with sibling functions, also merging
  its file/blob codepaths. It means the filename codepath now uses
  OpenSSL's built-in loader first, and resorts to libssh2's own loader
  if OpenSSL's failed.
  Follow-up to b560cb4c7bf268ba4cbb1947a417facb676b9782 #2379

Follow-up to 3bb068e48de11d12b848f645b2200063510d651b #2394
