### PR TITLE
packet: fix use-after-free of ignored extended data on eagain

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -950,8 +950,6 @@ ssh2_packet_add_jump_point5:
                 LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE) &&
                (msg == SSH_MSG_CHANNEL_EXTENDED_DATA)) {
                 /* Pretend we did not receive this */
-                SSH2_FREE(session, data);
-
                 ssh2_deb((session, LIBSSH2_TRACE_CONN,
                           "Ignoring extended data and refunding %ld bytes",
                           (long)(datalen - 13)));
@@ -971,7 +969,7 @@ ssh2_packet_add_jump_point5:
 
                 session->packAdd_channelp = channelp;
 
-                /* Adjust the window based on the block we freed */
+                /* Adjust the window based on the block we ignore */
 ssh2_packet_add_jump_point1:
                 session->packAdd_state = ssh2_NB_state_jump1;
                 rc = ssh2_channel_receive_window_adjust(session->
@@ -981,6 +979,11 @@ ssh2_packet_add_jump_point1:
                 if(rc == LIBSSH2_ERROR_EAGAIN)
                     return rc;
 
+                /* free only now that the window adjust is done: 'data' aliases
+                   session->packet.payload, which the transport layer re-passes
+                   to us if the adjust returns EAGAIN, so an earlier free would
+                   leave that pointer dangling */
+                SSH2_FREE(session, data);
                 session->packAdd_state = ssh2_NB_state_idle;
                 return 0;
             }


### PR DESCRIPTION
the extended-data ignore path in ssh2_packet_add frees data before the ssh2_channel_receive_window_adjust jump point, but data aliases session->packet.payload and the plain free doesn't clear that alias. when the window adjust returns eagain the packAdd_state is left at jump1, so the transport eagain guard that only nulls p->payload on the idle state is skipped and the alias is left dangling: the retry re-reads data[0] from the freed buffer and a session teardown while suspended frees the same buffer again. defer the free to after the eagain check so the buffer stays live across re-entry and gets nulled by the transport layer on the success return. reachable with LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE set when the server sends extended data and the window-adjust send would block.