### PR TITLE
misc: optimize out an `strlen()` call in `ssh2_match_string()`

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -897,10 +897,15 @@ int ssh2_get_u64(struct string_buf *buf, libssh2_uint64_t *out)
 int ssh2_match_string(struct string_buf *buf, const char *match)
 {
     char *out;
-    size_t len = 0;
-    if(ssh2_get_chars(buf, &out, &len) || len != strlen(match) ||
-       strncmp(out, match, strlen(match)))
+    size_t len = 0, match_len;
+
+    if(ssh2_get_chars(buf, &out, &len))
         return -1;
+
+    match_len = strlen(match);
+    if(len != match_len || strncmp(out, match, match_len))
+        return -1;
+
     return 0;
 }
 


### PR DESCRIPTION
Ref: https://github.com/libssh2/libssh2/pull/2424#discussion_r3644994946

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
