### PR TITLE
tests: add support to disable hex debug dumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
       MATRIX_TARGET: '${{ matrix.target }}'
       MATRIX_TEST: '${{ matrix.test }}'
       MATRIX_ZLIB: '${{ matrix.zlib }}'
-      FIXTURE_TRACE_ALL_CONNECT: 0
+      FIXTURE_TRACE_ALL_CONNECT: '1'  # to debug OpenSSL (ML-KEM) flaky CI failures
       AWSLC_VERSION: 5.0.0
       AWSLC_SHA256: b4e1ea639d526c54243b8fbd9d21e101360423965bca5cbd72b862e7c9efdb12
       BORINGSSL_VERSION: 0.20260616.0
@@ -537,7 +537,7 @@ jobs:
               options+=' -DCMAKE_C_STANDARD=90'
               cflags+=' -D_DEFAULT_SOURCE'  # for glibc ISO mode, in tests: popen(), pclose(), in examples: fileno(), tcsetattr()
             fi
-            if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
+            if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ] || [[ "${MATRIX_CRYPTO}" = 'OpenSSL' && "${MATRIX_COMPILER}" = 'clang-tidy' ]]; then
               options+=' -DENABLE_DEBUG_LOGGING=ON'
               cflags+=' -DLIBSSH2_DEBUG_MLKEM'
             fi
@@ -590,9 +590,6 @@ jobs:
         if: ${{ !matrix.target }}
         timeout-minutes: 10
         run: |
-          if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ]; then
-            export FIXTURE_TRACE_ALL_CONNECT=1  # try to close in on flaky CI failures
-          fi
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
             [ -d "$HOME"/usr ] && export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/usr/lib"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ permissions: {}
 
 env:
   DO_NOT_TRACK: '1'
+  FIXTURE_TRACE_NO_DEBUGDUMP: '1'
   HOMEBREW_NO_INSTALL_CLEANUP: '1'
   MAKEFLAGS: -j 5
 

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -72,6 +72,7 @@ fi
 if [[ "${TESTS:-}" != *'skipall'* && "${TESTS:-}" != *'skiprun'* ]]; then
   if [[ "${CMAKE_GENERATE:-}" = *'WinCNG'* ]]; then
     export FIXTURE_TRACE_ALL_CONNECT=1
+    export FIXTURE_TRACE_NO_DEBUGDUMP=1
   fi
   # Connection to test server has been failing consistently since 2024-08-29
   export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE="ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)"

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -138,13 +138,13 @@ LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err)
     }
 
     if(getenv("FIXTURE_TRACE_ALL_CONNECT")) {
-        libssh2_trace(connected_session, ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP")
-                                           ? LIBSSH2_TRACE_TRANS : 0));
+        libssh2_trace(connected_session,
+            ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP") ? LIBSSH2_TRACE_TRANS : 0));
         fprintf(stdout, "Trace all enabled for connect_to_server.\n");
     }
     else if(getenv("FIXTURE_TRACE_ALL")) {
-        libssh2_trace(connected_session, ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP")
-                                           ? LIBSSH2_TRACE_TRANS : 0));
+        libssh2_trace(connected_session,
+            ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP") ? LIBSSH2_TRACE_TRANS : 0));
         fprintf(stdout, "Trace all enabled.\n");
     }
 

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -138,11 +138,17 @@ LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err)
     }
 
     if(getenv("FIXTURE_TRACE_ALL_CONNECT")) {
-        libssh2_trace(connected_session, ~0);
+        if(getenv("FIXTURE_TRACE_NO_DEBUGDUMP"))
+            libssh2_trace(connected_session, ~LIBSSH2_TRACE_TRANS);
+        else
+            libssh2_trace(connected_session, ~0);
         fprintf(stdout, "Trace all enabled for connect_to_server.\n");
     }
     else if(getenv("FIXTURE_TRACE_ALL")) {
-        libssh2_trace(connected_session, ~0);
+        if(getenv("FIXTURE_TRACE_NO_DEBUGDUMP"))
+            libssh2_trace(connected_session, ~LIBSSH2_TRACE_TRANS);
+        else
+            libssh2_trace(connected_session, ~0);
         fprintf(stdout, "Trace all enabled.\n");
     }
 

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -138,17 +138,13 @@ LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err)
     }
 
     if(getenv("FIXTURE_TRACE_ALL_CONNECT")) {
-        if(getenv("FIXTURE_TRACE_NO_DEBUGDUMP"))
-            libssh2_trace(connected_session, ~LIBSSH2_TRACE_TRANS);
-        else
-            libssh2_trace(connected_session, ~0);
+        libssh2_trace(connected_session, ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP")
+                                           ? LIBSSH2_TRACE_TRANS : 0));
         fprintf(stdout, "Trace all enabled for connect_to_server.\n");
     }
     else if(getenv("FIXTURE_TRACE_ALL")) {
-        if(getenv("FIXTURE_TRACE_NO_DEBUGDUMP"))
-            libssh2_trace(connected_session, ~LIBSSH2_TRACE_TRANS);
-        else
-            libssh2_trace(connected_session, ~0);
+        libssh2_trace(connected_session, ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP")
+                                           ? LIBSSH2_TRACE_TRANS : 0));
         fprintf(stdout, "Trace all enabled.\n");
     }
 

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -137,7 +137,10 @@ int main(int argc, char *argv[])
 
     if(getenv("FIXTURE_TRACE_ALL_CONNECT") ||
        getenv("FIXTURE_TRACE_ALL")) {
-        libssh2_trace(session, ~0);
+        if(getenv("FIXTURE_TRACE_NO_DEBUGDUMP"))
+            libssh2_trace(session, ~LIBSSH2_TRACE_TRANS);
+        else
+            libssh2_trace(session, ~0);
         fprintf(stdout, "Trace all enabled.\n");
     }
 

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -137,11 +137,8 @@ int main(int argc, char *argv[])
 
     if(getenv("FIXTURE_TRACE_ALL_CONNECT") ||
        getenv("FIXTURE_TRACE_ALL")) {
-        if(getenv("FIXTURE_TRACE_NO_DEBUGDUMP"))
-            libssh2_trace(session, ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP")
-                                     ? LIBSSH2_TRACE_TRANS : 0));
-        else
-            libssh2_trace(session, ~0);
+        libssh2_trace(session,
+            ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP") ? LIBSSH2_TRACE_TRANS : 0));
         fprintf(stdout, "Trace all enabled.\n");
     }
 

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -138,7 +138,8 @@ int main(int argc, char *argv[])
     if(getenv("FIXTURE_TRACE_ALL_CONNECT") ||
        getenv("FIXTURE_TRACE_ALL")) {
         if(getenv("FIXTURE_TRACE_NO_DEBUGDUMP"))
-            libssh2_trace(session, ~LIBSSH2_TRACE_TRANS);
+            libssh2_trace(session, ~(getenv("FIXTURE_TRACE_NO_DEBUGDUMP")
+                                     ? LIBSSH2_TRACE_TRANS : 0));
         else
             libssh2_trace(session, ~0);
         fprintf(stdout, "Trace all enabled.\n");


### PR DESCRIPTION
via new env `FIXTURE_TRACE_NO_DEBUGDUMP`.

Also:
- CI: set `FIXTURE_TRACE_NO_DEBUGDUMP` to make detailed logs (much)
  shorter and more readable for the common debug use-case.

- GHA: enable debug trace for clang-tidy OpenSSL jobs and simplify
  configuration.

Cherry-picked from #2485
