### PR TITLE
mbedtls: drop local `mbed_zero_free()` function

### DIFF
--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -81,17 +81,6 @@ int ssh2_random(unsigned char *buf, size_t len)
     return psa_generate_random(buf, len) == PSA_SUCCESS ? 0 : -1;
 }
 
-static void mbed_zero_free(void *buf, size_t len)
-{
-    if(!buf)
-        return;
-
-    if(len > 0)
-        ssh2_explicit_zero(buf, len);
-
-    mbedtls_free(buf);
-}
-
 int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
                      unsigned char *iv, unsigned char *secret, int encrypt)
 {
@@ -280,7 +269,9 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
             memcpy(block, output, olen);
         }
 
-        mbed_zero_free(output, osize);
+        if(osize)
+            ssh2_explicit_zero(output, osize * sizeof(char));
+        mbedtls_free(output);
     }
     else
         ret = -1;


### PR DESCRIPTION
Only a single caller remained after recent updates.

Follow-up to 62a2a7ec2c2d408d579c4d8b255678a988c418ad #2552
Follow-up to 420dbba6a4bd7add13f753b7c947e1d4b0c4ad68 #2550
