### PR TITLE
spacecheck: cap max lines per file, use single-quotes

### DIFF
--- a/scripts/spacecheck.pl
+++ b/scripts/spacecheck.pl
@@ -71,10 +71,7 @@ sub fn_match {
 }
 
 sub eol_detect {
-    my ($content) = @_;
-
-    my $cr = () = $content =~ /\r/g;
-    my $lf = () = $content =~ /\n/g;
+    my ($cr, $lf) = @_;
 
     if($cr > 0 && $lf == 0) {
         return 'cr';
@@ -94,6 +91,7 @@ sub eol_detect {
 
 my $max_repeat_space = 79;
 my $max_line_len = 192;
+my $max_lines = 10000;
 my $max_path_len = 64;
 my $max_filename_len = 48;
 
@@ -127,7 +125,10 @@ while(my $filename = <$git_ls_files>) {
         push @err, 'content: has tab';
     }
 
-    my $eol = eol_detect($content);
+    my $cnt_cr = () = $content =~ /\r/g;
+    my $cnt_lf = () = $content =~ /\n/g;
+
+    my $eol = eol_detect($cnt_cr, $cnt_lf);
 
     if($eol eq '') {
         push @err, 'content: has mixed EOL types';
@@ -141,6 +142,13 @@ while(my $filename = <$git_ls_files>) {
     if($eol ne 'lf' && $content ne '' &&
        !fn_match($filename, @need_crlf)) {
         push @err, 'content: must use LF EOL for this file type';
+    }
+
+    if($cnt_cr > $max_lines) {
+        push @err, sprintf('content: too many lines (%d > %d)', $cnt_cr, $max_lines);
+    }
+    elsif($cnt_lf > $max_lines) {
+        push @err, sprintf('content: too many lines (%d > %d)', $cnt_lf, $max_lines);
     }
 
     if(!fn_match($filename, @trailing_ws) &&

--- a/scripts/spacecheck.pl
+++ b/scripts/spacecheck.pl
@@ -29,8 +29,8 @@ use warnings;
 use File::Basename;
 
 my @tabs = (
-    "Makefile\\.[a-z]+\$",
-    "m4/libssh2-link\.m4\$",
+    'Makefile\\.[a-z]+$',
+    'm4/libssh2-link\.m4$',
 );
 
 my @mixed_eol = (
@@ -40,23 +40,23 @@ my @need_crlf = (
 );
 
 my @trailing_ws = (
-    "tests/keys/id_.+\.pub\$",
+    'tests/keys/id_.+\.pub$',
 );
 
 my @double_empty_lines = (
 );
 
 my @longline = (
-    "^libssh2-style\.el\$",
-    "tests/keys/id_.+\.pub\$",
-    "tests/openssh_server/authorized_keys\$",
-    "tests/openssh_server/ca_.+\.pub\$",
-    "tests/openssh_server/sshd_config\$",
+    '^libssh2-style\.el$',
+    'tests/keys/id_.+\.pub$',
+    'tests/openssh_server/authorized_keys$',
+    'tests/openssh_server/ca_.+\.pub$',
+    'tests/openssh_server/sshd_config$',
 );
 
 my @non_ascii = (
-    "AUTHORS",
-    "RELEASE-NOTES",
+    'AUTHORS',
+    'RELEASE-NOTES',
 );
 
 sub fn_match {

--- a/scripts/spacecheck.pl
+++ b/scripts/spacecheck.pl
@@ -29,7 +29,7 @@ use warnings;
 use File::Basename;
 
 my @tabs = (
-    'Makefile\\.[a-z]+$',
+    'Makefile\.[a-z]+$',
     'm4/libssh2-link\.m4$',
 );
 


### PR DESCRIPTION
- limit lines to 10000 per file to prevent committing a large file by
  accident.

  Current top-5:
  ```
      4007 src/kex.c
      3886 src/sftp.c
      3674 src/openssl.c
      3256 src/wincng.c
      2848 src/channel.c
  ```
- use single-quotes to reduce escaping.
