### PR TITLE
os400qc3: use `ssh2_zero_free()` in `try_pem_load()`

### DIFF
--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -2075,10 +2075,7 @@ static int try_pem_load(LIBSSH2_SESSION *session,
         if(!ret) {
             ret = (*proc)(session, data, datalen, passphrase, loadkeydata);
             if(!ret) {
-                if(data) {
-                    ssh2_explicit_zero(data, datalen);
-                    SSH2_FREE(session, data);
-                }
+                ssh2_zero_free(session, data, datalen);
                 return 0; /* success */
             }
         }
@@ -2086,10 +2083,8 @@ static int try_pem_load(LIBSSH2_SESSION *session,
         blob_pos += blob_offset;
         blob_left -= blob_offset;
 
-        if(data) {
-            ssh2_explicit_zero(data, datalen);
-            SSH2_SAFEFREE(session, data);
-        }
+        ssh2_zero_free(session, data, datalen);
+        data = NULL;
     }
 
     return -1;


### PR DESCRIPTION
Follow-up to a2ac6bd4e8cba6f083c76be4f15683a6943583b8 #2544

