### PR TITLE
GHA: add tests with legacy options enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,73 +247,18 @@ jobs:
         exclude:
           - { compiler: clang-tidy, zlib: 'OFF' }
         include:
-          - compiler: gcc
-            arch: amd64
-            crypto: AWS-LC
-            build: 'CM'
-            zlib: 'ON'
-          - compiler: gcc
-            arch: amd64
-            crypto: BoringSSL
-            build: 'CM'
-            zlib: 'ON'
-          - compiler: gcc
-            arch: amd64
-            crypto: LibreSSL
-            build: 'CM'
-            zlib: 'ON'
-          - compiler: gcc
-            arch: i386
-            crypto: mbedTLS-from-source
-            build: 'CM'
-            zlib: 'ON'
-            image: ubuntu-26.04
-          - compiler: gcc
-            arch: amd64
-            crypto: OpenSSL
-            build: 'AM'
-            zlib: 'OFF'
-          - compiler: clang
-            arch: amd64
-            crypto: OpenSSL
-            build: 'AM'
-            zlib: 'OFF'
-          - compiler: clang
-            arch: amd64
-            crypto: OpenSSL
-            build: 'AM'
-            zlib: 'ON'
-            target: 'distcheck'
-          - compiler: clang
-            arch: amd64
-            crypto: OpenSSL
-            build: 'AM'
-            zlib: 'ON'
-            target: 'maketgz'
-          - compiler: gcc
-            arch: amd64
-            crypto: OpenSSL-3-no-deprecated
-            build: 'CM'
-            zlib: 'ON'
-            image: ubuntu-26.04
-          - compiler: gcc
-            arch: amd64
-            crypto: OpenSSL-111-from-source
-            build: 'CM'
-            zlib: 'ON'
-            image: ubuntu-26.04
-          - compiler: clang
-            arch: amd64
-            crypto: wolfSSL-from-source
-            build: 'CM'
-            zlib: 'ON'
-            image: ubuntu-26.04
-          - compiler: clang
-            arch: amd64
-            crypto: wolfSSL-from-source-prev
-            build: 'CM'
-            zlib: 'ON'
-            image: ubuntu-26.04
+          - { compiler: gcc  , arch: amd64, crypto: AWS-LC                  , build: 'CM', zlib: 'ON' }
+          - { compiler: gcc  , arch: amd64, crypto: BoringSSL               , build: 'CM', zlib: 'ON' }
+          - { compiler: gcc  , arch: amd64, crypto: LibreSSL                , build: 'CM', zlib: 'ON' }
+          - { compiler: gcc  , arch: i386 , crypto: mbedTLS-from-source     , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
+          - { compiler: gcc  , arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'OFF', target: 'legacy-options' }
+          - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'OFF' }
+          - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'ON', target: 'distcheck' }
+          - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'ON', target: 'maketgz' }
+          - { compiler: gcc  , arch: amd64, crypto: OpenSSL-3-no-deprecated , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
+          - { compiler: gcc  , arch: amd64, crypto: OpenSSL-111-from-source , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
+          - { compiler: clang, arch: amd64, crypto: wolfSSL-from-source     , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
+          - { compiler: clang, arch: amd64, crypto: wolfSSL-from-source-prev, build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
     env:
       CC: ${{ matrix.compiler == 'clang-tidy' && 'clang' || matrix.compiler }}
       MATRIX_ARCH: '${{ matrix.arch }}'
@@ -583,6 +528,10 @@ jobs:
             fi
             if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ] && [ "${MATRIX_COMPILER}" = 'clang-tidy' ]; then
               options+=' -DRUN_SSHD_TESTS=OFF'  # fails on due to lack of support for modern algos offered by sshd on Ubuntu 26.04 used with clang-tidy
+            fi
+            if [[ ("${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'off') || "${MATRIX_TARGET}" = 'legacy-options' ]]; then
+              cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE -DLIBSSH2_DSA_ENABLE'
+              cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
             fi
             if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
               options+=' -DENABLE_DEBUG_LOGGING=ON'
@@ -889,7 +838,7 @@ jobs:
           - { build: 'CM', sys: msys   , crypto: OpenSSL, env: x86_64 }
           - { build: 'AM', sys: mingw64, crypto: wincng , env: x86_64 }
           - { build: 'AM', sys: mingw64, crypto: openssl, env: x86_64 }
-          - { build: 'AM', sys: mingw32, crypto: openssl, env: i686 }
+          - { build: 'AM', sys: mingw32, crypto: openssl, env: i686, test: 'legacy-options' }
           - { build: 'AM', sys: ucrt64 , crypto: openssl, env: ucrt-x86_64 }
           - { build: 'AM', sys: clang64, crypto: openssl, env: clang-x86_64 }
           - { build: 'AM', sys: clang64, crypto: wincng , env: clang-x86_64, test: 'unicode' }
@@ -941,10 +890,12 @@ jobs:
                 gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
                 cflags+=" -specs=$(cygpath -w "${specs}")"
               fi
+            elif [ "${MATRIX_TEST}" = 'legacy-options' ]; then
+              cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE -DLIBSSH2_DSA_ENABLE'
+              cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
             elif [ "${MATRIX_TEST}" = 'no-options' ]; then
               options+=' -DLIBSSH2_NO_DEPRECATED=ON'
-              cflags+=' -DLIBSSH2_NO_MD5 -DLIBSSH2_NO_MD5_PEM -DLIBSSH2_NO_HMAC_RIPEMD -DLIBSSH2_DSA_ENABLE'
-              cflags+=' -DLIBSSH2_NO_AES_CBC -DLIBSSH2_NO_AES_CTR -DLIBSSH2_NO_BLOWFISH -DLIBSSH2_NO_RC4 -DLIBSSH2_NO_CAST -DLIBSSH2_NO_3DES'
+              cflags+=' -DLIBSSH2_NO_AES_CBC -DLIBSSH2_NO_AES_CTR'
             fi
             if [[ "${MATRIX_TEST}" = *'unicode'* ]]; then
               options+=' -DENABLE_UNICODE=ON'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,10 @@ jobs:
         env:
           MATRIX_COMPILER: '${{ matrix.compiler }}'
         run: |
+          if [[ ("${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'OFF') || "${MATRIX_TEST}" = 'legacy-options' ]]; then
+            cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE -DLIBSSH2_DSA_ENABLE'
+            cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
+          fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             if [ "${MATRIX_CRYPTO}" = 'AWS-LC' ] || \
                [ "${MATRIX_CRYPTO}" = 'BoringSSL' ] || \
@@ -530,11 +534,7 @@ jobs:
             if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ] && [ "${MATRIX_COMPILER}" = 'clang-tidy' ]; then
               options+=' -DRUN_SSHD_TESTS=OFF'  # fails on due to lack of support for modern algos offered by sshd on Ubuntu 26.04 used with clang-tidy
             fi
-            if [[ ("${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'off') || "${MATRIX_TEST}" = 'legacy-options' ]]; then
-              cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE -DLIBSSH2_DSA_ENABLE'
-              cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
-            fi
-            if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
+           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
               options+=' -DENABLE_DEBUG_LOGGING=ON'
               cflags+=' -DLIBSSH2_DEBUG_MLKEM'
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,8 +502,11 @@ jobs:
           MATRIX_COMPILER: '${{ matrix.compiler }}'
         run: |
           if [[ ("${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'OFF') || "${MATRIX_TEST}" = 'legacy-options' ]]; then
-            cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE -DLIBSSH2_DSA_ENABLE'
+            cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE '
             cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
+          fi
+          if [ "${MATRIX_TARGET}" = 'distcheck' ]; then
+            cflags+=' -DLIBSSH2_DSA_ENABLE'  # build test only, it cannot pass test in CI
           fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             if [ "${MATRIX_CRYPTO}" = 'AWS-LC' ] || \
@@ -894,10 +897,11 @@ jobs:
                 cflags+=" -specs=$(cygpath -w "${specs}")"
               fi
             elif [ "${MATRIX_TEST}" = 'legacy-options' ]; then
-              cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE -DLIBSSH2_DSA_ENABLE'
+              cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE'
               cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
             elif [ "${MATRIX_TEST}" = 'no-options' ]; then
               options+=' -DLIBSSH2_NO_DEPRECATED=ON'
+              cflags+=' -DLIBSSH2_DSA_ENABLE'
               cflags+=' -DLIBSSH2_NO_AES_CBC -DLIBSSH2_NO_AES_CTR'
             fi
             if [[ "${MATRIX_TEST}" = *'unicode'* ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
           MATRIX_COMPILER: '${{ matrix.compiler }}'
         run: |
           cflags=''
-          if [[ ("${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'OFF') || "${MATRIX_TEST}" = 'legacy-options' ]]; then
+          if [[ ( "${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'OFF' ) || "${MATRIX_TEST}" = 'legacy-options' ]]; then
             cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE '
             cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,9 +576,9 @@ jobs:
         if: ${{ !matrix.target }}
         run: |
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
-            cmake --build bld --target package
+            cmake --build bld --verbose --target package
           else
-            make -C bld
+            make -C bld V=1
           fi
 
       - name: 'tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
           - { compiler: gcc  , arch: amd64, crypto: BoringSSL               , build: 'CM', zlib: 'ON' }
           - { compiler: gcc  , arch: amd64, crypto: LibreSSL                , build: 'CM', zlib: 'ON' }
           - { compiler: gcc  , arch: i386 , crypto: mbedTLS-from-source     , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
-          - { compiler: gcc  , arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'OFF', target: 'legacy-options' }
+          - { compiler: gcc  , arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'OFF', test: 'legacy-options' }
           - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'OFF' }
           - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'ON', target: 'distcheck' }
           - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'ON', target: 'maketgz' }
@@ -266,6 +266,7 @@ jobs:
       MATRIX_COMPILER: '${{ matrix.compiler }}'
       MATRIX_CRYPTO: '${{ matrix.crypto }}'
       MATRIX_TARGET: '${{ matrix.target }}'
+      MATRIX_TEST: '${{ matrix.test }}'
       MATRIX_ZLIB: '${{ matrix.zlib }}'
       FIXTURE_TRACE_ALL_CONNECT: 0
       AWSLC_VERSION: 5.0.0
@@ -529,7 +530,7 @@ jobs:
             if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ] && [ "${MATRIX_COMPILER}" = 'clang-tidy' ]; then
               options+=' -DRUN_SSHD_TESTS=OFF'  # fails on due to lack of support for modern algos offered by sshd on Ubuntu 26.04 used with clang-tidy
             fi
-            if [[ ("${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'off') || "${MATRIX_TARGET}" = 'legacy-options' ]]; then
+            if [[ ("${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'off') || "${MATRIX_TEST}" = 'legacy-options' ]]; then
               cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE -DLIBSSH2_DSA_ENABLE'
               cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,7 @@ jobs:
         env:
           MATRIX_COMPILER: '${{ matrix.compiler }}'
         run: |
+          cflags=''
           if [[ ("${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'OFF') || "${MATRIX_TEST}" = 'legacy-options' ]]; then
             cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE '
             cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
@@ -880,13 +881,17 @@ jobs:
         env:
           SSHD: 'C:/Program Files/Git/usr/bin/sshd.exe'
         run: |
+          cflags=''
+          if [ "${MATRIX_TEST}" = 'legacy-options' ]; then
+            cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE'
+            cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
+          fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             if [[ "${MATRIX_ENV}" = 'clang'* ]]; then
               options=' -DCMAKE_C_COMPILER=clang'
             else
               options=' -DCMAKE_C_COMPILER=gcc'
             fi
-            cflags=''
             if [ "${MATRIX_TEST}" = 'uwp' ]; then
               options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
               cflags+=' -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0a00'
@@ -896,9 +901,6 @@ jobs:
                 gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
                 cflags+=" -specs=$(cygpath -w "${specs}")"
               fi
-            elif [ "${MATRIX_TEST}" = 'legacy-options' ]; then
-              cflags+=' -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE'
-              cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
             elif [ "${MATRIX_TEST}" = 'no-options' ]; then
               options+=' -DLIBSSH2_NO_DEPRECATED=ON'
               cflags+=' -DLIBSSH2_DSA_ENABLE'
@@ -918,12 +920,14 @@ jobs:
               -DRUN_SSHD_TESTS=OFF \
               -DCMAKE_VERBOSE_MAKEFILE=ON
           else
+            export CFLAGS
             if [ "${MATRIX_CRYPTO}" = 'wincng' ] && [[ "${MATRIX_ENV}" = 'clang'* ]]; then
               options=' --enable-ecdsa-wincng'
             fi
             if [[ "${MATRIX_TEST}" = *'unicode'* ]]; then
               options+=' --enable-windows-unicode'
             fi
+            CFLAGS+=" ${cflags}"
             # sshd tests sometimes hang
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
@@ -946,9 +950,9 @@ jobs:
       - name: 'build'
         run: |
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
-            cmake --build bld
+            cmake --build bld --verbose
           else
-            make -C bld
+            make -C bld V=1
           fi
 
       - name: 'tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,9 +545,10 @@ jobs:
               -DCRYPTO_BACKEND=${crypto} \
               -DENABLE_ZLIB_COMPRESSION="${MATRIX_ZLIB}"
           else
+            export CFLAGS
             if [ "${MATRIX_ARCH}" = 'i386' ]; then
               options='--host=i686-pc-linux-gnu'
-              export CFLAGS=-m32
+              cflags+=' -m32'
             fi
             mkdir bld && cd bld
             if [ "${MATRIX_ZLIB}" = 'OFF' ]; then
@@ -558,6 +559,7 @@ jobs:
             if [ "${MATRIX_TARGET}" != 'distcheck' ]; then
               options+=' --disable-examples-build'
             fi
+            CFLAGS+=" ${cflags}"
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               ${options} \
               --disable-dependency-tracking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,7 @@ jobs:
             if [ "${MATRIX_CRYPTO}" = 'Libgcrypt' ] && [ "${MATRIX_COMPILER}" = 'clang-tidy' ]; then
               options+=' -DRUN_SSHD_TESTS=OFF'  # fails on due to lack of support for modern algos offered by sshd on Ubuntu 26.04 used with clang-tidy
             fi
-           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
+            if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
               options+=' -DENABLE_DEBUG_LOGGING=ON'
               cflags+=' -DLIBSSH2_DEBUG_MLKEM'
             fi

--- a/src/pem.c
+++ b/src/pem.c
@@ -194,7 +194,6 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     if(passphrase &&
        strlen(line) == sizeof(crypt_annotation) - 1 &&
        !memcmp(line, crypt_annotation, sizeof(crypt_annotation) - 1)) {
-
         const struct crypt_method **all_methods, *cur_method;
         int i;
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -61,6 +61,10 @@ static int pem_readline(char *line, size_t line_size,
     return *blob_offset > off ? 0 : -1;
 }
 
+#define LINE_SIZE 128
+
+static const char crypt_annotation[] = "Proc-Type: 4,ENCRYPTED";
+
 static unsigned char pem_hex_decode(char digit)
 {
     return (unsigned char)
@@ -147,8 +151,6 @@ out:
     return ret;
 }
 
-#define LINE_SIZE 128
-
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
@@ -158,8 +160,6 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    unsigned char **data, size_t *datalen,
                    size_t *blob_offset)
 {
-    static const char crypt_annotation[] = "Proc-Type: 4,ENCRYPTED";
-
     char line[LINE_SIZE];
     unsigned char iv[LINE_SIZE];
     char *b64data = NULL;
@@ -184,20 +184,19 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     do {
         *line = '\0';
 
-        if(pem_readline(line, sizeof(line), blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
     } while(strcmp(line, headerbegin));
 
-    if(pem_readline(line, sizeof(line), blob, blob_len, &off))
+    if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
         goto out;
 
     if(passphrase &&
-       strlen(line) == sizeof(crypt_annotation) - 1 &&
        !memcmp(line, crypt_annotation, sizeof(crypt_annotation) - 1)) {
         const struct crypt_method **all_methods, *cur_method;
         int i;
 
-        if(pem_readline(line, sizeof(line), blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
 
         all_methods = ssh2_crypt_methods();
@@ -226,7 +225,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
         }
 
         /* skip to the next line */
-        if(pem_readline(line, sizeof(line), blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
     }
 
@@ -249,7 +248,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
 
         *line = '\0';
 
-        if(pem_readline(line, sizeof(line), blob, blob_len, &off))
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
             goto out;
     } while(strcmp(line, headerend));
 
@@ -755,7 +754,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(pem_readline(line, sizeof(line), blob, blob_len, &off)) {
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off)) {
             ret = -1;
             goto out;
         }
@@ -788,7 +787,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(pem_readline(line, sizeof(line), blob, blob_len, &off)) {
+        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off)) {
             ret = -1;
             goto out;
         }

--- a/src/pem.c
+++ b/src/pem.c
@@ -191,8 +191,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
         goto out;
 
-    if(passphrase &&
-       !memcmp(line, crypt_annotation, sizeof(crypt_annotation) - 1)) {
+    if(passphrase && SSH2_IS_LITERAL(line, strlen(line), crypt_annotation)) {
         const struct crypt_method **all_methods, *cur_method;
         int i;
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -191,7 +191,10 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     if(pem_readline(line, sizeof(line), blob, blob_len, &off))
         goto out;
 
-    if(passphrase && SSH2_IS_LITERAL(line, strlen(line), crypt_annotation)) {
+    if(passphrase &&
+       strlen(line) == sizeof(crypt_annotation) - 1 &&
+       !memcmp(line, crypt_annotation, sizeof(crypt_annotation) - 1)) {
+
         const struct crypt_method **all_methods, *cur_method;
         int i;
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -61,10 +61,6 @@ static int pem_readline(char *line, size_t line_size,
     return *blob_offset > off ? 0 : -1;
 }
 
-#define LINE_SIZE 128
-
-static const char crypt_annotation[] = "Proc-Type: 4,ENCRYPTED";
-
 static unsigned char pem_hex_decode(char digit)
 {
     return (unsigned char)
@@ -151,6 +147,8 @@ out:
     return ret;
 }
 
+#define LINE_SIZE 128
+
 int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    const char *headerbegin,
                    const char *headerend,
@@ -160,6 +158,8 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
                    unsigned char **data, size_t *datalen,
                    size_t *blob_offset)
 {
+    static const char crypt_annotation[] = "Proc-Type: 4,ENCRYPTED";
+
     char line[LINE_SIZE];
     unsigned char iv[LINE_SIZE];
     char *b64data = NULL;
@@ -184,18 +184,18 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     do {
         *line = '\0';
 
-        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, sizeof(line), blob, blob_len, &off))
             goto out;
     } while(strcmp(line, headerbegin));
 
-    if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
+    if(pem_readline(line, sizeof(line), blob, blob_len, &off))
         goto out;
 
     if(passphrase && SSH2_IS_LITERAL(line, strlen(line), crypt_annotation)) {
         const struct crypt_method **all_methods, *cur_method;
         int i;
 
-        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, sizeof(line), blob, blob_len, &off))
             goto out;
 
         all_methods = ssh2_crypt_methods();
@@ -224,7 +224,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
         }
 
         /* skip to the next line */
-        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, sizeof(line), blob, blob_len, &off))
             goto out;
     }
 
@@ -247,7 +247,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
 
         *line = '\0';
 
-        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
+        if(pem_readline(line, sizeof(line), blob, blob_len, &off))
             goto out;
     } while(strcmp(line, headerend));
 
@@ -753,7 +753,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off)) {
+        if(pem_readline(line, sizeof(line), blob, blob_len, &off)) {
             ret = -1;
             goto out;
         }
@@ -786,7 +786,7 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
             goto out;
         }
 
-        if(pem_readline(line, LINE_SIZE, blob, blob_len, &off)) {
+        if(pem_readline(line, sizeof(line), blob, blob_len, &off)) {
             ret = -1;
             goto out;
         }


### PR DESCRIPTION
Also:
- reflow an `include` section to be more compact and readable.
- enable verbose build for Linux jobs to confirm build options.
- keep DSA disabled because it fails test `test_auth_pubkey_ok_dsa`, due
  to lack of server support.

Follow-up to b89858b83d68d7e29e0c5b0bb803f8a68271710c #1531
