### PR TITLE
os400qc3: check `getASN1Element()` result in `asn1_new_from_bytes()`

### DIFF
--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -650,7 +650,9 @@ static struct asn1Element *asn1_new_from_bytes(const unsigned char *data,
     struct asn1Element *e;
     struct asn1Element et;
 
-    getASN1Element(&et, (unsigned char *)data, (unsigned char *)data + length);
+    if(!getASN1Element(&et, (unsigned char *)data,
+                       (unsigned char *)data + length))
+        return NULL;
     e = asn1_new(et.tag, et.end - et.beg);
 
     if(e)


### PR DESCRIPTION
asn1_new_from_bytes() ignores the return value of getASN1Element(), so a malformed PKCS#1 blob (for example one whose first content byte is 0x00) leaves the local asn1Element uninitialized, and the following asn1_new()/memcpy() sizes the copy from stale stack values and reads past the input buffer. This is reachable when loading an untrusted key through libssh2_userauth_publickey_frommemory()/fromfile(). Bail out when the parse fails, the way every other getASN1Element() caller in the file already does.