### PR TITLE
pem: avoid a pointer cast in `pem_parse_data_openssh()` (tidy-up)

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -408,7 +408,7 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
     unsigned char *key = NULL;
     unsigned char *key_part = NULL;
     unsigned char *iv_part = NULL;
-    unsigned char *f = NULL;
+    char *f = NULL;
     size_t f_len = 0;
     int ret = 0, keylen = 0, ivlen = 0, total_len = 0;
     size_t kdf_len = 0, tmp_len = 0, salt_len = 0;
@@ -417,14 +417,14 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
         *decrypted_buf = NULL;
 
     /* decode file */
-    if(ssh2_base64_decode(session, (char **)&f, &f_len, b64data, b64datalen)) {
+    if(ssh2_base64_decode(session, &f, &f_len, b64data, b64datalen)) {
         ret = -1;
         goto out;
     }
 
     /* Parse the file */
-    decoded.data = f;
-    decoded.dataptr = f;
+    decoded.data = (unsigned char *)f;
+    decoded.dataptr = decoded.data;
     decoded.len = f_len;
 
     if(decoded.len < sizeof(OPENSSH_PRIVKEY_AUTH_MAGIC)) {


### PR DESCRIPTION
Follow-up to a34302491c164d53c900fec9b3cbb050ecebe719 #2361
Follow-up to 03092292597ac601c3f9f0c267ecb145dda75e4e #248

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
