### PR TITLE
src: fix potential OOB reads in EDCDA/ED25519 OpenSSH-formatted key parsing

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -200,6 +200,10 @@ struct iovec {
 #define SSH2_MAX(x, y)  ((x) > (y) ? (x) : (y))
 #define SSH2_MIN(x, y)  ((x) < (y) ? (x) : (y))
 
+/* Compare memory buffer with string literal */
+#define SSH2_IS_LITERAL(have, have_len, want) \
+    ((have_len) == sizeof(want) && !memcmp(have, want, sizeof(want)))
+
 #define MAX_BLOCKSIZE 32    /* MUST fit biggest crypto block size we use/get */
 #define MAX_MACSIZE 64      /* MUST fit biggest MAC length we support */
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -202,7 +202,7 @@ struct iovec {
 
 /* Compare memory buffer with string literal */
 #define SSH2_IS_LITERAL(have, have_len, want) \
-    ((have_len) == sizeof(want) && !memcmp(have, want, sizeof(want)))
+    ((have_len) == (sizeof(want) - 1) && !memcmp(have, want, sizeof(want) - 1))
 
 #define MAX_BLOCKSIZE 32    /* MUST fit biggest crypto block size we use/get */
 #define MAX_MACSIZE 64      /* MUST fit biggest MAC length we support */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -201,8 +201,9 @@ struct iovec {
 #define SSH2_MIN(x, y)  ((x) < (y) ? (x) : (y))
 
 /* Compare memory buffer with string literal */
-#define SSH2_IS_LITERAL(have, have_len, want) \
-    ((have_len) == (sizeof(want) - 1) && !memcmp(have, want, sizeof(want) - 1))
+#define SSH2_IS_LITERAL(have, have_len, want)      \
+    ((have) && (have_len) == (sizeof(want) - 1) && \
+     !memcmp(have, want, sizeof(want) - 1))
 
 #define MAX_BLOCKSIZE 32    /* MUST fit biggest crypto block size we use/get */
 #define MAX_MACSIZE 64      /* MUST fit biggest MAC length we support */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1001,11 +1001,11 @@ static int mbed_ecdsa_curve_type_from_name(const char *name, size_t name_len,
     if(!name || name_len != 19)
         return -1;
 
-    if(!strcmp(name, "ecdsa-sha2-nistp256"))
+    if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp256"))
         type = SSH2_EC_CURVE_NISTP256;
-    else if(!strcmp(name, "ecdsa-sha2-nistp384"))
+    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp384"))
         type = SSH2_EC_CURVE_NISTP384;
-    else if(!strcmp(name, "ecdsa-sha2-nistp521"))
+    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp521"))
         type = SSH2_EC_CURVE_NISTP521;
     else
         return -1;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1021,17 +1021,17 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
                                   const char *data, size_t data_len,
                                   const char *passphrase)
 {
-    ssh2_curve_type type;
-    char *name = NULL;
     struct string_buf *decrypted = NULL;
-    size_t curvelen, exponentlen, pointlen;
+    char *name = NULL;
     unsigned char *curve, *exponent, *point_buf;
+    size_t name_len, curvelen, exponentlen, pointlen;
+    ssh2_curve_type type;
 
     if(ssh2_openssh_pem_parse(session, NULL, data, data_len,
                               passphrase, &decrypted))
         goto failed;
 
-    if(ssh2_get_chars(decrypted, &name, NULL))
+    if(ssh2_get_chars(decrypted, &name, &name_len))
         goto failed;
 
     if(mbed_ecdsa_curve_type_from_name(name, &type))

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -993,12 +993,12 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx)
 /*
  * returns 0 for success, key curve type that maps to ssh2_curve_type
  */
-static int mbed_ecdsa_curve_type_from_name(const char *name,
+static int mbed_ecdsa_curve_type_from_name(const char *name, size_t name_len,
                                            ssh2_curve_type *out_curve)
 {
     ssh2_curve_type type;
 
-    if(!name || strlen(name) != 19)
+    if(!name || name_len != 19)
         return -1;
 
     if(!strcmp(name, "ecdsa-sha2-nistp256"))
@@ -1034,7 +1034,7 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
     if(ssh2_get_chars(decrypted, &name, &name_len))
         goto failed;
 
-    if(mbed_ecdsa_curve_type_from_name(name, &type))
+    if(mbed_ecdsa_curve_type_from_name(name, name_len, &type))
         goto failed;
 
     if(ssh2_get_string(decrypted, &curve, &curvelen))

--- a/src/misc.c
+++ b/src/misc.c
@@ -396,7 +396,7 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
     size_t i = 0, len = 0;
 
     *datalen = 0;
-    *data = SSH2_ALLOC(session, src_len);
+    *data = SSH2_ALLOC(session, src_len + 1);
     d = (unsigned char *)*data;
     if(!d)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
@@ -430,6 +430,8 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
         SSH2_SAFEFREE(session, *data);
         return ssh2_err(session, LIBSSH2_ERROR_INVAL, "Invalid base64");
     }
+
+    (*data)[len] = '\0';
 
     *datalen = len;
     return 0;

--- a/src/misc.c
+++ b/src/misc.c
@@ -431,8 +431,6 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
         return ssh2_err(session, LIBSSH2_ERROR_INVAL, "Invalid base64");
     }
 
-    (*data)[len] = '\0';
-
     *datalen = len;
     return 0;
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -396,7 +396,7 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session,
     size_t i = 0, len = 0;
 
     *datalen = 0;
-    *data = SSH2_ALLOC(session, src_len + 1);
+    *data = SSH2_ALLOC(session, src_len);
     d = (unsigned char *)*data;
     if(!d)
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -679,12 +679,12 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx)
 /*
  * returns 0 for success, key curve type that maps to ssh2_curve_type
  */
-static int ossl_ecdsa_curve_type_from_name(const char *name,
+static int ossl_ecdsa_curve_type_from_name(const char *name, size_t name_len,
                                            ssh2_curve_type *out_curve)
 {
     ssh2_curve_type type;
 
-    if(!name || strlen(name) != 19)
+    if(!name || name_len != 19)
         return -1;
 
     if(!strcmp(name, "ecdsa-sha2-nistp256"))
@@ -3379,14 +3379,16 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
     (void)pubkeydata_len;
 
 #if LIBSSH2_ED25519
-    if(!strcmp("ssh-ed25519", buf) &&
+    if(buf_len == sizeof("ssh-ed25519") - 1 &&
+       !strcmp("ssh-ed25519", buf) &&
        (!want_method || !strcmp("ssh-ed25519", want_method)))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
                                                  method,
                                                  pubkeydata, pubkeydata_len,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 
-    if(!strcmp("sk-ssh-ed25519@openssh.com", buf) &&
+    if(buf_len == sizeof("sk-ssh-ed25519@openssh.com") - 1 &&
+       !strcmp("sk-ssh-ed25519@openssh.com", buf) &&
        (!want_method || !strcmp("sk-ssh-ed25519@openssh.com", want_method)))
         rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
                                                     method,
@@ -3395,7 +3397,8 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 #endif
 #if LIBSSH2_RSA
-    if(!strcmp("ssh-rsa", buf) &&
+    if(buf_len == sizeof("ssh-rsa") - 1 &&
+       !strcmp("ssh-rsa", buf) &&
        (!want_method || !strcmp("ssh-rsa", want_method)))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
                                              method,
@@ -3403,7 +3406,8 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                              (ssh2_rsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_DSA
-    if(!strcmp("ssh-dss", buf) &&
+    if(buf_len == sizeof("ssh-dss") - 1 &&
+       !strcmp("ssh-dss", buf) &&
        (!want_method || !strcmp("ssh-dss", want_method)))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
                                              method,
@@ -3411,13 +3415,14 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                              (ssh2_dsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_ECDSA
-    if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", buf))
+    if(buf_len == sizeof("sk-ecdsa-sha2-nistp256@openssh.com") - 1 &&
+       !strcmp("sk-ecdsa-sha2-nistp256@openssh.com", buf))
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
                                                   method,
                                                   pubkeydata, pubkeydata_len,
                                                   NULL, NULL, NULL, NULL,
                                                   (ssh2_ecdsa_ctx **)key_ctx);
-    else if(ossl_ecdsa_curve_type_from_name(buf, &type) == 0 &&
+    else if(ossl_ecdsa_curve_type_from_name(buf, buf_len, &type) == 0 &&
             (!want_method || !strcmp("ssh-ecdsa", want_method)))
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
                                                method,
@@ -3487,7 +3492,8 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
     (void)key_handle_len;
 
 #if LIBSSH2_ED25519
-    if(!strcmp("sk-ssh-ed25519@openssh.com", buf)) {
+    if(buf_len == sizeof("sk-ssh-ed25519@openssh.com") - 1 &&
+       !strcmp("sk-ssh-ed25519@openssh.com", buf)) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ED25519;
         rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted, method,
                                                     pubkeydata,
@@ -3499,7 +3505,8 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
     }
 #endif
 #if LIBSSH2_ECDSA
-    if(!strcmp("sk-ecdsa-sha2-nistp256@openssh.com", buf)) {
+    if(buf_len == sizeof("sk-ecdsa-sha2-nistp256@openssh.com") - 1 &&
+       !strcmp("sk-ecdsa-sha2-nistp256@openssh.com", buf)) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ECDSA_256;
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted, method,
                                                   pubkeydata,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -687,11 +687,11 @@ static int ossl_ecdsa_curve_type_from_name(const char *name, size_t name_len,
     if(!name || name_len != 19)
         return -1;
 
-    if(!strcmp(name, "ecdsa-sha2-nistp256"))
+    if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp256"))
         type = SSH2_EC_CURVE_NISTP256;
-    else if(!strcmp(name, "ecdsa-sha2-nistp384"))
+    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp384"))
         type = SSH2_EC_CURVE_NISTP384;
-    else if(!strcmp(name, "ecdsa-sha2-nistp521"))
+    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp521"))
         type = SSH2_EC_CURVE_NISTP521;
     else
         return -1;
@@ -3379,16 +3379,14 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
     (void)pubkeydata_len;
 
 #if LIBSSH2_ED25519
-    if(buf_len == sizeof("ssh-ed25519") - 1 &&
-       !strcmp("ssh-ed25519", buf) &&
+    if(SSH2_IS_LITERAL(buf, buf_len, "ssh-ed25519") &&
        (!want_method || !strcmp("ssh-ed25519", want_method)))
         rc = ossl_ed25519_openssh_priv_to_pubkey(session, decrypted,
                                                  method,
                                                  pubkeydata, pubkeydata_len,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 
-    if(buf_len == sizeof("sk-ssh-ed25519@openssh.com") - 1 &&
-       !strcmp("sk-ssh-ed25519@openssh.com", buf) &&
+    if(SSH2_IS_LITERAL(buf, buf_len, "sk-ssh-ed25519@openssh.com") &&
        (!want_method || !strcmp("sk-ssh-ed25519@openssh.com", want_method)))
         rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted,
                                                     method,
@@ -3397,8 +3395,7 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                                  (ssh2_ed25519_ctx **)key_ctx);
 #endif
 #if LIBSSH2_RSA
-    if(buf_len == sizeof("ssh-rsa") - 1 &&
-       !strcmp("ssh-rsa", buf) &&
+    if(SSH2_IS_LITERAL(buf, buf_len, "ssh-rsa") &&
        (!want_method || !strcmp("ssh-rsa", want_method)))
         rc = ossl_rsa_openssh_priv_to_pubkey(session, decrypted,
                                              method,
@@ -3406,8 +3403,7 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                              (ssh2_rsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_DSA
-    if(buf_len == sizeof("ssh-dss") - 1 &&
-       !strcmp("ssh-dss", buf) &&
+    if(SSH2_IS_LITERAL(buf, buf_len, "ssh-dss") &&
        (!want_method || !strcmp("ssh-dss", want_method)))
         rc = ossl_dsa_openssh_priv_to_pubkey(session, decrypted,
                                              method,
@@ -3415,8 +3411,7 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                              (ssh2_dsa_ctx **)key_ctx);
 #endif
 #if LIBSSH2_ECDSA
-    if(buf_len == sizeof("sk-ecdsa-sha2-nistp256@openssh.com") - 1 &&
-       !strcmp("sk-ecdsa-sha2-nistp256@openssh.com", buf))
+    if(SSH2_IS_LITERAL(buf, buf_len, "sk-ecdsa-sha2-nistp256@openssh.com"))
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted,
                                                   method,
                                                   pubkeydata, pubkeydata_len,
@@ -3492,8 +3487,7 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
     (void)key_handle_len;
 
 #if LIBSSH2_ED25519
-    if(buf_len == sizeof("sk-ssh-ed25519@openssh.com") - 1 &&
-       !strcmp("sk-ssh-ed25519@openssh.com", buf)) {
+    if(SSH2_IS_LITERAL(buf, buf_len, "sk-ssh-ed25519@openssh.com")) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ED25519;
         rc = ossl_ed25519_sk_openssh_priv_to_pubkey(session, decrypted, method,
                                                     pubkeydata,
@@ -3505,8 +3499,7 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
     }
 #endif
 #if LIBSSH2_ECDSA
-    if(buf_len == sizeof("sk-ecdsa-sha2-nistp256@openssh.com") - 1 &&
-       !strcmp("sk-ecdsa-sha2-nistp256@openssh.com", buf)) {
+    if(SSH2_IS_LITERAL(buf, buf_len, "sk-ecdsa-sha2-nistp256@openssh.com")) {
         *algorithm = LIBSSH2_HOSTKEY_TYPE_ECDSA_256;
         rc = ossl_ecdsa_sk_openssh_priv_to_pubkey(session, decrypted, method,
                                                   pubkeydata,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3340,6 +3340,7 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
 {
     int rc;
     char *buf = NULL;
+    size_t buf_len = 0;
     struct string_buf *decrypted = NULL;
 #if LIBSSH2_ECDSA
     ssh2_curve_type type;
@@ -3363,7 +3364,7 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
         return rc;
 
     /* We have a new key file, now try and parse it using supported types */
-    rc = ssh2_get_chars(decrypted, &buf, NULL);
+    rc = ssh2_get_chars(decrypted, &buf, &buf_len);
     if(rc || !buf) {
         rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                       "Public key type in decrypted key data not found");
@@ -3448,6 +3449,7 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
 {
     int rc;
     char *buf = NULL;
+    size_t buf_len = 0;
     struct string_buf *decrypted = NULL;
 
     if(!session)
@@ -3465,7 +3467,7 @@ int ssh2_sk_pubkey(LIBSSH2_SESSION *session, char **method,
         return rc;
 
     /* We have a new key file, now try and parse it using supported types */
-    rc = ssh2_get_chars(decrypted, &buf, NULL);
+    rc = ssh2_get_chars(decrypted, &buf, &buf_len);
     if(rc || !buf) {
         rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                       "Public key type in decrypted key data not found");

--- a/src/pem.c
+++ b/src/pem.c
@@ -411,7 +411,8 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
     char *f = NULL;
     size_t f_len = 0;
     int ret = 0, keylen = 0, ivlen = 0, total_len = 0;
-    size_t kdf_len = 0, tmp_len = 0, salt_len = 0;
+    size_t ciphername_len = 0, kdfname_len = 0, kdf_len = 0, tmp_len = 0,
+        salt_len = 0;
 
     if(decrypted_buf)
         *decrypted_buf = NULL;
@@ -441,14 +442,14 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
 
     decoded.dataptr += sizeof(OPENSSH_PRIVKEY_AUTH_MAGIC);
 
-    if(ssh2_get_chars(&decoded, &ciphername, &tmp_len) ||
-       tmp_len == 0) {
+    if(ssh2_get_chars(&decoded, &ciphername, &ciphername_len) ||
+       ciphername_len == 0) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "ciphername is missing");
         goto out;
     }
 
-    if(ssh2_get_chars(&decoded, &kdfname, &tmp_len) ||
-       tmp_len == 0) {
+    if(ssh2_get_chars(&decoded, &kdfname, &kdfname_len) ||
+       kdfname_len == 0) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "kdfname is missing");
         goto out;
     }

--- a/src/pem.c
+++ b/src/pem.c
@@ -465,19 +465,21 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
     }
 
     if((!passphrase || strlen(passphrase) == 0) &&
-       strcmp(ciphername, "none")) {
+       (ciphername_len != sizeof("none") - 1 || strcmp(ciphername, "none"))) {
         /* passphrase required */
         ret = LIBSSH2_ERROR_KEYFILE_AUTH_FAILED;
         goto out;
     }
 
-    if(strcmp(kdfname, "none") && strcmp(kdfname, "bcrypt")) {
+    if((kdfname_len != sizeof("none") - 1 || strcmp(kdfname, "none")) &&
+       (kdfname_len != sizeof("bcrypt") - 1 || strcmp(kdfname, "bcrypt"))) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                        "unrecognized KDF algorithm");
         goto out;
     }
 
-    if(!strcmp(kdfname, "none") && strcmp(ciphername, "none")) {
+    if(kdfname_len == sizeof("none") - 1 && !strcmp(kdfname, "none") &&
+       (ciphername_len != sizeof("none") - 1 || strcmp(ciphername, "none"))) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "invalid format");
         goto out;
     }

--- a/src/pem.c
+++ b/src/pem.c
@@ -465,21 +465,21 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
     }
 
     if((!passphrase || strlen(passphrase) == 0) &&
-       (ciphername_len != sizeof("none") - 1 || strcmp(ciphername, "none"))) {
+       !SSH2_IS_LITERAL(ciphername, ciphername_len, "none")) {
         /* passphrase required */
         ret = LIBSSH2_ERROR_KEYFILE_AUTH_FAILED;
         goto out;
     }
 
-    if((kdfname_len != sizeof("none") - 1 || strcmp(kdfname, "none")) &&
-       (kdfname_len != sizeof("bcrypt") - 1 || strcmp(kdfname, "bcrypt"))) {
+    if(!SSH2_IS_LITERAL(kdfname, kdfname_len, "none") &&
+       !SSH2_IS_LITERAL(kdfname, kdfname_len, "bcrypt")) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                        "unrecognized KDF algorithm");
         goto out;
     }
 
-    if(kdfname_len == sizeof("none") - 1 && !strcmp(kdfname, "none") &&
-       (ciphername_len != sizeof("none") - 1 || strcmp(ciphername, "none"))) {
+    if(SSH2_IS_LITERAL(kdfname, kdfname_len, "none") &&
+       !SSH2_IS_LITERAL(ciphername, ciphername_len, "none")) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "invalid format");
         goto out;
     }

--- a/src/pem.c
+++ b/src/pem.c
@@ -508,15 +508,18 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
     decrypted.data = decrypted.dataptr = buf;
     decrypted.len = tmp_len;
 
-    if(ciphername && strcmp(ciphername, "none")) {
+    if(ciphername && !SSH2_IS_LITERAL(ciphername, ciphername_len, "none"))) {
         const struct crypt_method **all_methods, *cur_method;
 
         all_methods = ssh2_crypt_methods();
         /* !checksrc! disable EQUALSNULL 1 */
         while((cur_method = *all_methods++) != NULL) {
-            if(*cur_method->name && !memcmp(ciphername, cur_method->name,
-                                            strlen(cur_method->name)))
-                method = cur_method;
+            if(*cur_method->name) {
+                size_t want_len = strlen(cur_method->name);
+                if(ciphername_len == want_len &&
+                   !memcmp(ciphername, cur_method->name, want_len))
+                    method = cur_method;
+            }
         }
 
         /* None of the available crypt methods were able to decrypt the key */
@@ -544,7 +547,7 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(!strcmp(kdfname, "bcrypt") && passphrase) {
+        if(SSH2_IS_LITERAL(kdfname, kdfname_len, "bcrypt") && passphrase) {
             if(ssh2_get_string(&kdf_buf, &salt, &salt_len) ||
                ssh2_get_u32(&kdf_buf, &rounds) != 0) {
                 ret = ssh2_err(session, LIBSSH2_ERROR_PROTO,

--- a/src/pem.c
+++ b/src/pem.c
@@ -448,8 +448,7 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
         goto out;
     }
 
-    if(ssh2_get_chars(&decoded, &kdfname, &kdfname_len) ||
-       kdfname_len == 0) {
+    if(ssh2_get_chars(&decoded, &kdfname, &kdfname_len) || kdfname_len == 0) {
         ret = ssh2_err(session, LIBSSH2_ERROR_PROTO, "kdfname is missing");
         goto out;
     }

--- a/src/pem.c
+++ b/src/pem.c
@@ -507,7 +507,7 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
     decrypted.data = decrypted.dataptr = buf;
     decrypted.len = tmp_len;
 
-    if(ciphername && !SSH2_IS_LITERAL(ciphername, ciphername_len, "none"))) {
+    if(ciphername && !SSH2_IS_LITERAL(ciphername, ciphername_len, "none")) {
         const struct crypt_method **all_methods, *cur_method;
 
         all_methods = ssh2_crypt_methods();

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2203,6 +2203,7 @@ cleanup:
 }
 
 static int wcng_ecdsa_curve_type_from_name(IN const char *name,
+                                           IN size_t name_len,
                                            OUT ssh2_curve_type *out_curve)
 {
     unsigned int curve;
@@ -2212,7 +2213,8 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
         return LIBSSH2_ERROR_INVAL;
 
     for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++)
-        if(!strcmp(name, wcng_ecdsa_algs[curve].name)) {
+        if(name_len == strlen(wcng_ecdsa_algs[curve].name) &&
+           !strcmp(name, wcng_ecdsa_algs[curve].name)) {
             *out_curve = (ssh2_curve_type)curve;
             return LIBSSH2_ERROR_NONE;
         }
@@ -2367,7 +2369,8 @@ static int wcng_ecdsa_new_private_parse(OUT ssh2_ecdsa_ctx **ec_ctx,
     if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
 
-    result = wcng_ecdsa_curve_type_from_name(keytype, &curve_type);
+    result = wcng_ecdsa_curve_type_from_name(keytype,
+                                             keytype_len, &curve_type);
     if(result < 0)
         goto cleanup;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2213,8 +2213,9 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
         return LIBSSH2_ERROR_INVAL;
 
     for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++)
-        if(name_len == strlen(wcng_ecdsa_algs[curve].name) &&
-           !strcmp(name, wcng_ecdsa_algs[curve].name)) {
+        size_t want_len = strlen(wcng_ecdsa_algs[curve].name);
+        if(name_len == want_len &&
+           !memcmp(name, wcng_ecdsa_algs[curve].name, want_len)) {
             *out_curve = (ssh2_curve_type)curve;
             return LIBSSH2_ERROR_NONE;
         }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2212,13 +2212,14 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
     if(!name || !out_curve)
         return LIBSSH2_ERROR_INVAL;
 
-    for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++)
+    for(curve = 0; curve < SSH2_ARRAYSIZE(wcng_ecdsa_algs); curve++) {
         size_t want_len = strlen(wcng_ecdsa_algs[curve].name);
         if(name_len == want_len &&
            !memcmp(name, wcng_ecdsa_algs[curve].name, want_len)) {
             *out_curve = (ssh2_curve_type)curve;
             return LIBSSH2_ERROR_NONE;
         }
+    }
 
     return LIBSSH2_ERROR_INVAL;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2328,7 +2328,7 @@ static int wcng_ecdsa_new_private_parse(OUT ssh2_ecdsa_ctx **ec_ctx,
     unsigned char *publickey;
     size_t publickey_len;
 
-    ssh2_curve_type curve_type;
+    ssh2_curve_type curve;
     int result;
     uint32_t check1, check2;
     struct string_buf data_buffer;
@@ -2371,8 +2371,7 @@ static int wcng_ecdsa_new_private_parse(OUT ssh2_ecdsa_ctx **ec_ctx,
     if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
 
-    result = wcng_ecdsa_curve_type_from_name(keytype,
-                                             keytype_len, &curve_type);
+    result = wcng_ecdsa_curve_type_from_name(keytype, keytype_len, &curve);
     if(result < 0)
         goto cleanup;
 


### PR DESCRIPTION
Before this patch some checks were using `strcmp()` on received/read
buffers that may not necessarily have a null-terminator. Fix by always
using the buffer length returned by the buffer reader, compare this
length with the expected one, and use `memcmp()` to verify the content.

When reading ECDSA/ED25519 OpenSSH-formatted keys in
`mbed_parse_openssh_key()`, `ossl_key_from_openssh()`, OpenSSL's
`ssh2_sk_pubkey()`, `pem_parse_data_openssh()`,
`wcng_ecdsa_new_private_parse()`.

Introduce `SSH2_IS_LITERAL()` macro to hide the delicate logic of
comparing a non-null-terminated memory buffer with a string literal.

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2420#discussion_r3642143725
Bug: https://github.com/libssh2/libssh2/pull/2420#pullrequestreview-4771940538
Bug: https://github.com/libssh2/libssh2/pull/2426#pullrequestreview-4773039195
Bug: https://github.com/libssh2/libssh2/pull/2420#discussion_r3645328324
Bug: https://github.com/libssh2/libssh2/pull/2420#discussion_r3645328271
Ref: 0fcb66251b6022f4b800d94c77242217a628aa92 #2403

---

- [x] tackle WinCNG.
- [ ] use `memcmp()`.
- [ ] de-dupe ECDSA curve functions found in mbedtls and openssl.


"`ciphername`/`kdfname` (in `pem_parse_data_openssh()`) are obtained via
`ssh2_get_string()` from the base64-decoded key blob and later compared
with `strcmp()`. The decoded buffer from `ssh2_base64_decode()` is not
NUL-terminated, so these `strcmp()` calls can read past the end of the
allocation if an attacker crafts lengths such that no `\0` occurs before
the buffer end. NUL-terminate the decoded buffer immediately after
decoding to make later string comparisons bounded by the allocation."

```
mbedtls.c:    if(ssh2_get_chars(decrypted, &name, NULL))
openssl.c:    rc = ssh2_get_chars(decrypted, &buf, NULL);
openssl.c:    rc = ssh2_get_chars(decrypted, &buf, NULL);
pem.c:    if(ssh2_get_chars(&decoded, &ciphername, &tmp_len) ||
pem.c:    if(ssh2_get_chars(&decoded, &kdfname, &tmp_len) ||
wincng.c:    result = ssh2_get_chars(&data_buffer, &keytype, &keytype_len);
```
