### PR TITLE
pem: de-duplicate two identical curve type conversions functions

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1246,6 +1246,9 @@ int ssh2_pem_decode_sequence(unsigned char **data, size_t *datalen);
 int ssh2_pem_decode_integer(unsigned char **data, size_t *datalen,
                             unsigned char **i, unsigned int *ilen);
 
+int ssh2_pem_ecdsa_curve_type_from_name(const char *name, size_t name_len,
+                                        ssh2_curve_type *out_curve);
+
 /* global.c */
 void ssh2_init_if_needed(void);
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1246,8 +1246,10 @@ int ssh2_pem_decode_sequence(unsigned char **data, size_t *datalen);
 int ssh2_pem_decode_integer(unsigned char **data, size_t *datalen,
                             unsigned char **i, unsigned int *ilen);
 
+#if LIBSSH2_ECDSA
 int ssh2_pem_ecdsa_curve_type_from_name(const char *name, size_t name_len,
                                         ssh2_curve_type *out_curve);
+#endif
 
 /* global.c */
 void ssh2_init_if_needed(void);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -990,32 +990,6 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx)
     return (ssh2_curve_type)ec_ctx->MBEDTLS_PRIVATE(grp).id;
 }
 
-/*
- * returns 0 for success, key curve type that maps to ssh2_curve_type
- */
-static int mbed_ecdsa_curve_type_from_name(const char *name, size_t name_len,
-                                           ssh2_curve_type *out_curve)
-{
-    ssh2_curve_type type;
-
-    if(!name || name_len != 19)
-        return -1;
-
-    if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp256"))
-        type = SSH2_EC_CURVE_NISTP256;
-    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp384"))
-        type = SSH2_EC_CURVE_NISTP384;
-    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp521"))
-        type = SSH2_EC_CURVE_NISTP521;
-    else
-        return -1;
-
-    if(out_curve)
-        *out_curve = type;
-
-    return 0;
-}
-
 static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
                                   LIBSSH2_SESSION *session,
                                   const char *data, size_t data_len,
@@ -1034,7 +1008,7 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
     if(ssh2_get_chars(decrypted, &name, &name_len))
         goto failed;
 
-    if(mbed_ecdsa_curve_type_from_name(name, name_len, &type))
+    if(ssh2_pem_ecdsa_curve_type_from_name(name, name_len, &type))
         goto failed;
 
     if(ssh2_get_string(decrypted, &curve, &curvelen))

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -677,32 +677,6 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx)
 }
 
 /*
- * returns 0 for success, key curve type that maps to ssh2_curve_type
- */
-static int ossl_ecdsa_curve_type_from_name(const char *name, size_t name_len,
-                                           ssh2_curve_type *out_curve)
-{
-    ssh2_curve_type type;
-
-    if(!name || name_len != 19)
-        return -1;
-
-    if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp256"))
-        type = SSH2_EC_CURVE_NISTP256;
-    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp384"))
-        type = SSH2_EC_CURVE_NISTP384;
-    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp521"))
-        type = SSH2_EC_CURVE_NISTP521;
-    else
-        return -1;
-
-    if(out_curve)
-        *out_curve = type;
-
-    return 0;
-}
-
-/*
  * Creates a new public key given an octal string, length and type
  */
 int ssh2_ecdsa_curve_name_with_octal_new(
@@ -3417,7 +3391,7 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                                   pubkeydata, pubkeydata_len,
                                                   NULL, NULL, NULL, NULL,
                                                   (ssh2_ecdsa_ctx **)key_ctx);
-    else if(ossl_ecdsa_curve_type_from_name(buf, buf_len, &type) == 0 &&
+    else if(ssh2_pem_ecdsa_curve_type_from_name(buf, buf_len, &type) == 0 &&
             (!want_method || !strcmp("ssh-ecdsa", want_method)))
         rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
                                                method,

--- a/src/pem.c
+++ b/src/pem.c
@@ -903,3 +903,29 @@ int ssh2_pem_decode_integer(unsigned char **data, size_t *datalen,
 
     return 0;
 }
+
+/*
+ * returns 0 for success, key curve type that maps to ssh2_curve_type
+ */
+int ssh2_pem_ecdsa_curve_type_from_name(const char *name, size_t name_len,
+                                        ssh2_curve_type *out_curve)
+{
+    ssh2_curve_type type;
+
+    if(!name || name_len != 19)
+        return -1;
+
+    if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp256"))
+        type = SSH2_EC_CURVE_NISTP256;
+    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp384"))
+        type = SSH2_EC_CURVE_NISTP384;
+    else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp521"))
+        type = SSH2_EC_CURVE_NISTP521;
+    else
+        return -1;
+
+    if(out_curve)
+        *out_curve = type;
+
+    return 0;
+}

--- a/src/pem.c
+++ b/src/pem.c
@@ -904,6 +904,7 @@ int ssh2_pem_decode_integer(unsigned char **data, size_t *datalen,
     return 0;
 }
 
+#if LIBSSH2_ECDSA
 /*
  * returns 0 for success, key curve type that maps to ssh2_curve_type
  */
@@ -929,3 +930,4 @@ int ssh2_pem_ecdsa_curve_type_from_name(const char *name, size_t name_len,
 
     return 0;
 }
+#endif

--- a/src/pem.c
+++ b/src/pem.c
@@ -913,7 +913,7 @@ int ssh2_pem_ecdsa_curve_type_from_name(const char *name, size_t name_len,
 {
     ssh2_curve_type type;
 
-    if(!name || name_len != 19)
+    if(!name)
         return -1;
 
     if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp256"))

--- a/src/pem.c
+++ b/src/pem.c
@@ -913,9 +913,6 @@ int ssh2_pem_ecdsa_curve_type_from_name(const char *name, size_t name_len,
 {
     ssh2_curve_type type;
 
-    if(!name)
-        return -1;
-
     if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp256"))
         type = SSH2_EC_CURVE_NISTP256;
     else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp384"))


### PR DESCRIPTION
Also drop redundant sanity checks.

Follow-up to 262c97f7f3d18fad5792de0e75ed500cccda5d6b #2421
