### PR TITLE
pem: NUL-terminate decrypted OpenSSH key buffer to fix OOB read

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -670,7 +670,10 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        out_buf->data = SSH2_CALLOC(session, decrypted.len);
+        /* allocate one extra (zeroed) byte so the buffer is NUL-terminated;
+           ossl_key_from_openssh() runs strcmp() over the key type string it
+           reads back out of here */
+        out_buf->data = SSH2_CALLOC(session, decrypted.len + 1);
         if(!out_buf->data) {
             ret = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                            "Unable to allocate memory for decrypted struct");


### PR DESCRIPTION
pem_parse_data_openssh() copies the decrypted OpenSSH private key into a buffer sized to exactly decrypted.len, but ossl_key_from_openssh() then runs strcmp() against the key type string it reads back out of that buffer, so a "none"-cipher key whose private section ends right after the type name reads one byte past the allocation. The "none" path skips the block and padding handling, so the length is fully attacker-controlled and no padding byte trails the name. This allocates one extra zeroed byte so the buffer is NUL-terminated, the same way ssh2_file_to_blob() already terminates the file path.

Caught with AddressSanitizer feeding a crafted openssh-key-v1 blob whose private section is just check1, check2 and a "ssh-ed25519" type string: heap-buffer-overflow READ in ossl_key_from_openssh() before, clean after, and valid ed25519/rsa keys still load unchanged.