### PR TITLE
scp: delete two obsolete comments

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -584,7 +584,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
 
                 *(p++) = '\0';
-                /* Make sure we do not get fooled by leftover values */
+
                 /* !checksrc! disable BANNEDFUNC 1 */
                 session->scpRecv_mtime = strtol((char *)s, NULL, 10);
 
@@ -609,7 +609,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
 
                 *p = '\0';
-                /* Make sure we do not get fooled by leftover values */
+
                 /* !checksrc! disable BANNEDFUNC 1 */
                 session->scpRecv_atime = strtol((char *)s, NULL, 10);
 


### PR DESCRIPTION
In the initial commit both was followed by `errno = 0` instructions,
which are no longer present. Remove them, to avoid confusion.

Follow-up to ca2e81eb1f1bcb3c43cc14d60969650af181d82f
Follow-up to 7a5ffc8cee259bbde82ab92515cd8fea2166854b
