### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1126,7 +1126,7 @@ int libssh2_agent_connect(LIBSSH2_AGENT *agent)
     int i, rc = LIBSSH2_ERROR_METHOD_NOT_SUPPORTED;
     for(i = 0; agent_supported_backends[i].name; i++) {
         agent->ops = agent_supported_backends[i].ops;
-        rc = (agent->ops->connect)(agent);
+        rc = agent->ops->connect(agent);
         if(!rc)
             return LIBSSH2_ERROR_NONE;
     }

--- a/src/libssh2_setup.h
+++ b/src/libssh2_setup.h
@@ -38,7 +38,7 @@
 #ifdef _WIN32
 
 #if defined(__MINGW32__) && \
-  (!defined(__MINGW64_VERSION_MAJOR) || (__MINGW64_VERSION_MAJOR < 3))
+    (!defined(__MINGW64_VERSION_MAJOR) || (__MINGW64_VERSION_MAJOR < 3))
 #error "mingw-w64 3.0 or greater required"
 #endif
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -104,7 +104,7 @@ static void wcng_zero_free(void *buf, size_t len)
     if(!buf)
         return;
 
-    if(len > 0)
+    if(len)
         ssh2_explicit_zero(buf, len);
 
     free(buf);


### PR DESCRIPTION
- agent: drop redundant parentheses.
  Also to fix clang-tidy 23 warning.
- wincng: shorten condition.
- whitespace, indent.
