### PR TITLE
sshd_config: enable `ssh-rsa-cert-v01@openssh.com` more

### DIFF
--- a/tests/openssh_server/sshd_config
+++ b/tests/openssh_server/sshd_config
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 HostKeyAlgorithms +ssh-rsa,ssh-rsa-cert-v01@openssh.com
+# modern name in OpenSSH 8.5+: PubkeyAcceptedAlgorithms
 PubkeyAcceptedKeyTypes +ssh-rsa,ssh-rsa-cert-v01@openssh.com
 MACs +hmac-sha1,hmac-sha1-96,hmac-sha2-256,hmac-sha2-512,hmac-md5,hmac-md5-96,umac-64@openssh.com,umac-128@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,umac-64-etm@openssh.com,umac-128-etm@openssh.com
 Ciphers +3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com

--- a/tests/openssh_server/sshd_config
+++ b/tests/openssh_server/sshd_config
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-HostKeyAlgorithms +ssh-rsa
+HostKeyAlgorithms +ssh-rsa,ssh-rsa-cert-v01@openssh.com
 PubkeyAcceptedKeyTypes +ssh-rsa,ssh-rsa-cert-v01@openssh.com
 MACs +hmac-sha1,hmac-sha1-96,hmac-sha2-256,hmac-sha2-512,hmac-md5,hmac-md5-96,umac-64@openssh.com,umac-128@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,umac-64-etm@openssh.com,umac-128-etm@openssh.com
 Ciphers +3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com


### PR DESCRIPTION
I'm not sure this is required, but I think it's worth a try to untangle
RSA tests. Ref: #2474.

Also add a comment about a config name change.
