### PR TITLE
autotools: fix `memset_s()` detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1092,8 +1092,8 @@ jobs:
             cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
           - name: 'OpenSSL 3'
             install: openssl@3
-            configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl@3
-            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3
+            configure: --with-crypto=openssl --with-libssl-prefix=/opt/homebrew/opt/openssl@3 CFLAGS=-std=c90
+            cmake: -DCRYPTO_BACKEND=OpenSSL -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3 -DCMAKE_C_STANDARD=90
           - name: 'wolfSSL'
             install: wolfssl
             configure: --with-crypto=wolfssl --with-libwolfssl-prefix=/opt/homebrew

--- a/configure.ac
+++ b/configure.ac
@@ -410,9 +410,7 @@ AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       #include <string.h>
     ]],[[
-      char buf[2];
-      if(memset_s(buf, sizeof(buf), 0, sizeof(buf)))
-        return 1;
+      (void)memset_s;
     ]])
   ],[
     AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -396,8 +396,37 @@ case $host in
     ;;
 esac
 
-AC_CHECK_FUNCS(gettimeofday select memset_s)
-if test "$ac_cv_func_memset_s" != "yes"; then
+AC_CHECK_FUNCS(gettimeofday select)
+
+dnl Check for memset_s()
+libssh2_cv_func_memset_s="no"
+AC_MSG_CHECKING([if memset_s can be linked])
+AC_LINK_IFELSE([
+  AC_LANG_FUNC_LINK_TRY([memset_s])
+],[
+  AC_MSG_RESULT([yes])
+  AC_MSG_CHECKING([if memset_s is compilable])
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+      #include <string.h>
+    ]],[[
+      char buf[2];
+      if(memset_s(buf, sizeof(buf), 0, sizeof(buf)))
+        return 1;
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    libssh2_cv_func_memset_s="yes"
+    AC_DEFINE_UNQUOTED(HAVE_MEMSET_S, 1,
+      [Define to 1 if you have the memset_s function.])
+  ],[
+    AC_MSG_RESULT([no])
+  ])
+],[
+  AC_MSG_RESULT([no])
+])
+
+if test "$libssh2_cv_func_memset_s" = "no"; then
   AC_CHECK_FUNCS(memset_explicit)
 fi
 


### PR DESCRIPTION
To also check for the prototype, avoiding mis-detection e.g. in C89 
(non-GNU) mode with Apple targets, and syncing this detection with
CMake.

Also: test C89 macOS builds in CI with both autotools and cmake.

Follow-up to 833b48519cf8f8b3f88ca3b792cc8fe438b65f07 #2456
Ref: 6f0dcc3e669b68902fe5ef6bb183d9a98493d16a #2455

---

- [x] rebase on #2456
