### PR TITLE
build: assume POSIX `select()` is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,6 @@ if(WIN32)
     endif()
   endif()
   set(HAVE_POLL 0)
-  set(HAVE_SELECT 1)
 endif()
 
 ## Platform checks
@@ -385,7 +384,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
 else()
   check_function_exists("poll" HAVE_POLL)
 endif()
-check_function_exists("select" HAVE_SELECT)
 
 # Non-blocking socket support tests. Use a separate, yet unset variable
 # for the socket libraries to not link against the other configured

--- a/configure.ac
+++ b/configure.ac
@@ -396,13 +396,6 @@ case $host in
     ;;
 esac
 
-if test "x$have_windows_h" = "xyes"; then
-  AC_DEFINE_UNQUOTED(HAVE_SELECT, 1,
-    [Define to 1 if you have the select function.])
-else
-  AC_CHECK_FUNCS(select)
-fi
-
 AC_CHECK_FUNCS(gettimeofday)
 
 dnl Check for memset_s()

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -72,9 +72,6 @@
 /* Define to 1 if you have the `poll' function. */
 #undef HAVE_POLL
 
-/* Define to 1 if you have the select function. */
-#define HAVE_SELECT 1
-
 /* use SO_NONBLOCK for non-blocking sockets */
 #undef HAVE_SO_NONBLOCK
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -51,7 +51,6 @@
 #cmakedefine HAVE_MEMSET_EXPLICIT
 
 #cmakedefine HAVE_POLL
-#cmakedefine HAVE_SELECT
 
 /* Socket non-blocking support */
 #cmakedefine HAVE_O_NONBLOCK

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -61,7 +61,7 @@
    would break backwards compatibility. */
 #ifdef HAVE_POLL
 #include <poll.h>
-#elif defined(HAVE_SELECT) && defined(HAVE_SYS_SELECT_H)
+#elif defined(HAVE_SYS_SELECT_H)
 #include <sys/select.h>
 #endif
 

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -24,8 +24,6 @@
    Keep this synced with root CMakeLists.txt */
 #elif defined(_WIN32)
 
-#define HAVE_SELECT
-
 #ifdef __MINGW32__
 #  define HAVE_UNISTD_H
 #  define HAVE_INTTYPES_H

--- a/src/session.c
+++ b/src/session.c
@@ -1760,8 +1760,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
                 }
             }
         }
-#endif /* HAVE_POLL */
-          timeout_remaining) is equal to 0 */
+#endif /* HAVE_POLL, timeout_ms (and by extension timeout_remaining) is 0 */
     } while(timeout_remaining > 0 && !active_fds);
 
 #ifdef HAVE_POLL

--- a/src/session.c
+++ b/src/session.c
@@ -1504,7 +1504,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
             return -1;
         }
     }
-#elif defined(HAVE_SELECT)
+#else /* !HAVE_POLL, use select() */
     LIBSSH2_SESSION *session = NULL;
     libssh2_socket_t maxfd = 0;
     fd_set rfds, wfds;
@@ -1578,15 +1578,11 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
             return -1;
         }
     }
-#else /* !HAVE_POLL && !HAVE_SELECT */
-    timeout_ms = 0;  /* no sockets structure to setup */
-#endif /* HAVE_POLL || HAVE_SELECT */
+#endif /* HAVE_POLL */
 
     timeout_remaining = ssh2_ms_to_timediff(timeout_ms);
     do {
-#if defined(HAVE_POLL) || defined(HAVE_SELECT)
         int sysret;
-#endif
         active_fds = 0;
 
         for(i = 0; i < nfds; i++) {
@@ -1707,7 +1703,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
             }
         }
 
-#elif defined(HAVE_SELECT)
+#else /* !HAVE_POLL, use select() */
 
         {
             ssh2_time_t start_time, now;
@@ -1764,7 +1760,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
                 }
             }
         }
-#endif /* !HAVE_POLL && !HAVE_SELECT -- timeout_ms (and by extension
+#endif /* HAVE_POLL */
           timeout_remaining) is equal to 0 */
     } while(timeout_remaining > 0 && !active_fds);
 

--- a/src/session.c
+++ b/src/session.c
@@ -1760,7 +1760,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
                 }
             }
         }
-#endif /* HAVE_POLL, timeout_ms (and by extension timeout_remaining) is 0 */
+#endif /* HAVE_POLL */
     } while(timeout_remaining > 0 && !active_fds);
 
 #ifdef HAVE_POLL

--- a/vms/libssh2_config.h
+++ b/vms/libssh2_config.h
@@ -21,7 +21,6 @@ typedef unsigned int socklen_t; /* missing in headers on VMS */
 #define HAVE_UNISTD_H
 #define HAVE_INTTYPES_H
 #define HAVE_SYS_TIME_H
-#define HAVE_SELECT
 #define HAVE_UIO
 
 #define HAVE_SYS_SOCKET_H


### PR DESCRIPTION
`select()` was used unconditionally in internal function
`ssh2_wait_socket()`, when `poll()` is not available, since
9d55db6501aa4e21f0858cf36cdc2ddc11b96e83 (2007-02-02, release 0.15)

It means the build was broken without `select()` in such case. There
were also no reports about this being an issue. Therefore detecting it
at configure time is superfluous.

Drop feature detections, and drop `libssh2_poll()` implementation
fallback logic dealing with an impossible no-poll-no-select build.

Follow-up to 9d55db6501aa4e21f0858cf36cdc2ddc11b96e83
