### PR TITLE
packet: fix memleak on receiving multiple `exit-signal` packets

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -1136,9 +1136,10 @@ ssh2_packet_add_jump_point1:
                             rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                           "signal name out of bounds");
                         else if(sig_len > 0) {
+                            if(channelp->exit_signal)
+                                SSH2_FREE(session, channelp->exit_signal);
                             channelp->exit_signal =
                                 SSH2_ALLOC(session, sig_len + 1);
-
                             if(channelp->exit_signal) {
                                 memcpy(channelp->exit_signal,
                                        sig_name, sig_len);
@@ -1155,8 +1156,8 @@ ssh2_packet_add_jump_point1:
                                 rc = ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                                               "exit signal alloc error");
                         }
-                        else
-                            channelp->exit_signal = NULL;
+                        else if(channelp->exit_signal)
+                            SSH2_SAFEFREE(session, channelp->exit_signal);
                     }
                 }
 


### PR DESCRIPTION
Reported-by: afldl on github
Fixes GHSA-53q9-wmqr-fh7c
Follow-up to 6140ec2de332ebdb618bdccf8c3c28b97eb6bde1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
