### PR TITLE
userauth: fix memory leaks in `libssh2_userauth_publickey_sk`

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -2182,8 +2182,12 @@ int libssh2_userauth_publickey_sk(
                                          libssh2_sign_sk, &sign_abstract);
     }
 
+    if(pubkeydata && pubkeydata != tmp_publickeydata)
+        SSH2_FREE(session, pubkeydata);
     if(tmp_publickeydata)
         SSH2_FREE(session, tmp_publickeydata);
+    if(sk_info.key_handle)
+        SSH2_FREE(session, SSH2_UNCONST(sk_info.key_handle));
     if(sk_info.application)
         SSH2_FREE(session, SSH2_UNCONST(sk_info.application));
 


### PR DESCRIPTION
`libssh2_userauth_publickey_sk()` gets the public key from the sk private key via `ssh2_sk_pubkey()`, and on success that helper returns `sk_info.application` and `sk_info.key_handle` as fresh allocations. The cleanup frees `application` but never `key_handle`, so every successful security-key authentication leaks it. When a caller passes both a private blob and its own `publickeydata`, the `pubkeydata` buffer that `userauth_read_pubkey()` allocates is also lost, since only `tmp_publickeydata` is released.

Free `key_handle` next to `application`, and free `pubkeydata` only when it is not the same pointer as `tmp_publickeydata` so the aliased branch still frees once. Ownership stays with the function that received the buffers, matching how `libssh2_userauth_publickey_fromfile()` and `_frommemory()` already free their `pubkeydata` after `ssh2_userauth_publickey()` returns.

Follow-up to ed439a29bb0b4d1c3f681f87ccfcd3e5a66c3ba0 #698
