### PR TITLE
src: tidy up/fix `ssh2_base64_decode()` calls

### DIFF
--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -181,22 +181,21 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
             goto error;
 
         if(!ptrlen) {
+            SSH2_FREE(hosts->session, ptr);
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL,
                           "Base64 decoded value is invalid");
             goto error;
         }
 
         if(!salt) {
-            if(ptr)
-                SSH2_FREE(hosts->session, ptr);
+            SSH2_FREE(hosts->session, ptr);
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL, "Salt is NULL");
             goto error;
         }
 
         salt_len = strlen(salt);
         if(salt_len > KNOWNHOST_MAX_LEN) {
-            if(ptr)
-                SSH2_FREE(hosts->session, ptr);
+            SSH2_FREE(hosts->session, ptr);
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                           "Salt too long");
             goto error;
@@ -210,6 +209,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
             goto error;
 
         if(!ptrlen) {
+            SSH2_FREE(hosts->session, ptr);
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL,
                           "Base64 decoded value is invalid");
             goto error;

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -180,9 +180,7 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         if(rc)
             goto error;
 
-        if(!ptr || ptrlen == 0) {
-            if(ptr)
-                SSH2_FREE(hosts->session, ptr);
+        if(!ptrlen) {
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL,
                           "Base64 decoded value is invalid");
             goto error;
@@ -207,15 +205,11 @@ static int knownhost_add(LIBSSH2_KNOWNHOSTS *hosts,
         entry->name = ptr;
         entry->name_len = ptrlen;
 
-        ptr = NULL;
-        ptrlen = 0;
         rc = ssh2_base64_decode(hosts->session, &ptr, &ptrlen, salt, salt_len);
         if(rc)
             goto error;
 
-        if(!ptr || ptrlen == 0) {
-            if(ptr)
-                SSH2_FREE(hosts->session, ptr);
+        if(!ptrlen) {
             rc = ssh2_err(hosts->session, LIBSSH2_ERROR_INVAL,
                           "Base64 decoded value is invalid");
             goto error;

--- a/src/misc.c
+++ b/src/misc.c
@@ -379,7 +379,11 @@ int libssh2_base64_decode(LIBSSH2_SESSION *session,
 #endif
 
 /*
- * Decode a base64 chunk and store it into a newly alloc'd buffer
+ * Decode a base64 chunk and store it into a newly allocated buffer
+ *
+ * Always initializes return buffer and length.
+ * Returns error and a NULL buffer if the internal allocation failed.
+ * May return success on zero 'src_len'.
  */
 int ssh2_base64_decode(LIBSSH2_SESSION *session,
                        char **data, size_t *datalen,

--- a/src/misc.c
+++ b/src/misc.c
@@ -381,6 +381,7 @@ int libssh2_base64_decode(LIBSSH2_SESSION *session,
 /*
  * Decode a base64 chunk and store it into a newly allocated buffer
  *
+ * Requires return buffer and length pointer to be non-NULL.
  * Always initializes return buffer and length.
  * Returns error and a NULL buffer if the internal allocation failed.
  * May return success on zero 'src_len'.

--- a/src/pem.c
+++ b/src/pem.c
@@ -259,7 +259,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
                           b64data, b64datalen))
         goto out;
 
-    if(*datalen == 0)
+    if(!*datalen)
         goto out; /* Invalid decode */
 
     if(method) {

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -669,6 +669,13 @@ static int userauth_read_pubkey(LIBSSH2_SESSION *session, char **method,
                         "Invalid key data, not base64 encoded");
     }
 
+    if(!tmp_len) {
+        SSH2_FREE(session, pubkey);
+        SSH2_FREE(session, tmp);
+        return ssh2_err(session, LIBSSH2_ERROR_FILE,
+                        "Invalid key data, zero-length content");
+    }
+
     /* Wasting some bytes here (okay, more than some), but since it is likely
        to be freed soon anyway, we avoid the extra free/alloc and call
        it a wash */


### PR DESCRIPTION
- drop unnecessery pre-initializations.
  (`ssh2_base64_decode()` always initializes)

- drop redundant return buffer NULL checks.
  (`ssh2_base64_decode()` returns error on NULL)
  Follow-up to c6f897b70e14e3b002d2aed30df4b9fe62946ac0 #2025

- add missing check for zero-length result to `ssh2_pem_parse()`.

- document these `ssh2_base64_decode()` behaviors.

It'd be better to handle a zero-length input/output within     
`ssh2_base64_decode()`, but it introduces a slight breakage to the 
public API caller `libssh2_base64_decode()`. Even though the direct
`malloc()` with zero size is already implementation-dependent. 
