### PR TITLE
channel: add `libssh2_channel_has_exit_status()`

### DIFF
--- a/docs/Makefile.inc
+++ b/docs/Makefile.inc
@@ -35,6 +35,7 @@ man_MANS = \
   libssh2_channel_get_exit_status.3 \
   libssh2_channel_handle_extended_data.3 \
   libssh2_channel_handle_extended_data2.3 \
+  libssh2_channel_has_exit_status.3 \
   libssh2_channel_ignore_extended_data.3 \
   libssh2_channel_open_ex.3 \
   libssh2_channel_open_session.3 \

--- a/docs/libssh2_channel_get_exit_status.md
+++ b/docs/libssh2_channel_get_exit_status.md
@@ -5,6 +5,7 @@ Title: libssh2_channel_get_exit_status
 Section: 3
 Source: libssh2
 See-also:
+  - libssh2_channel_has_exit_status(3)
 ---
 
 # NAME

--- a/docs/libssh2_channel_has_exit_status.md
+++ b/docs/libssh2_channel_has_exit_status.md
@@ -1,0 +1,49 @@
+---
+c: Copyright (C) The libssh2 project and its contributors.
+SPDX-License-Identifier: BSD-3-Clause
+Title: libssh2_channel_has_exit_status
+Section: 3
+Source: libssh2
+See-also:
+  - libssh2_channel_get_exit_status(3)
+---
+
+# NAME
+
+libssh2_channel_has_exit_status - check if an exit status arrived
+
+# SYNOPSIS
+
+~~~c
+#include <libssh2.h>
+
+int libssh2_channel_has_exit_status(LIBSSH2_CHANNEL *channel);
+~~~
+
+# DESCRIPTION
+
+*channel* - Closed channel stream to query.
+
+Report whether the remote host sent an `exit-status` request for the named
+channel. libssh2_channel_get_exit_status(3) returns 0 both for a real exit
+status of 0 and for a channel that never received the request, so it cannot
+tell the two apart on its own. A server may close a channel without sending
+the request, for example when OpenSSH enforces `ChannelTimeout`, and the
+command then keeps running on the remote host.
+
+# RETURN VALUE
+
+Returns 1 if an `exit-status` request was received for the channel,
+otherwise 0. Also returns 0 when *channel* is NULL.
+
+# EXAMPLE
+
+~~~c
+if(libssh2_channel_close(channel) == 0 &&
+   libssh2_channel_has_exit_status(channel))
+    exitcode = libssh2_channel_get_exit_status(channel);
+~~~
+
+# AVAILABILITY
+
+Added in libssh2 1.12.0

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -994,6 +994,7 @@ LIBSSH2_API int libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel,
     libssh2_channel_flush_ex(channel, SSH_EXTENDED_DATA_STDERR)
 
 LIBSSH2_API int libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel);
+LIBSSH2_API int libssh2_channel_has_exit_status(LIBSSH2_CHANNEL *channel);
 LIBSSH2_API int libssh2_channel_get_exit_signal(LIBSSH2_CHANNEL *channel,
                                                 char **exitsignal,
                                                 size_t *exitsignal_len,

--- a/src/channel.c
+++ b/src/channel.c
@@ -1647,6 +1647,20 @@ int libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel)
 }
 
 /*
+ * Return 1 if the channel received an exit-status request, otherwise 0.
+ * libssh2_channel_get_exit_status() cannot report this.  A server that closes
+ * a channel without sending the request leaves the status at 0, the same
+ * value a successful command reports.  We return a zero if channel is NULL.
+ */
+int libssh2_channel_has_exit_status(LIBSSH2_CHANNEL *channel)
+{
+    if(!channel)
+        return 0;
+
+    return channel->exit_status_received;
+}
+
+/*
  * Get exit signal (without leading "SIG"), error message, and language
  * tag into newly allocated buffers of indicated length.  Caller can
  * use NULL pointers to indicate that the value should not be set.  The

--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -466,6 +466,9 @@ struct _LIBSSH2_CHANNEL {
     /* channel's program exit status */
     int exit_status;
 
+    /* Set to 1 when an exit-status request has been received */
+    int exit_status_received;
+
     /* channel's program exit signal (without the SIG prefix) */
     char *exit_signal;
 

--- a/src/packet.c
+++ b/src/packet.c
@@ -1108,6 +1108,8 @@ ssh2_packet_add_jump_point1:
                         if(ssh2_get_u32(&buf, &status))
                             rc = ssh2_err(session, LIBSSH2_ERROR_PROTO,
                                           "exit-signal status error");
+                        else
+                            channelp->exit_status_received = 1;
 
                         channelp->exit_status = (int)status;
 

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -39,6 +39,7 @@ DOCKER_TESTS = \
   test_auth_pubkey_ok_rsa_pem_signed \
   test_auth_pubkey_ok_rsa_pkcs8 \
   test_auth_pubkey_ok_rsa_pkcs8_encrypted \
+  test_exit_status \
   test_hostkey_hash \
   test_read
 

--- a/tests/test_exit_status.c
+++ b/tests/test_exit_status.c
@@ -1,0 +1,62 @@
+/* Copyright (C) The libssh2 project and its contributors.
+ *
+ * libssh2 test telling a received exit status apart from none
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "runner.h"
+
+int test(LIBSSH2_SESSION *session)
+{
+    LIBSSH2_CHANNEL *channel;
+
+    /* set in Dockerfile */
+    if(test_auth_pubkey(session, 0, "libssh2", NULL,
+                        "keys/id_rsa_pem.pub", "keys/id_rsa_pem"))
+        return 1;
+
+    /* A finished command sends an exit-status, so its receipt is reported
+       and the value read back is a real 0. */
+    channel = libssh2_channel_open_session(session);
+    if(!channel) {
+        print_last_session_error("libssh2_channel_open_session");
+        return 1;
+    }
+    if(libssh2_channel_exec(channel, "exit 0")) {
+        print_last_session_error("libssh2_channel_exec");
+        return 1;
+    }
+    while(!libssh2_channel_eof(channel)) {
+        char buf[1024];
+        if(libssh2_channel_read(channel, buf, sizeof(buf)) < 0)
+            break;
+    }
+    libssh2_channel_close(channel);
+    if(!libssh2_channel_has_exit_status(channel)) {
+        fprintf(stderr, "exit status not reported as received\n");
+        return 1;
+    }
+    if(libssh2_channel_get_exit_status(channel) != 0) {
+        fprintf(stderr, "unexpected exit status: %d\n",
+                libssh2_channel_get_exit_status(channel));
+        return 1;
+    }
+    libssh2_channel_free(channel);
+
+    /* A channel that runs no command receives no exit-status, so its absence
+       is reported rather than read as a 0. */
+    channel = libssh2_channel_open_session(session);
+    if(!channel) {
+        print_last_session_error("libssh2_channel_open_session");
+        return 1;
+    }
+    libssh2_channel_close(channel);
+    if(libssh2_channel_has_exit_status(channel)) {
+        fprintf(stderr, "exit status reported for a channel that had none\n");
+        return 1;
+    }
+    libssh2_channel_free(channel);
+
+    return 0;
+}


### PR DESCRIPTION
`libssh2_channel_get_exit_status()` returns 0 both for a real exit status of 0 and for a channel that never received an `exit-status` request. A server that force-closes a session, like OpenSSH under `ChannelTimeout`, makes a still-running command look like a clean exit 0. Reproduction with the stock `example/ssh2_exec` is in #2515

This adds `libssh2_channel_has_exit_status()`, returning 1 once the request arrived, the name you suggested.

The new field sits in `_LIBSSH2_CHANNEL` in `libssh2_priv.h` and callers only ever hold a pointer, so no ABI change. `libssh2_channel_get_exit_signal()` already lets a caller see whether that request arrived by leaving the pointer NULL, exit-status was the odd one out

Man page and a `test_exit_status` covering both states are included

Follow-up to 77bd3c121550dfb7c94d37360a49914898f64069
Fixes #2515
