### PR TITLE
session_fixture: re-enable algos disabled for mbedTLS, the issue is fixed now

### DIFF
--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -65,19 +65,6 @@ static int connect_to_server(void)
 
 /* List of crypto protocols for which tests are skipped */
 static char const *skip_crypt[] = {
-#ifdef LIBSSH2_MBEDTLS
-    /* Due to a bug with mbedTLS support, these crypt methods fail.
-       Until that bug is fixed, do not run them there to avoid this
-       known issue causing red tests.
-       See: https://github.com/libssh2/libssh2/issues/793 */
-    "3des-cbc",
-    "aes128-cbc",
-    "aes192-cbc",
-    "aes256-cbc",
-    "aes128-gcm@openssh.com",
-    "aes256-gcm@openssh.com",
-    "rijndael-cbc@lysator.liu.se",
-#endif
 #if !LIBSSH2_3DES
     "3des-cbc",
 #endif


### PR DESCRIPTION
PR #1758 indeed fixed the issue reported in #793. Let's re-enable the
tests disabled earlier as a CI workaround.

Follow-up to 26f57efd2f2bd2e2ee051b7a43e047017f7db634 #1758
Follow-up to 9ecb22daab7a56b9357771573755c31a8670f043 #969
Follow-up to 7487dcf4b4ddae54b2a850737789b57b4251b0ae
Ref: #793
