### PR TITLE
libgcrypt: guard zero-length datum in `ssh2_dsa_sha1_sign()`

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -532,7 +532,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
     if(!tmp)
         goto err;
 
-    if(tmp[0] == '\0') {
+    if(size && tmp[0] == '\0') {
         tmp++;
         size--;
     }
@@ -554,7 +554,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
     if(!tmp)
         goto err;
 
-    if(tmp[0] == '\0') {
+    if(size && tmp[0] == '\0') {
         tmp++;
         size--;
     }


### PR DESCRIPTION
ssh2_dsa_sha1_sign strips a leading zero from the r and s components returned by gcry_sexp_nth_data before it checks their length, so a zero-length datum makes tmp[0] a one-byte out-of-bounds read and the following size-- wrap to SIZE_MAX. the later size > 20 test does catch the wrapped value before the memcpy, so nothing is written out of bounds, but the stray read is still there. the sibling strippers already avoid this: ssh2_rsa_sha2_sign in this same file guards with `if(size && s[0] == '\0')` and the wincng backend does the same for both halves, so this brings the dsa path in line by testing size first. valid signatures fall in the 1..20 range and are unchanged.