### PR TITLE
clang-tidy: enable `readability-redundant-casting`, fix/silence findings

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -36,7 +36,7 @@ Checks:
   - readability-inconsistent-declaration-parameter-name
   - readability-misleading-indentation
   - readability-named-parameter
-  # readability-redundant-casting  # false positives in types that change from platform to platform, even with IgnoreTypeAliases: true
+  - readability-redundant-casting
   - readability-redundant-control-flow
   - readability-redundant-declaration
   - readability-redundant-function-ptr-dereference

--- a/example/x11.c
+++ b/example/x11.c
@@ -229,6 +229,7 @@ static int x11_send_receive(LIBSSH2_CHANNEL *channel, libssh2_socket_t sock)
         }
     }
 
+    /* NOLINTNEXTLINE(readability-redundant-casting) */
     rc = select((int)(sock + 1), &set, NULL, NULL, &timeval_out);
     if(rc > 0) {
         memset(buf, 0, bufsize);

--- a/example/x11.c
+++ b/example/x11.c
@@ -494,6 +494,7 @@ int main(int argc, char *argv[])
             current_node = next_node;
         }
 
+        /* NOLINTNEXTLINE(readability-redundant-casting) */
         rc = select((int)(fileno(stdin) + 1), &set, NULL, NULL, &timeval_out);
         if(rc > 0) {
             ssize_t wr = 0;

--- a/example/x11.c
+++ b/example/x11.c
@@ -494,8 +494,7 @@ int main(int argc, char *argv[])
             current_node = next_node;
         }
 
-        /* NOLINTNEXTLINE(readability-redundant-casting) */
-        rc = select((int)(fileno(stdin) + 1), &set, NULL, NULL, &timeval_out);
+        rc = select(fileno(stdin) + 1, &set, NULL, NULL, &timeval_out);
         if(rc > 0) {
             ssize_t wr = 0;
             nread = read(fileno(stdin), buf, 1); /* Data in stdin */

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -783,8 +783,6 @@ int ssh2_ecdsa_verify(ssh2_ecdsa_ctx *ec_ctx, LIBSSH2_SESSION *session,
     EVP_PKEY_CTX *ctx = NULL;
     unsigned char *der = NULL;
     int der_len = 0;
-#else
-    EC_KEY *ec_key = (EC_KEY *)ec_ctx;
 #endif
 
     ECDSA_SIG *ecdsa_sig;
@@ -863,17 +861,17 @@ cleanup:
     if(curve == SSH2_EC_CURVE_NISTP256) {
         unsigned char hash[SSH2_SHA256_DIG_LEN];
         if(ssh2_hash(SSH2_SHA256_ALG, m, m_len, hash, sizeof(hash)))
-            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
+            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_ctx);
     }
     else if(curve == SSH2_EC_CURVE_NISTP384) {
         unsigned char hash[SSH2_SHA384_DIG_LEN];
         if(ssh2_hash(SSH2_SHA384_ALG, m, m_len, hash, sizeof(hash)))
-            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
+            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_ctx);
     }
     else if(curve == SSH2_EC_CURVE_NISTP521) {
         unsigned char hash[SSH2_SHA512_DIG_LEN];
         if(ssh2_hash(SSH2_SHA512_ALG, m, m_len, hash, sizeof(hash)))
-            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_key);
+            ret = ECDSA_do_verify(hash, sizeof(hash), ecdsa_sig, ec_ctx);
     }
 #endif
 

--- a/src/scp.c
+++ b/src/scp.c
@@ -860,6 +860,7 @@ LIBSSH2_CHANNEL *libssh2_scp_recv(LIBSSH2_SESSION *session, const char *path,
 
         sb->st_mtime = sb_intl.st_mtime;
         sb->st_atime = sb_intl.st_atime;
+        /* NOLINTNEXTLINE(readability-redundant-casting) */
         sb->st_size = (off_t)sb_intl.st_size;
         sb->st_mode = sb_intl.st_mode;
     }

--- a/src/session.c
+++ b/src/session.c
@@ -647,6 +647,7 @@ int ssh2_wait_socket(LIBSSH2_SESSION *session, ssh2_time_t start_time)
             writefd = &wfd;
         }
 
+        /* NOLINTNEXTLINE(readability-redundant-casting) */
         rc = select((int)(session->socket_fd + 1), readfd, writefd, NULL,
                     has_timeout ? &tv : NULL);
     }
@@ -1730,6 +1731,7 @@ int libssh2_poll(LIBSSH2_POLLFD *fds, unsigned int nfds, long timeout_ms)
             tv.tv_usec = ssh2_timediff_to_usec(timeout_remaining);
 #endif
             start_time = ssh2_now();
+            /* NOLINTNEXTLINE(readability-redundant-casting) */
             sysret = select((int)(maxfd + 1), &rfds, &wfds, NULL,
                             timeout_remaining >= 0 ? &tv : NULL);
             now = ssh2_now();


### PR DESCRIPTION
Also:
- openssl: drop redundant local variable in non-OpenSSL3 branch.
- x11: drop redundant cast.
- silence false positives.

Follow-up to 0b915eab676631644731cc571956d735e40a5da4 #2586

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
