### PR TITLE
openssl: fix allocate/free mismatch on failure in `ssh2_ecdsa_sign()` with OpenSSL 3+

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2350,7 +2350,8 @@ int ssh2_ecdsa_sign(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
 
     p = temp_buffer;
     sig = d2i_ECDSA_SIG(NULL, &p, (long)out_buffer_len);
-    ssh2_explicit_zero(temp_buffer, out_buffer_len);
+    ssh2_zero_free(session, temp_buffer, out_buffer_len);
+    temp_buffer = NULL;
 #else
     sig = ECDSA_do_sign(hash, (int)hash_len, ec_ctx);
     if(!sig)

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -2330,7 +2330,7 @@ int ssh2_ecdsa_sign(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
         return ssh2_err(session, LIBSSH2_ERROR_ALLOC, "out of memory");
 
     out_buffer_len = EVP_PKEY_get_size(ec_ctx);
-    temp_buffer = OPENSSL_malloc(out_buffer_len);
+    temp_buffer = SSH2_ALLOC(session, out_buffer_len);
     if(!temp_buffer)
         goto clean_exit;
 
@@ -2350,7 +2350,7 @@ int ssh2_ecdsa_sign(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
 
     p = temp_buffer;
     sig = d2i_ECDSA_SIG(NULL, &p, (long)out_buffer_len);
-    OPENSSL_clear_free(temp_buffer, out_buffer_len);
+    ssh2_explicit_zero(temp_buffer, out_buffer_len);
 #else
     sig = ECDSA_do_sign(hash, (int)hash_len, ec_ctx);
     if(!sig)


### PR DESCRIPTION
Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2544#discussion_r3874339530
Follow-up to b0ab005fe79260e6e9fe08f8d73b58dd4856943d #1207
