### PR TITLE
channel, packet: validate packet size received from server

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -224,7 +224,6 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
 
         if(session->open_data[0] == SSH_MSG_CHANNEL_OPEN_CONFIRMATION) {
 
-            uint32_t window_size_2;
             uint32_t packet_size_2;
 
             if(session->open_data_len < 17) {
@@ -233,19 +232,20 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
                 goto channel_error;
             }
 
-            window_size_2 = ssh2_ntohu32(session->open_data + 9);
             packet_size_2 = ssh2_ntohu32(session->open_data + 13);
 
-            if(!packet_size_2 || !window_size_2) {
+            if(!packet_size_2) {
                 ssh2_err(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
-                         "Invalid packet or window size received from server");
+                         "Invalid packet size received from server");
                 goto channel_error;
             }
 
             session->open_channel->remote.id =
                 ssh2_ntohu32(session->open_data + 5);
-            session->open_channel->local.window_size = window_size_2;
-            session->open_channel->local.window_size_initial = window_size_2;
+            session->open_channel->local.window_size =
+                ssh2_ntohu32(session->open_data + 9);
+            session->open_channel->local.window_size_initial =
+                ssh2_ntohu32(session->open_data + 9);
             session->open_channel->local.packet_size = packet_size_2;
             ssh2_deb((session, LIBSSH2_TRACE_CONN,
                       "Connection Established - ID: %u/%u win: %u/%u"

--- a/src/channel.c
+++ b/src/channel.c
@@ -223,6 +223,8 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
         }
 
         if(session->open_data[0] == SSH_MSG_CHANNEL_OPEN_CONFIRMATION) {
+            uint32_t window_size;
+            uint32_t packet_size;
 
             if(session->open_data_len < 17) {
                 ssh2_err(session, LIBSSH2_ERROR_PROTO,
@@ -230,14 +232,20 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
                 goto channel_error;
             }
 
+            window_size = ssh2_ntohu32(session->open_data + 9);
+            packet_size = ssh2_ntohu32(session->open_data + 13);
+
+            if(!packet_size || !window_size) {
+                ssh2_err(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
+                         "Invalid packet or window size received from server");
+                goto channel_error;
+            }
+
             session->open_channel->remote.id =
                 ssh2_ntohu32(session->open_data + 5);
-            session->open_channel->local.window_size =
-                ssh2_ntohu32(session->open_data + 9);
-            session->open_channel->local.window_size_initial =
-                ssh2_ntohu32(session->open_data + 9);
-            session->open_channel->local.packet_size =
-                ssh2_ntohu32(session->open_data + 13);
+            session->open_channel->local.window_size = window_size;
+            session->open_channel->local.window_size_initial = window_size;
+            session->open_channel->local.packet_size = packet_size;
             ssh2_deb((session, LIBSSH2_TRACE_CONN,
                       "Connection Established - ID: %u/%u win: %u/%u"
                       " pack: %u/%u",

--- a/src/channel.c
+++ b/src/channel.c
@@ -224,17 +224,15 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
 
         if(session->open_data[0] == SSH_MSG_CHANNEL_OPEN_CONFIRMATION) {
 
-            uint32_t packet_size_2;
-
             if(session->open_data_len < 17) {
                 ssh2_err(session, LIBSSH2_ERROR_PROTO,
                          "Unexpected packet size");
                 goto channel_error;
             }
 
-            packet_size_2 = ssh2_ntohu32(session->open_data + 13);
+            packet_size = ssh2_ntohu32(session->open_data + 13);
 
-            if(!packet_size_2) {
+            if(!packet_size) {
                 ssh2_err(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
                          "Invalid packet size received from server");
                 goto channel_error;
@@ -246,7 +244,7 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
                 ssh2_ntohu32(session->open_data + 9);
             session->open_channel->local.window_size_initial =
                 ssh2_ntohu32(session->open_data + 9);
-            session->open_channel->local.packet_size = packet_size_2;
+            session->open_channel->local.packet_size = packet_size;
             ssh2_deb((session, LIBSSH2_TRACE_CONN,
                       "Connection Established - ID: %u/%u win: %u/%u"
                       " pack: %u/%u",

--- a/src/channel.c
+++ b/src/channel.c
@@ -223,8 +223,6 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
         }
 
         if(session->open_data[0] == SSH_MSG_CHANNEL_OPEN_CONFIRMATION) {
-            uint32_t window_size;
-            uint32_t packet_size;
 
             if(session->open_data_len < 17) {
                 ssh2_err(session, LIBSSH2_ERROR_PROTO,

--- a/src/channel.c
+++ b/src/channel.c
@@ -224,16 +224,19 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
 
         if(session->open_data[0] == SSH_MSG_CHANNEL_OPEN_CONFIRMATION) {
 
+            uint32_t window_size_2;
+            uint32_t packet_size_2;
+
             if(session->open_data_len < 17) {
                 ssh2_err(session, LIBSSH2_ERROR_PROTO,
                          "Unexpected packet size");
                 goto channel_error;
             }
 
-            window_size = ssh2_ntohu32(session->open_data + 9);
-            packet_size = ssh2_ntohu32(session->open_data + 13);
+            window_size_2 = ssh2_ntohu32(session->open_data + 9);
+            packet_size_2 = ssh2_ntohu32(session->open_data + 13);
 
-            if(!packet_size || !window_size) {
+            if(!packet_size_2 || !window_size_2) {
                 ssh2_err(session, LIBSSH2_ERROR_CHANNEL_FAILURE,
                          "Invalid packet or window size received from server");
                 goto channel_error;
@@ -241,9 +244,9 @@ LIBSSH2_CHANNEL *ssh2_channel_open(LIBSSH2_SESSION *session,
 
             session->open_channel->remote.id =
                 ssh2_ntohu32(session->open_data + 5);
-            session->open_channel->local.window_size = window_size;
-            session->open_channel->local.window_size_initial = window_size;
-            session->open_channel->local.packet_size = packet_size;
+            session->open_channel->local.window_size = window_size_2;
+            session->open_channel->local.window_size_initial = window_size_2;
+            session->open_channel->local.packet_size = packet_size_2;
             ssh2_deb((session, LIBSSH2_TRACE_CONN,
                       "Connection Established - ID: %u/%u win: %u/%u"
                       " pack: %u/%u",

--- a/src/packet.c
+++ b/src/packet.c
@@ -132,6 +132,14 @@ static SSH2_INLINE int packet_queue_listener(
                         break;
                     }
 
+                    if(!listen_state->packet_size) {
+                        ssh2_deb((session, LIBSSH2_TRACE_CONN,
+                                  "Invalid packet size received from server"));
+                        failure_code = SSH_OPEN_CONNECT_FAILED;
+                        listen_state->state = ssh2_NB_state_sent;
+                        break;
+                    }
+
                     channel = SSH2_CALLOC(session, sizeof(LIBSSH2_CHANNEL));
                     if(!channel) {
                         ssh2_err(session, LIBSSH2_ERROR_ALLOC,
@@ -325,6 +333,13 @@ static SSH2_INLINE int packet_x11_open(
 
     if(session->x11) {
         if(x11open_state->state == ssh2_NB_state_allocated) {
+            if(!x11open_state->packet_size) {
+                ssh2_deb((session, LIBSSH2_TRACE_CONN,
+                          "Invalid packet size received from server"));
+                failure_code = SSH_OPEN_CONNECT_FAILED;
+                goto x11_exit;
+            }
+
             channel = SSH2_CALLOC(session, sizeof(LIBSSH2_CHANNEL));
             if(!channel) {
                 ssh2_err(session, LIBSSH2_ERROR_ALLOC,
@@ -476,6 +491,13 @@ static SSH2_INLINE int packet_authagent_open(
 
     if(session->authagent) {
         if(authagent_state->state == ssh2_NB_state_allocated) {
+            if(!authagent_state->packet_size) {
+                ssh2_deb((session, LIBSSH2_TRACE_CONN,
+                          "Invalid packet size received from server"));
+                failure_code = SSH_OPEN_CONNECT_FAILED;
+                goto authagent_exit;
+            }
+
             channel = SSH2_CALLOC(session, sizeof(LIBSSH2_CHANNEL));
             authagent_state->channel = channel;
 


### PR DESCRIPTION
To avoid continuing with a zero value and entering a busy-loop.

Reported-by: Nora-Qiu
Fixes GHSA-4q73-hh48-fmr8

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
