### PR TITLE
clang-tidy: fix `readability-redundant-casting` findings

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -36,6 +36,7 @@ Checks:
   - readability-inconsistent-declaration-parameter-name
   - readability-misleading-indentation
   - readability-named-parameter
+  # readability-redundant-casting  # false positives in types that change from platform to platform, even with IgnoreTypeAliases: true
   - readability-redundant-control-flow
   - readability-redundant-declaration
   - readability-redundant-function-ptr-dereference

--- a/src/kex.c
+++ b/src/kex.c
@@ -1821,7 +1821,7 @@ static int kex_method_ecdh_key_exchange(
 
         ret = kex_ecdh_sha2_nistp(session, curve, key_state->data,
                                   key_state->data_len,
-                                  (unsigned char *)key_state->public_key_oct,
+                                  key_state->public_key_oct,
                                   key_state->public_key_oct_len,
                                   key_state->private_key,
                                   &key_state->exchange_state);
@@ -2169,7 +2169,7 @@ static int kex_method_mlkem_nistp_key_exchange(
 
     if(key_state->state == ssh2_NB_state_sent2) {
         ret = kex_mlkem_nistp(session, key_state->data, key_state->data_len,
-                              (unsigned char *)key_state->public_key_oct,
+                              key_state->public_key_oct,
                               key_state->public_key_oct_len,
                               key_state->private_key,
                               key_state->mlkem_public_key,

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -3008,8 +3008,8 @@ static int sftp_posix_rename(LIBSSH2_SFTP *sftp, const char *source_filename,
     }
     else if(rc) {
         sftp->posix_rename_state = ssh2_NB_state_idle;
-        return (int)ssh2_err(session, (int)rc,
-                             "Error waiting for FXP EXTENDED REPLY");
+        return ssh2_err(session, (int)rc,
+                        "Error waiting for FXP EXTENDED REPLY");
     }
 
     sftp->posix_rename_state = ssh2_NB_state_idle;


### PR DESCRIPTION
Do not enforce due to false positives.

Ref: https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-casting.html
