### PR TITLE
crypt, mac: add build-time warning with none method enabled

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -37,6 +37,7 @@
 #include <assert.h>
 
 #if defined(LIBSSH2DEBUG) && defined(LIBSSH2_CRYPT_NONE_INSECURE)
+#warning "crypt: no encryption method enabled. DO NOT USE."
 /*
  * Minimalist cipher: no encryption. DO NOT USE.
  *

--- a/src/mac.c
+++ b/src/mac.c
@@ -34,6 +34,7 @@
 #include "mac.h"
 
 #if defined(LIBSSH2DEBUG) && defined(LIBSSH2_MAC_NONE_INSECURE)
+#warning "mac: no MAC enabled. DO NOT USE."
 /*
  * Minimalist MAC: No MAC. DO NOT USE.
  *


### PR DESCRIPTION
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
