### PR TITLE
misc: add non-unsigned char variant for `ssh2_get_string()`

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -898,7 +898,7 @@ int ssh2_match_string(struct string_buf *buf, const char *match)
 {
     char *out;
     size_t len = 0;
-    if(ssh2_get_schars(buf, &out, &len) || len != strlen(match) ||
+    if(ssh2_get_chars(buf, &out, &len) || len != strlen(match) ||
        strncmp(out, match, strlen(match)))
         return -1;
     return 0;
@@ -922,7 +922,7 @@ int ssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
 }
 
 /* Same as ssh2_get_string() but returning a 'char **' pointer */
-int ssh2_get_schars(struct string_buf *buf, char **outbuf, size_t *outlen)
+int ssh2_get_chars(struct string_buf *buf, char **outbuf, size_t *outlen)
 {
     uint32_t data_len;
     if(!buf || ssh2_get_u32(buf, &data_len) != 0)

--- a/src/misc.c
+++ b/src/misc.c
@@ -896,10 +896,10 @@ int ssh2_get_u64(struct string_buf *buf, libssh2_uint64_t *out)
 
 int ssh2_match_string(struct string_buf *buf, const char *match)
 {
-    unsigned char *out;
+    char *out;
     size_t len = 0;
-    if(ssh2_get_string(buf, &out, &len) || len != strlen(match) ||
-       strncmp((const char *)out, match, strlen(match)))
+    if(ssh2_get_schars(buf, &out, &len) || len != strlen(match) ||
+       strncmp(out, match, strlen(match)))
         return -1;
     return 0;
 }
@@ -913,6 +913,23 @@ int ssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
     if(!ssh2_check_length(buf, data_len))
         return -1;
     *outbuf = buf->dataptr;
+    buf->dataptr += data_len;
+
+    if(outlen)
+        *outlen = (size_t)data_len;
+
+    return 0;
+}
+
+/* Same as ssh2_get_string() but returning a 'char **' pointer */
+int ssh2_get_schars(struct string_buf *buf, char **outbuf, size_t *outlen)
+{
+    uint32_t data_len;
+    if(!buf || ssh2_get_u32(buf, &data_len) != 0)
+        return -1;
+    if(!ssh2_check_length(buf, data_len))
+        return -1;
+    *outbuf = (char *)buf->dataptr;
     buf->dataptr += data_len;
 
     if(outlen)

--- a/src/misc.c
+++ b/src/misc.c
@@ -921,7 +921,7 @@ int ssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
     return 0;
 }
 
-/* Same as ssh2_get_string() but returning a 'char **' pointer */
+/* Same as ssh2_get_string() but returning 'char **' pointer */
 int ssh2_get_chars(struct string_buf *buf, char **outbuf, size_t *outlen)
 {
     uint32_t data_len;

--- a/src/misc.h
+++ b/src/misc.h
@@ -152,7 +152,7 @@ int ssh2_get_byte(struct string_buf *buf, unsigned char *out);
 int ssh2_get_u32(struct string_buf *buf, uint32_t *out);
 int ssh2_get_u64(struct string_buf *buf, libssh2_uint64_t *out);
 int ssh2_match_string(struct string_buf *buf, const char *match);
-int ssh2_get_schars(struct string_buf *buf, char **outbuf, size_t *outlen);
+int ssh2_get_chars(struct string_buf *buf, char **outbuf, size_t *outlen);
 int ssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
                     size_t *outlen);
 int ssh2_copy_string(LIBSSH2_SESSION *session, struct string_buf *buf,

--- a/src/misc.h
+++ b/src/misc.h
@@ -152,6 +152,7 @@ int ssh2_get_byte(struct string_buf *buf, unsigned char *out);
 int ssh2_get_u32(struct string_buf *buf, uint32_t *out);
 int ssh2_get_u64(struct string_buf *buf, libssh2_uint64_t *out);
 int ssh2_match_string(struct string_buf *buf, const char *match);
+int ssh2_get_schars(struct string_buf *buf, char **outbuf, size_t *outlen);
 int ssh2_get_string(struct string_buf *buf, unsigned char **outbuf,
                     size_t *outlen);
 int ssh2_copy_string(LIBSSH2_SESSION *session, struct string_buf *buf,


### PR DESCRIPTION
Also use it from `ssh2_match_string()` to reduce casts.

Apparently casting the return pointer of `ssh2_get_string()` buffer is
frowned upon, though existing practice and not completelely clear if UB
or not.

Current practice (with two exceptions, now reduced to one in WinCNG
code) is to declare the return buffer as `unsigned char *`, then cast
that result everywhere on use. It results in excessive casts. The
frowned-upon alternative to avoid this, is to declare as `char *` and
pass it to `ssh2_get_string()` as `(unsigned char **)&data`. This new
API avoid this, and allows to declare as `char *data`, retrieve it
without cast, and use it without casts too.

Ref: #2420
Ref: a7d05f958f4c3414b534107076e8b0f88b233461 #2422
