### PR TITLE
agent: fix potential infinite loop while receiving data from SSH agent

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -618,8 +618,8 @@ static int agent_connect_unix(LIBSSH2_AGENT *agent)
             rc = (func)(socket,                                           \
                         (char *)(buffer) + finished, (length) - finished, \
                         flags, abstract);                                 \
-            if(rc < 0)                                                    \
-                return rc;                                                \
+            if(rc <= 0)                                                   \
+                return rc ? rc : LIBSSH2_ERROR_SOCKET_DISCONNECT;         \
                                                                           \
             finished += rc;                                               \
         }                                                                 \

--- a/src/agent.c
+++ b/src/agent.c
@@ -426,11 +426,14 @@ cleanup:
     int rc;                                                            \
                                                                        \
     while(*(total) < (length)) {                                       \
-        if(!(agent)->pending_io)                                       \
+        if(!(agent)->pending_io) {                                     \
             ret = (func)((agent)->pipe, (char *)(buffer) + *(total),   \
                          (DWORD)((length) - *(total)),                 \
                          &bytes_transferred,                           \
                          &(agent)->overlapped);                        \
+            if(ret && !bytes_transferred)                              \
+                return LIBSSH2_ERROR_SOCKET_DISCONNECT;                \
+        }                                                              \
         else                                                           \
             ret = GetOverlappedResult((agent)->pipe,                   \
                                       &(agent)->overlapped,            \

--- a/src/agent.c
+++ b/src/agent.c
@@ -621,8 +621,10 @@ static int agent_connect_unix(LIBSSH2_AGENT *agent)
             rc = (func)(socket,                                           \
                         (char *)(buffer) + finished, (length) - finished, \
                         flags, abstract);                                 \
-            if(rc <= 0)                                                   \
-                return rc ? rc : LIBSSH2_ERROR_SOCKET_DISCONNECT;         \
+            if(rc < 0)                                                    \
+                return rc;                                                \
+            else if(!rc)                                                  \
+                return LIBSSH2_ERROR_SOCKET_DISCONNECT;                   \
                                                                           \
             finished += rc;                                               \
         }                                                                 \


### PR DESCRIPTION
If the local SSH agent terminates while we are receiving data from it.

Refs:
https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-readfile#pipes
https://linux.die.net/man/2/recv
https://www.man7.org/linux/man-pages/man2/recv.2.html

Reported-by: afldl on github

---

- [x] I assume the patch is broken for `send()`/`WriteFile()`, need fix. [SKIP, can't confirm if it's necessary]
  https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-writefile#pipes
