### PR TITLE
crypto: propagate `session` to key alloc/free functions, switch to SSH2 allocator

### DIFF
--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -436,7 +436,7 @@ If defined as 0, the rest of this section can be omitted.
 `ssh2_rsa_ctx`: Type of an RSA computation context. Generally a struct.
 
 ```c
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                  const unsigned char *edata, size_t elen,
                  const unsigned char *ndata, size_t nlen,
                  const unsigned char *ddata, size_t dlen,

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -512,7 +512,7 @@ This procedure is already prototyped in `crypto.h`.
 Note: this procedure is not used if macro `ssh2_rsa_sha1_signv()` is defined.
 
 ```c
-void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session);
 ```
 Releases the RSA computation context at `rsa`.
 
@@ -627,7 +627,7 @@ DSA signs the (`hash`, `hash_len`) data using SHA-1 and store the signature at
 This procedure is already prototyped in `crypto.h`.
 
 ```c
-void ssh2_dsa_free(ssh2_dsa_ctx *dsa);
+void ssh2_dsa_free(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session);
 ```
 Releases the DSA computation context at `dsa`.
 
@@ -729,7 +729,7 @@ Returns the curve type associated with given context.
 This procedure is already prototyped in `crypto.h`.
 
 ```c
-void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx);
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session);
 ```
 Releases the ECDSA computation context at `ec_ctx`.
 
@@ -813,7 +813,7 @@ Returns 0 if OK, else -1.
 This procedure is already prototyped in `crypto.h`.
 
 ```c
-void ssh2_ed25519_free(ssh2_ed25519_ctx *ed_ctx);
+void ssh2_ed25519_free(ssh2_ed25519_ctx *ed_ctx, LIBSSH2_SESSION *session);
 ```
 Releases the ED25519 computation context at `ed_ctx`.
 

--- a/src/HACKING-CRYPTO.md
+++ b/src/HACKING-CRYPTO.md
@@ -575,7 +575,7 @@ defined as 0, the rest of this section can be omitted.
 `ssh2_dsa_ctx`: Type of a DSA computation context. Generally a struct.
 
 ```c
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
+int ssh2_dsa_new(ssh2_dsa_ctx **dsa, LIBSSH2_SESSION *session,
                  const unsigned char *pdata, size_t plen,
                  const unsigned char *qdata, size_t qlen,
                  const unsigned char *gdata, size_t glen,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -124,7 +124,7 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx);
 #define SSH2_MLKEM_1024_CIPHERTEXT      1568
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                  const unsigned char *edata, size_t elen,
                  const unsigned char *ndata, size_t nlen,
                  const unsigned char *ddata, size_t dlen,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -156,7 +156,7 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
                          const unsigned char *m, size_t m_len);
 #endif
 #ifndef ssh2_rsa_free
-void ssh2_rsa_free(ssh2_rsa_ctx *rsa);
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session);
 #endif
 #endif /* LIBSSH2_RSA */
 
@@ -179,7 +179,7 @@ int ssh2_dsa_sha1_verify(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
                          const unsigned char *sig,
                          const unsigned char *m, size_t m_len);
 #ifndef ssh2_dsa_free
-void ssh2_dsa_free(ssh2_dsa_ctx *dsa);
+void ssh2_dsa_free(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session);
 #endif
 #endif /* LIBSSH2_DSA */
 
@@ -220,7 +220,7 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
                       const unsigned char *s, size_t s_len,
                       const unsigned char *m, size_t m_len);
 #ifndef ssh2_ecdsa_free
-void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx);
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session);
 #endif
 #endif /* LIBSSH2_ECDSA */
 
@@ -252,7 +252,7 @@ int ssh2_ed25519_verify(ssh2_ed25519_ctx *ed_ctx, LIBSSH2_SESSION *session,
                         const uint8_t *s, size_t s_len,
                         const uint8_t *m, size_t m_len);
 #ifndef ssh2_ed25519_free
-void ssh2_ed25519_free(ssh2_ed25519_ctx *ed_ctx);
+void ssh2_ed25519_free(ssh2_ed25519_ctx *ed_ctx, LIBSSH2_SESSION *session);
 #endif
 #endif /* LIBSSH2_ED25519 */
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -161,7 +161,7 @@ void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session);
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
+int ssh2_dsa_new(ssh2_dsa_ctx **dsa, LIBSSH2_SESSION *session,
                  const unsigned char *pdata, size_t plen,
                  const unsigned char *qdata, size_t qlen,
                  const unsigned char *gdata, size_t glen,

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -855,10 +855,9 @@ static int hostkey_method_ssh_ed25519_dtor(LIBSSH2_SESSION *session,
                                            void **abstract)
 {
     ssh2_ed25519_ctx *ed_ctx = (ssh2_ed25519_ctx *)(*abstract);
-    (void)session;
 
     if(ed_ctx)
-        ssh2_ed25519_free(ed_ctx);
+        ssh2_ed25519_free(ed_ctx, session);
 
     *abstract = NULL;
 

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -447,7 +447,8 @@ static int hostkey_method_ssh_dss_init(LIBSSH2_SESSION *session,
        !ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_dsa_new(&dsa, p, p_len, q, q_len, g, g_len, y, y_len, NULL, 0))
+    if(ssh2_dsa_new(&dsa, session, p, p_len, q, q_len, g, g_len, y, y_len,
+                    NULL, 0))
         return -1;
 
     *abstract = dsa;

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -98,7 +98,7 @@ static int hostkey_method_ssh_rsa_init(LIBSSH2_SESSION *session,
        !ssh2_eob(&buf))
         return -1;
 
-    if(ssh2_rsa_new(&rsa, e, e_len, n, n_len,
+    if(ssh2_rsa_new(&rsa, session, e, e_len, n, n_len,
                     NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0))
         return -1;
 

--- a/src/hostkey.c
+++ b/src/hostkey.c
@@ -45,10 +45,9 @@ static int hostkey_method_ssh_rsa_dtor(LIBSSH2_SESSION *session,
                                        void **abstract)
 {
     ssh2_rsa_ctx *rsa = (ssh2_rsa_ctx *)(*abstract);
-    (void)session;
 
     if(rsa)
-        ssh2_rsa_free(rsa);
+        ssh2_rsa_free(rsa, session);
 
     *abstract = NULL;
 
@@ -404,10 +403,9 @@ static int hostkey_method_ssh_dss_dtor(LIBSSH2_SESSION *session,
                                        void **abstract)
 {
     ssh2_dsa_ctx *dsa = (ssh2_dsa_ctx *)(*abstract);
-    (void)session;
 
     if(dsa)
-        ssh2_dsa_free(dsa);
+        ssh2_dsa_free(dsa, session);
 
     *abstract = NULL;
 
@@ -577,10 +575,9 @@ static int hostkey_method_ssh_ecdsa_dtor(LIBSSH2_SESSION *session,
                                          void **abstract)
 {
     ssh2_ecdsa_ctx *ec_ctx = (ssh2_ecdsa_ctx *)(*abstract);
-    (void)session;
 
     if(ec_ctx)
-        ssh2_ecdsa_free(ec_ctx);
+        ssh2_ecdsa_free(ec_ctx, session);
 
     *abstract = NULL;
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -1551,7 +1551,7 @@ static void kex_method_ecdh_cleanup(LIBSSH2_SESSION *session,
         SSH2_SAFEFREE(session, key_state->public_key_oct);
 
     if(key_state->private_key) {
-        ssh2_ecdsa_free(key_state->private_key);
+        ssh2_ecdsa_free(key_state->private_key, session);
         key_state->private_key = NULL;
     }
 
@@ -1856,7 +1856,7 @@ static void kex_method_mlkem_nistp_cleanup(
         SSH2_SAFEFREE(session, key_state->public_key_oct);
 
     if(key_state->private_key) {
-        ssh2_ecdsa_free(key_state->private_key);
+        ssh2_ecdsa_free(key_state->private_key, session);
         key_state->private_key = NULL;
     }
 

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -98,7 +98,7 @@ void ssh2_hmac_cleanup(ssh2_hmac_ctx *ctx)
 }
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                  const unsigned char *edata, size_t elen,
                  const unsigned char *ndata, size_t nlen,
                  const unsigned char *ddata, size_t dlen,
@@ -110,6 +110,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
 {
     int rc;
 
+    (void)session;
     (void)e1data;
     (void)e1len;
     (void)e2data;
@@ -333,7 +334,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
         goto fail;
     }
 
-    if(ssh2_rsa_new(rsa, e, elen, n, nlen, d, dlen, p, plen, q, qlen,
+    if(ssh2_rsa_new(rsa, session, e, elen, n, nlen, d, dlen, p, plen, q, qlen,
                     e1, e1len, e2, e2len, coeff, coefflen)) {
         ret = -1;
         goto fail;

--- a/src/libgcrypt.c
+++ b/src/libgcrypt.c
@@ -208,7 +208,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 #endif
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
+int ssh2_dsa_new(ssh2_dsa_ctx **dsa, LIBSSH2_SESSION *session,
                  const unsigned char *pdata, size_t plen,
                  const unsigned char *qdata, size_t qlen,
                  const unsigned char *gdata, size_t glen,
@@ -216,6 +216,8 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
                  const unsigned char *xdata, size_t xlen)
 {
     int rc;
+
+    (void)session;
 
     if(xlen)
         rc = gcry_sexp_build(dsa, NULL,
@@ -416,7 +418,8 @@ int ssh2_dsa_new_priv(ssh2_dsa_ctx **dsa,
         goto fail;
     }
 
-    if(ssh2_dsa_new(dsa, p, plen, q, qlen, g, glen, y, ylen, x, xlen)) {
+    if(ssh2_dsa_new(dsa, session, p, plen, q, qlen, g, glen, y, ylen,
+                    x, xlen)) {
         ret = -1;
         goto fail;
     }

--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -86,10 +86,12 @@
 #endif
 
 #define ssh2_rsa_ctx          struct gcry_sexp
-#define ssh2_rsa_free(rsa)    gcry_sexp_release(rsa)
+#define ssh2_rsa_free(rsa, session) \
+    (gcry_sexp_release(rsa), (void)(session))
 
 #define ssh2_dsa_ctx          struct gcry_sexp
-#define ssh2_dsa_free(dsa)    gcry_sexp_release(dsa)
+#define ssh2_dsa_free(dsa, session) \
+    (gcry_sexp_release(dsa), (void)(session))
 
 #define SSH2_CIPHER_T(name)   int name
 #define ssh2_cipher_ctx       gcry_cipher_hd_t

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -648,8 +648,10 @@ int ssh2_rsa_sha1_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 
 void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session)
 {
-    mbedtls_rsa_free(rsa);
-    SSH2_FREE(session, rsa);
+    if(rsa) {
+        mbedtls_rsa_free(rsa);
+        SSH2_FREE(session, rsa);
+    }
 }
 
 static unsigned char *mbed_gen_publickey_from_rsa(LIBSSH2_SESSION *session,
@@ -1306,8 +1308,10 @@ cleanup:
 
 void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session)
 {
-    mbedtls_ecdsa_free(ec_ctx);
-    SSH2_FREE(session, ec_ctx);
+    if(ec_ctx) {
+        mbedtls_ecdsa_free(ec_ctx);
+        SSH2_FREE(session, ec_ctx);
+    }
 }
 #endif /* LIBSSH2_ECDSA */
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -464,7 +464,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
         ret = mbedtls_rsa_check_pubkey(ctx);
 
     if(ret && ctx) {
-        ssh2_rsa_free(ctx);
+        ssh2_rsa_free(ctx, session);
         ctx = NULL;
     }
     *rsa = ctx;
@@ -496,7 +496,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
            private-key from memory fails if the last byte is not a null byte */
         data_nullterm = SSH2_CALLOC(session, blob_len + 1);
         if(!data_nullterm) {
-            ssh2_rsa_free(*rsa);
+            ssh2_rsa_free(*rsa, session);
             *rsa = NULL;
             return -1;
         }
@@ -521,7 +521,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 
     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
         mbedtls_pk_free(&pkey);
-        ssh2_rsa_free(*rsa);
+        ssh2_rsa_free(*rsa, session);
         *rsa = NULL;
         return -1;
     }
@@ -646,8 +646,9 @@ int ssh2_rsa_sha1_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 }
 #endif
 
-void ssh2_rsa_free(ssh2_rsa_ctx *rsa)
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session)
 {
+    (void)session;
     mbedtls_rsa_free(rsa);
     mbedtls_free(rsa);
 }
@@ -925,7 +926,7 @@ int ssh2_ecdsa_create_key(ssh2_ec_key **ec_ctx, LIBSSH2_SESSION *session,
 
 failed:
 
-    ssh2_ecdsa_free(*ec_ctx);
+    ssh2_ecdsa_free(*ec_ctx, session);
     *ec_ctx = NULL;
     if(*out_public_key_octal) {
         ssh2_explicit_zero(*out_public_key_octal, plen);
@@ -966,7 +967,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
 
 failed:
 
-    ssh2_ecdsa_free(*ec_ctx);
+    ssh2_ecdsa_free(*ec_ctx, session);
     *ec_ctx = NULL;
 
     return -1;
@@ -1080,7 +1081,8 @@ cleanup:
     return rc == 0 ? 0 : -1;
 }
 
-static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx, mbedtls_pk_context *pkey,
+static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx, LIBSSH2_SESSION *session,
+                            mbedtls_pk_context *pkey,
                             const char *data, size_t data_len,
                             const char *passphrase)
 {
@@ -1105,7 +1107,7 @@ static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx, mbedtls_pk_context *pkey,
 
 failed:
 
-    ssh2_ecdsa_free(*ctx);
+    ssh2_ecdsa_free(*ctx, session);
     *ctx = NULL;
 
     return -1;
@@ -1176,7 +1178,7 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
 
 failed:
 
-    ssh2_ecdsa_free(*ctx);
+    ssh2_ecdsa_free(*ctx, session);
     *ctx = NULL;
 
 cleanup:
@@ -1215,7 +1217,7 @@ int ssh2_ecdsa_new_priv(ssh2_ecdsa_ctx **ec_ctx,
         data_nullterm[blob_len] = '\0';  /* for mbedtls_pk_parse_key() */
     }
 
-    if(mbed_parse_eckey(ec_ctx, &pkey, data_nullterm, data_len + 1,
+    if(mbed_parse_eckey(ec_ctx, session, &pkey, data_nullterm, data_len + 1,
                         passphrase) == 0)
         goto cleanup;
 
@@ -1303,8 +1305,9 @@ cleanup:
     return *signature ? 0 : -1;
 }
 
-void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx)
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session)
 {
+    (void)session;
     mbedtls_ecdsa_free(ec_ctx);
     mbedtls_free(ec_ctx);
 }

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -427,7 +427,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
     int ret;
     ssh2_rsa_ctx *ctx;
 
-    ctx = mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
+    ctx = SSH2_CALLOC(session, sizeof(ssh2_rsa_ctx));
     if(!ctx)
         return -1;
 
@@ -484,7 +484,7 @@ int ssh2_rsa_new_priv(ssh2_rsa_ctx **rsa,
 
     (void)session;
 
-    *rsa = mbedtls_calloc(1, sizeof(ssh2_rsa_ctx));
+    *rsa = SSH2_CALLOC(session, sizeof(ssh2_rsa_ctx));
     if(!*rsa)
         return -1;
 
@@ -648,9 +648,8 @@ int ssh2_rsa_sha1_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 
 void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session)
 {
-    (void)session;
     mbedtls_rsa_free(rsa);
-    mbedtls_free(rsa);
+    SSH2_FREE(session, rsa);
 }
 
 static unsigned char *mbed_gen_publickey_from_rsa(LIBSSH2_SESSION *session,
@@ -900,7 +899,7 @@ int ssh2_ecdsa_create_key(ssh2_ec_key **ec_ctx, LIBSSH2_SESSION *session,
 {
     size_t plen = 0;
 
-    *ec_ctx = mbedtls_calloc(1, sizeof(mbedtls_ecp_keypair));
+    *ec_ctx = SSH2_CALLOC(session, sizeof(mbedtls_ecp_keypair));
     if(!*ec_ctx)
         goto failed;
 
@@ -946,7 +945,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
 {
     (void)session;
 
-    *ec_ctx = mbedtls_calloc(1, sizeof(mbedtls_ecp_keypair));
+    *ec_ctx = SSH2_CALLOC(session, sizeof(mbedtls_ecp_keypair));
     if(!*ec_ctx)
         goto failed;
 
@@ -1096,7 +1095,7 @@ static int mbed_parse_eckey(ssh2_ecdsa_ctx **ctx, LIBSSH2_SESSION *session,
     if(mbedtls_pk_get_type(pkey) != MBEDTLS_PK_ECKEY)
         goto failed;
 
-    *ctx = mbedtls_calloc(1, sizeof(ssh2_ecdsa_ctx));
+    *ctx = SSH2_CALLOC(session, sizeof(ssh2_ecdsa_ctx));
     if(!*ctx)
         goto failed;
 
@@ -1151,7 +1150,7 @@ static int mbed_parse_openssh_key(ssh2_ecdsa_ctx **ctx,
     if(ssh2_get_bignum_bytes(decrypted, &exponent, &exponent_len))
         goto failed;
 
-    *ctx = mbedtls_calloc(1, sizeof(ssh2_ecdsa_ctx));
+    *ctx = SSH2_CALLOC(session, sizeof(ssh2_ecdsa_ctx));
     if(!*ctx)
         goto failed;
 
@@ -1307,9 +1306,8 @@ cleanup:
 
 void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session)
 {
-    (void)session;
     mbedtls_ecdsa_free(ec_ctx);
-    mbedtls_free(ec_ctx);
+    SSH2_FREE(session, ec_ctx);
 }
 #endif /* LIBSSH2_ECDSA */
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -414,7 +414,7 @@ static int mbed_bn_random(ssh2_bn *bn, int bits, int top, int bottom)
  */
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                  const unsigned char *edata, size_t elen,
                  const unsigned char *ndata, size_t nlen,
                  const unsigned char *ddata, size_t dlen,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -427,7 +427,7 @@ int ssh2_rsa_sha1_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
+int ssh2_dsa_new(ssh2_dsa_ctx **dsa, LIBSSH2_SESSION *session,
                  const unsigned char *pdata, size_t plen,
                  const unsigned char *qdata, size_t qlen,
                  const unsigned char *gdata, size_t glen,
@@ -444,6 +444,8 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     unsigned char *g_buf = NULL;
     unsigned char *y_buf = NULL;
     unsigned char *x_buf = NULL;
+
+    (void)session;
 
     if(pdata && plen > 0) {
         p_buf = OPENSSL_malloc(plen);
@@ -523,6 +525,8 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
     BIGNUM *g_bn = NULL;
     BIGNUM *pub_key = NULL;
     BIGNUM *priv_key = NULL;
+
+    (void)session;
 
     p_bn = BN_new();
     if(!p_bn)
@@ -1473,7 +1477,7 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_dsa_new(&ctx, p, plen, q, qlen, g, glen,
+    rc = ssh2_dsa_new(&ctx, session, p, plen, q, qlen, g, glen,
                       pub_key, pub_len, priv_key, priv_len);
     if(rc) {
         ssh2_deb((session, LIBSSH2_ERROR_PROTO,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -187,7 +187,7 @@ int ssh2_random(unsigned char *buf, size_t len)
 }
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                  const unsigned char *edata, size_t elen,
                  const unsigned char *ndata, size_t nlen,
                  const unsigned char *ddata, size_t dlen,
@@ -206,6 +206,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     unsigned char *ebuf = NULL;
     unsigned char *dbuf = NULL;
 
+    (void)session;
     (void)pdata;
     (void)plen;
     (void)qdata;
@@ -274,6 +275,8 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     BIGNUM *dmp1 = NULL;
     BIGNUM *dmq1 = NULL;
     BIGNUM *iqmp = NULL;
+
+    (void)session;
 
     e = BN_new();
     if(!e)
@@ -1231,7 +1234,7 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
         return -1;
     }
 
-    rc = ssh2_rsa_new(&ctx, e, elen, n, nlen, d, dlen,
+    rc = ssh2_rsa_new(&ctx, session, e, elen, n, nlen, d, dlen,
                       p, plen, q, qlen, NULL, 0, NULL, 0, coeff, coefflen);
     if(rc) {
         ssh2_deb((session, LIBSSH2_TRACE_AUTH,

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1264,14 +1264,14 @@ static int ossl_rsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     if(rsa)
         *rsa = ctx;
     else
-        ssh2_rsa_free(ctx);
+        ssh2_rsa_free(ctx, session);
 
     return rc;
 
 fail:
 
     if(ctx)
-        ssh2_rsa_free(ctx);
+        ssh2_rsa_free(ctx, session);
 
     return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                     "Unable to allocate memory for private key data");
@@ -1498,14 +1498,14 @@ static int ossl_dsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     if(dsa)
         *dsa = ctx;
     else
-        ssh2_dsa_free(ctx);
+        ssh2_dsa_free(ctx, session);
 
     return rc;
 
 fail:
 
     if(ctx)
-        ssh2_dsa_free(ctx);
+        ssh2_dsa_free(ctx, session);
 
     return ssh2_err(session, LIBSSH2_ERROR_ALLOC,
                     "Unable to allocate memory for private key data");
@@ -1774,14 +1774,14 @@ static int ossl_ed25519_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     if(ed_ctx)
         *ed_ctx = ctx;
     else if(ctx)
-        ssh2_ed25519_free(ctx);
+        ssh2_ed25519_free(ctx, session);
 
     return 0;
 
 clean_exit:
 
     if(ctx)
-        ssh2_ed25519_free(ctx);
+        ssh2_ed25519_free(ctx, session);
 
     if(method_buf)
         SSH2_FREE(session, method_buf);
@@ -1903,14 +1903,14 @@ static int ossl_ed25519_sk_openssh_priv_to_pubkey(
     if(ed_ctx)
         *ed_ctx = ctx;
     else if(ctx)
-        ssh2_ed25519_free(ctx);
+        ssh2_ed25519_free(ctx, session);
 
     return 0;
 
 clean_exit:
 
     if(ctx)
-        ssh2_ed25519_free(ctx);
+        ssh2_ed25519_free(ctx, session);
 
     if(method_buf)
         SSH2_FREE(session, method_buf);
@@ -1954,7 +1954,7 @@ int ssh2_ed25519_new_priv(ssh2_ed25519_ctx **ed_ctx,
     BIO_free(bp);
 
     if(*ed_ctx && EVP_PKEY_id(*ed_ctx) != EVP_PKEY_ED25519) {
-        ssh2_ed25519_free(*ed_ctx);
+        ssh2_ed25519_free(*ed_ctx, session);
         *ed_ctx = NULL;
         return ssh2_err(session, LIBSSH2_ERROR_PROTO,
                         "Private key is not an ED25519 key");
@@ -2677,7 +2677,7 @@ static int ossl_ecdsa_openssh_priv_to_pubkey(LIBSSH2_SESSION *session,
     if(ec_ctx)
         *ec_ctx = ctx;
     else
-        ssh2_ecdsa_free(ctx);
+        ssh2_ecdsa_free(ctx, session);
 
     return rc;
 
@@ -2688,7 +2688,7 @@ fail:
 #endif
 
     if(ctx)
-        ssh2_ecdsa_free(ctx);
+        ssh2_ecdsa_free(ctx, session);
 
     return rc;
 }
@@ -2805,13 +2805,13 @@ static int ossl_ecdsa_sk_openssh_priv_to_pubkey(
     if(ec_ctx)
         *ec_ctx = ctx;
     else
-        ssh2_ecdsa_free(ctx);
+        ssh2_ecdsa_free(ctx, session);
 
     return rc;
 
 fail:
     if(ctx)
-        ssh2_ecdsa_free(ctx);
+        ssh2_ecdsa_free(ctx, session);
 
     if(key)
         SSH2_FREE(session, key);

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -273,31 +273,33 @@
 #if LIBSSH2_RSA
 #ifdef USE_OPENSSL_3
 #define ssh2_rsa_ctx                 EVP_PKEY
-#define ssh2_rsa_free(rsa)           EVP_PKEY_free(rsa)
+#define ssh2_rsa_free(rsa, session)  (EVP_PKEY_free(rsa), (void)(session))
 #else
 #define ssh2_rsa_ctx                 RSA
-#define ssh2_rsa_free(rsa)           RSA_free(rsa)
+#define ssh2_rsa_free(rsa, session)  (RSA_free(rsa), (void)(session))
 #endif
 #endif /* LIBSSH2_RSA */
 
 #if LIBSSH2_DSA
 #ifdef USE_OPENSSL_3
 #define ssh2_dsa_ctx                 EVP_PKEY
-#define ssh2_dsa_free(dsa)           EVP_PKEY_free(dsa)
+#define ssh2_dsa_free(dsa, session)  (EVP_PKEY_free(dsa), (void)(session))
 #else
 #define ssh2_dsa_ctx                 DSA
-#define ssh2_dsa_free(dsa)           DSA_free(dsa)
+#define ssh2_dsa_free(dsa, session)  (DSA_free(dsa), (void)(session))
 #endif
 #endif /* LIBSSH2_DSA */
 
 #if LIBSSH2_ECDSA
 #ifdef USE_OPENSSL_3
 #define ssh2_ecdsa_ctx               EVP_PKEY
-#define ssh2_ecdsa_free(ec_ctx)      EVP_PKEY_free(ec_ctx)
+#define ssh2_ecdsa_free(ec_ctx, session) \
+    (EVP_PKEY_free(ec_ctx), (void)(session))
 #define ssh2_ec_key                  EVP_PKEY
 #else
 #define ssh2_ecdsa_ctx               EC_KEY
-#define ssh2_ecdsa_free(ec_ctx)      EC_KEY_free(ec_ctx)
+#define ssh2_ecdsa_free(ec_ctx, session) \
+    (EC_KEY_free(ec_ctx), (void)(session))
 #define ssh2_ec_key                  EC_KEY
 #endif
 
@@ -310,7 +312,8 @@ typedef enum {
 
 #if LIBSSH2_ED25519
 #define ssh2_ed25519_ctx             EVP_PKEY
-#define ssh2_ed25519_free(ed_ctx)    EVP_PKEY_free(ed_ctx)
+#define ssh2_ed25519_free(ed_ctx, session) \
+    (EVP_PKEY_free(ed_ctx), (void)(session))
 #endif /* LIBSSH2_ED25519 */
 
 #define SSH2_CIPHER_T(name)          const EVP_CIPHER *(*(name))(void)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -911,11 +911,10 @@ static struct asn1Element *rsaprivatekeyinfo(struct asn1Element *privkey)
  *******************************************************************/
 
 static struct os400qc3_crypto_ctx *init_crypto_ctx(
-    struct os400qc3_crypto_ctx *ctx,
-    LIBSSH2_SESSION *session)
+    struct os400qc3_crypto_ctx *ctx)
 {
     if(!ctx)
-        ctx = SSH2_ALLOC(session, sizeof(*ctx));
+        ctx = malloc(sizeof(*ctx));
 
     if(ctx) {
         memset((char *)ctx, 0, sizeof(*ctx));
@@ -1103,7 +1102,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     if(!ctx)
         return -1;
 
-    init_crypto_ctx(ctx, NULL);
+    init_crypto_ctx(ctx);
     algd.Block_Cipher_Alg = algo.algo;
     algd.Block_Length = algo.size;
     algd.Mode = algo.mode;
@@ -1190,7 +1189,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
 
     (void)session;
 
-    ctx = init_crypto_ctx(NULL, session);
+    ctx = init_crypto_ctx(NULL);
     if(!ctx)
         ret = -1;
     if(!ret) {
@@ -1816,12 +1815,12 @@ static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
     memcpy(algd.Init_Vector, pkcs5.iv, pkcs5.ivlen);
 
     /* Create the key and algorithm context tokens. */
-    *ctx = init_crypto_ctx(NULL, session);
+    *ctx = init_crypto_ctx(NULL);
     if(!*ctx) {
         SSH2_FREE(session, dk);
         return -1;
     }
-    init_crypto_ctx(*ctx, NULL);
+    init_crypto_ctx(*ctx);
     set_EC_length(errcode, sizeof(errcode));
     Qc3CreateKeyContext(dk, &pkcs5.dklen, binstring, &algd.Block_Cipher_Alg,
                         qc3clear, NULL, NULL, (*ctx)->key.Key_Context_Token,
@@ -2296,7 +2295,7 @@ static int os400_rsa_new_priv_from_file(ssh2_rsa_ctx **rsa,
                                         const char *filename,
                                         const char *passphrase)
 {
-    ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL, session);
+    ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL);
     int ret;
 
     if(!ctx)
@@ -2317,7 +2316,7 @@ static int os400_rsa_new_priv_from_blob(ssh2_rsa_ctx **rsa,
                                         const char *blob, size_t blob_len,
                                         const char *passphrase)
 {
-    ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL, session);
+    ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL);
     unsigned char *data = NULL;
     size_t datalen = 0;
     int ret;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1162,7 +1162,7 @@ int ssh2_cipher_crypt(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
  *******************************************************************/
 
 #if LIBSSH2_RSA
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                  const unsigned char *edata, size_t elen,
                  const unsigned char *ndata, size_t nlen,
                  const unsigned char *ddata, size_t dlen,
@@ -1186,6 +1186,8 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     int keytype;
     int ret = 0;
     int i;
+
+    (void)session;
 
     ctx = init_crypto_ctx(NULL);
     if(!ctx)

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -911,10 +911,11 @@ static struct asn1Element *rsaprivatekeyinfo(struct asn1Element *privkey)
  *******************************************************************/
 
 static struct os400qc3_crypto_ctx *init_crypto_ctx(
-    struct os400qc3_crypto_ctx *ctx)
+    struct os400qc3_crypto_ctx *ctx,
+    LIBSSH2_SESSION *session)
 {
     if(!ctx)
-        ctx = malloc(sizeof(*ctx));
+        ctx = SSH2_ALLOC(session, sizeof(*ctx));
 
     if(ctx) {
         memset((char *)ctx, 0, sizeof(*ctx));
@@ -1102,7 +1103,7 @@ int ssh2_cipher_init(ssh2_cipher_ctx *ctx, SSH2_CIPHER_T(algo),
     if(!ctx)
         return -1;
 
-    init_crypto_ctx(ctx);
+    init_crypto_ctx(ctx, NULL);
     algd.Block_Cipher_Alg = algo.algo;
     algd.Block_Length = algo.size;
     algd.Mode = algo.mode;
@@ -1189,7 +1190,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
 
     (void)session;
 
-    ctx = init_crypto_ctx(NULL);
+    ctx = init_crypto_ctx(NULL, session);
     if(!ctx)
         ret = -1;
     if(!ret) {
@@ -1815,12 +1816,12 @@ static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
     memcpy(algd.Init_Vector, pkcs5.iv, pkcs5.ivlen);
 
     /* Create the key and algorithm context tokens. */
-    *ctx = init_crypto_ctx(NULL);
+    *ctx = init_crypto_ctx(NULL, session);
     if(!*ctx) {
         SSH2_FREE(session, dk);
         return -1;
     }
-    init_crypto_ctx(*ctx);
+    init_crypto_ctx(*ctx, NULL);
     set_EC_length(errcode, sizeof(errcode));
     Qc3CreateKeyContext(dk, &pkcs5.dklen, binstring, &algd.Block_Cipher_Alg,
                         qc3clear, NULL, NULL, (*ctx)->key.Key_Context_Token,
@@ -2295,7 +2296,7 @@ static int os400_rsa_new_priv_from_file(ssh2_rsa_ctx **rsa,
                                         const char *filename,
                                         const char *passphrase)
 {
-    ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL);
+    ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL, session);
     int ret;
 
     if(!ctx)
@@ -2316,7 +2317,7 @@ static int os400_rsa_new_priv_from_blob(ssh2_rsa_ctx **rsa,
                                         const char *blob, size_t blob_len,
                                         const char *passphrase)
 {
-    ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL);
+    ssh2_rsa_ctx *ctx = init_crypto_ctx(NULL, session);
     unsigned char *data = NULL;
     size_t datalen = 0;
     int ret;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -1252,7 +1252,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     asn1delete(key);
     asn1delete(structkey);
     if(ret && ctx) {
-        ssh2_rsa_free(ctx);
+        ssh2_rsa_free(ctx, session);
         ctx = NULL;
     }
     *rsa = ctx;

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -946,8 +946,7 @@ void ssh2_os400qc3_crypto_dtor(struct os400qc3_crypto_ctx *x)
     }
     if(x->kek) {
         ssh2_os400qc3_crypto_dtor(x->kek);
-        free((char *)x->kek);
-        x->kek = NULL;
+        SSH2_SAFEFREE(session, x->kek);
     }
 }
 
@@ -1828,8 +1827,7 @@ static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
                         (char *)&errcode);
     SSH2_FREE(session, dk);
     if(errcode.Bytes_Available) {
-        free((char *)*ctx);
-        *ctx = NULL;
+        SSH2_SAFEFREE(session, *ctx);
         return -1;
     }
 
@@ -1837,8 +1835,7 @@ static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
                               (*ctx)->hash.Alg_Context_Token, &errcode);
     if(errcode.Bytes_Available) {
         Qc3DestroyKeyContext((*ctx)->key.Key_Context_Token, (char *)&ecnull);
-        free((char *)*ctx);
-        *ctx = NULL;
+        SSH2_SAFEFREE(session, *ctx);
         return -1;
     }
     return 1; /* Tell it is encrypted. */

--- a/src/os400qc3.c
+++ b/src/os400qc3.c
@@ -946,7 +946,8 @@ void ssh2_os400qc3_crypto_dtor(struct os400qc3_crypto_ctx *x)
     }
     if(x->kek) {
         ssh2_os400qc3_crypto_dtor(x->kek);
-        SSH2_SAFEFREE(session, x->kek);
+        free((char *)x->kek);
+        x->kek = NULL;
     }
 }
 
@@ -1827,7 +1828,8 @@ static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
                         (char *)&errcode);
     SSH2_FREE(session, dk);
     if(errcode.Bytes_Available) {
-        SSH2_SAFEFREE(session, *ctx);
+        free((char *)*ctx);
+        *ctx = NULL;
         return -1;
     }
 
@@ -1835,7 +1837,8 @@ static int pkcs8kek(LIBSSH2_SESSION *session, struct os400qc3_crypto_ctx **ctx,
                               (*ctx)->hash.Alg_Context_Token, &errcode);
     if(errcode.Bytes_Available) {
         Qc3DestroyKeyContext((*ctx)->key.Key_Context_Token, (char *)&ecnull);
-        SSH2_SAFEFREE(session, *ctx);
+        free((char *)*ctx);
+        *ctx = NULL;
         return -1;
     }
     return 1; /* Tell it is encrypted. */

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -260,8 +260,8 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 
 #if LIBSSH2_RSA
 #define ssh2_rsa_ctx             struct os400qc3_crypto_ctx
-#define ssh2_rsa_free(rsa) \
-    (ssh2_os400qc3_crypto_dtor(rsa), free((char *)rsa))
+#define ssh2_rsa_free(rsa, session) \
+    (ssh2_os400qc3_crypto_dtor(rsa), free((char *)rsa), (void)(session))
 #define ssh2_prepare_iovec(vec, len) \
     memset((char *)(vec), 0, (len) * sizeof(struct iovec))
 #if LIBSSH2_RSA_SHA1

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -261,7 +261,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #if LIBSSH2_RSA
 #define ssh2_rsa_ctx             struct os400qc3_crypto_ctx
 #define ssh2_rsa_free(rsa, session) \
-    (ssh2_os400qc3_crypto_dtor(rsa), free((char *)rsa), (void)(session))
+    (ssh2_os400qc3_crypto_dtor(rsa), SSH2_FREE(session, rsa))
 #define ssh2_prepare_iovec(vec, len) \
     memset((char *)(vec), 0, (len) * sizeof(struct iovec))
 #if LIBSSH2_RSA_SHA1

--- a/src/os400qc3.h
+++ b/src/os400qc3.h
@@ -261,7 +261,7 @@ struct os400qc3_dh_ctx {  /* Diffie-Hellman context. */
 #if LIBSSH2_RSA
 #define ssh2_rsa_ctx             struct os400qc3_crypto_ctx
 #define ssh2_rsa_free(rsa, session) \
-    (ssh2_os400qc3_crypto_dtor(rsa), SSH2_FREE(session, rsa))
+    (ssh2_os400qc3_crypto_dtor(rsa), free((char *)rsa), (void)(session))
 #define ssh2_prepare_iovec(vec, len) \
     memset((char *)(vec), 0, (len) * sizeof(struct iovec))
 #if LIBSSH2_RSA_SHA1

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1128,7 +1128,7 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
         keylen += p1len * 3 + p2len * 2 + mlen;
     }
 
-    rsakey = malloc(keylen);
+    rsakey = SSH2_ALLOC(session, keylen);
     if(!rsakey)
         return -1;
 
@@ -1212,14 +1212,14 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgRSA, NULL, lpszBlobType,
                               &hKey, (PUCHAR)rsakey, (ULONG)keylen, 0);
     if(!BCRYPT_SUCCESS(ret)) {
-        wcng_zero_free(rsakey, keylen);
+        ssh2_zero_free(session, rsakey, keylen);
         return -1;
     }
 
-    *rsa = malloc(sizeof(ssh2_rsa_ctx));
+    *rsa = SSH2_ALLOC(session, sizeof(ssh2_rsa_ctx));
     if(!*rsa) {
         BCryptDestroyKey(hKey);
-        wcng_zero_free(rsakey, keylen);
+        ssh2_zero_free(session, rsakey, keylen);
         return -1;
     }
 
@@ -1255,7 +1255,7 @@ static int wcng_rsa_new_private_parse(ssh2_rsa_ctx **rsa,
         return -1;
     }
 
-    *rsa = malloc(sizeof(ssh2_rsa_ctx));
+    *rsa = SSH2_ALLOC(session, sizeof(ssh2_rsa_ctx));
     if(!*rsa) {
         BCryptDestroyKey(hKey);
         wcng_zero_free(pbStructInfo, cbStructInfo);
@@ -1385,16 +1385,14 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 
 void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session)
 {
-    (void)session;
-
     if(!rsa)
         return;
 
     BCryptDestroyKey(rsa->hKey);
     rsa->hKey = NULL;
 
-    wcng_zero_free(rsa->pbKeyObject, rsa->cbKeyObject);
-    wcng_zero_free(rsa, sizeof(ssh2_rsa_ctx));
+    ssh2_zero_free(session, rsa->pbKeyObject, rsa->cbKeyObject);
+    ssh2_zero_free(session, rsa, sizeof(ssh2_rsa_ctx));
 }
 #endif
 
@@ -1425,7 +1423,7 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa, LIBSSH2_SESSION *session,
     if(xdata && xlen > 0)
         keylen += 20;
 
-    dsakey = malloc(keylen);
+    dsakey = SSH2_ALLOC(session, keylen);
     if(!dsakey)
         return -1;
 
@@ -1484,14 +1482,14 @@ int ssh2_dsa_new(ssh2_dsa_ctx **dsa, LIBSSH2_SESSION *session,
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgDSA, NULL, lpszBlobType,
                               &hKey, (PUCHAR)dsakey, (ULONG)keylen, 0);
     if(!BCRYPT_SUCCESS(ret)) {
-        wcng_zero_free(dsakey, keylen);
+        ssh2_zero_free(session, dsakey, keylen);
         return -1;
     }
 
-    *dsa = malloc(sizeof(ssh2_dsa_ctx));
+    *dsa = SSH2_ALLOC(session, sizeof(ssh2_dsa_ctx));
     if(!*dsa) {
         BCryptDestroyKey(hKey);
-        wcng_zero_free(dsakey, keylen);
+        ssh2_zero_free(session, dsakey, keylen);
         return -1;
     }
 
@@ -1608,16 +1606,14 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
 
 void ssh2_dsa_free(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session)
 {
-    (void)session;
-
     if(!dsa)
         return;
 
     BCryptDestroyKey(dsa->hKey);
     dsa->hKey = NULL;
 
-    wcng_zero_free(dsa->pbKeyObject, dsa->cbKeyObject);
-    wcng_zero_free(dsa, sizeof(ssh2_dsa_ctx));
+    ssh2_zero_free(session, dsa->pbKeyObject, dsa->cbKeyObject);
+    ssh2_zero_free(session, dsa, sizeof(ssh2_dsa_ctx));
 }
 #endif
 
@@ -1944,13 +1940,12 @@ cleanup:
  */
 void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session)
 {
-    (void)session;
-
     if(!ec_ctx)
         return;
 
     (void)BCryptDestroyKey(ec_ctx->handle);
-    free(ec_ctx);
+
+    SSH2_FREE(session, ec_ctx);
 }
 
 /*
@@ -1981,7 +1976,7 @@ int ssh2_ecdsa_create_key(OUT ssh2_ecdsa_ctx **ec_ctx,
     *out_public_key_octal = NULL;
     *out_public_key_octal_len = 0;
 
-    *ec_ctx = malloc(sizeof(ssh2_ecdsa_ctx));
+    *ec_ctx = SSH2_ALLOC(session, sizeof(ssh2_ecdsa_ctx));
     if(!*ec_ctx) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2025,10 +2020,8 @@ cleanup:
     if(result != LIBSSH2_ERROR_NONE) {
         if(key_handle)
             (void)BCryptDestroyKey(key_handle);
-        if(*ec_ctx) {
-            free(*ec_ctx);
-            *ec_ctx = NULL;
-        }
+        if(*ec_ctx)
+            SSH2_SAFEFREE(session, *ec_ctx);
     }
 
     return result;
@@ -2056,7 +2049,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     if(!ec_ctx)
         return LIBSSH2_ERROR_INVAL;
 
-    *ec_ctx = malloc(sizeof(ssh2_ecdsa_ctx));
+    *ec_ctx = SSH2_ALLOC(session, sizeof(ssh2_ecdsa_ctx));
     if(!*ec_ctx) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2081,10 +2074,8 @@ int ssh2_ecdsa_curve_name_with_octal_new(
 
 cleanup:
 
-    if(result != LIBSSH2_ERROR_NONE) {
-        free(*ec_ctx);
-        *ec_ctx = NULL;
-    }
+    if(result != LIBSSH2_ERROR_NONE)
+        SSH2_SAFEFREE(session, *ec_ctx);
 
     return result;
 }
@@ -2342,7 +2333,7 @@ static int wcng_ecdsa_new_private_parse(OUT ssh2_ecdsa_ctx **ec_ctx,
 
     BCRYPT_KEY_HANDLE key_handle = NULL;
 
-    *ec_ctx = malloc(sizeof(ssh2_ecdsa_ctx));
+    *ec_ctx = SSH2_ALLOC(session, sizeof(ssh2_ecdsa_ctx));
     if(!*ec_ctx) {
         result = LIBSSH2_ERROR_ALLOC;
         goto cleanup;
@@ -2422,10 +2413,8 @@ cleanup:
     if(result != LIBSSH2_ERROR_NONE) {
         if(key_handle)
             (void)BCryptDestroyKey(key_handle);
-        if(*ec_ctx) {
-            free(*ec_ctx);
-            *ec_ctx = NULL;
-        }
+        if(*ec_ctx)
+            SSH2_SAFEFREE(session, *ec_ctx);
 
         result = ssh2_err(session, result,
                           "wcng_ecdsa_new_private_parse() failed");

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1098,7 +1098,7 @@ static size_t wcng_bn_size(const unsigned char *bignum, size_t length)
  * Windows CNG backend: RSA functions
  */
 
-int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
+int ssh2_rsa_new(ssh2_rsa_ctx **rsa, LIBSSH2_SESSION *session,
                  const unsigned char *edata, size_t elen,
                  const unsigned char *ndata, size_t nlen,
                  const unsigned char *ddata, size_t dlen,
@@ -1113,6 +1113,8 @@ int ssh2_rsa_new(ssh2_rsa_ctx **rsa,
     LPCWSTR lpszBlobType;
     size_t keylen, offset, mlen, p1len = 0, p2len = 0;
     int ret;
+
+    (void)session;
 
     mlen = max(wcng_bn_size(ndata, nlen),
                wcng_bn_size(ddata, dlen));

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1730,7 +1730,8 @@ static int wcng_p1363signature_from_point(IN LIBSSH2_SESSION *session,
 /*
  * Create a CNG public key from an ECC point.
  */
-static int wcng_publickey_from_point(IN wcng_ecc_keytype keytype,
+static int wcng_publickey_from_point(IN LIBSSH2_SESSION *session,
+                                     IN wcng_ecc_keytype keytype,
                                      IN struct ecdsa_point *point,
                                      OUT BCRYPT_KEY_HANDLE *key)
 {
@@ -1751,7 +1752,7 @@ static int wcng_publickey_from_point(IN wcng_ecc_keytype keytype,
 
     /* Initialize a blob to import */
     ecc_blob_len = sizeof(BCRYPT_ECCKEY_BLOB) + point->x_len + point->y_len;
-    ecc_blob = malloc(ecc_blob_len);
+    ecc_blob = SSH2_ALLOC(session, ecc_blob_len);
     if(!ecc_blob)
         return LIBSSH2_ERROR_ALLOC;
 
@@ -1782,14 +1783,15 @@ static int wcng_publickey_from_point(IN wcng_ecc_keytype keytype,
     result = LIBSSH2_ERROR_NONE;
 
 cleanup:
-    free(ecc_blob);
+    SSH2_FREE(session, ecc_blob);
     return result;
 }
 
 /*
  * Create a CNG private key from an ECC point.
  */
-static int wcng_privatekey_from_point(IN wcng_ecc_keytype keytype,
+static int wcng_privatekey_from_point(IN LIBSSH2_SESSION *session,
+                                      IN wcng_ecc_keytype keytype,
                                       IN struct ecdsa_point *q,
                                       IN unsigned char *d,
                                       IN size_t d_len,
@@ -1813,7 +1815,7 @@ static int wcng_privatekey_from_point(IN wcng_ecc_keytype keytype,
     /* Initialize a blob to import */
     ecc_blob_len =
         sizeof(BCRYPT_ECCPRIVATE_BLOB) + q->x_len + q->y_len + d_len;
-    ecc_blob = malloc(ecc_blob_len);
+    ecc_blob = SSH2_ALLOC(session, ecc_blob_len);
     if(!ecc_blob)
         return LIBSSH2_ERROR_ALLOC;
 
@@ -1846,7 +1848,7 @@ static int wcng_privatekey_from_point(IN wcng_ecc_keytype keytype,
     result = LIBSSH2_ERROR_NONE;
 
 cleanup:
-    free(ecc_blob);
+    SSH2_FREE(session, ecc_blob);
     return result;
 }
 
@@ -2070,7 +2072,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
     if(result != LIBSSH2_ERROR_NONE)
         goto cleanup;
 
-    result = wcng_publickey_from_point(
+    result = wcng_publickey_from_point(session,
         WCNG_ECC_KEYTYPE_ECDSA,
         &publickey,
         &publickey_handle);
@@ -2121,7 +2123,7 @@ int ssh2_ecdh_gen_k(OUT ssh2_bn **k, LIBSSH2_SESSION *session,
     if(result != LIBSSH2_ERROR_NONE)
         return result;
 
-    result = wcng_publickey_from_point(
+    result = wcng_publickey_from_point(session,
         WCNG_ECC_KEYTYPE_ECDH,
         &server_publickey,
         &publickey_handle);
@@ -2402,7 +2404,7 @@ static int wcng_ecdsa_new_private_parse(OUT ssh2_ecdsa_ctx **ec_ctx,
     /* Ignore the rest (comment, etc) */
 
     /* Use Q and d to create a key handle */
-    result = wcng_privatekey_from_point(
+    result = wcng_privatekey_from_point(session,
         WCNG_ECC_KEYTYPE_ECDSA,
         &q,
         d,

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1381,8 +1381,10 @@ int ssh2_rsa_sha2_sign(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
 }
 #endif
 
-void ssh2_rsa_free(ssh2_rsa_ctx *rsa)
+void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session)
 {
+    (void)session;
+
     if(!rsa)
         return;
 
@@ -1602,8 +1604,10 @@ int ssh2_dsa_sha1_sign(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session,
     return BCRYPT_SUCCESS(ret) ? 0 : -1;
 }
 
-void ssh2_dsa_free(ssh2_dsa_ctx *dsa)
+void ssh2_dsa_free(ssh2_dsa_ctx *dsa, LIBSSH2_SESSION *session)
 {
+    (void)session;
+
     if(!dsa)
         return;
 
@@ -1936,8 +1940,10 @@ cleanup:
 /*
  * Windows CNG backend: ECDSA functions
  */
-void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx)
+void ssh2_ecdsa_free(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session)
 {
+    (void)session;
+
     if(!ec_ctx)
         return;
 

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -920,7 +920,8 @@ static int wcng_load_priv(LIBSSH2_SESSION *session,
     return ret;
 }
 
-static int wcng_asn_decode(unsigned char *pbEncoded, DWORD cbEncoded,
+static int wcng_asn_decode(LIBSSH2_SESSION *session,
+                           unsigned char *pbEncoded, DWORD cbEncoded,
                            LPCSTR lpszStructType,
                            unsigned char **ppbDecoded, DWORD *pcbDecoded)
 {
@@ -935,7 +936,7 @@ static int wcng_asn_decode(unsigned char *pbEncoded, DWORD cbEncoded,
     if(!ret)
         return -1;
 
-    pbDecoded = malloc(cbDecoded);
+    pbDecoded = SSH2_ALLOC(session, cbDecoded);
     if(!pbDecoded)
         return -1;
 
@@ -944,7 +945,7 @@ static int wcng_asn_decode(unsigned char *pbEncoded, DWORD cbEncoded,
                               pbEncoded, cbEncoded, 0, NULL,
                               pbDecoded, &cbDecoded);
     if(!ret) {
-        wcng_zero_free(pbDecoded, cbDecoded);
+        ssh2_zero_free(session, pbDecoded, cbDecoded);
         return -1;
     }
 
@@ -988,7 +989,8 @@ static int wcng_bn_ltob(unsigned char *pbInput, DWORD cbInput,
     return 0;
 }
 
-static int wcng_asn_decode_bn(unsigned char *pbEncoded, DWORD cbEncoded,
+static int wcng_asn_decode_bn(LIBSSH2_SESSION *session,
+                              unsigned char *pbEncoded, DWORD cbEncoded,
                               unsigned char **ppbDecoded, DWORD *pcbDecoded)
 {
     unsigned char *pbDecoded = NULL;
@@ -996,7 +998,7 @@ static int wcng_asn_decode_bn(unsigned char *pbEncoded, DWORD cbEncoded,
     DWORD cbDecoded = 0, cbInteger;
     int ret;
 
-    ret = wcng_asn_decode(pbEncoded, cbEncoded, X509_MULTI_BYTE_UINT,
+    ret = wcng_asn_decode(session, pbEncoded, cbEncoded, X509_MULTI_BYTE_UINT,
                           (void *)&pbInteger, &cbInteger);
     if(!ret) {
         ret = wcng_bn_ltob(pbInteger->pbData,
@@ -1006,13 +1008,14 @@ static int wcng_asn_decode_bn(unsigned char *pbEncoded, DWORD cbEncoded,
             *ppbDecoded = pbDecoded;
             *pcbDecoded = cbDecoded;
         }
-        wcng_zero_free(pbInteger, cbInteger);
+        ssh2_zero_free(session, pbInteger, cbInteger);
     }
 
     return ret;
 }
 
-static int wcng_asn_decode_bns(unsigned char *pbEncoded,
+static int wcng_asn_decode_bns(LIBSSH2_SESSION *session,
+                               unsigned char *pbEncoded,
                                DWORD cbEncoded,
                                unsigned char ***prpbDecoded,
                                DWORD **prcbDecoded,
@@ -1024,7 +1027,7 @@ static int wcng_asn_decode_bns(unsigned char *pbEncoded,
     DWORD cbDecoded, *rcbDecoded, index, length;
     int ret;
 
-    ret = wcng_asn_decode(pbEncoded, cbEncoded, X509_SEQUENCE_OF_ANY,
+    ret = wcng_asn_decode(session, pbEncoded, cbEncoded, X509_SEQUENCE_OF_ANY,
                           (void *)&pbDecoded, &cbDecoded);
     if(!ret) {
         length = pbDecoded->cValue;
@@ -1035,7 +1038,8 @@ static int wcng_asn_decode_bns(unsigned char *pbEncoded,
             if(rcbDecoded) {
                 for(index = 0; index < length; index++) {
                     pBlob = &pbDecoded->rgValue[index];
-                    ret = wcng_asn_decode_bn(pBlob->pbData,
+                    ret = wcng_asn_decode_bn(session,
+                                             pBlob->pbData,
                                              pBlob->cbData,
                                              &rpbDecoded[index],
                                              &rcbDecoded[index]);
@@ -1067,7 +1071,7 @@ static int wcng_asn_decode_bns(unsigned char *pbEncoded,
         else
             ret = -1;
 
-        wcng_zero_free(pbDecoded, cbDecoded);
+        ssh2_zero_free(session, pbDecoded, cbDecoded);
     }
 
     return ret;
@@ -1242,7 +1246,8 @@ static int wcng_rsa_new_private_parse(ssh2_rsa_ctx **rsa,
 
     (void)session;
 
-    ret = wcng_asn_decode(pbEncoded, (DWORD)cbEncoded, PKCS_RSA_PRIVATE_KEY,
+    ret = wcng_asn_decode(session,
+                          pbEncoded, (DWORD)cbEncoded, PKCS_RSA_PRIVATE_KEY,
                           &pbStructInfo, &cbStructInfo);
     ssh2_zero_free(session, pbEncoded, cbEncoded);
     if(ret)
@@ -1251,14 +1256,14 @@ static int wcng_rsa_new_private_parse(ssh2_rsa_ctx **rsa,
     ret = BCryptImportKeyPair(ssh2_wcng.hAlgRSA, NULL, LEGACY_RSAPRIVATE_BLOB,
                               &hKey, pbStructInfo, cbStructInfo, 0);
     if(!BCRYPT_SUCCESS(ret)) {
-        wcng_zero_free(pbStructInfo, cbStructInfo);
+        ssh2_zero_free(session, pbStructInfo, cbStructInfo);
         return -1;
     }
 
     *rsa = SSH2_ALLOC(session, sizeof(ssh2_rsa_ctx));
     if(!*rsa) {
         BCryptDestroyKey(hKey);
-        wcng_zero_free(pbStructInfo, cbStructInfo);
+        ssh2_zero_free(session, pbStructInfo, cbStructInfo);
         return -1;
     }
 
@@ -1511,7 +1516,7 @@ static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
 
     (void)session;
 
-    ret = wcng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
+    ret = wcng_asn_decode_bns(session, pbEncoded, (DWORD)cbEncoded,
                               &rpbDecoded, &rcbDecoded, &length);
     ssh2_zero_free(session, pbEncoded, cbEncoded);
     if(ret)
@@ -2608,7 +2613,7 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session, char **method,
     DWORD index, off, length = 0;
     int ret;
 
-    ret = wcng_asn_decode_bns(pbEncoded, (DWORD)cbEncoded,
+    ret = wcng_asn_decode_bns(session, pbEncoded, (DWORD)cbEncoded,
                               &rpbDecoded, &rcbDecoded, &length);
     ssh2_zero_free(session, pbEncoded, cbEncoded);
     if(ret)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1032,9 +1032,9 @@ static int wcng_asn_decode_bns(LIBSSH2_SESSION *session,
     if(!ret) {
         length = pbDecoded->cValue;
 
-        rpbDecoded = malloc(sizeof(PBYTE) * length);
+        rpbDecoded = SSH2_ALLOC(session, sizeof(PBYTE) * length);
         if(rpbDecoded) {
-            rcbDecoded = malloc(sizeof(DWORD) * length);
+            rcbDecoded = SSH2_ALLOC(session, sizeof(DWORD) * length);
             if(rcbDecoded) {
                 for(index = 0; index < length; index++) {
                     pBlob = &pbDecoded->rgValue[index];
@@ -1054,17 +1054,18 @@ static int wcng_asn_decode_bns(LIBSSH2_SESSION *session,
                 }
                 else {
                     for(length = 0; length < index; length++) {
-                        wcng_zero_free(rpbDecoded[length],
+                        ssh2_zero_free(session,
+                                       rpbDecoded[length],
                                        rcbDecoded[length]);
                         rpbDecoded[length] = NULL;
                         rcbDecoded[length] = 0;
                     }
-                    free(rpbDecoded);
-                    free(rcbDecoded);
+                    SSH2_FREE(session, rpbDecoded);
+                    SSH2_FREE(session, rcbDecoded);
                 }
             }
             else {
-                free(rpbDecoded);
+                SSH2_FREE(session, rpbDecoded);
                 ret = -1;
             }
         }
@@ -1533,13 +1534,13 @@ static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
         ret = -1;
 
     for(index = 0; index < length; index++) {
-        wcng_zero_free(rpbDecoded[index], rcbDecoded[index]);
+        ssh2_zero_free(session, rpbDecoded[index], rcbDecoded[index]);
         rpbDecoded[index] = NULL;
         rcbDecoded[index] = 0;
     }
 
-    free(rpbDecoded);
-    free(rcbDecoded);
+    SSH2_FREE(session, rpbDecoded);
+    SSH2_FREE(session, rcbDecoded);
 
     return ret;
 }
@@ -2677,13 +2678,13 @@ static int wcng_pub_privkey_file_parse(LIBSSH2_SESSION *session, char **method,
 cleanup:
 
     for(index = 0; index < length; index++) {
-        wcng_zero_free(rpbDecoded[index], rcbDecoded[index]);
+        ssh2_zero_free(session, rpbDecoded[index], rcbDecoded[index]);
         rpbDecoded[index] = NULL;
         rcbDecoded[index] = 0;
     }
 
-    free(rpbDecoded);
-    free(rcbDecoded);
+    SSH2_FREE(session, rpbDecoded);
+    SSH2_FREE(session, rcbDecoded);
 
     if(ret) {
         if(method_buf)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -955,7 +955,8 @@ static int wcng_asn_decode(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static int wcng_bn_ltob(unsigned char *pbInput, DWORD cbInput,
+static int wcng_bn_ltob(LIBSSH2_SESSION *session,
+                        unsigned char *pbInput, DWORD cbInput,
                         unsigned char **ppbOutput, DWORD *pcbOutput)
 {
     unsigned char *pbOutput;
@@ -975,7 +976,7 @@ static int wcng_bn_ltob(unsigned char *pbInput, DWORD cbInput,
         cbOutput += offset;
     }
 
-    pbOutput = malloc(cbOutput);
+    pbOutput = SSH2_ALLOC(session, cbOutput);
     if(!pbOutput)
         return -1;
 
@@ -1001,7 +1002,8 @@ static int wcng_asn_decode_bn(LIBSSH2_SESSION *session,
     ret = wcng_asn_decode(session, pbEncoded, cbEncoded, X509_MULTI_BYTE_UINT,
                           (void *)&pbInteger, &cbInteger);
     if(!ret) {
-        ret = wcng_bn_ltob(pbInteger->pbData,
+        ret = wcng_bn_ltob(session,
+                           pbInteger->pbData,
                            pbInteger->cbData,
                            &pbDecoded, &cbDecoded);
         if(!ret) {

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2074,7 +2074,7 @@ int ssh2_ecdsa_curve_name_with_octal_new(
 
 cleanup:
 
-    if(result != LIBSSH2_ERROR_NONE)
+    if(result != LIBSSH2_ERROR_NONE && *ec_ctx)
         SSH2_SAFEFREE(session, *ec_ctx);
 
     return result;

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -1404,7 +1404,7 @@ void ssh2_rsa_free(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session)
  */
 
 #if LIBSSH2_DSA
-int ssh2_dsa_new(ssh2_dsa_ctx **dsa,
+int ssh2_dsa_new(ssh2_dsa_ctx **dsa, LIBSSH2_SESSION *session,
                  const unsigned char *pdata, size_t plen,
                  const unsigned char *qdata, size_t qlen,
                  const unsigned char *gdata, size_t glen,
@@ -1520,7 +1520,7 @@ static int wcng_dsa_new_private_parse(ssh2_dsa_ctx **dsa,
         return -1;
 
     if(length == 6)
-        ret = ssh2_dsa_new(dsa,
+        ret = ssh2_dsa_new(dsa, session,
                            rpbDecoded[1], rcbDecoded[1],
                            rpbDecoded[2], rcbDecoded[2],
                            rpbDecoded[3], rcbDecoded[3],


### PR DESCRIPTION
To shift allocation from raw or backend-specific allocators to libssh2's
own. To respect custom allocators set via `libssh2_session_init_ex()`,
and to reduce the chance for mismatched alloc/free calls.

- pass `session` to `ssh2_rsa_new()` and `ssh2_dsa_new()` and all the
  `ssh2_*_free()` deallocators.
- mbedtls: replace mbedTLS alloc/free with libssh2 alloc/free.
- wincng: replace malloc/free with libssh2 alloc/free.
- wincng: use libssh2 allocator in `wcng_asn_decode()` to sycn up with
  the above change and avoid using mixed allocators in key contexts.
- wincng: use libssh2 allocator in `wcng_asn_decode_bns()`, 
  `wcng_publickey_from_point()`, `wcng_privatekey_from_point()`.
