### PR TITLE
misc: replace `gettimeofday()` with `ssh2_now()` in `ssh2_deb_low()`

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -308,6 +308,7 @@ typedef enum {
 
 #define ssh2_time_t               libssh2_int64_t /* us */
 #define ssh2_timediff_t           libssh2_int64_t /* us */
+#define SSH2_TIME_T_FORMAT        SSH2_INT64_T_FORMAT
 #define ssh2_sec_to_timediff(sec) ((ssh2_time_t)(sec) * 1000000)
 #define ssh2_timediff_to_sec(td)  ((td) / 1000000)
 #define ssh2_timediff_to_usec(td) ((td) % 1000000)

--- a/src/misc.c
+++ b/src/misc.c
@@ -554,12 +554,12 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         "Publickey",
         "Socket",
     };
-    static long firstsec;
+    static ssh2_time_t firstsec;
 
     char buffer[1536];
     int len, msglen, buflen = sizeof(buffer);
     va_list vargs;
-    struct timeval now;
+    ssh2_time_t now;
     const char *contexttext = contexts[0];
     unsigned int contextindex;
 
@@ -575,14 +575,14 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         }
     }
 
-    ssh2_gettimeofday(&now, NULL);
+    now = ssh2_now();
     if(!firstsec)
-        firstsec = now.tv_sec;
-    now.tv_sec -= firstsec;
+        firstsec = now;
+    now -= firstsec;
 
     /* '[libssh2] 9999999999.9999999999 Failure Event: ' */
     len = ssh2_snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
-                        (int)now.tv_sec, (int)now.tv_usec, contexttext);
+                        (int)now / 1000000, (int)now % 1000000, contexttext);
     if(len < 0 || len >= buflen) {
         msglen = len < 0 ? 0 : (buflen - 1);
         buffer[msglen] = '\0';

--- a/src/misc.c
+++ b/src/misc.c
@@ -580,9 +580,12 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         firstsec = now;
     now -= firstsec;
 
-    /* '[libssh2] 9999999999.9999999999 Failure Event: ' */
-    len = ssh2_snprintf(buffer, buflen, "[libssh2] %d.%06d %s: ",
-                        (int)now / 1000000, (int)now % 1000000, contexttext);
+    /* '[libssh2] 99999999999999999999.99999999999999999999 Failure Event: ' */
+    len = ssh2_snprintf(buffer, buflen, "[libssh2]"
+                        " %" SSH2_TIME_T_FORMAT ".%06" SSH2_TIME_T_FORMAT
+                        " %s: ",
+                        ssh2_timediff_to_sec(now),
+                        ssh2_timediff_to_usec(now), contexttext);
     if(len < 0 || len >= buflen) {
         msglen = len < 0 ? 0 : (buflen - 1);
         buffer[msglen] = '\0';

--- a/src/misc.c
+++ b/src/misc.c
@@ -554,7 +554,7 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
         "Publickey",
         "Socket",
     };
-    static ssh2_time_t firstsec;
+    static ssh2_time_t firstnow;
 
     char buffer[1536];
     int len, msglen, buflen = sizeof(buffer);
@@ -576,9 +576,9 @@ void ssh2_deb_low(LIBSSH2_SESSION *session, int context,
     }
 
     now = ssh2_now();
-    if(!firstsec)
-        firstsec = now;
-    now -= firstsec;
+    if(!firstnow)
+        firstnow = now;
+    now -= firstnow;
 
     /* '[libssh2] 99999999999999999999.99999999999999999999 Failure Event: ' */
     len = ssh2_snprintf(buffer, buflen, "[libssh2]"


### PR DESCRIPTION
To de-duplicate current-time methods, to avoid relying on deprecated
`gettimeofday()` in core code, and to avoid an additional
Windows-specific retrieval method.

Also:
- add and use `SSH2_TIME_T_FORMAT` macro.

Follow-up to c97959e9b6e2ff3bb322ca1061fae8d2a242cf3a #2489
Cherry-picked from #2485
