### PR TITLE
crypto: try dropping unused RSA/DSA private key generation codepaths

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -436,26 +436,14 @@ If defined as 0, the rest of this section can be omitted.
 `ssh2_rsa_ctx`: Type of an RSA computation context. Generally a struct.
 
 ```c
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, size_t elen,
-                 const unsigned char *ndata, size_t nlen,
-                 const unsigned char *ddata, size_t dlen,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *e1data, size_t e1len,
-                 const unsigned char *e2data, size_t e2len,
-                 const unsigned char *coeffdata, size_t coefflen);
+int ssh2_rsa_new_pub(ssh2_rsa_ctx **rsa,
+                     const unsigned char *edata, size_t elen,
+                     const unsigned char *ndata, size_t nlen);
 ```
 Creates a new context for RSA computations from key source values:
 
-- `pdata`, `plen` Prime number p. Only used if private key known (`ddata`).
-- `qdata`, `qlen` Prime number q. Only used if private key known (`ddata`).
 - `ndata`, `nlen` Modulus n.
 - `edata`, `elen` Exponent e.
-- `ddata`, `dlen` e^-1 % phi(n) = private key. May be NULL if unknown.
-- `e1data`, `e1len` dp = d % (p-1). Only used if private key known (`ddata`).
-- `e2data`, `e2len` dq = d % (q-1). Only used if private key known (`ddata`).
-- `coeffdata`, `coefflen` q^-1 % p. Only used if private key known.
 
 Returns 0 if OK.
 This procedure is already prototyped in `crypto.h`.
@@ -575,12 +563,11 @@ defined as 0, the rest of this section can be omitted.
 `ssh2_dsa_ctx`: Type of a DSA computation context. Generally a struct.
 
 ```c
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *gdata, size_t glen,
-                 const unsigned char *ydata, size_t ylen,
-                 const unsigned char *x, size_t x_len);
+int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
+                     const unsigned char *pdata, size_t plen,
+                     const unsigned char *qdata, size_t qlen,
+                     const unsigned char *gdata, size_t glen,
+                     const unsigned char *ydata, size_t ylen);
 ```
 
 Creates a new context for DSA computations from source key values:
@@ -589,7 +576,6 @@ Creates a new context for DSA computations from source key values:
 - `qdata`, `qlen` Prime number q. Only used if private key known (`ddata`).
 - `gdata`, `glen` G number.
 - `ydata`, `ylen` Public key.
-- `xdata`, `xlen` Private key. Only taken if xlen non-zero.
 
 Returns 0 if OK.
 This procedure is already prototyped in `crypto.h`.

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -124,15 +124,9 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 #define SSH2_MLKEM_1024_CIPHERTEXT      1568
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, size_t elen,
-                 const unsigned char *ndata, size_t nlen,
-                 const unsigned char *ddata, size_t dlen,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *e1data, size_t e1len,
-                 const unsigned char *e2data, size_t e2len,
-                 const unsigned char *coeffdata, size_t coefflen);
+int ssh2_rsa_new_pub(ssh2_rsa_ctx **rsa,
+                     const unsigned char *edata, size_t elen,
+                     const unsigned char *ndata, size_t nlen);
 int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
                       LIBSSH2_SESSION *session,
                       const char *filename,
@@ -161,12 +155,11 @@ void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *gdata, size_t glen,
-                 const unsigned char *ydata, size_t ylen,
-                 const unsigned char *xdata, size_t xlen);
+int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
+                     const unsigned char *pdata, size_t plen,
+                     const unsigned char *qdata, size_t qlen,
+                     const unsigned char *gdata, size_t glen,
+                     const unsigned char *ydata, size_t ylen);
 int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
                       LIBSSH2_SESSION *session,
                       const char *filename,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -99,8 +99,7 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
        !ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_rsa_new(&rsa, e, e_len, n, n_len,
-                    NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0))
+    if(ssh2_rsa_new_pub(&rsa, e, e_len, n, n_len))
         return -1;
 
     *abstract = rsa;
@@ -449,7 +448,7 @@ static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
        !ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_dsa_new(&dsa, p, p_len, q, q_len, g, g_len, y, y_len, NULL, 0))
+    if(ssh2_dsa_new_pub(&dsa, p, p_len, q, q_len, g, g_len, y, y_len))
         return -1;
 
     *abstract = dsa;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -98,15 +98,15 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 }
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, size_t elen,
-                 const unsigned char *ndata, size_t nlen,
-                 const unsigned char *ddata, size_t dlen,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *e1data, size_t e1len,
-                 const unsigned char *e2data, size_t e2len,
-                 const unsigned char *coeffdata, size_t coefflen)
+static int lgcr_rsa_new(ssh2_rsa_ctx **rsa,
+                        const unsigned char *edata, size_t elen,
+                        const unsigned char *ndata, size_t nlen,
+                        const unsigned char *ddata, size_t dlen,
+                        const unsigned char *pdata, size_t plen,
+                        const unsigned char *qdata, size_t qlen,
+                        const unsigned char *e1data, size_t e1len,
+                        const unsigned char *e2data, size_t e2len,
+                        const unsigned char *coeffdata, size_t coefflen)
 {
     int rc;
 
@@ -131,6 +131,14 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     }
 
     return 0;
+}
+
+int ssh2_rsa_new_pub(ssh2_rsa_ctx **rsa,
+                     const unsigned char *edata, size_t elen,
+                     const unsigned char *ndata, size_t nlen)
+{
+    return lgcr_rsa_new(rsa, edata, elen, ndata, nlen,
+                        NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0);
 }
 
 int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
@@ -344,7 +352,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
         goto fail;
     }
 
-    if(ssh2_rsa_new(rsa, e, elen, n, nlen, d, dlen, p, plen, q, qlen,
+    if(lgcr_rsa_new(rsa, e, elen, n, nlen, d, dlen, p, plen, q, qlen,
                     e1, e1len, e2, e2len, coeff, coefflen)) {
         ret = -1;
         goto fail;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -207,12 +207,12 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 #endif
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *gdata, size_t glen,
-                 const unsigned char *ydata, size_t ylen,
-                 const unsigned char *xdata, size_t xlen)
+static int lgcr_dsa_new(ssh2_dsa_ctx **dsa,
+                        const unsigned char *pdata, size_t plen,
+                        const unsigned char *qdata, size_t qlen,
+                        const unsigned char *gdata, size_t glen,
+                        const unsigned char *ydata, size_t ylen,
+                        const unsigned char *xdata, size_t xlen)
 {
     int rc;
 
@@ -233,6 +233,17 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     }
 
     return 0;
+}
+
+int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
+                 const unsigned char *pdata, size_t plen,
+                 const unsigned char *qdata, size_t qlen,
+                 const unsigned char *gdata, size_t glen,
+                 const unsigned char *ydata, size_t ylen,
+                 const unsigned char *xdata, size_t xlen)
+{
+    return lgcr_dsa_new(dsa, pdata, plen, qdata, qlen, gdata, glen,
+                        ydata, ylen, NULL, 0);
 }
 #endif
 
@@ -415,7 +426,7 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
         goto fail;
     }
 
-    if(ssh2_dsa_new(dsa, p, plen, q, qlen, g, glen, y, ylen, x, xlen)) {
+    if(lgcr_dsa_new(dsa, p, plen, q, qlen, g, glen, y, ylen, x, xlen)) {
         ret = -1;
         goto fail;
     }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -104,16 +104,9 @@ static int lgcr_rsa_new(ssh2_rsa_ctx **rsa,
                         const unsigned char *ddata, size_t dlen,
                         const unsigned char *pdata, size_t plen,
                         const unsigned char *qdata, size_t qlen,
-                        const unsigned char *e1data, size_t e1len,
-                        const unsigned char *e2data, size_t e2len,
                         const unsigned char *coeffdata, size_t coefflen)
 {
     int rc;
-
-    (void)e1data;
-    (void)e1len;
-    (void)e2data;
-    (void)e2len;
 
     if(ddata)
         rc = gcry_sexp_build(rsa, NULL,
@@ -138,7 +131,7 @@ int ssh2_rsa_new_pub(ssh2_rsa_ctx **rsa,
                      const unsigned char *ndata, size_t nlen)
 {
     return lgcr_rsa_new(rsa, edata, elen, ndata, nlen,
-                        NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0);
+                        NULL, 0, NULL, 0, NULL, 0, NULL, 0);
 }
 
 int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
@@ -264,8 +257,8 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
     unsigned char *data, *save_data;
     size_t datalen;
     int ret;
-    unsigned char *n, *e, *d, *p, *q, *e1, *e2, *coeff;
-    unsigned int nlen, elen, dlen, plen, qlen, e1len, e2len, coefflen;
+    unsigned char *n, *e, *d, *p, *q, *coeff, *t;
+    unsigned int nlen, elen, dlen, plen, qlen, coefflen, tlen;
 
     ret = ssh2_pem_parse(session, PEM_RSA_HEADER, PEM_RSA_FOOTER,
                          filename, blob, blob_len, passphrase,
@@ -297,8 +290,8 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
      */
 
     /* First read Version field (should be 0). */
-    ret = ssh2_pem_decode_integer(&data, &datalen, &n, &nlen);
-    if(ret || (nlen != 1 && *n != '\0')) {
+    ret = ssh2_pem_decode_integer(&data, &datalen, &t, &tlen);
+    if(ret || (tlen != 1 && *t != '\0')) {
         ret = -1;
         goto fail;
     }
@@ -333,13 +326,13 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
         goto fail;
     }
 
-    ret = ssh2_pem_decode_integer(&data, &datalen, &e1, &e1len);
+    ret = ssh2_pem_decode_integer(&data, &datalen, &t, &tlen);
     if(ret) {
         ret = -1;
         goto fail;
     }
 
-    ret = ssh2_pem_decode_integer(&data, &datalen, &e2, &e2len);
+    ret = ssh2_pem_decode_integer(&data, &datalen, &t, &tlen);
     if(ret) {
         ret = -1;
         goto fail;
@@ -352,7 +345,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
     }
 
     if(lgcr_rsa_new(rsa, e, elen, n, nlen, d, dlen, p, plen, q, qlen,
-                    e1, e1len, e2, e2len, coeff, coefflen)) {
+                    coeff, coefflen)) {
         ret = -1;
         goto fail;
     }

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -243,12 +243,11 @@ static int lgcr_dsa_new(ssh2_dsa_ctx **dsa,
     return 0;
 }
 
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *gdata, size_t glen,
-                 const unsigned char *ydata, size_t ylen,
-                 const unsigned char *xdata, size_t xlen)
+int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
+                     const unsigned char *pdata, size_t plen,
+                     const unsigned char *qdata, size_t qlen,
+                     const unsigned char *gdata, size_t glen,
+                     const unsigned char *ydata, size_t ylen)
 {
     return lgcr_dsa_new(dsa, pdata, plen, qdata, qlen, gdata, glen,
                         ydata, ylen, NULL, 0);

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -414,15 +414,9 @@ static int mbed_bn_random(ssh2_bn *bn, int bits, int top, int bottom)
  */
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, size_t elen,
-                 const unsigned char *ndata, size_t nlen,
-                 const unsigned char *ddata, size_t dlen,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *e1data, size_t e1len,
-                 const unsigned char *e2data, size_t e2len,
-                 const unsigned char *coeffdata, size_t coefflen)
+int ssh2_rsa_new_pub(ssh2_rsa_ctx **rsa,
+                     const unsigned char *edata, size_t elen,
+                     const unsigned char *ndata, size_t nlen)
 {
     int ret;
     ssh2_rsa_ctx *ctx;
@@ -438,30 +432,12 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
        mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(N)), ndata, nlen))
         ret = -1;
 
-    if(!ret)
+    if(!ret) {
         ctx->MBEDTLS_PRIVATE(len) =
             mbedtls_mpi_size(&(ctx->MBEDTLS_PRIVATE(N)));
 
-    if(!ret && ddata) {
-        if(mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(D)),
-                                   ddata, dlen) ||
-           mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(P)),
-                                   pdata, plen) ||
-           mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(Q)),
-                                   qdata, qlen) ||
-           mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(DP)),
-                                   e1data, e1len) ||
-           mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(DQ)),
-                                   e2data, e2len) ||
-           mbedtls_mpi_read_binary(&(ctx->MBEDTLS_PRIVATE(QP)),
-                                   coeffdata, coefflen)) {
-            ret = -1;
-        }
-        else
-            ret = mbedtls_rsa_check_privkey(ctx);
-    }
-    else if(!ret)
         ret = mbedtls_rsa_check_pubkey(ctx);
+    }
 
     if(ret && ctx) {
         ssh2_rsa_free(ctx);

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -187,15 +187,9 @@ int ssh2_random(unsigned char *buf, size_t len)
 }
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, size_t elen,
-                 const unsigned char *ndata, size_t nlen,
-                 const unsigned char *ddata, size_t dlen,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *e1data, size_t e1len,
-                 const unsigned char *e2data, size_t e2len,
-                 const unsigned char *coeffdata, size_t coefflen)
+int ssh2_rsa_new_pub(ssh2_rsa_ctx **rsa,
+                     const unsigned char *edata, size_t elen,
+                     const unsigned char *ndata, size_t nlen)
 {
 #ifdef USE_OPENSSL_3
     int ret = 0;
@@ -204,18 +198,6 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     int param_num = 0;
     unsigned char *nbuf = NULL;
     unsigned char *ebuf = NULL;
-    unsigned char *dbuf = NULL;
-
-    (void)pdata;
-    (void)plen;
-    (void)qdata;
-    (void)qlen;
-    (void)e1data;
-    (void)e1len;
-    (void)e2data;
-    (void)e2len;
-    (void)coeffdata;
-    (void)coefflen;
 
     if(ndata && nlen > 0) {
         nbuf = OPENSSL_malloc(nlen);
@@ -237,16 +219,6 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
         }
     }
 
-    if(ddata && dlen > 0) {
-        dbuf = OPENSSL_malloc(dlen);
-        if(dbuf) {
-            memcpy(dbuf, ddata, dlen);
-            ssh2_swap_bytes(dbuf, dlen);
-            params[param_num++] =
-                OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_D, dbuf, dlen);
-        }
-    }
-
     params[param_num] = OSSL_PARAM_construct_end();
 
     *rsa = NULL;
@@ -259,8 +231,6 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
         OPENSSL_clear_free(nbuf, nlen);
     if(ebuf)
         OPENSSL_clear_free(ebuf, elen);
-    if(dbuf)
-        OPENSSL_clear_free(dbuf, dlen);
 
     EVP_PKEY_CTX_free(ctx);
 
@@ -268,12 +238,6 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 #else /* !USE_OPENSSL_3 */
     BIGNUM *e = NULL;
     BIGNUM *n = NULL;
-    BIGNUM *d = NULL;
-    BIGNUM *p = NULL;
-    BIGNUM *q = NULL;
-    BIGNUM *dmp1 = NULL;
-    BIGNUM *dmq1 = NULL;
-    BIGNUM *iqmp = NULL;
 
     e = BN_new();
     if(!e)
@@ -285,45 +249,11 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
         goto fail;
     BN_bin2bn(ndata, (int)nlen, n);
 
-    if(ddata) {
-        d = BN_new();
-        if(!d)
-            goto fail;
-        BN_bin2bn(ddata, (int)dlen, d);
-
-        p = BN_new();
-        if(!p)
-            goto fail;
-        BN_bin2bn(pdata, (int)plen, p);
-
-        q = BN_new();
-        if(!q)
-            goto fail;
-        BN_bin2bn(qdata, (int)qlen, q);
-
-        dmp1 = BN_new();
-        if(!dmp1)
-            goto fail;
-        BN_bin2bn(e1data, (int)e1len, dmp1);
-
-        dmq1 = BN_new();
-        if(!dmq1)
-            goto fail;
-        BN_bin2bn(e2data, (int)e2len, dmq1);
-
-        iqmp = BN_new();
-        if(!iqmp)
-            goto fail;
-        BN_bin2bn(coeffdata, (int)coefflen, iqmp);
-    }
-
     *rsa = RSA_new();
     if(!*rsa)
         goto fail;
 
-    RSA_set0_key(*rsa, n, e, d);
-    RSA_set0_factors(*rsa, p, q);
-    RSA_set0_crt_params(*rsa, dmp1, dmq1, iqmp);
+    RSA_set0_key(*rsa, n, e, NULL);
 
     return 0;
 
@@ -331,12 +261,6 @@ fail:
 
     BN_clear_free(e);
     BN_clear_free(n);
-    BN_clear_free(d);
-    BN_clear_free(p);
-    BN_clear_free(q);
-    BN_clear_free(dmp1);
-    BN_clear_free(dmq1);
-    BN_clear_free(iqmp);
 
     return -1;
 #endif /* USE_OPENSSL_3 */
@@ -424,12 +348,11 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *gdata, size_t glen,
-                 const unsigned char *ydata, size_t ylen,
-                 const unsigned char *xdata, size_t xlen)
+int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
+                     const unsigned char *pdata, size_t plen,
+                     const unsigned char *qdata, size_t qlen,
+                     const unsigned char *gdata, size_t glen,
+                     const unsigned char *ydata, size_t ylen)
 {
 #ifdef USE_OPENSSL_3
     int ret = 0;
@@ -440,7 +363,6 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     unsigned char *q_buf = NULL;
     unsigned char *g_buf = NULL;
     unsigned char *y_buf = NULL;
-    unsigned char *x_buf = NULL;
 
     if(pdata && plen > 0) {
         p_buf = OPENSSL_malloc(plen);
@@ -482,16 +404,6 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         }
     }
 
-    if(xdata && xlen > 0) {
-        x_buf = OPENSSL_malloc(xlen);
-        if(x_buf) {
-            memcpy(x_buf, xdata, xlen);
-            ssh2_swap_bytes(x_buf, xlen);
-            params[param_num++] =
-                OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PRIV_KEY, x_buf, xlen);
-        }
-    }
-
     params[param_num] = OSSL_PARAM_construct_end();
 
     *dsa = NULL;
@@ -506,8 +418,6 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         OPENSSL_clear_free(q_buf, qlen);
     if(g_buf)
         OPENSSL_clear_free(g_buf, glen);
-    if(x_buf)
-        OPENSSL_clear_free(x_buf, xlen);
     if(y_buf)
         OPENSSL_clear_free(y_buf, ylen);
 
@@ -519,7 +429,6 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     BIGNUM *q_bn = NULL;
     BIGNUM *g_bn = NULL;
     BIGNUM *pub_key = NULL;
-    BIGNUM *priv_key = NULL;
 
     p_bn = BN_new();
     if(!p_bn)
@@ -541,19 +450,12 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         goto fail;
     BN_bin2bn(ydata, (int)ylen, pub_key);
 
-    if(xlen) {
-        priv_key = BN_new();
-        if(!priv_key)
-            goto fail;
-        BN_bin2bn(xdata, (int)xlen, priv_key);
-    }
-
     *dsa = DSA_new();
     if(!*dsa)
         goto fail;
 
     DSA_set0_pqg(*dsa, p_bn, q_bn, g_bn);
-    DSA_set0_key(*dsa, pub_key, priv_key);
+    DSA_set0_key(*dsa, pub_key, NULL);
 
     return 0;
 
@@ -563,7 +465,6 @@ fail:
     BN_clear_free(q_bn);
     BN_clear_free(g_bn);
     BN_free(pub_key);
-    BN_clear_free(priv_key);
 
     return -1;
 #endif /* USE_OPENSSL_3 */

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1164,23 +1164,11 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
 #if LIBSSH2_RSA
 int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
                  const unsigned char *edata, size_t elen,
-                 const unsigned char *ndata, size_t nlen,
-                 const unsigned char *ddata, size_t dlen,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *e1data, size_t e1len,
-                 const unsigned char *e2data, size_t e2len,
-                 const unsigned char *coeffdata, size_t coefflen)
+                 const unsigned char *ndata, size_t nlen)
 {
     ssh2_rsa_ctx *ctx;
     ssh2_bn *e = ssh2_bn_init_from_bin();
     ssh2_bn *n = ssh2_bn_init_from_bin();
-    ssh2_bn *d = NULL;
-    ssh2_bn *p = NULL;
-    ssh2_bn *q = NULL;
-    ssh2_bn *e1 = NULL;
-    ssh2_bn *e2 = NULL;
-    ssh2_bn *coeff = NULL;
     struct asn1Element *key = NULL;
     struct asn1Element *structkey = NULL;
     int keytype;
@@ -1196,31 +1184,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
         if(!e || !n)
             ret = -1;
     }
-    if(!ret && ddata) {
-        /* Private key. */
-        d = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(d, ddata, dlen);
-        p = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(p, pdata, plen);
-        q = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(q, qdata, qlen);
-        e1 = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(e1, e1data, e1len);
-        e2 = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(e2, e2data, e2len);
-        coeff = ssh2_bn_init_from_bin();
-        ssh2_bn_from_bin(coeff, coeffdata, coefflen);
-        if(!d || !p || !q || !e1 || !e2 || !coeff)
-            ret = -1;
-
-        if(!ret) {
-            /* Build a PKCS#8 private key. */
-            key = rsaprivatekey(e, n, d, p, q, e1, e2, coeff);
-            structkey = rsaprivatekeyinfo(key);
-        }
-        keytype = Qc3_RSA_Private;
-    }
-    else if(!ret) {
+    if(!ret) {
         key = rsapublickey(e, n);
         structkey = rsasubjectpublickeyinfo(key);
         keytype = Qc3_RSA_Public;
@@ -1243,12 +1207,6 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 
     ssh2_bn_free(e);
     ssh2_bn_free(n);
-    ssh2_bn_free(d);
-    ssh2_bn_free(p);
-    ssh2_bn_free(q);
-    ssh2_bn_free(e1);
-    ssh2_bn_free(e2);
-    ssh2_bn_free(coeff);
     asn1delete(key);
     asn1delete(structkey);
     if(ret && ctx) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1098,33 +1098,19 @@ static size_t wcng_bn_size(const unsigned char *bignum, size_t length)
  * Windows CNG backend: RSA functions
  */
 
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
-                 const unsigned char *edata, size_t elen,
-                 const unsigned char *ndata, size_t nlen,
-                 const unsigned char *ddata, size_t dlen,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *e1data, size_t e1len,
-                 const unsigned char *e2data, size_t e2len,
-                 const unsigned char *coeffdata, size_t coefflen)
+int ssh2_rsa_new_pub(ssh2_rsa_ctx **rsa,
+                     const unsigned char *edata, size_t elen,
+                     const unsigned char *ndata, size_t nlen)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_RSAKEY_BLOB *rsakey;
     LPCWSTR lpszBlobType;
-    size_t keylen, offset, mlen, p1len = 0, p2len = 0;
+    size_t keylen, offset, mlen;
     int ret;
 
-    mlen = max(wcng_bn_size(ndata, nlen),
-               wcng_bn_size(ddata, dlen));
+    mlen = wcng_bn_size(ndata, nlen);
     offset = sizeof(BCRYPT_RSAKEY_BLOB);
     keylen = offset + elen + mlen;
-    if(ddata && dlen > 0) {
-        p1len = max(wcng_bn_size(pdata, plen),
-                    wcng_bn_size(e1data, e1len));
-        p2len = max(wcng_bn_size(qdata, qlen),
-                    wcng_bn_size(e2data, e2len));
-        keylen += p1len * 3 + p2len * 2 + mlen;
-    }
 
     rsakey = malloc(keylen);
     if(!rsakey)
@@ -1145,67 +1131,10 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     else
         memcpy((unsigned char *)rsakey + offset, ndata + nlen - mlen, mlen);
 
-    if(ddata && dlen > 0) {
-        offset += mlen;
-
-        if(plen < p1len)
-            memcpy((unsigned char *)rsakey + offset + p1len - plen,
-                   pdata, plen);
-        else
-            memcpy((unsigned char *)rsakey + offset,
-                   pdata + plen - p1len, p1len);
-        offset += p1len;
-
-        if(qlen < p2len)
-            memcpy((unsigned char *)rsakey + offset + p2len - qlen,
-                   qdata, qlen);
-        else
-            memcpy((unsigned char *)rsakey + offset,
-                   qdata + qlen - p2len, p2len);
-        offset += p2len;
-
-        if(e1len < p1len)
-            memcpy((unsigned char *)rsakey + offset + p1len - e1len,
-                   e1data, e1len);
-        else
-            memcpy((unsigned char *)rsakey + offset,
-                   e1data + e1len - p1len, p1len);
-        offset += p1len;
-
-        if(e2len < p2len)
-            memcpy((unsigned char *)rsakey + offset + p2len - e2len,
-                   e2data, e2len);
-        else
-            memcpy((unsigned char *)rsakey + offset,
-                   e2data + e2len - p2len, p2len);
-        offset += p2len;
-
-        if(coefflen < p1len)
-            memcpy((unsigned char *)rsakey + offset + p1len - coefflen,
-                   coeffdata, coefflen);
-        else
-            memcpy((unsigned char *)rsakey + offset,
-                   coeffdata + coefflen - p1len, p1len);
-        offset += p1len;
-
-        if(dlen < mlen)
-            memcpy((unsigned char *)rsakey + offset + mlen - dlen,
-                   ddata, dlen);
-        else
-            memcpy((unsigned char *)rsakey + offset,
-                   ddata + dlen - mlen, mlen);
-
-        lpszBlobType = BCRYPT_RSAFULLPRIVATE_BLOB;
-        rsakey->Magic = BCRYPT_RSAFULLPRIVATE_MAGIC;
-        rsakey->cbPrime1 = (ULONG)p1len;
-        rsakey->cbPrime2 = (ULONG)p2len;
-    }
-    else {
-        lpszBlobType = BCRYPT_RSAPUBLIC_BLOB;
-        rsakey->Magic = BCRYPT_RSAPUBLIC_MAGIC;
-        rsakey->cbPrime1 = 0;
-        rsakey->cbPrime2 = 0;
-    }
+    lpszBlobType = BCRYPT_RSAPUBLIC_BLOB;
+    rsakey->Magic = BCRYPT_RSAPUBLIC_MAGIC;
+    rsakey->cbPrime1 = 0;
+    rsakey->cbPrime2 = 0;
 
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgRSA, NULL, lpszBlobType,
                               &hKey, (PUCHAR)rsakey, (ULONG)keylen, 0);
@@ -1400,12 +1329,11 @@ void ssh2_rsa_free(ssh2_rsa_ctx *rsa)
  */
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
-                 const unsigned char *pdata, size_t plen,
-                 const unsigned char *qdata, size_t qlen,
-                 const unsigned char *gdata, size_t glen,
-                 const unsigned char *ydata, size_t ylen,
-                 const unsigned char *xdata, size_t xlen)
+int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
+                     const unsigned char *pdata, size_t plen,
+                     const unsigned char *qdata, size_t qlen,
+                     const unsigned char *gdata, size_t glen,
+                     const unsigned char *ydata, size_t ylen)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_DSA_KEY_BLOB *dsakey;
@@ -1418,8 +1346,6 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
                  wcng_bn_size(ydata, ylen));
     offset = sizeof(BCRYPT_DSA_KEY_BLOB);
     keylen = offset + length * 3;
-    if(xdata && xlen > 0)
-        keylen += 20;
 
     dsakey = malloc(keylen);
     if(!dsakey)
@@ -1461,21 +1387,8 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
         memcpy((unsigned char *)dsakey + offset,
                ydata + ylen - length, length);
 
-    if(xdata && xlen > 0) {
-        offset += length;
-
-        if(xlen < 20)
-            memcpy((unsigned char *)dsakey + offset + 20 - xlen, xdata, xlen);
-        else
-            memcpy((unsigned char *)dsakey + offset, xdata + xlen - 20, 20);
-
-        lpszBlobType = BCRYPT_DSA_PRIVATE_BLOB;
-        dsakey->dwMagic = BCRYPT_DSA_PRIVATE_MAGIC;
-    }
-    else {
-        lpszBlobType = BCRYPT_DSA_PUBLIC_BLOB;
-        dsakey->dwMagic = BCRYPT_DSA_PUBLIC_MAGIC;
-    }
+    lpszBlobType = BCRYPT_DSA_PUBLIC_BLOB;
+    dsakey->dwMagic = BCRYPT_DSA_PUBLIC_MAGIC;
 
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgDSA, NULL, lpszBlobType,
                               &hKey, (PUCHAR)dsakey, (ULONG)keylen, 0);

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1329,11 +1329,12 @@ void ssh2_rsa_free(ssh2_rsa_ctx *rsa)
  */
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
-                     const unsigned char *pdata, size_t plen,
-                     const unsigned char *qdata, size_t qlen,
-                     const unsigned char *gdata, size_t glen,
-                     const unsigned char *ydata, size_t ylen)
+static int wcng_dsa_new(ssh2_dsa_ctx **dsa,
+                        const unsigned char *pdata, size_t plen,
+                        const unsigned char *qdata, size_t qlen,
+                        const unsigned char *gdata, size_t glen,
+                        const unsigned char *ydata, size_t ylen,
+                        const unsigned char *xdata, size_t xlen)
 {
     BCRYPT_KEY_HANDLE hKey;
     BCRYPT_DSA_KEY_BLOB *dsakey;
@@ -1346,6 +1347,8 @@ int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
                  wcng_bn_size(ydata, ylen));
     offset = sizeof(BCRYPT_DSA_KEY_BLOB);
     keylen = offset + length * 3;
+    if(xdata && xlen > 0)
+        keylen += 20;
 
     dsakey = malloc(keylen);
     if(!dsakey)
@@ -1387,8 +1390,21 @@ int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
         memcpy((unsigned char *)dsakey + offset,
                ydata + ylen - length, length);
 
-    lpszBlobType = BCRYPT_DSA_PUBLIC_BLOB;
-    dsakey->dwMagic = BCRYPT_DSA_PUBLIC_MAGIC;
+    if(xdata && xlen > 0) {
+        offset += length;
+
+        if(xlen < 20)
+            memcpy((unsigned char *)dsakey + offset + 20 - xlen, xdata, xlen);
+        else
+            memcpy((unsigned char *)dsakey + offset, xdata + xlen - 20, 20);
+
+        lpszBlobType = BCRYPT_DSA_PRIVATE_BLOB;
+        dsakey->dwMagic = BCRYPT_DSA_PRIVATE_MAGIC;
+    }
+    else {
+        lpszBlobType = BCRYPT_DSA_PUBLIC_BLOB;
+        dsakey->dwMagic = BCRYPT_DSA_PUBLIC_MAGIC;
+    }
 
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgDSA, NULL, lpszBlobType,
                               &hKey, (PUCHAR)dsakey, (ULONG)keylen, 0);
@@ -1411,6 +1427,16 @@ int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
     return 0;
 }
 
+int ssh2_dsa_new_pub(ssh2_dsa_ctx **dsa,
+                     const unsigned char *pdata, size_t plen,
+                     const unsigned char *qdata, size_t qlen,
+                     const unsigned char *gdata, size_t glen,
+                     const unsigned char *ydata, size_t ylen)
+{
+    return wcng_dsa_new(dsa, pdata, plen, qdata, qlen, gdata, glen,
+                        ydata, ylen, NULL, 0);
+}
+
 static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
                                       LIBSSH2_SESSION *session,
                                       unsigned char *pbEncoded,
@@ -1429,7 +1455,7 @@ static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
         return -1;
 
     if(length == 6)
-        ret = ssh2_dsa_new(dsa,
+        ret = wcng_dsa_new(dsa,
                            rpbDecoded[1], rcbDecoded[1],
                            rpbDecoded[2], rcbDecoded[2],
                            rpbDecoded[3], rcbDecoded[3],


### PR DESCRIPTION
Internal crypto API `ssh2_rsa_new()` and `ssh2_dsa_new()` were able to
generate both public and private keys. However, the private key part was
not actually used by any external callers (from `hostkey.c`). It was 
used in backends lacking a native private key loader: libgcrypt for both
RSA and DSA, and WinCNG for DSA [1].

Also add `_pub` suffic to RSA/DSA APIs to reflect their actual purpose.

[1] bcrypt seems to offer support for DSA, but not implemented in
WinCNG, it also makes no sense to try implementing it now that DSA is
dead and WinCNG is untestable in CI.
