### PR TITLE
build: drop `CLEAR_MEMORY=NO` and `--disable-clear-memory` options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -217,19 +217,6 @@ fi
 
 AC_SUBST(LIBSSH2_PC_REQUIRES_PRIVATE)
 
-dnl
-dnl Optional Settings
-dnl
-AC_ARG_ENABLE(clear-memory,
-  AS_HELP_STRING([--disable-clear-memory],[Disable clearing of memory before being freed]),
-  [CLEAR_MEMORY=$enableval])
-if test "$CLEAR_MEMORY" = "no"; then
-  AC_DEFINE(LIBSSH2_NO_CLEAR_MEMORY, 1, [Disable clearing of memory before being freed])
-  enable_clear_memory=no
-else
-  enable_clear_memory=yes
-fi
-
 LIBSSH2_CFLAG_EXTRAS=""
 
 LIBSSH2_CHECK_OPTION_WERROR
@@ -514,7 +501,6 @@ AC_MSG_NOTICE([summary of build options:
   Crypto library:   ${found_crypto_str}
   WinCNG ECDSA:     $wincng_ecdsa
   zlib compression: ${found_libz}
-  Clear memory:     $enable_clear_memory
   Deprecated APIs:  $with_deprecated
   Debug build:      $enable_debug
   Build examples:   $build_examples

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -83,11 +83,6 @@ The following options are available:
    Enable the libssh2_trace() function for showing debug traces.
    Can be `ON` or `OFF`. Default: `OFF` in Release, `ON` in `Debug`
 
-* `CLEAR_MEMORY=OFF`
-
-   Disable secure zero memory before freeing it (not recommended).
-   Can be `ON` or `OFF`. Default: `ON`
-
 ## Using AWS-LC or BoringSSL
 
 You can also build against [AWS-LC](https://github.com/aws/aws-lc) or

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,11 +43,6 @@ endif()
 
 set(_libssh2_definitions "")
 
-option(CLEAR_MEMORY "Enable clearing of memory before being freed" ON)
-if(NOT CLEAR_MEMORY)
-  list(APPEND _libssh2_definitions "LIBSSH2_NO_CLEAR_MEMORY")
-endif()
-
 option(ENABLE_ZLIB_COMPRESSION "Use zlib for compression" OFF)
 add_feature_info("Compression" ENABLE_ZLIB_COMPRESSION "using zlib for compression")
 if(ENABLE_ZLIB_COMPRESSION)

--- a/src/misc.c
+++ b/src/misc.c
@@ -809,11 +809,14 @@ void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size)
 }
 
 #ifdef LIBSSH2_MEMZERO
-static void *(* const volatile memset_libssh)(void *, int, size_t) = memset;
+static void *(* const volatile p_ssh2_memset)(void *buf, int val,
+                                              size_t size) = memset;
 
-void ssh2_memzero(void *buf, size_t size)
+/* Local fallback in case there is no system function to securely zero a memory
+   buffer. */
+void ssh2_explicit_zero(void *buf, size_t size)
 {
-    memset_libssh(buf, 0, size);
+    p_ssh2_memset(buf, 0, size);
 }
 #endif
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -53,7 +53,7 @@ int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
 #endif
 
 #ifndef _LIBSSH2_LOCAL_MEMZERO /* to be removed after a couple of releases */
-#if defined(_WIN32)
+#ifdef _WIN32
 #if defined(_MSC_VER) && defined(NTDDI_VERSION) && \
   (NTDDI_VERSION >= 0x0A000010) /* MS SDK 10.0.26100.0+ */
 #pragma comment(lib, "volatileaccessu.lib")

--- a/src/misc.h
+++ b/src/misc.h
@@ -52,13 +52,8 @@ int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
 #define ssh2_snprintf   snprintf
 #endif
 
-#ifdef LIBSSH2_NO_CLEAR_MEMORY
-#define ssh2_explicit_zero(buf, size) \
-    do {                              \
-        (void)(buf);                  \
-        (void)(size);                 \
-    } while(0)
-#elif defined(_WIN32)
+#ifndef _LIBSSH2_LOCAL_MEMZERO /* to be removed after a couple of releases */
+#if defined(_WIN32)
 #if defined(_MSC_VER) && defined(NTDDI_VERSION) && \
   (NTDDI_VERSION >= 0x0A000010) /* MS SDK 10.0.26100.0+ */
 #pragma comment(lib, "volatileaccessu.lib")
@@ -72,10 +67,11 @@ int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
 #define ssh2_explicit_zero(buf, size) (void)explicit_memset(buf, 0, size)
 #elif defined(HAVE_MEMSET_S)
 #define ssh2_explicit_zero(buf, size) (void)memset_s(buf, size, 0, size)
-#else
+#endif /* !_LIBSSH2_LOCAL_MEMZERO */
+
+#ifndef ssh2_explicit_zero
 #define LIBSSH2_MEMZERO
-void ssh2_memzero(void *buf, size_t size);
-#define ssh2_explicit_zero(buf, size) ssh2_memzero(buf, size)
+void ssh2_explicit_zero(void *buf, size_t size);
 #endif
 
 #ifdef HAVE_SYS_TIME_H

--- a/src/misc.h
+++ b/src/misc.h
@@ -67,6 +67,7 @@ int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
 #define ssh2_explicit_zero(buf, size) (void)explicit_memset(buf, 0, size)
 #elif defined(HAVE_MEMSET_S)
 #define ssh2_explicit_zero(buf, size) (void)memset_s(buf, size, 0, size)
+#endif
 #endif /* !_LIBSSH2_LOCAL_MEMZERO */
 
 #ifndef ssh2_explicit_zero

--- a/src/version.c
+++ b/src/version.c
@@ -210,13 +210,6 @@ static const char *ssh2_build_options =
 #endif
     " "
 #endif
-    "clear-memory:"
-#ifndef LIBSSH2_NO_CLEAR_MEMORY
-    "on"
-#else
-    "off"
-#endif
-    " "
     "debug-logging:"
 #ifdef LIBSSH2DEBUG
     "on"


### PR DESCRIPTION
Drop autotools option `--disable-clear-memory`, CMake option
`-DCLEAR_MEMORY=NO`.

Keep this option always enabled. If there is not API support, use the
local fallback.

Introduce a temporary CPPFLAG to disable system memory clearing
functions, in case they cause a build issue.

Follow-up to a0e424a51c27cc27af611ba20d134f9a9ae35273 #810
