### PR TITLE
wincng: avoid pointer cast in `wcng_ecdsa_new_private_parse()`

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2363,8 +2363,7 @@ static int wcng_ecdsa_new_private_parse(OUT ssh2_ecdsa_ctx **ec_ctx,
     /* draft-miller-ssh-agent, section-3.2.2 */
 
     /* Read the key type */
-    result = ssh2_get_string(&data_buffer,
-                             (unsigned char **)&keytype, &keytype_len);
+    result = ssh2_get_chars(&data_buffer, &keytype, &keytype_len);
     if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
 


### PR DESCRIPTION
By using the recently added non-unsigned internal API variant.

Follow-up to 907fe84f7051397f9df65523be7db8a605639020 #2424
Follow-up to 3e72343737e5b17ac98236c03d5591d429b119ae #1315

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
