### PR TITLE
test_sshd.test: sync an option with `sshd_config` used in `Dockerfile`

### DIFF
--- a/tests/test_sshd.test
+++ b/tests/test_sshd.test
@@ -86,6 +86,7 @@ chmod go-rwx \
   -o 'PidFile sshd.pid' \
   -o "AuthorizedKeysFile ${PUBKEY} ${d}/openssh_server/authorized_keys" \
   -o "TrustedUserCAKeys ${cakeys}" \
+  -o 'KbdInteractiveAuthentication yes' \
   -o 'PermitRootLogin yes' \
   -D \
   ${SSHD_FLAGS} &


### PR DESCRIPTION
Follow-up to d4690e950995658eccb316cb9403ad6d31e19dba #1024

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
