### PR TITLE
clang-tidy: enable `readability-redundant-nested-if`, fix findings

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -39,6 +39,7 @@ Checks:
   - readability-redundant-control-flow
   - readability-redundant-declaration
   - readability-redundant-function-ptr-dereference
+  - readability-redundant-nested-if
   - readability-redundant-parentheses
   - readability-redundant-preprocessor
   - readability-suspicious-call-argument

--- a/src/kex.c
+++ b/src/kex.c
@@ -3692,18 +3692,17 @@ int ssh2_kex_exchange(LIBSSH2_SESSION *session, int reexchange,
     else
         key_state->state = ssh2_NB_state_sent2;
 
-    if(rc == 0 && session->kex && session->kex->exchange_keys) {
-        if(key_state->state == ssh2_NB_state_sent2) {
-            retcode = session->kex->exchange_keys(session,
-                                                  &key_state->key_state_low);
-            if(retcode == LIBSSH2_ERROR_EAGAIN) {
-                session->state &= ~SSH2_STATE_KEX_ACTIVE;
-                return retcode;
-            }
-            else if(retcode)
-                rc = ssh2_err(session, LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE,
-                              "Unrecoverable error exchanging keys");
+    if(rc == 0 && session->kex && session->kex->exchange_keys &&
+       key_state->state == ssh2_NB_state_sent2) {
+        retcode = session->kex->exchange_keys(session,
+                                              &key_state->key_state_low);
+        if(retcode == LIBSSH2_ERROR_EAGAIN) {
+            session->state &= ~SSH2_STATE_KEX_ACTIVE;
+            return retcode;
         }
+        else if(retcode)
+            rc = ssh2_err(session, LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE,
+                          "Unrecoverable error exchanging keys");
     }
 
     /* Done with kexinit buffers */

--- a/src/kex.c
+++ b/src/kex.c
@@ -3241,21 +3241,19 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session, size_t kex_flags,
     while(hostkeyp && *hostkeyp && (*hostkeyp)->name) {
         s = ssh2_kex_agree_instr(hostkey, hostkey_len,
                                  (*hostkeyp)->name, strlen((*hostkeyp)->name));
-        if(s) {
-            /* OK so far, but does it suit our purposes? (Encrypting vs
-               Signing) */
-            if((kex_flags & KEX_METHOD_FLAG_REQ_ENC_HOSTKEY) == 0 ||
-               (*hostkeyp)->encrypt) {
-                /* Either this hostkey can do encryption or this kex
-                   does not require it */
-                if((kex_flags & KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY) == 0 ||
-                   (*hostkeyp)->sig_verify) {
-                    /* Either this hostkey can do signing or this kex
-                       does not require it */
-                    session->hostkey = *hostkeyp;
-                    return 0;
-                }
-            }
+        if(s &&
+           /* OK so far, but does it suit our purposes? (Encrypting vs
+              Signing) */
+           ((kex_flags & KEX_METHOD_FLAG_REQ_ENC_HOSTKEY) == 0 ||
+            (*hostkeyp)->encrypt) &&
+           /* Either this hostkey can do encryption or this kex
+              does not require it */
+           ((kex_flags & KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY) == 0 ||
+            (*hostkeyp)->sig_verify)) {
+            /* Either this hostkey can do signing or this kex
+               does not require it */
+            session->hostkey = *hostkeyp;
+            return 0;
         }
         hostkeyp++;
     }

--- a/src/kex.c
+++ b/src/kex.c
@@ -3313,21 +3313,20 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION *session,
     while(*kexp && (*kexp)->name) {
         s = ssh2_kex_agree_instr(kex, kex_len,
                                  (*kexp)->name, strlen((*kexp)->name));
-        if(s) {
-            /* We have agreed on a key exchange method,
-             * Can we agree on a hostkey that works with this kex?
-             */
-            if(kex_agree_hostkey(session, (*kexp)->flags, hostkey,
-                                 hostkey_len) == 0) {
-                session->kex = *kexp;
-                if(session->burn_optimistic_kexinit && kex == s)
-                    /* Server sent an optimistic packet, and client agrees
-                     * with preference cancel burning the first KEX_INIT
-                     * packet that comes in */
-                    session->burn_optimistic_kexinit = 0;
+        if(s &&
+           /* We have agreed on a key exchange method,
+            * Can we agree on a hostkey that works with this kex?
+            */
+           kex_agree_hostkey(session, (*kexp)->flags, hostkey,
+                             hostkey_len) == 0) {
+            session->kex = *kexp;
+            if(session->burn_optimistic_kexinit && kex == s)
+                /* Server sent an optimistic packet, and client agrees
+                 * with preference cancel burning the first KEX_INIT
+                 * packet that comes in */
+                session->burn_optimistic_kexinit = 0;
 
-                return 0;
-            }
+            return 0;
         }
         kexp++;
     }

--- a/src/kex.c
+++ b/src/kex.c
@@ -340,22 +340,18 @@ static int kex_finish(LIBSSH2_SESSION *session,
     if(session->local.comp && session->local.comp->dtor)
         session->local.comp->dtor(session, 1, &session->local.comp_abstract);
 
-    if(session->local.comp && session->local.comp->init) {
-        if(session->local.comp->init(session, 1,
-                                     &session->local.comp_abstract))
-            return LIBSSH2_ERROR_KEX_FAILURE;
-    }
+    if(session->local.comp && session->local.comp->init &&
+       session->local.comp->init(session, 1, &session->local.comp_abstract))
+        return LIBSSH2_ERROR_KEX_FAILURE;
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Client to Server compression initialized"));
 
     if(session->remote.comp && session->remote.comp->dtor)
         session->remote.comp->dtor(session, 0, &session->remote.comp_abstract);
 
-    if(session->remote.comp && session->remote.comp->init) {
-        if(session->remote.comp->init(session, 0,
-                                      &session->remote.comp_abstract))
-            return LIBSSH2_ERROR_KEX_FAILURE;
-    }
+    if(session->remote.comp && session->remote.comp->init &&
+       session->remote.comp->init(session, 0, &session->remote.comp_abstract))
+        return LIBSSH2_ERROR_KEX_FAILURE;
     ssh2_deb((session, LIBSSH2_TRACE_KEX,
               "Server to Client compression initialized"));
 

--- a/src/kex.c
+++ b/src/kex.c
@@ -3219,17 +3219,16 @@ static int kex_agree_hostkey(LIBSSH2_SESSION *session, size_t kex_flags,
 
                 /* OK so far, but does it suit our purposes? (Encrypting
                    vs Signing) */
-                if((kex_flags & KEX_METHOD_FLAG_REQ_ENC_HOSTKEY) == 0 ||
-                   method->encrypt) {
-                    /* Either this hostkey can do encryption or this kex
-                       does not require it */
-                    if((kex_flags & KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY) == 0 ||
-                       method->sig_verify) {
+                if(((kex_flags & KEX_METHOD_FLAG_REQ_ENC_HOSTKEY) == 0 ||
+                    method->encrypt) &&
+                   /* Either this hostkey can do encryption or this kex
+                      does not require it */
+                   ((kex_flags & KEX_METHOD_FLAG_REQ_SIGN_HOSTKEY) == 0 ||
+                    method->sig_verify)) {
                         /* Either this hostkey can do signing or this kex
                            does not require it */
-                        session->hostkey = method;
-                        return 0;
-                    }
+                    session->hostkey = method;
+                    return 0;
                 }
             }
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -401,13 +401,11 @@ int ssh2_rsa_sha2_verify(ssh2_rsa_ctx *rsa, LIBSSH2_SESSION *session,
     else if(nid_type == NID_sha512)
         md = EVP_sha512();
 
-    if(ctx && md) {
-        if(EVP_PKEY_verify_init(ctx) > 0 &&
-           EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_PADDING) > 0 &&
-           EVP_PKEY_CTX_set_signature_md(ctx, md) > 0) {
-            ret = EVP_PKEY_verify(ctx, sig, sig_len, hash, hash_len);
-        }
-    }
+    if(ctx && md &&
+       EVP_PKEY_verify_init(ctx) > 0 &&
+       EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_PADDING) > 0 &&
+       EVP_PKEY_CTX_set_signature_md(ctx, md) > 0)
+        ret = EVP_PKEY_verify(ctx, sig, sig_len, hash, hash_len);
 
     if(ctx)
         EVP_PKEY_CTX_free(ctx);

--- a/src/transport.c
+++ b/src/transport.c
@@ -1261,16 +1261,15 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
             }
         }
 
-        if(etm &&
-           /* Calculate MAC hash. Put the output at index packet_length,
-              since that size includes the whole packet. The MAC is
-              calculated on the entire packet (length plain the rest
-              encrypted), including all fields except the MAC field
-              itself. */
-           local_mac->hash(session, p->outbuf + packet_length,
-                           session->local.seqno, p->outbuf,
-                           packet_length, NULL, 0,
-                           &session->local.mac_abstract))
+        /* Calculate MAC hash. Put the output at index packet_length,
+           since that size includes the whole packet. The MAC is
+           calculated on the entire packet (length plain the rest
+           encrypted), including all fields except the MAC field
+           itself. */
+        if(etm && local_mac->hash(session, p->outbuf + packet_length,
+                                  session->local.seqno, p->outbuf,
+                                  packet_length, NULL, 0,
+                                  &session->local.mac_abstract))
             return ssh2_err(session, LIBSSH2_ERROR_MAC_FAILURE,
                             "Failed to calculate MAC");
     }

--- a/src/transport.c
+++ b/src/transport.c
@@ -1261,11 +1261,10 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
             }
         }
 
-        /* Calculate MAC hash. Put the output at index packet_length,
-           since that size includes the whole packet. The MAC is
-           calculated on the entire packet (length plain the rest
-           encrypted), including all fields except the MAC field
-           itself. */
+        /* Calculate MAC hash. Put the output at index packet_length, since
+           that size includes the whole packet. The MAC is calculated on the
+           entire packet (length plain the rest encrypted), including all
+           fields except the MAC field itself. */
         if(etm && local_mac->hash(session, p->outbuf + packet_length,
                                   session->local.seqno, p->outbuf,
                                   packet_length, NULL, 0,

--- a/src/transport.c
+++ b/src/transport.c
@@ -1261,19 +1261,18 @@ int ssh2_transport_send(LIBSSH2_SESSION *session,
             }
         }
 
-        if(etm) {
-            /* Calculate MAC hash. Put the output at index packet_length,
-               since that size includes the whole packet. The MAC is
-               calculated on the entire packet (length plain the rest
-               encrypted), including all fields except the MAC field
-               itself. */
-            if(local_mac->hash(session, p->outbuf + packet_length,
-                               session->local.seqno, p->outbuf,
-                               packet_length, NULL, 0,
-                               &session->local.mac_abstract))
-                return ssh2_err(session, LIBSSH2_ERROR_MAC_FAILURE,
-                                "Failed to calculate MAC");
-        }
+        if(etm &&
+           /* Calculate MAC hash. Put the output at index packet_length,
+              since that size includes the whole packet. The MAC is
+              calculated on the entire packet (length plain the rest
+              encrypted), including all fields except the MAC field
+              itself. */
+           local_mac->hash(session, p->outbuf + packet_length,
+                           session->local.seqno, p->outbuf,
+                           packet_length, NULL, 0,
+                           &session->local.mac_abstract))
+            return ssh2_err(session, LIBSSH2_ERROR_MAC_FAILURE,
+                            "Failed to calculate MAC");
     }
 
     session->local.seqno++;

--- a/tests/session_fixture.c
+++ b/tests/session_fixture.c
@@ -191,27 +191,25 @@ LIBSSH2_SESSION *start_session_fixture(int *skipped, int *err)
     }
 
     /* Override crypt algorithm for the test */
-    if(crypt) {
-        if(libssh2_session_method_pref(connected_session,
-                                       LIBSSH2_METHOD_CRYPT_CS, crypt) ||
-           libssh2_session_method_pref(connected_session,
-                                       LIBSSH2_METHOD_CRYPT_SC, crypt)) {
-            fprintf(stderr, "libssh2_session_method_pref CRYPT failed "
-                            "(probably disabled in the build): '%s'\n", crypt);
-            return NULL;
-        }
+    if(crypt &&
+       (libssh2_session_method_pref(connected_session,
+                                    LIBSSH2_METHOD_CRYPT_CS, crypt) ||
+        libssh2_session_method_pref(connected_session,
+                                    LIBSSH2_METHOD_CRYPT_SC, crypt))) {
+        fprintf(stderr, "libssh2_session_method_pref CRYPT failed "
+                        "(probably disabled in the build): '%s'\n", crypt);
+        return NULL;
     }
 
     /* Override mac algorithm for the test */
-    if(mac) {
-        if(libssh2_session_method_pref(connected_session,
-                                       LIBSSH2_METHOD_MAC_CS, mac) ||
-           libssh2_session_method_pref(connected_session,
-                                       LIBSSH2_METHOD_MAC_SC, mac)) {
-            fprintf(stderr, "libssh2_session_method_pref MAC failed "
-                            "(probably disabled in the build): '%s'\n", mac);
-            return NULL;
-        }
+    if(mac &&
+       (libssh2_session_method_pref(connected_session,
+                                    LIBSSH2_METHOD_MAC_CS, mac) ||
+        libssh2_session_method_pref(connected_session,
+                                    LIBSSH2_METHOD_MAC_SC, mac))) {
+        fprintf(stderr, "libssh2_session_method_pref MAC failed "
+                        "(probably disabled in the build): '%s'\n", mac);
+        return NULL;
     }
 
     /* Without an explicit override, limit accepted hostkey types to those


### PR DESCRIPTION
Ref: https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-nested-if.html
