### PR TITLE
transport: avoid `CRYPT_FLAG_*()` doing symbol concatenation

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -1076,16 +1076,6 @@ struct crypt_method {
 /* Crypto method must encrypt and decrypt entire messages */
 #define SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET      4
 
-/* Convenience macros for accessing crypt flags */
-/* Local crypto flags */
-#define CRYPT_FLAG_L(session, flag)                            \
-    ((session)->local.crypt &&                                 \
-     ((session)->local.crypt->flags & SSH2_CRYPT_FLAG_##flag))
-/* Remote crypto flags */
-#define CRYPT_FLAG_R(session, flag)                             \
-    ((session)->remote.crypt &&                                 \
-     ((session)->remote.crypt->flags & SSH2_CRYPT_FLAG_##flag))
-
 /* Values for firstlast */
 #define FIRST_BLOCK  1
 #define MIDDLE_BLOCK 0

--- a/src/transport.c
+++ b/src/transport.c
@@ -121,13 +121,11 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
 
 /* Convenience macros for accessing crypt flags */
 /* Local crypto flags */
-#define CRYPT_FLAG_L(session, flag)                            \
-    ((session)->local.crypt &&                                 \
-     ((session)->local.crypt->flags & SSH2_CRYPT_FLAG_##flag))
+#define CRYPT_FLAG_L(session, flag) \
+    ((session)->local.crypt && ((session)->local.crypt->flags & (flag)))
 /* Remote crypto flags */
-#define CRYPT_FLAG_R(session, flag)                             \
-    ((session)->remote.crypt &&                                 \
-     ((session)->remote.crypt->flags & SSH2_CRYPT_FLAG_##flag))
+#define CRYPT_FLAG_R(session, flag) \
+    ((session)->remote.crypt && ((session)->remote.crypt->flags & (flag)))
 
 /* transport_decrypt() decrypts 'len' bytes from 'source' to 'dest' in units of
  * blocksize.
@@ -143,7 +141,7 @@ static int transport_decrypt(LIBSSH2_SESSION *session, unsigned char *source,
     /* if we get called with a len that is not an even number of blocksizes
        we risk losing those extra bytes. AAD is an exception, since those first
        few bytes are not encrypted so it throws off the rest of the count. */
-    if(!CRYPT_FLAG_R(session, PKTLEN_AAD))
+    if(!CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_PKTLEN_AAD))
         assert((len % blocksize) == 0);
 
     while(len > 0) {
@@ -158,7 +156,8 @@ static int transport_decrypt(LIBSSH2_SESSION *session, unsigned char *source,
         /* If the last block would be less than a whole blocksize, combine it
            with the previous block to make it larger. This ensures that the
            whole MAC is included in a single decrypt call. */
-        if(CRYPT_FLAG_R(session, PKTLEN_AAD) && IS_LAST(firstlast) &&
+        if(CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_PKTLEN_AAD) &&
+           IS_LAST(firstlast) &&
            len < blocksize * 2) {
             decryptlen = len;
             lowerfirstlast = LAST_BLOCK;
@@ -199,8 +198,9 @@ static int transport_fullpacket(LIBSSH2_SESSION *session,
 
     memset(macbuf, '\0', sizeof(macbuf));
 
-    if(!encrypted || (!CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET) &&
-                      !CRYPT_FLAG_R(session, INTEGRATED_MAC)))
+    if(!encrypted ||
+       (!CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET) &&
+        !CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_INTEGRATED_MAC)))
         remote_mac = session->remote.mac;
 
     if(session->fullpacket_state == ssh2_NB_state_idle) {
@@ -298,7 +298,8 @@ static int transport_fullpacket(LIBSSH2_SESSION *session,
                 p->payload = decrypt_buffer;
             }
         }
-        else if(encrypted && CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET))
+        else if(encrypted &&
+                CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET))
             /* etm trim off padding byte from payload */
             memmove(p->payload, &p->payload[1], p->packet_length - 1);
 
@@ -462,7 +463,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
         }
 
         if(encrypted) {
-            if(CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET))
+            if(CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET))
                 auth_len = session->remote.crypt->auth_len;
             else
                 remote_mac = session->remote.mac;
@@ -484,7 +485,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
         assert(remainbuf >= 0);
 
         if(remainbuf < blocksize ||
-           (CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET) &&
+           (CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET) &&
             (ssize_t)p->total_num > remainbuf)) {
             /* If we have less than a blocksize left, it is too
                little data to deal with, read more */
@@ -612,7 +613,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                 p->packet_length = ssh2_ntohu32(block);
             }
 
-            if(!encrypted || !CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
+            if(!encrypted ||
+               !CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET)) {
                 if(p->packet_length < 1)
                     return LIBSSH2_ERROR_DECRYPT;
                 else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD)
@@ -691,7 +693,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
             /* init write pointer to start of payload buffer */
             p->wptr = p->payload;
 
-            if(!encrypted || !CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
+            if(!encrypted ||
+               !CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET)) {
                 if(!etm && blocksize > 5) {
                     /* copy the data from index 5 to the end of
                        the blocksize from the temporary buffer to
@@ -734,7 +737,8 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                particular packet, we limit this round to this packet only */
             numbytes = remainpack;
 
-        if(encrypted && CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
+        if(encrypted &&
+           CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET)) {
             if(numbytes < remainpack) {
                 /* need a full packet before checking MAC */
                 session->socket_block_directions |=
@@ -755,7 +759,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                since it is used for the hash later on. */
             int skip = (remote_mac ? remote_mac->mac_len : 0) + auth_len;
 
-            if(CRYPT_FLAG_R(session, INTEGRATED_MAC))
+            if(CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_INTEGRATED_MAC))
                 /* This crypto method DOES need the MAC to go through
                    decryption so it can be authenticated. */
                 skip = 0;
@@ -781,7 +785,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
                        after it */
                     numbytes = 0;
                 }
-                if(CRYPT_FLAG_R(session, INTEGRATED_MAC)) {
+                if(CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_INTEGRATED_MAC)) {
                     /* Make sure that we save enough bytes to make the last
                        block large enough to hold the entire integrated MAC */
                     numdecrypt = SSH2_MIN(numdecrypt,
@@ -799,7 +803,7 @@ int ssh2_transport_read(LIBSSH2_SESSION *session)
         /* if there are bytes to decrypt, do that */
         if(numdecrypt > 0) {
             /* now decrypt the lot */
-            if(CRYPT_FLAG_R(session, REQUIRES_FULL_PACKET)) {
+            if(CRYPT_FLAG_R(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET)) {
                 if(session->remote.crypt->crypt(session,
                                                session->remote.seqno,
                                                &p->buf[p->readidx],
@@ -1059,7 +1063,7 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
     encrypted = (session->state & SSH2_STATE_NEWKEYS) ? 1 : 0;
 
     if(encrypted && session->local.crypt &&
-       CRYPT_FLAG_L(session, REQUIRES_FULL_PACKET))
+       CRYPT_FLAG_L(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET))
         auth_len = session->local.crypt->auth_len;
     else
         local_mac = session->local.mac;
@@ -1129,7 +1133,8 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
     /* subtract 4 bytes of the packet_length field when padding AES-GCM
        or with ETM */
     crypt_offset = (etm || auth_len ||
-                    (encrypted && CRYPT_FLAG_L(session, PKTLEN_AAD)))
+                    (encrypted &&
+                     CRYPT_FLAG_L(session, SSH2_CRYPT_FLAG_PKTLEN_AAD)))
                    ? 4 : 0;
     etm_crypt_offset = etm ? 4 : 0;
 
@@ -1183,7 +1188,8 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
            fields except the MAC field itself. This is skipped in the
            INTEGRATED_MAC case, where the crypto algorithm also does its
            own hash. */
-        if(!etm && local_mac && !CRYPT_FLAG_L(session, INTEGRATED_MAC)) {
+        if(!etm && local_mac &&
+           !CRYPT_FLAG_L(session, SSH2_CRYPT_FLAG_INTEGRATED_MAC)) {
             if(local_mac->hash(session, p->outbuf + packet_length,
                                session->local.seqno, p->outbuf,
                                packet_length, NULL, 0,
@@ -1192,7 +1198,7 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
                                 "Failed to calculate MAC");
         }
 
-        if(CRYPT_FLAG_L(session, REQUIRES_FULL_PACKET)) {
+        if(CRYPT_FLAG_L(session, SSH2_CRYPT_FLAG_REQUIRES_FULL_PACKET)) {
             if(session->local.crypt->crypt(session,
                                            session->local.seqno,
                                            p->outbuf,
@@ -1215,7 +1221,7 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
                 /* The INTEGRATED_MAC case always has an extra call below, so
                    it never is LAST_BLOCK up here. */
                 int firstlast = i == 0 ? FIRST_BLOCK :
-                    (!CRYPT_FLAG_L(session, INTEGRATED_MAC) &&
+                    (!CRYPT_FLAG_L(session, SSH2_CRYPT_FLAG_INTEGRATED_MAC) &&
                      (i == packet_length - session->local.crypt->blocksize)
                      ? LAST_BLOCK : MIDDLE_BLOCK);
                 /* In the AAD case, the last block would be only 4 bytes
@@ -1224,7 +1230,7 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
                    last short packet with the previous one since AES-GCM
                    crypt() assumes that the entire MAC is available in that
                    packet so it can set that to the authentication tag. */
-                if(!CRYPT_FLAG_L(session, INTEGRATED_MAC) &&
+                if(!CRYPT_FLAG_L(session, SSH2_CRYPT_FLAG_INTEGRATED_MAC) &&
                    i > packet_length - 2 * bsize) {
                     /* increase the final block size */
                     bsize = packet_length - i;
@@ -1242,7 +1248,7 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
 
             /* Call crypt() one last time so it can be filled in with the
                MAC */
-            if(CRYPT_FLAG_L(session, INTEGRATED_MAC)) {
+            if(CRYPT_FLAG_L(session, SSH2_CRYPT_FLAG_INTEGRATED_MAC)) {
                 int authlen = local_mac ? local_mac->mac_len : 0;
                 assert((size_t)total_length <=
                        packet_length + session->local.crypt->blocksize);

--- a/src/transport.c
+++ b/src/transport.c
@@ -119,6 +119,16 @@ static void transport_debugdump(LIBSSH2_SESSION *session, const char *desc,
 #define transport_debugdump(a, x, y, z) do {} while(0)
 #endif
 
+/* Convenience macros for accessing crypt flags */
+/* Local crypto flags */
+#define CRYPT_FLAG_L(session, flag)                            \
+    ((session)->local.crypt &&                                 \
+     ((session)->local.crypt->flags & SSH2_CRYPT_FLAG_##flag))
+/* Remote crypto flags */
+#define CRYPT_FLAG_R(session, flag)                             \
+    ((session)->remote.crypt &&                                 \
+     ((session)->remote.crypt->flags & SSH2_CRYPT_FLAG_##flag))
+
 /* transport_decrypt() decrypts 'len' bytes from 'source' to 'dest' in units of
  * blocksize.
  *


### PR DESCRIPTION
To make the `SSH2_CRYPT_FLAG_*` macros greppable and easier to
recognize.

Slight downside that it makes these macros longer to type. If it becomes
an issue, the flag symbols could be shortened.

Also: move these macro from global internal header to the only source
where they are used, `transport.c`.

Follow-up to 3c953c05d67eb1ebcfd3316f279f12c4b1d600b4 #797
