### PR TITLE
tidy-up: C nits

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
     sin.sin_port = htons(22);
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "Failed to connect to %s.\n", inet_ntoa(sin.sin_addr));
         goto shutdown;
     }

--- a/example/scp.c
+++ b/example/scp.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = htonl(0x7F000001);
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
     fprintf(stderr, "Connecting to %s:%d as user %s\n",
             inet_ntoa(sin.sin_addr), ntohs(sin.sin_port), username);
 
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
     sin.sin_family = AF_INET;
     sin.sin_port = htons(22);
     sin.sin_addr.s_addr = hostaddr;
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "failed to connect.\n");
         goto shutdown;
     }

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
     sin.sin_port = htons(830);
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "Failed to connect to %s.\n", inet_ntoa(sin.sin_addr));
         goto shutdown;
     }

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
         goto shutdown;
     }
     sin.sin_port = htons(22);
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "Failed to connect to %s.\n", inet_ntoa(sin.sin_addr));
         goto shutdown;
     }

--- a/example/x11.c
+++ b/example/x11.c
@@ -340,7 +340,7 @@ int main(int argc, char *argv[])
     sin.sin_port = htons((unsigned short)port);
     sin.sin_addr.s_addr = hostaddr;
 
-    if(connect(sock, (struct sockaddr *)(&sin), sizeof(struct sockaddr_in))) {
+    if(connect(sock, (struct sockaddr *)&sin, sizeof(struct sockaddr_in))) {
         fprintf(stderr, "Failed to establish connection.\n");
         return 1;
     }

--- a/src/agent.c
+++ b/src/agent.c
@@ -599,7 +599,7 @@ static int agent_connect_unix(LIBSSH2_AGENT *agent)
     memcpy(s_un.sun_path, path, plen);
     s_un.sun_path[plen] = '\0';
 
-    if(connect(agent->fd, (struct sockaddr *)(&s_un), sizeof(s_un)) != 0) {
+    if(connect(agent->fd, (struct sockaddr *)&s_un, sizeof(s_un)) != 0) {
         close(agent->fd);
         return ssh2_err(agent->session, LIBSSH2_ERROR_AGENT_PROTOCOL,
                         "failed connecting with agent");

--- a/src/packet.c
+++ b/src/packet.c
@@ -1327,7 +1327,7 @@ ssh2_packet_add_jump_authagent:
 
     if((msg == SSH_MSG_KEXINIT &&
         !(session->state & SSH2_STATE_EXCHANGING_KEYS)) ||
-       (session->packAdd_state == ssh2_NB_state_sent2)) {
+       session->packAdd_state == ssh2_NB_state_sent2) {
 
         if(session->packAdd_state == ssh2_NB_state_sent1) {
             /*

--- a/src/packet.c
+++ b/src/packet.c
@@ -626,7 +626,6 @@ int ssh2_packet_add(LIBSSH2_SESSION *session, unsigned char *data,
             SSH2_MACERROR(session, (char *)data, datalen))) {
             /* Bad MAC input, but no callback set or non-zero return from the
                callback */
-
             SSH2_FREE(session, data);
             return ssh2_err(session, LIBSSH2_ERROR_INVALID_MAC,
                             "Invalid MAC received");

--- a/src/pem.c
+++ b/src/pem.c
@@ -459,7 +459,7 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
     }
     else {
         kdf_buf.data = kdf;
-        kdf_buf.dataptr = kdf;
+        kdf_buf.dataptr = kdf_buf.data;
         kdf_buf.len = kdf_len;
     }
 

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -184,7 +184,7 @@ static int publickey_response_id(unsigned char **pdata, size_t data_len)
 
     while(codes->name) {
         if((unsigned long)codes->name_len == response_len &&
-           !strncmp(codes->name, (char *)data, response_len)) {
+           !strncmp(codes->name, (const char *)data, response_len)) {
             *pdata = data + response_len;
             return codes->code;
         }

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -963,7 +963,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
             SSH2_FREE(session, extversion_str);
         }
         if(extname_len == 24 &&
-           !strncmp("posix-rename@openssh.com", (char *)extname, 24)) {
+           !strncmp("posix-rename@openssh.com", (const char *)extname, 24)) {
             sftp_handle->posix_rename_version = extversion;
         }
     }

--- a/src/userauth_kbd_packet.c
+++ b/src/userauth_kbd_packet.c
@@ -59,7 +59,7 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
     /* string    name (ISO-10646 UTF-8) */
     if(ssh2_copy_string(session, &decoded,
                         &session->userauth_kybd_auth_name,
-                        &session->userauth_kybd_auth_name_len) == -1) {
+                        &session->userauth_kybd_auth_name_len)) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to decode keyboard-interactive 'name' "
                  "request field");
@@ -69,7 +69,7 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
     /* string    instruction (ISO-10646 UTF-8) */
     if(ssh2_copy_string(session, &decoded,
                         &session->userauth_kybd_auth_instruction,
-                        &session->userauth_kybd_auth_instruction_len) == -1) {
+                        &session->userauth_kybd_auth_instruction_len)) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to decode keyboard-interactive 'instruction' "
                  "request field");
@@ -77,7 +77,7 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
     }
 
     /* string    language tag (as defined in [RFC-3066]) */
-    if(ssh2_get_string(&decoded, &language_tag, &language_tag_len) == -1) {
+    if(ssh2_get_string(&decoded, &language_tag, &language_tag_len)) {
         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                  "Unable to decode keyboard-interactive 'language tag' "
                  "request field");
@@ -85,7 +85,7 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
     }
 
     /* int       num-prompts */
-    if(ssh2_get_u32(&decoded, &tmp_u32) == -1) {
+    if(ssh2_get_u32(&decoded, &tmp_u32)) {
         ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                  "Unable to decode "
                  "keyboard-interactive number of keyboard prompts");
@@ -134,7 +134,7 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
         /* string    prompt[1] (ISO-10646 UTF-8) */
         if(ssh2_copy_string(session, &decoded,
                             &session->userauth_kybd_prompts[i].text,
-                            &session->userauth_kybd_prompts[i].length) == -1) {
+                            &session->userauth_kybd_prompts[i].length)) {
             ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                      "Unable to decode keyboard-interactive prompt message");
             return -1;
@@ -142,7 +142,7 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
 
         /* boolean   echo[1] */
         if(ssh2_get_boolean(&decoded,
-                            &session->userauth_kybd_prompts[i].echo) == -1) {
+                            &session->userauth_kybd_prompts[i].echo)) {
             ssh2_err(session, LIBSSH2_ERROR_BUFFER_TOO_SMALL,
                      "Unable to decode user auth keyboard prompt echo");
             return -1;

--- a/src/userauth_kbd_packet.c
+++ b/src/userauth_kbd_packet.c
@@ -44,7 +44,7 @@ int userauth_keyboard_interactive_decode_info_request(LIBSSH2_SESSION *session)
     struct string_buf decoded;
 
     decoded.data = session->userauth_kybd_data;
-    decoded.dataptr = session->userauth_kybd_data;
+    decoded.dataptr = decoded.data;
     decoded.len = session->userauth_kybd_data_len;
 
     if(session->userauth_kybd_data_len < 17) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2346,7 +2346,7 @@ static int wcng_ecdsa_new_private_parse(OUT ssh2_ecdsa_ctx **ec_ctx,
     }
 
     data_buffer.data = SSH2_UNCONST(privatekey);
-    data_buffer.dataptr = SSH2_UNCONST(privatekey);
+    data_buffer.dataptr = data_buffer.data;
     data_buffer.len = privatekey_len;
 
     /* Read the 2 checkints and check that they match */


### PR DESCRIPTION
- drop redundant `== -1` to match rest of code.
- sync outlier pattern to init `struct string_buf` `dataptr`, to drop 
  repeat code and casts.
- drop redundant parentheses.
- add const to casts where missing.
