### PR TITLE
tests: add script to dump test keys in more parsable formats

### DIFF
--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -72,6 +72,7 @@ librunner_la_SOURCES = \
 EXTRA_DIST = \
   .checksrc \
   CMakeLists.txt \
+  keys-dump.sh \
   keys-generate.sh \
   keys/ca_host_ecdsa \
   keys/ca_host_ecdsa.pub \

--- a/tests/keys-dump.sh
+++ b/tests/keys-dump.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Copyright (C) Viktor Szakats
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Dump keys in more human-parsable formats
+
+for dir in keys openssh_server; do
+  [ -d "${dir}-dump" ] || mkdir "${dir}-dump"
+  rm -f "${dir}-dump"/*
+
+  find "${dir}" -maxdepth 1 \( -name 'ca_host_*' -o -name 'ca_user_*' -o -name 'id_*' \) | while read -r f; do
+    o="${dir}-dump/$(basename $f)"
+    echo $f
+    if [[ "$f" = *'.pub' ]]; then
+      b64="$(grep -o -E ' .+ ' "$f")"
+      [ -z "$b64" ] && b64="$(grep -o -E ' .+$' "$f")"
+      echo "$b64" | tr -d ' ' | base64 -d > "$o.bin"
+      if [[ "$f" = *'cert'* ]]; then
+        ssh-keygen -L -f "$f" > "$o.cert.txt"
+      fi
+    else
+      if [[ "$f" = *'pkcs8'* ]]; then
+        openssl asn1parse -dump -in "$f" > "$o.pkey.asn1.txt"
+      else
+        grep -v -E '^(DEK-Info|Proc-Type)' "$f" | base64 -d > "$o.pkey.bin"
+      fi
+      openssl pkey -text -noout -passin pass:libssh2 -in "$f" >> "$o.pkey.txt" 2>/dev/null
+      [ -s "$o.pkey.txt" ] || rm -f "$o.pkey.txt"
+    fi
+    cp -p "$f" "$o"
+  done
+done
+
+openssl -version

--- a/tests/keys-dump.sh
+++ b/tests/keys-dump.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (C) Viktor Szakats
 # SPDX-License-Identifier: BSD-3-Clause
@@ -10,8 +10,8 @@ for dir in keys openssh_server; do
   rm -f "${dir}-dump"/*
 
   find "${dir}" -maxdepth 1 \( -name 'ca_host_*' -o -name 'ca_user_*' -o -name 'id_*' \) | while read -r f; do
-    o="${dir}-dump/$(basename $f)"
-    echo $f
+    o="${dir}-dump/$(basename "$f")"
+    echo "$f"
     if [[ "$f" = *'.pub' ]]; then
       b64="$(grep -o -E ' .+ ' "$f")"
       [ -z "$b64" ] && b64="$(grep -o -E ' .+$' "$f")"

--- a/tests/keys-dump.sh
+++ b/tests/keys-dump.sh
@@ -9,13 +9,13 @@ for dir in keys openssh_server; do
   [ -d "${dir}-dump" ] || mkdir "${dir}-dump"
   rm -f "${dir}-dump"/*
 
-  find "${dir}" -maxdepth 1 \( -name 'ca_host_*' -o -name 'ca_user_*' -o -name 'id_*' \) | while read -r f; do
+  find "${dir}" -maxdepth 1 \( -name 'ca_*' -o -name 'id_*' -o -name 'ssh_*' \) | while read -r f; do
     o="${dir}-dump/$(basename "$f")"
     echo "$f"
     if [[ "$f" = *'.pub' ]]; then
       b64="$(grep -o -E ' .+ ' "$f")"
       [ -z "$b64" ] && b64="$(grep -o -E ' .+$' "$f")"
-      echo "$b64" | tr -d ' ' | base64 -d > "$o.bin"
+      echo "$b64" | tr -d ' ' | gbase64 -d > "$o.bin"
       if [[ "$f" = *'cert'* ]]; then
         ssh-keygen -L -f "$f" > "$o.cert.txt"
       fi
@@ -23,7 +23,7 @@ for dir in keys openssh_server; do
       if [[ "$f" = *'pkcs8'* ]]; then
         openssl asn1parse -dump -in "$f" > "$o.pkey.asn1.txt"
       else
-        grep -v -E '^(DEK-Info|Proc-Type)' "$f" | base64 -d > "$o.pkey.bin"
+        grep -v -E '^(-----|DEK-Info|Proc-Type)' "$f" | gbase64 -d > "$o.pkey.bin"
       fi
       openssl pkey -text -noout -passin pass:libssh2 -in "$f" >> "$o.pkey.txt" 2>/dev/null
       [ -s "$o.pkey.txt" ] || rm -f "$o.pkey.txt"

--- a/tests/keys-dump.sh
+++ b/tests/keys-dump.sh
@@ -15,7 +15,7 @@ for dir in keys openssh_server; do
     if [[ "$f" = *'.pub' ]]; then
       b64="$(grep -o -E ' .+ ' "$f")"
       [ -z "$b64" ] && b64="$(grep -o -E ' .+$' "$f")"
-      echo "$b64" | tr -d ' ' | gbase64 -d > "$o.bin"
+      echo "$b64" | tr -d ' ' | base64 -d > "$o.bin"
       if [[ "$f" = *'cert'* ]]; then
         ssh-keygen -L -f "$f" > "$o.cert.txt"
       fi
@@ -23,7 +23,7 @@ for dir in keys openssh_server; do
       if [[ "$f" = *'pkcs8'* ]]; then
         openssl asn1parse -dump -in "$f" > "$o.pkey.asn1.txt"
       else
-        grep -v -E '^(-----|DEK-Info|Proc-Type)' "$f" | gbase64 -d > "$o.pkey.bin"
+        grep -v -E '^(-----|DEK-Info|Proc-Type)' "$f" | base64 -d > "$o.pkey.bin"
       fi
       openssl pkey -text -noout -passin pass:libssh2 -in "$f" >> "$o.pkey.txt" 2>/dev/null
       [ -s "$o.pkey.txt" ] || rm -f "$o.pkey.txt"


### PR DESCRIPTION
In some cases this is binary, in others it's textual.

To better see what's in the keys, to debug them, and debug code dealing
with them. It's a manual script, not run automatically by this repo.
