### PR TITLE
examples: drop `HAVE_GETTIMEOFDAY` macro use, fill it in for MSVC

### DIFF
--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -44,14 +44,31 @@ static const char *username = "username";
 static const char *password = "password";
 static const char *scppath = "/tmp/TEST";
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+static int gettimeofday(struct timeval *tp, void *tzp)
+{
+    (void)tzp;
+    if(tp) {
+/* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
+#define WIN32_FT_OFFSET 116444736000000000
+        union {
+            libssh2_uint64_t ns100; /* time since 1 Jan 1601 in 100ns units */
+            FILETIME ft;
+        } now;
+        GetSystemTimeAsFileTime(&now.ft);
+        tp->tv_usec = (long)((now.ns100 / 10) % 1000000);
+        tp->tv_sec = (long)((now.ns100 - WIN32_FT_OFFSET) / 10000000);
+    }
+    return 0;
+}
+#endif
+
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
     return (newer.tv_sec - older.tv_sec) * 1000 +
         (newer.tv_usec - older.tv_usec) / 1000;
 }
-#endif
 
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
@@ -101,11 +118,9 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     libssh2_struct_stat fileinfo;
-#ifndef _MSC_VER
     struct timeval start;
     struct timeval end;
     long time_ms;
-#endif
     int spin = 0;
     libssh2_struct_stat_size got = 0;
     libssh2_struct_stat_size total = 0;
@@ -164,9 +179,7 @@ int main(int argc, char *argv[])
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
 
-#ifndef _MSC_VER
     gettimeofday(&start, NULL);
-#endif
 
     /* ... start it up. This trades welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -282,16 +295,12 @@ int main(int argc, char *argv[])
         break;
     }
 
-#ifndef _MSC_VER
     gettimeofday(&end, NULL);
 
     time_ms = tvdiff(end, start);
     fprintf(stderr, "Got %ld bytes in %ld ms = %.1f bytes/sec spin: %d\n",
             (long)total, time_ms,
             (double)total / ((double)time_ms / 1000.0), spin);
-#else
-    fprintf(stderr, "Got %ld bytes spin: %d\n", (long)total, spin);
-#endif
 
     libssh2_channel_free(channel);
 

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -32,7 +32,7 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
 #include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif
 
@@ -44,7 +44,7 @@ static const char *username = "username";
 static const char *password = "password";
 static const char *scppath = "/tmp/TEST";
 
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     libssh2_struct_stat fileinfo;
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
     struct timeval start;
     struct timeval end;
     long time_ms;
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
 
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
     gettimeofday(&start, NULL);
 #endif
 
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
         break;
     }
 
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
     gettimeofday(&end, NULL);
 
     time_ms = tvdiff(end, start);

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -44,7 +44,7 @@ static const char *username = "username";
 static const char *password = "password";
 static const char *scppath = "/tmp/TEST";
 
-#ifdef HAVE_GETTIMEOFDAY
+#if !defined(_WIN32) || defined(__MINGW32__)
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_CHANNEL *channel;
     libssh2_struct_stat fileinfo;
-#ifdef HAVE_GETTIMEOFDAY
+#if !defined(_WIN32) || defined(__MINGW32__)
     struct timeval start;
     struct timeval end;
     long time_ms;
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
 
-#ifdef HAVE_GETTIMEOFDAY
+#if !defined(_WIN32) || defined(__MINGW32__)
     gettimeofday(&start, NULL);
 #endif
 
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
         break;
     }
 
-#ifdef HAVE_GETTIMEOFDAY
+#if !defined(_WIN32) || defined(__MINGW32__)
     gettimeofday(&end, NULL);
 
     time_ms = tvdiff(end, start);

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -33,7 +33,7 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
 #include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif
 
@@ -45,7 +45,7 @@ static const char *username = "username";
 static const char *password = "password";
 static const char *sftppath = "/tmp/TEST";
 
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
     struct timeval start;
     struct timeval end;
     long time_ms;
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
 
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
     gettimeofday(&start, NULL);
 #endif
 
@@ -277,7 +277,7 @@ int main(int argc, char *argv[])
             break;
     } while(1);
 
-#if !defined(_WIN32) || defined(__MINGW32__)
+#ifndef _MSC_VER
     gettimeofday(&end, NULL);
     time_ms = tvdiff(end, start);
     fprintf(stderr, "Got %ld bytes in %ld ms = %.1f bytes/sec spin: %d\n",

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -45,7 +45,7 @@ static const char *username = "username";
 static const char *password = "password";
 static const char *sftppath = "/tmp/TEST";
 
-#ifdef HAVE_GETTIMEOFDAY
+#if !defined(_WIN32) || defined(__MINGW32__)
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
-#ifdef HAVE_GETTIMEOFDAY
+#if !defined(_WIN32) || defined(__MINGW32__)
     struct timeval start;
     struct timeval end;
     long time_ms;
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
 
-#ifdef HAVE_GETTIMEOFDAY
+#if !defined(_WIN32) || defined(__MINGW32__)
     gettimeofday(&start, NULL);
 #endif
 
@@ -277,7 +277,7 @@ int main(int argc, char *argv[])
             break;
     } while(1);
 
-#ifdef HAVE_GETTIMEOFDAY
+#if !defined(_WIN32) || defined(__MINGW32__)
     gettimeofday(&end, NULL);
     time_ms = tvdiff(end, start);
     fprintf(stderr, "Got %ld bytes in %ld ms = %.1f bytes/sec spin: %d\n",

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -45,14 +45,31 @@ static const char *username = "username";
 static const char *password = "password";
 static const char *sftppath = "/tmp/TEST";
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+static int gettimeofday(struct timeval *tp, void *tzp)
+{
+    (void)tzp;
+    if(tp) {
+/* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
+#define WIN32_FT_OFFSET 116444736000000000
+        union {
+            libssh2_uint64_t ns100; /* time since 1 Jan 1601 in 100ns units */
+            FILETIME ft;
+        } now;
+        GetSystemTimeAsFileTime(&now.ft);
+        tp->tv_usec = (long)((now.ns100 / 10) % 1000000);
+        tp->tv_sec = (long)((now.ns100 - WIN32_FT_OFFSET) / 10000000);
+    }
+    return 0;
+}
+#endif
+
 /* diff in ms */
 static long tvdiff(struct timeval newer, struct timeval older)
 {
     return (newer.tv_sec - older.tv_sec) * 1000 +
         (newer.tv_usec - older.tv_usec) / 1000;
 }
-#endif
 
 static int waitsocket(libssh2_socket_t socket_fd, LIBSSH2_SESSION *session)
 {
@@ -102,11 +119,9 @@ int main(int argc, char *argv[])
     LIBSSH2_SESSION *session = NULL;
     LIBSSH2_SFTP *sftp_session;
     LIBSSH2_SFTP_HANDLE *sftp_handle;
-#ifndef _MSC_VER
     struct timeval start;
     struct timeval end;
     long time_ms;
-#endif
     libssh2_struct_stat_size total = 0;
     int spin = 0;
 
@@ -165,9 +180,7 @@ int main(int argc, char *argv[])
     /* Since we have set non-blocking, tell libssh2 we are non-blocking */
     libssh2_session_set_blocking(session, 0);
 
-#ifndef _MSC_VER
     gettimeofday(&start, NULL);
-#endif
 
     /* ... start it up. This trades welcome banners, exchange keys,
      * and setup crypto, compression, and MAC layers
@@ -277,15 +290,11 @@ int main(int argc, char *argv[])
             break;
     } while(1);
 
-#ifndef _MSC_VER
     gettimeofday(&end, NULL);
     time_ms = tvdiff(end, start);
     fprintf(stderr, "Got %ld bytes in %ld ms = %.1f bytes/sec spin: %d\n",
             (long)total, time_ms,
             (double)total / ((double)time_ms / 1000.0), spin);
-#else
-    fprintf(stderr, "Got %ld bytes spin: %d\n", (long)total, spin);
-#endif
 
     libssh2_sftp_close(sftp_handle);
     libssh2_sftp_shutdown(sftp_session);


### PR DESCRIPTION
Replace `HAVE_GETTIMEOFDAY` with `_MSC_VER`. Assuming it everywhere
except on MSVC. On MSVC, fill in the missing function with a local
implementation copied from `src/misc.c`.

To improve building standalone by reducing the reliance on autotools,
cmake configure. Also to bring MSVC builds to the same functionality as 
other platforms.

Cherry-picked from #2485

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
