### PR TITLE
publickey: cap number of public keys in `libssh2_publickey_list_fetch()`

### DIFF
--- a/src/publickey.c
+++ b/src/publickey.c
@@ -942,6 +942,11 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
         }
         case SSH2_PUBLICKEY_RESPONSE_PUBLICKEY:
             /* What we want */
+            if(keys > 128000) {
+                ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
+                         "Too many public keys");
+                goto err_exit;
+            }
             if(keys >= max_keys) {
                 libssh2_publickey_list *newlist;
                 /* Grow the key list if necessary */

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -942,7 +942,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
         }
         case SSH2_PUBLICKEY_RESPONSE_PUBLICKEY:
             /* What we want */
-            if(keys >= 128000) {
+            if(keys >= 32768) {
                 ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                          "Too many public keys");
                 goto err_exit;

--- a/src/publickey.c
+++ b/src/publickey.c
@@ -942,7 +942,7 @@ int libssh2_publickey_list_fetch(LIBSSH2_PUBLICKEY *pkey,
         }
         case SSH2_PUBLICKEY_RESPONSE_PUBLICKEY:
             /* What we want */
-            if(keys > 128000) {
+            if(keys >= 128000) {
                 ssh2_err(session, LIBSSH2_ERROR_OUT_OF_BOUNDARY,
                          "Too many public keys");
                 goto err_exit;


### PR DESCRIPTION
to the abitrary value of 32768. To avoid overflowing the counter and 
letting it wrap around, and to avoid exhausting memory if the list is
large or keeps coming from the server.
