### PR TITLE
SECURITY.md: use GitHub PVR as the channel for security reports, drop email

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,8 +10,7 @@ See [SECURITY.md](https://github.com/libssh2/libssh2/blob/master/docs/SECURITY.m
 
 ## Reporting a Vulnerability
 
-We accept reports via
-https://github.com/libssh2/libssh2/security
+We accept reports via <https://github.com/libssh2/libssh2/security>.
 
 **Do not submit suspected security issues in the public bug tracker!**
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,8 +10,8 @@ See [SECURITY.md](https://github.com/libssh2/libssh2/blob/master/docs/SECURITY.m
 
 ## Reporting a Vulnerability
 
-If you have found or suspect a security problem somewhere in libssh2,
-email `libssh2-security@haxx.se` about it.
+We accept reports via
+https://github.com/libssh2/libssh2/security
 
 **Do not submit suspected security issues in the public bug tracker!**
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,15 +31,11 @@ reference to the security nature of the commit if done prior to the public
 announcement.
 
 - The person discovering the issue, the reporter, reports the vulnerability
-  privately via <https://github.com/libssh2/libssh2/security>. That is an email
-  alias that reaches a handful of selected and trusted people.
+  privately via <https://github.com/libssh2/libssh2/security>.
 
 - Messages that do not relate to the reporting or managing of an undisclosed
   security vulnerability in libssh2 are ignored and no further action is
   required.
-
-- A person in the security team sends an email to the original reporter to
-  acknowledge the report.
 
 - The security team investigates the report and either rejects it or accepts
   it.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,8 +31,8 @@ reference to the security nature of the commit if done prior to the public
 announcement.
 
 - The person discovering the issue, the reporter, reports the vulnerability
-  privately to `libssh2-security@haxx.se`. That is an email alias that reaches
-  a handful of selected and trusted people.
+  privately via <https://github.com/libssh2/libssh2/security>. That is an email
+  alias that reaches a handful of selected and trusted people.
 
 - Messages that do not relate to the reporting or managing of an undisclosed
   security vulnerability in libssh2 are ignored and no further action is
@@ -137,9 +137,9 @@ that being the end of the world.
 There need to be more and special circumstances to treat such problems as
 security issues.
 
-# LIBSSH2-SECURITY (at haxx dot se)
+# Security team
 
-Who is on this list? There are a couple of criteria you must meet, and then we
+Who is on the team? There are a couple of criteria you must meet, and then we
 might ask you to join the list or you can ask to join it. It really is not
 formal. We only require that you have a long-term presence in the libssh2
 project and you have shown an understanding for the project and its way of
@@ -148,8 +148,3 @@ plans in vanishing in the near future.
 
 We do not make the list of participants public mostly because it tends to vary
 somewhat over time and a list somewhere only risks getting outdated.
-
-# GitHub Private Vulnerability Reporting
-
-We also accept reports via:
-https://github.com/libssh2/libssh2/security


### PR DESCRIPTION
Emails became practically unmanageable. There are many duplicate 
reports, often reporting multiple issues per email. Figuring out who
reported what in what order is a challenge, and easy to confuse or miss.
It's also next to impossible to track the status and progress of each
reported issue.
