### PR TITLE
src: de-duplicate two byte swap functions into `ssh2_swap_bytes()`

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -218,6 +218,9 @@ SSH2_INLINE void ssh2_swap_bytes(unsigned char *buf, size_t len)
             end--;
         }
     }
+#else
+    (void)buf;
+    (void)len;
 #endif
 }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -208,11 +208,14 @@ SSH2_INLINE void ssh2_swap_bytes(unsigned char *buf, size_t len)
 {
 #if !defined(WORDS_BIGENDIAN) || !WORDS_BIGENDIAN
     if(buf && len >= 2) {
-        size_t i, j;
-        for(i = 0, j = len - 1; i < j; i++, j--) {
-            unsigned char temp = buf[i];
-            buf[i] = buf[j];
-            buf[j] = temp;
+        unsigned char *start = buf;
+        unsigned char *end = buf + len - 1;
+        while(start < end) {
+            unsigned char tmp = *end;
+            *end = *start;
+            *start = tmp;
+            start++;
+            end--;
         }
     }
 #endif

--- a/src/misc.c
+++ b/src/misc.c
@@ -204,6 +204,20 @@ ssize_t ssh2_send(libssh2_socket_t socket,
     return rc;
 }
 
+SSH2_INLINE void ssh2_swap_bytes(unsigned char *buf, size_t len)
+{
+#if !defined(WORDS_BIGENDIAN) || !WORDS_BIGENDIAN
+    if(buf && len >= 2) {
+        size_t i, j;
+        for(i = 0, j = len - 1; i < j; i++, j--) {
+            unsigned char temp = buf[i];
+            buf[i] = buf[j];
+            buf[j] = temp;
+        }
+    }
+#endif
+}
+
 uint32_t ssh2_ntohu32(const unsigned char *buf)
 {
     return

--- a/src/misc.c
+++ b/src/misc.c
@@ -204,7 +204,7 @@ ssize_t ssh2_send(libssh2_socket_t socket,
     return rc;
 }
 
-SSH2_INLINE void ssh2_swap_bytes(unsigned char *buf, size_t len)
+void ssh2_swap_bytes(unsigned char *buf, size_t len)
 {
 #if !defined(WORDS_BIGENDIAN) || !WORDS_BIGENDIAN
     if(buf && len >= 2) {

--- a/src/misc.h
+++ b/src/misc.h
@@ -144,6 +144,7 @@ int ssh2_base64_decode(LIBSSH2_SESSION *session, char **data, size_t *datalen,
 size_t ssh2_base64_encode(LIBSSH2_SESSION *session,
                           const char *inp, size_t insize, char **outptr);
 
+void ssh2_swap_bytes(unsigned char *buf, size_t len);
 uint32_t ssh2_ntohu32(const unsigned char *buf);
 libssh2_uint64_t ssh2_ntohu64(const unsigned char *buf);
 void ssh2_htonu32(unsigned char *buf, uint32_t value);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -178,23 +178,6 @@ static unsigned char *ossl_write_bn(unsigned char *buf,
 }
 #endif
 
-#ifdef USE_OPENSSL_3
-static SSH2_INLINE void ossl_swap_bytes(unsigned char *buf, size_t len)
-{
-#if !defined(WORDS_BIGENDIAN) || !WORDS_BIGENDIAN
-    size_t i, j;
-    /* a zero length would underflow len - 1 below into a huge index */
-    if(len < 2)
-        return;
-    for(i = 0, j = len - 1; i < j; i++, j--) {
-        unsigned char temp = buf[i];
-        buf[i] = buf[j];
-        buf[j] = temp;
-    }
-#endif
-}
-#endif
-
 int ssh2_random(unsigned char *buf, size_t len)
 {
     if(len > INT_MAX)
@@ -239,7 +222,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 
         if(nbuf) {
             memcpy(nbuf, ndata, nlen);
-            ossl_swap_bytes(nbuf, nlen);
+            ssh2_swap_bytes(nbuf, nlen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_N, nbuf, nlen);
         }
@@ -249,7 +232,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
         ebuf = OPENSSL_malloc(elen);
         if(ebuf) {
             memcpy(ebuf, edata, elen);
-            ossl_swap_bytes(ebuf, elen);
+            ssh2_swap_bytes(ebuf, elen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_E, ebuf, elen);
         }
@@ -259,7 +242,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
         dbuf = OPENSSL_malloc(dlen);
         if(dbuf) {
             memcpy(dbuf, ddata, dlen);
-            ossl_swap_bytes(dbuf, dlen);
+            ssh2_swap_bytes(dbuf, dlen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_D, dbuf, dlen);
         }
@@ -463,7 +446,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         p_buf = OPENSSL_malloc(plen);
         if(p_buf) {
             memcpy(p_buf, pdata, plen);
-            ossl_swap_bytes(p_buf, plen);
+            ssh2_swap_bytes(p_buf, plen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_FFC_P, p_buf, plen);
         }
@@ -473,7 +456,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         q_buf = OPENSSL_malloc(qlen);
         if(q_buf) {
             memcpy(q_buf, qdata, qlen);
-            ossl_swap_bytes(q_buf, qlen);
+            ssh2_swap_bytes(q_buf, qlen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_FFC_Q, q_buf, qlen);
         }
@@ -483,7 +466,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         g_buf = OPENSSL_malloc(glen);
         if(g_buf) {
             memcpy(g_buf, gdata, glen);
-            ossl_swap_bytes(g_buf, glen);
+            ssh2_swap_bytes(g_buf, glen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_FFC_G, g_buf, glen);
         }
@@ -493,7 +476,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         y_buf = OPENSSL_malloc(ylen);
         if(y_buf) {
             memcpy(y_buf, ydata, ylen);
-            ossl_swap_bytes(y_buf, ylen);
+            ssh2_swap_bytes(y_buf, ylen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PUB_KEY, y_buf, ylen);
         }
@@ -503,7 +486,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         x_buf = OPENSSL_malloc(xlen);
         if(x_buf) {
             memcpy(x_buf, xdata, xlen);
-            ossl_swap_bytes(x_buf, xlen);
+            ssh2_swap_bytes(x_buf, xlen);
             params[param_num++] =
                 OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PRIV_KEY, x_buf, xlen);
         }
@@ -2614,7 +2597,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         goto fail;
 
     memcpy(group_name, n, strlen(n) + 1);
-    ossl_swap_bytes(exponent, exponent_len);
+    ssh2_swap_bytes(exponent, exponent_len);
 
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
                                                  group_name, 0);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -124,21 +124,6 @@ static void wcng_memcpy_with_be_padding(unsigned char *dest,
     memcpy((dest + dest_len) - src_len, src, src_len);
 }
 
-static void wcng_reverse_bytes(IN PUCHAR buffer, IN size_t buffer_len)
-{
-    if(buffer && buffer_len >= 2) {
-        PUCHAR start = buffer;
-        PUCHAR end = buffer + buffer_len - 1;
-        while(start < end) {
-            unsigned char tmp = *end;
-            *end = *start;
-            *start = tmp;
-            start++;
-            end--;
-        }
-    }
-}
-
 /*******************************************************************/
 /*
  * Windows CNG backend: BigNumber functions
@@ -2188,7 +2173,7 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **k,
      * raw secret, so we need to swap it to big endian order.
      */
 
-    wcng_reverse_bytes((*k)->bignum, secret_len);
+    ssh2_swap_bytes((*k)->bignum, secret_len);
 
     result = LIBSSH2_ERROR_NONE;
 
@@ -3231,7 +3216,7 @@ int ssh2_dh_secret(ssh2_dh_ctx *dhctx, ssh2_bn *secret, ssh2_bn *f,
         /* Counter to all the other data in the BCrypt APIs, the raw secret is
          * returned to us in host byte order, so we need to swap it to big
          * endian order. */
-        wcng_reverse_bytes(secret->bignum, secret->length);
+        ssh2_swap_bytes(secret->bignum, secret->length);
 
         status = 0;
         ssh2_wcng.hasAlgDHwithKDF = 1;


### PR DESCRIPTION
`ossl_swap_bytes()` and `wcng_reverse_bytes()` were functionally 
identical. Merge them into a shared function.

Also:
- fix unused argument warning with `WORDS_BIGENDIAN` defined.
- drop `inline` (previously set for openssl).
