### PR TITLE
build: assume `sys/socket.h` on non-Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,6 @@ check_include_files("unistd.h" HAVE_UNISTD_H)
 if(NOT WIN32)
   check_include_files("sys/select.h" HAVE_SYS_SELECT_H)
   check_include_files("sys/uio.h" HAVE_SYS_UIO_H)
-  check_include_files("sys/socket.h" HAVE_SYS_SOCKET_H)
   check_include_files("sys/ioctl.h" HAVE_SYS_IOCTL_H)
   check_include_files("sys/un.h" HAVE_SYS_UN_H)
   check_include_files("arpa/inet.h" HAVE_ARPA_INET_H)  # example and tests

--- a/configure.ac
+++ b/configure.ac
@@ -374,7 +374,7 @@ AM_CONDITIONAL([USE_OSSFUZZ_STATIC], [test -f "$LIB_FUZZING_ENGINE"])
 
 dnl Checks for header files.
 AC_CHECK_HEADERS([unistd.h sys/uio.h])
-AC_CHECK_HEADERS([sys/select.h sys/socket.h sys/ioctl.h])
+AC_CHECK_HEADERS([sys/select.h sys/ioctl.h])
 AC_CHECK_HEADERS([arpa/inet.h netinet/in.h])
 AC_CHECK_HEADERS([sys/un.h])
 

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -12,7 +12,7 @@
 #define send(s, b, l, f)  send(s, b, (int)(l), f)
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/scp.c
+++ b/example/scp.c
@@ -12,7 +12,7 @@
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -17,7 +17,7 @@
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -8,7 +8,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -8,7 +8,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -19,7 +19,7 @@
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -18,7 +18,7 @@
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -18,7 +18,7 @@
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -18,7 +18,7 @@
 #define strdup _strdup
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -14,7 +14,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -22,7 +22,7 @@
 #define strdup _strdup
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -12,7 +12,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -16,7 +16,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -17,7 +17,7 @@
 
 #ifndef LIBSSH2_NO_DEPRECATED
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -13,7 +13,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -6,7 +6,7 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -12,7 +12,7 @@
 #define send(s, b, l, f)  send(s, b, (int)(l), f)
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/example/x11.c
+++ b/example/x11.c
@@ -22,7 +22,7 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H

--- a/os400/libssh2_config.h
+++ b/os400/libssh2_config.h
@@ -81,9 +81,6 @@
 /* Define to 1 if you have the <sys/select.h> header file. */
 #undef HAVE_SYS_SELECT_H
 
-/* Define to 1 if you have the <sys/socket.h> header file. */
-#define HAVE_SYS_SOCKET_H 1
-
 /* Define to 1 if you have the <sys/uio.h> header file. */
 #define HAVE_SYS_UIO_H 1
 

--- a/src/libssh2_config_cmake.h.in
+++ b/src/libssh2_config_cmake.h.in
@@ -36,7 +36,6 @@
 #cmakedefine HAVE_INTTYPES_H
 #cmakedefine HAVE_SYS_SELECT_H
 #cmakedefine HAVE_SYS_UIO_H
-#cmakedefine HAVE_SYS_SOCKET_H
 #cmakedefine HAVE_SYS_IOCTL_H
 #cmakedefine HAVE_SYS_TIME_H
 #cmakedefine HAVE_SYS_UN_H

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -70,7 +70,7 @@
 #include <sys/uio.h>
 #endif
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_IOCTL_H

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -33,9 +33,6 @@
 #include "session_fixture.h"
 #include "openssh_fixture.h"
 
-#ifdef HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -33,9 +33,6 @@
 #include "session_fixture.h"
 #include "openssh_fixture.h"
 
-#ifdef HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -8,7 +8,7 @@
 #include "libssh2_setup.h"
 #include "libssh2.h"
 
-#ifdef HAVE_SYS_SOCKET_H
+#ifndef _WIN32
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/vms/libssh2_config.h
+++ b/vms/libssh2_config.h
@@ -22,7 +22,6 @@ typedef unsigned int socklen_t; /* missing in headers on VMS */
 #define HAVE_INTTYPES_H
 #define HAVE_UIO
 
-#define HAVE_SYS_SOCKET_H
 #define HAVE_NETINET_IN_H
 #define HAVE_ARPA_INET_H
 


### PR DESCRIPTION
Drop feature detection for it at configure time.
    
To simplify, improve configure performance, make examples build better
standalone, and sync with curl.
