### PR TITLE
src: make `ssh2_store_str()` accept void pointer to reduce casts

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -198,8 +198,7 @@ static int agent_transact_pageant(LIBSSH2_AGENT *agent,
                         "failed to open pageant filemap for writing");
     }
 
-    ssh2_store_str(&p2, (const char *)transctx->request,
-                   transctx->request_len);
+    ssh2_store_str(&p2, transctx->request, transctx->request_len);
 
     cds.dwData = PAGEANT_COPYDATA_ID;
     cds.cbData = (DWORD)(1 + strlen(mapname));
@@ -779,10 +778,10 @@ static int agent_sign(LIBSSH2_SESSION *session,
 
         *s++ = SSH2_AGENTC_SIGN_REQUEST;
         /* key blob */
-        ssh2_store_str(&s, (const char *)identity->external.blob,
-                       identity->external.blob_len);
+        ssh2_store_str(&s, identity->external.blob,
+                           identity->external.blob_len);
         /* data */
-        ssh2_store_str(&s, (const char *)data, data_len);
+        ssh2_store_str(&s, data, data_len);
 
         /* flags */
         if(session->userauth_pblc_method && *session->userauth_pblc_method) {

--- a/src/kex.c
+++ b/src/kex.c
@@ -1788,8 +1788,8 @@ static int kex_method_ecdh_key_exchange(
 
         key_state->request[0] = SSH2_MSG_KEX_ECDH_INIT;
         s = key_state->request + 1;
-        ssh2_store_str(&s, (const char *)key_state->public_key_oct,
-                       key_state->public_key_oct_len);
+        ssh2_store_str(&s, key_state->public_key_oct,
+                           key_state->public_key_oct_len);
         key_state->request_len = key_state->public_key_oct_len + 5;
 
         ssh2_deb((session, LIBSSH2_TRACE_KEX,
@@ -2142,11 +2142,10 @@ static int kex_method_mlkem_nistp_key_exchange(
 
         key_state->request[0] = SSH2_MSG_KEX_ECDH_INIT;
         s = key_state->request + 1;
-        ssh2_store_hybrid_str(&s,
-                              (const char *)key_state->mlkem_public_key,
-                              mlkem_public_key_len,
-                              (const char *)key_state->public_key_oct,
-                              key_state->public_key_oct_len);
+        ssh2_store_hybrid_str(&s, key_state->mlkem_public_key,
+                                  mlkem_public_key_len,
+                                  key_state->public_key_oct,
+                                  key_state->public_key_oct_len);
         key_state->request_len = mlkem_public_key_len +
                                  key_state->public_key_oct_len + 5;
 
@@ -2415,8 +2414,8 @@ static int kex_method_curve25519_key_exchange(
 
         key_state->request[0] = SSH2_MSG_KEX_ECDH_INIT;
         s = key_state->request + 1;
-        ssh2_store_str(&s, (const char *)key_state->curve25519_public_key,
-                       SSH2_ED25519_KEY_LEN);
+        ssh2_store_str(&s, key_state->curve25519_public_key,
+                           SSH2_ED25519_KEY_LEN);
         key_state->request_len = SSH2_ED25519_KEY_LEN + 5;
 
         ssh2_deb((session, LIBSSH2_TRACE_KEX, "Initiating curve25519 SHA2"));

--- a/src/misc.c
+++ b/src/misc.c
@@ -295,8 +295,8 @@ int ssh2_store_hybrid_str(unsigned char **buf, const void *str_1,
     return len_stored == len_1 + len_2;
 }
 
-int ssh2_store_bignum_bytes(unsigned char **buf,
-                            const unsigned char *bytes, size_t len)
+int ssh2_store_bignum_bytes(unsigned char **buf, const void *bytes,
+                            size_t len)
 {
     uint32_t len_stored;
     uint32_t extraByte;

--- a/src/misc.c
+++ b/src/misc.c
@@ -295,8 +295,8 @@ int ssh2_store_hybrid_str(unsigned char **buf, const void *str_1,
     return len_stored == len_1 + len_2;
 }
 
-int ssh2_store_bignum_bytes(unsigned char **buf, const void *bytes,
-                            size_t len)
+int ssh2_store_bignum_bytes(unsigned char **buf,
+                            const unsigned char *bytes, size_t len)
 {
     uint32_t len_stored;
     uint32_t extraByte;

--- a/src/misc.c
+++ b/src/misc.c
@@ -256,7 +256,7 @@ void ssh2_store_u64(unsigned char **buf, libssh2_uint64_t value)
     *buf += sizeof(libssh2_uint64_t);
 }
 
-int ssh2_store_str(unsigned char **buf, const char *str, size_t len)
+int ssh2_store_str(unsigned char **buf, const void *str, size_t len)
 {
     uint32_t len_stored = (uint32_t)len;
 
@@ -270,8 +270,8 @@ int ssh2_store_str(unsigned char **buf, const char *str, size_t len)
     return len_stored == len;
 }
 
-int ssh2_store_hybrid_str(unsigned char **buf, const char *str_1,
-                          size_t len_1, const char *str_2, size_t len_2)
+int ssh2_store_hybrid_str(unsigned char **buf, const void *str_1,
+                          size_t len_1, const void *str_2, size_t len_2)
 {
     uint32_t len_stored;
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -141,8 +141,8 @@ void ssh2_store_u64(unsigned char **buf, libssh2_uint64_t value);
 int ssh2_store_str(unsigned char **buf, const void *str, size_t len);
 int ssh2_store_hybrid_str(unsigned char **buf, const void *str_1,
                           size_t len_1, const void *str_2, size_t len_2);
-int ssh2_store_bignum_bytes(unsigned char **buf, const void *bytes,
-                            size_t len);
+int ssh2_store_bignum_bytes(unsigned char **buf,
+                            const unsigned char *bytes, size_t len);
 void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size);
 
 struct string_buf *ssh2_string_buf_new(LIBSSH2_SESSION *session);

--- a/src/misc.h
+++ b/src/misc.h
@@ -141,8 +141,8 @@ void ssh2_store_u64(unsigned char **buf, libssh2_uint64_t value);
 int ssh2_store_str(unsigned char **buf, const void *str, size_t len);
 int ssh2_store_hybrid_str(unsigned char **buf, const void *str_1,
                           size_t len_1, const void *str_2, size_t len_2);
-int ssh2_store_bignum_bytes(unsigned char **buf,
-                            const unsigned char *bytes, size_t len);
+int ssh2_store_bignum_bytes(unsigned char **buf, const void *bytes,
+                            size_t len);
 void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size);
 
 struct string_buf *ssh2_string_buf_new(LIBSSH2_SESSION *session);

--- a/src/misc.h
+++ b/src/misc.h
@@ -138,9 +138,9 @@ libssh2_uint64_t ssh2_ntohu64(const unsigned char *buf);
 void ssh2_htonu32(unsigned char *buf, uint32_t value);
 void ssh2_store_u32(unsigned char **buf, uint32_t value);
 void ssh2_store_u64(unsigned char **buf, libssh2_uint64_t value);
-int ssh2_store_str(unsigned char **buf, const char *str, size_t len);
-int ssh2_store_hybrid_str(unsigned char **buf, const char *str_1,
-                          size_t len_1, const char *str_2, size_t len_2);
+int ssh2_store_str(unsigned char **buf, const void *str, size_t len);
+int ssh2_store_hybrid_str(unsigned char **buf, const void *str_1,
+                          size_t len_1, const void *str_2, size_t len_2);
 int ssh2_store_bignum_bytes(unsigned char **buf,
                             const unsigned char *bytes, size_t len);
 void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1791,7 +1791,7 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     }
 
     ssh2_store_str(&p, method_name, sizeof(method_name) - 1);
-    ssh2_store_str(&p, (const char *)pub_key, SSH2_ED25519_KEY_LEN);
+    ssh2_store_str(&p, pub_key, SSH2_ED25519_KEY_LEN);
 
     memcpy(method_buf, method_name, sizeof(method_name));
 
@@ -1908,8 +1908,8 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
     }
 
     ssh2_store_str(&p, method_name, sizeof(method_name) - 1);
-    ssh2_store_str(&p, (const char *)pub_key, SSH2_ED25519_KEY_LEN);
-    ssh2_store_str(&p, (const char *)app, app_len);
+    ssh2_store_str(&p, pub_key, SSH2_ED25519_KEY_LEN);
+    ssh2_store_str(&p, app, app_len);
 
     if(application && app_len > 0) {
         *application = SSH2_ALLOC(session, app_len + 1);
@@ -2552,12 +2552,11 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
     if(is_sk)
         ssh2_store_str(&p, "nistp256", sizeof("nistp256") - 1);
     else
-        ssh2_store_str(&p,
-           (const char *)method_buf + sizeof("ecdsa-sha2-") - 1,
-           sizeof("nistp256") - 1);
+        ssh2_store_str(&p, method_buf + sizeof("ecdsa-sha2-") - 1,
+                           sizeof("nistp256") - 1);
 
     /* Public key */
-    ssh2_store_str(&p, (const char *)octal_value, octal_len);
+    ssh2_store_str(&p, octal_value, octal_len);
 
     *method = method_buf;
 
@@ -2810,7 +2809,7 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
         p += *pubkeydata_len;
 
         memcpy(key, *pubkeydata, *pubkeydata_len);
-        ssh2_store_str(&p, (const char *)app, app_len);
+        ssh2_store_str(&p, app, app_len);
 
         if(application && app_len > 0) {
             *application = SSH2_ALLOC(session, app_len + 1);

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -855,8 +855,7 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
 
             if(*sig) {
                 p = *sig;
-                ssh2_store_str(&p, (const char *)sig_info.sig_r,
-                               sig_info.sig_r_len);
+                ssh2_store_str(&p, sig_info.sig_r, sig_info.sig_r_len);
             }
             else {
                 ssh2_deb((session, LIBSSH2_ERROR_ALLOC,
@@ -974,8 +973,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
         ssh2_store_str(&session->userauth_host_s, "hostbased", 9);
         ssh2_store_str(&session->userauth_host_s,
                        session->userauth_host_method, host_method_len);
-        ssh2_store_str(&session->userauth_host_s, (const char *)pubkeydata,
-                       pubkeydata_len);
+        ssh2_store_str(&session->userauth_host_s, pubkeydata, pubkeydata_len);
         SSH2_FREE(session, pubkeydata);
         ssh2_store_str(&session->userauth_host_s, hostname, hostname_len);
         ssh2_store_str(&session->userauth_host_s, local_username,
@@ -1040,7 +1038,7 @@ static int userauth_hostbased_fromfile(LIBSSH2_SESSION *session,
                        session->userauth_host_method, host_method_len);
         SSH2_SAFEFREE(session, session->userauth_host_method);
 
-        ssh2_store_str(&session->userauth_host_s, (const char *)sig, sig_len);
+        ssh2_store_str(&session->userauth_host_s, sig, sig_len);
         SSH2_FREE(session, sig);
 
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
@@ -1501,7 +1499,7 @@ retry_auth:
         *s++ = 0;
 
         ssh2_store_str(&s, session->userauth_pblc_method, method_len);
-        ssh2_store_str(&s, (const char *)pubkeydata, pubkeydata_len);
+        ssh2_store_str(&s, pubkeydata, pubkeydata_len);
 
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,
                   "Attempting publickey authentication"));
@@ -1587,8 +1585,7 @@ retry_auth:
                             "Unable to allocate memory for "
                             "userauth-publickey signed data");
 
-        ssh2_store_str(&s, (const char *)session->session_id,
-                       session->session_id_len);
+        ssh2_store_str(&s, session->session_id, session->session_id_len);
 
         memcpy(s, session->userauth_pblc_packet,
                session->userauth_pblc_packet_len);
@@ -1663,7 +1660,7 @@ retry_auth:
             ssh2_store_u32(&s, (uint32_t)(4 + method_len +
                                           4 + sig_len));
             ssh2_store_str(&s, session->userauth_pblc_method, method_len);
-            ssh2_store_str(&s, (const char *)sig, sig_len);
+            ssh2_store_str(&s, sig, sig_len);
         }
 
         SSH2_SAFEFREE(session, session->userauth_pblc_method);


### PR DESCRIPTION
Also its sibling function `ssh2_store_hybrid_str()`.

They use `memcpy()` internally.
