### PR TITLE
tidy-up: variable name sync, comment/formatting nits

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
 
-    /* Must use non-blocking IO hereafter due to the current libssh2 API */
+    /* Must use non-blocking I/O hereafter due to the current libssh2 API */
     libssh2_session_set_blocking(session, 0);
 
     for(;;) {

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
             remote_listenhost, remote_listenport,
             local_destip, local_destport);
 
-    /* Must use non-blocking IO hereafter due to the current libssh2 API */
+    /* Must use non-blocking I/O hereafter due to the current libssh2 API */
     libssh2_session_set_blocking(session, 0);
 
     for(;;) {

--- a/src/agent.c
+++ b/src/agent.c
@@ -361,7 +361,7 @@ static int agent_connect_openssh(LIBSSH2_AGENT *agent)
     for(;;) {
         /* Non-blocking mode for agent connections is not implemented at
          * the point this was implemented. The code for Win32 OpenSSH
-         * should support non-blocking IO, but the code calling it does not
+         * should support non-blocking I/O, but the code calling it does not
          * support it as of yet.
          * When non-blocking I/O is implemented for the surrounding code,
          * uncomment the following line to enable support within the Win32
@@ -543,7 +543,7 @@ static int agent_disconnect_openssh(LIBSSH2_AGENT *agent)
 {
     if(!CancelIo(agent->pipe))
         return ssh2_err(agent->session, LIBSSH2_ERROR_SOCKET_DISCONNECT,
-                        "failed to cancel pending IO of agent pipe");
+                        "failed to cancel pending I/O of agent pipe");
     if(!CloseHandle(agent->overlapped.hEvent))
         return ssh2_err(agent->session, LIBSSH2_ERROR_SOCKET_DISCONNECT,
                         "failed to close handle to async I/O event");

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -619,7 +619,7 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
     char *type_str, *domain;
     unsigned char *public_key;
     size_t key_len, len;
-    ssh2_curve_type type;
+    ssh2_curve_type curve;
     struct string_buf buf;
 
     if(abstract && *abstract) {
@@ -640,22 +640,22 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
         return -1;
 
     if(!strncmp(type_str, "ecdsa-sha2-nistp256", 19))
-        type = SSH2_EC_CURVE_NISTP256;
+        curve = SSH2_EC_CURVE_NISTP256;
     else if(!strncmp(type_str, "ecdsa-sha2-nistp384", 19))
-        type = SSH2_EC_CURVE_NISTP384;
+        curve = SSH2_EC_CURVE_NISTP384;
     else if(!strncmp(type_str, "ecdsa-sha2-nistp521", 19))
-        type = SSH2_EC_CURVE_NISTP521;
+        curve = SSH2_EC_CURVE_NISTP521;
     else
         return -1;
 
     if(ssh2_get_chars(&buf, &domain, &len) || len != 8)
         return -1;
 
-    if(type == SSH2_EC_CURVE_NISTP256 && strncmp(domain, "nistp256", 8))
+    if(curve == SSH2_EC_CURVE_NISTP256 && strncmp(domain, "nistp256", 8))
         return -1;
-    else if(type == SSH2_EC_CURVE_NISTP384 && strncmp(domain, "nistp384", 8))
+    else if(curve == SSH2_EC_CURVE_NISTP384 && strncmp(domain, "nistp384", 8))
         return -1;
-    else if(type == SSH2_EC_CURVE_NISTP521 && strncmp(domain, "nistp521", 8))
+    else if(curve == SSH2_EC_CURVE_NISTP521 && strncmp(domain, "nistp521", 8))
         return -1;
 
     /* public key */
@@ -666,7 +666,7 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
         return -1;
 
     if(ssh2_ecdsa_curve_name_with_octal_new(&ec_ctx, public_key,
-                                            key_len, type))
+                                            key_len, curve))
         return -1;
 
     if(abstract)
@@ -755,22 +755,22 @@ static int hostkey_method_ssh_ecdsa_signv(LIBSSH2_SESSION *session,
                                           void **abstract)
 {
     ssh2_ecdsa_ctx *ec_ctx = (ssh2_ecdsa_ctx *)(*abstract);
-    ssh2_curve_type type = ssh2_ecdsa_get_curve_type(ec_ctx);
+    ssh2_curve_type curve = ssh2_ecdsa_get_curve_type(ec_ctx);
     unsigned char hash[MAX_SHA_DIGEST_LEN];
     ssh2_hash_ctx ctx;
     ssh2_hash_alg hash_alg;
     size_t hash_len;
     int i;
 
-    if(type == SSH2_EC_CURVE_NISTP256) {
+    if(curve == SSH2_EC_CURVE_NISTP256) {
         hash_alg = SSH2_SHA256_ALG;
         hash_len = SSH2_SHA256_DIG_LEN;
     }
-    else if(type == SSH2_EC_CURVE_NISTP384) {
+    else if(curve == SSH2_EC_CURVE_NISTP384) {
         hash_alg = SSH2_SHA384_ALG;
         hash_len = SSH2_SHA384_DIG_LEN;
     }
-    else if(type == SSH2_EC_CURVE_NISTP521) {
+    else if(curve == SSH2_EC_CURVE_NISTP521) {
         hash_alg = SSH2_SHA512_ALG;
         hash_len = SSH2_SHA512_DIG_LEN;
     }

--- a/src/kex.c
+++ b/src/kex.c
@@ -1760,7 +1760,7 @@ static int kex_method_ecdh_key_exchange(
     int ret = 0;
     int rc = 0;
     unsigned char *s;
-    ssh2_curve_type type;
+    ssh2_curve_type curve;
 
     if(key_state->state == ssh2_NB_state_idle) {
         key_state->public_key_oct = NULL;
@@ -1768,7 +1768,7 @@ static int kex_method_ecdh_key_exchange(
     }
 
     if(key_state->state == ssh2_NB_state_created) {
-        rc = kex_session_curve_type(session->kex->name, &type);
+        rc = kex_session_curve_type(session->kex->name, &curve);
         if(rc) {
             ret = ssh2_err(session, -1, "Unrecognized KEX nistp curve type");
             goto ecdh_clean_exit;
@@ -1776,7 +1776,7 @@ static int kex_method_ecdh_key_exchange(
 
         rc = ssh2_ecdsa_create_key(&key_state->private_key, session,
                                    &key_state->public_key_oct,
-                                   &key_state->public_key_oct_len, type);
+                                   &key_state->public_key_oct_len, curve);
         if(rc) {
             ret = ssh2_err(session, rc, "Unable to create private key");
             goto ecdh_clean_exit;
@@ -1823,13 +1823,13 @@ static int kex_method_ecdh_key_exchange(
     }
 
     if(key_state->state == ssh2_NB_state_sent2) {
-        rc = kex_session_curve_type(session->kex->name, &type);
+        rc = kex_session_curve_type(session->kex->name, &curve);
         if(rc) {
             ret = ssh2_err(session, -1, "Unrecognized KEX nistp curve type");
             goto ecdh_clean_exit;
         }
 
-        ret = kex_ecdh_sha2_nistp(session, type, key_state->data,
+        ret = kex_ecdh_sha2_nistp(session, curve, key_state->data,
                                   key_state->data_len,
                                   (unsigned char *)key_state->public_key_oct,
                                   key_state->public_key_oct_len,
@@ -1905,17 +1905,17 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
     int ret = 0;
     int rc, mlkem_size;
     ssh2_hash_alg hash_alg;
-    ssh2_curve_type type;
+    ssh2_curve_type curve;
     size_t digest_len, mlkem_cipher_len, public_pq_key_len;
     unsigned char *shared_secret = NULL;
 
-    if(kex_session_curve_type(session->kex->name, &type)) {
+    if(kex_session_curve_type(session->kex->name, &curve)) {
         ret = ssh2_err(session, -1,
                        "Unrecognized KEX hybrid nistp curve type");
         goto clean_exit;
     }
 
-    switch(type) {
+    switch(curve) {
     case SSH2_EC_CURVE_NISTP256:
         hash_alg = SSH2_SHA256_ALG;
         digest_len = SSH2_SHA256_DIG_LEN;
@@ -2088,19 +2088,19 @@ static int kex_method_mlkem_nistp_key_exchange(
     }
 
     if(key_state->state == ssh2_NB_state_created) {
-        ssh2_curve_type type;
+        ssh2_curve_type curve;
         int mlkem_size;
         size_t mlkem_public_key_len;
         size_t mlkem_private_key_len;
         unsigned char *s = NULL;
 
-        if(kex_session_curve_type(session->kex->name, &type)) {
+        if(kex_session_curve_type(session->kex->name, &curve)) {
             ret = ssh2_err(session, -1,
                            "Unrecognized KEX hybrid nistp curve type");
             goto clean_exit;
         }
 
-        switch(type) {
+        switch(curve) {
         case SSH2_EC_CURVE_NISTP256:
             mlkem_size = 768;
             mlkem_public_key_len = SSH2_MLKEM_768_PUBLIC_KEY_LEN;
@@ -2119,7 +2119,7 @@ static int kex_method_mlkem_nistp_key_exchange(
 
         rc = ssh2_ecdsa_create_key(&key_state->private_key, session,
                                    &key_state->public_key_oct,
-                                   &key_state->public_key_oct_len, type);
+                                   &key_state->public_key_oct_len, curve);
         if(rc) {
             ret = ssh2_err(session, rc, "Unable to create ecdh private key");
             goto clean_exit;

--- a/src/kex.c
+++ b/src/kex.c
@@ -1577,7 +1577,7 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
 /*
  * Elliptic Curve Diffie Hellman Key Exchange
  */
-static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
+static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type curve,
                                unsigned char *data, size_t data_len,
                                unsigned char *public_key,
                                size_t public_key_len, ssh2_ec_key *private_key,
@@ -1589,15 +1589,15 @@ static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type type,
     ssh2_hash_alg hash_alg;
     size_t digest_len = 0;
 
-    if(type == SSH2_EC_CURVE_NISTP256) {
+    if(curve == SSH2_EC_CURVE_NISTP256) {
         hash_alg = SSH2_SHA256_ALG;
         digest_len = SSH2_SHA256_DIG_LEN;
     }
-    else if(type == SSH2_EC_CURVE_NISTP384) {
+    else if(curve == SSH2_EC_CURVE_NISTP384) {
         hash_alg = SSH2_SHA384_ALG;
         digest_len = SSH2_SHA384_DIG_LEN;
     }
-    else if(type == SSH2_EC_CURVE_NISTP521) {
+    else if(curve == SSH2_EC_CURVE_NISTP521) {
         hash_alg = SSH2_SHA512_ALG;
         digest_len = SSH2_SHA512_DIG_LEN;
     }

--- a/src/kex.c
+++ b/src/kex.c
@@ -119,8 +119,10 @@ static int kex_proc_hostkey(LIBSSH2_SESSION *session, struct string_buf *buf,
 
 #if LIBSSH2_MD5
     session->server_hostkey_md5_valid = ssh2_hash(SSH2_MD5_ALG,
-        session->server_hostkey, session->server_hostkey_len,
-        session->server_hostkey_md5, sizeof(session->server_hostkey_md5));
+                                                  session->server_hostkey,
+                                                  session->server_hostkey_len,
+                                                  session->server_hostkey_md5,
+                                          sizeof(session->server_hostkey_md5));
 #ifdef LIBSSH2DEBUG
     {
         char fingerprint[SSH2_MD5_DIG_LEN * 3 + 1];

--- a/src/kex.c
+++ b/src/kex.c
@@ -119,10 +119,8 @@ static int kex_proc_hostkey(LIBSSH2_SESSION *session, struct string_buf *buf,
 
 #if LIBSSH2_MD5
     session->server_hostkey_md5_valid = ssh2_hash(SSH2_MD5_ALG,
-                                                  session->server_hostkey,
-                                                  session->server_hostkey_len,
-                                                  session->server_hostkey_md5,
-                                          sizeof(session->server_hostkey_md5));
+        session->server_hostkey, session->server_hostkey_len,
+        session->server_hostkey_md5, sizeof(session->server_hostkey_md5));
 #ifdef LIBSSH2DEBUG
     {
         char fingerprint[SSH2_MD5_DIG_LEN * 3 + 1];

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -389,7 +389,7 @@ struct key_exchange_state {
 
 struct packet_queue_listener_state {
     ssh2_NB_states state;
-    unsigned char packet[17 + (sizeof(FwdNotReq) - 1)];
+    unsigned char packet[17 + sizeof(FwdNotReq) - 1];
     unsigned char *host;
     unsigned char *shost;
     uint32_t sender_channel;
@@ -406,7 +406,7 @@ struct packet_queue_listener_state {
 
 struct packet_x11_open_state {
     ssh2_NB_states state;
-    unsigned char packet[17 + (sizeof(X11FwdUnAvil) - 1)];
+    unsigned char packet[17 + sizeof(X11FwdUnAvil) - 1];
     unsigned char *shost;
     uint32_t sender_channel;
     uint32_t initial_window_size;
@@ -420,7 +420,7 @@ struct packet_x11_open_state {
 
 struct packet_authagent_state {
     ssh2_NB_states state;
-    unsigned char packet[17 + (sizeof(AuthAgentUnavail) - 1)];
+    unsigned char packet[17 + sizeof(AuthAgentUnavail) - 1];
     uint32_t sender_channel;
     uint32_t initial_window_size;
     uint32_t packet_size;
@@ -911,7 +911,7 @@ struct _LIBSSH2_SESSION {
     unsigned char *pkeyInit_data;
     size_t pkeyInit_data_len;
     /* 19 = packet_len(4) + version_len(4) + "version"(7) + version_num(4) */
-    unsigned char pkeyInit_buffer[4 + 4 + (sizeof("version") - 1) + 4];
+    unsigned char pkeyInit_buffer[4 + 4 + sizeof("version") - 1 + 4];
     size_t pkeyInit_buffer_sent; /* how much of buffer that has been sent */
 
     /* State variables used in ssh2_packet_add() */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -997,9 +997,9 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
 {
     struct string_buf *decrypted = NULL;
     char *name = NULL;
-    unsigned char *curve, *exponent, *point_buf;
-    size_t name_len, curvelen, exponentlen, pointlen;
-    ssh2_curve_type type;
+    unsigned char *curvebuf, *exponent, *pointbuf;
+    size_t name_len, curvebuf_len, exponent_len, pointbuf_len;
+    ssh2_curve_type curve;
 
     if(ssh2_openssh_pem_parse(session, NULL, data, data_len,
                               passphrase, &decrypted))
@@ -1008,16 +1008,16 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
     if(ssh2_get_chars(decrypted, &name, &name_len))
         goto failed;
 
-    if(ssh2_pem_ecdsa_curve_type_from_name(name, name_len, &type))
+    if(ssh2_pem_ecdsa_curve_type_from_name(name, name_len, &curve))
         goto failed;
 
-    if(ssh2_get_string(decrypted, &curve, &curvelen))
+    if(ssh2_get_string(decrypted, &curvebuf, &curvebuf_len))
         goto failed;
 
-    if(ssh2_get_string(decrypted, &point_buf, &pointlen))
+    if(ssh2_get_string(decrypted, &pointbuf, &pointbuf_len))
         goto failed;
 
-    if(ssh2_get_bignum_bytes(decrypted, &exponent, &exponentlen))
+    if(ssh2_get_bignum_bytes(decrypted, &exponent, &exponent_len))
         goto failed;
 
     *ctx = mbedtls_calloc(1, sizeof(ssh2_ecdsa_ctx));
@@ -1027,11 +1027,11 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
     mbedtls_ecdsa_init(*ctx);
 
     if(mbedtls_ecp_group_load(&(*ctx)->MBEDTLS_PRIVATE(grp),
-                              (mbedtls_ecp_group_id)type))
+                              (mbedtls_ecp_group_id)curve))
         goto failed;
 
     if(mbedtls_mpi_read_binary(&(*ctx)->MBEDTLS_PRIVATE(d),
-                               exponent, exponentlen))
+                               exponent, exponent_len))
         goto failed;
 
     if(mbedtls_ecp_mul(&(*ctx)->MBEDTLS_PRIVATE(grp),

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2561,7 +2561,7 @@ clean_exit:
 }
 
 static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
-                                             ssh2_curve_type curve_type,
+                                             ssh2_curve_type curve,
                                              struct string_buf *decrypted,
                                              char **method,
                                              unsigned char **pubkeydata,
@@ -2576,7 +2576,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
 #ifdef USE_OPENSSL_3
     EVP_PKEY_CTX *fromdata_ctx = NULL;
     OSSL_PARAM params[4];
-    const char *n = EC_curve_nid2nist(curve_type);
+    const char *n = EC_curve_nid2nist(curve);
     char *group_name = NULL;
 #else
     BIGNUM *bn_exponent;
@@ -2633,7 +2633,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         OPENSSL_clear_free(group_name, strlen(n) + 1);
 #else
     rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, point_buf, pointlen,
-                                              curve_type);
+                                              curve);
     if(rc) {
         rc = -1;
         ssh2_err(session, LIBSSH2_ERROR_PROTO, "ECDSA could not create key");

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1870,9 +1870,10 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
         goto clean_exit;
     }
 
-    /* Key form is: type_len(4) + type(26) + pub_key_len(4) +
-       pub_key(32) + application_len(4) + application(X). */
-    key_len = SSH2_ED25519_KEY_LEN + 38 + app_len;
+    /* Key form is: type_len(4) + type(26) + pub_key_len(4) + pub_key(32)
+       + application_len(4) + application(X). */
+    key_len = 4 + sizeof(method_name) - 1 + 4 + SSH2_ED25519_KEY_LEN +
+              4 + app_len;
     key = p = SSH2_CALLOC(session, key_len);
     if(!key) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -769,7 +769,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
                       const unsigned char *m, size_t m_len)
 {
     int ret = 0;
-    ssh2_curve_type type = ssh2_ecdsa_get_curve_type(ec_ctx);
+    ssh2_curve_type curve = ssh2_ecdsa_get_curve_type(ec_ctx);
 
 #ifdef USE_OPENSSL_3
     EVP_PKEY_CTX *ctx = NULL;
@@ -818,7 +818,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
         goto cleanup;
     }
 
-    if(type == SSH2_EC_CURVE_NISTP256) {
+    if(curve == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
         if(ssh2_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
@@ -826,7 +826,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
         }
     }
-    else if(type == SSH2_EC_CURVE_NISTP384) {
+    else if(curve == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
         if(ssh2_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
@@ -834,7 +834,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
                 ret = EVP_PKEY_verify(ctx, der, der_len, hash, sizeof(hash));
         }
     }
-    else if(type == SSH2_EC_CURVE_NISTP521) {
+    else if(curve == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
         if(ssh2_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash))) {
             ret = EVP_PKEY_verify_init(ctx);
@@ -850,17 +850,17 @@ cleanup:
     if(der)
         OPENSSL_free(der);
 #else
-    if(type == SSH2_EC_CURVE_NISTP256) {
+    if(curve == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
         if(ssh2_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
-    else if(type == SSH2_EC_CURVE_NISTP384) {
+    else if(curve == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
         if(ssh2_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
     }
-    else if(type == SSH2_EC_CURVE_NISTP521) {
+    else if(curve == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
         if(ssh2_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)))
             ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
@@ -2425,13 +2425,13 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
     size_t key_len = 0;
     unsigned char *octal_value = NULL;
     size_t octal_len;
-    ssh2_curve_type type;
+    ssh2_curve_type curve;
 
 #ifdef USE_OPENSSL_3
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing public key from EC private key envelope"));
 
-    type = ssh2_ecdsa_get_curve_type(pk);
+    curve = ssh2_ecdsa_get_curve_type(pk);
 #else
     EC_KEY *ec = NULL;
     const EC_POINT *public_key;
@@ -2453,7 +2453,7 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
 
     public_key = EC_KEY_get0_public_key(ec);
     group = EC_KEY_get0_group(ec);
-    type = ssh2_ecdsa_get_curve_type(ec);
+    curve = ssh2_ecdsa_get_curve_type(ec);
 #endif
 
     if(is_sk)
@@ -2468,11 +2468,11 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
     if(is_sk)
         memcpy(method_buf, "sk-ecdsa-sha2-nistp256@openssh.com",
                method_buf_len + 1);
-    else if(type == SSH2_EC_CURVE_NISTP256)
+    else if(curve == SSH2_EC_CURVE_NISTP256)
         memcpy(method_buf, "ecdsa-sha2-nistp256", method_buf_len + 1);
-    else if(type == SSH2_EC_CURVE_NISTP384)
+    else if(curve == SSH2_EC_CURVE_NISTP384)
         memcpy(method_buf, "ecdsa-sha2-nistp384", method_buf_len + 1);
-    else if(type == SSH2_EC_CURVE_NISTP521)
+    else if(curve == SSH2_EC_CURVE_NISTP521)
         memcpy(method_buf, "ecdsa-sha2-nistp521", method_buf_len + 1);
     else {
         ssh2_deb((session, LIBSSH2_TRACE_ERROR,
@@ -3318,7 +3318,7 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
     size_t buf_len = 0;
     struct string_buf *decrypted = NULL;
 #if LIBSSH2_ECDSA
-    ssh2_curve_type type;
+    ssh2_curve_type curve;
 #endif
 
     if(key_ctx)
@@ -3392,9 +3392,9 @@ static int ossl_key_from_openssh(LIBSSH2_SESSION *session,
                                                   pubkeydata, pubkeydata_len,
                                                   NULL, NULL, NULL, NULL,
                                                   (ssh2_ecdsa_ctx **)key_ctx);
-    else if(ssh2_pem_ecdsa_curve_type_from_name(buf, buf_len, &type) == 0 &&
+    else if(ssh2_pem_ecdsa_curve_type_from_name(buf, buf_len, &curve) == 0 &&
             (!want_method || !strcmp("ssh-ecdsa", want_method)))
-        rc = ossl_ecdsa_openssh_priv_to_pubkey(session, type, decrypted,
+        rc = ossl_ecdsa_openssh_priv_to_pubkey(session, curve, decrypted,
                                                method,
                                                pubkeydata, pubkeydata_len,
                                                (ssh2_ecdsa_ctx **)key_ctx);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2569,8 +2569,8 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                              ssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
-    size_t curvebuf_len, exponentlen, pointlen;
-    unsigned char *curvebuf, *exponent, *point_buf;
+    size_t curvebuf_len, exponentlen, pointbuf_len;
+    unsigned char *curvebuf, *exponent, *pointbuf;
     ssh2_ecdsa_ctx *ctx = NULL;
 
 #ifdef USE_OPENSSL_3
@@ -2590,7 +2590,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    if(ssh2_get_string(decrypted, &point_buf, &pointlen)) {
+    if(ssh2_get_string(decrypted, &pointbuf, &pointbuf_len)) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO, "ECDSA no point");
         return -1;
     }
@@ -2618,7 +2618,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
                                                  group_name, 0);
     params[1] = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
-                                                  point_buf, pointlen);
+                                                  pointbuf, pointbuf_len);
     params[2] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PRIV_KEY, exponent,
                                         exponentlen);
     params[3] = OSSL_PARAM_construct_end();
@@ -2632,7 +2632,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     if(group_name)
         OPENSSL_clear_free(group_name, strlen(n) + 1);
 #else
-    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, point_buf, pointlen,
+    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, pointbuf, pointbuf_len,
                                               curve);
     if(rc) {
         rc = -1;
@@ -2707,8 +2707,8 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     ssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
-    size_t curvebuf_len, pointlen, key_len, app_len;
-    unsigned char *curvebuf, *point_buf, *p, *key = NULL, *app;
+    size_t curvebuf_len, pointbuf_len, key_len, app_len;
+    unsigned char *curvebuf, *pointbuf, *p, *key = NULL, *app;
     ssh2_ecdsa_ctx *ctx = NULL;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Extracting ECDSA-SK public key"));
@@ -2718,12 +2718,12 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
         return -1;
     }
 
-    if(ssh2_get_string(decrypted, &point_buf, &pointlen)) {
+    if(ssh2_get_string(decrypted, &pointbuf, &pointbuf_len)) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO, "ECDSA no point");
         return -1;
     }
 
-    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, point_buf, pointlen,
+    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, pointbuf, pointbuf_len,
                                               SSH2_EC_CURVE_NISTP256);
     if(rc) {
         rc = -1;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2569,7 +2569,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                              ssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
-    size_t curvebuf_len, exponentlen, pointbuf_len;
+    size_t curvebuf_len, exponent_len, pointbuf_len;
     unsigned char *curvebuf, *exponent, *pointbuf;
     ssh2_ecdsa_ctx *ctx = NULL;
 
@@ -2595,7 +2595,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    if(ssh2_get_bignum_bytes(decrypted, &exponent, &exponentlen)) {
+    if(ssh2_get_bignum_bytes(decrypted, &exponent, &exponent_len)) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO, "ECDSA no exponent");
         return -1;
     }
@@ -2613,14 +2613,14 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto fail;
 
     memcpy(group_name, n, strlen(n) + 1);
-    ossl_swap_bytes(exponent, exponentlen);
+    ossl_swap_bytes(exponent, exponent_len);
 
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
                                                  group_name, 0);
     params[1] = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
                                                   pointbuf, pointbuf_len);
     params[2] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PRIV_KEY, exponent,
-                                        exponentlen);
+                                        exponent_len);
     params[3] = OSSL_PARAM_construct_end();
 
     if(EVP_PKEY_fromdata_init(fromdata_ctx) <= 0)
@@ -2648,7 +2648,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto fail;
     }
 
-    BN_bin2bn(exponent, (int)exponentlen, bn_exponent);
+    BN_bin2bn(exponent, (int)exponent_len, bn_exponent);
     rc = (EC_KEY_set_private_key(ctx, bn_exponent) != 1);
     BN_free(bn_exponent);
 #endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3550,8 +3550,7 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
         /* Try OpenSSH format */
         if(!ossl_key_from_openssh(session, NULL, NULL, method,
                                   pubkeydata, pubkeydata_len,
-                                  privkeyfile,
-                                  privkeyblob, privkeyblob_len,
+                                  privkeyfile, privkeyblob, privkeyblob_len,
                                   passphrase))
             return 0;
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2569,8 +2569,8 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
                                              ssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
-    size_t curvelen, exponentlen, pointlen;
-    unsigned char *curve, *exponent, *point_buf;
+    size_t curvebuf_len, exponentlen, pointlen;
+    unsigned char *curvebuf, *exponent, *point_buf;
     ssh2_ecdsa_ctx *ctx = NULL;
 
 #ifdef USE_OPENSSL_3
@@ -2585,7 +2585,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     ssh2_deb((session, LIBSSH2_TRACE_AUTH,
               "Computing ECDSA keys from private key data"));
 
-    if(ssh2_get_string(decrypted, &curve, &curvelen) || curvelen == 0) {
+    if(ssh2_get_string(decrypted, &curvebuf, &curvebuf_len) || !curvebuf_len) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO, "ECDSA no curve");
         return -1;
     }
@@ -2707,13 +2707,13 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     ssh2_ecdsa_ctx **ec_ctx)
 {
     int rc = 0;
-    size_t curvelen, pointlen, key_len, app_len;
-    unsigned char *curve, *point_buf, *p, *key = NULL, *app;
+    size_t curvebuf_len, pointlen, key_len, app_len;
+    unsigned char *curvebuf, *point_buf, *p, *key = NULL, *app;
     ssh2_ecdsa_ctx *ctx = NULL;
 
     ssh2_deb((session, LIBSSH2_TRACE_AUTH, "Extracting ECDSA-SK public key"));
 
-    if(ssh2_get_string(decrypted, &curve, &curvelen) || curvelen == 0) {
+    if(ssh2_get_string(decrypted, &curvebuf, &curvebuf_len) || !curvebuf_len) {
         ssh2_err(session, LIBSSH2_ERROR_PROTO, "ECDSA no curve");
         return -1;
     }

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1405,7 +1405,7 @@ static int ossl_dsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
     dsa = EVP_PKEY_get1_DSA(pk);
 #endif
     if(!dsa)
-        /* Assume memory allocation error... what else could it be ? */
+        /* Assume memory allocation error... what else could it be? */
         goto alloc_error;
 
     method_buf = SSH2_ALLOC(session, sizeof(method_name));

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3576,25 +3576,25 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
         rc = ossl_ed25519_evp_to_pubkey(session, method,
                                         pubkeydata, pubkeydata_len, pk);
         break;
-#endif /* LIBSSH2_ED25519 */
+#endif
 #if LIBSSH2_RSA
     case EVP_PKEY_RSA:
         rc = ossl_rsa_evp_to_pubkey(session, method,
                                     pubkeydata, pubkeydata_len, pk);
         break;
-#endif /* LIBSSH2_RSA */
+#endif
 #if LIBSSH2_DSA
     case EVP_PKEY_DSA:
         rc = ossl_dsa_evp_to_pubkey(session, method,
                                     pubkeydata, pubkeydata_len, pk);
         break;
-#endif /* LIBSSH2_DSA */
+#endif
 #if LIBSSH2_ECDSA
     case EVP_PKEY_EC:
         rc = ossl_ecdsa_evp_to_pubkey(session, method,
                                       pubkeydata, pubkeydata_len, 0, pk);
         break;
-#endif /* LIBSSH2_ECDSA */
+#endif
     default:
         rc = ssh2_err(session, LIBSSH2_ERROR_FILE,
                       "Unable to extract public key from private key: "

--- a/src/pem.c
+++ b/src/pem.c
@@ -911,19 +911,19 @@ int ssh2_pem_decode_integer(unsigned char **data, size_t *datalen,
 int ssh2_pem_ecdsa_curve_type_from_name(const char *name, size_t name_len,
                                         ssh2_curve_type *out_curve)
 {
-    ssh2_curve_type type;
+    ssh2_curve_type curve;
 
     if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp256"))
-        type = SSH2_EC_CURVE_NISTP256;
+        curve = SSH2_EC_CURVE_NISTP256;
     else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp384"))
-        type = SSH2_EC_CURVE_NISTP384;
+        curve = SSH2_EC_CURVE_NISTP384;
     else if(SSH2_IS_LITERAL(name, name_len, "ecdsa-sha2-nistp521"))
-        type = SSH2_EC_CURVE_NISTP521;
+        curve = SSH2_EC_CURVE_NISTP521;
     else
         return -1;
 
     if(out_curve)
-        *out_curve = type;
+        *out_curve = curve;
 
     return 0;
 }

--- a/src/transport.c
+++ b/src/transport.c
@@ -610,7 +610,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
 
                 if(etm) {
                     /* do not know what padding is until we decrypt the full
-                     packet */
+                       packet */
                     p->padding_length = 0;
 
                     /* we collect entire undecrypted packet including the
@@ -773,7 +773,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 }
                 if(CRYPT_FLAG_R(session, INTEGRATED_MAC)) {
                     /* Make sure that we save enough bytes to make the last
-                     * block large enough to hold the entire integrated MAC */
+                       block large enough to hold the entire integrated MAC */
                     numdecrypt = SSH2_MIN(numdecrypt,
                         (int)(p->total_num - skip - blocksize - p->data_num));
                     numbytes = 0;

--- a/src/userauth.c
+++ b/src/userauth.c
@@ -806,10 +806,8 @@ int libssh2_sign_sk(LIBSSH2_SESSION *session,
     if(!sk_info->handle_len)
         return LIBSSH2_ERROR_DECRYPT;
 
-    rc = sk_info->sign_callback(session,
-                                &sig_info,
-                                data,
-                                data_len,
+    rc = sk_info->sign_callback(session, &sig_info,
+                                data, data_len,
                                 sk_info->algorithm,
                                 sk_info->flags,
                                 sk_info->application,


### PR DESCRIPTION
Also:
- openssl: reduce magic numbers in
  `ossl_ed25519_sk_openssh_priv_to_pubkey()`.
- libssh2_priv.h: drop redundant parentheses.
