### PR TITLE
scp: enable 64-bit timestamp support in `libssh2_scp_recv2()`

### DIFF
--- a/example/scp.c
+++ b/example/scp.c
@@ -148,9 +148,9 @@ int main(int argc, char *argv[])
     }
 
     fprintf(stderr,
-            "size = %lu byte(s)\nmode = 0%o\nmtime = %ld\natime = %ld\n",
+            "size = %lu byte(s)\nmode = 0%lo\nmtime = %ld\natime = %ld\n",
             (unsigned long)fileinfo.st_size,
-            (unsigned int)fileinfo.st_mode,
+            (unsigned long)fileinfo.st_mode,
             (long)fileinfo.st_mtime,
             (long)fileinfo.st_atime);
 

--- a/example/scp.c
+++ b/example/scp.c
@@ -141,12 +141,18 @@ int main(int argc, char *argv[])
 
     /* Request a file via SCP */
     channel = libssh2_scp_recv2(session, scppath, &fileinfo);
-
     if(!channel) {
         fprintf(stderr, "Unable to open a session: %d\n",
                 libssh2_session_last_errno(session));
         goto shutdown;
     }
+
+    fprintf(stderr,
+            "size = %lu byte(s)\nmode = 0%o\nmtime = %ld\natime = %ld\n",
+            (unsigned long)fileinfo.st_size,
+            (unsigned int)fileinfo.st_mode,
+            (long)fileinfo.st_mtime,
+            (long)fileinfo.st_atime);
 
     while(got < fileinfo.st_size) {
         char mem[1024];

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -226,7 +226,6 @@ int main(int argc, char *argv[])
     fprintf(stderr, "libssh2_scp_recv2().\n");
     do {
         channel = libssh2_scp_recv2(session, scppath, &fileinfo);
-
         if(!channel) {
             if(libssh2_session_last_errno(session) != LIBSSH2_ERROR_EAGAIN) {
                 char *err_msg;
@@ -242,6 +241,13 @@ int main(int argc, char *argv[])
         }
     } while(!channel);
     fprintf(stderr, "libssh2_scp_recv2() is done, now receive data.\n");
+
+    fprintf(stderr,
+            "size = %lu byte(s)\nmode = 0%o\nmtime = %ld\natime = %ld\n",
+            (unsigned long)fileinfo.st_size,
+            (unsigned int)fileinfo.st_mode,
+            (long)fileinfo.st_mtime,
+            (long)fileinfo.st_atime);
 
     while(got < fileinfo.st_size) {
         char mem[1024 * 24];

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -243,9 +243,9 @@ int main(int argc, char *argv[])
     fprintf(stderr, "libssh2_scp_recv2() is done, now receive data.\n");
 
     fprintf(stderr,
-            "size = %lu byte(s)\nmode = 0%o\nmtime = %ld\natime = %ld\n",
+            "size = %lu byte(s)\nmode = 0%lo\nmtime = %ld\natime = %ld\n",
             (unsigned long)fileinfo.st_size,
-            (unsigned int)fileinfo.st_mode,
+            (unsigned long)fileinfo.st_mode,
             (long)fileinfo.st_mtime,
             (long)fileinfo.st_atime);
 

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -952,7 +952,7 @@ struct _LIBSSH2_SESSION {
     size_t scpRecv_response_len;
     long scpRecv_mode;
     libssh2_int64_t scpRecv_size;
-    libssh2_struct_stat scpRecv_time;
+    libssh2_struct_stat scpRecv_stat;
     LIBSSH2_CHANNEL *scpRecv_channel;
 
     /* State variables used in libssh2_scp_send_ex() */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -952,7 +952,8 @@ struct _LIBSSH2_SESSION {
     size_t scpRecv_response_len;
     long scpRecv_mode;
     libssh2_int64_t scpRecv_size;
-    libssh2_struct_stat scpRecv_stat;
+    time_t scpRecv_mtime;
+    time_t scpRecv_atime;
     LIBSSH2_CHANNEL *scpRecv_channel;
 
     /* State variables used in libssh2_scp_send_ex() */

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -952,8 +952,7 @@ struct _LIBSSH2_SESSION {
     size_t scpRecv_response_len;
     long scpRecv_mode;
     libssh2_int64_t scpRecv_size;
-    long scpRecv_mtime;
-    long scpRecv_atime;
+    libssh2_struct_stat scpRecv_time;
     LIBSSH2_CHANNEL *scpRecv_channel;
 
     /* State variables used in libssh2_scp_send_ex() */

--- a/src/scp.c
+++ b/src/scp.c
@@ -358,8 +358,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
     if(session->scpRecv_state == ssh2_NB_state_idle) {
         session->scpRecv_mode = 0;
         session->scpRecv_size = 0;
-        session->scpRecv_time.st_mtime = 0;
-        session->scpRecv_time.st_atime = 0;
+        session->scpRecv_stat.st_mtime = 0;
+        session->scpRecv_stat.st_atime = 0;
 
         session->scpRecv_command_len =
             shell_quotedsize(path) + sizeof("scp -f ") + (sb ? 1 : 0);
@@ -584,7 +584,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
                 *(p++) = '\0';
 
-                session->scpRecv_time.st_mtime =
+                session->scpRecv_stat.st_mtime =
                     (time_t)ssh2_strtoll((char *)s, NULL, 10);
 
                 s = (unsigned char *)strchr((char *)p, ' ');
@@ -608,7 +608,7 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
                 *p = '\0';
 
-                session->scpRecv_time.st_atime =
+                session->scpRecv_stat.st_atime =
                     (time_t)ssh2_strtoll((char *)s, NULL, 10);
 
                 /* SCP ACK */
@@ -631,8 +631,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 ssh2_deb((session, LIBSSH2_TRACE_SCP,
                           "mtime = %" SSH2_INT64_T_FORMAT ", "
                           "atime = %" SSH2_INT64_T_FORMAT,
-                          (libssh2_int64_t)session->scpRecv_time.st_mtime,
-                          (libssh2_int64_t)session->scpRecv_time.st_atime));
+                          (libssh2_int64_t)session->scpRecv_stat.st_mtime,
+                          (libssh2_int64_t)session->scpRecv_stat.st_atime));
 
                 /* We *should* check that atime.usec is valid, but why let
                    that stop use? */
@@ -805,8 +805,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
     if(sb) {
         memset(sb, 0, sizeof(libssh2_struct_stat));
 
-        sb->st_mtime = session->scpRecv_time.st_mtime;
-        sb->st_atime = session->scpRecv_time.st_atime;
+        sb->st_mtime = session->scpRecv_stat.st_mtime;
+        sb->st_atime = session->scpRecv_stat.st_atime;
         sb->st_size = (libssh2_struct_stat_size)session->scpRecv_size;
         sb->st_mode = (unsigned short)session->scpRecv_mode;
     }

--- a/src/scp.c
+++ b/src/scp.c
@@ -39,11 +39,11 @@
 #include <stdlib.h>  /* strtoll(), _strtoi64(), strtol() */
 
 #ifdef HAVE_STRTOLL
-#define scpsize_strtol strtoll
+#define ssh2_strtoll strtoll
 #elif defined(HAVE_STRTOI64)
-#define scpsize_strtol _strtoi64
+#define ssh2_strtoll _strtoi64
 #else
-#define scpsize_strtol strtol
+#define ssh2_strtoll strtol
 #endif
 
 /* Max. length of a quoted string after scp_shell_quotearg() processing */
@@ -116,7 +116,7 @@ int ssh2_scp_parse_c_fields(const char *buf, size_t len,
     memcpy(tmp, buf + size_start, size_len);
     tmp[size_len] = '\0';
     end = NULL;
-    *size_out = (libssh2_int64_t)scpsize_strtol(tmp, &end, 10);
+    *size_out = (libssh2_int64_t)ssh2_strtoll(tmp, &end, 10);
     if(end && *end)
         return SCP_C_FIELDS_MALFORMED;
 
@@ -358,8 +358,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
     if(session->scpRecv_state == ssh2_NB_state_idle) {
         session->scpRecv_mode = 0;
         session->scpRecv_size = 0;
-        session->scpRecv_mtime = 0;
-        session->scpRecv_atime = 0;
+        session->scpRecv_time.st_mtime = 0;
+        session->scpRecv_time.st_atime = 0;
 
         session->scpRecv_command_len =
             shell_quotedsize(path) + sizeof("scp -f ") + (sb ? 1 : 0);
@@ -582,11 +582,10 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                              "malformed mtime");
                     goto scp_recv_error;
                 }
-
                 *(p++) = '\0';
 
-                /* !checksrc! disable BANNEDFUNC 1 */
-                session->scpRecv_mtime = strtol((char *)s, NULL, 10);
+                session->scpRecv_time.st_mtime = ssh2_strtoll((char *)s,
+                                                              NULL, 10);
 
                 s = (unsigned char *)strchr((char *)p, ' ');
                 if(!s || (s - p) <= 0) {
@@ -607,11 +606,10 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                              "too short or malformed");
                     goto scp_recv_error;
                 }
-
                 *p = '\0';
 
-                /* !checksrc! disable BANNEDFUNC 1 */
-                session->scpRecv_atime = strtol((char *)s, NULL, 10);
+                session->scpRecv_time.st_atime = ssh2_strtoll((char *)s,
+                                                              NULL, 10);
 
                 /* SCP ACK */
                 session->scpRecv_response[0] = '\0';
@@ -631,9 +629,10 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                     goto scp_recv_error;
 
                 ssh2_deb((session, LIBSSH2_TRACE_SCP,
-                          "mtime = %ld, atime = %ld",
-                          session->scpRecv_mtime,
-                          session->scpRecv_atime));
+                          "mtime = %" SSH2_INT64_T_FORMAT ", "
+                          "atime = %" SSH2_INT64_T_FORMAT,
+                          (libssh2_int64_t)session->scpRecv_time.st_mtime,
+                          (libssh2_int64_t)session->scpRecv_time.st_atime));
 
                 /* We *should* check that atime.usec is valid, but why let
                    that stop use? */
@@ -806,8 +805,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
     if(sb) {
         memset(sb, 0, sizeof(libssh2_struct_stat));
 
-        sb->st_mtime = session->scpRecv_mtime;
-        sb->st_atime = session->scpRecv_atime;
+        sb->st_mtime = session->scpRecv_time.st_mtime;
+        sb->st_atime = session->scpRecv_time.st_atime;
         sb->st_size = (libssh2_struct_stat_size)session->scpRecv_size;
         sb->st_mode = (unsigned short)session->scpRecv_mode;
     }

--- a/src/scp.c
+++ b/src/scp.c
@@ -358,8 +358,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
     if(session->scpRecv_state == ssh2_NB_state_idle) {
         session->scpRecv_mode = 0;
         session->scpRecv_size = 0;
-        session->scpRecv_stat.st_mtime = 0;
-        session->scpRecv_stat.st_atime = 0;
+        session->scpRecv_mtime = 0;
+        session->scpRecv_atime = 0;
 
         session->scpRecv_command_len =
             shell_quotedsize(path) + sizeof("scp -f ") + (sb ? 1 : 0);
@@ -584,8 +584,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
                 *(p++) = '\0';
 
-                session->scpRecv_stat.st_mtime =
-                    (time_t)ssh2_strtoll((char *)s, NULL, 10);
+                session->scpRecv_mtime = (time_t)ssh2_strtoll((char *)s,
+                                                              NULL, 10);
 
                 s = (unsigned char *)strchr((char *)p, ' ');
                 if(!s || (s - p) <= 0) {
@@ -608,8 +608,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
                 *p = '\0';
 
-                session->scpRecv_stat.st_atime =
-                    (time_t)ssh2_strtoll((char *)s, NULL, 10);
+                session->scpRecv_atime = (time_t)ssh2_strtoll((char *)s,
+                                                              NULL, 10);
 
                 /* SCP ACK */
                 session->scpRecv_response[0] = '\0';
@@ -631,8 +631,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 ssh2_deb((session, LIBSSH2_TRACE_SCP,
                           "mtime = %" SSH2_INT64_T_FORMAT ", "
                           "atime = %" SSH2_INT64_T_FORMAT,
-                          (libssh2_int64_t)session->scpRecv_stat.st_mtime,
-                          (libssh2_int64_t)session->scpRecv_stat.st_atime));
+                          (libssh2_int64_t)session->scpRecv_mtime,
+                          (libssh2_int64_t)session->scpRecv_atime));
 
                 /* We *should* check that atime.usec is valid, but why let
                    that stop use? */
@@ -805,8 +805,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
     if(sb) {
         memset(sb, 0, sizeof(libssh2_struct_stat));
 
-        sb->st_mtime = session->scpRecv_stat.st_mtime;
-        sb->st_atime = session->scpRecv_stat.st_atime;
+        sb->st_mtime = session->scpRecv_mtime;
+        sb->st_atime = session->scpRecv_atime;
         sb->st_size = (libssh2_struct_stat_size)session->scpRecv_size;
         sb->st_mode = (unsigned short)session->scpRecv_mode;
     }

--- a/src/scp.c
+++ b/src/scp.c
@@ -584,8 +584,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
                 *(p++) = '\0';
 
-                session->scpRecv_time.st_mtime = ssh2_strtoll((char *)s,
-                                                              NULL, 10);
+                session->scpRecv_time.st_mtime =
+                    (time_t)ssh2_strtoll((char *)s, NULL, 10);
 
                 s = (unsigned char *)strchr((char *)p, ' ');
                 if(!s || (s - p) <= 0) {
@@ -608,8 +608,8 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
                 }
                 *p = '\0';
 
-                session->scpRecv_time.st_atime = ssh2_strtoll((char *)s,
-                                                              NULL, 10);
+                session->scpRecv_time.st_atime =
+                    (time_t)ssh2_strtoll((char *)s, NULL, 10);
 
                 /* SCP ACK */
                 session->scpRecv_response[0] = '\0';


### PR DESCRIPTION
By bumping internal mtime/atime from `long` to `time_t`, and adjusting
internals to read and log these as 64-bit values.

Before this patch, these internal variables used `long`.

Also: show fileinfo in scp read examples.
