### PR TITLE
include: delete conditional `sys/uio.h` include

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -107,10 +107,6 @@ extern "C" {
 #  endif /* _WIN32 && LIBSSH2_EXPORTS */
 #endif /* !LIBSSH2_API */
 
-#ifdef HAVE_SYS_UIO_H
-#include <sys/uio.h>
-#endif
-
 #include <stdint.h>
 typedef unsigned long long libssh2_uint64_t;
 typedef long long libssh2_int64_t;


### PR DESCRIPTION
Being included if `HAVE_SYS_UIO_H` was set. This macro is set by libssh2
autotools and cmake configure and thus not meant to be available or used
in public headers. It may trigger this include in libssh2-user projects
which accidentally set this macro on their own.

Also the stated reason for this include elsewhere in the code is "for
struct iovec on some platforms", but `iovec` isn't referenced from
public headers. The original commit says it is for Windows, but Windows
(MSVC and mingw-w64 that is) do not provide this header. Then it was
subsequently guarded for Darwin builds, and then switched to the current
guard in the commit initially bringing CMake support to libssh2.

This patch may in theory break 3rd-party projects which by accident 
relied on `libssh2.h` include this header for them.

Follow-up to 6bf898336889b5151503f882e1f76eecd480a191
Follow-up to c070bdacc7adde6ac4aca4999e7c6b21a85a952f
