### PR TITLE
libssh2.pc: add the Link.ABI, Source and License tags

### DIFF
--- a/libssh2.pc.in
+++ b/libssh2.pc.in
@@ -14,8 +14,10 @@ Name: libssh2
 URL: https://libssh2.org/
 Description: Library for SSH-based communication
 Version: @LIBSSH2_VERSION@
+Source: https://libssh2.org/download/libssh2-@LIBSSH2_VERSION@.tar.gz
 Requires: @LIBSSH2_PC_REQUIRES@
 Requires.private: @LIBSSH2_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} -lssh2 @LIBSSH2_PC_LIBS@
 Libs.private: @LIBSSH2_PC_LIBS_PRIVATE@
 Cflags: -I${includedir}
+Link.ABI: c

--- a/libssh2.pc.in
+++ b/libssh2.pc.in
@@ -13,6 +13,7 @@ includedir=@includedir@
 Name: libssh2
 URL: https://libssh2.org/
 Description: Library for SSH-based communication
+License: BSD-3-Clause
 Version: @LIBSSH2_VERSION@
 Source: https://libssh2.org/download/libssh2-@LIBSSH2_VERSION@.tar.gz
 Requires: @LIBSSH2_PC_REQUIRES@


### PR DESCRIPTION
Link.ABI is a feature of pkgconf 3.0 and indicates the ABI against which
a consumer must link the package. For libssh2, this is hard-coded as C.
Source is a URL from which to download the package tarball. Also
include to SPDX license identifier.

Refs:
https://github.com/curl/curl/commit/3f1c033afe008123680306663cc01279e831ac2d
https://github.com/curl/curl/pull/22519
https://github.com/curl/curl/commit/4d9ba9fef48e43903815e0c0e96f917eaf9f185c
https://github.com/curl/curl/pull/22545
    
Credits-to: Dan Fandrich
