### PR TITLE
crypto: rename `ssh2_dh_is_valid()` to `ssh2_dh_validate()`

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -310,7 +310,7 @@ int ssh2_bn_to_bin(const ssh2_bn *bn, unsigned char *bin);
 void ssh2_dh_init(ssh2_dh_ctx *dhctx);
 int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
                      ssh2_bn *p, int group_order, ssh2_bn_ctx *bnctx);
-int ssh2_dh_is_valid(ssh2_bn *f, ssh2_bn *p); /* for unit tests */
+int ssh2_dh_validate(ssh2_bn *f, ssh2_bn *p); /* for unit tests */
 int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                    ssh2_bn *p, ssh2_bn_ctx *bnctx);
 void ssh2_dh_dtor(ssh2_dh_ctx *dhctx);

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -696,7 +696,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     return 0;
 }
 
-int ssh2_dh_is_valid(ssh2_bn *f, ssh2_bn *p)
+int ssh2_dh_validate(ssh2_bn *f, ssh2_bn *p)
 {
     gcry_mpi_t tmp;
     unsigned int n, i, bits_set;
@@ -729,7 +729,7 @@ int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
 {
     (void)bnctx;
 
-    if(ssh2_dh_is_valid(f, p))  /* Verify if parameters are valid */
+    if(ssh2_dh_validate(f, p))  /* Verify if parameters are valid */
         return -1;
 
     /* Compute the shared secret */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -696,7 +696,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     return 0;
 }
 
-int ssh2_dh_is_valid(ssh2_bn *f, ssh2_bn *p)
+int ssh2_dh_validate(ssh2_bn *f, ssh2_bn *p)
 {
     mbedtls_mpi one, tmp;
     size_t n, i, bits_set;
@@ -743,7 +743,7 @@ int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
 {
     (void)bnctx;
 
-    if(ssh2_dh_is_valid(f, p))  /* Verify if parameters are valid */
+    if(ssh2_dh_validate(f, p))  /* Verify if parameters are valid */
         return -1;
 
     /* Compute the shared secret */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3650,7 +3650,7 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, ssh2_bn *g,
     return 0;
 }
 
-int ssh2_dh_is_valid(ssh2_bn *f, ssh2_bn *p)
+int ssh2_dh_validate(ssh2_bn *f, ssh2_bn *p)
 {
     BIGNUM *tmp;
     int n, i, bits_set;
@@ -3684,7 +3684,7 @@ int ssh2_dh_is_valid(ssh2_bn *f, ssh2_bn *p)
 int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
                    ssh2_bn *p, ssh2_bn_ctx *bnctx)
 {
-    if(ssh2_dh_is_valid(f, p))  /* Verify if parameters are valid */
+    if(ssh2_dh_validate(f, p))  /* Verify if parameters are valid */
         return -1;
 
     /* Compute the shared secret */

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -58,7 +58,7 @@ static int test_ssh2_base64_decode(LIBSSH2_SESSION *session)
     return 0;
 }
 
-static int test_ssh2_dh_is_valid(void)
+static int test_ssh2_dh_validate(void)
 {
     struct tbn {
         const char *f; const char *p; int expected;
@@ -85,7 +85,7 @@ static int test_ssh2_dh_is_valid(void)
         gcry_mpi_t p = gcry_mpi_set_ui(NULL, atoi(tests[i].p));
         if(tests[i].f[0] == '-')
             gcry_mpi_neg(f, f);
-        got = ssh2_dh_is_valid(f, p);
+        got = ssh2_dh_validate(f, p);
         gcry_mpi_release(f);
         gcry_mpi_release(p);
 #elif defined(LIBSSH2_MBEDTLS)
@@ -96,7 +96,7 @@ static int test_ssh2_dh_is_valid(void)
            mbedtls_mpi_read_string(&p, 10, tests[i].p))
             got = -9;
         else
-            got = ssh2_dh_is_valid(&f, &p);
+            got = ssh2_dh_validate(&f, &p);
         mbedtls_mpi_free(&f);
         mbedtls_mpi_free(&p);
 #elif defined(LIBSSH2_OPENSSL) || \
@@ -106,7 +106,7 @@ static int test_ssh2_dh_is_valid(void)
            !BN_dec2bn(&p, tests[i].p))
             got = -9;
         else
-            got = ssh2_dh_is_valid(f, p);
+            got = ssh2_dh_validate(f, p);
         BN_free(f);
         BN_free(p);
 #else
@@ -114,7 +114,7 @@ static int test_ssh2_dh_is_valid(void)
 #endif
         if(got != tests[i].expected) {
             fprintf(stderr,
-                    "ssh2_dh_is_valid/%lu: f=%s p=%s: expected %d got %d\n",
+                    "ssh2_dh_validate/%lu: f=%s p=%s: expected %d got %d\n",
                     (unsigned long)i,
                     tests[i].f, tests[i].p, tests[i].expected, got);
             err++;
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
     }
 
     rc = test_ssh2_base64_decode(session);
-    rc |= test_ssh2_dh_is_valid();
+    rc |= test_ssh2_dh_validate();
 
     libssh2_session_free(session);
 


### PR DESCRIPTION
To reflect that the return value is not a boolean.

Reported-by: Patrick Monnerat
Bug: https://github.com/libssh2/libssh2/pull/2402#discussion_r3637772506
Follow-up to fcf830788d0c8dcd6bed7dcd532506aabf196523 #2239

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
