### PR TITLE
version: reflect KEX-SHA1, MAC-SHA1, deprecated APIs in `libssh2_build_options()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,7 @@ jobs:
         run: |
           cflags=''
           if [[ ( "${MATRIX_CRYPTO}" = 'Libgcrypt' && "${MATRIX_ZLIB}" = 'OFF' ) || "${MATRIX_TEST}" = 'legacy-options' ]]; then
-            cflags+=' -DLIBSSH2_KEX_SHA1_ENABLE -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_SHA1_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE '
+            cflags+=' -DLIBSSH2_KEX_SHA1_ENABLE -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_SHA1_ENABLE -DLIBSSH2_HMAC_RIPEMD_ENABLE'
             cflags+=' -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_CAST_ENABLE -DLIBSSH2_3DES_ENABLE'
           fi
           if [ "${MATRIX_TARGET}" = 'distcheck' ]; then

--- a/src/version.c
+++ b/src/version.c
@@ -175,7 +175,7 @@ static const char *ssh2_build_options =
     "off"
 #endif
     " "
-    "deprecated-API:"
+    "deprecated-APIs:"
 #ifndef LIBSSH2_NO_DEPRECATED
     "on"
 #else

--- a/src/version.c
+++ b/src/version.c
@@ -175,7 +175,7 @@ static const char *ssh2_build_options =
     "off"
 #endif
     " "
-    "deprecated-API-1:"
+    "deprecated-API:"
 #ifndef LIBSSH2_NO_DEPRECATED
     "on"
 #else

--- a/src/version.c
+++ b/src/version.c
@@ -161,6 +161,20 @@ static const char *ssh2_build_options =
     "off"
 #endif
     " "
+    "KEX-SHA1:"
+#ifdef LIBSSH2_KEX_SHA1_ENABLE
+    "on"
+#else
+    "off"
+#endif
+    " "
+    "MAC-SHA1:"
+#ifdef LIBSSH2_HMAC_SHA1_ENABLE
+    "on"
+#else
+    "off"
+#endif
+    " "
     "zlib:"
 #ifdef LIBSSH2_HAVE_ZLIB
     "on"

--- a/src/version.c
+++ b/src/version.c
@@ -175,6 +175,13 @@ static const char *ssh2_build_options =
     "off"
 #endif
     " "
+    "deprecated-API-1:"
+#ifndef LIBSSH2_NO_DEPRECATED
+    "on"
+#else
+    "off"
+#endif
+    " "
     "zlib:"
 #ifdef LIBSSH2_HAVE_ZLIB
     "on"


### PR DESCRIPTION
Follow-up to 3e14d67d2621049f621f079159f4b6240677395a #2444
Follow-up to 99f935358d942283194e15c1ded76a247a3d9087 #2443
Follow-up to 2673970d2a60075630a7bfdc84b64ddba016595e #2178
