### PR TITLE
sftp: fix memleak on OOM in `sftp_init()`

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -951,6 +951,7 @@ static LIBSSH2_SFTP *sftp_init(LIBSSH2_SESSION *session)
         if(extdata_len > 0) {
             char *extversion_str = SSH2_ALLOC(session, extdata_len + 1);
             if(!extversion_str) {
+                SSH2_FREE(session, data);
                 ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                          "Unable to allocate memory for SSH_FXP_VERSION "
                          "packet");


### PR DESCRIPTION
Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2456#pullrequestreview-4828564268
Follow-up to fb6527468c26d18c800580f765ae8c8ea8edb88b #1386
