### PR TITLE
openssl: sync patterns between functions (tidy-up)

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1608,8 +1608,7 @@ int ssh2_curve25519_new(LIBSSH2_SESSION *session,
         pub = NULL;
     }
 
-    /* success */
-    rc = 0;
+    rc = 0; /* success */
 
 clean_exit:
 
@@ -2044,11 +2043,11 @@ int ssh2_mlkem_new(LIBSSH2_SESSION *session, int mlkem_size,
     }
 
     if(out_private_key) {
+        actualPrivLen = privLen;
         priv = SSH2_ALLOC(session, privLen);
         if(!priv)
             goto clean_exit;
 
-        actualPrivLen = privLen;
         if(EVP_PKEY_get_raw_private_key(key, priv, &actualPrivLen) != 1 ||
            privLen != actualPrivLen) {
             goto clean_exit;
@@ -2059,11 +2058,11 @@ int ssh2_mlkem_new(LIBSSH2_SESSION *session, int mlkem_size,
     }
 
     if(out_public_key) {
+        actualPubLen = pubLen;
         pub = SSH2_ALLOC(session, pubLen);
         if(!pub)
             goto clean_exit;
 
-        actualPubLen = pubLen;
         if(EVP_PKEY_get_raw_public_key(key, pub, &actualPubLen) != 1 ||
            pubLen != actualPubLen) {
             goto clean_exit;
@@ -2073,8 +2072,7 @@ int ssh2_mlkem_new(LIBSSH2_SESSION *session, int mlkem_size,
         pub = NULL;
     }
 
-    /* success */
-    rc = 0;
+    rc = 0; /* success */
 
 clean_exit:
 


### PR DESCRIPTION
- `ssh2_mlkem_new()` with `ssh2_curve25519_new()`.
- also inline two comments.

Follow-up to 1164743de0cb6ca14881cd1347ff0542ed29732f #2308
Follow-up to 41389f8f9213bd9fda6d1a3a05531ef3913fea17 #2029
Follow-up to 3ba252e2a6fe04d17ea13ad870698a4028c8ab4c #1644

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
