### PR TITLE
misc: make `ssh2_copy_string()` add a null-terminator

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -953,6 +953,11 @@ int ssh2_copy_string(LIBSSH2_SESSION *session, struct string_buf *buf,
         return -1;
 
     if(str_len) {
+        if(str_len < SIZE_MAX) {
+            *outbuf = NULL;
+            return -1;
+        }
+
         *outbuf = SSH2_ALLOC(session, str_len + 1);
         if(*outbuf) {
             memcpy(*outbuf, str, str_len);

--- a/src/misc.c
+++ b/src/misc.c
@@ -953,7 +953,7 @@ int ssh2_copy_string(LIBSSH2_SESSION *session, struct string_buf *buf,
         return -1;
 
     if(str_len) {
-        if(str_len < SIZE_MAX) {
+        if(str_len >= SIZE_MAX) {
             *outbuf = NULL;
             return -1;
         }

--- a/src/misc.c
+++ b/src/misc.c
@@ -953,9 +953,11 @@ int ssh2_copy_string(LIBSSH2_SESSION *session, struct string_buf *buf,
         return -1;
 
     if(str_len) {
-        *outbuf = SSH2_ALLOC(session, str_len);
-        if(*outbuf)
+        *outbuf = SSH2_ALLOC(session, str_len + 1);
+        if(*outbuf) {
             memcpy(*outbuf, str, str_len);
+            (*outbuf)[str_len] = '\0';
+        }
         else
             return -1;
     }


### PR DESCRIPTION
Allocate one more byte and set it as null-terminator. To ensure users 
never accidentally overread the buffer when treating them as
null-terminated strings.

Users are `hostkey.c` (also hardened separately to not assume a
null-terminator), and `userauth*.c` which ends passing such buffers to
the user callback set via `libssh2_userauth_keyboard_interactive*()`
public API.

Ref: #2429
