### PR TITLE
clang-tidy: enable `readability-misleading-indentation`

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -34,6 +34,7 @@ Checks:
   - portability-*
   - readability-duplicate-include
   - readability-inconsistent-declaration-parameter-name
+  - readability-misleading-indentation
   - readability-named-parameter
   - readability-redundant-control-flow
   - readability-redundant-declaration


### PR DESCRIPTION
Ref: https://clang.llvm.org/extra/clang-tidy/checks/readability/misleading-indentation.html
