### PR TITLE
publickey: initialize the list terminator

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -941,7 +941,8 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
                     goto err_exit;
                 }
                 list = newlist;
-                memset(&list[keys], 0, (max_keys - keys) * sizeof(list[keys]));
+                memset(&list[keys], 0,
+                       (max_keys - keys + 1) * sizeof(list[keys]));
             }
             if(pkey->version == 1) {
                 unsigned long comment_len;


### PR DESCRIPTION
The allocation reserves `max_keys + 1` entries, while the initialization after
growth currently covers only `max_keys - keys` entries. Include the additional
reserved entry in that initialization so the list terminator is initialized at
exact capacity boundaries.

Validation included a static CMake build with GCC, boundary-focused regression
coverage under ASan/UBSan/LeakSanitizer, the configured standalone upstream
test, `scripts/checksrc-all.pl`, and `git diff --check`.

OpenAI Codex assisted with the analysis, patch preparation and test harness. I
manually reviewed the source diff, the description and the test results.

Follow-up to c2f1a3a21b4c922cbcf50bf7c009b740141a1e7a #2380