### PR TITLE
openssl: fix potential OOB read/write with AES-GCM in `ssh2_cipher_crypt()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -946,13 +946,15 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo), int encrypt,
     const int aadlen = (is_aesgcm && IS_FIRST(firstlast)) ? 4 : 0;
     /* size of AT, if present */
     const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
-    /* length to encrypt */
-    const int cryptlen = (unsigned int)blocksize - aadlen - authenticationtag;
+    unsigned int cryptlen; /* length to encrypt */
 
     (void)algo;
 
-    assert(blocksize <= sizeof(buf));
-    assert(cryptlen >= 0);
+    if(blocksize > sizeof(buf) ||
+       blocksize < (size_t)(aadlen + authenticationtag))
+        return 1;
+
+    cryptlen = (unsigned int)blocksize - aadlen - authenticationtag;
 
 #if LIBSSH2_AES_GCM
     /* First block */


### PR DESCRIPTION
By applying two bounds checks to non-debug builds.

Reported-by: Vladimir Eli Tokarev
Fixes GHSA-c4f7-cvfc-33j7
Reported-by: Trzik on github
Fixes #1491
Thanks-to: Afonso Januário
Follow-up to 3c953c05d67eb1ebcfd3316f279f12c4b1d600b4 #797
