### PR TITLE
knownhost: match equivalent IPv6 literals

### DIFF
--- a/docs/libssh2_knownhost_check.md
+++ b/docs/libssh2_knownhost_check.md
@@ -34,6 +34,11 @@ and returns info back about the (partially) matched entry.
 *host* is a pointer the hostname in plain text. The hostname can be the
 IP numerical address of the host or the full name.
 
+For LIBSSH2_KNOWNHOST_TYPE_PLAIN, valid IPv6 literals are compared by their
+binary address, so equivalent compressed and expanded representations match.
+No DNS lookup is performed. Hostnames, custom names and hashed known-host
+entries retain their existing matching behavior.
+
 *key* is a pointer to the key for the given host.
 
 *keylen* is the total size in bytes of the key pointed to by the *key*

--- a/docs/libssh2_knownhost_checkp.md
+++ b/docs/libssh2_knownhost_checkp.md
@@ -34,6 +34,11 @@ and returns info back about the (partially) matched entry.
 *host* is a pointer the hostname in plain text. The hostname can be the
 IP numerical address of the host or the full name.
 
+For LIBSSH2_KNOWNHOST_TYPE_PLAIN, valid IPv6 literals are compared by their
+binary address, so equivalent compressed and expanded representations match.
+No DNS lookup is performed. Hostnames, custom names and hashed known-host
+entries retain their existing matching behavior.
+
 *port* is the port number used by the host (or a negative number
 to check the generic host). If the port number is given, libssh2
 checks the key for the specific host + port number combination in

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -395,7 +395,7 @@ static int knownhost_parse_ipv4(const char *src, const char *end,
 
     while(src < end) {
         if(*src >= '0' && *src <= '9') {
-            if(digits == 3)
+            if(digits == 3 || (digits && !value))
                 return 0;
             value = value * 10 + (unsigned int)(*src - '0');
             if(value > 255)

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -465,7 +465,6 @@ static int knownhost_parse_ipv6(const char *src, size_t len,
                 (unsigned short)(((unsigned int)ipv4[0] << 8) | ipv4[1]);
             words[count++] =
                 (unsigned short)(((unsigned int)ipv4[2] << 8) | ipv4[3]);
-            p = end;
             break;
         }
 

--- a/src/knownhost.c
+++ b/src/knownhost.c
@@ -375,6 +375,206 @@ int libssh2_knownhost_addc(LIBSSH2_KNOWNHOSTS *hosts,
  * LIBSSH2_KNOWNHOST_CHECK_MATCH
  * LIBSSH2_KNOWNHOST_CHECK_MISMATCH
  */
+static int knownhost_hex_value(char c)
+{
+    if(c >= '0' && c <= '9')
+        return c - '0';
+    if(c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    if(c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+    return -1;
+}
+
+static int knownhost_parse_ipv4(const char *src, const char *end,
+                                unsigned char result[4])
+{
+    unsigned int value = 0;
+    size_t digits = 0;
+    size_t count = 0;
+
+    while(src < end) {
+        if(*src >= '0' && *src <= '9') {
+            if(digits == 3)
+                return 0;
+            value = value * 10 + (unsigned int)(*src - '0');
+            if(value > 255)
+                return 0;
+            digits++;
+        }
+        else if(*src == '.' && digits && count < 3) {
+            result[count++] = (unsigned char)value;
+            value = 0;
+            digits = 0;
+        }
+        else
+            return 0;
+        src++;
+    }
+
+    if(!digits || count != 3)
+        return 0;
+
+    result[3] = (unsigned char)value;
+    return 1;
+}
+
+static int knownhost_parse_ipv6(const char *src, size_t len,
+                                unsigned char result[16])
+{
+    unsigned short words[8];
+    const char *p = src;
+    const char *end = src + len;
+    size_t count = 0;
+    int compressed = -1;
+    size_t i;
+
+    if(!len)
+        return 0;
+
+    memset(words, 0, sizeof(words));
+
+    if(*p == ':') {
+        if(p + 1 >= end || p[1] != ':')
+            return 0;
+        compressed = 0;
+        p += 2;
+    }
+
+    while(p < end) {
+        const char *part = p;
+        unsigned int value = 0;
+        size_t digits = 0;
+        int hex;
+
+        while(p < end && (hex = knownhost_hex_value(*p)) >= 0) {
+            if(digits == 4)
+                return 0;
+            value = (value << 4) | (unsigned int)hex;
+            digits++;
+            p++;
+        }
+
+        if(p < end && *p == '.') {
+            unsigned char ipv4[4];
+
+            if(count > 6 || !knownhost_parse_ipv4(part, end, ipv4))
+                return 0;
+
+            words[count++] =
+                (unsigned short)(((unsigned int)ipv4[0] << 8) | ipv4[1]);
+            words[count++] =
+                (unsigned short)(((unsigned int)ipv4[2] << 8) | ipv4[3]);
+            p = end;
+            break;
+        }
+
+        if(!digits || count >= 8)
+            return 0;
+
+        words[count++] = (unsigned short)value;
+
+        if(p == end)
+            break;
+        if(*p != ':')
+            return 0;
+
+        p++;
+        if(p < end && *p == ':') {
+            if(compressed >= 0)
+                return 0;
+            compressed = (int)count;
+            p++;
+            if(p == end)
+                break;
+        }
+        else if(p == end)
+            return 0;
+    }
+
+    if(compressed >= 0) {
+        size_t position = (size_t)compressed;
+        size_t zeros;
+
+        if(count >= 8)
+            return 0;
+
+        zeros = 8 - count;
+        memmove(&words[position + zeros], &words[position],
+                (count - position) * sizeof(words[0]));
+        memset(&words[position], 0, zeros * sizeof(words[0]));
+    }
+    else if(count != 8)
+        return 0;
+
+    for(i = 0; i < 8; i++) {
+        result[i * 2] = (unsigned char)(words[i] >> 8);
+        result[i * 2 + 1] = (unsigned char)words[i];
+    }
+
+    return 1;
+}
+
+static int knownhost_ipv6_part(const char *host, const char **address,
+                               size_t *address_len, const char **suffix)
+{
+    if(host[0] == '[') {
+        const char *close = strchr(host + 1, ']');
+        const char *port;
+
+        if(!close || close == host + 1 || close[1] != ':' || !close[2])
+            return 0;
+
+        port = close + 2;
+        while(*port) {
+            if(*port < '0' || *port > '9')
+                return 0;
+            port++;
+        }
+
+        *address = host + 1;
+        *address_len = (size_t)(close - host - 1);
+        *suffix = close + 1;
+    }
+    else {
+        *address = host;
+        *address_len = strlen(host);
+        *suffix = host + *address_len;
+    }
+
+    return 1;
+}
+
+static int knownhost_plain_match(const char *host, const char *known)
+{
+    const char *host_address;
+    const char *known_address;
+    const char *host_suffix;
+    const char *known_suffix;
+    size_t host_len;
+    size_t known_len;
+    unsigned char host_binary[16];
+    unsigned char known_binary[16];
+
+    if(!strcmp(host, known))
+        return 1;
+
+    if((host[0] == '[') != (known[0] == '['))
+        return 0;
+
+    if(!knownhost_ipv6_part(host, &host_address, &host_len, &host_suffix) ||
+       !knownhost_ipv6_part(known, &known_address, &known_len,
+                            &known_suffix) ||
+       strcmp(host_suffix, known_suffix))
+        return 0;
+
+    if(!knownhost_parse_ipv6(host_address, host_len, host_binary) ||
+       !knownhost_parse_ipv6(known_address, known_len, known_binary))
+        return 0;
+
+    return !memcmp(host_binary, known_binary, sizeof(host_binary));
+}
+
 static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
                            const char *hostp, int port,
                            const char *key, size_t keylen,
@@ -448,7 +648,7 @@ static int knownhost_check(LIBSSH2_KNOWNHOSTS *hosts,
             switch(node->typemask & LIBSSH2_KNOWNHOST_TYPE_MASK) {
             case LIBSSH2_KNOWNHOST_TYPE_PLAIN:
                 if(type == LIBSSH2_KNOWNHOST_TYPE_PLAIN)
-                    match = !strcmp(host, node->name);
+                    match = knownhost_plain_match(host, node->name);
                 break;
             case LIBSSH2_KNOWNHOST_TYPE_CUSTOM:
                 if(type == LIBSSH2_KNOWNHOST_TYPE_CUSTOM)

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -201,6 +201,20 @@ static int test_knownhost_ipv6(LIBSSH2_SESSION *session)
         "::ffff:192.0.2.256",
         -1, LIBSSH2_KNOWNHOST_CHECK_NOTFOUND);
 
+    /* Embedded IPv4 octets with leading zeros are not valid. */
+    err |= test_knownhost_ipv6_case(
+        session,
+        "::ffff:192.168.001.1",
+        "::ffff:192.168.1.1",
+        -1, LIBSSH2_KNOWNHOST_CHECK_NOTFOUND);
+
+    /* Identical malformed names retain the historical exact-string match. */
+    err |= test_knownhost_ipv6_case(
+        session,
+        "::ffff:192.168.001.1",
+        "::ffff:192.168.001.1",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
     /*
      * Preserve the historical exact-string behavior even when a plain host
      * containing colons is not a valid IPv6 literal.

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -66,7 +66,8 @@ static int test_knownhost_ipv6_case(LIBSSH2_SESSION *session,
                                     int expected)
 {
     static const char key[] = "AAAA";
-    const int typemask = LIBSSH2_KNOWNHOST_TYPE_PLAIN |
+    const int typemask =
+        LIBSSH2_KNOWNHOST_TYPE_PLAIN |
         LIBSSH2_KNOWNHOST_KEYENC_BASE64 |
         LIBSSH2_KNOWNHOST_KEY_SSHRSA;
     LIBSSH2_KNOWNHOSTS *hosts;

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -59,6 +59,160 @@ static int test_ssh2_base64_decode(LIBSSH2_SESSION *session)
     return 0;
 }
 
+static int test_knownhost_ipv6_case(LIBSSH2_SESSION *session,
+                                    const char *stored,
+                                    const char *checked,
+                                    int port,
+                                    int expected)
+{
+    static const char key[] = "AAAA";
+    const int typemask = LIBSSH2_KNOWNHOST_TYPE_PLAIN |
+        LIBSSH2_KNOWNHOST_KEYENC_BASE64 |
+        LIBSSH2_KNOWNHOST_KEY_SSHRSA;
+    LIBSSH2_KNOWNHOSTS *hosts;
+    int rc;
+
+    hosts = libssh2_knownhost_init(session);
+    if(!hosts) {
+        fprintf(stderr, "libssh2_knownhost_init() failed\n");
+        return 1;
+    }
+
+    rc = libssh2_knownhost_addc(hosts, stored, NULL, key, strlen(key),
+                                NULL, 0, typemask, NULL);
+    if(rc) {
+        fprintf(stderr, "libssh2_knownhost_addc(%s) failed: %d\n",
+                stored, rc);
+        libssh2_knownhost_free(hosts);
+        return 1;
+    }
+
+    if(port >= 0)
+        rc = libssh2_knownhost_checkp(hosts, checked, port, key,
+                                      strlen(key), typemask, NULL);
+    else
+        rc = libssh2_knownhost_check(hosts, checked, key, strlen(key),
+                                     typemask, NULL);
+
+    libssh2_knownhost_free(hosts);
+
+    if(rc != expected) {
+        fprintf(stderr,
+                "knownhost IPv6: stored=%s checked=%s port=%d "
+                "expected=%d got=%d\n",
+                stored, checked, port, expected, rc);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int test_knownhost_ipv6(LIBSSH2_SESSION *session)
+{
+    int err = 0;
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "fd5f:4268:2387:97c1:0000:0000:0000:0002",
+        "fd5f:4268:2387:97c1::2",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "fd5f:4268:2387:97c1::2",
+        "fd5f:4268:2387:97c1:0:0:0:2",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "0:0:0:0:0:ffff:c000:0201",
+        "::ffff:192.0.2.1",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "[fd5f:4268:2387:97c1:0000:0000:0000:0002]:2222",
+        "fd5f:4268:2387:97c1::2",
+        2222, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "[fd5f:4268:2387:97c1:0000:0000:0000:0002]:2222",
+        "fd5f:4268:2387:97c1::2",
+        22, LIBSSH2_KNOWNHOST_CHECK_NOTFOUND);
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "fd5f:4268:2387:97c1::2",
+        "fd5f:4268:2387:97c1::3",
+        -1, LIBSSH2_KNOWNHOST_CHECK_NOTFOUND);
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "fd5f:4268:2387:97c1::2",
+        "fd5f:4268:2387:97c1::1::2",
+        -1, LIBSSH2_KNOWNHOST_CHECK_NOTFOUND);
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "example.com",
+        "example.com",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    err |= test_knownhost_ipv6_case(
+        session,
+        "example.com",
+        "EXAMPLE.COM",
+        -1, LIBSSH2_KNOWNHOST_CHECK_NOTFOUND);
+
+    /* Hexadecimal digits are case-insensitive. */
+    err |= test_knownhost_ipv6_case(
+        session,
+        "2001:0DB8:0000:0000:0000:0000:0000:0001",
+        "2001:db8::1",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    /* Compression may represent the complete address. */
+    err |= test_knownhost_ipv6_case(
+        session,
+        "0:0:0:0:0:0:0:0",
+        "::",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    /* Compression at the end must expand to the remaining words. */
+    err |= test_knownhost_ipv6_case(
+        session,
+        "2001:db8:1:2:3:4:0:0",
+        "2001:db8:1:2:3:4::",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    /* More than eight words is not a valid IPv6 literal. */
+    err |= test_knownhost_ipv6_case(
+        session,
+        "2001:db8::1",
+        "1:2:3:4:5:6:7:8:9",
+        -1, LIBSSH2_KNOWNHOST_CHECK_NOTFOUND);
+
+    /* An embedded IPv4 address must contain valid octets. */
+    err |= test_knownhost_ipv6_case(
+        session,
+        "::ffff:192.0.2.1",
+        "::ffff:192.0.2.256",
+        -1, LIBSSH2_KNOWNHOST_CHECK_NOTFOUND);
+
+    /*
+     * Preserve the historical exact-string behavior even when a plain host
+     * containing colons is not a valid IPv6 literal.
+     */
+    err |= test_knownhost_ipv6_case(
+        session,
+        "fd5f::1::2",
+        "fd5f::1::2",
+        -1, LIBSSH2_KNOWNHOST_CHECK_MATCH);
+
+    return err > 0;
+}
+
 static int test_ssh2_dh_validate(void)
 {
     struct tbn {
@@ -212,6 +366,7 @@ int main(int argc, char *argv[])
     }
 
     rc = test_ssh2_base64_decode(session);
+    rc |= test_knownhost_ipv6(session);
     rc |= test_ssh2_dh_validate();
     rc |= test_ssh2_scp_parse_c_fields();
 


### PR DESCRIPTION
Plain known-host entries are currently compared as text, so equivalent expanded and compressed IPv6 literals do not match.

This change keeps the existing exact-string fast path and compares two valid plain IPv6 literals by their 128-bit address. It also supports bracketed IPv6 host-and-port entries while requiring the port suffix to match exactly.

No DNS lookup is performed. Hostname matching and the CUSTOM and hashed known-host paths remain unchanged.

Validation:

- regression test fails against the original master commit for four equivalent IPv6 representations;
- GCC build, project checksrc, ASan, and UBSan pass on Linux;
- MSVC x64 build and the regression test pass with WinCNG on Windows Server 2025;
- compressed, expanded, uppercase, all-zero, embedded-IPv4, port, malformed, and compatibility cases are covered.

Reported-by: Krisscut on github
Fixes #1398
