### PR TITLE
mac: use HMAC stub for chacha20-poly1305@openssh.com

### DIFF
--- a/src/mac.c
+++ b/src/mac.c
@@ -423,11 +423,11 @@ static int mac_method_none_dtor(LIBSSH2_SESSION *session, void **abstract)
     return 0;
 }
 
-/* Stub for chacha20-poly1305@openssh.com and aes256-gcm@openssh.com crypto
-   types, which have an integrated HMAC method. This must not be added to
-   mac_methods[] since it cannot be negotiated separately. */
+/* Stub for AEAD ciphers which provide an integrated authentication tag.
+   This must not be added to mac_methods[] since it cannot be negotiated
+   separately. */
 static const struct mac_method mac_method_hmac_integrated = {
-    "INTEGRATED-HMAC",  /* made up name for display only */
+    "INTEGRATED-MAC",  /* made up name for display only */
     16,
     16,
     mac_method_none_init,

--- a/src/mac.c
+++ b/src/mac.c
@@ -426,7 +426,7 @@ static int mac_method_none_dtor(LIBSSH2_SESSION *session, void **abstract)
 /* Stub for AEAD ciphers which provide an integrated authentication tag.
    This must not be added to mac_methods[] since it cannot be negotiated
    separately. */
-static const struct mac_method mac_method_hmac_integrated = {
+static const struct mac_method mac_method_integrated = {
     "INTEGRATED-MAC",  /* made up name for display only */
     16,
     16,
@@ -441,11 +441,11 @@ static const struct mac_method mac_method_hmac_integrated = {
 const struct mac_method *ssh2_mac_override(const struct crypt_method *crypt)
 {
     if(!strcmp(crypt->name, "chacha20-poly1305@openssh.com"))
-        return &mac_method_hmac_integrated;
+        return &mac_method_integrated;
 #if LIBSSH2_AES_GCM
     if(!strcmp(crypt->name, "aes256-gcm@openssh.com") ||
        !strcmp(crypt->name, "aes128-gcm@openssh.com"))
-        return &mac_method_hmac_integrated;
+        return &mac_method_integrated;
 #endif
     return NULL;
 }

--- a/src/mac.c
+++ b/src/mac.c
@@ -398,12 +398,12 @@ static int mac_method_none_init(LIBSSH2_SESSION *session, unsigned char *key,
     return 0;
 }
 
-static int mac_method_hmac_none_hash(LIBSSH2_SESSION *session,
-                                     unsigned char *buf, uint32_t seqno,
-                                     const unsigned char *packet,
-                                     size_t packet_len,
-                                     const unsigned char *addtl,
-                                     size_t addtl_len, void **abstract)
+static int mac_method_none_hash(LIBSSH2_SESSION *session,
+                                unsigned char *buf, uint32_t seqno,
+                                const unsigned char *packet,
+                                size_t packet_len,
+                                const unsigned char *addtl,
+                                size_t addtl_len, void **abstract)
 {
     (void)session;
     (void)buf;
@@ -431,7 +431,7 @@ static const struct mac_method mac_method_integrated = {
     16,
     16,
     mac_method_none_init,
-    mac_method_hmac_none_hash,
+    mac_method_none_hash,
     mac_method_none_dtor,
     0
 };

--- a/src/mac.c
+++ b/src/mac.c
@@ -388,7 +388,6 @@ const struct mac_method **ssh2_mac_methods(void)
     return mac_methods;
 }
 
-#if LIBSSH2_AES_GCM
 static int mac_method_none_init(LIBSSH2_SESSION *session, unsigned char *key,
                                 int *free_key, void **abstract)
 {
@@ -424,11 +423,11 @@ static int mac_method_none_dtor(LIBSSH2_SESSION *session, void **abstract)
     return 0;
 }
 
-/* Stub for aes256-gcm@openssh.com crypto type, which has an integrated
-   HMAC method. This must not be added to mac_methods[] since it cannot be
-   negotiated separately. */
-static const struct mac_method mac_method_hmac_aesgcm = {
-    "INTEGRATED-AES-GCM",  /* made up name for display only */
+/* Stub for chacha20-poly1305@openssh.com and aes256-gcm@openssh.com crypto
+   types, which have an integrated HMAC method. This must not be added to
+   mac_methods[] since it cannot be negotiated separately. */
+static const struct mac_method mac_method_hmac_integrated = {
+    "INTEGRATED-HMAC",  /* made up name for display only */
     16,
     16,
     mac_method_none_init,
@@ -436,18 +435,17 @@ static const struct mac_method mac_method_hmac_aesgcm = {
     mac_method_none_dtor,
     0
 };
-#endif /* LIBSSH2_AES_GCM */
 
 /* See if the negotiated crypto method has its own authentication scheme that
  * obviates the need for a separate negotiated hmac method */
 const struct mac_method *ssh2_mac_override(const struct crypt_method *crypt)
 {
+    if(!strcmp(crypt->name, "chacha20-poly1305@openssh.com"))
+        return &mac_method_hmac_integrated;
 #if LIBSSH2_AES_GCM
     if(!strcmp(crypt->name, "aes256-gcm@openssh.com") ||
        !strcmp(crypt->name, "aes128-gcm@openssh.com"))
-        return &mac_method_hmac_aesgcm;
-#else
-    (void)crypt;
-#endif /* LIBSSH2_AES_GCM */
+        return &mac_method_hmac_integrated;
+#endif
     return NULL;
 }


### PR DESCRIPTION
Reuse the stub already used for AES-GCM.

Reported-by: afldl on github
Ref: #2023
Follow-up to 492bc543bbb6ee39df588e2bffdd3478aff2f7e5 #1426

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
