### PR TITLE
sftp: fix handling unexpected EOF in `sftp_packet_read()`

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -289,6 +289,12 @@ static int sftp_packet_read(LIBSSH2_SFTP *sftp)
                 return (int)rc;
             else if(rc < 0)
                 return ssh2_err(session, (int)rc, "channel read");
+            else if(rc == 0) {
+                sftp->packet_header_len = 0;
+                return ssh2_err(session, LIBSSH2_ERROR_SOCKET_RECV,
+                                "Unexpected channel EOF while reading "
+                                "SFTP packet header");
+            }
 
             sftp->packet_header_len += rc;
 
@@ -381,11 +387,15 @@ window_adjust:
                 sftp->packet_state = ssh2_NB_state_sent1;
                 return (int)rc;
             }
-            else if(rc < 0) {
+            else if(rc <= 0) {
                 SSH2_FREE(session, packet);
                 sftp->partial_packet = NULL;
-                return ssh2_err(session, (int)rc,
-                                "Error waiting for SFTP packet");
+                if(rc < 0)
+                    return ssh2_err(session, (int)rc,
+                                    "Error waiting for SFTP packet");
+                return ssh2_err(session, LIBSSH2_ERROR_SOCKET_RECV,
+                                "Unexpected channel EOF while reading "
+                                "SFTP packet body");
             }
             sftp->partial_received += rc;
         }


### PR DESCRIPTION
If the server failed to serve the promised amount of data, 
`sftp_packet_read()` could be stuck in a loop, prior to this patch.

Report-and-patch-by: RELAUNCH DEPT.
Fixes GHSA-2q3j-q544-xxp7

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
