### PR TITLE
build: set `LIBSSH2_TESTS` macro for all tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS "LIBSSH2_TESTS")
+
 list(APPEND LIBSSH2_LIBS ${LIBSSH2_LIBS_SOCKET})
 
 libssh2_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,6 @@
 SUBDIRS = ossfuzz
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/src -I$(top_srcdir)/include
-
 AM_CPPFLAGS += -DLIBSSH2_TESTS
 
 # This might hold -Werror

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,6 +4,8 @@ SUBDIRS = ossfuzz
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_srcdir)/src -I$(top_srcdir)/include
 
+AM_CPPFLAGS += -DLIBSSH2_TESTS
+
 # This might hold -Werror
 AM_CFLAGS = @LIBSSH2_CFLAG_EXTRAS@
 

--- a/tests/ossfuzz/Makefile.am
+++ b/tests/ossfuzz/Makefile.am
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 AM_CPPFLAGS = -I$(top_builddir)/include
+AM_CPPFLAGS += -DLIBSSH2_TESTS
+
 LDADD = $(top_builddir)/src/libssh2.la
 
 if USE_OSSFUZZ_FLAG

--- a/tests/session_fixture.h
+++ b/tests/session_fixture.h
@@ -33,8 +33,6 @@
 #ifndef LIBSSH2_TESTS_SESSION_FIXTURE_H
 #define LIBSSH2_TESTS_SESSION_FIXTURE_H
 
-#define LIBSSH2_TESTS
-
 #include "libssh2_priv.h"
 
 LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err);


### PR DESCRIPTION
To apply to all test apps. Prior to this patch it was set for fixtures only.

Ref: https://github.com/libssh2/libssh2/pull/2408#issuecomment-5061010305

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
