### PR TITLE
kex, pem: use `ssh2_zero_free()` where applicable

### DIFF
--- a/src/kex.c
+++ b/src/kex.c
@@ -245,8 +245,10 @@ static int kex_finish(LIBSSH2_SESSION *session,
                             "Unable to initialize local encryption context");
         }
 
-        ssh2_zero_free(session, iv, session->local.crypt->iv_len);
-        ssh2_zero_free(session, secret, session->local.crypt->secret_len);
+        if(free_iv)
+            ssh2_zero_free(session, iv, session->local.crypt->iv_len);
+        if(free_secret)
+            ssh2_zero_free(session, secret, session->local.crypt->secret_len);
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Client to Server IV and Key calculated"));
@@ -282,8 +284,10 @@ static int kex_finish(LIBSSH2_SESSION *session,
                             "Failed to initialize remote encryption context");
         }
 
-        ssh2_zero_free(session, iv, session->remote.crypt->iv_len);
-        ssh2_zero_free(session, secret, session->remote.crypt->secret_len);
+        if(free_iv)
+            ssh2_zero_free(session, iv, session->remote.crypt->iv_len);
+        if(free_secret)
+            ssh2_zero_free(session, secret, session->remote.crypt->secret_len);
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Server to Client IV and Key calculated"));
@@ -303,8 +307,8 @@ static int kex_finish(LIBSSH2_SESSION *session,
 
         session->local.mac->init(session, key, &free_key,
                                  &session->local.mac_abstract);
-
-        ssh2_zero_free(session, key, session->local.mac->key_len);
+        if(free_key)
+            ssh2_zero_free(session, key, session->local.mac->key_len);
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Client to Server HMAC Key calculated"));
@@ -324,8 +328,8 @@ static int kex_finish(LIBSSH2_SESSION *session,
 
         session->remote.mac->init(session, key, &free_key,
                                   &session->remote.mac_abstract);
-
-        ssh2_zero_free(session, key, session->remote.mac->key_len);
+        if(free_key)
+            ssh2_zero_free(session, key, session->remote.mac->key_len);
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Server to Client HMAC Key calculated"));

--- a/src/kex.c
+++ b/src/kex.c
@@ -245,15 +245,8 @@ static int kex_finish(LIBSSH2_SESSION *session,
                             "Unable to initialize local encryption context");
         }
 
-        if(free_iv) {
-            ssh2_explicit_zero(iv, session->local.crypt->iv_len);
-            SSH2_FREE(session, iv);
-        }
-
-        if(free_secret) {
-            ssh2_explicit_zero(secret, session->local.crypt->secret_len);
-            SSH2_FREE(session, secret);
-        }
+        ssh2_zero_free(session, iv, session->local.crypt->iv_len);
+        ssh2_zero_free(session, secret, session->local.crypt->secret_len);
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Client to Server IV and Key calculated"));
@@ -289,15 +282,8 @@ static int kex_finish(LIBSSH2_SESSION *session,
                             "Failed to initialize remote encryption context");
         }
 
-        if(free_iv) {
-            ssh2_explicit_zero(iv, session->remote.crypt->iv_len);
-            SSH2_FREE(session, iv);
-        }
-
-        if(free_secret) {
-            ssh2_explicit_zero(secret, session->remote.crypt->secret_len);
-            SSH2_FREE(session, secret);
-        }
+        ssh2_zero_free(session, iv, session->remote.crypt->iv_len);
+        ssh2_zero_free(session, secret, session->remote.crypt->secret_len);
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Server to Client IV and Key calculated"));
@@ -317,10 +303,8 @@ static int kex_finish(LIBSSH2_SESSION *session,
 
         session->local.mac->init(session, key, &free_key,
                                  &session->local.mac_abstract);
-        if(free_key) {
-            ssh2_explicit_zero(key, session->local.mac->key_len);
-            SSH2_FREE(session, key);
-        }
+
+        ssh2_zero_free(session, key, session->local.mac->key_len);
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Client to Server HMAC Key calculated"));
@@ -340,10 +324,8 @@ static int kex_finish(LIBSSH2_SESSION *session,
 
         session->remote.mac->init(session, key, &free_key,
                                   &session->remote.mac_abstract);
-        if(free_key) {
-            ssh2_explicit_zero(key, session->remote.mac->key_len);
-            SSH2_FREE(session, key);
-        }
+
+        ssh2_zero_free(session, key, session->remote.mac->key_len);
     }
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Server to Client HMAC Key calculated"));
@@ -1874,19 +1856,17 @@ static void kex_method_mlkem_nistp_cleanup(
         key_state->private_key = NULL;
     }
 
-    if(key_state->mlkem_public_key) {
-        ssh2_explicit_zero(key_state->mlkem_public_key,
-                           key_state->mlkem_public_key_len);
-        SSH2_SAFEFREE(session, key_state->mlkem_public_key);
-        key_state->mlkem_public_key_len = 0;
-    }
+    ssh2_zero_free(session,
+                   key_state->mlkem_public_key,
+                   key_state->mlkem_public_key_len);
+    key_state->mlkem_public_key = NULL;
+    key_state->mlkem_public_key_len = 0;
 
-    if(key_state->mlkem_private_key) {
-        ssh2_explicit_zero(key_state->mlkem_private_key,
-                           key_state->mlkem_private_key_len);
-        SSH2_SAFEFREE(session, key_state->mlkem_private_key);
-        key_state->mlkem_private_key_len = 0;
-    }
+    ssh2_zero_free(session,
+                   key_state->mlkem_private_key,
+                   key_state->mlkem_private_key_len);
+    key_state->mlkem_private_key = NULL;
+    key_state->mlkem_private_key_len = 0;
 
     if(key_state->data)
         SSH2_SAFEFREE(session, key_state->data);
@@ -2220,17 +2200,13 @@ static void kex_curve25519_exchange_state_cleanup(
 static void kex_method_curve25519_cleanup(
     LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
-    if(key_state->curve25519_public_key) {
-        ssh2_explicit_zero(key_state->curve25519_public_key,
-                           SSH2_ED25519_KEY_LEN);
-        SSH2_SAFEFREE(session, key_state->curve25519_public_key);
-    }
+    ssh2_zero_free(session,
+                   key_state->curve25519_public_key, SSH2_ED25519_KEY_LEN);
+    key_state->curve25519_public_key = NULL;
 
-    if(key_state->curve25519_private_key) {
-        ssh2_explicit_zero(key_state->curve25519_private_key,
-                           SSH2_ED25519_KEY_LEN);
-        SSH2_SAFEFREE(session, key_state->curve25519_private_key);
-    }
+    ssh2_zero_free(session,
+                   key_state->curve25519_private_key, SSH2_ED25519_KEY_LEN);
+    key_state->curve25519_private_key = NULL;
 
     if(key_state->data)
         SSH2_SAFEFREE(session, key_state->data);
@@ -2484,31 +2460,25 @@ static void kex_mlkem768x25519_exchange_state_cleanup(
 static void kex_method_mlkem768x25519_cleanup(
     LIBSSH2_SESSION *session, struct key_exchange_state_low *key_state)
 {
-    if(key_state->curve25519_public_key) {
-        ssh2_explicit_zero(key_state->curve25519_public_key,
-                           SSH2_ED25519_KEY_LEN);
-        SSH2_SAFEFREE(session, key_state->curve25519_public_key);
-    }
+    ssh2_zero_free(session,
+                   key_state->curve25519_public_key, SSH2_ED25519_KEY_LEN);
+    key_state->curve25519_public_key = NULL;
 
-    if(key_state->curve25519_private_key) {
-        ssh2_explicit_zero(key_state->curve25519_private_key,
-                           SSH2_ED25519_KEY_LEN);
-        SSH2_SAFEFREE(session, key_state->curve25519_private_key);
-    }
+    ssh2_zero_free(session,
+                   key_state->curve25519_private_key, SSH2_ED25519_KEY_LEN);
+    key_state->curve25519_private_key = NULL;
 
-    if(key_state->mlkem_public_key) {
-        ssh2_explicit_zero(key_state->mlkem_public_key,
-                           key_state->mlkem_public_key_len);
-        SSH2_SAFEFREE(session, key_state->mlkem_public_key);
-        key_state->mlkem_public_key_len = 0;
-    }
+    ssh2_zero_free(session,
+                   key_state->mlkem_public_key,
+                   key_state->mlkem_public_key_len);
+    key_state->mlkem_public_key = NULL;
+    key_state->mlkem_public_key_len = 0;
 
-    if(key_state->mlkem_private_key) {
-        ssh2_explicit_zero(key_state->mlkem_private_key,
-                           key_state->mlkem_private_key_len);
-        SSH2_SAFEFREE(session, key_state->mlkem_private_key);
-        key_state->mlkem_private_key_len = 0;
-    }
+    ssh2_zero_free(session,
+                   key_state->mlkem_private_key,
+                   key_state->mlkem_private_key_len);
+    key_state->mlkem_private_key = NULL;
+    key_state->mlkem_private_key_len = 0;
 
     if(key_state->data)
         SSH2_SAFEFREE(session, key_state->data);

--- a/src/pem.c
+++ b/src/pem.c
@@ -136,10 +136,8 @@ out:
         *blob = filedata;
         *blob_len = filedata_len;
     }
-    else if(filedata) {
-        ssh2_explicit_zero(filedata, filedata_len + 1);
-        SSH2_FREE(session, filedata);
-    }
+    else
+        ssh2_zero_free(session, filedata, filedata_len + 1);
 
     if(fp)
         fclose(fp);

--- a/src/pem.c
+++ b/src/pem.c
@@ -363,20 +363,13 @@ int ssh2_pem_parse(LIBSSH2_SESSION *session,
 out:
 
     if(ret && *data) {
-        ssh2_explicit_zero(*data, *datalen);
-        SSH2_SAFEFREE(session, *data);
+        ssh2_zero_free(session, *data, *datalen);
+        *data = NULL;
         *datalen = 0;
     }
 
-    if(filedata) {
-        ssh2_explicit_zero(filedata, filedata_len + 1);
-        SSH2_FREE(session, filedata);
-    }
-
-    if(b64data) {
-        ssh2_explicit_zero(b64data, b64datalen);
-        SSH2_FREE(session, b64data);
-    }
+    ssh2_zero_free(session, filedata, filedata_len + 1);
+    ssh2_zero_free(session, b64data, b64datalen);
 
     if(blob_offset)
         *blob_offset = off;

--- a/src/pem.c
+++ b/src/pem.c
@@ -795,15 +795,8 @@ int ssh2_openssh_pem_parse(LIBSSH2_SESSION *session,
 
 out:
 
-    if(filedata) {
-        ssh2_explicit_zero(filedata, filedata_len + 1);
-        SSH2_FREE(session, filedata);
-    }
-
-    if(b64data) {
-        ssh2_explicit_zero(b64data, b64datalen);
-        SSH2_FREE(session, b64data);
-    }
+    ssh2_zero_free(session, filedata, filedata_len + 1);
+    ssh2_zero_free(session, b64data, b64datalen);
 
     return ret;
 }

--- a/src/pem.c
+++ b/src/pem.c
@@ -697,7 +697,6 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
 
 out:
 
-    /* Clean up */
     ssh2_zero_free(session, key, total_len);
     ssh2_zero_free(session, key_part, keylen);
     ssh2_zero_free(session, iv_part, ivlen);

--- a/src/pem.c
+++ b/src/pem.c
@@ -707,22 +707,10 @@ static int pem_parse_data_openssh(LIBSSH2_SESSION *session,
 out:
 
     /* Clean up */
-    if(key) {
-        ssh2_explicit_zero(key, total_len);
-        SSH2_FREE(session, key);
-    }
-    if(key_part) {
-        ssh2_explicit_zero(key_part, keylen);
-        SSH2_FREE(session, key_part);
-    }
-    if(iv_part) {
-        ssh2_explicit_zero(iv_part, ivlen);
-        SSH2_FREE(session, iv_part);
-    }
-    if(f) {
-        ssh2_explicit_zero(f, f_len);
-        SSH2_FREE(session, f);
-    }
+    ssh2_zero_free(session, key, total_len);
+    ssh2_zero_free(session, key_part, keylen);
+    ssh2_zero_free(session, iv_part, ivlen);
+    ssh2_zero_free(session, f, f_len);
 
     return ret;
 }


### PR DESCRIPTION
Merge `ssh2_explicit_zero()` / `SSH2_[SAFE]FREE()` pairs into
`ssh2_zero_free()` calls, to simplify a common pattern, also allowing to
drop the NULL check at each call-site.

Follow-up to a2ac6bd4e8cba6f083c76be4f15683a6943583b8 #2544
