### PR TITLE
mac: disable SHA1-based MACs by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,7 @@ jobs:
         run: |
           cflags=''
           if [[ ( "${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'OFF' ) || "${MATRIX_TEST}" = 'legacy-options' ]]; then
-            cflags+=' -DLIBSSH2_KEX_SHA1_ENABLE -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE '
+            cflags+=' -DLIBSSH2_KEX_SHA1_ENABLE -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_SHA1_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE '
             cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
           fi
           if [ "${MATRIX_TARGET}" = 'distcheck' ]; then
@@ -883,7 +883,7 @@ jobs:
         run: |
           cflags=''
           if [ "${MATRIX_TEST}" = 'legacy-options' ]; then
-            cflags+=' -DLIBSSH2_KEX_SHA1_ENABLE -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE'
+            cflags+=' -DLIBSSH2_KEX_SHA1_ENABLE -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_SHA1_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE'
             cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
           fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -13,6 +13,9 @@ Deprecation notices:
   - DSA: `ssh-dss` hostkeys.
     You can enable it with `-DLIBSSH2_DSA_ENABLE`.
 
+  - SHA1-based MACs: `hmac-sha1`, `hmac-sha1-etm@openssh.com`, `hmac-sha1-96`
+    You can enable them with `-DLIBSSH2_HMAC_SHA1_ENABLE`.
+
   - MD5-based MACs and hashes: `hmac-md5`, `hmac-md5-96`,
     `LIBSSH2_HOSTKEY_HASH_MD5`
     You can enable it with `-DLIBSSH2_MD5_ENABLE`.

--- a/src/mac.c
+++ b/src/mac.c
@@ -197,6 +197,7 @@ static const struct mac_method mac_method_hmac_sha2_256_etm = {
 };
 #endif
 
+#ifdef LIBSSH2_HMAC_SHA1_ENABLE
 /*
  * Calculate hash using full sha1 value
  */
@@ -261,6 +262,7 @@ static const struct mac_method mac_method_hmac_sha1_96 = {
     mac_method_common_dtor,
     0
 };
+#endif /* LIBSSH2_HMAC_SHA1_ENABLE */
 
 #if LIBSSH2_MD5
 /*
@@ -366,9 +368,11 @@ static const struct mac_method *mac_methods[] = {
     &mac_method_hmac_sha2_512,
     &mac_method_hmac_sha2_512_etm,
 #endif
+#ifdef LIBSSH2_HMAC_SHA1_ENABLE
     &mac_method_hmac_sha1,
     &mac_method_hmac_sha1_etm,
     &mac_method_hmac_sha1_96,
+#endif
 #if LIBSSH2_MD5
     &mac_method_hmac_md5,
     &mac_method_hmac_md5_96,

--- a/tests/ossfuzz/ossfuzz.sh
+++ b/tests/ossfuzz/ossfuzz.sh
@@ -10,11 +10,15 @@ set -eu
 # Save off the current folder as the build root.
 export BUILD_ROOT="$PWD"
 
+export CPPFLAGS
+CPPFLAGS+=' -DLIBSSH2_HMAC_SHA1_ENABLE'  # Workaround for infinite hang on start
+
 echo "CC: ${CC:-}"
 echo "CXX: ${CXX:-}"
 echo "LIB_FUZZING_ENGINE: ${LIB_FUZZING_ENGINE:-}"
 echo "CFLAGS: ${CFLAGS:-}"
 echo "CXXFLAGS: ${CXXFLAGS:-}"
+echo "CPPFLAGS: ${CPPFLAGS:-}"
 echo "OUT: ${OUT:-}"
 
 MAKEFLAGS+=" -j$(nproc)"

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -78,6 +78,11 @@ static char const *skip_crypt[] = {
 
 /* List of MAC protocols for which tests are skipped */
 static char const *skip_mac[] = {
+#ifndef LIBSSH2_HMAC_SHA1_ENABLE
+    "hmac-sha1",
+    "hmac-sha1-etm@openssh.com",
+    "hmac-sha1-96",
+#endif
 #if !LIBSSH2_MD5
     "hmac-md5",
     "hmac-md5-96",


### PR DESCRIPTION
Also:
- RELEASE-NOTES: announce removal after next release.
- allow build-time macro to enable in the meantime.
- skip in tests if disabled.
- keep testing in CI with other legacy options.
- workaround oss-fuzzer hang and timeout after 10 minutes by keeping 
  SHA1-based MACs enabled in the fuzzer build.
  Ref: https://github.com/libssh2/libssh2/pull/2444#issuecomment-5110853610

Follow-up to 99f935358d942283194e15c1ded76a247a3d9087 #2443
