### PR TITLE
libgcrypt: tidy up variables names, S-expressions

### DIFF
--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -170,8 +170,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
         goto out;
     }
 
-    if(gcry_sexp_build(&s_hash, NULL,
-                       "(data (flags pkcs1) (hash %s %b))",
+    if(gcry_sexp_build(&s_hash, NULL, "(data (flags pkcs1) (hash %s %b))",
                        algo, hash_len, hash)) {
         ret = -1;
         goto out;
@@ -419,7 +418,7 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                        unsigned char **signature, size_t *signature_len)
 {
     const char *algo;
-    gcry_sexp_t s_tmp = NULL;
+    gcry_sexp_t s_hash = NULL;
     gcry_sexp_t s_sig = NULL;
     gcry_error_t err;
     const char *tmp;
@@ -439,21 +438,20 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
         return -1;
     }
 
-    if(gcry_sexp_build(&s_tmp, NULL,
-                       "(data (flags pkcs1) (hash %s %b))",
+    if(gcry_sexp_build(&s_hash, NULL, "(data (flags pkcs1) (hash %s %b))",
                        algo, hash_len, hash))
         return -1;
 
-    err = gcry_pk_sign(&s_sig, s_tmp, rsa);
-    gcry_sexp_release(s_tmp);
+    err = gcry_pk_sign(&s_sig, s_hash, rsa);
+    gcry_sexp_release(s_hash);
     if(err)
         return -1;
 
-    s_tmp = gcry_sexp_find_token(s_sig, "s", 0);
-    if(!s_tmp)
+    s_hash = gcry_sexp_find_token(s_sig, "s", 0);
+    if(!s_hash)
         goto out;
 
-    tmp = gcry_sexp_nth_data(s_tmp, 1, &size);
+    tmp = gcry_sexp_nth_data(s_hash, 1, &size);
     if(!tmp)
         goto out;
 
@@ -465,15 +463,15 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     out_sig = SSH2_ALLOC(session, size);
     if(!out_sig)
         goto out;
-    memcpy(out_sig, s, size);
+    memcpy(out_sig, tmp, size);
 
     *signature = out_sig;
     *signature_len = size;
     ret = 0;
 
 out:
-    if(s_tmp)
-        gcry_sexp_release(s_tmp);
+    if(s_hash)
+        gcry_sexp_release(s_hash);
     if(s_sig)
         gcry_sexp_release(s_sig);
 
@@ -497,8 +495,8 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                        unsigned char *signature)
 {
     unsigned char zhash[SSH2_SHA1_DIG_LEN + 1];
-    gcry_sexp_t sig_sexp;
-    gcry_sexp_t data;
+    gcry_sexp_t s_sig;
+    gcry_sexp_t s_data;
     int ret;
     const char *tmp;
     size_t size;
@@ -511,12 +509,12 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
     memcpy(zhash + 1, hash, hash_len);
     zhash[0] = 0;
 
-    if(gcry_sexp_build(&data, NULL, "(data (value %b))",
+    if(gcry_sexp_build(&s_data, NULL, "(data (value %b))",
                        (int)(hash_len + 1), zhash))
         return -1;
 
-    ret = gcry_pk_sign(&sig_sexp, data, dsa);
-    gcry_sexp_release(data);
+    ret = gcry_pk_sign(&s_sig, s_data, dsa);
+    gcry_sexp_release(s_data);
     if(ret)
         return -1;
 
@@ -524,11 +522,11 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
 
     /* Extract R. */
 
-    data = gcry_sexp_find_token(sig_sexp, "r", 0);
-    if(!data)
+    s_data = gcry_sexp_find_token(s_sig, "r", 0);
+    if(!s_data)
         goto err;
 
-    tmp = gcry_sexp_nth_data(data, 1, &size);
+    tmp = gcry_sexp_nth_data(s_data, 1, &size);
     if(!tmp)
         goto err;
 
@@ -542,15 +540,15 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
 
     memcpy(signature + (20 - size), tmp, size);
 
-    gcry_sexp_release(data);
+    gcry_sexp_release(s_data);
 
     /* Extract S. */
 
-    data = gcry_sexp_find_token(sig_sexp, "s", 0);
-    if(!data)
+    s_data = gcry_sexp_find_token(s_sig, "s", 0);
+    if(!s_data)
         goto err;
 
-    tmp = gcry_sexp_nth_data(data, 1, &size);
+    tmp = gcry_sexp_nth_data(s_data, 1, &size);
     if(!tmp)
         goto err;
 
@@ -569,10 +567,10 @@ err:
     ret = -1;
 
 out:
-    if(sig_sexp)
-        gcry_sexp_release(sig_sexp);
-    if(data)
-        gcry_sexp_release(data);
+    if(s_sig)
+        gcry_sexp_release(s_sig);
+    if(s_data)
+        gcry_sexp_release(s_data);
     return ret;
 }
 
@@ -581,7 +579,8 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                          const unsigned char *m, size_t m_len)
 {
     unsigned char hash[SSH2_SHA1_DIG_LEN + 1];
-    gcry_sexp_t s_sig, s_hash;
+    gcry_sexp_t s_hash = NULL;
+    gcry_sexp_t s_sig = NULL;
     int rc = -1;
 
     (void)session;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -422,7 +422,7 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     gcry_sexp_t s_tmp = NULL;
     gcry_sexp_t s_sig = NULL;
     gcry_error_t err;
-    const char *s;
+    const char *tmp;
     size_t size;
     unsigned char *out_sig;
     int ret = -1;
@@ -453,12 +453,12 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     if(!s_tmp)
         goto out;
 
-    s = gcry_sexp_nth_data(s_tmp, 1, &size);
-    if(!s)
+    tmp = gcry_sexp_nth_data(s_tmp, 1, &size);
+    if(!tmp)
         goto out;
 
-    if(size && s[0] == '\0') {
-        ++s;
+    if(size && tmp[0] == '\0') {
+        ++tmp;
         --size;
     }
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -262,17 +262,20 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
         goto fail;
     }
 
-    /* RSA private key
-       version          integer
-       modulus          integer, n
-       publicExponent   integer, e
-       privateExponent  integer, d
-       prime1           integer, p
-       prime2           integer, q
-       exponent1        integer, d mod (p - 1)
-       exponent2        integer, d mod (q - 1)
-       coefficient      integer, (inverse of q) mod p
-       otherPrimeInfos  OPTIONAL
+    /* RSAPrivateKey ::= SEQUENCE {
+           version           Version,
+           modulus           INTEGER,  -- n
+           publicExponent    INTEGER,  -- e
+           privateExponent   INTEGER,  -- d
+           prime1            INTEGER,  -- p
+           prime2            INTEGER,  -- q
+           exponent1         INTEGER,  -- d mod (p-1)
+           exponent2         INTEGER,  -- d mod (q-1)
+           coefficient       INTEGER,  -- (inverse of q) mod p
+           otherPrimeInfos   OtherPrimeInfos OPTIONAL
+       }
+
+       https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.1.2
      */
 
     /* First read Version field (should be 0). */

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -117,11 +117,12 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 
     if(ddata)
         rc = gcry_sexp_build(rsa, NULL,
-                 "(private-key(rsa(n%b)(e%b)(d%b)(q%b)(p%b)(u%b)))",
+                 "(private-key (rsa (n %b) (e %b) (d %b) "
+                 "(q %b) (p %b) (u %b)))",
                  (int)nlen, ndata, (int)elen, edata, (int)dlen, ddata,
                  (int)plen, pdata, (int)qlen, qdata, (int)coefflen, coeffdata);
     else
-        rc = gcry_sexp_build(rsa, NULL, "(public-key(rsa(n%b)(e%b)))",
+        rc = gcry_sexp_build(rsa, NULL, "(public-key (rsa (n %b) (e %b)))",
                              (int)nlen, ndata, (int)elen, edata);
 
     if(rc) {
@@ -176,7 +177,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
         goto out;
     }
 
-    if(gcry_sexp_build(&s_sig, NULL, "(sig-val(rsa(s %b)))", sig_len, sig)) {
+    if(gcry_sexp_build(&s_sig, NULL, "(sig-val (rsa (s %b)))", sig_len, sig)) {
         ret = -1;
         goto out;
     }
@@ -217,15 +218,14 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
 
     if(xlen)
         rc = gcry_sexp_build(dsa, NULL,
-                             "(private-key(dsa(p%b)(q%b)(g%b)(y%b)(x%b)))",
-                             (int)plen, pdata, (int)qlen, qdata,
-                             (int)glen, gdata, (int)ylen, ydata,
-                             (int)xlen, xdata);
+                 "(private-key (dsa (p %b) (q %b) (g %b) (y %b) (x %b)))",
+                 (int)plen, pdata, (int)qlen, qdata,
+                 (int)glen, gdata, (int)ylen, ydata, (int)xlen, xdata);
     else
         rc = gcry_sexp_build(dsa, NULL,
-                             "(public-key(dsa(p%b)(q%b)(g%b)(y%b)))",
-                             (int)plen, pdata, (int)qlen, qdata,
-                             (int)glen, gdata, (int)ylen, ydata);
+                 "(public-key (dsa (p %b) (q %b) (g %b) (y %b)))",
+                 (int)plen, pdata, (int)qlen, qdata,
+                 (int)glen, gdata, (int)ylen, ydata);
 
     if(rc) {
         *dsa = NULL;
@@ -589,11 +589,11 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
 
     hash[0] = 0;
 
-    if(gcry_sexp_build(&s_hash, NULL, "(data(flags raw)(value %b))",
+    if(gcry_sexp_build(&s_hash, NULL, "(data (flags raw) (value %b))",
                        SSH2_SHA1_DIG_LEN + 1, hash))
         return -1;
 
-    if(gcry_sexp_build(&s_sig, NULL, "(sig-val(dsa(r %b)(s %b)))",
+    if(gcry_sexp_build(&s_sig, NULL, "(sig-val (dsa (r %b) (s %b)))",
                        20, sig, 20, sig + 20)) {
         gcry_sexp_release(s_hash);
         return -1;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -420,6 +420,7 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     const char *algo;
     gcry_sexp_t s_hash = NULL;
     gcry_sexp_t s_sig = NULL;
+    gcry_sexp_t s_data = NULL;
     gcry_error_t err;
     const char *tmp;
     size_t size;
@@ -447,11 +448,13 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     if(err)
         return -1;
 
-    s_hash = gcry_sexp_find_token(s_sig, "s", 0);
-    if(!s_hash)
+    /* Extract S. */
+
+    s_data = gcry_sexp_find_token(s_sig, "s", 0);
+    if(!s_data)
         goto out;
 
-    tmp = gcry_sexp_nth_data(s_hash, 1, &size);
+    tmp = gcry_sexp_nth_data(s_data, 1, &size);
     if(!tmp)
         goto out;
 
@@ -470,10 +473,10 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     ret = 0;
 
 out:
-    if(s_hash)
-        gcry_sexp_release(s_hash);
     if(s_sig)
         gcry_sexp_release(s_sig);
+    if(s_data)
+        gcry_sexp_release(s_data);
 
     return ret;
 }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -516,9 +516,7 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
         return -1;
 
     ret = gcry_pk_sign(&sig_sexp, data, dsa);
-
     gcry_sexp_release(data);
-
     if(ret)
         return -1;
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -262,6 +262,19 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
         goto fail;
     }
 
+    /* RSA private key
+       version          integer
+       modulus          integer, n
+       publicExponent   integer, e
+       privateExponent  integer, d
+       prime1           integer, p
+       prime2           integer, q
+       exponent1        integer, d mod (p - 1)
+       exponent2        integer, d mod (q - 1)
+       coefficient      integer, (inverse of q) mod p
+       otherPrimeInfos  OPTIONAL
+     */
+
     /* First read Version field (should be 0). */
     ret = ssh2_pem_decode_integer(&data, &datalen, &n, &nlen);
     if(ret || (nlen != 1 && *n != '\0')) {
@@ -317,8 +330,8 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
         goto fail;
     }
 
-    if(ssh2_rsa_new(rsa, e, elen, n, nlen, d, dlen, p, plen,
-                    q, qlen, e1, e1len, e2, e2len, coeff, coefflen)) {
+    if(ssh2_rsa_new(rsa, e, elen, n, nlen, d, dlen, p, plen, q, qlen,
+                    e1, e1len, e2, e2len, coeff, coefflen)) {
         ret = -1;
         goto fail;
     }


### PR DESCRIPTION
For consistency across functions.

Also:
- fold/unfold.
- add comment and RFC link for PEM RSA private key format.

Ref: https://en.wikipedia.org/wiki/Lisp_(programming_language)

---

- [x] ~~fix P and Q mixup when creating RSA private key?
  Fixed to be swapped here? Maybe swapped elsewhere up in the chain?
  Ref: 20527d9688938afee5bf9695e44d528074d1085a
  Can't figure out why the swapparoo works, p/q is read correctly,
  passed around correctly, yet needs to be passed reversed to libgcrypt.~~
