### PR TITLE
openssl: fix allocator/free mismatch in `ossl_ecdsa_evp_to_pubkey()` with OpenSSL 3+

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2488,7 +2488,7 @@ static int ossl_ecdsa_evp_to_pubkey(LIBSSH2_SESSION *session, char **method,
         goto clean_exit;
     }
 
-    octal_value = malloc(octal_len);
+    octal_value = SSH2_ALLOC(session, octal_len);
     if(!octal_value) {
         rc = -1;
         goto clean_exit;
@@ -2541,7 +2541,7 @@ clean_exit:
 #endif
 
     if(octal_value)
-        free(octal_value);
+        SSH2_FREE(session, octal_value);
 
     if(rc == 0)
         return 0;


### PR DESCRIPTION
OpenSSL 3+ was allocating with `SSH2_ALLOC()` and freeing with `free()`,
OpenSSL 1.1.1 was OK. Fix by upgrading the OpenSSL 1.1.1 codepath to use
`SSH2_ALLOC()` and free with `SSH2_FREE()`.

Follow-up to b0ab005fe79260e6e9fe08f8d73b58dd4856943d #1207

---

That fixed, I think no libssh2 code should ever be using bare `malloc()`.
Fixing that'd still leave a bunch of backend-API-specific allocators, e.g.
OPENSSL_malloc(), mbedtls_calloc(), maybe more, which were often
mismatched with their free counterpart, maybe some of them still are.
I don't think these should be used unless the API requires it.
