### PR TITLE
test_simple: cast to avoid `-Wsign-conversion` (clang-tidy)

### DIFF
--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -81,8 +81,8 @@ static int test_ssh2_dh_validate(void)
         int got;
 #ifdef LIBSSH2_LIBGCRYPT
         int fi = atoi(tests[i].f);
-        gcry_mpi_t f = gcry_mpi_set_ui(NULL, fi >= 0 ? fi : -fi);
-        gcry_mpi_t p = gcry_mpi_set_ui(NULL, atoi(tests[i].p));
+        gcry_mpi_t f = gcry_mpi_set_ui(NULL, (unsigned long)(fi >= 0 ? fi : -fi));
+        gcry_mpi_t p = gcry_mpi_set_ui(NULL, (unsigned long)atoi(tests[i].p));
         if(tests[i].f[0] == '-')
             gcry_mpi_neg(f, f);
         got = ssh2_dh_validate(f, p);

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -78,12 +78,12 @@ static int test_ssh2_dh_validate(void)
     int err = 0;
 
     for(i = 0; i < SSH2_ARRAYSIZE(tests); i++) {
+        struct tbn t = tests[i];
         int got;
 #ifdef LIBSSH2_LIBGCRYPT
-        int j = atoi(tests[i].f);
-        gcry_mpi_t f = gcry_mpi_set_ui(NULL, (unsigned long)(j < 0 ? -j : j));
-        gcry_mpi_t p = gcry_mpi_set_ui(NULL, (unsigned long)atoi(tests[i].p));
-        if(tests[i].f[0] == '-')
+        gcry_mpi_t f = gcry_mpi_set_ui(NULL, (unsigned long)abs(atoi(t.f)));
+        gcry_mpi_t p = gcry_mpi_set_ui(NULL, (unsigned long)atoi(t.p));
+        if(t.f[0] == '-')
             gcry_mpi_neg(f, f);
         got = ssh2_dh_validate(f, p);
         gcry_mpi_release(f);
@@ -92,8 +92,8 @@ static int test_ssh2_dh_validate(void)
         mbedtls_mpi f, p;
         mbedtls_mpi_init(&f);
         mbedtls_mpi_init(&p);
-        if(mbedtls_mpi_read_string(&f, 10, tests[i].f) ||
-           mbedtls_mpi_read_string(&p, 10, tests[i].p))
+        if(mbedtls_mpi_read_string(&f, 10, t.f) ||
+           mbedtls_mpi_read_string(&p, 10, t.p))
             got = -9;
         else
             got = ssh2_dh_validate(&f, &p);
@@ -102,21 +102,21 @@ static int test_ssh2_dh_validate(void)
 #elif defined(LIBSSH2_OPENSSL) || \
     (defined(LIBSSH2_WOLFSSL) && LIBWOLFSSL_VERSION_HEX >= 0x05006000)
         BIGNUM *f = BN_new(), *p = BN_new();
-        if(!BN_dec2bn(&f, tests[i].f) ||
-           !BN_dec2bn(&p, tests[i].p))
+        if(!BN_dec2bn(&f, t.f) ||
+           !BN_dec2bn(&p, t.p))
             got = -9;
         else
             got = ssh2_dh_validate(f, p);
         BN_free(f);
         BN_free(p);
 #else
-        got = tests[i].expected;
+        got = t.expected;
 #endif
-        if(got != tests[i].expected) {
+        if(got != t.expected) {
             fprintf(stderr,
                     "ssh2_dh_validate/%lu: f=%s p=%s: expected %d got %d\n",
                     (unsigned long)i,
-                    tests[i].f, tests[i].p, tests[i].expected, got);
+                    t.f, t.p, t.expected, got);
             err++;
         }
     }

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -80,8 +80,8 @@ static int test_ssh2_dh_validate(void)
     for(i = 0; i < SSH2_ARRAYSIZE(tests); i++) {
         int got;
 #ifdef LIBSSH2_LIBGCRYPT
-        int fi = atoi(tests[i].f);
-        gcry_mpi_t f = gcry_mpi_set_ui(NULL, (unsigned long)(fi >= 0 ? fi : -fi));
+        int j = atoi(tests[i].f);
+        gcry_mpi_t f = gcry_mpi_set_ui(NULL, (unsigned long)(j < 0 ? -j : j));
         gcry_mpi_t p = gcry_mpi_set_ui(NULL, (unsigned long)atoi(tests[i].p));
         if(tests[i].f[0] == '-')
             gcry_mpi_neg(f, f);


### PR DESCRIPTION
Fixing:
```
tests/test_simple.c:84:56: error: operand of ? changes signedness: 'int' to 'unsigned long' [clang-diagnostic-sign-conversion]
   84 |         gcry_mpi_t f = gcry_mpi_set_ui(NULL, fi >= 0 ? fi : -fi);
      |                        ~~~~~~~~~~~~~~~                 ^~
tests/test_simple.c:84:61: error: operand of ? changes signedness: 'int' to 'unsigned long' [clang-diagnostic-sign-conversion]
   84 |         gcry_mpi_t f = gcry_mpi_set_ui(NULL, fi >= 0 ? fi : -fi);
      |                        ~~~~~~~~~~~~~~~                      ^~~
tests/test_simple.c:85:46: error: implicit conversion changes signedness: 'int' to 'unsigned long' [clang-diagnostic-sign-conversion]
   85 |         gcry_mpi_t p = gcry_mpi_set_ui(NULL, atoi(tests[i].p));
      |                        ~~~~~~~~~~~~~~~       ^~~~~~~~~~~~~~~~
```
Ref: https://github.com/libssh2/libssh2/actions/runs/30043871895/job/89330114459#step:24:124

Also add intermediate current test holder var to keep code readable.

Follow-up to 76d30e5d984cdc88ed802aafc12a34132f370ed8 #2417
Follow-up to fcf830788d0c8dcd6bed7dcd532506aabf196523 #2239

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
