### PR TITLE
mbedtls: add support for AES-GCM ciphers

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -203,16 +203,14 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     unsigned char *output;
     size_t osize, olen, finish_olen;
 
-    (void)algo;
-
     cctx = *ctx;
     if(!cctx)
         return -1;
 
 #if LIBSSH2_AES_GCM
     /* Check if this is a GCM algorithm based on stored algo type */
-    if(cctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
-       cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
+    if(algo == MBEDTLS_CIPHER_AES_128_GCM ||
+       algo == MBEDTLS_CIPHER_AES_256_GCM) {
         const int authlen = 16;  /* GCM authentication tag length */
         const int aadlen = IS_FIRST(firstlast) ? 4 : 0;
         const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -238,8 +238,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         /* First block: start GCM operation */
         if(IS_FIRST(firstlast)) {
             ret = mbedtls_gcm_starts(&cctx->ctx.gcm.gcm_ctx,
-                                     cctx->encrypt ? MBEDTLS_GCM_ENCRYPT :
-                                                     MBEDTLS_GCM_DECRYPT,
+                                     cctx->encrypt ? MBEDTLS_GCM_ENCRYPT
+                                                   : MBEDTLS_GCM_DECRYPT,
                                      cctx->ctx.gcm.iv, 12);
             if(ret) {
                 mbed_zero_free(buf, cryptlen);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -95,7 +95,6 @@ static void mbed_zero_free(void *buf, size_t len)
 int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
-    struct ssh2_mbedtls_cipher_ctx *cctx;
     const mbedtls_cipher_info_t *cipher_info;
     mbedtls_operation_t op;
     int ret;
@@ -195,7 +194,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)
 {
-    struct ssh2_mbedtls_cipher_ctx *cctx;
+    struct ssh2_mbed_cipher_ctx *cctx;
     int ret;
     unsigned char *output;
     size_t osize, olen, finish_olen;
@@ -290,6 +289,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         return 0;
     }
 #else
+    (void)encrypt;
     (void)firstlast;
 #endif
 
@@ -326,7 +326,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
 void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
 {
-    struct ssh2_mbedtls_cipher_ctx *cctx = *ctx;
+    struct ssh2_mbed_cipher_ctx *cctx = *ctx;
 
     if(!cctx)
         return;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -118,10 +118,10 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         unsigned int keybits;
 
         /* Store the initial IV (will be incremented per packet) */
-        memcpy(cctx->ctx.gcm.iv, iv, 12);
+        memcpy(cctx->u.gcm.iv, iv, 12);
 
         /* Initialize GCM context */
-        mbedtls_gcm_init(&cctx->ctx.gcm.gcm_ctx);
+        mbedtls_gcm_init(&cctx->u.gcm.ctx);
 
         /* Set key length based on algorithm */
         if(algo == MBEDTLS_CIPHER_AES_128_GCM)
@@ -130,12 +130,12 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             keybits = 256;
 
         /* Setup GCM with AES cipher and key */
-        ret = mbedtls_gcm_setkey(&cctx->ctx.gcm.gcm_ctx,
+        ret = mbedtls_gcm_setkey(&cctx->u.gcm.ctx,
                                  MBEDTLS_CIPHER_ID_AES,
                                  secret,
                                  keybits);
         if(ret) {
-            mbedtls_gcm_free(&cctx->ctx.gcm.gcm_ctx);
+            mbedtls_gcm_free(&cctx->u.gcm.ctx);
             mbedtls_free(cctx);
             return -1;
         }
@@ -155,8 +155,8 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         return -1;
     }
 
-    mbedtls_cipher_init(&cctx->ctx.cipher_ctx);
-    ret = mbedtls_cipher_setup(&cctx->ctx.cipher_ctx, cipher_info);
+    mbedtls_cipher_init(&cctx->u.cipher);
+    ret = mbedtls_cipher_setup(&cctx->u.cipher, cipher_info);
 
     /* libssh2 computes and adds SSH packet padding itself, so for CBC
        tell mbedTLS to expect no padding on the cipher layer. Only call
@@ -171,21 +171,21 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 #endif
        )
       ) {
-        ret = mbedtls_cipher_set_padding_mode(&cctx->ctx.cipher_ctx,
+        ret = mbedtls_cipher_set_padding_mode(&cctx->u.cipher,
                                               MBEDTLS_PADDING_NONE);
     }
 
     if(!ret)
-        ret = mbedtls_cipher_setkey(&cctx->ctx.cipher_ctx,
+        ret = mbedtls_cipher_setkey(&cctx->u.cipher,
                   secret,
                   (int)mbedtls_cipher_info_get_key_bitlen(cipher_info), op);
 
     if(!ret)
-        ret = mbedtls_cipher_set_iv(&cctx->ctx.cipher_ctx, iv,
+        ret = mbedtls_cipher_set_iv(&cctx->u.cipher, iv,
                   mbedtls_cipher_info_get_iv_size(cipher_info));
 
     if(ret) {
-        mbedtls_cipher_free(&cctx->ctx.cipher_ctx);
+        mbedtls_cipher_free(&cctx->u.cipher);
         mbedtls_free(cctx);
     }
     else
@@ -232,10 +232,10 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
         /* First block: start GCM operation */
         if(IS_FIRST(firstlast)) {
-            ret = mbedtls_gcm_starts(&cctx->ctx.gcm.gcm_ctx,
+            ret = mbedtls_gcm_starts(&cctx->u.gcm.ctx,
                                      encrypt ? MBEDTLS_GCM_ENCRYPT
                                              : MBEDTLS_GCM_DECRYPT,
-                                     cctx->ctx.gcm.iv, 12);
+                                     cctx->u.gcm.iv, 12);
             if(ret) {
                 mbed_zero_free(buf, cryptlen);
                 return -1;
@@ -243,7 +243,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
             /* Process AAD (Additional Authenticated Data) */
             if(aadlen) {
-                ret = mbedtls_gcm_update_ad(&cctx->ctx.gcm.gcm_ctx,
+                ret = mbedtls_gcm_update_ad(&cctx->u.gcm.ctx,
                                             block, aadlen);
                 if(ret) {
                     mbed_zero_free(buf, cryptlen);
@@ -255,7 +255,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         /* Process payload */
         if(cryptlen > 0) {
             olen = 0;
-            ret = mbedtls_gcm_update(&cctx->ctx.gcm.gcm_ctx,
+            ret = mbedtls_gcm_update(&cctx->u.gcm.ctx,
                                      block + aadlen, cryptlen,
                                      buf, cryptlen, &olen);
             if(ret) {
@@ -273,7 +273,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
             finish_olen = 0;
 
-            ret = mbedtls_gcm_finish(&cctx->ctx.gcm.gcm_ctx,
+            ret = mbedtls_gcm_finish(&cctx->u.gcm.ctx,
                                     finish_buf, sizeof(finish_buf),
                                     &finish_olen, tag, authlen);
             if(ret)
@@ -287,7 +287,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
             /* Increment IV for next packet */
             for(i = 11; i >= 4; i--)
-                if(++cctx->ctx.gcm.iv[i])
+                if(++cctx->u.gcm.iv[i])
                     break;
         }
 
@@ -298,21 +298,21 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 #endif
 
     /* Non-GCM algorithms: use standard cipher API */
-    osize = blocksize + mbedtls_cipher_get_block_size(&cctx->ctx.cipher_ctx);
+    osize = blocksize + mbedtls_cipher_get_block_size(&cctx->u.cipher);
 
     output = mbedtls_calloc(osize, sizeof(char));
     if(output) {
         olen = 0;
         finish_olen = 0;
 
-        ret = mbedtls_cipher_reset(&cctx->ctx.cipher_ctx);
+        ret = mbedtls_cipher_reset(&cctx->u.cipher);
 
         if(!ret)
-            ret = mbedtls_cipher_update(&cctx->ctx.cipher_ctx, block,
+            ret = mbedtls_cipher_update(&cctx->u.cipher, block,
                                         blocksize, output, &olen);
 
         if(!ret)
-            ret = mbedtls_cipher_finish(&cctx->ctx.cipher_ctx,
+            ret = mbedtls_cipher_finish(&cctx->u.cipher,
                                         output + olen, &finish_olen);
 
         if(!ret) {
@@ -338,7 +338,7 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
 #if LIBSSH2_AES_GCM
     if(cctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
        cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
-        mbedtls_gcm_free(&cctx->ctx.gcm.gcm_ctx);
+        mbedtls_gcm_free(&cctx->u.gcm.ctx);
         mbedtls_free(cctx);
         *ctx = NULL;
         return;
@@ -346,7 +346,7 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
 #endif
 
     /* Regular cipher context */
-    mbedtls_cipher_free(&cctx->ctx.cipher_ctx);
+    mbedtls_cipher_free(&cctx->u.cipher);
     mbedtls_free(cctx);
     *ctx = NULL;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -142,7 +142,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         }
 
         /* Store the context pointer */
-        *h = cctx;
+        *ctx = cctx;
         return 0;
     }
 #endif

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -218,9 +218,15 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         const int authlen = 16;  /* GCM authentication tag length */
         const int aadlen = IS_FIRST(firstlast) ? 4 : 0;
         const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
-        const int cryptlen = (int)blocksize - aadlen - authenticationtag;
+        unsigned int cryptlen; /* length of encrypt */
         unsigned char tag[16];
         unsigned char *buf = NULL;
+
+        if(blocksize > sizeof(buf) ||
+           blocksize < (size_t)(aadlen + authenticationtag))
+            return 1;
+
+        cryptlen = (unsigned int)blocksize - aadlen - authenticationtag;
 
         /* Allocate temporary buffer for output */
         if(cryptlen > 0) {

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -263,7 +263,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                 memcpy(block + blocksize - authlen, tag, authlen);
             else if(ssh2_timingsafe_bcmp(tag, block + blocksize - authlen,
                                          authlen))
-                return MBEDTLS_ERR_GCM_AUTH_FAILED;
+                return -1;  /* GCM auth failed */
 
             /* Increment IV for next packet */
             for(i = 11; i >= 4; i--)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -222,8 +222,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         unsigned char tag[16];
         unsigned char *buf = NULL;
 
-        if(blocksize > sizeof(buf) ||
-           blocksize < (size_t)(aadlen + authenticationtag))
+        if(blocksize < (size_t)(aadlen + authenticationtag))
             return 1;
 
         cryptlen = (unsigned int)blocksize - aadlen - authenticationtag;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -125,9 +125,8 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             keybits = 256;
 
         /* Setup GCM with AES cipher and key */
-        ret = mbedtls_gcm_setkey(&ctx->u.gcm.ctx, MBEDTLS_CIPHER_ID_AES,
-                                 secret, keybits);
-        if(ret) {
+        if(mbedtls_gcm_setkey(&ctx->u.gcm.ctx, MBEDTLS_CIPHER_ID_AES,
+                              secret, keybits)) {
             mbedtls_gcm_free(&ctx->u.gcm.ctx);
             return -1;
         }
@@ -211,32 +210,28 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
         /* First block: start GCM operation */
         if(IS_FIRST(firstlast)) {
-            ret = mbedtls_gcm_starts(&ctx->u.gcm.ctx,
-                                     encrypt ? MBEDTLS_GCM_ENCRYPT
-                                             : MBEDTLS_GCM_DECRYPT,
-                                     ctx->u.gcm.iv, 12);
-            if(ret) {
+            if(mbedtls_gcm_starts(&ctx->u.gcm.ctx,
+                                  encrypt ? MBEDTLS_GCM_ENCRYPT
+                                          : MBEDTLS_GCM_DECRYPT,
+                                  ctx->u.gcm.iv, 12)) {
                 mbed_zero_free(buf, cryptlen);
                 return -1;
             }
 
             /* Process AAD (Additional Authenticated Data) */
-            if(aadlen) {
-                ret = mbedtls_gcm_update_ad(&ctx->u.gcm.ctx, block, aadlen);
-                if(ret) {
-                    mbed_zero_free(buf, cryptlen);
-                    return -1;
-                }
+            if(aadlen &&
+               mbedtls_gcm_update_ad(&ctx->u.gcm.ctx, block, aadlen)) {
+                mbed_zero_free(buf, cryptlen);
+                return -1;
             }
         }
 
         /* Process payload */
         if(cryptlen > 0) {
             olen = 0;
-            ret = mbedtls_gcm_update(&ctx->u.gcm.ctx,
-                                     block + aadlen, cryptlen,
-                                     buf, cryptlen, &olen);
-            if(ret) {
+            if(mbedtls_gcm_update(&ctx->u.gcm.ctx,
+                                  block + aadlen, cryptlen,
+                                  buf, cryptlen, &olen)) {
                 mbed_zero_free(buf, cryptlen);
                 return -1;
             }
@@ -251,10 +246,9 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
             finish_olen = 0;
 
-            ret = mbedtls_gcm_finish(&ctx->u.gcm.ctx,
-                                     finish_buf, sizeof(finish_buf),
-                                     &finish_olen, tag, authlen);
-            if(ret)
+            if(mbedtls_gcm_finish(&ctx->u.gcm.ctx,
+                                  finish_buf, sizeof(finish_buf),
+                                  &finish_olen, tag, authlen))
                 return -1;
 
             if(encrypt)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -110,7 +110,6 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
     /* Store algorithm type and encryption flag */
     cctx->algo = algo;
-    cctx->encrypt = encrypt;
 
 #if LIBSSH2_AES_GCM
     /* Check if this is a GCM algorithm */
@@ -204,7 +203,6 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     unsigned char *output;
     size_t osize, olen, finish_olen;
 
-    (void)encrypt;
     (void)algo;
 
     cctx = *ctx;
@@ -237,8 +235,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         /* First block: start GCM operation */
         if(IS_FIRST(firstlast)) {
             ret = mbedtls_gcm_starts(&cctx->ctx.gcm.gcm_ctx,
-                                     cctx->encrypt ? MBEDTLS_GCM_ENCRYPT
-                                                   : MBEDTLS_GCM_DECRYPT,
+                                     encrypt ? MBEDTLS_GCM_ENCRYPT
+                                             : MBEDTLS_GCM_DECRYPT,
                                      cctx->ctx.gcm.iv, 12);
             if(ret) {
                 mbed_zero_free(buf, cryptlen);
@@ -283,7 +281,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             if(ret)
                 return -1;
 
-            if(cctx->encrypt)
+            if(encrypt)
                 memcpy(block + blocksize - authlen, tag, authlen);
             else if(ssh2_timingsafe_bcmp(tag, block + blocksize - authlen,
                                          authlen))

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -227,6 +227,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             memcpy(block + aadlen, buf, olen);
         }
 
+        ret = 0;
+
         /* Last block: finalize and handle authentication tag */
         if(IS_LAST(firstlast)) {
             unsigned char finish_buf[16];
@@ -242,7 +244,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                 memcpy(block + blocksize - authlen, tag, authlen);
             else if(ssh2_timingsafe_bcmp(tag, block + blocksize - authlen,
                                          authlen))
-                return -1;  /* GCM auth failed */
+                ret = -1;  /* GCM auth failed */
 
             /* Increment IV for next packet */
             for(i = 11; i >= 4; i--)
@@ -250,7 +252,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                     break;
         }
 
-        return 0;
+        return ret;
     }
 #else
     (void)encrypt;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -267,15 +267,12 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         finish_olen = 0;
 
         ret = mbedtls_cipher_reset(&ctx->u.cipher);
-
         if(!ret)
             ret = mbedtls_cipher_update(&ctx->u.cipher, block,
                                         blocksize, output, &olen);
-
         if(!ret)
             ret = mbedtls_cipher_finish(&ctx->u.cipher,
                                         output + olen, &finish_olen);
-
         if(!ret) {
             olen += finish_olen;
             memcpy(block, output, olen);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -113,7 +113,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         ctx->is_gcm = 1;
 
         /* Store the initial IV (will be incremented per packet) */
-        memcpy(ctx->u.gcm.iv, iv, 12);
+        memcpy(ctx->u.gcm.iv, iv, sizeof(ctx->u.gcm.iv));
 
         /* Initialize GCM context */
         mbedtls_gcm_init(&ctx->u.gcm.ctx);
@@ -135,7 +135,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     }
 #endif
 
-    /* Non-GCM algorithms: use standard cipher API */
+    /* Non-GCM algorithms: use cipher API */
     op = encrypt ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
 
     cipher_info = mbedtls_cipher_info_from_type(algo);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -236,7 +236,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                                                      MBEDTLS_GCM_DECRYPT,
                                      cctx->ctx.gcm.iv, 12);
             if(ret) {
-                mbed_zero_free(output, osize);
+                mbed_zero_free(buf, cryptlen);
                 return -1;
             }
 
@@ -245,7 +245,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                 ret = mbedtls_gcm_update_ad(&cctx->ctx.gcm.gcm_ctx,
                                             block, aadlen);
                 if(ret) {
-                    mbed_zero_free(output, cryptlen);
+                    mbed_zero_free(buf, cryptlen);
                     return -1;
                 }
             }
@@ -262,7 +262,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                 return -1;
             }
             memcpy(block + aadlen, buf, olen);
-            mbed_zero_free(output, cryptlen);
+            mbed_zero_free(buf, cryptlen);
         }
 
         /* Last block: finalize and handle authentication tag */
@@ -270,11 +270,11 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             unsigned char finish_buf[16];
             int i;
 
-            olen_finish = 0;
+            finish_olen = 0;
 
             ret = mbedtls_gcm_finish(&cctx->ctx.gcm.gcm_ctx,
                                     finish_buf, sizeof(finish_buf),
-                                    &olen_finish, tag, authlen);
+                                    &finish_olen, tag, authlen);
             if(ret)
                 return -1;
 
@@ -297,11 +297,13 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 #endif
 
     /* Non-GCM algorithms: use standard cipher API */
-    osize = blocksize +
-            mbedtls_cipher_get_block_size(&cctx->ctx.cipher_ctx);
+    osize = blocksize + mbedtls_cipher_get_block_size(&cctx->ctx.cipher_ctx);
 
     output = mbedtls_calloc(osize, sizeof(char));
     if(output) {
+        olen = 0;
+        finish_olen = 0;
+
         ret = mbedtls_cipher_reset(&cctx->ctx.cipher_ctx);
 
         if(!ret)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -104,8 +104,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
     memset(ctx, 0, sizeof(*ctx));
 
-    /* Store algorithm type and encryption flag */
-    ctx->algo = algo;
+    ctx->algo = algo;  /* Store algorithm type */
 
 #if LIBSSH2_AES_GCM
     /* Check if this is a GCM algorithm */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -234,6 +234,29 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     return ret == 0 ? 0 : -1;
 }
 
+void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
+{
+    struct ssh2_mbedtls_cipher_ctx *cctx = *ctx;
+
+    if(!cctx)
+        return;
+
+#if LIBSSH2_AES_GCM
+    if(cctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
+       cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
+        mbedtls_gcm_free(&cctx->ctx.gcm.gcm_ctx);
+        mbedtls_free(cctx);
+        *ctx = NULL;
+        return;
+    }
+#endif
+
+    /* Regular cipher context */
+    mbedtls_cipher_free(&cctx->ctx.cipher_ctx);
+    mbedtls_free(cctx);
+    *ctx = NULL;
+}
+
 int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)
 {
     *ctx = psa_hash_operation_init();

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -314,7 +314,7 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
     }
 #endif
 
-    mbedtls_cipher_free(&ctx->u.cipher);  /* Regular cipher context */
+    mbedtls_cipher_free(&ctx->u.cipher);
 }
 
 int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -216,7 +216,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         unsigned char *buf = NULL;
 
         if(blocksize < (size_t)(aadlen + authenticationtag))
-            return 1;
+            return -1;
 
         cryptlen = (unsigned int)blocksize - aadlen - authenticationtag;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -104,13 +104,13 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
     memset(ctx, 0, sizeof(*ctx));
 
-    ctx->algo = algo;  /* Store algorithm type */
-
 #if LIBSSH2_AES_GCM
     /* Check if this is a GCM algorithm */
     if(algo == MBEDTLS_CIPHER_AES_128_GCM ||
        algo == MBEDTLS_CIPHER_AES_256_GCM) {
         unsigned int keybits;
+
+        ctx->is_gcm = 1;
 
         /* Store the initial IV (will be incremented per packet) */
         memcpy(ctx->u.gcm.iv, iv, 12);
@@ -189,9 +189,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         return -1;
 
 #if LIBSSH2_AES_GCM
-    /* Check if this is a GCM algorithm based on stored algo type */
-    if(algo == MBEDTLS_CIPHER_AES_128_GCM ||
-       algo == MBEDTLS_CIPHER_AES_256_GCM) {
+    if(ctx->is_gcm) {
         const int authlen = 16;  /* GCM authentication tag length */
         const int aadlen = IS_FIRST(firstlast) ? 4 : 0;
         const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
@@ -316,8 +314,7 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
         return;
 
 #if LIBSSH2_AES_GCM
-    if(ctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
-       ctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
+    if(ctx->is_gcm) {
         mbedtls_gcm_free(&ctx->u.gcm.ctx);
         return;
     }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -274,8 +274,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             finish_olen = 0;
 
             ret = mbedtls_gcm_finish(&cctx->u.gcm.ctx,
-                                    finish_buf, sizeof(finish_buf),
-                                    &finish_olen, tag, authlen);
+                                     finish_buf, sizeof(finish_buf),
+                                     &finish_olen, tag, authlen);
             if(ret)
                 return -1;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -195,14 +195,14 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         const int authlen = 16;  /* GCM authentication tag length */
         const int aadlen = IS_FIRST(firstlast) ? 4 : 0;
         const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
-        unsigned int cryptlen; /* length of encrypt */
+        size_t cryptlen; /* length of encrypt */
         unsigned char tag[16];
         unsigned char *buf = NULL;
 
         if(blocksize < (size_t)(aadlen + authenticationtag))
             return -1;
 
-        cryptlen = (unsigned int)blocksize - aadlen - authenticationtag;
+        cryptlen = blocksize - aadlen - authenticationtag;
 
         /* Allocate temporary buffer for output */
         if(cryptlen > 0) {

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -213,7 +213,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             if(mbedtls_gcm_starts(&ctx->u.gcm.ctx,
                                   encrypt ? MBEDTLS_GCM_ENCRYPT
                                           : MBEDTLS_GCM_DECRYPT,
-                                  ctx->u.gcm.iv, 12)) {
+                                  ctx->u.gcm.iv, sizeof(ctx->u.gcm.iv))) {
                 mbed_zero_free(buf, cryptlen);
                 return -1;
             }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -95,6 +95,7 @@ static void mbed_zero_free(void *buf, size_t len)
 int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
+    struct ssh2_mbedtls_cipher_ctx *cctx;
     const mbedtls_cipher_info_t *cipher_info;
     mbedtls_operation_t op;
     int ret;
@@ -102,14 +103,61 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     if(!ctx)
         return -1;
 
+    /* Allocate unified context structure */
+    cctx = mbedtls_calloc(1, sizeof(*cctx));
+    if(!cctx)
+        return -1;
+
+    /* Store algorithm type and encryption flag */
+    cctx->algo = algo;
+    cctx->encrypt = encrypt;
+
+#if LIBSSH2_AES_GCM
+    /* Check if this is a GCM algorithm */
+    if(algo == MBEDTLS_CIPHER_AES_128_GCM ||
+       algo == MBEDTLS_CIPHER_AES_256_GCM) {
+        unsigned int keybits;
+
+        /* Store the initial IV (will be incremented per packet) */
+        memcpy(cctx->ctx.gcm.iv, iv, 12);
+
+        /* Initialize GCM context */
+        mbedtls_gcm_init(&cctx->ctx.gcm.gcm_ctx);
+
+        /* Set key length based on algorithm */
+        if(algo == MBEDTLS_CIPHER_AES_128_GCM)
+            keybits = 128;
+        else /* MBEDTLS_CIPHER_AES_256_GCM */
+            keybits = 256;
+
+        /* Setup GCM with AES cipher and key */
+        ret = mbedtls_gcm_setkey(&cctx->ctx.gcm.gcm_ctx,
+                                 MBEDTLS_CIPHER_ID_AES,
+                                 secret,
+                                 keybits);
+        if(ret) {
+            mbedtls_gcm_free(&cctx->ctx.gcm.gcm_ctx);
+            mbedtls_free(cctx);
+            return -1;
+        }
+
+        /* Store the context pointer */
+        *h = cctx;
+        return 0;
+    }
+#endif
+
+    /* Non-GCM algorithms: use standard cipher API */
     op = encrypt ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
 
     cipher_info = mbedtls_cipher_info_from_type(algo);
-    if(!cipher_info)
+    if(!cipher_info) {
+        mbedtls_free(cctx);
         return -1;
+    }
 
-    mbedtls_cipher_init(ctx);
-    ret = mbedtls_cipher_setup(ctx, cipher_info);
+    mbedtls_cipher_init(&cctx->ctx.cipher_ctx);
+    ret = mbedtls_cipher_setup(&cctx->ctx.cipher_ctx, cipher_info);
 
     /* libssh2 computes and adds SSH packet padding itself, so for CBC
        tell mbedTLS to expect no padding on the cipher layer. Only call
@@ -124,17 +172,25 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 #endif
        )
       ) {
-        ret = mbedtls_cipher_set_padding_mode(ctx, MBEDTLS_PADDING_NONE);
+        ret = mbedtls_cipher_set_padding_mode(&cctx->ctx.cipher_ctx,
+                                              MBEDTLS_PADDING_NONE);
     }
 
     if(!ret)
-        ret = mbedtls_cipher_setkey(ctx,
+        ret = mbedtls_cipher_setkey(&cctx->ctx.cipher_ctx,
                   secret,
                   (int)mbedtls_cipher_info_get_key_bitlen(cipher_info), op);
 
     if(!ret)
-        ret = mbedtls_cipher_set_iv(ctx, iv,
+        ret = mbedtls_cipher_set_iv(&cctx->ctx.cipher_ctx, iv,
                   mbedtls_cipher_info_get_iv_size(cipher_info));
+
+    if(ret) {
+        mbedtls_cipher_free(&cctx->ctx.cipher_ctx);
+        mbedtls_free(cctx);
+    }
+    else
+        *ctx = cctx;  /* Store the context pointer */
 
     return ret == 0 ? 0 : -1;
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -110,7 +110,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
        algo == MBEDTLS_CIPHER_AES_256_GCM) {
         unsigned int keybits;
 
-        ctx->is_gcm = 1;
+        ctx->is_aesgcm = 1;
 
         /* Store the initial IV (will be incremented per packet) */
         memcpy(ctx->u.gcm.iv, iv, sizeof(ctx->u.gcm.iv));
@@ -190,7 +190,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     (void)algo;
 
 #if LIBSSH2_AES_GCM
-    if(ctx->is_gcm) {
+    if(ctx->is_aesgcm) {
         unsigned char buf[32];
         unsigned char tag[16];  /* GCM authentication tag */
         const int authlen = sizeof(tag);
@@ -294,7 +294,7 @@ void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
         return;
 
 #if LIBSSH2_AES_GCM
-    if(ctx->is_gcm) {
+    if(ctx->is_aesgcm) {
         mbedtls_gcm_free(&ctx->u.gcm.ctx);
         return;
     }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -276,6 +276,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     }
 #else
     (void)encrypt;
+    (void)algo;
     (void)firstlast;
 #endif
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -187,6 +187,8 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     if(!ctx)
         return -1;
 
+    (void)algo;
+
 #if LIBSSH2_AES_GCM
     if(ctx->is_gcm) {
         unsigned char tag[16];  /* GCM authentication tag */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -191,41 +191,30 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
 #if LIBSSH2_AES_GCM
     if(ctx->is_gcm) {
+        unsigned char buf[32];
         unsigned char tag[16];  /* GCM authentication tag */
         const int authlen = sizeof(tag);
         const int aadlen = IS_FIRST(firstlast) ? 4 : 0;
         const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
         size_t cryptlen; /* length of encrypt */
-        unsigned char *buf = NULL;
 
-        if(blocksize < (size_t)(aadlen + authenticationtag))
+        if(blocksize > sizeof(buf) ||
+           blocksize < (size_t)(aadlen + authenticationtag))
             return -1;
 
         cryptlen = blocksize - aadlen - authenticationtag;
-
-        /* Allocate temporary buffer for output */
-        if(cryptlen > 0) {
-            buf = mbedtls_calloc(cryptlen, 1);
-            if(!buf)
-                return -1;
-        }
 
         /* First block: start GCM operation */
         if(IS_FIRST(firstlast)) {
             if(mbedtls_gcm_starts(&ctx->u.gcm.ctx,
                                   encrypt ? MBEDTLS_GCM_ENCRYPT
                                           : MBEDTLS_GCM_DECRYPT,
-                                  ctx->u.gcm.iv, sizeof(ctx->u.gcm.iv))) {
-                mbed_zero_free(buf, cryptlen);
+                                  ctx->u.gcm.iv, sizeof(ctx->u.gcm.iv)))
                 return -1;
-            }
 
             /* Process AAD (Additional Authenticated Data) */
-            if(aadlen &&
-               mbedtls_gcm_update_ad(&ctx->u.gcm.ctx, block, aadlen)) {
-                mbed_zero_free(buf, cryptlen);
+            if(aadlen && mbedtls_gcm_update_ad(&ctx->u.gcm.ctx, block, aadlen))
                 return -1;
-            }
         }
 
         /* Process payload */
@@ -233,12 +222,9 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             olen = 0;
             if(mbedtls_gcm_update(&ctx->u.gcm.ctx,
                                   block + aadlen, cryptlen,
-                                  buf, cryptlen, &olen)) {
-                mbed_zero_free(buf, cryptlen);
+                                  buf, cryptlen, &olen))
                 return -1;
-            }
             memcpy(block + aadlen, buf, olen);
-            mbed_zero_free(buf, cryptlen);
         }
 
         /* Last block: finalize and handle authentication tag */

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -189,11 +189,11 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
 #if LIBSSH2_AES_GCM
     if(ctx->is_gcm) {
-        const int authlen = 16;  /* GCM authentication tag length */
+        unsigned char tag[16];  /* GCM authentication tag */
+        const int authlen = sizeof(tag);
         const int aadlen = IS_FIRST(firstlast) ? 4 : 0;
         const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
         size_t cryptlen; /* length of encrypt */
-        unsigned char tag[16];
         unsigned char *buf = NULL;
 
         if(blocksize < (size_t)(aadlen + authenticationtag))

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -245,7 +245,6 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             int i;
 
             finish_olen = 0;
-
             if(mbedtls_gcm_finish(&ctx->u.gcm.ctx,
                                   finish_buf, sizeof(finish_buf),
                                   &finish_olen, tag, authlen))

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -199,27 +199,118 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)
 {
+    struct ssh2_mbedtls_cipher_ctx *cctx;
     int ret;
     unsigned char *output;
-    size_t osize;
+    size_t osize, olen, finish_olen;
 
     (void)encrypt;
     (void)algo;
-    (void)firstlast;
 
-    osize = blocksize + mbedtls_cipher_get_block_size(ctx);
+    cctx = *ctx;
+    if(!cctx)
+        return -1;
+
+#if LIBSSH2_AES_GCM
+    /* Check if this is a GCM algorithm based on stored algo type */
+    if(cctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
+       cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
+        const int authlen = 16;  /* GCM authentication tag length */
+        const int aadlen = IS_FIRST(firstlast) ? 4 : 0;
+        const int authenticationtag = IS_LAST(firstlast) ? authlen : 0;
+        const int cryptlen = (int)blocksize - aadlen - authenticationtag;
+        unsigned char tag[16];
+        unsigned char *buf = NULL;
+
+        /* Allocate temporary buffer for output */
+        if(cryptlen > 0) {
+            buf = mbedtls_calloc(cryptlen, 1);
+            if(!buf)
+                return -1;
+        }
+
+        /* First block: start GCM operation */
+        if(IS_FIRST(firstlast)) {
+            ret = mbedtls_gcm_starts(&cctx->ctx.gcm.gcm_ctx,
+                                     cctx->encrypt ? MBEDTLS_GCM_ENCRYPT :
+                                                     MBEDTLS_GCM_DECRYPT,
+                                     cctx->ctx.gcm.iv, 12);
+            if(ret) {
+                mbed_zero_free(output, osize);
+                return -1;
+            }
+
+            /* Process AAD (Additional Authenticated Data) */
+            if(aadlen) {
+                ret = mbedtls_gcm_update_ad(&cctx->ctx.gcm.gcm_ctx,
+                                            block, aadlen);
+                if(ret) {
+                    mbed_zero_free(output, cryptlen);
+                    return -1;
+                }
+            }
+        }
+
+        /* Process payload */
+        if(cryptlen > 0) {
+            olen = 0;
+            ret = mbedtls_gcm_update(&cctx->ctx.gcm.gcm_ctx,
+                                     block + aadlen, cryptlen,
+                                     buf, cryptlen, &olen);
+            if(ret) {
+                mbed_zero_free(buf, cryptlen);
+                return -1;
+            }
+            memcpy(block + aadlen, buf, olen);
+            mbed_zero_free(output, cryptlen);
+        }
+
+        /* Last block: finalize and handle authentication tag */
+        if(IS_LAST(firstlast)) {
+            unsigned char finish_buf[16];
+            int i;
+
+            olen_finish = 0;
+
+            ret = mbedtls_gcm_finish(&cctx->ctx.gcm.gcm_ctx,
+                                    finish_buf, sizeof(finish_buf),
+                                    &olen_finish, tag, authlen);
+            if(ret)
+                return -1;
+
+            if(cctx->encrypt)
+                memcpy(block + blocksize - authlen, tag, authlen);
+            else if(ssh2_timingsafe_bcmp(tag, block + blocksize - authlen,
+                                         authlen))
+                return MBEDTLS_ERR_GCM_AUTH_FAILED;
+
+            /* Increment IV for next packet */
+            for(i = 11; i >= 4; i--)
+                if(++cctx->ctx.gcm.iv[i])
+                    break;
+        }
+
+        return 0;
+    }
+#else
+    (void)firstlast;
+#endif
+
+    /* Non-GCM algorithms: use standard cipher API */
+    osize = blocksize +
+            mbedtls_cipher_get_block_size(&cctx->ctx.cipher_ctx);
 
     output = mbedtls_calloc(osize, sizeof(char));
     if(output) {
-        size_t olen = 0, finish_olen = 0;
-
-        ret = mbedtls_cipher_reset(ctx);
+        ret = mbedtls_cipher_reset(&cctx->ctx.cipher_ctx);
 
         if(!ret)
-            ret = mbedtls_cipher_update(ctx, block, blocksize, output, &olen);
+            ret = mbedtls_cipher_update(&cctx->ctx.cipher_ctx, block,
+                                        blocksize, output, &olen);
 
         if(!ret)
-            ret = mbedtls_cipher_finish(ctx, output + olen, &finish_olen);
+            ret = mbedtls_cipher_finish(&cctx->ctx.cipher_ctx,
+                                        output + olen, &finish_olen);
 
         if(!ret) {
             olen += finish_olen;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -102,13 +102,10 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     if(!ctx)
         return -1;
 
-    /* Allocate unified context structure */
-    cctx = mbedtls_calloc(1, sizeof(*cctx));
-    if(!cctx)
-        return -1;
+    memset(ctx, 0, sizeof(*ctx));
 
     /* Store algorithm type and encryption flag */
-    cctx->algo = algo;
+    ctx->algo = algo;
 
 #if LIBSSH2_AES_GCM
     /* Check if this is a GCM algorithm */
@@ -117,10 +114,10 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         unsigned int keybits;
 
         /* Store the initial IV (will be incremented per packet) */
-        memcpy(cctx->u.gcm.iv, iv, 12);
+        memcpy(ctx->u.gcm.iv, iv, 12);
 
         /* Initialize GCM context */
-        mbedtls_gcm_init(&cctx->u.gcm.ctx);
+        mbedtls_gcm_init(&ctx->u.gcm.ctx);
 
         /* Set key length based on algorithm */
         if(algo == MBEDTLS_CIPHER_AES_128_GCM)
@@ -129,16 +126,13 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             keybits = 256;
 
         /* Setup GCM with AES cipher and key */
-        ret = mbedtls_gcm_setkey(&cctx->u.gcm.ctx, MBEDTLS_CIPHER_ID_AES,
+        ret = mbedtls_gcm_setkey(&ctx->u.gcm.ctx, MBEDTLS_CIPHER_ID_AES,
                                  secret, keybits);
         if(ret) {
-            mbedtls_gcm_free(&cctx->u.gcm.ctx);
-            mbedtls_free(cctx);
+            mbedtls_gcm_free(&ctx->u.gcm.ctx);
             return -1;
         }
 
-        /* Store the context pointer */
-        *ctx = cctx;
         return 0;
     }
 #endif
@@ -147,13 +141,11 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     op = encrypt ? MBEDTLS_ENCRYPT : MBEDTLS_DECRYPT;
 
     cipher_info = mbedtls_cipher_info_from_type(algo);
-    if(!cipher_info) {
-        mbedtls_free(cctx);
+    if(!cipher_info)
         return -1;
-    }
 
-    mbedtls_cipher_init(&cctx->u.cipher);
-    ret = mbedtls_cipher_setup(&cctx->u.cipher, cipher_info);
+    mbedtls_cipher_init(&ctx->u.cipher);
+    ret = mbedtls_cipher_setup(&ctx->u.cipher, cipher_info);
 
     /* libssh2 computes and adds SSH packet padding itself, so for CBC
        tell mbedTLS to expect no padding on the cipher layer. Only call
@@ -168,24 +160,20 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 #endif
        )
       ) {
-        ret = mbedtls_cipher_set_padding_mode(&cctx->u.cipher,
+        ret = mbedtls_cipher_set_padding_mode(&ctx->u.cipher,
                                               MBEDTLS_PADDING_NONE);
     }
 
     if(!ret)
-        ret = mbedtls_cipher_setkey(&cctx->u.cipher, secret,
+        ret = mbedtls_cipher_setkey(&ctx->u.cipher, secret,
                   (int)mbedtls_cipher_info_get_key_bitlen(cipher_info), op);
 
     if(!ret)
-        ret = mbedtls_cipher_set_iv(&cctx->u.cipher, iv,
+        ret = mbedtls_cipher_set_iv(&ctx->u.cipher, iv,
                   mbedtls_cipher_info_get_iv_size(cipher_info));
 
-    if(ret) {
-        mbedtls_cipher_free(&cctx->u.cipher);
-        mbedtls_free(cctx);
-    }
-    else
-        *ctx = cctx;  /* Store the context pointer */
+    if(ret)
+        mbedtls_cipher_free(&ctx->u.cipher);
 
     return ret == 0 ? 0 : -1;
 }
@@ -194,13 +182,11 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                       int encrypt, unsigned char *block, size_t blocksize,
                       int firstlast)
 {
-    struct ssh2_mbed_cipher_ctx *cctx;
     int ret;
     unsigned char *output;
     size_t osize, olen, finish_olen;
 
-    cctx = *ctx;
-    if(!cctx)
+    if(!ctx)
         return -1;
 
 #if LIBSSH2_AES_GCM
@@ -228,10 +214,10 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
         /* First block: start GCM operation */
         if(IS_FIRST(firstlast)) {
-            ret = mbedtls_gcm_starts(&cctx->u.gcm.ctx,
+            ret = mbedtls_gcm_starts(&ctx->u.gcm.ctx,
                                      encrypt ? MBEDTLS_GCM_ENCRYPT
                                              : MBEDTLS_GCM_DECRYPT,
-                                     cctx->u.gcm.iv, 12);
+                                     ctx->u.gcm.iv, 12);
             if(ret) {
                 mbed_zero_free(buf, cryptlen);
                 return -1;
@@ -239,7 +225,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
             /* Process AAD (Additional Authenticated Data) */
             if(aadlen) {
-                ret = mbedtls_gcm_update_ad(&cctx->u.gcm.ctx, block, aadlen);
+                ret = mbedtls_gcm_update_ad(&ctx->u.gcm.ctx, block, aadlen);
                 if(ret) {
                     mbed_zero_free(buf, cryptlen);
                     return -1;
@@ -250,7 +236,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
         /* Process payload */
         if(cryptlen > 0) {
             olen = 0;
-            ret = mbedtls_gcm_update(&cctx->u.gcm.ctx,
+            ret = mbedtls_gcm_update(&ctx->u.gcm.ctx,
                                      block + aadlen, cryptlen,
                                      buf, cryptlen, &olen);
             if(ret) {
@@ -268,7 +254,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
             finish_olen = 0;
 
-            ret = mbedtls_gcm_finish(&cctx->u.gcm.ctx,
+            ret = mbedtls_gcm_finish(&ctx->u.gcm.ctx,
                                      finish_buf, sizeof(finish_buf),
                                      &finish_olen, tag, authlen);
             if(ret)
@@ -282,7 +268,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
             /* Increment IV for next packet */
             for(i = 11; i >= 4; i--)
-                if(++cctx->u.gcm.iv[i])
+                if(++ctx->u.gcm.iv[i])
                     break;
         }
 
@@ -294,21 +280,21 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 #endif
 
     /* Non-GCM algorithms: use standard cipher API */
-    osize = blocksize + mbedtls_cipher_get_block_size(&cctx->u.cipher);
+    osize = blocksize + mbedtls_cipher_get_block_size(&ctx->u.cipher);
 
     output = mbedtls_calloc(osize, sizeof(char));
     if(output) {
         olen = 0;
         finish_olen = 0;
 
-        ret = mbedtls_cipher_reset(&cctx->u.cipher);
+        ret = mbedtls_cipher_reset(&ctx->u.cipher);
 
         if(!ret)
-            ret = mbedtls_cipher_update(&cctx->u.cipher, block,
+            ret = mbedtls_cipher_update(&ctx->u.cipher, block,
                                         blocksize, output, &olen);
 
         if(!ret)
-            ret = mbedtls_cipher_finish(&cctx->u.cipher,
+            ret = mbedtls_cipher_finish(&ctx->u.cipher,
                                         output + olen, &finish_olen);
 
         if(!ret) {
@@ -326,25 +312,18 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
 void ssh2_cipher_dtor(ssh2_cipher_ctx *ctx)
 {
-    struct ssh2_mbed_cipher_ctx *cctx = *ctx;
-
-    if(!cctx)
+    if(!ctx)
         return;
 
 #if LIBSSH2_AES_GCM
-    if(cctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
-       cctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
-        mbedtls_gcm_free(&cctx->u.gcm.ctx);
-        mbedtls_free(cctx);
-        *ctx = NULL;
+    if(ctx->algo == MBEDTLS_CIPHER_AES_128_GCM ||
+       ctx->algo == MBEDTLS_CIPHER_AES_256_GCM) {
+        mbedtls_gcm_free(&ctx->u.gcm.ctx);
         return;
     }
 #endif
 
-    /* Regular cipher context */
-    mbedtls_cipher_free(&cctx->u.cipher);
-    mbedtls_free(cctx);
-    *ctx = NULL;
+    mbedtls_cipher_free(&ctx->u.cipher);  /* Regular cipher context */
 }
 
 int ssh2_hash_init(ssh2_hash_ctx *ctx, ssh2_hash_alg alg)

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -130,10 +130,8 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             keybits = 256;
 
         /* Setup GCM with AES cipher and key */
-        ret = mbedtls_gcm_setkey(&cctx->u.gcm.ctx,
-                                 MBEDTLS_CIPHER_ID_AES,
-                                 secret,
-                                 keybits);
+        ret = mbedtls_gcm_setkey(&cctx->u.gcm.ctx, MBEDTLS_CIPHER_ID_AES,
+                                 secret, keybits);
         if(ret) {
             mbedtls_gcm_free(&cctx->u.gcm.ctx);
             mbedtls_free(cctx);
@@ -176,8 +174,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     }
 
     if(!ret)
-        ret = mbedtls_cipher_setkey(&cctx->u.cipher,
-                  secret,
+        ret = mbedtls_cipher_setkey(&cctx->u.cipher, secret,
                   (int)mbedtls_cipher_info_get_key_bitlen(cipher_info), op);
 
     if(!ret)
@@ -243,8 +240,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 
             /* Process AAD (Additional Authenticated Data) */
             if(aadlen) {
-                ret = mbedtls_gcm_update_ad(&cctx->u.gcm.ctx,
-                                            block, aadlen);
+                ret = mbedtls_gcm_update_ad(&cctx->u.gcm.ctx, block, aadlen);
                 if(ret) {
                     mbed_zero_free(buf, cryptlen);
                     return -1;

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -197,7 +197,7 @@ struct ssh2_mbed_cipher_ctx {
     } u;
 };
 
-#define ssh2_cipher_ctx        struct ssh2_mbed_cipher_ctx *
+#define ssh2_cipher_ctx        struct ssh2_mbed_cipher_ctx
 
 #define SSH2_CIPHER_T(algo)    mbedtls_cipher_type_t algo
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -43,6 +43,7 @@
 #include <mbedtls/rsa.h>
 #include <mbedtls/bignum.h>
 #include <mbedtls/cipher.h>
+#include <mbedtls/gcm.h>
 #ifdef MBEDTLS_ECDH_C
 # include <mbedtls/ecdh.h>
 #endif
@@ -79,7 +80,7 @@
 
 #define LIBSSH2_AES_CBC 1
 #define LIBSSH2_AES_CTR 1
-#define LIBSSH2_AES_GCM 0
+#define LIBSSH2_AES_GCM 1
 #define LIBSSH2_BLOWFISH 0
 #define LIBSSH2_RC4 0
 #define LIBSSH2_CAST 0

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -184,7 +184,7 @@ typedef enum {
 /* Unified cipher context structure.
    Handles both regular ciphers and AEAD ciphers (GCM)
    using a union to optimize memory usage. */
-struct ssh2_mbedtls_cipher_ctx {
+struct ssh2_mbed_cipher_ctx {
     mbedtls_cipher_type_t algo;
     union {
         mbedtls_cipher_context_t cipher;
@@ -197,7 +197,7 @@ struct ssh2_mbedtls_cipher_ctx {
     } u;
 };
 
-#define ssh2_cipher_ctx        struct ssh2_mbedtls_cipher_ctx *
+#define ssh2_cipher_ctx        struct ssh2_mbed_cipher_ctx *
 
 #define SSH2_CIPHER_T(algo)    mbedtls_cipher_type_t algo
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -217,12 +217,6 @@ struct ssh2_mbedtls_cipher_ctx {
 
 /*******************************************************************/
 /*
- * mbedTLS backend: Cipher functions
- */
-#define ssh2_cipher_dtor(ctx)  mbedtls_cipher_free(ctx)
-
-/*******************************************************************/
-/*
  * mbedTLS backend: BigNumber Support
  */
 

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -80,7 +80,11 @@
 
 #define LIBSSH2_AES_CBC 1
 #define LIBSSH2_AES_CTR 1
+#ifdef MBEDTLS_GCM_C
 #define LIBSSH2_AES_GCM 1
+#else
+#define LIBSSH2_AES_GCM 0
+#endif
 #define LIBSSH2_BLOWFISH 0
 #define LIBSSH2_RC4 0
 #define LIBSSH2_CAST 0

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -191,7 +191,7 @@ typedef enum {
    Handles both regular ciphers and AEAD ciphers (GCM)
    using a union to optimize memory usage. */
 struct ssh2_mbed_cipher_ctx {
-    int is_gcm;
+    int is_aesgcm;
     union {
         mbedtls_cipher_context_t cipher;
 #if LIBSSH2_AES_GCM

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -180,7 +180,24 @@ typedef enum {
  * mbedTLS backend: Cipher Context structure
  */
 
-#define ssh2_cipher_ctx        mbedtls_cipher_context_t
+/* Unified cipher context structure.
+   Handles both regular ciphers and AEAD ciphers (GCM)
+   using a union to optimize memory usage. */
+struct ssh2_mbedtls_cipher_ctx {
+    mbedtls_cipher_type_t algo;
+    int encrypt;
+    union {
+        mbedtls_cipher_context_t cipher_ctx;
+#if LIBSSH2_AES_GCM
+        struct {
+            mbedtls_gcm_context gcm_ctx;
+            unsigned char iv[12];
+        } gcm;
+#endif
+    } ctx;
+};
+
+#define ssh2_cipher_ctx        struct ssh2_mbedtls_cipher_ctx *
 
 #define SSH2_CIPHER_T(algo)    mbedtls_cipher_type_t algo
 
@@ -193,6 +210,8 @@ typedef enum {
 #if LIBSSH2_3DES
 #define ssh2_cipher_3des       MBEDTLS_CIPHER_DES_EDE3_CBC
 #endif
+#define ssh2_cipher_aes128gcm  MBEDTLS_CIPHER_AES_128_GCM
+#define ssh2_cipher_aes256gcm  MBEDTLS_CIPHER_AES_256_GCM
 #define ssh2_cipher_chacha20   MBEDTLS_CIPHER_CHACHA20_POLY1305
 
 /*******************************************************************/

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -189,7 +189,7 @@ typedef enum {
    Handles both regular ciphers and AEAD ciphers (GCM)
    using a union to optimize memory usage. */
 struct ssh2_mbed_cipher_ctx {
-    mbedtls_cipher_type_t algo;
+    int is_gcm;
     union {
         mbedtls_cipher_context_t cipher;
 #if LIBSSH2_AES_GCM

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -186,7 +186,6 @@ typedef enum {
    using a union to optimize memory usage. */
 struct ssh2_mbedtls_cipher_ctx {
     mbedtls_cipher_type_t algo;
-    int encrypt;
     union {
         mbedtls_cipher_context_t cipher_ctx;
 #if LIBSSH2_AES_GCM

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -43,7 +43,9 @@
 #include <mbedtls/rsa.h>
 #include <mbedtls/bignum.h>
 #include <mbedtls/cipher.h>
-#include <mbedtls/gcm.h>
+#ifdef MBEDTLS_GCM_C
+# include <mbedtls/gcm.h>
+#endif
 #ifdef MBEDTLS_ECDH_C
 # include <mbedtls/ecdh.h>
 #endif

--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -187,14 +187,14 @@ typedef enum {
 struct ssh2_mbedtls_cipher_ctx {
     mbedtls_cipher_type_t algo;
     union {
-        mbedtls_cipher_context_t cipher_ctx;
+        mbedtls_cipher_context_t cipher;
 #if LIBSSH2_AES_GCM
         struct {
-            mbedtls_gcm_context gcm_ctx;
+            mbedtls_gcm_context ctx;
             unsigned char iv[12];
         } gcm;
 #endif
-    } ctx;
+    } u;
 };
 
 #define ssh2_cipher_ctx        struct ssh2_mbedtls_cipher_ctx *

--- a/tests/openssh_server/sshd_config
+++ b/tests/openssh_server/sshd_config
@@ -7,7 +7,6 @@ HostKeyAlgorithms +ssh-rsa
 # modern name in OpenSSH 8.5+: PubkeyAcceptedAlgorithms
 PubkeyAcceptedKeyTypes +ssh-rsa,ssh-rsa-cert-v01@openssh.com
 MACs +hmac-sha1,hmac-sha1-96,hmac-sha2-256,hmac-sha2-512,hmac-md5,hmac-md5-96,umac-64@openssh.com,umac-128@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,umac-64-etm@openssh.com,umac-128-etm@openssh.com
-Ciphers -chacha20-poly1305@openssh.com
-Ciphers +3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com
+Ciphers 3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
 # for libgcrypt, WinCNG
 KexAlgorithms +diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256

--- a/tests/openssh_server/sshd_config
+++ b/tests/openssh_server/sshd_config
@@ -7,6 +7,6 @@ HostKeyAlgorithms +ssh-rsa
 # modern name in OpenSSH 8.5+: PubkeyAcceptedAlgorithms
 PubkeyAcceptedKeyTypes +ssh-rsa,ssh-rsa-cert-v01@openssh.com
 MACs +hmac-sha1,hmac-sha1-96,hmac-sha2-256,hmac-sha2-512,hmac-md5,hmac-md5-96,umac-64@openssh.com,umac-128@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,umac-64-etm@openssh.com,umac-128-etm@openssh.com
-Ciphers 3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+Ciphers +3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com
 # for libgcrypt, WinCNG
 KexAlgorithms +diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256

--- a/tests/openssh_server/sshd_config
+++ b/tests/openssh_server/sshd_config
@@ -7,6 +7,7 @@ HostKeyAlgorithms +ssh-rsa
 # modern name in OpenSSH 8.5+: PubkeyAcceptedAlgorithms
 PubkeyAcceptedKeyTypes +ssh-rsa,ssh-rsa-cert-v01@openssh.com
 MACs +hmac-sha1,hmac-sha1-96,hmac-sha2-256,hmac-sha2-512,hmac-md5,hmac-md5-96,umac-64@openssh.com,umac-128@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,umac-64-etm@openssh.com,umac-128-etm@openssh.com
+Ciphers -chacha20-poly1305@openssh.com
 Ciphers +3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com
 # for libgcrypt, WinCNG
 KexAlgorithms +diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256


### PR DESCRIPTION
In addition to the original patch:
- simplify cipher object. drop the allocation and double redirection,
  drop redundant `encrypt` member, shorten/dedupe names, replace `algo`
  with `is_gcm`.
- replace heap alloc with stack buffer for GCM in `ssh2_cipher_crypt()`.
- use the algo argument instead of the context copy.
  (for speed and to match OpenSSL sibling code.)
- fix returned error value on GCM auth fail.
- increment IV on decrypt auth fail. Copilot suggestion. I cannot 
  confirm this, so erring on the side caution to avoid a potential IV
  reuse.
- support mbedTLS builds without GCM built-in, via `MBEDTLS_GCM_C`.
- retrofit bounds check applied to OpenSSL backend earlier.
  Follow-up to a2ed82d40964bbc0d64cd717aa0a5a892117d2e6 #2401
- misc tidy-ups.

Original-patch-by: Adrian Moran
Closes #1764
