### PR TITLE
misc: fall back to POSIX `gettimeofday()` unconditionally on non-Windows

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -749,6 +749,11 @@ ssh2_time_t ssh2_now(void) /* us */
     if(!clock_gettime(CLOCK_MONOTONIC, &ts))
         return (ssh2_time_t)ts.tv_sec * 1000000 +
             (ssh2_time_t)ts.tv_nsec / 1000;
+#elif defined(CLOCK_REALTIME) /* POSIX fallback */
+    struct timespec ts;
+    if(!clock_gettime(CLOCK_REALTIME, &ts))
+        return (ssh2_time_t)ts.tv_sec * 1000000 +
+            (ssh2_time_t)ts.tv_nsec / 1000;
 #else
     struct timeval tv;
     if(!gettimeofday(&tv, NULL))

--- a/src/misc.c
+++ b/src/misc.c
@@ -749,7 +749,7 @@ ssh2_time_t ssh2_now(void) /* us */
     if(!clock_gettime(CLOCK_MONOTONIC, &ts))
         return (ssh2_time_t)ts.tv_sec * 1000000 +
             (ssh2_time_t)ts.tv_nsec / 1000;
-#elif defined(HAVE_GETTIMEOFDAY)
+#else
     struct timeval tv;
     if(!gettimeofday(&tv, NULL))
         return (ssh2_time_t)tv.tv_sec * 1000000 + (ssh2_time_t)tv.tv_usec;

--- a/src/misc.c
+++ b/src/misc.c
@@ -749,11 +749,6 @@ ssh2_time_t ssh2_now(void) /* us */
     if(!clock_gettime(CLOCK_MONOTONIC, &ts))
         return (ssh2_time_t)ts.tv_sec * 1000000 +
             (ssh2_time_t)ts.tv_nsec / 1000;
-#elif defined(CLOCK_REALTIME) /* POSIX fallback */
-    struct timespec ts;
-    if(!clock_gettime(CLOCK_REALTIME, &ts))
-        return (ssh2_time_t)ts.tv_sec * 1000000 +
-            (ssh2_time_t)ts.tv_nsec / 1000;
 #else
     struct timeval tv;
     if(!gettimeofday(&tv, NULL))


### PR DESCRIPTION
Assume it present on platform not offering a more modern alternative.

To avoid needing a configure-time detection.

This has a slight risk, and not done like this in curl. Let us know if 
it causes an issue.

Cherry-picked from #2485

---

Perhaps falling back to `clock_gettime(CLOCK_REALTIME)` first may
be useful?

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
