### PR TITLE
channel: clamp `buflen` to `UINT32_MAX` before requesting a window adjustment in `libssh2_channel_read*()`

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2095,9 +2095,18 @@ ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id,
     recv_window = libssh2_channel_window_read_ex(channel, NULL, NULL);
 
     if(buflen > recv_window) {
+        /* The window adjustment amount travels over the wire as a uint32,
+           so a caller-supplied buflen beyond that range must be clamped
+           rather than truncated: casting it directly can wrap around to
+           a small value that requests far less window than intended, and
+           once local window bookkeeping and what the server actually
+           granted disagree, a later adjustment can appear to overflow the
+           remote window even though the client is not asking for more
+           than the protocol allows. */
+        uint32_t want = (buflen > UINT32_MAX) ? UINT32_MAX : (uint32_t)buflen;
         BLOCK_ADJUST(rc, channel->session,
                      ssh2_channel_receive_window_adjust(channel,
-                                                        (uint32_t)buflen,
+                                                        want,
                                                         1, NULL));
     }
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -2102,12 +2102,23 @@ ssize_t libssh2_channel_read_ex(LIBSSH2_CHANNEL *channel, int stream_id,
            once local window bookkeeping and what the server actually
            granted disagree, a later adjustment can appear to overflow the
            remote window even though the client is not asking for more
-           than the protocol allows. */
-        uint32_t want = (buflen > UINT32_MAX) ? UINT32_MAX : (uint32_t)buflen;
-        BLOCK_ADJUST(rc, channel->session,
-                     ssh2_channel_receive_window_adjust(channel,
-                                                        want,
-                                                        1, NULL));
+           than the protocol allows.
+
+           Clamping to UINT32_MAX alone is not enough on its own, though:
+           ssh2_channel_receive_window_adjust() adds this value to the
+           existing remote window and rejects the result if it would
+           overflow a uint32, so the clamp also has to leave room for
+           whatever window is already outstanding. */
+        uint32_t max_adjust = (recv_window >= UINT32_MAX)
+                                  ? 0
+                                  : (uint32_t)(UINT32_MAX - recv_window);
+        uint32_t want = (buflen > max_adjust) ? max_adjust : (uint32_t)buflen;
+        if(want > 0) {
+            BLOCK_ADJUST(rc, channel->session,
+                         ssh2_channel_receive_window_adjust(channel,
+                                                            want,
+                                                            1, NULL));
+        }
     }
 
     BLOCK_ADJUST(rc, channel->session,


### PR DESCRIPTION
Fixes the truncation described in #1182.

libssh2_channel_read_ex() casts the caller's buflen straight to uint32_t when it needs a bigger receive window. Window adjustments do travel over the wire as a uint32, so that part isn't wrong on its own, but a plain cast wraps around instead of clamping. A buflen of 4GB + 2MB, for example, turns into a request for a 2MB window rather than the 4GB+ one actually wanted. Once the client's own bookkeeping about how much window it has diverges from what it actually asked the server for, a later window-adjust packet can look like it overflows the remote window even though the client never asked for more than the protocol allows, which matches the symptom in #1182.

Clamping to UINT32_MAX when buflen exceeds it keeps the request within what a single window-adjust packet can express, instead of silently asking for a much smaller and essentially arbitrary amount.

I reproduced the exact wraparound arithmetic by hand (4294967296 + 2097152 casts to 2097152, clamps correctly to 4294967295 with the fix) and the change compiles clean. I wasn't able to get the openssh_server-backed integration suite (test_read and friends) running end to end in my environment though, the fixture's local sshd never accepts a connection here even on an unmodified checkout, so this is a pre-existing setup issue on my side rather than something the patch introduced. Flagging that honestly since I couldn't verify against a live session.

Reported-by: Teon Banek
Fixes #1182
