### PR TITLE
openssl: pass `session` to `ssh2_ecdsa_curve_name_with_octal_new()`, use SSH2 allocators

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -676,6 +676,7 @@ This procedure is already prototyped in `crypto.h`.
 
 ```c
 int ssh2_ecdsa_curve_name_with_octal_new(ssh2_ecdsa_ctx **ec_ctx,
+                                         LIBSSH2_SESSION *session,
                                          const unsigned char *k,
                                          size_t k_len,
                                          ssh2_curve_type curve);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -202,7 +202,7 @@ int ssh2_ecdsa_create_key(ssh2_ec_key **ec_ctx, LIBSSH2_SESSION *session,
                           ssh2_curve_type curve);
 
 int ssh2_ecdsa_curve_name_with_octal_new(
-    ssh2_ecdsa_ctx **ec_ctx,
+    ssh2_ecdsa_ctx **ec_ctx, LIBSSH2_SESSION *session,
     const unsigned char *publickey_encoded, size_t publickey_encoded_len,
     ssh2_curve_type curve);
 

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -648,7 +648,7 @@ static int hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION *session,
     if(!ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_ecdsa_curve_name_with_octal_new(&ec_ctx, public_key,
+    if(ssh2_ecdsa_curve_name_with_octal_new(&ec_ctx, session, public_key,
                                             key_len, curve))
         return -1;
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -948,10 +948,12 @@ failed:
  * Creates a new public key given an octal string, length and type
  */
 int ssh2_ecdsa_curve_name_with_octal_new(
-    ssh2_ecdsa_ctx **ec_ctx,
+    ssh2_ecdsa_ctx **ec_ctx, LIBSSH2_SESSION *session,
     const unsigned char *publickey_encoded, size_t publickey_encoded_len,
     ssh2_curve_type curve)
 {
+    (void)session;
+
     *ec_ctx = mbedtls_calloc(1, sizeof(mbedtls_ecp_keypair));
     if(!*ec_ctx)
         goto failed;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -709,7 +709,8 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     else
         ret = -1;
 
-    ssh2_zero_free(session, group_name, strlen(n) + 1);
+    if(n)
+        ssh2_zero_free(session, group_name, strlen(n) + 1);
     ssh2_zero_free(session, data, publickey_encoded_len);
 
     EVP_PKEY_CTX_free(ctx);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -668,7 +668,7 @@ ssh2_curve_type ssh2_ecdsa_get_curve_type(ssh2_ecdsa_ctx *ec_ctx)
  * Creates a new public key given an octal string, length and type
  */
 int ssh2_ecdsa_curve_name_with_octal_new(
-    ssh2_ecdsa_ctx **ec_ctx,
+    ssh2_ecdsa_ctx **ec_ctx, LIBSSH2_SESSION *session,
     const unsigned char *publickey_encoded, size_t publickey_encoded_len,
     ssh2_curve_type curve)
 {
@@ -684,10 +684,10 @@ int ssh2_ecdsa_curve_name_with_octal_new(
         return -1;
 
     if(n)
-        group_name = OPENSSL_zalloc(strlen(n) + 1);
+        group_name = SSH2_CALLOC(session, strlen(n) + 1);
 
     if(publickey_encoded_len > 0)
-        data = OPENSSL_malloc(publickey_encoded_len);
+        data = SSH2_ALLOC(session, publickey_encoded_len);
 
     if(group_name && data) {
         OSSL_PARAM params[3] = { 0 };
@@ -709,11 +709,8 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     else
         ret = -1;
 
-    if(group_name)
-        OPENSSL_clear_free(group_name, strlen(n) + 1);
-
-    if(data)
-        OPENSSL_clear_free(data, publickey_encoded_len);
+    ssh2_zero_free(session, group_name, strlen(n) + 1);
+    ssh2_zero_free(session, data, publickey_encoded_len);
 
     EVP_PKEY_CTX_free(ctx);
 #else
@@ -2631,8 +2628,8 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
 
     ssh2_zero_free(session, group_name, strlen(n) + 1);
 #else
-    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, pointbuf, pointbuf_len,
-                                              curve);
+    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, session,
+                                              pointbuf, pointbuf_len, curve);
     if(rc) {
         rc = -1;
         ssh2_err(session, LIBSSH2_ERROR_PROTO, "ECDSA could not create key");
@@ -2722,7 +2719,8 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
         return -1;
     }
 
-    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, pointbuf, pointbuf_len,
+    rc = ssh2_ecdsa_curve_name_with_octal_new(&ctx, session,
+                                              pointbuf, pointbuf_len,
                                               SSH2_EC_CURVE_NISTP256);
     if(rc) {
         rc = -1;

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -709,7 +709,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     else
         ret = -1;
 
-    if(n)
+    if(group_name)
         ssh2_zero_free(session, group_name, strlen(n) + 1);
     ssh2_zero_free(session, data, publickey_encoded_len);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -716,6 +716,8 @@ int ssh2_ecdsa_curve_name_with_octal_new(
 #else
     EC_KEY *ec_key = EC_KEY_new_by_curve_name(curve);
 
+    (void)session;
+
     if(ec_key) {
         const EC_GROUP *ec_group = NULL;
         EC_POINT *point = NULL;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2030,7 +2030,7 @@ cleanup:
  * Creates an ECDSA public key from an uncompressed point.
  */
 int ssh2_ecdsa_curve_name_with_octal_new(
-    OUT ssh2_ecdsa_ctx **ec_ctx,
+    OUT ssh2_ecdsa_ctx **ec_ctx, IN LIBSSH2_SESSION *session,
     IN const unsigned char *publickey_encoded, IN size_t publickey_encoded_len,
     IN ssh2_curve_type curve)
 {
@@ -2038,6 +2038,8 @@ int ssh2_ecdsa_curve_name_with_octal_new(
 
     BCRYPT_KEY_HANDLE publickey_handle;
     struct ecdsa_point publickey;
+
+    (void)session;
 
     /* Validate parameters */
     if(curve >= SSH2_ARRAYSIZE(wcng_ecdsa_algs))


### PR DESCRIPTION
Replacing `OPENSSL_malloc()`/`OPENSSL_zalloc()`.

Follow-up to a2ac6bd4e8cba6f083c76be4f15683a6943583b8 #2544
