### PR TITLE
cmake: drop `gettimeofday()` detection for Windows, non-mingw-w64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,8 +350,6 @@ endif()
 
 if(NOT WIN32 OR MINGW)
   check_symbol_exists("gettimeofday" "sys/time.h" HAVE_GETTIMEOFDAY)
-else()
-  check_function_exists("gettimeofday" HAVE_GETTIMEOFDAY)
 endif()
 if(NOT WIN32)
   check_symbol_exists("memset_s" "string.h" HAVE_MEMSET_S)


### PR DESCRIPTION
Library code doesn't use this function on Windows, even if detected.

It affects a few lines of non-critical code in two examples when using
unsupported Windows compilers.
