### PR TITLE
crypto: fix `LIBSSH2_NO_RSA` to explicitly disable both RSA SHA1/SHA2

### DIFF
--- a/src/crypto_config.h
+++ b/src/crypto_config.h
@@ -25,11 +25,6 @@
 #define LIBSSH2_DSA 0
 #endif
 
-#ifndef LIBSSH2_RSA_SHA1_ENABLE
-#undef LIBSSH2_RSA_SHA1
-#define LIBSSH2_RSA_SHA1 0
-#endif
-
 #ifdef LIBSSH2_NO_RSA
 #undef LIBSSH2_RSA
 #define LIBSSH2_RSA 0
@@ -37,6 +32,11 @@
 #define LIBSSH2_RSA_SHA1 0
 #undef LIBSSH2_RSA_SHA2
 #define LIBSSH2_RSA_SHA2 0
+#endif
+
+#ifndef LIBSSH2_RSA_SHA1_ENABLE
+#undef LIBSSH2_RSA_SHA1
+#define LIBSSH2_RSA_SHA1 0
 #endif
 
 #ifdef LIBSSH2_NO_ECDSA

--- a/src/crypto_config.h
+++ b/src/crypto_config.h
@@ -25,14 +25,18 @@
 #define LIBSSH2_DSA 0
 #endif
 
-#ifdef LIBSSH2_NO_RSA
-#undef LIBSSH2_RSA
-#define LIBSSH2_RSA 0
-#endif
-
 #ifndef LIBSSH2_RSA_SHA1_ENABLE
 #undef LIBSSH2_RSA_SHA1
 #define LIBSSH2_RSA_SHA1 0
+#endif
+
+#ifdef LIBSSH2_NO_RSA
+#undef LIBSSH2_RSA
+#define LIBSSH2_RSA 0
+#undef LIBSSH2_RSA_SHA1
+#define LIBSSH2_RSA_SHA1 0
+#undef LIBSSH2_RSA_SHA2
+#define LIBSSH2_RSA_SHA2 0
 #endif
 
 #ifdef LIBSSH2_NO_ECDSA


### PR DESCRIPTION
To simplify RSA feature guards and fix pre-existing ones in tests, e.g.
in `test_auth_pubkey_ok_rsa_pem_sha2_512_signed.c`.

Bug: https://github.com/libssh2/libssh2/pull/2539/files#discussion_r3880534427
Bug: https://github.com/libssh2/libssh2/pull/2539/files#discussion_r3880534393
