### PR TITLE
example: assume `unistd.h` header on non-Windows

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -14,12 +14,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/scp.c
+++ b/example/scp.c
@@ -14,8 +14,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -19,12 +19,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -10,8 +10,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -10,12 +10,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -21,8 +21,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -20,12 +20,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -16,8 +16,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -16,8 +16,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -16,8 +16,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -20,12 +20,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -16,8 +16,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -16,12 +16,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -16,12 +16,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -20,8 +20,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -16,8 +16,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -24,8 +24,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -14,8 +14,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -18,12 +18,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -19,12 +19,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -15,12 +15,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -8,8 +8,6 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
-#endif
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -14,12 +14,10 @@
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/example/x11.c
+++ b/example/x11.c
@@ -24,12 +24,10 @@
 #endif
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>


### PR DESCRIPTION
To avoid relying on the `HAVE_UNITSTD_H` macro set by autotools/cmake.
Also to sync with curl examples.
