### PR TITLE
libssh2_scp_recv2: fix stat struct type in man page prototype

### DIFF
--- a/docs/libssh2_scp_recv2.md
+++ b/docs/libssh2_scp_recv2.md
@@ -19,7 +19,7 @@ libssh2_scp_recv2 - request a remote file via SCP
 #include <libssh2.h>
 
 LIBSSH2_CHANNEL *libssh2_scp_recv2(LIBSSH2_SESSION *session, const char *path,
-                                   struct stat *sb);
+                                   libssh2_struct_stat *sb);
 ~~~
 
 # DESCRIPTION


### PR DESCRIPTION
Follow-up to 6c84a426beb494980579e5c1d244ea54d3fc1a3f

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
