### PR TITLE
scp: drain long C-response basenames past fixed buffer

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -672,7 +672,7 @@ struct _LIBSSH2_PUBLICKEY {
 #define SSH2_SCP_RESPONSE_BUFLEN     256
 
 /* Parse SCP "C" response mode/size; used by scp_recv and unit tests. */
-int ssh2_scp_parse_c_fields(const unsigned char *buf, size_t len,
+int ssh2_scp_parse_c_fields(const char *buf, size_t len,
                             long *mode_out, libssh2_int64_t *size_out);
 
 struct flags {

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -671,6 +671,10 @@ struct _LIBSSH2_PUBLICKEY {
 
 #define SSH2_SCP_RESPONSE_BUFLEN     256
 
+/* Parse SCP "C" response mode/size; used by scp_recv and unit tests. */
+int ssh2_scp_parse_c_fields(const unsigned char *buf, size_t len,
+                            long *mode_out, libssh2_int64_t *size_out);
+
 struct flags {
     int sigpipe;     /* LIBSSH2_FLAG_SIGPIPE */
     int compress;    /* LIBSSH2_FLAG_COMPRESS */

--- a/src/scp.c
+++ b/src/scp.c
@@ -99,8 +99,7 @@ int ssh2_scp_parse_c_fields(const unsigned char *buf, size_t len,
     if(!size_len)
         return (i >= len) ? SCP_C_FIELDS_INCOMPLETE : SCP_C_FIELDS_MALFORMED;
     if(i >= len)
-        /* size digits may still continue */
-        return SCP_C_FIELDS_INCOMPLETE;
+        return SCP_C_FIELDS_INCOMPLETE; /* size digits may still continue */
     if(buf[i] != ' ' && buf[i] != '\r' && buf[i] != '\n')
         return SCP_C_FIELDS_MALFORMED;
 

--- a/src/scp.c
+++ b/src/scp.c
@@ -68,7 +68,7 @@
  *
  * Returns SCP_C_FIELDS_OK, SCP_C_FIELDS_INCOMPLETE, or SCP_C_FIELDS_MALFORMED.
  */
-int ssh2_scp_parse_c_fields(const unsigned char *buf, size_t len,
+int ssh2_scp_parse_c_fields(const char *buf, size_t len,
                             long *mode_out, libssh2_int64_t *size_out)
 {
     size_t i;
@@ -695,9 +695,9 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 int prc;
 
                 /* Complete line in the fixed buffer (common case). */
-                prc = ssh2_scp_parse_c_fields(session->scpRecv_response,
-                                              session->scpRecv_response_len,
-                                              &mode, &size);
+                prc = ssh2_scp_parse_c_fields(
+                    (const char *)session->scpRecv_response,
+                    session->scpRecv_response_len, &mode, &size);
                 if(prc != SCP_C_FIELDS_OK) {
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid response from SCP server");
@@ -722,9 +722,9 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                  * we have and drain the rest of the name until newline
                  * (basename is unused by libssh2).
                  */
-                prc = ssh2_scp_parse_c_fields(session->scpRecv_response,
-                                              session->scpRecv_response_len,
-                                              &mode, &size);
+                prc = ssh2_scp_parse_c_fields(
+                    (const char *)session->scpRecv_response,
+                    session->scpRecv_response_len, &mode, &size);
                 if(prc == SCP_C_FIELDS_OK) {
                     session->scpRecv_mode = mode;
                     session->scpRecv_size = size;

--- a/src/scp.c
+++ b/src/scp.c
@@ -55,7 +55,7 @@
 /* ssh2_scp_parse_c_fields() results */
 #define SCP_C_FIELDS_OK          0
 #define SCP_C_FIELDS_INCOMPLETE  1
-#define SCP_C_FIELDS_MALFORMED  (-1)
+#define SCP_C_FIELDS_MALFORMED   (-1)
 
 /*
  * Parse mode and size from an SCP "C" response line fragment.

--- a/src/scp.c
+++ b/src/scp.c
@@ -76,62 +76,50 @@ int ssh2_scp_parse_c_fields(const unsigned char *buf, size_t len,
     char tmp[32];
     char *end = NULL;
 
-    if(!buf || len < 1 || buf[0] != 'C') {
+    if(!buf || len < 1 || buf[0] != 'C')
         return SCP_C_FIELDS_MALFORMED;
-    }
 
     i = 1;
     mode_start = i;
-    while(i < len && buf[i] >= '0' && buf[i] <= '7') {
+    while(i < len && buf[i] >= '0' && buf[i] <= '7')
         i++;
-    }
     mode_len = i - mode_start;
-    if(!mode_len) {
+    if(!mode_len)
         return (i >= len) ? SCP_C_FIELDS_INCOMPLETE : SCP_C_FIELDS_MALFORMED;
-    }
-    if(i >= len) {
+    if(i >= len)
         return SCP_C_FIELDS_INCOMPLETE;
-    }
-    if(buf[i] != ' ') {
+    if(buf[i] != ' ')
         return SCP_C_FIELDS_MALFORMED;
-    }
     i++; /* skip space after mode */
 
     size_start = i;
-    while(i < len && buf[i] >= '0' && buf[i] <= '9') {
+    while(i < len && buf[i] >= '0' && buf[i] <= '9')
         i++;
-    }
     size_len = i - size_start;
-    if(!size_len) {
+    if(!size_len)
         return (i >= len) ? SCP_C_FIELDS_INCOMPLETE : SCP_C_FIELDS_MALFORMED;
-    }
-    if(i >= len) {
+    if(i >= len)
         /* size digits may still continue */
         return SCP_C_FIELDS_INCOMPLETE;
-    }
-    if(buf[i] != ' ' && buf[i] != '\r' && buf[i] != '\n') {
+    if(buf[i] != ' ' && buf[i] != '\r' && buf[i] != '\n')
         return SCP_C_FIELDS_MALFORMED;
-    }
 
-    if(mode_len >= sizeof(tmp) || size_len >= sizeof(tmp)) {
+    if(mode_len >= sizeof(tmp) || size_len >= sizeof(tmp))
         return SCP_C_FIELDS_MALFORMED;
-    }
 
     memcpy(tmp, buf + mode_start, mode_len);
     tmp[mode_len] = '\0';
     /* !checksrc! disable BANNEDFUNC 1 */
     *mode_out = strtol(tmp, &end, 8);
-    if(end && *end) {
+    if(end && *end)
         return SCP_C_FIELDS_MALFORMED;
-    }
 
     memcpy(tmp, buf + size_start, size_len);
     tmp[size_len] = '\0';
     end = NULL;
     *size_out = (libssh2_int64_t)scpsize_strtol(tmp, &end, 10);
-    if(end && *end) {
+    if(end && *end)
         return SCP_C_FIELDS_MALFORMED;
-    }
 
     return SCP_C_FIELDS_OK;
 }
@@ -733,7 +721,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                  * Fixed buffer is full without a newline. Mode and size always
                  * fit early; a long basename overflows the buffer. Parse what
                  * we have and drain the rest of the name until newline
-                 * (basename is unused by libssh2). See issue #1738.
+                 * (basename is unused by libssh2).
                  */
                 prc = ssh2_scp_parse_c_fields(session->scpRecv_response,
                                               session->scpRecv_response_len,
@@ -753,7 +741,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
         }
     }
 
-    /* Drain remaining basename after the fixed buffer filled (#1738). */
+    /* Drain remaining basename after the fixed buffer filled. */
     if(session->scpRecv_state == ssh2_NB_state_jump1) {
         for(;;) {
             unsigned char discard;

--- a/src/scp.c
+++ b/src/scp.c
@@ -49,6 +49,93 @@
 /* Max. length of a quoted string after scp_shell_quotearg() processing */
 #define shell_quotedsize(s)  (3 * strlen(s) + 2)
 
+/* Cap on basename bytes drained after the fixed response buffer is full */
+#define SCP_C_NAME_DRAIN_MAX  (64 * 1024)
+
+/* ssh2_scp_parse_c_fields() results */
+#define SCP_C_FIELDS_OK          0
+#define SCP_C_FIELDS_INCOMPLETE  1
+#define SCP_C_FIELDS_MALFORMED  (-1)
+
+/*
+ * Parse mode and size from an SCP "C" response line fragment.
+ *
+ * Format: C<octal-mode> <decimal-size> <name>\n
+ *
+ * The basename (and trailing newline) need not be present yet. Once the size
+ * field is terminated by a space or end-of-line character, mode and size are
+ * considered complete. libssh2 does not use the basename.
+ *
+ * Returns SCP_C_FIELDS_OK, SCP_C_FIELDS_INCOMPLETE, or SCP_C_FIELDS_MALFORMED.
+ */
+int ssh2_scp_parse_c_fields(const unsigned char *buf, size_t len,
+                            long *mode_out, libssh2_int64_t *size_out)
+{
+    size_t i;
+    size_t mode_start, mode_len, size_start, size_len;
+    char tmp[32];
+    char *end = NULL;
+
+    if(!buf || len < 1 || buf[0] != 'C') {
+        return SCP_C_FIELDS_MALFORMED;
+    }
+
+    i = 1;
+    mode_start = i;
+    while(i < len && buf[i] >= '0' && buf[i] <= '7') {
+        i++;
+    }
+    mode_len = i - mode_start;
+    if(!mode_len) {
+        return (i >= len) ? SCP_C_FIELDS_INCOMPLETE : SCP_C_FIELDS_MALFORMED;
+    }
+    if(i >= len) {
+        return SCP_C_FIELDS_INCOMPLETE;
+    }
+    if(buf[i] != ' ') {
+        return SCP_C_FIELDS_MALFORMED;
+    }
+    i++; /* skip space after mode */
+
+    size_start = i;
+    while(i < len && buf[i] >= '0' && buf[i] <= '9') {
+        i++;
+    }
+    size_len = i - size_start;
+    if(!size_len) {
+        return (i >= len) ? SCP_C_FIELDS_INCOMPLETE : SCP_C_FIELDS_MALFORMED;
+    }
+    if(i >= len) {
+        /* size digits may still continue */
+        return SCP_C_FIELDS_INCOMPLETE;
+    }
+    if(buf[i] != ' ' && buf[i] != '\r' && buf[i] != '\n') {
+        return SCP_C_FIELDS_MALFORMED;
+    }
+
+    if(mode_len >= sizeof(tmp) || size_len >= sizeof(tmp)) {
+        return SCP_C_FIELDS_MALFORMED;
+    }
+
+    memcpy(tmp, buf + mode_start, mode_len);
+    tmp[mode_len] = '\0';
+    /* !checksrc! disable BANNEDFUNC 1 */
+    *mode_out = strtol(tmp, &end, 8);
+    if(end && *end) {
+        return SCP_C_FIELDS_MALFORMED;
+    }
+
+    memcpy(tmp, buf + size_start, size_len);
+    tmp[size_len] = '\0';
+    end = NULL;
+    *size_out = (libssh2_int64_t)scpsize_strtol(tmp, &end, 10);
+    if(end && *end) {
+        return SCP_C_FIELDS_MALFORMED;
+    }
+
+    return SCP_C_FIELDS_OK;
+}
+
 /* This function quotes a string in a way suitable to be used with a
    shell, e.g. the filename
    one two
@@ -577,149 +664,152 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
         session->scpRecv_state = ssh2_NB_state_sent5;
     }
 
-    if(session->scpRecv_state == ssh2_NB_state_sent5 ||
-       session->scpRecv_state == ssh2_NB_state_sent6) {
+    if(session->scpRecv_state == ssh2_NB_state_sent5) {
         while(session->scpRecv_response_len < SSH2_SCP_RESPONSE_BUFLEN) {
-            char *s, *p, *e = NULL;
+            unsigned char last;
 
-            if(session->scpRecv_state == ssh2_NB_state_sent5) {
-                rc = (int)ssh2_channel_read(session->scpRecv_channel, 0,
-                                            (char *)session->
-                                            scpRecv_response +
-                                            session->scpRecv_response_len, 1);
-                if(rc == LIBSSH2_ERROR_EAGAIN) {
-                    ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
-                             "Would block waiting for SCP response");
-                    return NULL;
-                }
-                else if(rc < 0) {
-                    /* error, bail out */
-                    ssh2_err(session, rc, "Failed reading SCP response");
-                    goto scp_recv_error;
-                }
-                else if(rc == 0)
-                    goto scp_recv_empty_channel;
+            rc = (int)ssh2_channel_read(session->scpRecv_channel, 0,
+                                        (char *)session->
+                                        scpRecv_response +
+                                        session->scpRecv_response_len, 1);
+            if(rc == LIBSSH2_ERROR_EAGAIN) {
+                ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
+                         "Would block waiting for SCP response");
+                return NULL;
+            }
+            else if(rc < 0) {
+                /* error, bail out */
+                ssh2_err(session, rc, "Failed reading SCP response");
+                goto scp_recv_error;
+            }
+            else if(rc == 0)
+                goto scp_recv_empty_channel;
 
-                session->scpRecv_response_len++;
+            session->scpRecv_response_len++;
+            last = session->scpRecv_response[
+                session->scpRecv_response_len - 1];
 
-                if(session->scpRecv_response[0] != 'C') {
+            if(session->scpRecv_response[0] != 'C') {
+                ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
+                         "Invalid response from SCP server");
+                goto scp_recv_error;
+            }
+
+            if(session->scpRecv_response_len > 1 &&
+               last != '\r' && last != '\n' && last < 32) {
+                ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
+                         "Invalid data in SCP response");
+                goto scp_recv_error;
+            }
+
+            if(last == '\n') {
+                long mode = 0;
+                libssh2_int64_t size = 0;
+                int prc;
+
+                /* Complete line in the fixed buffer (common case). */
+                prc = ssh2_scp_parse_c_fields(session->scpRecv_response,
+                                              session->scpRecv_response_len,
+                                              &mode, &size);
+                if(prc != SCP_C_FIELDS_OK) {
                     ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
                              "Invalid response from SCP server");
                     goto scp_recv_error;
                 }
-
-                if(session->scpRecv_response_len > 1 &&
-                   session->scpRecv_response[session->scpRecv_response_len -
-                                             1] != '\r' &&
-                   session->scpRecv_response[session->scpRecv_response_len -
-                                             1] != '\n' &&
-                   session->scpRecv_response[session->scpRecv_response_len -
-                                             1] < 32) {
-                    ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                             "Invalid data in SCP response");
-                    goto scp_recv_error;
-                }
-
-                if(session->scpRecv_response_len < 7 ||
-                   session->scpRecv_response[session->scpRecv_response_len -
-                                             1] != '\n') {
-                    if(session->scpRecv_response_len ==
-                       SSH2_SCP_RESPONSE_BUFLEN) {
-                        /* You had your chance */
-                        ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                                 "Unterminated response from SCP server");
-                        goto scp_recv_error;
-                    }
-                    /* Way too short to be an SCP response, or not done yet,
-                       short circuit */
-                    continue;
-                }
-
-                /* We are guaranteed not to go under response_len == 0 by the
-                   logic above */
-                while(
-                    session->scpRecv_response[session->scpRecv_response_len -
-                                              1] == '\r' ||
-                    session->scpRecv_response[session->scpRecv_response_len -
-                                              1] == '\n') {
-                    session->scpRecv_response_len--;
-                }
-                session->scpRecv_response[session->scpRecv_response_len] =
-                    '\0';
-
-                if(session->scpRecv_response_len < 6) {
-                    /* EOL came too soon */
-                    ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                             "Invalid response from SCP server, too short");
-                    goto scp_recv_error;
-                }
-
-                s = (char *)session->scpRecv_response + 1;
-
-                p = strchr(s, ' ');
-                if(!p || (p - s) <= 0) {
-                    /* No spaces or space in the wrong spot */
-                    ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                             "Invalid response from SCP server, "
-                             "malformed mode");
-                    goto scp_recv_error;
-                }
-
-                *(p++) = '\0';
-                /* Make sure we do not get fooled by leftover values */
-                /* !checksrc! disable BANNEDFUNC 1 */
-                session->scpRecv_mode = strtol(s, &e, 8);
-                if(e && *e) {
-                    ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                             "Invalid response from SCP server, invalid mode");
-                    goto scp_recv_error;
-                }
-
-                s = strchr(p, ' ');
-                if(!s || (s - p) <= 0) {
-                    /* No spaces or space in the wrong spot */
-                    ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                             "Invalid response from SCP server, "
-                             "too short or malformed");
-                    goto scp_recv_error;
-                }
-
-                *s = '\0';
-                /* Make sure we do not get fooled by leftover values */
-                session->scpRecv_size = scpsize_strtol(p, &e, 10);
-                if(e && *e) {
-                    ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                             "Invalid response from SCP server, invalid size");
-                    goto scp_recv_error;
-                }
-
+                session->scpRecv_mode = mode;
+                session->scpRecv_size = size;
                 /* SCP ACK */
                 session->scpRecv_response[0] = '\0';
-
                 session->scpRecv_state = ssh2_NB_state_sent6;
-            }
-
-            if(session->scpRecv_state == ssh2_NB_state_sent6) {
-                rc = (int)ssh2_channel_write(session->scpRecv_channel, 0,
-                                             session->scpRecv_response, 1);
-                if(rc == LIBSSH2_ERROR_EAGAIN) {
-                    ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
-                             "Would block sending SCP ACK");
-                    return NULL;
-                }
-                else if(rc != 1)
-                    goto scp_recv_error;
-
-                ssh2_deb((session, LIBSSH2_TRACE_SCP, "mode = 0%lo size = %ld",
-                          (unsigned long)session->scpRecv_mode,
-                          (long)session->scpRecv_size));
-
-                /* We *should* check that basename is valid, but why let that
-                   stop us? */
                 break;
             }
-        }
 
+            if(session->scpRecv_response_len == SSH2_SCP_RESPONSE_BUFLEN) {
+                long mode = 0;
+                libssh2_int64_t size = 0;
+                int prc;
+
+                /*
+                 * Fixed buffer is full without a newline. Mode and size always
+                 * fit early; a long basename overflows the buffer. Parse what
+                 * we have and drain the rest of the name until newline
+                 * (basename is unused by libssh2). See issue #1738.
+                 */
+                prc = ssh2_scp_parse_c_fields(session->scpRecv_response,
+                                              session->scpRecv_response_len,
+                                              &mode, &size);
+                if(prc == SCP_C_FIELDS_OK) {
+                    session->scpRecv_mode = mode;
+                    session->scpRecv_size = size;
+                    /* Reuse response_len as drained-byte counter */
+                    session->scpRecv_response_len = 0;
+                    session->scpRecv_state = ssh2_NB_state_jump1;
+                    break;
+                }
+                ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
+                         "Unterminated response from SCP server");
+                goto scp_recv_error;
+            }
+        }
+    }
+
+    /* Drain remaining basename after the fixed buffer filled (#1738). */
+    if(session->scpRecv_state == ssh2_NB_state_jump1) {
+        for(;;) {
+            unsigned char discard;
+
+            rc = (int)ssh2_channel_read(session->scpRecv_channel, 0,
+                                        (char *)&discard, 1);
+            if(rc == LIBSSH2_ERROR_EAGAIN) {
+                ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
+                         "Would block draining SCP response name");
+                return NULL;
+            }
+            else if(rc < 0) {
+                ssh2_err(session, rc, "Failed draining SCP response");
+                goto scp_recv_error;
+            }
+            else if(rc == 0)
+                goto scp_recv_empty_channel;
+
+            if(discard == '\n') {
+                session->scpRecv_response[0] = '\0';
+                session->scpRecv_state = ssh2_NB_state_sent6;
+                break;
+            }
+            if(discard == '\r')
+                continue;
+            if(discard < 32) {
+                ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
+                         "Invalid data in SCP response");
+                goto scp_recv_error;
+            }
+            session->scpRecv_response_len++;
+            if(session->scpRecv_response_len > SCP_C_NAME_DRAIN_MAX) {
+                ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
+                         "SCP response name too long");
+                goto scp_recv_error;
+            }
+        }
+    }
+
+    if(session->scpRecv_state == ssh2_NB_state_sent6) {
+        rc = (int)ssh2_channel_write(session->scpRecv_channel, 0,
+                                     session->scpRecv_response, 1);
+        if(rc == LIBSSH2_ERROR_EAGAIN) {
+            ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
+                     "Would block sending SCP ACK");
+            return NULL;
+        }
+        else if(rc != 1)
+            goto scp_recv_error;
+
+        ssh2_deb((session, LIBSSH2_TRACE_SCP, "mode = 0%lo size = %ld",
+                  (unsigned long)session->scpRecv_mode,
+                  (long)session->scpRecv_size));
+
+        /* We *should* check that basename is valid, but why let that
+           stop us? */
         session->scpRecv_state = ssh2_NB_state_sent7;
     }
 

--- a/src/scp.c
+++ b/src/scp.c
@@ -734,8 +734,12 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                     session->scpRecv_state = ssh2_NB_state_jump1;
                     break;
                 }
-                ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
-                         "Unterminated response from SCP server");
+                if(prc == SCP_C_FIELDS_MALFORMED)
+                    ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
+                             "Invalid response from SCP server");
+                else
+                    ssh2_err(session, LIBSSH2_ERROR_SCP_PROTOCOL,
+                             "Unterminated response from SCP server");
                 goto scp_recv_error;
             }
         }

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -132,7 +132,6 @@ static int test_ssh2_scp_parse_c_fields(void)
     libssh2_int64_t size = -1;
     unsigned char long_line[SSH2_SCP_RESPONSE_BUFLEN];
     size_t prefix_len;
-    size_t i;
     int prc;
     int err = 0;
 
@@ -167,15 +166,11 @@ static int test_ssh2_scp_parse_c_fields(void)
     /*
      * Fixed buffer full of "Cmode size " + long name without newline. Mode and
      * size must still parse so scp_recv can drain the unused basename.
-     * Use memcpy for the prefix (tests do not call ssh2_snprintf).
      */
-    {
-        static const char prefix[] = "C0644 99 ";
-        prefix_len = sizeof(prefix) - 1;
-        memcpy(long_line, prefix, prefix_len);
-    }
-    for(i = prefix_len; i < sizeof(long_line); i++)
-        long_line[i] = 'a';
+    prefix_len = (size_t)snprintf((char *)long_line, sizeof(long_line),
+                                  "C0644 99 ");
+    memset(long_line + prefix_len, 'a',
+           sizeof(long_line) - prefix_len);
     mode = -1;
     size = -1;
     prc = ssh2_scp_parse_c_fields(long_line, sizeof(long_line), &mode, &size);

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -31,7 +31,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#define LIBSSH2_TESTS
 #include "libssh2_priv.h"
 
 #include <stdio.h>
@@ -131,14 +130,13 @@ static int test_ssh2_scp_parse_c_fields(void)
 {
     long mode = -1;
     libssh2_int64_t size = -1;
-    unsigned char long_line[SSH2_SCP_RESPONSE_BUFLEN];
-    size_t prefix_len;
+    char long_line[SSH2_SCP_RESPONSE_BUFLEN];
+    int prefix_len;
     int prc;
     int err = 0;
 
     /* Normal complete line with short name */
-    prc = ssh2_scp_parse_c_fields(
-        (const unsigned char *)"C0644 123 shortname\n", 20, &mode, &size);
+    prc = ssh2_scp_parse_c_fields("C0644 123 shortname\n", 20, &mode, &size);
     if(prc || mode != 420L || size != 123) { /* 0644 octal == 420 */
         fprintf(stderr, "scp_parse short: prc=%d mode=%ld size=%lu\n",
                 prc, mode, (unsigned long)size);
@@ -148,8 +146,7 @@ static int test_ssh2_scp_parse_c_fields(void)
     /* Fields complete without trailing newline (name unfinished) */
     mode = -1;
     size = -1;
-    prc = ssh2_scp_parse_c_fields(
-        (const unsigned char *)"C0755 42 ", 9, &mode, &size);
+    prc = ssh2_scp_parse_c_fields("C0755 42 ", 9, &mode, &size);
     if(prc || mode != 493L || size != 42) { /* 0755 octal == 493 */
         fprintf(stderr, "scp_parse partial-name: prc=%d mode=%ld size=%lu\n",
                 prc, mode, (unsigned long)size);
@@ -157,8 +154,7 @@ static int test_ssh2_scp_parse_c_fields(void)
     }
 
     /* Incomplete size digits still growing */
-    prc = ssh2_scp_parse_c_fields(
-        (const unsigned char *)"C0644 12", 8, &mode, &size);
+    prc = ssh2_scp_parse_c_fields("C0644 12", 8, &mode, &size);
     if(prc != 1) {
         fprintf(stderr, "scp_parse incomplete size: prc=%d (want 1)\n", prc);
         err++;
@@ -168,10 +164,13 @@ static int test_ssh2_scp_parse_c_fields(void)
      * Fixed buffer full of "Cmode size " + long name without newline. Mode and
      * size must still parse so scp_recv can drain the unused basename.
      */
-    prefix_len = (size_t)snprintf((char *)long_line, sizeof(long_line),
-                                  "C0644 99 ");
-    memset(long_line + prefix_len, 'a',
-           sizeof(long_line) - prefix_len);
+    prefix_len = snprintf(long_line, sizeof(long_line), "C0644 99 ");
+    if(prefix_len < 0 || (size_t)prefix_len >= sizeof(long_line)) {
+        fprintf(stderr, "scp_parse long-name: snprintf failed (%d)\n",
+                prefix_len);
+        return 1;
+    }
+    memset(long_line + prefix_len, 'a', sizeof(long_line) - (size_t)prefix_len);
     mode = -1;
     size = -1;
     prc = ssh2_scp_parse_c_fields(long_line, sizeof(long_line), &mode, &size);
@@ -183,8 +182,7 @@ static int test_ssh2_scp_parse_c_fields(void)
     }
 
     /* Malformed: bad mode */
-    prc = ssh2_scp_parse_c_fields(
-        (const unsigned char *)"Cxyz 1 name\n", 12, &mode, &size);
+    prc = ssh2_scp_parse_c_fields("Cxyz 1 name\n", 12, &mode, &size);
     if(prc != -1) {
         fprintf(stderr, "scp_parse bad mode: prc=%d (want -1)\n", prc);
         err++;

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -139,8 +139,9 @@ static int test_ssh2_scp_parse_c_fields(void)
     prc = ssh2_scp_parse_c_fields(
         (const unsigned char *)"C0644 123 shortname\n", 20, &mode, &size);
     if(prc || mode != 420L || size != 123) { /* 0644 octal == 420 */
-        fprintf(stderr, "scp_parse short: prc=%d mode=%ld size=%lld\n",
-                prc, mode, (long long)size);
+        fprintf(stderr, "scp_parse short: prc=%d mode=%ld size=%"
+                SSH2_INT64_T_FORMAT "\n",
+                prc, mode, size);
         err++;
     }
 
@@ -150,8 +151,9 @@ static int test_ssh2_scp_parse_c_fields(void)
     prc = ssh2_scp_parse_c_fields(
         (const unsigned char *)"C0755 42 ", 9, &mode, &size);
     if(prc || mode != 493L || size != 42) { /* 0755 octal == 493 */
-        fprintf(stderr, "scp_parse partial-name: prc=%d mode=%ld size=%lld\n",
-                prc, mode, (long long)size);
+        fprintf(stderr, "scp_parse partial-name: prc=%d mode=%ld size=%"
+                SSH2_INT64_T_FORMAT "\n",
+                prc, mode, size);
         err++;
     }
 
@@ -176,8 +178,9 @@ static int test_ssh2_scp_parse_c_fields(void)
     prc = ssh2_scp_parse_c_fields(long_line, sizeof(long_line), &mode, &size);
     if(prc || mode != 420L || size != 99) { /* 0644 octal == 420 */
         fprintf(stderr,
-                "scp_parse long-name buffer: prc=%d mode=%ld size=%lld\n",
-                prc, mode, (long long)size);
+                "scp_parse long-name buffer: prc=%d mode=%ld size=%"
+                SSH2_INT64_T_FORMAT "\n",
+                prc, mode, size);
         err++;
     }
 

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -124,6 +124,74 @@ static int test_ssh2_dh_validate(void)
     return err > 0;
 }
 
+/* Return codes match scp.c (SCP_C_FIELDS_*). */
+static int test_ssh2_scp_parse_c_fields(void)
+{
+    long mode = -1;
+    libssh2_int64_t size = -1;
+    unsigned char long_line[SSH2_SCP_RESPONSE_BUFLEN];
+    size_t prefix_len;
+    size_t i;
+    int prc;
+    int err = 0;
+
+    /* Normal complete line with short name */
+    prc = ssh2_scp_parse_c_fields(
+        (const unsigned char *)"C0644 123 shortname\n", 20, &mode, &size);
+    if(prc || mode != 420L || size != 123) { /* 0644 octal == 420 */
+        fprintf(stderr, "scp_parse short: prc=%d mode=%ld size=%lld\n",
+                prc, mode, (long long)size);
+        err++;
+    }
+
+    /* Fields complete without trailing newline (name unfinished) */
+    mode = -1;
+    size = -1;
+    prc = ssh2_scp_parse_c_fields(
+        (const unsigned char *)"C0755 42 ", 9, &mode, &size);
+    if(prc || mode != 493L || size != 42) { /* 0755 octal == 493 */
+        fprintf(stderr, "scp_parse partial-name: prc=%d mode=%ld size=%lld\n",
+                prc, mode, (long long)size);
+        err++;
+    }
+
+    /* Incomplete size digits still growing */
+    prc = ssh2_scp_parse_c_fields(
+        (const unsigned char *)"C0644 12", 8, &mode, &size);
+    if(prc != 1) {
+        fprintf(stderr, "scp_parse incomplete size: prc=%d (want 1)\n", prc);
+        err++;
+    }
+
+    /*
+     * Reproduce #1738 shape: fixed buffer full of "Cmode size " + long name
+     * without newline. Mode and size must still parse so scp_recv can drain.
+     */
+    prefix_len = (size_t)snprintf((char *)long_line, sizeof(long_line),
+                                  "C0644 99 ");
+    for(i = prefix_len; i < sizeof(long_line); i++)
+        long_line[i] = 'a';
+    mode = -1;
+    size = -1;
+    prc = ssh2_scp_parse_c_fields(long_line, sizeof(long_line), &mode, &size);
+    if(prc || mode != 420L || size != 99) { /* 0644 octal == 420 */
+        fprintf(stderr,
+                "scp_parse long-name buffer: prc=%d mode=%ld size=%lld\n",
+                prc, mode, (long long)size);
+        err++;
+    }
+
+    /* Malformed: bad mode */
+    prc = ssh2_scp_parse_c_fields(
+        (const unsigned char *)"Cxyz 1 name\n", 12, &mode, &size);
+    if(prc != -1) {
+        fprintf(stderr, "scp_parse bad mode: prc=%d (want -1)\n", prc);
+        err++;
+    }
+
+    return err > 0;
+}
+
 int main(int argc, char *argv[])
 {
     LIBSSH2_SESSION *session;
@@ -145,6 +213,7 @@ int main(int argc, char *argv[])
 
     rc = test_ssh2_base64_decode(session);
     rc |= test_ssh2_dh_validate();
+    rc |= test_ssh2_scp_parse_c_fields();
 
     libssh2_session_free(session);
 

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -166,9 +166,13 @@ static int test_ssh2_scp_parse_c_fields(void)
     /*
      * Reproduce #1738 shape: fixed buffer full of "Cmode size " + long name
      * without newline. Mode and size must still parse so scp_recv can drain.
+     * Avoid snprintf: old MSVC (AppVeyor VS2010) lacks it.
      */
-    prefix_len = (size_t)snprintf((char *)long_line, sizeof(long_line),
-                                  "C0644 99 ");
+    {
+        static const char prefix[] = "C0644 99 ";
+        prefix_len = sizeof(prefix) - 1;
+        memcpy(long_line, prefix, prefix_len);
+    }
     for(i = prefix_len; i < sizeof(long_line); i++)
         long_line[i] = 'a';
     mode = -1;

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -34,6 +34,7 @@
 #include "libssh2_priv.h"
 
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>  /* for atoi() */
 
 static int test_ssh2_base64_decode(LIBSSH2_SESSION *session)
@@ -139,9 +140,8 @@ static int test_ssh2_scp_parse_c_fields(void)
     prc = ssh2_scp_parse_c_fields(
         (const unsigned char *)"C0644 123 shortname\n", 20, &mode, &size);
     if(prc || mode != 420L || size != 123) { /* 0644 octal == 420 */
-        fprintf(stderr, "scp_parse short: prc=%d mode=%ld size=%"
-                SSH2_INT64_T_FORMAT "\n",
-                prc, mode, size);
+        fprintf(stderr, "scp_parse short: prc=%d mode=%ld size=%lu\n",
+                prc, mode, (unsigned long)size);
         err++;
     }
 
@@ -151,9 +151,8 @@ static int test_ssh2_scp_parse_c_fields(void)
     prc = ssh2_scp_parse_c_fields(
         (const unsigned char *)"C0755 42 ", 9, &mode, &size);
     if(prc || mode != 493L || size != 42) { /* 0755 octal == 493 */
-        fprintf(stderr, "scp_parse partial-name: prc=%d mode=%ld size=%"
-                SSH2_INT64_T_FORMAT "\n",
-                prc, mode, size);
+        fprintf(stderr, "scp_parse partial-name: prc=%d mode=%ld size=%lu\n",
+                prc, mode, (unsigned long)size);
         err++;
     }
 
@@ -168,9 +167,13 @@ static int test_ssh2_scp_parse_c_fields(void)
     /*
      * Fixed buffer full of "Cmode size " + long name without newline. Mode and
      * size must still parse so scp_recv can drain the unused basename.
+     * Use memcpy for the prefix (tests do not call ssh2_snprintf).
      */
-    prefix_len = (size_t)ssh2_snprintf((char *)long_line, sizeof(long_line),
-                                       "C0644 99 ");
+    {
+        static const char prefix[] = "C0644 99 ";
+        prefix_len = sizeof(prefix) - 1;
+        memcpy(long_line, prefix, prefix_len);
+    }
     for(i = prefix_len; i < sizeof(long_line); i++)
         long_line[i] = 'a';
     mode = -1;
@@ -178,9 +181,8 @@ static int test_ssh2_scp_parse_c_fields(void)
     prc = ssh2_scp_parse_c_fields(long_line, sizeof(long_line), &mode, &size);
     if(prc || mode != 420L || size != 99) { /* 0644 octal == 420 */
         fprintf(stderr,
-                "scp_parse long-name buffer: prc=%d mode=%ld size=%"
-                SSH2_INT64_T_FORMAT "\n",
-                prc, mode, size);
+                "scp_parse long-name buffer: prc=%d mode=%ld size=%lu\n",
+                prc, mode, (unsigned long)size);
         err++;
     }
 

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -31,6 +31,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#define LIBSSH2_TESTS
 #include "libssh2_priv.h"
 
 #include <stdio.h>

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -164,15 +164,11 @@ static int test_ssh2_scp_parse_c_fields(void)
     }
 
     /*
-     * Reproduce #1738 shape: fixed buffer full of "Cmode size " + long name
-     * without newline. Mode and size must still parse so scp_recv can drain.
-     * Avoid snprintf: old MSVC (AppVeyor VS2010) lacks it.
+     * Fixed buffer full of "Cmode size " + long name without newline. Mode and
+     * size must still parse so scp_recv can drain the unused basename.
      */
-    {
-        static const char prefix[] = "C0644 99 ";
-        prefix_len = sizeof(prefix) - 1;
-        memcpy(long_line, prefix, prefix_len);
-    }
+    prefix_len = (size_t)ssh2_snprintf((char *)long_line, sizeof(long_line),
+                                       "C0644 99 ");
     for(i = prefix_len; i < sizeof(long_line); i++)
         long_line[i] = 'a';
     mode = -1;

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -170,7 +170,8 @@ static int test_ssh2_scp_parse_c_fields(void)
                 prefix_len);
         return 1;
     }
-    memset(long_line + prefix_len, 'a', sizeof(long_line) - (size_t)prefix_len);
+    memset(long_line + prefix_len, 'a',
+           sizeof(long_line) - (size_t)prefix_len);
     mode = -1;
     size = -1;
     prc = ssh2_scp_parse_c_fields(long_line, sizeof(long_line), &mode, &size);


### PR DESCRIPTION
## Summary

`libssh2_scp_recv2` fails with `LIBSSH2_ERROR_SCP_PROTOCOL`
(\"Unterminated response from SCP server\") when the server SCP `C` line
exceeds the fixed 256-byte response buffer. Mode and size always fit early;
long basenames overflow the buffer.

Parse mode and size as soon as those fields are complete. If the buffer
fills before the trailing newline, drain the unused basename until `\n`
and continue with the SCP ACK. libssh2 does not use the basename.

## Evidence

- Issue: #1738
- Unit: `tests/test_simple` covers short lines, partial name, incomplete
  size, full 256-byte long-name buffer, and malformed mode

Fixes #1738