### PR TITLE
mbedtls: fix mismatched alloc/free in `ssh2_ecdsa_sign()`

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -1307,7 +1307,7 @@ cleanup:
     mbedtls_mpi_free(&pr);
     mbedtls_mpi_free(&ps);
 
-    mbed_zero_free(tmp_sign, tmp_sign_len);
+    ssh2_zero_free(session, tmp_sign, tmp_sign_len);
 
     return *signature ? 0 : -1;
 }


### PR DESCRIPTION
Follow-up to f7fa81ca5956610c0e3e17caba560e30309a4470 #2196
Follow-up to 5528f3da02eba1de425535481de049b21c48e9eb #385

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
