### PR TITLE
example: drop two local macros, merge/simplify header guards

### DIFF
--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -6,6 +6,10 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #ifdef _WIN32
 #include <ws2tcpip.h>  /* for socklen_t */
 #define recv(s, b, l, f)  recv(s, b, (int)(l), f)
@@ -26,10 +30,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifndef INADDR_NONE
 #define INADDR_NONE ((in_addr_t)~0)

--- a/example/direct_tcpip.c
+++ b/example/direct_tcpip.c
@@ -10,9 +10,7 @@
 #include <ws2tcpip.h>  /* for socklen_t */
 #define recv(s, b, l, f)  recv(s, b, (int)(l), f)
 #define send(s, b, l, f)  send(s, b, (int)(l), f)
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/scp.c
+++ b/example/scp.c
@@ -10,9 +10,7 @@
 
 #ifdef _WIN32
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/scp.c
+++ b/example/scp.c
@@ -8,6 +8,8 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+
 #ifdef _WIN32
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #else
@@ -20,8 +22,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -47,15 +47,13 @@ static int gettimeofday(struct timeval *tp, void *tzp)
 {
     (void)tzp;
     if(tp) {
-/* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
-#define WIN32_FT_OFFSET 116444736000000000
         union {
             libssh2_uint64_t ns100; /* time since 1 Jan 1601 in 100ns units */
             FILETIME ft;
         } now;
         GetSystemTimeAsFileTime(&now.ft);
         tp->tv_usec = (long)((now.ns100 / 10) % 1000000);
-        tp->tv_sec = (long)((now.ns100 - WIN32_FT_OFFSET) / 10000000);
+        tp->tv_sec = (long)((now.ns100 - 116444736000000000) / 10000000);
     }
     return 0;
 }

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -13,6 +13,8 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+
 #ifdef _WIN32
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #else
@@ -31,8 +33,6 @@
 #ifndef _MSC_VER
 #include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp_nonblock.c
+++ b/example/scp_nonblock.c
@@ -15,9 +15,7 @@
 
 #ifdef _WIN32
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -8,7 +8,13 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#undef stat
+#define stat _stat
+#undef fstat
+#define fstat _fstat
+#define fileno _fileno
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
@@ -20,14 +26,6 @@
 #endif
 
 #include <stdio.h>
-
-#ifdef _WIN32
-#undef stat
-#define stat _stat
-#undef fstat
-#define fstat _fstat
-#define fileno _fileno
-#endif
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp_write.c
+++ b/example/scp_write.c
@@ -8,6 +8,8 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+
 #ifdef _WIN32
 #undef stat
 #define stat _stat
@@ -24,8 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -8,6 +8,9 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+#include <time.h>  /* for time() */
+
 #ifdef _WIN32
 #undef stat
 #define stat _stat
@@ -30,9 +33,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdio.h>
-#include <time.h>  /* for time() */
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/scp_write_nonblock.c
+++ b/example/scp_write_nonblock.c
@@ -8,7 +8,13 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#undef stat
+#define stat _stat
+#undef fstat
+#define fstat _fstat
+#define fileno _fileno
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
@@ -27,14 +33,6 @@
 
 #include <stdio.h>
 #include <time.h>  /* for time() */
-
-#ifdef _WIN32
-#undef stat
-#define stat _stat
-#undef fstat
-#define fstat _fstat
-#define fileno _fileno
-#endif
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -14,6 +14,9 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+#include <string.h>
+
 #ifdef _WIN32
 #define strdup          _strdup
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
@@ -27,9 +30,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
-#include <string.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp.c
+++ b/example/sftp.c
@@ -17,9 +17,7 @@
 #ifdef _WIN32
 #define strdup          _strdup
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -14,6 +14,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+
 #ifdef _WIN32
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #else
@@ -29,8 +31,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_RW_nonblock.c
+++ b/example/sftp_RW_nonblock.c
@@ -16,9 +16,7 @@
 
 #ifdef _WIN32
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/sftp_append.c
+++ b/example/sftp_append.c
@@ -14,6 +14,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -24,8 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_mkdir.c
+++ b/example/sftp_mkdir.c
@@ -14,6 +14,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -24,8 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_mkdir_nonblock.c
+++ b/example/sftp_mkdir_nonblock.c
@@ -14,6 +14,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -24,8 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -14,6 +14,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+
 #ifdef _WIN32
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
 #else
@@ -32,8 +34,6 @@
 #ifndef _MSC_VER
 #include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -48,15 +48,13 @@ static int gettimeofday(struct timeval *tp, void *tzp)
 {
     (void)tzp;
     if(tp) {
-/* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
-#define WIN32_FT_OFFSET 116444736000000000
         union {
             libssh2_uint64_t ns100; /* time since 1 Jan 1601 in 100ns units */
             FILETIME ft;
         } now;
         GetSystemTimeAsFileTime(&now.ft);
         tp->tv_usec = (long)((now.ns100 / 10) % 1000000);
-        tp->tv_sec = (long)((now.ns100 - WIN32_FT_OFFSET) / 10000000);
+        tp->tv_sec = (long)((now.ns100 - 116444736000000000) / 10000000);
     }
     return 0;
 }

--- a/example/sftp_nonblock.c
+++ b/example/sftp_nonblock.c
@@ -16,9 +16,7 @@
 
 #ifdef _WIN32
 #define write(f, b, c)  _write(f, b, (unsigned int)(c))
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/sftp_write.c
+++ b/example/sftp_write.c
@@ -14,6 +14,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -24,8 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_write_nonblock.c
+++ b/example/sftp_write_nonblock.c
@@ -14,6 +14,9 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+#include <time.h>  /* for time() */
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -30,9 +33,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdio.h>
-#include <time.h>  /* for time() */
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftp_write_sliding.c
+++ b/example/sftp_write_sliding.c
@@ -14,6 +14,10 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+#include <time.h>  /* for time() */
+#include <string.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -30,10 +34,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdio.h>
-#include <time.h>  /* for time() */
-#include <string.h>
 
 static const char *pubkey = "/home/username/.ssh/id_rsa.pub";
 static const char *privkey = "/home/username/.ssh/id_rsa";

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -16,9 +16,7 @@
 
 #ifdef _WIN32
 #define strdup _strdup
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/sftpdir.c
+++ b/example/sftpdir.c
@@ -14,6 +14,9 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+#include <string.h>
+
 #ifdef _WIN32
 #define strdup _strdup
 #else
@@ -26,9 +29,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
-#include <string.h>
 
 #ifdef _MSC_VER
 #define LIBSSH2_FILESIZE_MASK "I64u"

--- a/example/sftpdir_nonblock.c
+++ b/example/sftpdir_nonblock.c
@@ -14,6 +14,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 
+#include <stdio.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -24,8 +26,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
 
 #ifdef _MSC_VER
 #define LIBSSH2_FILESIZE_MASK "I64u"

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -20,9 +20,7 @@
 
 #ifdef _WIN32
 #define strdup _strdup
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/ssh2.c
+++ b/example/ssh2.c
@@ -18,6 +18,10 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #ifdef _WIN32
 #define strdup _strdup
 #else
@@ -30,10 +34,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 static const char *pubkey = ".ssh/id_rsa.pub";
 static const char *privkey = ".ssh/id_rsa";

--- a/example/ssh2_agent.c
+++ b/example/ssh2_agent.c
@@ -12,6 +12,9 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+#include <string.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -22,9 +25,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
-#include <string.h>
 
 static const char *username = "username";
 

--- a/example/ssh2_agent_forwarding.c
+++ b/example/ssh2_agent_forwarding.c
@@ -16,6 +16,9 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -32,9 +35,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdio.h>
-#include <stdlib.h>
 
 static const char *hostname = "127.0.0.1";
 static const char *commandline = "uptime";

--- a/example/ssh2_echo.c
+++ b/example/ssh2_echo.c
@@ -17,6 +17,9 @@
 
 #ifndef LIBSSH2_NO_DEPRECATED
 
+#include <stdlib.h>
+#include <string.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -33,9 +36,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdlib.h>
-#include <string.h>
 
 static const char *hostname = "127.0.0.1";
 static const char *commandline = "cat";

--- a/example/ssh2_exec.c
+++ b/example/ssh2_exec.c
@@ -13,6 +13,10 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -29,10 +33,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 static const char *hostname = "127.0.0.1";
 static const char *commandline = "uptime";

--- a/example/subsystem_netconf.c
+++ b/example/subsystem_netconf.c
@@ -6,6 +6,9 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+#include <string.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -16,9 +19,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-
-#include <stdio.h>
-#include <string.h>
 
 #ifndef INADDR_NONE
 #define INADDR_NONE ((in_addr_t)~0)

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -6,6 +6,10 @@
 #include "libssh2_setup.h"
 #include <libssh2.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #ifdef _WIN32
 #include <ws2tcpip.h>  /* for socklen_t */
 #define recv(s, b, l, f)  recv(s, b, (int)(l), f)
@@ -26,10 +30,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval */
 #endif
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifndef INADDR_NONE
 #define INADDR_NONE ((in_addr_t)~0)

--- a/example/tcpip-forward.c
+++ b/example/tcpip-forward.c
@@ -10,9 +10,7 @@
 #include <ws2tcpip.h>  /* for socklen_t */
 #define recv(s, b, l, f)  recv(s, b, (int)(l), f)
 #define send(s, b, l, f)  send(s, b, (int)(l), f)
-#endif
-
-#ifndef _WIN32
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 #endif

--- a/example/x11.c
+++ b/example/x11.c
@@ -16,6 +16,9 @@
 
 #if defined(HAVE_SYS_UN_H) && !defined(LIBSSH2_NO_DEPRECATED)
 
+#include <stdlib.h>
+#include <string.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
@@ -38,9 +41,6 @@
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif
-
-#include <stdlib.h>
-#include <string.h>
 
 #include <termios.h>
 

--- a/example/x11.c
+++ b/example/x11.c
@@ -16,15 +16,15 @@
 
 #if defined(HAVE_SYS_UN_H) && !defined(LIBSSH2_NO_DEPRECATED)
 
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
-#endif
-#ifndef _WIN32
-#include <sys/socket.h>
-#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>


### PR DESCRIPTION
Also: include standard headers first to not interfere with Windows
redefinitions.
