### PR TITLE
openssl: clear local secret before free in `ssh2_ecdh_gen_k()` with OpenSSL 1.1.1

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3071,7 +3071,7 @@ int ssh2_ecdh_gen_k(ssh2_bn **k, ssh2_ec_key *private_key,
 #else
     int rc = -1;
     unsigned char *secret = NULL;
-    size_t secret_size;
+    size_t secret_size = 0;
     int secret_len;
     const EC_GROUP *private_key_group;
     EC_POINT *server_public_key_point;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3070,8 +3070,9 @@ int ssh2_ecdh_gen_k(ssh2_bn **k, ssh2_ec_key *private_key,
         ret = -1;
 #else
     int rc = -1;
-    size_t secret_len;
     unsigned char *secret = NULL;
+    size_t secret_size;
+    int secret_len;
     const EC_GROUP *private_key_group;
     EC_POINT *server_public_key_point;
 
@@ -3095,21 +3096,21 @@ int ssh2_ecdh_gen_k(ssh2_bn **k, ssh2_ec_key *private_key,
         goto clean_exit;
     }
 
-    secret_len = (EC_GROUP_get_degree(private_key_group) + 7) / 8;
-    secret = malloc(secret_len);
+    secret_size = (EC_GROUP_get_degree(private_key_group) + 7) / 8;
+    secret = malloc(secret_size);
     if(!secret) {
         ret = -1;
         goto clean_exit;
     }
 
-    secret_len = ECDH_compute_key(secret, secret_len, server_public_key_point,
+    secret_len = ECDH_compute_key(secret, secret_size, server_public_key_point,
                                   private_key, NULL);
     if(secret_len <= 0 || secret_len > EC_MAX_POINT_LEN) {
         ret = -1;
         goto clean_exit;
     }
 
-    BN_bin2bn(secret, (int)secret_len, *k);
+    BN_bin2bn(secret, secret_len, *k);
 #endif
 
 clean_exit:
@@ -3130,7 +3131,7 @@ clean_exit:
         BN_CTX_free(bn_ctx);
 
     if(secret) {
-        ssh2_explicit_zero(secret, secret_len);
+        ssh2_explicit_zero(secret, secret_size);
         free(secret);
     }
 #endif

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -3129,8 +3129,10 @@ clean_exit:
     if(bn_ctx)
         BN_CTX_free(bn_ctx);
 
-    if(secret)
+    if(secret) {
+        ssh2_explicit_zero(secret, secret_len);
         free(secret);
+    }
 #endif
 
 #ifdef USE_OPENSSL_3


### PR DESCRIPTION
Also:
- use separate variable to store the secret buffer size and the length
  of the actual secret.
- fix the type of the actual secret size to be `int` to match the API
  and avoid a cast.

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2544#discussion_r3872878545
Follow-up to aba34f5f56890563e6f0147ad8bc0e36aa966f49 #41

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
