### PR TITLE
mbedtls: fix double-free in `mbed_pub_priv_key()` error path

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -583,10 +583,8 @@ static int mbed_pub_priv_key(LIBSSH2_SESSION *session, char **method,
     int ret;
     mbedtls_rsa_context *rsa;
 
-    if(mbedtls_pk_get_type(pkey) != MBEDTLS_PK_RSA) {
-        mbedtls_pk_free(pkey);
+    if(mbedtls_pk_get_type(pkey) != MBEDTLS_PK_RSA)
         return ssh2_err(session, LIBSSH2_ERROR_FILE, "Key type not supported");
-    }
 
     ret = 0;
 


### PR DESCRIPTION
"`mbed_pub_priv_key()` frees `pkey` on the unsupported-key path, but the
caller (`ssh2_pub_privkey()`) unconditionally calls
`mbedtls_pk_free(&pkey)` after this helper returns. That makes this a
double-free on the error path (memory corruption). The helper should not
free `pkey`; leave ownership/cleanup to the caller."

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2501#discussion_r3704437259
Bug: https://github.com/libssh2/libssh2/pull/2501#discussion_r3704591298
Follow-up to 186f1a2d75560d960bc9ec0e727c14328f51ca4a #132

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
