### PR TITLE
include: restore parentheses for macro arguments, for compatibility

### DIFF
--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -918,7 +918,7 @@ LIBSSH2_API unsigned long libssh2_channel_window_read_ex(
     unsigned long *read_avail,
     unsigned long *window_size_initial);
 #define libssh2_channel_window_read(channel) \
-    libssh2_channel_window_read_ex(channel, NULL, NULL)
+    libssh2_channel_window_read_ex((channel), NULL, NULL)
 
 #ifndef LIBSSH2_NO_DEPRECATED
 LIBSSH2_DEPRECATED(1.1.0, "Use libssh2_channel_receive_window_adjust2()")

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -614,8 +614,8 @@ LIBSSH2_API int libssh2_session_disconnect_ex(LIBSSH2_SESSION *session,
                                               const char *description,
                                               const char *lang);
 #define libssh2_session_disconnect(session, description) \
-    libssh2_session_disconnect_ex(session, SSH_DISCONNECT_BY_APPLICATION, \
-                                  description, "")
+    libssh2_session_disconnect_ex((session), SSH_DISCONNECT_BY_APPLICATION, \
+                                  (description), "")
 
 LIBSSH2_API int libssh2_session_free(LIBSSH2_SESSION *session);
 
@@ -659,10 +659,10 @@ LIBSSH2_API int libssh2_userauth_password_ex(
     unsigned int password_len,
     LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb));
 
-#define libssh2_userauth_password(session, username, password) \
-    libssh2_userauth_password_ex(session, \
-                                 username, (unsigned int)strlen(username), \
-                                 password, (unsigned int)strlen(password), \
+#define libssh2_userauth_password(session, username, password)               \
+    libssh2_userauth_password_ex((session), \
+                                 (username), (unsigned int)strlen(username), \
+                                 (password), (unsigned int)strlen(password), \
                                  NULL)
 
 LIBSSH2_API int libssh2_userauth_publickey_fromfile_ex(
@@ -676,10 +676,10 @@ LIBSSH2_API int libssh2_userauth_publickey_fromfile_ex(
 #define libssh2_userauth_publickey_fromfile(session, username,             \
                                             pubkeyfile,                    \
                                             privkeyfile, passphrase)       \
-    libssh2_userauth_publickey_fromfile_ex(session, username,              \
+    libssh2_userauth_publickey_fromfile_ex((session), (username),          \
                                            (unsigned int)strlen(username), \
-                                           pubkeyfile,                     \
-                                           privkeyfile, passphrase)
+                                           (pubkeyfile),                   \
+                                           (privkeyfile), (passphrase))
 
 LIBSSH2_API int libssh2_userauth_publickey(
     LIBSSH2_SESSION *session,
@@ -705,13 +705,13 @@ LIBSSH2_API int libssh2_userauth_hostbased_fromfile_ex(
                                             pubkeyfile,                       \
                                             privkeyfile, passphrase,          \
                                             hostname)                         \
-    libssh2_userauth_hostbased_fromfile_ex(session, username,                 \
+    libssh2_userauth_hostbased_fromfile_ex((session), (username),             \
                                            (unsigned int)strlen(username),    \
-                                           pubkeyfile,                        \
-                                           privkeyfile, passphrase,           \
-                                           hostname,                          \
+                                           (pubkeyfile),                      \
+                                           (privkeyfile), (passphrase),       \
+                                           (hostname),                        \
                                            (unsigned int)strlen(hostname),    \
-                                           username,                          \
+                                           (username),                        \
                                            (unsigned int)strlen(username))
 
 LIBSSH2_API int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
@@ -737,9 +737,9 @@ LIBSSH2_API int libssh2_userauth_keyboard_interactive_ex(
 
 #define libssh2_userauth_keyboard_interactive(session, username,             \
                                               response_callback)             \
-    libssh2_userauth_keyboard_interactive_ex(session, username,              \
+    libssh2_userauth_keyboard_interactive_ex((session), (username),          \
                                              (unsigned int)strlen(username), \
-                                             response_callback)
+                                             (response_callback))
 
 LIBSSH2_API int libssh2_userauth_publickey_sk(
     LIBSSH2_SESSION *session,
@@ -804,7 +804,7 @@ LIBSSH2_API LIBSSH2_CHANNEL *libssh2_channel_open_ex(
     const char *message, unsigned int message_len);
 
 #define libssh2_channel_open_session(session) \
-    libssh2_channel_open_ex(session, "session", sizeof("session") - 1, \
+    libssh2_channel_open_ex((session), "session", sizeof("session") - 1, \
                             LIBSSH2_CHANNEL_WINDOW_DEFAULT, \
                             LIBSSH2_CHANNEL_PACKET_DEFAULT, NULL, 0)
 
@@ -812,7 +812,7 @@ LIBSSH2_API LIBSSH2_CHANNEL *libssh2_channel_direct_tcpip_ex(
     LIBSSH2_SESSION *session, const char *host,
     int port, const char *shost, int sport);
 #define libssh2_channel_direct_tcpip(session, host, port) \
-    libssh2_channel_direct_tcpip_ex(session, host, port, "127.0.0.1", 22)
+    libssh2_channel_direct_tcpip_ex((session), (host), (port), "127.0.0.1", 22)
 
 LIBSSH2_API LIBSSH2_CHANNEL *libssh2_channel_direct_streamlocal_ex(
     LIBSSH2_SESSION *session,
@@ -824,7 +824,7 @@ LIBSSH2_API LIBSSH2_LISTENER *libssh2_channel_forward_listen_ex(
     int port, int *bound_port,
     int queue_maxsize);
 #define libssh2_channel_forward_listen(session, port) \
-    libssh2_channel_forward_listen_ex(session, NULL, port, NULL, 16)
+    libssh2_channel_forward_listen_ex((session), NULL, (port), NULL, 16)
 
 LIBSSH2_API int libssh2_channel_forward_cancel(LIBSSH2_LISTENER *listener);
 
@@ -837,10 +837,10 @@ LIBSSH2_API int libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
                                           const char *value,
                                           unsigned int value_len);
 
-#define libssh2_channel_setenv(channel, varname, value)               \
-    libssh2_channel_setenv_ex(channel,                                \
-                              varname, (unsigned int)strlen(varname), \
-                              value, (unsigned int)strlen(value))
+#define libssh2_channel_setenv(channel, varname, value)                 \
+    libssh2_channel_setenv_ex((channel),                                \
+                              (varname), (unsigned int)strlen(varname), \
+                              (value), (unsigned int)strlen(value))
 
 LIBSSH2_API int libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel);
 
@@ -852,8 +852,8 @@ LIBSSH2_API int libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel,
                                                int width, int height,
                                                int width_px, int height_px);
 #define libssh2_channel_request_pty(channel, term)                      \
-    libssh2_channel_request_pty_ex(channel,                             \
-                                   term, (unsigned int)strlen(term),    \
+    libssh2_channel_request_pty_ex((channel),                           \
+                                   (term), (unsigned int)strlen(term),  \
                                    NULL, 0,                             \
                                    LIBSSH2_TERM_WIDTH,                  \
                                    LIBSSH2_TERM_HEIGHT,                 \
@@ -865,7 +865,7 @@ LIBSSH2_API int libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel,
                                                     int width_px,
                                                     int height_px);
 #define libssh2_channel_request_pty_size(channel, width, height) \
-    libssh2_channel_request_pty_size_ex(channel, width, height, 0, 0)
+    libssh2_channel_request_pty_size_ex((channel), (width), (height), 0, 0)
 
 LIBSSH2_API int libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel,
                                            int single_connection,
@@ -873,13 +873,13 @@ LIBSSH2_API int libssh2_channel_x11_req_ex(LIBSSH2_CHANNEL *channel,
                                            const char *auth_cookie,
                                            int screen_number);
 #define libssh2_channel_x11_req(channel, screen_number) \
-    libssh2_channel_x11_req_ex(channel, 0, NULL, NULL, screen_number)
+    libssh2_channel_x11_req_ex((channel), 0, NULL, NULL, (screen_number))
 
 LIBSSH2_API int libssh2_channel_signal_ex(LIBSSH2_CHANNEL *channel,
                                           const char *signame,
                                           size_t signame_len);
 #define libssh2_channel_signal(channel, signame) \
-    libssh2_channel_signal_ex(channel, signame, strlen(signame))
+    libssh2_channel_signal_ex((channel), signame, strlen(signame))
 
 LIBSSH2_API int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                                 const char *request,
@@ -887,23 +887,25 @@ LIBSSH2_API int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                                 const char *message,
                                                 unsigned int message_len);
 #define libssh2_channel_shell(channel) \
-    libssh2_channel_process_startup(channel, "shell", sizeof("shell") - 1, \
+    libssh2_channel_process_startup((channel), "shell", sizeof("shell") - 1, \
                                     NULL, 0)
 #define libssh2_channel_exec(channel, command) \
-    libssh2_channel_process_startup(channel, "exec", sizeof("exec") - 1, \
-                                    command, (unsigned int)strlen(command))
+    libssh2_channel_process_startup((channel), "exec", sizeof("exec") - 1, \
+                                    (command), (unsigned int)strlen(command))
 #define libssh2_channel_subsystem(channel, subsystem) \
-    libssh2_channel_process_startup(channel, "subsystem", \
+    libssh2_channel_process_startup((channel), "subsystem", \
                                     sizeof("subsystem") - 1, \
-                                    subsystem, (unsigned int)strlen(subsystem))
+                                    (subsystem), (unsigned int)strlen(subsystem))
 
 LIBSSH2_API ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel,
                                             int stream_id, char *buf,
                                             size_t buflen);
 #define libssh2_channel_read(channel, buf, buflen) \
-    libssh2_channel_read_ex(channel, 0, buf, buflen)
+    libssh2_channel_read_ex((channel), 0, \
+                            (buf), (buflen))
 #define libssh2_channel_read_stderr(channel, buf, buflen) \
-    libssh2_channel_read_ex(channel, SSH_EXTENDED_DATA_STDERR, buf, buflen)
+    libssh2_channel_read_ex((channel), SSH_EXTENDED_DATA_STDERR, \
+                            (buf), (buflen))
 
 #ifndef LIBSSH2_NO_DEPRECATED
 LIBSSH2_DEPRECATED(1.2.0, "")
@@ -936,14 +938,16 @@ LIBSSH2_API ssize_t libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel,
                                              size_t buflen);
 
 #define libssh2_channel_write(channel, buf, buflen) \
-    libssh2_channel_write_ex(channel, 0, buf, buflen)
+    libssh2_channel_write_ex((channel), 0, \
+                             (buf), (buflen))
 #define libssh2_channel_write_stderr(channel, buf, buflen) \
-    libssh2_channel_write_ex(channel, SSH_EXTENDED_DATA_STDERR, buf, buflen)
+    libssh2_channel_write_ex((channel), SSH_EXTENDED_DATA_STDERR, \
+                             (buf), (buflen))
 
 LIBSSH2_API unsigned long libssh2_channel_window_write_ex(
     LIBSSH2_CHANNEL *channel, unsigned long *window_size_initial);
 #define libssh2_channel_window_write(channel) \
-    libssh2_channel_window_write_ex(channel, NULL)
+    libssh2_channel_window_write_ex((channel), NULL)
 
 LIBSSH2_API void libssh2_session_set_blocking(LIBSSH2_SESSION *session,
                                               int blocking);
@@ -978,7 +982,7 @@ LIBSSH2_API int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
  */
 /* DEPRECATED since 0.3.0. Use libssh2_channel_handle_extended_data2(). */
 #define libssh2_channel_ignore_extended_data(channel, ignore)                 \
-    libssh2_channel_handle_extended_data(channel, (ignore) ?                  \
+    libssh2_channel_handle_extended_data((channel), (ignore) ?                \
                                        LIBSSH2_CHANNEL_EXTENDED_DATA_IGNORE : \
                                        LIBSSH2_CHANNEL_EXTENDED_DATA_NORMAL)
 #endif
@@ -987,9 +991,9 @@ LIBSSH2_API int libssh2_channel_handle_extended_data2(LIBSSH2_CHANNEL *channel,
 #define LIBSSH2_CHANNEL_FLUSH_ALL               (-2)
 LIBSSH2_API int libssh2_channel_flush_ex(LIBSSH2_CHANNEL *channel,
                                          int streamid);
-#define libssh2_channel_flush(channel) libssh2_channel_flush_ex(channel, 0)
+#define libssh2_channel_flush(channel) libssh2_channel_flush_ex((channel), 0)
 #define libssh2_channel_flush_stderr(channel) \
-    libssh2_channel_flush_ex(channel, SSH_EXTENDED_DATA_STDERR)
+    libssh2_channel_flush_ex((channel), SSH_EXTENDED_DATA_STDERR)
 
 LIBSSH2_API int libssh2_channel_get_exit_status(LIBSSH2_CHANNEL *channel);
 LIBSSH2_API int libssh2_channel_has_exit_status(LIBSSH2_CHANNEL *channel);
@@ -1024,7 +1028,7 @@ LIBSSH2_API LIBSSH2_CHANNEL *libssh2_scp_send_ex(LIBSSH2_SESSION *session,
                                                  size_t size, long mtime,
                                                  long atime);
 #define libssh2_scp_send(session, path, mode, size) \
-    libssh2_scp_send_ex(session, path, mode, size, 0, 0)
+    libssh2_scp_send_ex((session), (path), (mode), (size), 0, 0)
 #endif
 LIBSSH2_API LIBSSH2_CHANNEL *libssh2_scp_send64(LIBSSH2_SESSION *session,
                                                 const char *path, int mode,

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -659,8 +659,8 @@ LIBSSH2_API int libssh2_userauth_password_ex(
     unsigned int password_len,
     LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb));
 
-#define libssh2_userauth_password(session, username, password)             \
-    libssh2_userauth_password_ex((session),                                \
+#define libssh2_userauth_password(session, username, password) \
+    libssh2_userauth_password_ex((session), \
                                  username, (unsigned int)strlen(username), \
                                  password, (unsigned int)strlen(password), \
                                  NULL)

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -701,17 +701,17 @@ LIBSSH2_API int libssh2_userauth_hostbased_fromfile_ex(
     const char *local_username,
     unsigned int local_username_len);
 
-#define libssh2_userauth_hostbased_fromfile(session, username,             \
-                                            pubkeyfile,                    \
-                                            privkeyfile, passphrase,       \
-                                            hostname)                      \
-    libssh2_userauth_hostbased_fromfile_ex((session), username,            \
-                                           (unsigned int)strlen(username), \
-                                           (pubkeyfile),                   \
-                                           (privkeyfile), (passphrase),    \
-                                           hostname,                       \
-                                           (unsigned int)strlen(hostname), \
-                                           username,                       \
+#define libssh2_userauth_hostbased_fromfile(session, username,                \
+                                            pubkeyfile,                       \
+                                            privkeyfile, passphrase,          \
+                                            hostname)                         \
+    libssh2_userauth_hostbased_fromfile_ex((session), username,               \
+                                           (unsigned int)strlen(username),    \
+                                           (pubkeyfile),                      \
+                                           (privkeyfile), (passphrase),       \
+                                           hostname,                          \
+                                           (unsigned int)strlen(hostname),    \
+                                           username,                          \
                                            (unsigned int)strlen(username))
 
 LIBSSH2_API int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -659,10 +659,10 @@ LIBSSH2_API int libssh2_userauth_password_ex(
     unsigned int password_len,
     LIBSSH2_PASSWD_CHANGEREQ_FUNC(*passwd_change_cb));
 
-#define libssh2_userauth_password(session, username, password)               \
-    libssh2_userauth_password_ex((session), \
-                                 (username), (unsigned int)strlen(username), \
-                                 (password), (unsigned int)strlen(password), \
+#define libssh2_userauth_password(session, username, password)             \
+    libssh2_userauth_password_ex((session),                                \
+                                 username, (unsigned int)strlen(username), \
+                                 password, (unsigned int)strlen(password), \
                                  NULL)
 
 LIBSSH2_API int libssh2_userauth_publickey_fromfile_ex(
@@ -676,7 +676,7 @@ LIBSSH2_API int libssh2_userauth_publickey_fromfile_ex(
 #define libssh2_userauth_publickey_fromfile(session, username,             \
                                             pubkeyfile,                    \
                                             privkeyfile, passphrase)       \
-    libssh2_userauth_publickey_fromfile_ex((session), (username),          \
+    libssh2_userauth_publickey_fromfile_ex((session), username,            \
                                            (unsigned int)strlen(username), \
                                            (pubkeyfile),                   \
                                            (privkeyfile), (passphrase))
@@ -701,17 +701,17 @@ LIBSSH2_API int libssh2_userauth_hostbased_fromfile_ex(
     const char *local_username,
     unsigned int local_username_len);
 
-#define libssh2_userauth_hostbased_fromfile(session, username,                \
-                                            pubkeyfile,                       \
-                                            privkeyfile, passphrase,          \
-                                            hostname)                         \
-    libssh2_userauth_hostbased_fromfile_ex((session), (username),             \
-                                           (unsigned int)strlen(username),    \
-                                           (pubkeyfile),                      \
-                                           (privkeyfile), (passphrase),       \
-                                           (hostname),                        \
-                                           (unsigned int)strlen(hostname),    \
-                                           (username),                        \
+#define libssh2_userauth_hostbased_fromfile(session, username,             \
+                                            pubkeyfile,                    \
+                                            privkeyfile, passphrase,       \
+                                            hostname)                      \
+    libssh2_userauth_hostbased_fromfile_ex((session), username,            \
+                                           (unsigned int)strlen(username), \
+                                           (pubkeyfile),                   \
+                                           (privkeyfile), (passphrase),    \
+                                           hostname,                       \
+                                           (unsigned int)strlen(hostname), \
+                                           username,                       \
                                            (unsigned int)strlen(username))
 
 LIBSSH2_API int libssh2_userauth_publickey_frommemory(LIBSSH2_SESSION *session,
@@ -737,7 +737,7 @@ LIBSSH2_API int libssh2_userauth_keyboard_interactive_ex(
 
 #define libssh2_userauth_keyboard_interactive(session, username,             \
                                               response_callback)             \
-    libssh2_userauth_keyboard_interactive_ex((session), (username),          \
+    libssh2_userauth_keyboard_interactive_ex((session), username,            \
                                              (unsigned int)strlen(username), \
                                              (response_callback))
 
@@ -837,10 +837,10 @@ LIBSSH2_API int libssh2_channel_setenv_ex(LIBSSH2_CHANNEL *channel,
                                           const char *value,
                                           unsigned int value_len);
 
-#define libssh2_channel_setenv(channel, varname, value)                 \
-    libssh2_channel_setenv_ex((channel),                                \
-                              (varname), (unsigned int)strlen(varname), \
-                              (value), (unsigned int)strlen(value))
+#define libssh2_channel_setenv(channel, varname, value)               \
+    libssh2_channel_setenv_ex((channel),                              \
+                              varname, (unsigned int)strlen(varname), \
+                              value, (unsigned int)strlen(value))
 
 LIBSSH2_API int libssh2_channel_request_auth_agent(LIBSSH2_CHANNEL *channel);
 
@@ -851,13 +851,13 @@ LIBSSH2_API int libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel,
                                                unsigned int modes_len,
                                                int width, int height,
                                                int width_px, int height_px);
-#define libssh2_channel_request_pty(channel, term)                      \
-    libssh2_channel_request_pty_ex((channel),                           \
-                                   (term), (unsigned int)strlen(term),  \
-                                   NULL, 0,                             \
-                                   LIBSSH2_TERM_WIDTH,                  \
-                                   LIBSSH2_TERM_HEIGHT,                 \
-                                   LIBSSH2_TERM_WIDTH_PX,               \
+#define libssh2_channel_request_pty(channel, term)                    \
+    libssh2_channel_request_pty_ex((channel),                         \
+                                   term, (unsigned int)strlen(term),  \
+                                   NULL, 0,                           \
+                                   LIBSSH2_TERM_WIDTH,                \
+                                   LIBSSH2_TERM_HEIGHT,               \
+                                   LIBSSH2_TERM_WIDTH_PX,             \
                                    LIBSSH2_TERM_HEIGHT_PX)
 
 LIBSSH2_API int libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel,
@@ -891,11 +891,11 @@ LIBSSH2_API int libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
                                     NULL, 0)
 #define libssh2_channel_exec(channel, command) \
     libssh2_channel_process_startup((channel), "exec", sizeof("exec") - 1, \
-                                    (command), (unsigned int)strlen(command))
+                                    command, (unsigned int)strlen(command))
 #define libssh2_channel_subsystem(channel, subsystem) \
     libssh2_channel_process_startup((channel), "subsystem", \
                                     sizeof("subsystem") - 1, \
-                                    (subsystem), (unsigned int)strlen(subsystem))
+                                    subsystem, (unsigned int)strlen(subsystem))
 
 LIBSSH2_API ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel,
                                             int stream_id, char *buf,

--- a/include/libssh2.h
+++ b/include/libssh2.h
@@ -851,13 +851,13 @@ LIBSSH2_API int libssh2_channel_request_pty_ex(LIBSSH2_CHANNEL *channel,
                                                unsigned int modes_len,
                                                int width, int height,
                                                int width_px, int height_px);
-#define libssh2_channel_request_pty(channel, term)                    \
-    libssh2_channel_request_pty_ex((channel),                         \
-                                   term, (unsigned int)strlen(term),  \
-                                   NULL, 0,                           \
-                                   LIBSSH2_TERM_WIDTH,                \
-                                   LIBSSH2_TERM_HEIGHT,               \
-                                   LIBSSH2_TERM_WIDTH_PX,             \
+#define libssh2_channel_request_pty(channel, term)                      \
+    libssh2_channel_request_pty_ex((channel),                           \
+                                   term, (unsigned int)strlen(term),    \
+                                   NULL, 0,                             \
+                                   LIBSSH2_TERM_WIDTH,                  \
+                                   LIBSSH2_TERM_HEIGHT,                 \
+                                   LIBSSH2_TERM_WIDTH_PX,               \
                                    LIBSSH2_TERM_HEIGHT_PX)
 
 LIBSSH2_API int libssh2_channel_request_pty_size_ex(LIBSSH2_CHANNEL *channel,

--- a/include/libssh2_publickey.h
+++ b/include/libssh2_publickey.h
@@ -96,11 +96,9 @@ LIBSSH2_API int libssh2_publickey_add_ex(
     unsigned long blob_len, char overwrite,
     unsigned long num_attrs,
     const libssh2_publickey_attribute attrs[]);
-#define libssh2_publickey_add(pkey, name, blob, blob_len, overwrite, \
-                              num_attrs, attrs)                      \
-    libssh2_publickey_add_ex((pkey),                                 \
-                             name, strlen(name),                     \
-                             (blob), (blob_len),                     \
+#define libssh2_publickey_add(pkey, name, blob, blob_len, overwrite,         \
+                              num_attrs, attrs)                              \
+    libssh2_publickey_add_ex((pkey), name, strlen(name), (blob), (blob_len), \
                              (overwrite), (num_attrs), (attrs))
 
 LIBSSH2_API int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
@@ -109,9 +107,7 @@ LIBSSH2_API int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
                                             const unsigned char *blob,
                                             unsigned long blob_len);
 #define libssh2_publickey_remove(pkey, name, blob, blob_len) \
-    libssh2_publickey_remove_ex((pkey),                      \
-                                name, strlen(name),          \
-                                (blob), (blob_len))
+    libssh2_publickey_remove_ex((pkey), name, strlen(name), (blob), (blob_len))
 
 LIBSSH2_API int libssh2_publickey_list_fetch(
     LIBSSH2_PUBLICKEY *pkey,

--- a/include/libssh2_publickey.h
+++ b/include/libssh2_publickey.h
@@ -97,9 +97,11 @@ LIBSSH2_API int libssh2_publickey_add_ex(
     unsigned long num_attrs,
     const libssh2_publickey_attribute attrs[]);
 #define libssh2_publickey_add(pkey, name, blob, blob_len, overwrite, \
-                              num_attrs, attrs) \
-    libssh2_publickey_add_ex(pkey, name, strlen(name), blob, blob_len, \
-                             overwrite, num_attrs, attrs)
+                              num_attrs, attrs)                      \
+    libssh2_publickey_add_ex((pkey),                                 \
+                             (name), strlen(name),                   \
+                             (blob), (blob_len),                     \
+                             (overwrite), (num_attrs), (attrs))
 
 LIBSSH2_API int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
                                             const unsigned char *name,
@@ -107,7 +109,9 @@ LIBSSH2_API int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
                                             const unsigned char *blob,
                                             unsigned long blob_len);
 #define libssh2_publickey_remove(pkey, name, blob, blob_len) \
-    libssh2_publickey_remove_ex(pkey, name, strlen(name), blob, blob_len)
+    libssh2_publickey_remove_ex((pkey),                      \
+                                (name), strlen(name),        \
+                                (blob), (blob_len))
 
 LIBSSH2_API int libssh2_publickey_list_fetch(
     LIBSSH2_PUBLICKEY *pkey,

--- a/include/libssh2_publickey.h
+++ b/include/libssh2_publickey.h
@@ -96,8 +96,8 @@ LIBSSH2_API int libssh2_publickey_add_ex(
     unsigned long blob_len, char overwrite,
     unsigned long num_attrs,
     const libssh2_publickey_attribute attrs[]);
-#define libssh2_publickey_add(pkey, name, blob, blob_len, overwrite,         \
-                              num_attrs, attrs)                              \
+#define libssh2_publickey_add(pkey, name, blob, blob_len, overwrite, \
+                              num_attrs, attrs) \
     libssh2_publickey_add_ex((pkey), name, strlen(name), (blob), (blob_len), \
                              (overwrite), (num_attrs), (attrs))
 

--- a/include/libssh2_publickey.h
+++ b/include/libssh2_publickey.h
@@ -99,7 +99,7 @@ LIBSSH2_API int libssh2_publickey_add_ex(
 #define libssh2_publickey_add(pkey, name, blob, blob_len, overwrite, \
                               num_attrs, attrs)                      \
     libssh2_publickey_add_ex((pkey),                                 \
-                             (name), strlen(name),                   \
+                             name, strlen(name),                     \
                              (blob), (blob_len),                     \
                              (overwrite), (num_attrs), (attrs))
 
@@ -110,7 +110,7 @@ LIBSSH2_API int libssh2_publickey_remove_ex(LIBSSH2_PUBLICKEY *pkey,
                                             unsigned long blob_len);
 #define libssh2_publickey_remove(pkey, name, blob, blob_len) \
     libssh2_publickey_remove_ex((pkey),                      \
-                                (name), strlen(name),        \
+                                name, strlen(name),          \
                                 (blob), (blob_len))
 
 LIBSSH2_API int libssh2_publickey_list_fetch(

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -246,8 +246,7 @@ LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(
     LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs) \
     libssh2_sftp_open_ex_r((sftp), filename, strlen(filename), \
-                           (flags), (mode), LIBSSH2_SFTP_OPENFILE, \
-                           (attrs))
+                           (flags), (mode), LIBSSH2_SFTP_OPENFILE, (attrs))
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                                       char *buffer, size_t buffer_maxlen);

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -234,10 +234,12 @@ LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex(
     const char *filename, unsigned int filename_len,
     unsigned long flags, long mode, int open_type);
 #define libssh2_sftp_open(sftp, filename, flags, mode) \
-    libssh2_sftp_open_ex(sftp, filename, (unsigned int)strlen(filename), \
-                         flags, mode, LIBSSH2_SFTP_OPENFILE)
+    libssh2_sftp_open_ex((sftp), \
+                         (filename), (unsigned int)strlen(filename), \
+                         (flags), (mode), LIBSSH2_SFTP_OPENFILE)
 #define libssh2_sftp_opendir(sftp, path) \
-    libssh2_sftp_open_ex(sftp, path, (unsigned int)strlen(path), \
+    libssh2_sftp_open_ex((sftp), \
+                         (path), (unsigned int)strlen(path), \
                          0, 0, LIBSSH2_SFTP_OPENDIR)
 LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(
     LIBSSH2_SFTP *sftp,
@@ -245,8 +247,9 @@ LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(
     unsigned long flags, long mode, int open_type,
     LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs) \
-    libssh2_sftp_open_ex_r(sftp, filename, strlen(filename), \
-                           flags, mode, LIBSSH2_SFTP_OPENFILE, attrs)
+    libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), \
+                           (flags), (mode), LIBSSH2_SFTP_OPENFILE, \
+                           (attrs))
 
 LIBSSH2_API ssize_t libssh2_sftp_read(LIBSSH2_SFTP_HANDLE *handle,
                                       char *buffer, size_t buffer_maxlen);
@@ -257,7 +260,8 @@ LIBSSH2_API int libssh2_sftp_readdir_ex(LIBSSH2_SFTP_HANDLE *handle, \
                                         size_t longentry_maxlen,
                                         LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_readdir(handle, buffer, buffer_maxlen, attrs) \
-    libssh2_sftp_readdir_ex(handle, buffer, buffer_maxlen, NULL, 0, attrs)
+    libssh2_sftp_readdir_ex((handle), (buffer), (buffer_maxlen), NULL, 0, \
+                            (attrs))
 
 LIBSSH2_API ssize_t libssh2_sftp_write(LIBSSH2_SFTP_HANDLE *handle,
                                        const char *buffer, size_t count);
@@ -275,7 +279,7 @@ LIBSSH2_API size_t libssh2_sftp_tell(LIBSSH2_SFTP_HANDLE *handle);
 #endif
 LIBSSH2_API void libssh2_sftp_seek64(LIBSSH2_SFTP_HANDLE *handle,
                                      libssh2_uint64_t offset);
-#define libssh2_sftp_rewind(handle) libssh2_sftp_seek64(handle, 0)
+#define libssh2_sftp_rewind(handle) libssh2_sftp_seek64((handle), 0)
 
 LIBSSH2_API libssh2_uint64_t libssh2_sftp_tell64(LIBSSH2_SFTP_HANDLE *handle);
 
@@ -283,9 +287,9 @@ LIBSSH2_API int libssh2_sftp_fstat_ex(LIBSSH2_SFTP_HANDLE *handle,
                                       LIBSSH2_SFTP_ATTRIBUTES *attrs,
                                       int setstat);
 #define libssh2_sftp_fstat(handle, attrs) \
-    libssh2_sftp_fstat_ex(handle, attrs, 0)
+    libssh2_sftp_fstat_ex((handle), (attrs), 0)
 #define libssh2_sftp_fsetstat(handle, attrs) \
-    libssh2_sftp_fstat_ex(handle, attrs, 1)
+    libssh2_sftp_fstat_ex((handle), (attrs), 1)
 
 /* Miscellaneous Ops */
 LIBSSH2_API int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
@@ -295,9 +299,9 @@ LIBSSH2_API int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
                                        unsigned int dest_filename_len,
                                        long flags);
 #define libssh2_sftp_rename(sftp, sourcefile, destfile) \
-    libssh2_sftp_rename_ex(sftp, \
-                           sourcefile, (unsigned int)strlen(sourcefile), \
-                           destfile, (unsigned int)strlen(destfile), \
+    libssh2_sftp_rename_ex((sftp), \
+                           (sourcefile), (unsigned int)strlen(sourcefile), \
+                           (destfile), (unsigned int)strlen(destfile), \
                            LIBSSH2_SFTP_RENAME_OVERWRITE | \
                            LIBSSH2_SFTP_RENAME_ATOMIC | \
                            LIBSSH2_SFTP_RENAME_NATIVE)
@@ -308,14 +312,14 @@ LIBSSH2_API int libssh2_sftp_posix_rename_ex(LIBSSH2_SFTP *sftp,
                                              const char *dest_filename,
                                              size_t dest_filename_len);
 #define libssh2_sftp_posix_rename(sftp, sourcefile, destfile) \
-    libssh2_sftp_posix_rename_ex(sftp, sourcefile, strlen(sourcefile), \
-                                 destfile, strlen(destfile))
+    libssh2_sftp_posix_rename_ex((sftp), (sourcefile), strlen(sourcefile), \
+                                 (destfile), strlen(destfile))
 
 LIBSSH2_API int libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp,
                                        const char *filename,
                                        unsigned int filename_len);
 #define libssh2_sftp_unlink(sftp, filename) \
-    libssh2_sftp_unlink_ex(sftp, filename, (unsigned int)strlen(filename))
+    libssh2_sftp_unlink_ex((sftp), (filename), (unsigned int)strlen(filename))
 
 LIBSSH2_API int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
                                       LIBSSH2_SFTP_STATVFS *st);
@@ -328,26 +332,26 @@ LIBSSH2_API int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path, unsigned int path_len,
                                       long mode);
 #define libssh2_sftp_mkdir(sftp, path, mode) \
-    libssh2_sftp_mkdir_ex(sftp, path, (unsigned int)strlen(path), mode)
+    libssh2_sftp_mkdir_ex((sftp), (path), (unsigned int)strlen(path), (mode))
 
 LIBSSH2_API int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path, unsigned int path_len);
 #define libssh2_sftp_rmdir(sftp, path) \
-    libssh2_sftp_rmdir_ex(sftp, path, (unsigned int)strlen(path))
+    libssh2_sftp_rmdir_ex((sftp), (path), (unsigned int)strlen(path))
 
 LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                                      const char *path, unsigned int path_len,
                                      int stat_type,
                                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_stat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex(sftp, path, (unsigned int)strlen(path), \
-                         LIBSSH2_SFTP_STAT, attrs)
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_STAT, (attrs))
 #define libssh2_sftp_lstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex(sftp, path, (unsigned int)strlen(path), \
-                         LIBSSH2_SFTP_LSTAT, attrs)
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_LSTAT, (attrs))
 #define libssh2_sftp_setstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex(sftp, path, (unsigned int)strlen(path), \
-                         LIBSSH2_SFTP_SETSTAT, attrs)
+    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+                         LIBSSH2_SFTP_SETSTAT, (attrs))
 
 LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         const char *path,
@@ -355,16 +359,20 @@ LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         char *target, unsigned int target_len,
                                         int link_type);
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \
-    libssh2_sftp_symlink_ex(sftp, \
-                            orig, (unsigned int)strlen(orig), \
-                            linkpath, (unsigned int)strlen(linkpath), \
+    libssh2_sftp_symlink_ex((sftp), \
+                            (orig), (unsigned int)strlen(orig), \
+                            (linkpath), (unsigned int)strlen(linkpath), \
                             LIBSSH2_SFTP_SYMLINK)
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex(sftp, path, (unsigned int)strlen(path), \
-                            target, maxlen, LIBSSH2_SFTP_READLINK)
+    libssh2_sftp_symlink_ex((sftp), \
+                            (path), (unsigned int)strlen(path), \
+                            (target), (maxlen), \
+                            LIBSSH2_SFTP_READLINK)
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex(sftp, path, (unsigned int)strlen(path), \
-                            target, maxlen, LIBSSH2_SFTP_REALPATH)
+    libssh2_sftp_symlink_ex((sftp), \
+                            (path), (unsigned int)strlen(path), \
+                            (target), (maxlen), \
+                            LIBSSH2_SFTP_REALPATH)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -361,12 +361,10 @@ LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                             LIBSSH2_SFTP_SYMLINK)
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
     libssh2_sftp_symlink_ex((sftp), path, (unsigned int)strlen(path), \
-                            (target), (maxlen), \
-                            LIBSSH2_SFTP_READLINK)
+                            (target), (maxlen), LIBSSH2_SFTP_READLINK)
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \
     libssh2_sftp_symlink_ex((sftp), path, (unsigned int)strlen(path), \
-                            (target), (maxlen), \
-                            LIBSSH2_SFTP_REALPATH)
+                            (target), (maxlen), LIBSSH2_SFTP_REALPATH)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -357,7 +357,7 @@ LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         int link_type);
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \
     libssh2_sftp_symlink_ex((sftp), orig, (unsigned int)strlen(orig), \
-                            (linkpath), (unsigned int)strlen(linkpath), \
+                            linkpath, (unsigned int)strlen(linkpath), \
                             LIBSSH2_SFTP_SYMLINK)
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
     libssh2_sftp_symlink_ex((sftp), path, (unsigned int)strlen(path), \

--- a/include/libssh2_sftp.h
+++ b/include/libssh2_sftp.h
@@ -234,12 +234,10 @@ LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex(
     const char *filename, unsigned int filename_len,
     unsigned long flags, long mode, int open_type);
 #define libssh2_sftp_open(sftp, filename, flags, mode) \
-    libssh2_sftp_open_ex((sftp), \
-                         (filename), (unsigned int)strlen(filename), \
+    libssh2_sftp_open_ex((sftp), filename, (unsigned int)strlen(filename), \
                          (flags), (mode), LIBSSH2_SFTP_OPENFILE)
 #define libssh2_sftp_opendir(sftp, path) \
-    libssh2_sftp_open_ex((sftp), \
-                         (path), (unsigned int)strlen(path), \
+    libssh2_sftp_open_ex((sftp), path, (unsigned int)strlen(path), \
                          0, 0, LIBSSH2_SFTP_OPENDIR)
 LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(
     LIBSSH2_SFTP *sftp,
@@ -247,7 +245,7 @@ LIBSSH2_API LIBSSH2_SFTP_HANDLE *libssh2_sftp_open_ex_r(
     unsigned long flags, long mode, int open_type,
     LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_open_r(sftp, filename, flags, mode, attrs) \
-    libssh2_sftp_open_ex_r((sftp), (filename), strlen(filename), \
+    libssh2_sftp_open_ex_r((sftp), filename, strlen(filename), \
                            (flags), (mode), LIBSSH2_SFTP_OPENFILE, \
                            (attrs))
 
@@ -300,8 +298,8 @@ LIBSSH2_API int libssh2_sftp_rename_ex(LIBSSH2_SFTP *sftp,
                                        long flags);
 #define libssh2_sftp_rename(sftp, sourcefile, destfile) \
     libssh2_sftp_rename_ex((sftp), \
-                           (sourcefile), (unsigned int)strlen(sourcefile), \
-                           (destfile), (unsigned int)strlen(destfile), \
+                           sourcefile, (unsigned int)strlen(sourcefile), \
+                           destfile, (unsigned int)strlen(destfile), \
                            LIBSSH2_SFTP_RENAME_OVERWRITE | \
                            LIBSSH2_SFTP_RENAME_ATOMIC | \
                            LIBSSH2_SFTP_RENAME_NATIVE)
@@ -312,14 +310,14 @@ LIBSSH2_API int libssh2_sftp_posix_rename_ex(LIBSSH2_SFTP *sftp,
                                              const char *dest_filename,
                                              size_t dest_filename_len);
 #define libssh2_sftp_posix_rename(sftp, sourcefile, destfile) \
-    libssh2_sftp_posix_rename_ex((sftp), (sourcefile), strlen(sourcefile), \
-                                 (destfile), strlen(destfile))
+    libssh2_sftp_posix_rename_ex((sftp), sourcefile, strlen(sourcefile), \
+                                 destfile, strlen(destfile))
 
 LIBSSH2_API int libssh2_sftp_unlink_ex(LIBSSH2_SFTP *sftp,
                                        const char *filename,
                                        unsigned int filename_len);
 #define libssh2_sftp_unlink(sftp, filename) \
-    libssh2_sftp_unlink_ex((sftp), (filename), (unsigned int)strlen(filename))
+    libssh2_sftp_unlink_ex((sftp), filename, (unsigned int)strlen(filename))
 
 LIBSSH2_API int libssh2_sftp_fstatvfs(LIBSSH2_SFTP_HANDLE *handle,
                                       LIBSSH2_SFTP_STATVFS *st);
@@ -332,25 +330,25 @@ LIBSSH2_API int libssh2_sftp_mkdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path, unsigned int path_len,
                                       long mode);
 #define libssh2_sftp_mkdir(sftp, path, mode) \
-    libssh2_sftp_mkdir_ex((sftp), (path), (unsigned int)strlen(path), (mode))
+    libssh2_sftp_mkdir_ex((sftp), path, (unsigned int)strlen(path), (mode))
 
 LIBSSH2_API int libssh2_sftp_rmdir_ex(LIBSSH2_SFTP *sftp,
                                       const char *path, unsigned int path_len);
 #define libssh2_sftp_rmdir(sftp, path) \
-    libssh2_sftp_rmdir_ex((sftp), (path), (unsigned int)strlen(path))
+    libssh2_sftp_rmdir_ex((sftp), path, (unsigned int)strlen(path))
 
 LIBSSH2_API int libssh2_sftp_stat_ex(LIBSSH2_SFTP *sftp,
                                      const char *path, unsigned int path_len,
                                      int stat_type,
                                      LIBSSH2_SFTP_ATTRIBUTES *attrs);
 #define libssh2_sftp_stat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+    libssh2_sftp_stat_ex((sftp), path, (unsigned int)strlen(path), \
                          LIBSSH2_SFTP_STAT, (attrs))
 #define libssh2_sftp_lstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+    libssh2_sftp_stat_ex((sftp), path, (unsigned int)strlen(path), \
                          LIBSSH2_SFTP_LSTAT, (attrs))
 #define libssh2_sftp_setstat(sftp, path, attrs) \
-    libssh2_sftp_stat_ex((sftp), (path), (unsigned int)strlen(path), \
+    libssh2_sftp_stat_ex((sftp), path, (unsigned int)strlen(path), \
                          LIBSSH2_SFTP_SETSTAT, (attrs))
 
 LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
@@ -359,18 +357,15 @@ LIBSSH2_API int libssh2_sftp_symlink_ex(LIBSSH2_SFTP *sftp,
                                         char *target, unsigned int target_len,
                                         int link_type);
 #define libssh2_sftp_symlink(sftp, orig, linkpath) \
-    libssh2_sftp_symlink_ex((sftp), \
-                            (orig), (unsigned int)strlen(orig), \
+    libssh2_sftp_symlink_ex((sftp), orig, (unsigned int)strlen(orig), \
                             (linkpath), (unsigned int)strlen(linkpath), \
                             LIBSSH2_SFTP_SYMLINK)
 #define libssh2_sftp_readlink(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), \
-                            (path), (unsigned int)strlen(path), \
+    libssh2_sftp_symlink_ex((sftp), path, (unsigned int)strlen(path), \
                             (target), (maxlen), \
                             LIBSSH2_SFTP_READLINK)
 #define libssh2_sftp_realpath(sftp, path, target, maxlen) \
-    libssh2_sftp_symlink_ex((sftp), \
-                            (path), (unsigned int)strlen(path), \
+    libssh2_sftp_symlink_ex((sftp), path, (unsigned int)strlen(path), \
                             (target), (maxlen), \
                             LIBSSH2_SFTP_REALPATH)
 


### PR DESCRIPTION
To avoid the chance of breaking compatibility. Make an exception for
values also passed to `strlen()` because these were already not 
supporting callers passing `x, y`-style macro expressions to these
macros, as arguments.

Also note that SFTP handle args already did not support this due to the
lack of parentheses in `libssh2_sftp_close()`, `libssh2_sftp_closedir()`
macros.

Follow-up to b6f307dca9ad38657722ab2238c92837164d4f21 #1898
