### PR TITLE
src: make `ssh2_xor_data()` static to WinCNG

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -808,19 +808,6 @@ void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size)
     return p;
 }
 
-/* XOR operation on buffers input1 and input2, result in output.
-   It is safe to use an input buffer as the output buffer. */
-void ssh2_xor_data(unsigned char *output,
-                   const unsigned char *input1,
-                   const unsigned char *input2,
-                   size_t length)
-{
-    size_t i;
-
-    for(i = 0; i < length; i++)
-        *output++ = *input1++ ^ *input2++;
-}
-
 #ifdef LIBSSH2_MEMZERO
 static void *(* const volatile memset_libssh)(void *, int, size_t) = memset;
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -162,11 +162,6 @@ int ssh2_get_bignum_bytes(struct string_buf *buf, unsigned char **outbuf,
 int ssh2_check_length(struct string_buf *buf, size_t requested_len);
 int ssh2_eob(struct string_buf *buf);
 
-void ssh2_xor_data(unsigned char *output,
-                   const unsigned char *input1,
-                   const unsigned char *input2,
-                   size_t length);
-
 int ssh2_timingsafe_bcmp(const void *b1, const void *b2, size_t n);
 
 #endif /* LIBSSH2_MISC_H */

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2832,7 +2832,7 @@ static void wcng_aes_ctr_increment(unsigned char *ctr, size_t length)
     }
 }
 
-/* XOR operation on buffers input1 and input2, result in output.
+/* XOR operation on buffers input1 and input2, result in dst.
    It is safe to use an input buffer as the output buffer. */
 static void wcng_xor_data(unsigned char *dst,
                           const unsigned char *input1,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2832,6 +2832,19 @@ static void wcng_aes_ctr_increment(unsigned char *ctr, size_t length)
     }
 }
 
+/* XOR operation on buffers input1 and input2, result in output.
+   It is safe to use an input buffer as the output buffer. */
+static void wcng_xor_data(unsigned char *output,
+                          const unsigned char *input1,
+                          const unsigned char *input2,
+                          size_t length)
+{
+    size_t i;
+
+    for(i = 0; i < length; i++)
+        *output++ = *input1++ ^ *input2++;
+}
+
 int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)
@@ -2874,7 +2887,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                     /* CTR mode intentionally XORs in place:
                        block = block XOR pbOutput. */
                     /* NOLINTNEXTLINE(readability-suspicious-call-argument) */
-                    ssh2_xor_data(block, block, pbOutput, blocksize);
+                    wcng_xor_data(block, block, pbOutput, blocksize);
                     wcng_aes_ctr_increment(ctx->pbCtr, ctx->dwCtrLength);
                 }
                 else

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2834,7 +2834,7 @@ static void wcng_aes_ctr_increment(unsigned char *ctr, size_t length)
 
 /* XOR operation on buffers input1 and input2, result in output.
    It is safe to use an input buffer as the output buffer. */
-static void wcng_xor_data(unsigned char *output,
+static void wcng_xor_data(unsigned char *dst,
                           const unsigned char *input1,
                           const unsigned char *input2,
                           size_t length)
@@ -2842,7 +2842,7 @@ static void wcng_xor_data(unsigned char *output,
     size_t i;
 
     for(i = 0; i < length; i++)
-        *output++ = *input1++ ^ *input2++;
+        *dst++ = *input1++ ^ *input2++;
 }
 
 int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
@@ -2886,7 +2886,6 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                 if(algo.ctrMode) {
                     /* CTR mode intentionally XORs in place:
                        block = block XOR pbOutput. */
-                    /* NOLINTNEXTLINE(readability-suspicious-call-argument) */
                     wcng_xor_data(block, block, pbOutput, blocksize);
                     wcng_aes_ctr_increment(ctx->pbCtr, ctx->dwCtrLength);
                 }


### PR DESCRIPTION
Also rename one of its arguments to avoid clang-tidy false positive
`readability-suspicious-call-argument` warning and drop NOLINT.

Follow-up to ec0a51db1f69eafa14ead6d17e6aca13075c034b #739
