### PR TITLE
openssl: bound EC point length in `ssh2_ecdsa_create_key()`

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2880,6 +2880,11 @@ int ssh2_ecdsa_create_key(ssh2_ec_key **ec_ctx, LIBSSH2_SESSION *session,
     if(ret <= 0)
         goto clean_exit;
 
+    if(octal_len > EC_MAX_POINT_LEN) {
+        ret = -1;
+        goto clean_exit;
+    }
+
     *out_public_key_octal = SSH2_ALLOC(session, octal_len);
     if(!*out_public_key_octal) {
         ret = -1;


### PR DESCRIPTION
The OpenSSL 3 path of ssh2_ecdsa_create_key copies the generated public point into the fixed octal_value[EC_MAX_POINT_LEN] stack buffer, handing the length reported by EVP_PKEY_get_octet_string_param straight back as the destination capacity without checking it against the buffer. Every other point extraction in this file bounds the length against EC_MAX_POINT_LEN first, including the legacy path a few lines below in the same function. Add the same check right after the length is queried so both branches guard the stack write the same way.