### PR TITLE
openssl: guard zero-length input in ossl_swap_bytes

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -183,6 +183,9 @@ static SSH2_INLINE void ossl_swap_bytes(unsigned char *buf, size_t len)
 {
 #if !defined(WORDS_BIGENDIAN) || !WORDS_BIGENDIAN
     size_t i, j;
+    /* a zero length would underflow len - 1 below into a huge index */
+    if(len < 2)
+        return;
     for(i = 0, j = len - 1; i < j; i++, j--) {
         unsigned char temp = buf[i];
         buf[i] = buf[j];


### PR DESCRIPTION
ossl_swap_bytes() sets j = len - 1 and loops while i < j, so a zero length wraps j to SIZE_MAX and the in-place byte reversal runs off the heap. On OpenSSL 3 builds that len can be zero: ossl_ecdsa_openssh_priv_to_pubkey() takes the private scalar from ssh2_get_bignum_bytes(), which returns a zero length for an empty or all-zero mpint in an OpenSSH key blob, and unlike the ssh2_rsa_new()/ssh2_dsa_new() call sites this one has no length guard. Return early when len < 2, the same way wcng_reverse_bytes() does in the WinCNG backend.