### PR TITLE
src: bump `ssh2_time_t`/`ssh2_timediff_t` resolution from milliseconds to microseconds

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -306,12 +306,12 @@ typedef enum {
     ssh2_NB_state_jumpauthagent
 } ssh2_NB_states;
 
-#define ssh2_time_t               libssh2_int64_t /* ms */
-#define ssh2_timediff_t           libssh2_int64_t /* ms */
-#define ssh2_sec_to_timediff(sec) ((ssh2_time_t)(sec) * 1000)
-#define ssh2_timediff_to_sec(td)  ((td) / 1000)
-#define ssh2_ms_to_timediff(ms)   ((ssh2_time_t)(ms))
-#define ssh2_timediff_to_ms(td)   (td)
+#define ssh2_time_t               libssh2_int64_t /* us */
+#define ssh2_timediff_t           libssh2_int64_t /* us */
+#define ssh2_sec_to_timediff(sec) ((ssh2_time_t)(sec) * 1000000)
+#define ssh2_timediff_to_sec(td)  ((td) / 1000000)
+#define ssh2_ms_to_timediff(ms)   ((ssh2_time_t)(ms) * 1000)
+#define ssh2_timediff_to_ms(td)   ((td) / 1000)
 ssh2_time_t ssh2_now(void);
 
 struct packet_require_state {

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -310,6 +310,7 @@ typedef enum {
 #define ssh2_timediff_t           libssh2_int64_t /* us */
 #define ssh2_sec_to_timediff(sec) ((ssh2_time_t)(sec) * 1000000)
 #define ssh2_timediff_to_sec(td)  ((td) / 1000000)
+#define ssh2_timediff_to_usec(td) ((td) % 1000000)
 #define ssh2_ms_to_timediff(ms)   ((ssh2_time_t)(ms) * 1000)
 #define ssh2_timediff_to_ms(td)   ((td) / 1000)
 ssh2_time_t ssh2_now(void);

--- a/src/misc.c
+++ b/src/misc.c
@@ -734,25 +734,25 @@ ssh2_time_t ssh2_now(void) /* ms */
     sec = (ssh2_time_t)(count.QuadPart / freq.QuadPart);
     ns = (ssh2_time_t)(((count.QuadPart % freq.QuadPart) *
         1000000000) / freq.QuadPart);
-    return sec * 1000 + ns / 1000000;
+    return sec * 1000000 + ns / 1000;
 #else /* !_WIN32 */
 #if defined(CLOCK_MONOTONIC_RAW) /* Apple/Linux */
     struct timespec ts;
     if(!clock_gettime(CLOCK_MONOTONIC_RAW, &ts))
-        return (ssh2_time_t)ts.tv_sec * 1000 +
-            (ssh2_time_t)ts.tv_nsec / 1000000;
+        return (ssh2_time_t)ts.tv_sec * 1000000 +
+            (ssh2_time_t)ts.tv_nsec / 1000;
 #elif defined(CLOCK_MONOTONIC) /* POSIX */
     struct timespec ts;
     if(!clock_gettime(CLOCK_MONOTONIC, &ts))
-        return (ssh2_time_t)ts.tv_sec * 1000 +
-            (ssh2_time_t)ts.tv_nsec / 1000000;
+        return (ssh2_time_t)ts.tv_sec * 1000000 +
+            (ssh2_time_t)ts.tv_nsec / 1000;
 #elif defined(HAVE_GETTIMEOFDAY)
     struct timeval tv;
     if(!gettimeofday(&tv, NULL))
-        return (ssh2_time_t)tv.tv_sec * 1000 + (ssh2_time_t)tv.tv_usec / 1000;
+        return (ssh2_time_t)tv.tv_sec * 1000000 + (ssh2_time_t)tv.tv_usec;
 #endif
     {
-        ssh2_time_t ms = (ssh2_time_t)time(NULL) * 1000;
+        ssh2_time_t ms = (ssh2_time_t)time(NULL) * 1000000;
         return ms ? ms : 1;
     }
 #endif /* _WIN32 */

--- a/src/misc.c
+++ b/src/misc.c
@@ -723,7 +723,7 @@ void ssh2_list_insert(struct list_node *after, /* insert before this */
 }
 #endif
 
-ssh2_time_t ssh2_now(void) /* ms */
+ssh2_time_t ssh2_now(void) /* us */
 {
 #ifdef _WIN32
     ssh2_time_t sec, ns;
@@ -752,8 +752,8 @@ ssh2_time_t ssh2_now(void) /* ms */
         return (ssh2_time_t)tv.tv_sec * 1000000 + (ssh2_time_t)tv.tv_usec;
 #endif
     {
-        ssh2_time_t ms = (ssh2_time_t)time(NULL) * 1000000;
-        return ms ? ms : 1;
+        ssh2_time_t us = (ssh2_time_t)time(NULL) * 1000000;
+        return us ? us : 1;
     }
 #endif /* _WIN32 */
 }

--- a/src/session.c
+++ b/src/session.c
@@ -1708,11 +1708,12 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
         {
             ssh2_time_t start_time, now;
             struct timeval tv;
-            tv.tv_sec = (long)(timeout_remaining / 1000);
+            tv.tv_sec = (long)ssh2_timediff_to_sec(timeout_remaining);
 #ifdef libssh2_usec_t
-            tv.tv_usec = (libssh2_usec_t)((timeout_remaining % 1000) * 1000);
+            tv.tv_usec =
+                (libssh2_usec_t)ssh2_timediff_to_usec(timeout_remaining);
 #else
-            tv.tv_usec = (timeout_remaining % 1000) * 1000;
+            tv.tv_usec = ssh2_timediff_to_usec(timeout_remaining);
 #endif
             start_time = ssh2_now();
             sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL,

--- a/src/session.c
+++ b/src/session.c
@@ -614,13 +614,11 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
         fd_set *writefd = NULL;
         fd_set *readfd = NULL;
         struct timeval tv;
-        ssh2_timediff_t ms_to_next = ssh2_timediff_to_ms(time_to_next);
-
-        tv.tv_sec = (long)(ms_to_next / 1000);
+        tv.tv_sec = (long)ssh2_timediff_to_sec(time_to_next);
 #ifdef libssh2_usec_t
-        tv.tv_usec = (libssh2_usec_t)((ms_to_next - tv.tv_sec * 1000) * 1000);
+        tv.tv_usec = (libssh2_usec_t)ssh2_timediff_to_usec(time_to_next);
 #else
-        tv.tv_usec = (ms_to_next - tv.tv_sec * 1000) * 1000;
+        tv.tv_usec = ssh2_timediff_to_usec(time_to_next);
 #endif
 
         if(dir & LIBSSH2_SESSION_BLOCK_INBOUND) {


### PR DESCRIPTION
To make it fit to replace `gettimeofday()` in `ssh2_deb_low()`, which
needs this resolution for meaningful log output:
```
[libssh2] 0.616496 Transport: Looking for packet of type: 52
[libssh2] 0.616497 Transport: Looking for packet of type: 51
```

Also:
- session: make `ssh2_wait_socket() and `libssh2_poll()` use
  time conversion macros in their `select()` codepaths.
  Also making use of the microsecond resolution.

Follow-up to 9c421761bc8b0975fbb0dccc236a9e88fd45fb50 #2341
Cherry-picked from #2485
