### PR TITLE
pem: fix to exactly match the legacy PEM crypt annotation header

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -192,6 +192,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
         goto out;
 
     if(passphrase &&
+       strlen(line) == sizeof(crypt_annotation) - 1 &&
        !memcmp(line, crypt_annotation, sizeof(crypt_annotation) - 1)) {
         const struct crypt_method **all_methods, *cur_method;
         int i;

--- a/src/pem.c
+++ b/src/pem.c
@@ -191,7 +191,9 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
         goto out;
 
-    if(passphrase && !strncmp(line, crypt_annotation, strlen(line))) {
+    if(passphrase &&
+       strlen(line) == sizeof(crypt_annotation) - 1 &&
+       !memcmp(line, crypt_annotation, sizeof(crypt_annotation) - 1)) {
         const struct crypt_method **all_methods, *cur_method;
         int i;
 

--- a/src/pem.c
+++ b/src/pem.c
@@ -191,9 +191,7 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
     if(pem_readline(line, LINE_SIZE, blob, blob_len, &off))
         goto out;
 
-    if(passphrase &&
-       strlen(line) == sizeof(crypt_annotation) - 1 &&
-       !memcmp(line, crypt_annotation, sizeof(crypt_annotation) - 1)) {
+    if(passphrase && !strncmp(line, crypt_annotation, strlen(line))) {
         const struct crypt_method **all_methods, *cur_method;
         int i;
 


### PR DESCRIPTION
Before this patch it matched if the header had extra characters appended
to it.

Reported by Copilot
https://github.com/libssh2/libssh2/pull/2438#discussion_r3662058408
Follow-up to 386e012292a96fcf0dc6861588397845df0aba2c
