### PR TITLE
src: propagate `session` to replace bare allocators with SSH2 ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -839,6 +839,7 @@ jobs:
           - { build: 'AM', sys: msys   , crypto: openssl, env: x86_64 }
           - { build: 'CM', sys: msys   , crypto: OpenSSL, env: x86_64 }
           - { build: 'AM', sys: mingw64, crypto: wincng , env: x86_64 }
+          - { build: 'CM', sys: mingw64, crypto: wincng , env: x86_64, test: 'legacy-options' }
           - { build: 'AM', sys: mingw64, crypto: openssl, env: x86_64 }
           - { build: 'AM', sys: mingw32, crypto: openssl, env: i686, test: 'legacy-options' }
           - { build: 'AM', sys: ucrt64 , crypto: openssl, env: ucrt-x86_64 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -839,7 +839,7 @@ jobs:
           - { build: 'AM', sys: msys   , crypto: openssl, env: x86_64 }
           - { build: 'CM', sys: msys   , crypto: OpenSSL, env: x86_64 }
           - { build: 'AM', sys: mingw64, crypto: wincng , env: x86_64 }
-          - { build: 'CM', sys: mingw64, crypto: wincng , env: x86_64, test: 'legacy-options' }
+          - { build: 'CM', sys: mingw64, crypto: WinCNG , env: x86_64, test: 'legacy-options' }
           - { build: 'AM', sys: mingw64, crypto: openssl, env: x86_64 }
           - { build: 'AM', sys: mingw32, crypto: openssl, env: i686, test: 'legacy-options' }
           - { build: 'AM', sys: ucrt64 , crypto: openssl, env: ucrt-x86_64 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1014,7 +1014,12 @@ jobs:
             ldflags+=' -OPT:NOREF -OPT:NOICF -APPCONTAINER:NO'
             vsglobals=';AppxPackage=false;WindowsAppContainer=false'
           fi
-          [ "${MATRIX_CRYPTO}" = 'WinCNG' ] && options+=" -DENABLE_ECDSA_WINCNG=${MATRIX_WINCND_ECDSA}"
+          if [ "${MATRIX_CRYPTO}" = 'WinCNG' ]; then
+            options+=" -DENABLE_ECDSA_WINCNG=${MATRIX_WINCND_ECDSA}"
+            cflags+=' -DLIBSSH2_KEX_SHA1_ENABLE -DLIBSSH2_MD5_ENABLE -DLIBSSH2_MD5_PEM_ENABLE -DLIBSSH2_HMAC_SHA1_ENABLE'
+            cflags+=' -DLIBSSH2_RSA_SHA1_ENABLE -DLIBSSH2_BLOWFISH_ENABLE -DLIBSSH2_RC4_ENABLE -DLIBSSH2_3DES_ENABLE'
+            cflags+=' -DLIBSSH2_DSA_ENABLE'
+          fi
           cmake -B bld ${options} \
             -DCMAKE_C_FLAGS="${cflags}" \
             -DCMAKE_EXE_LINKER_FLAGS="${ldflags}" \

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -608,7 +608,7 @@ Returns 0 if OK, else -1.
 This procedure is already prototyped in `crypto.h`.
 
 ```c
-int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len);
 ```

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -478,9 +478,8 @@ Return 0 if OK, else -1.
 This procedure is already prototyped in `crypto.h`.
 
 ```c
-int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
-                         const unsigned char *sig,
-                         size_t sig_len,
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
+                         const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len);
 ```
 Verify (`sig`, `sig_len`) signature of (`m`, `m_len`) using an SHA-1 hash and
@@ -558,7 +557,7 @@ Returns 0 if OK, else -1.
 Note: this procedure is optional: if provided, it MUST be defined as a macro.
 
 ```c
-int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa,
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          size_t hash_len,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len);
@@ -619,7 +618,7 @@ Returns 0 if OK, else -1.
 This procedure is already prototyped in `crypto.h`.
 
 ```c
-int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash,
                        size_t hash_len, unsigned char *sig);
 ```
@@ -712,7 +711,7 @@ Returns 0 if OK, else -1.
 This procedure is already prototyped in `crypto.h`.
 
 ```c
-int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
+int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                       const unsigned char *r, size_t r_len,
                       const unsigned char *s, size_t s_len,
                       const unsigned char *m, size_t m_len);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -175,7 +175,7 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
 int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash, size_t hash_len,
                        unsigned char *signature);
-int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len);
 #ifndef ssh2_dsa_free

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -189,7 +189,8 @@ void ssh2_dsa_free(ssh2_dsa_ctx *dsa);
  */
 #define EC_MAX_POINT_LEN ((((521 + 7) / 8) * 2) + 1)
 
-int ssh2_ecdh_gen_k(ssh2_bn **k, ssh2_ec_key *private_key,
+int ssh2_ecdh_gen_k(ssh2_bn **k, LIBSSH2_SESSION *session,
+                    ssh2_ec_key *private_key,
                     const unsigned char *server_public_key,
                     size_t server_public_key_len);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -142,7 +142,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 int ssh2_rsa_sha1_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash, size_t hash_len,
                        unsigned char **signature, size_t *signature_len);
-int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len);
 #endif
@@ -150,7 +150,8 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
 int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash, size_t hash_len,
                        unsigned char **signature, size_t *signature_len);
-int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
+                         size_t hash_len,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len);
 #endif
@@ -171,7 +172,7 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
                       const char *filename,
                       const char *blob, size_t blob_len,
                       const char *passphrase);
-int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash, size_t hash_len,
                        unsigned char *signature);
 int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
@@ -213,7 +214,7 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
 int ssh2_ecdsa_sign(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                     const unsigned char *hash, size_t hash_len,
                     unsigned char **signature, size_t *signature_len);
-int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
+int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                       const unsigned char *r, size_t r_len,
                       const unsigned char *s, size_t s_len,
                       const unsigned char *m, size_t m_len);

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -146,7 +146,6 @@ static int hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION *session,
                                              size_t m_len, void **abstract)
 {
     ssh2_rsa_ctx *rsa = (ssh2_rsa_ctx *)(*abstract);
-    (void)session;
 
     /* Skip past keyname_len(4) + keyname(7){"ssh-rsa"} + signature_len(4) */
     if(sig_len <= 15)
@@ -154,7 +153,7 @@ static int hostkey_method_ssh_rsa_sig_verify(LIBSSH2_SESSION *session,
 
     sig += 15;
     sig_len -= 15;
-    return ssh2_rsa_sha1_verify(rsa, sig, sig_len, m, m_len);
+    return ssh2_rsa_sha1_verify(rsa, session, sig, sig_len, m, m_len);
 }
 
 /*
@@ -208,7 +207,6 @@ static int hostkey_method_ssh_rsa_sha2_256_sig_verify(
     size_t m_len, void **abstract)
 {
     ssh2_rsa_ctx *rsa = (ssh2_rsa_ctx *)(*abstract);
-    (void)session;
 
     /* Skip past keyname_len(4) + keyname(12){"rsa-sha2-256"} +
        signature_len(4) */
@@ -217,8 +215,8 @@ static int hostkey_method_ssh_rsa_sha2_256_sig_verify(
 
     sig += 20;
     sig_len -= 20;
-    return ssh2_rsa_sha2_verify(rsa, SSH2_SHA256_DIG_LEN, sig, sig_len,
-                                m, m_len);
+    return ssh2_rsa_sha2_verify(rsa, session, SSH2_SHA256_DIG_LEN,
+                                sig, sig_len, m, m_len);
 }
 
 /*
@@ -279,8 +277,8 @@ static int hostkey_method_ssh_rsa_sha2_512_sig_verify(
 
     sig += 20;
     sig_len -= 20;
-    return ssh2_rsa_sha2_verify(rsa, SSH2_SHA512_DIG_LEN, sig, sig_len,
-                                m, m_len);
+    return ssh2_rsa_sha2_verify(rsa, session, SSH2_SHA512_DIG_LEN,
+                                sig, sig_len, m, m_len);
 }
 
 /*
@@ -540,7 +538,7 @@ static int hostkey_method_ssh_dss_signv(LIBSSH2_SESSION *session,
     if(!ssh2_hash_final(&ctx, hash, sizeof(hash)))
         goto cleanup;
 
-    if(ssh2_dsa_sha1_sign(dsa, hash, SSH2_SHA1_DIG_LEN, *signature))
+    if(ssh2_dsa_sha1_sign(dsa, session, hash, SSH2_SHA1_DIG_LEN, *signature))
         goto cleanup;
 
     return 0;
@@ -703,8 +701,6 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
     struct string_buf buf;
     ssh2_ecdsa_ctx *ec_ctx = (ssh2_ecdsa_ctx *)(*abstract);
 
-    (void)session;
-
     if(sig_len < 35)
         return -1;
 
@@ -726,7 +722,7 @@ static int hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION *session,
     if(ssh2_get_string(&buf, &s, &s_len))
         return -1;
 
-    return ssh2_ecdsa_verify(ec_ctx, r, r_len, s, s_len, m, m_len);
+    return ssh2_ecdsa_verify(ec_ctx, session, r, r_len, s, s_len, m, m_len);
 }
 
 /*

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -502,7 +502,7 @@ static int hostkey_method_ssh_dss_sig_verify(LIBSSH2_SESSION *session,
 
     sig += 15;
 
-    return ssh2_dsa_sha1_verify(dsa, sig, m, m_len);
+    return ssh2_dsa_sha1_verify(dsa, session, sig, m, m_len);
 }
 
 /*

--- a/src/kex.c
+++ b/src/kex.c
@@ -1651,7 +1651,7 @@ static int kex_ecdh_sha2_nistp(LIBSSH2_SESSION *session, ssh2_curve_type curve,
         }
 
         /* Compute the shared secret K */
-        rc = ssh2_ecdh_gen_k(&exchange_state->k, private_key,
+        rc = ssh2_ecdh_gen_k(&exchange_state->k, session, private_key,
                              server_public_key, server_public_key_len);
         if(rc) {
             ret = ssh2_err(session, LIBSSH2_ERROR_KEX_FAILURE,
@@ -1995,7 +1995,7 @@ static int kex_mlkem_nistp(LIBSSH2_SESSION *session,
         ssh2_htonu32(exchange_state->k_value, (uint32_t)digest_len);
 
         /* Compute the ecdh shared secret K */
-        rc = ssh2_ecdh_gen_k(&exchange_state->k, private_t_key,
+        rc = ssh2_ecdh_gen_k(&exchange_state->k, session, private_t_key,
                              server_public_key + mlkem_cipher_len,
                              server_public_key_len - mlkem_cipher_len);
         if(rc) {

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -578,13 +578,15 @@ out:
     return ret;
 }
 
-int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len)
 {
     unsigned char hash[SSH2_SHA1_DIG_LEN + 1];
     gcry_sexp_t s_sig, s_hash;
     int rc = -1;
+
+    (void)session;
 
     gcry_md_hash_buffer(GCRY_MD_SHA1, hash + 1, m, m_len);
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -132,7 +132,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     return 0;
 }
 
-int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa,
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          size_t hash_len,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
@@ -143,7 +143,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa,
     gcry_sexp_t s_hash = NULL;
     gcry_sexp_t s_sig = NULL;
 
-    hash = malloc(hash_len);
+    hash = SSH2_ALLOC(session, hash_len);
     if(!hash)
         return -1;
 
@@ -190,18 +190,18 @@ out:
     if(s_hash)
         gcry_sexp_release(s_hash);
     if(hash)
-        free(hash);
+        SSH2_FREE(session, hash);
 
     return ret;
 }
 
 #if LIBSSH2_RSA_SHA1
-int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsa, SSH2_SHA1_DIG_LEN, sig, sig_len, m,
-                                m_len);
+    return ssh2_rsa_sha2_verify(rsa, session, SSH2_SHA1_DIG_LEN,
+                                sig, sig_len, m, m_len);
 }
 #endif
 #endif
@@ -492,7 +492,7 @@ int ssh2_rsa_sha1_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 #endif
 
 #if LIBSSH2_DSA
-int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash, size_t hash_len,
                        unsigned char *signature)
 {
@@ -502,6 +502,8 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
     int ret;
     const char *tmp;
     size_t size;
+
+    (void)session;
 
     if(hash_len != SSH2_SHA1_DIG_LEN)
         return -1;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -983,13 +983,15 @@ failed:
  * Computes the shared secret K given a local private key,
  * remote public key and length
  */
-int ssh2_ecdh_gen_k(ssh2_bn **k,
+int ssh2_ecdh_gen_k(ssh2_bn **k, LIBSSH2_SESSION *session,
                     ssh2_ec_key *private_key,
                     const unsigned char *server_public_key,
                     size_t server_public_key_len)
 {
     mbedtls_ecp_point pubkey;
     int rc = 0;
+
+    (void)session;
 
     if(!*k)
         return -1;

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -576,12 +576,12 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
         md_type = MBEDTLS_MD_SHA512;
     }
     else {
-        free(hash);
+        SSH2_FREE(session, hash);
         return -1; /* unsupported digest */
     }
 
     if(ret) {
-        free(hash);
+        SSH2_FREE(session, hash);
         return -1; /* failure */
     }
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -543,7 +543,8 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 }
 
 #if LIBSSH2_RSA_SHA2
-int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
+                         size_t hash_len,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
@@ -555,7 +556,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
     if(sig_len < mbedtls_rsa_get_len(rsa))
         return -1;
 
-    hash = malloc(hash_len);
+    hash = SSH2_ALLOC(session, hash_len);
     if(!hash)
         return -1;
 
@@ -587,7 +588,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
     ret = mbedtls_rsa_pkcs1_verify(rsa,
                                    md_type, (unsigned int)hash_len,
                                    hash, sig);
-    free(hash);
+    SSH2_FREE(session, hash);
 
     return ret == 0 ? 0 : -1;
 }
@@ -637,11 +638,11 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 #endif
 
 #if LIBSSH2_RSA_SHA1
-int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsa, SSH2_SHA1_DIG_LEN,
+    return ssh2_rsa_sha2_verify(rsa, session, SSH2_SHA1_DIG_LEN,
                                 sig, sig_len, m, m_len);
 }
 
@@ -1024,7 +1025,7 @@ cleanup:
 /*
  * Verifies the ECDSA signature of a hashed message
  */
-int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
+int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                       const unsigned char *r, size_t r_len,
                       const unsigned char *s, size_t s_len,
                       const unsigned char *m, size_t m_len)
@@ -1032,6 +1033,8 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     mbedtls_mpi pr, ps;
     size_t actual_len;
     int rc = -1;
+
+    (void)session;
 
     mbedtls_mpi_init(&pr);
     mbedtls_mpi_init(&ps);

--- a/src/misc.c
+++ b/src/misc.c
@@ -801,6 +801,17 @@ void ssh2_explicit_zero(void *buf, size_t size)
 }
 #endif
 
+void ssh2_zero_free(LIBSSH2_SESSION *session, void *buf, size_t len)
+{
+    if(!buf)
+        return;
+
+    if(len)
+        ssh2_explicit_zero(buf, len);
+
+    SSH2_FREE(session, buf);
+}
+
 /* String buffer */
 
 struct string_buf *ssh2_string_buf_new(LIBSSH2_SESSION *session)

--- a/src/misc.h
+++ b/src/misc.h
@@ -89,6 +89,8 @@ int ssh2_snprintf(char *buf, size_t buf_len, const char *fmt, ...)
 void ssh2_explicit_zero(void *buf, size_t size);
 #endif
 
+void ssh2_zero_free(LIBSSH2_SESSION *session, void *buf, size_t len);
+
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <sys/time.h>  /* for timeval, gettimeofday() */
 #endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -342,7 +342,8 @@ fail:
 #endif /* USE_OPENSSL_3 */
 }
 
-int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
+                         size_t hash_len,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
@@ -352,7 +353,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
 #endif
     int ret;
     int nid_type;
-    unsigned char *hash = malloc(hash_len);
+    unsigned char *hash = SSH2_ALLOC(session, hash_len);
     if(!hash)
         return -1;
 
@@ -406,18 +407,18 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
                      sig, (unsigned int)sig_len, rsa);
 #endif
 
-    free(hash);
+    SSH2_FREE(session, hash);
 
     return ret == 1 ? 0 : -1;
 }
 
 #if LIBSSH2_RSA_SHA1
-int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsa, SSH2_SHA1_DIG_LEN, sig, sig_len, m,
-                                m_len);
+    return ssh2_rsa_sha2_verify(rsa, session, SSH2_SHA1_DIG_LEN,
+                                sig, sig_len, m, m_len);
 }
 #endif
 #endif /* LIBSSH2_RSA */
@@ -748,7 +749,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     return ret == 1 ? 0 : -1;
 }
 
-int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
+int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                       const unsigned char *r, size_t r_len,
                       const unsigned char *s, size_t s_len,
                       const unsigned char *m, size_t m_len)
@@ -767,6 +768,8 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx,
     ECDSA_SIG *ecdsa_sig;
     BIGNUM *pr;
     BIGNUM *ps;
+
+    (void)session;
 
     pr = BN_new();
     if(!pr)
@@ -2236,7 +2239,7 @@ int ssh2_rsa_sha1_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 #endif
 
 #if LIBSSH2_DSA
-int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash, size_t hash_len,
                        unsigned char *signature)
 {
@@ -2274,6 +2277,8 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
 #endif
     if(!sig)
         return -1;
+
+    (void)session;
 
     DSA_SIG_get0(sig, &r, &s);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2980,7 +2980,8 @@ clean_exit:
  * Computes the shared secret K given a local private key,
  * remote public key and length
  */
-int ssh2_ecdh_gen_k(ssh2_bn **k, ssh2_ec_key *private_key,
+int ssh2_ecdh_gen_k(ssh2_bn **k, LIBSSH2_SESSION *session,
+                    ssh2_ec_key *private_key,
                     const unsigned char *server_public_key,
                     size_t server_public_key_len)
 {
@@ -2997,6 +2998,8 @@ int ssh2_ecdh_gen_k(ssh2_bn **k, ssh2_ec_key *private_key,
     OSSL_PARAM params[3];
 
     size_t out_len = 0;
+
+    (void)session;
 
     if(!k || !*k || server_public_key_len <= 0)
         return -1;
@@ -3104,7 +3107,7 @@ int ssh2_ecdh_gen_k(ssh2_bn **k, ssh2_ec_key *private_key,
     }
 
     secret_size = (EC_GROUP_get_degree(private_key_group) + 7) / 8;
-    secret = malloc(secret_size);
+    secret = SSH2_ALLOC(session, secret_size);
     if(!secret) {
         ret = -1;
         goto clean_exit;
@@ -3139,7 +3142,7 @@ clean_exit:
 
     if(secret) {
         ssh2_explicit_zero(secret, secret_size);
-        free(secret);
+        SSH2_FREE(session, secret);
     }
 #endif
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -375,7 +375,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     }
 
     if(!ret) {
-        free(hash);
+        SSH2_FREE(session, hash);
         return -1; /* failure */
     }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2362,7 +2362,7 @@ int ssh2_ecdsa_sign(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
     r_len = BN_num_bytes(pr) + 1;
     s_len = BN_num_bytes(ps) + 1;
 
-    temp_buffer = malloc(r_len + s_len + 8);
+    temp_buffer = SSH2_ALLOC(session, r_len + s_len + 8);
     if(!temp_buffer) {
         rc = -1;
         goto clean_exit;
@@ -2388,7 +2388,7 @@ int ssh2_ecdsa_sign(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
 clean_exit:
 
     if(temp_buffer)
-        free(temp_buffer);
+        SSH2_FREE(session, temp_buffer);
 
     if(sig)
         ECDSA_SIG_free(sig);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -569,7 +569,7 @@ fail:
 #endif /* USE_OPENSSL_3 */
 }
 
-int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len)
 {
@@ -584,6 +584,8 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
     DSA_SIG *dsasig;
     BIGNUM *r;
     BIGNUM *s;
+
+    (void)session;
 
     r = BN_new();
     if(!r)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3140,10 +3140,8 @@ clean_exit:
     if(bn_ctx)
         BN_CTX_free(bn_ctx);
 
-    if(secret) {
-        ssh2_explicit_zero(secret, secret_size);
-        SSH2_FREE(session, secret);
-    }
+    if(secret)
+        ssh2_zero_free(session, secret, secret_size);
 #endif
 
 #ifdef USE_OPENSSL_3

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2400,7 +2400,8 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 }
 
 #if LIBSSH2_RSA_SHA2
-int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
+                         size_t hash_len,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
@@ -2408,6 +2409,8 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
     Qc3_Format_ALGD0400_T algd;
     int slen = (int)sig_len;
     int mlen = (int)m_len;
+
+    (void)session;
 
     memset(&algd, 0, sizeof(algd));
     algd.Public_Key_Alg = Qc3_RSA;
@@ -2435,11 +2438,11 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
 }
 #endif
 #if LIBSSH2_RSA_SHA1
-int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return ssh2_rsa_sha2_verify(rsa, SSH2_SHA1_DIG_LEN,
+    return ssh2_rsa_sha2_verify(rsa, session, SSH2_SHA1_DIG_LEN,
                                 sig, sig_len, m, m_len);
 }
 #endif

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1344,7 +1344,7 @@ static int wcng_rsa_sha_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     }
 
     datalen = (ULONG)hash_len;
-    data = malloc(datalen);
+    data = SSH2_ALLOC(session, datalen);
     if(!data)
         return -1;
     memcpy(data, hash, datalen);
@@ -1370,7 +1370,9 @@ static int wcng_rsa_sha_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
             ret = (NTSTATUS)STATUS_NO_MEMORY;
     }
 
-    wcng_zero_free(data, datalen);
+    if(datalen)
+        ssh2_explicit_zero(data, datalen);
+    SSH2_FREE(session, data);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2501,7 +2501,7 @@ int ssh2_ecdsa_sign(IN ssh2_ecdsa_ctx *ec_ctx,
     *signature_len = 0;
 
     /* CNG expects a mutable buffer */
-    hash_buffer = malloc(hash_len);
+    hash_buffer = SSH2_ALLOC(session, hash_len);
     if(!hash_buffer) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2523,7 +2523,7 @@ int ssh2_ecdsa_sign(IN ssh2_ecdsa_ctx *ec_ctx,
         goto cleanup;
     }
 
-    cng_signature = malloc(cng_signature_len);
+    cng_signature = SSH2_ALLOC(session, cng_signature_len);
     if(!cng_signature) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2579,9 +2579,9 @@ cleanup:
     }
 
     if(cng_signature)
-        free(cng_signature);
+        SSH2_FEEE(session, cng_signature);
     if(hash_buffer)
-        free(hash_buffer);
+        SSH2_FREE(session, hash_buffer);
 
     return result;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -808,7 +808,9 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
  */
 
 #if LIBSSH2_RSA || LIBSSH2_DSA
-static int wcng_key_sha_verify(struct wcng_key_ctx *ctx, ULONG hash_len,
+static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
+                               LIBSSH2_SESSION *session,
+                               ULONG hash_len,
                                const unsigned char *sig, ULONG sig_len,
                                const unsigned char *m, ULONG m_len,
                                ULONG flags)
@@ -840,28 +842,36 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx, ULONG hash_len,
         return -1;
 
     datalen = m_len;
-    data = malloc(datalen);
+    data = SSH2_ALLOC(session, datalen);
     if(!data)
         return -1;
 
-    hash = malloc(hash_len);
+    hash = SSH2_ALLOC(session, hash_len);
     if(!hash) {
-        free(data);
+        SSH2_FREE(session, data);
         return -1;
     }
     memcpy(data, m, datalen);
 
     ret = ssh2_hash(hash_alg, data, datalen, hash, hash_len);
-    wcng_zero_free(data, datalen);
+
+    if(datalen)
+         ssh2_explicit_zero(data, datalen);
+    SSH2_SAFEFREE(session, data);
+
     if(!ret) {
-        wcng_zero_free(hash, hash_len);
+        if(hash_len)
+             ssh2_explicit_zero(hash, hash_len);
+        SSH2_FREE(session, hash);
         return -1;
     }
 
     datalen = sig_len;
-    data = malloc(datalen);
+    data = SSH2_ALLOC(session, datalen);
     if(!data) {
-        wcng_zero_free(hash, hash_len);
+        if(hash_len)
+             ssh2_explicit_zero(hash, hash_len);
+        SSH2_FREE(session, hash);
         return -1;
     }
 
@@ -875,8 +885,13 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx, ULONG hash_len,
     ret = BCryptVerifySignature(ctx->hKey, pPaddingInfo,
                                 hash, hash_len, data, datalen, flags);
 
-    wcng_zero_free(hash, hash_len);
-    wcng_zero_free(data, datalen);
+    if(hash_len)
+         ssh2_explicit_zero(hash, hash_len);
+    SSH2_FREE(session, hash);
+
+    if(datalen)
+         ssh2_explicit_zero(data, datalen);
+    SSH2_FREE(session, data);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
@@ -1282,22 +1297,23 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 }
 
 #if LIBSSH2_RSA_SHA1
-int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa,
+int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return wcng_key_sha_verify(rsa, SSH2_SHA1_DIG_LEN,
+    return wcng_key_sha_verify(rsa, session, SSH2_SHA1_DIG_LEN,
                                sig, (ULONG)sig_len,
                                m, (ULONG)m_len,
                                BCRYPT_PAD_PKCS1);
 }
 #endif
 #if LIBSSH2_RSA_SHA2
-int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, size_t hash_len,
+int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
+                         size_t hash_len,
                          const unsigned char *sig, size_t sig_len,
                          const unsigned char *m, size_t m_len)
 {
-    return wcng_key_sha_verify(rsa, (ULONG)hash_len,
+    return wcng_key_sha_verify(rsa, session, (ULONG)hash_len,
                                sig, (ULONG)sig_len,
                                m, (ULONG)m_len,
                                BCRYPT_PAD_PKCS1);
@@ -1558,7 +1574,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
                                40, m, (ULONG)m_len, 0);
 }
 
-int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                        const unsigned char *hash, size_t hash_len,
                        unsigned char *signature)
 {
@@ -1567,7 +1583,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
     NTSTATUS ret;
 
     datalen = (ULONG)hash_len;
-    data = malloc(datalen);
+    data = SSH2_ALLOC(session, datalen);
     if(!data)
         return -1;
 
@@ -1594,7 +1610,9 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa,
             ret = (NTSTATUS)STATUS_INVALID_PARAMETER;
     }
 
-    wcng_zero_free(data, datalen);
+    if(len > 0)
+        ssh2_explicit_zero(data, datalen);
+    SSH2_FREE(session, data);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
@@ -1660,7 +1678,8 @@ static int wcng_ecdsa_decode_uncompressed_point(
  * The IEEE P-1363 format is defined as r || s,
  * where r and s are of the same length.
  */
-static int wcng_p1363signature_from_point(IN const unsigned char *r,
+static int wcng_p1363signature_from_point(IN LIBSSH2_SESSION *session,
+                                          IN const unsigned char *r,
                                           IN size_t r_len,
                                           IN const unsigned char *s,
                                           IN size_t s_len,
@@ -1701,7 +1720,7 @@ static int wcng_p1363signature_from_point(IN const unsigned char *r,
         return LIBSSH2_ERROR_INVAL;
 
     /* Concatenate into zero-filled buffer and zero-pad if necessary */
-    *signature = calloc(1, *signature_length);
+    *signature = SSH2_CALLOC(session, *signature_length);
     if(!*signature)
         return LIBSSH2_ERROR_ALLOC;
 
@@ -2214,7 +2233,7 @@ static int wcng_ecdsa_curve_type_from_name(IN const char *name,
 /*
  * Verifies the ECDSA signature of a hashed message
  */
-int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
+int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                       IN const unsigned char *r, IN size_t r_len,
                       IN const unsigned char *s, IN size_t s_len,
                       IN const unsigned char *m, IN size_t m_len)
@@ -2229,7 +2248,7 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
     ssh2_hash_alg hash_alg;
 
     /* CNG expects signatures in IEEE P-1363 format. */
-    result = wcng_p1363signature_from_point(
+    result = wcng_p1363signature_from_point(session,
         r, r_len,
         s, s_len,
         ssh2_ecdsa_get_curve_type(ec_ctx),
@@ -2260,7 +2279,7 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
         goto cleanup;
     }
 
-    hash = malloc(hash_len);
+    hash = SSH2_ALLOC(session, hash_len);
     if(!hash) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2293,10 +2312,10 @@ int ssh2_ecdsa_verify(IN ssh2_ecdsa_ctx *ec_ctx,
 
 cleanup:
     if(hash)
-        free(hash);
+        SSH2_FREE(session, hash);
 
     if(signature_p1363)
-        free(signature_p1363);
+        SSH2_FREE(session, signature_p1363);
 
     return result;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1566,12 +1566,12 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
     return wcng_dsa_new_private_parse(dsa, session, pbEncoded, cbEncoded);
 }
 
-int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa,
+int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len)
 {
-    return wcng_key_sha_verify(dsa, SSH2_SHA1_DIG_LEN, sig,
-                               40, m, (ULONG)m_len, 0);
+    return wcng_key_sha_verify(dsa, session, SSH2_SHA1_DIG_LEN,
+                               sig, 40, m, (ULONG)m_len, 0);
 }
 
 int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
@@ -1610,7 +1610,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
             ret = (NTSTATUS)STATUS_INVALID_PARAMETER;
     }
 
-    if(len > 0)
+    if(datalen)
         ssh2_explicit_zero(data, datalen);
     SSH2_FREE(session, data);
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2102,7 +2102,7 @@ cleanup:
  * Computes the shared secret K given a local private key,
  * remote public key and length
  */
-int ssh2_ecdh_gen_k(OUT ssh2_bn **k,
+int ssh2_ecdh_gen_k(OUT ssh2_bn **k, LIBSSH2_SESSION *session,
                     IN ssh2_ecdsa_ctx *private_key,
                     IN const unsigned char *server_public_key,
                     IN size_t server_public_key_len)
@@ -2114,6 +2114,8 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **k,
     BCRYPT_SECRET_HANDLE agreed_secret_handle = NULL;
     ULONG secret_len;
     struct ecdsa_point server_publickey;
+
+    (void)session;
 
     /* Validate parameters */
     if(!k)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -854,24 +854,16 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
     memcpy(data, m, datalen);
 
     ret = ssh2_hash(hash_alg, data, datalen, hash, hash_len);
-
-    if(datalen)
-        ssh2_explicit_zero(data, datalen);
-    SSH2_SAFEFREE(session, data);
-
+    ssh2_zero_free(session, data, datalen);
     if(!ret) {
-        if(hash_len)
-            ssh2_explicit_zero(hash, hash_len);
-        SSH2_FREE(session, hash);
+        ssh2_zero_free(session, hash, hash_len);
         return -1;
     }
 
     datalen = sig_len;
     data = SSH2_ALLOC(session, datalen);
     if(!data) {
-        if(hash_len)
-            ssh2_explicit_zero(hash, hash_len);
-        SSH2_FREE(session, hash);
+        ssh2_zero_free(session, hash, hash_len);
         return -1;
     }
 
@@ -885,13 +877,8 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
     ret = BCryptVerifySignature(ctx->hKey, pPaddingInfo,
                                 hash, hash_len, data, datalen, flags);
 
-    if(hash_len)
-        ssh2_explicit_zero(hash, hash_len);
-    SSH2_FREE(session, hash);
-
-    if(datalen)
-        ssh2_explicit_zero(data, datalen);
-    SSH2_FREE(session, data);
+    ssh2_zero_free(session, hash, hash_len);
+    ssh2_zero_free(session, data, datalen);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
@@ -1370,9 +1357,7 @@ static int wcng_rsa_sha_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
             ret = (NTSTATUS)STATUS_NO_MEMORY;
     }
 
-    if(datalen)
-        ssh2_explicit_zero(data, datalen);
-    SSH2_FREE(session, data);
+    ssh2_zero_free(session, data, datalen);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
@@ -1603,9 +1588,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                 if(BCRYPT_SUCCESS(ret))
                     memcpy(signature, sig, siglen);
 
-                if(siglen)
-                    ssh2_explicit_zero(sig, siglen);
-                SSH2_FREE(session, sig);
+                ssh2_zero_free(session, sig, siglen);
             }
             else
                 ret = (NTSTATUS)STATUS_NO_MEMORY;
@@ -1614,9 +1597,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
             ret = (NTSTATUS)STATUS_INVALID_PARAMETER;
     }
 
-    if(datalen)
-        ssh2_explicit_zero(data, datalen);
-    SSH2_FREE(session, data);
+    ssh2_zero_free(session, data, datalen);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -856,12 +856,12 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
     ret = ssh2_hash(hash_alg, data, datalen, hash, hash_len);
 
     if(datalen)
-         ssh2_explicit_zero(data, datalen);
+        ssh2_explicit_zero(data, datalen);
     SSH2_SAFEFREE(session, data);
 
     if(!ret) {
         if(hash_len)
-             ssh2_explicit_zero(hash, hash_len);
+            ssh2_explicit_zero(hash, hash_len);
         SSH2_FREE(session, hash);
         return -1;
     }
@@ -870,7 +870,7 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
     data = SSH2_ALLOC(session, datalen);
     if(!data) {
         if(hash_len)
-             ssh2_explicit_zero(hash, hash_len);
+            ssh2_explicit_zero(hash, hash_len);
         SSH2_FREE(session, hash);
         return -1;
     }
@@ -886,11 +886,11 @@ static int wcng_key_sha_verify(struct wcng_key_ctx *ctx,
                                 hash, hash_len, data, datalen, flags);
 
     if(hash_len)
-         ssh2_explicit_zero(hash, hash_len);
+        ssh2_explicit_zero(hash, hash_len);
     SSH2_FREE(session, hash);
 
     if(datalen)
-         ssh2_explicit_zero(data, datalen);
+        ssh2_explicit_zero(data, datalen);
     SSH2_FREE(session, data);
 
     return BCRYPT_SUCCESS(ret) ? 0 : -1;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1594,14 +1594,16 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
     if(BCRYPT_SUCCESS(ret)) {
         siglen = cbData;
         if(siglen == 40) {
-            sig = malloc(siglen);
+            sig = SSH2_ALLOC(session, siglen);
             if(sig) {
                 ret = BCryptSignHash(dsa->hKey, NULL, data, datalen,
                                      sig, siglen, &cbData, 0);
                 if(BCRYPT_SUCCESS(ret))
                     memcpy(signature, sig, siglen);
 
-                wcng_zero_free(sig, siglen);
+                if(siglen)
+                    ssh2_explicit_zero(sig, siglen);
+                SSH2_FREE(session, sig);
             }
             else
                 ret = (NTSTATUS)STATUS_NO_MEMORY;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2560,7 +2560,7 @@ cleanup:
     }
 
     if(cng_signature)
-        SSH2_FEEE(session, cng_signature);
+        SSH2_FREE(session, cng_signature);
     if(hash_buffer)
         SSH2_FREE(session, hash_buffer);
 


### PR DESCRIPTION
Also:
- GHA: build test WinCNG with legacy options enabled with both mingw-w64 
  and MSVC.
- add `ssh2_zero_free()` to clear memory and free using `SSH2_FREE()`.
- openssl, wincng: use `ssh2_zero_free()`. 
- replace bare allocators with SSH2 ones in places where `session` was
  already available.
