### PR TITLE
src: add `static` to const strings and tables, where missing

### DIFF
--- a/src/cipher-chachapoly.c
+++ b/src/cipher-chachapoly.c
@@ -56,10 +56,10 @@ int chachapoly_crypt(struct chachapoly_ctx *ctx, libssh2_uint64_t seqnr,
                      unsigned char *dest, const unsigned char *src, size_t len,
                      size_t aadlen, int do_encrypt)
 {
-    unsigned char seqbuf[8];
-    const unsigned char one[8] = {
+    static const unsigned char one[8] = {
         1, 0, 0, 0, 0, 0, 0, 0  /* NB little-endian */
     };
+    unsigned char seqbuf[8];
     unsigned char expected_tag[POLY1305_TAGLEN], poly_key[POLY1305_KEYLEN];
     int r = LIBSSH2_ERROR_INVAL;
     unsigned char *ptr = NULL;

--- a/src/kex.c
+++ b/src/kex.c
@@ -3301,7 +3301,6 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session, unsigned char *kex,
                                  size_t hostkey_len)
 {
     static const char strict[] = "kex-strict-s-v00@openssh.com";
-
     const struct kex_method **kexp = kex_methods;
     unsigned char *s;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1651,7 +1651,7 @@ static int ossl_ed25519_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
                                       size_t *pubkeydata_len,
                                       EVP_PKEY *pk)
 {
-    const char method_name[] = "ssh-ed25519";
+    static const char method_name[] = "ssh-ed25519";
     char *method_buf = NULL;
     size_t rawKeyLen = 0;
     unsigned char *pub_key = NULL;
@@ -1716,8 +1716,8 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                                size_t *pubkeydata_len,
                                                ssh2_ed25519_ctx **ed_ctx)
 {
+    static const char method_name[] = "ssh-ed25519";
     ssh2_ed25519_ctx *ctx = NULL;
-    const char method_name[] = "ssh-ed25519";
     char *method_buf = NULL;
     unsigned char *key = NULL;
     int i;
@@ -1837,8 +1837,7 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
     size_t *key_handle_len,
     ssh2_ed25519_ctx **ed_ctx)
 {
-    const char method_name[] = "sk-ssh-ed25519@openssh.com";
-
+    static const char method_name[] = "sk-ssh-ed25519@openssh.com";
     ssh2_ed25519_ctx *ctx = NULL;
     char *method_buf = NULL;
     unsigned char *key = NULL;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1233,7 +1233,6 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
 static int userauth_key_sign_algs(LIBSSH2_SESSION *session, char **method)
 {
     static const char suffix[] = "-cert-v01@openssh.com";
-    static const size_t suffix_len = sizeof(suffix) - 1;
     static const char rsa_method[] = "ssh-rsa-cert-v01@openssh.com";
     static const char remote_ver_pre[] = "OpenSSH_";
 
@@ -1344,10 +1343,10 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session, char **method)
     if(match) {
         if(*method && !strcmp(*method, rsa_method)) {
             SSH2_FREE(session, *method);
-            *method = SSH2_ALLOC(session, match_len + suffix_len + 1);
+            *method = SSH2_ALLOC(session, match_len + sizeof(suffix));
             if(*method) {
                 memcpy(*method, match, match_len);
-                memcpy(*method + match_len, suffix, suffix_len + 1);
+                memcpy(*method + match_len, suffix, sizeof(suffix));
             }
         }
         else {

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1232,6 +1232,11 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
  */
 static int userauth_key_sign_algs(LIBSSH2_SESSION *session, char **method)
 {
+    static const char * const suffix = "-cert-v01@openssh.com";
+    static const size_t suffix_len = sizeof("-cert-v01@openssh.com") - 1;
+    static const char * const rsa_method = "ssh-rsa-cert-v01@openssh.com";
+    static const char * const remote_ver_pre = "OpenSSH_";
+
     const char *s = NULL;
     const char *a = NULL;
     const char *match = NULL;
@@ -1243,11 +1248,7 @@ static int userauth_key_sign_algs(LIBSSH2_SESSION *session, char **method)
     int rc = 0;
     size_t match_len = 0;
     char *filtered_algs = NULL;
-    const char * const suffix = "-cert-v01@openssh.com";
-    const size_t suffix_len = sizeof("-cert-v01@openssh.com") - 1;
-    const char * const rsa_method = "ssh-rsa-cert-v01@openssh.com";
     const char *remote_banner = NULL;
-    const char * const remote_ver_pre = "OpenSSH_";
 
     const char *supported_algs = userauth_supported_key_sign_algs(session,
                                                                   *method);

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1232,10 +1232,10 @@ static const char *userauth_supported_key_sign_algs(LIBSSH2_SESSION *session,
  */
 static int userauth_key_sign_algs(LIBSSH2_SESSION *session, char **method)
 {
-    static const char * const suffix = "-cert-v01@openssh.com";
-    static const size_t suffix_len = sizeof("-cert-v01@openssh.com") - 1;
-    static const char * const rsa_method = "ssh-rsa-cert-v01@openssh.com";
-    static const char * const remote_ver_pre = "OpenSSH_";
+    static const char suffix[] = "-cert-v01@openssh.com";
+    static const size_t suffix_len = sizeof(suffix) - 1;
+    static const char rsa_method[] = "ssh-rsa-cert-v01@openssh.com";
+    static const char remote_ver_pre[] = "OpenSSH_";
 
     const char *s = NULL;
     const char *a = NULL;


### PR DESCRIPTION
Also:
- replace `char * const` with `[]`.
- de-duplicate a string.
- replace interim length variable with `sizeof()`.
