### PR TITLE
RELEASE-NOTES: announce `libssh2_base64_decode()`, `libssh2_poll()` going no-ops

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -52,7 +52,7 @@ Deprecation notices:
 
 - This release always enables large file support on Windows.
 
-- The next release makes these deprecated functions no-ops and
+- The next release makes these deprecated functions no-ops that
   return permanent failure:
   - `libssh2_base64_decode()` (deprecated since 1.0.0, 2008-12-26)
   - `libssh2_poll()` (deprecated since 1.2.0, 2009-08-10)

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -52,6 +52,11 @@ Deprecation notices:
 
 - This release always enables large file support on Windows.
 
+- The next release makes these deprecated functions no-ops and
+  return permanent failure:
+  - `libssh2_base64_decode()` (deprecated since 1.0.0, 2008-12-26)
+  - `libssh2_poll()` (deprecated since 1.2.0, 2009-08-10)
+
 This release includes the following enhancements and bugfixes:
 
 - agent: fix unused macro compiler warnings in UWP non-unity builds (0e2bc3d6 #2325 #2313)


### PR DESCRIPTION
They have been deprecated for almost 2 decades. Debian code search shows
two uses, by Perl and PHP bindings. GitHub code search turns up a couple
more bindings.

After the next release these functions turn into no-ops, and will return
permanent failure, and NULL pointer/size. Along with compile-time
warnings (added in earlier commits).

Note, `libssh2_base64_decode()` causes an unfixable memory leak in user
code. Dropping `libssh2_poll()` code helps dropping its internal
dependencies, and simplifies maintenance.

Two users of `libssh2_poll()` are `example/ssh2_echo.c` and
`examples/x11.c`. They'll break and will  ideally need a revamp, or
dropped, after this.

Follow-up to 94d4a2d136e4e61ebd7fea5b01ed33149b1220fc #1838
Follow-up to cf3aac1aba420952855c33aeb7429ec76a3ff220
Follow-up to 2b8038e175e030113a0a75592a69cb4f98c23fe1
Follow-up to ba79d6b52de6d2a87fe26e027095b2fb29f54207
