### PR TITLE
session: free keyboard-interactive state

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -839,6 +839,7 @@ static int session_free(LIBSSH2_SESSION *session)
     struct packet *pkg;
     LIBSSH2_CHANNEL *ch;
     LIBSSH2_LISTENER *l;
+    unsigned int i;
     int packets_left = 0;
 
     if(session->free_state == ssh2_NB_state_idle) {
@@ -973,8 +974,23 @@ static int session_free(LIBSSH2_SESSION *session)
         SSH2_FREE(session, session->userauth_kybd_data);
     if(session->userauth_kybd_packet)
         SSH2_FREE(session, session->userauth_kybd_packet);
+    if(session->userauth_kybd_auth_name)
+        SSH2_FREE(session, session->userauth_kybd_auth_name);
     if(session->userauth_kybd_auth_instruction)
         SSH2_FREE(session, session->userauth_kybd_auth_instruction);
+    if(session->userauth_kybd_prompts) {
+        for(i = 0; i < session->userauth_kybd_num_prompts; i++)
+            if(session->userauth_kybd_prompts[i].text)
+                SSH2_FREE(session, session->userauth_kybd_prompts[i].text);
+        SSH2_FREE(session, session->userauth_kybd_prompts);
+    }
+    if(session->userauth_kybd_responses) {
+        for(i = 0; i < session->userauth_kybd_num_prompts; i++)
+            if(session->userauth_kybd_responses[i].text)
+                SSH2_FREE(session,
+                          session->userauth_kybd_responses[i].text);
+        SSH2_FREE(session, session->userauth_kybd_responses);
+    }
     if(session->open_packet)
         SSH2_FREE(session, session->open_packet);
     if(session->open_data)

--- a/tests/test_auth_keyboard_info_request.c
+++ b/tests/test_auth_keyboard_info_request.c
@@ -253,9 +253,11 @@ static int test_case(int num,
         return 1;
     }
 
-    session->userauth_kybd_data = SSH2_ALLOC(session, data_len);
-    session->userauth_kybd_data_len = data_len;
-    memcpy(session->userauth_kybd_data, data, data_len);
+    if(data_len) {
+        session->userauth_kybd_data = SSH2_ALLOC(session, data_len);
+        session->userauth_kybd_data_len = data_len;
+        memcpy(session->userauth_kybd_data, data, data_len);
+    }
 
     rc = userauth_keyboard_interactive_decode_info_request(session);
 


### PR DESCRIPTION
Free keyboard-interactive authentication state when a session is destroyed.

This covers the authentication name, prompt and response arrays, and their individual strings. Avoid calling memcpy() with null pointers for zero-length test input.

Tested with the complete CMake/OpenSSL test suite and the targeted ASan/UBSan test.