### PR TITLE
misc: drop `ssh2_gettimeofday()`, no longer used

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -761,48 +761,6 @@ ssh2_time_t ssh2_now(void) /* us */
 #endif /* _WIN32 */
 }
 
-#ifndef HAVE_GETTIMEOFDAY
-/*
- * Implementation according to:
- * The Open Group Base Specifications Issue 6
- * IEEE Std 1003.1, 2004 Edition
- *
- * THIS SOFTWARE IS NOT COPYRIGHTED
- *
- * This source code is offered for use in the public domain. You may
- * use, modify or distribute it freely.
- *
- * This code is distributed in the hope that it is useful but
- * WITHOUT ANY WARRANTY. ALL WARRANTIES, EXPRESS OR IMPLIED ARE HEREBY
- * DISCLAIMED. This includes but is not limited to warranties of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- */
-int ssh2_gettimeofday(struct timeval *tp, void *tzp)
-{
-    (void)tzp;
-    if(tp) {
-#ifdef _WIN32
-/* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
-#define SSH2_WIN32_FT_OFFSET 116444736000000000
-        union {
-            libssh2_uint64_t ns100; /* time since 1 Jan 1601 in 100ns units */
-            FILETIME ft;
-        } now;
-        GetSystemTimeAsFileTime(&now.ft);
-        tp->tv_usec = (long)((now.ns100 / 10) % 1000000);
-        tp->tv_sec = (long)((now.ns100 - SSH2_WIN32_FT_OFFSET) / 10000000);
-#else
-        /* Platforms without a native implementation or local replacement */
-        tp->tv_usec = 0;
-        tp->tv_sec = 0;
-#endif
-    }
-    /* Always return 0 as per Open Group Base Specifications Issue 6.
-       Do not set errno on error.  */
-    return 0;
-}
-#endif /* !HAVE_GETTIMEOFDAY */
-
 void *ssh2_calloc(LIBSSH2_SESSION *session, size_t size)
 {
     void *p = SSH2_ALLOC(session, size);

--- a/src/misc.h
+++ b/src/misc.h
@@ -93,12 +93,6 @@ void ssh2_explicit_zero(void *buf, size_t size);
 #include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif
 
-#ifdef HAVE_GETTIMEOFDAY
-#define ssh2_gettimeofday gettimeofday
-#else
-int ssh2_gettimeofday(struct timeval *tp, void *tzp);
-#endif
-
 struct list_head {
     struct list_node *last;
     struct list_node *first;


### PR DESCRIPTION
Follow-up to a43dc6d50414d66bb3956f745f2a7bfc2ceab6fe #2490
Cherry-picked from #2485

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
