### PR TITLE
RELEASE-NOTES: announce `libssh2_base64_decode()`, `libssh2_poll()` going no-ops (revert)

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -52,11 +52,6 @@ Deprecation notices:
 
 - This release always enables large file support on Windows.
 
-- The next release makes these deprecated functions no-ops that
-  return permanent failure:
-  - `libssh2_base64_decode()` (deprecated since 1.0.0, 2008-12-26)
-  - `libssh2_poll()` (deprecated since 1.2.0, 2009-08-10)
-
 This release includes the following enhancements and bugfixes:
 
 - agent: fix unused macro compiler warnings in UWP non-unity builds (0e2bc3d6 #2325 #2313)


### PR DESCRIPTION
It turned out that the `poll()` and `select()` dependencies are used not
just from `libssh2_poll()` but from another internal function, which
makes the no-opping pointless.

Revert to keep the deprecation process simple.

Follow-up to f84a56dd3b8d37a65072cd89088e8528bf905fb7 #2452
