### PR TITLE
scp: resume non-blocking error cleanup across calls

### DIFF
--- a/src/libssh2_priv.h
+++ b/src/libssh2_priv.h
@@ -306,6 +306,12 @@ typedef enum {
     ssh2_NB_state_jumpauthagent
 } ssh2_NB_states;
 
+struct scp_error_state {
+    const char *message;
+    int code;
+    int flags;
+};
+
 #define ssh2_time_t               libssh2_int64_t /* us */
 #define ssh2_timediff_t           libssh2_int64_t /* us */
 #define SSH2_TIME_T_FORMAT        SSH2_INT64_T_FORMAT
@@ -962,6 +968,7 @@ struct _LIBSSH2_SESSION {
     time_t scpRecv_mtime;
     time_t scpRecv_atime;
     LIBSSH2_CHANNEL *scpRecv_channel;
+    struct scp_error_state scpRecv_error;
 
     /* State variables used in libssh2_scp_send_ex() */
     ssh2_NB_states scpSend_state;
@@ -970,6 +977,7 @@ struct _LIBSSH2_SESSION {
     unsigned char scpSend_response[SSH2_SCP_RESPONSE_BUFLEN];
     size_t scpSend_response_len;
     LIBSSH2_CHANNEL *scpSend_channel;
+    struct scp_error_state scpSend_error;
 
     /* Keepalive variables used by keepalive.c. */
     ssh2_timediff_t keepalive_interval;

--- a/src/scp.c
+++ b/src/scp.c
@@ -47,6 +47,31 @@
 #define SCP_C_FIELDS_INCOMPLETE  1
 #define SCP_C_FIELDS_MALFORMED   (-1)
 
+static void scp_error_save(LIBSSH2_SESSION *session,
+                           struct scp_error_state *error)
+{
+    error->message = session->err_msg;
+    error->code = session->err_code;
+    error->flags = session->err_flags;
+
+    session->err_msg = NULL;
+    session->err_code = LIBSSH2_ERROR_NONE;
+    session->err_flags = 0;
+}
+
+static void scp_error_restore(LIBSSH2_SESSION *session,
+                              struct scp_error_state *error)
+{
+    if(session->err_msg && (session->err_flags & SSH2_ERR_FLAG_DUP))
+        SSH2_FREE(session, SSH2_UNCONST(session->err_msg));
+
+    session->err_msg = error->message;
+    session->err_code = error->code;
+    session->err_flags = error->flags;
+
+    memset(error, 0, sizeof(*error));
+}
+
 /*
  * Parse mode and size from an SCP "C" response line fragment.
  *
@@ -337,14 +362,15 @@ static LIBSSH2_CHANNEL *scp_recv(LIBSSH2_SESSION *session,
 {
     size_t cmd_len;
     int rc;
-    int tmp_err_code;
-    const char *tmp_err_msg;
 
     if(!path) {
         ssh2_err(session, LIBSSH2_ERROR_INVAL,
                  "Path argument can not be null");
         return NULL;
     }
+
+    if(session->scpRecv_state == ssh2_NB_state_error_closing)
+        goto scp_recv_error_closing;
 
     if(session->scpRecv_state == ssh2_NB_state_idle) {
         session->scpRecv_mode = 0;
@@ -820,13 +846,17 @@ scp_recv_empty_channel:
         return session->scpRecv_channel;
     /* fall-through */
 scp_recv_error:
-    tmp_err_code = session->err_code;
-    tmp_err_msg = session->err_msg;
-    while(libssh2_channel_free(session->scpRecv_channel) ==
-          LIBSSH2_ERROR_EAGAIN)
-        ;
-    session->err_code = tmp_err_code;
-    session->err_msg = tmp_err_msg;
+    scp_error_save(session, &session->scpRecv_error);
+    session->scpRecv_state = ssh2_NB_state_error_closing;
+
+scp_recv_error_closing:
+    rc = libssh2_channel_free(session->scpRecv_channel);
+    if(rc == LIBSSH2_ERROR_EAGAIN) {
+        ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
+                 "Would block closing SCP channel");
+        return NULL;
+    }
+    scp_error_restore(session, &session->scpRecv_error);
     session->scpRecv_channel = NULL;
     session->scpRecv_state = ssh2_NB_state_idle;
     return NULL;
@@ -891,14 +921,15 @@ static LIBSSH2_CHANNEL *scp_send(LIBSSH2_SESSION *session,
 {
     size_t cmd_len;
     int rc;
-    int tmp_err_code;
-    const char *tmp_err_msg;
 
     if(!path) {
         ssh2_err(session, LIBSSH2_ERROR_INVAL,
                  "Path argument can not be null");
         return NULL;
     }
+
+    if(session->scpSend_state == ssh2_NB_state_error_closing)
+        goto scp_send_error_closing;
 
     if(session->scpSend_state == ssh2_NB_state_idle) {
         session->scpSend_command_len =
@@ -1170,13 +1201,17 @@ scp_send_empty_channel:
         return session->scpSend_channel;
     /* fall-through */
 scp_send_error:
-    tmp_err_code = session->err_code;
-    tmp_err_msg = session->err_msg;
-    while(libssh2_channel_free(session->scpSend_channel) ==
-          LIBSSH2_ERROR_EAGAIN)
-        ;
-    session->err_code = tmp_err_code;
-    session->err_msg = tmp_err_msg;
+    scp_error_save(session, &session->scpSend_error);
+    session->scpSend_state = ssh2_NB_state_error_closing;
+
+scp_send_error_closing:
+    rc = libssh2_channel_free(session->scpSend_channel);
+    if(rc == LIBSSH2_ERROR_EAGAIN) {
+        ssh2_err(session, LIBSSH2_ERROR_EAGAIN,
+                 "Would block closing SCP channel");
+        return NULL;
+    }
+    scp_error_restore(session, &session->scpSend_error);
     session->scpSend_channel = NULL;
     session->scpSend_state = ssh2_NB_state_idle;
     return NULL;

--- a/src/session.c
+++ b/src/session.c
@@ -1004,8 +1004,14 @@ static int session_free(LIBSSH2_SESSION *session)
         SSH2_FREE(session, session->pkeyInit_data);
     if(session->scpRecv_command)
         SSH2_FREE(session, session->scpRecv_command);
+    if(session->scpRecv_error.message &&
+       (session->scpRecv_error.flags & SSH2_ERR_FLAG_DUP))
+        SSH2_FREE(session, SSH2_UNCONST(session->scpRecv_error.message));
     if(session->scpSend_command)
         SSH2_FREE(session, session->scpSend_command);
+    if(session->scpSend_error.message &&
+       (session->scpSend_error.flags & SSH2_ERR_FLAG_DUP))
+        SSH2_FREE(session, SSH2_UNCONST(session->scpSend_error.message));
     if(session->sftpInit_sftp)
         SSH2_FREE(session, session->sftpInit_sftp);
 

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -56,12 +56,14 @@ DOCKER_TESTS_STATIC = \
   test_hostkey
 
 STANDALONE_TESTS_STATIC = \
+  test_scp_nonblock \
   test_simple
 
 # Copy of the above for Makefile.am.
 # Is there a way to reuse the lists above?
 test_auth_keyboard_info_request_LDFLAGS = -static
 test_hostkey_LDFLAGS = -static
+test_scp_nonblock_LDFLAGS = -static
 test_simple_LDFLAGS = -static
 
 librunner_la_SOURCES = \

--- a/tests/test_scp_nonblock.c
+++ b/tests/test_scp_nonblock.c
@@ -243,8 +243,8 @@ static int test_error_cleanup_eagain(int send_case)
                 send_case ? "send" : "recv", (void *)result, rc,
                 session->err_msg ? session->err_msg : "(null)", api_calls,
                 eagain_returns, ctx.recv_calls, ctx.send_calls,
-                (unsigned int)(send_case ? session->scpSend_state :
-                                           session->scpRecv_state),
+                send_case ? (unsigned int)session->scpSend_state :
+                            (unsigned int)session->scpRecv_state,
                 (void *)(send_case ? session->scpSend_channel :
                                     session->scpRecv_channel));
         failed = 1;

--- a/tests/test_scp_nonblock.c
+++ b/tests/test_scp_nonblock.c
@@ -1,0 +1,337 @@
+/* Copyright (C) The libssh2 project and its contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "libssh2_priv.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct io_context {
+    LIBSSH2_CHANNEL *channel;
+    void *tracked_message;
+    unsigned int recv_calls;
+    unsigned int send_calls;
+    unsigned int close_after_call;
+    int tracked_message_freed;
+};
+
+static LIBSSH2_ALLOC_FUNC(tracking_alloc)
+{
+    (void)abstract;
+    return malloc(count);
+}
+
+static LIBSSH2_FREE_FUNC(tracking_free)
+{
+    struct io_context *ctx = *(struct io_context **)abstract;
+
+    if(ptr == ctx->tracked_message)
+        ctx->tracked_message_freed = 1;
+    free(ptr);
+}
+
+static LIBSSH2_RECV_FUNC(synthetic_recv)
+{
+    struct io_context *ctx = *(struct io_context **)abstract;
+
+    (void)socket;
+    (void)buffer;
+    (void)length;
+    (void)flags;
+
+    ctx->recv_calls++;
+    if(ctx->close_after_call &&
+       ctx->recv_calls >= ctx->close_after_call) {
+        ctx->channel->remote.close = 1;
+        ctx->channel->remote.eof = 1;
+    }
+
+    return -EAGAIN;
+}
+
+static LIBSSH2_SEND_FUNC(synthetic_send)
+{
+    struct io_context *ctx = *(struct io_context **)abstract;
+
+    (void)socket;
+    (void)buffer;
+    (void)flags;
+
+    ctx->send_calls++;
+    return (ssize_t)length;
+}
+
+static void store_u32(unsigned char *buffer, uint32_t value)
+{
+    buffer[0] = (unsigned char)(value >> 24);
+    buffer[1] = (unsigned char)(value >> 16);
+    buffer[2] = (unsigned char)(value >> 8);
+    buffer[3] = (unsigned char)value;
+}
+
+static int queue_channel_data(LIBSSH2_SESSION *session,
+                              LIBSSH2_CHANNEL *channel,
+                              const unsigned char *payload,
+                              size_t payload_len)
+{
+    struct packet *packet = SSH2_CALLOC(session, sizeof(*packet));
+
+    if(!packet)
+        return -1;
+
+    packet->data_len = 9 + payload_len;
+    packet->data = SSH2_CALLOC(session, packet->data_len);
+    if(!packet->data) {
+        SSH2_FREE(session, packet);
+        return -1;
+    }
+
+    packet->data[0] = SSH_MSG_CHANNEL_DATA;
+    store_u32(packet->data + 1, channel->local.id);
+    store_u32(packet->data + 5, (uint32_t)payload_len);
+    memcpy(packet->data + 9, payload, payload_len);
+    packet->data_head = 9;
+    channel->read_avail += payload_len;
+    ssh2_list_add(&session->packets, &packet->node);
+    return 0;
+}
+
+static LIBSSH2_CHANNEL *prepare_channel(LIBSSH2_SESSION *session)
+{
+    LIBSSH2_CHANNEL *channel = SSH2_CALLOC(session, sizeof(*channel));
+
+    if(!channel)
+        return NULL;
+
+    channel->session = session;
+    channel->local.id = 1;
+    channel->remote.id = 2;
+    channel->remote.window_size_initial = 1024 * 1024;
+    channel->remote.window_size = 1024 * 1024;
+    channel->remote.packet_size = 32768;
+    ssh2_list_add(&session->channels, &channel->node);
+    return channel;
+}
+
+static LIBSSH2_SESSION *prepare_session(struct io_context *ctx)
+{
+    LIBSSH2_SESSION *session =
+        libssh2_session_init_ex(tracking_alloc, tracking_free, NULL, ctx);
+
+    if(!session)
+        return NULL;
+
+    session->recv = synthetic_recv;
+    session->send = synthetic_send;
+    session->socket_fd = LIBSSH2_INVALID_SOCKET;
+    session->socket_state = SSH2_SOCKET_CONNECTED;
+    session->state = 0;
+    libssh2_session_set_blocking(session, 0);
+
+    ctx->channel = prepare_channel(session);
+    if(!ctx->channel) {
+        session->socket_state = SSH2_SOCKET_DISCONNECTED;
+        libssh2_session_free(session);
+        return NULL;
+    }
+
+    return session;
+}
+
+static void force_session_free(LIBSSH2_SESSION *session)
+{
+    if(session) {
+        session->socket_state = SSH2_SOCKET_DISCONNECTED;
+        (void)libssh2_session_free(session);
+    }
+}
+
+static int test_error_cleanup_eagain(int send_case)
+{
+    static const unsigned char error_payload[] = {
+        1, 'm', 'i', 's', 's', 'i', 'n', 'g', '\n'
+    };
+    static const char cleanup_error[] = "Would block closing SCP channel";
+    struct io_context ctx;
+    LIBSSH2_SESSION *session;
+    LIBSSH2_CHANNEL *result = NULL;
+    const char *final_message;
+    unsigned int api_calls = 0;
+    unsigned int eagain_returns = 0;
+    unsigned int cleanup_start_call = send_case ? 2 : 3;
+    int rc = LIBSSH2_ERROR_NONE;
+    int state_is_closing;
+    int pointer_preserved;
+    int failed = 0;
+
+    memset(&ctx, 0, sizeof(ctx));
+    /* Return EAGAIN during cleanup four times, keeping the test bounded. */
+    ctx.close_after_call = cleanup_start_call + 3;
+    session = prepare_session(&ctx);
+    if(!session)
+        return 1;
+
+    if(queue_channel_data(session, ctx.channel, error_payload,
+                          sizeof(error_payload))) {
+        force_session_free(session);
+        return 1;
+    }
+
+    if(send_case) {
+        session->scpSend_channel = ctx.channel;
+        session->scpSend_state = ssh2_NB_state_sent1;
+        final_message = "Invalid ACK response from remote";
+    }
+    else {
+        session->scpRecv_channel = ctx.channel;
+        session->scpRecv_state = ssh2_NB_state_sent2;
+        final_message = "Failed to recv file";
+    }
+
+    do {
+        api_calls++;
+        if(send_case)
+            result = libssh2_scp_send64(session, "synthetic-file", 0644,
+                                        1, 0, 0);
+        else {
+            libssh2_struct_stat file_info;
+
+            memset(&file_info, 0, sizeof(file_info));
+            result = libssh2_scp_recv2(session, "synthetic-file", &file_info);
+        }
+
+        rc = libssh2_session_last_errno(session);
+        if(rc == LIBSSH2_ERROR_EAGAIN) {
+            eagain_returns++;
+            state_is_closing = send_case ?
+                session->scpSend_state == ssh2_NB_state_error_closing :
+                session->scpRecv_state == ssh2_NB_state_error_closing;
+            pointer_preserved = send_case ?
+                session->scpSend_channel == ctx.channel :
+                session->scpRecv_channel == ctx.channel;
+            if(result || !state_is_closing || !pointer_preserved ||
+               !session->err_msg ||
+               strcmp(session->err_msg, cleanup_error)) {
+                fprintf(stderr,
+                        "%s cleanup EAGAIN %u: result=%p state=%d "
+                        "channel=%d message=%s\n",
+                        send_case ? "send" : "recv", eagain_returns,
+                        (void *)result, state_is_closing, pointer_preserved,
+                        session->err_msg ? session->err_msg : "(null)");
+                failed = 1;
+                break;
+            }
+        }
+    } while(rc == LIBSSH2_ERROR_EAGAIN && api_calls < 16);
+
+    if(result || rc != LIBSSH2_ERROR_SCP_PROTOCOL ||
+       !session->err_msg || strcmp(session->err_msg, final_message) ||
+       api_calls != 5 || eagain_returns != 4 ||
+       ctx.recv_calls != ctx.close_after_call || ctx.send_calls != 2 ||
+       (send_case ? session->scpSend_state : session->scpRecv_state) !=
+           ssh2_NB_state_idle ||
+       (send_case ? session->scpSend_channel : session->scpRecv_channel) ||
+       session->channels.first || session->channels.last ||
+       session->packets.first || session->packets.last) {
+        fprintf(stderr,
+                "%s cleanup final: result=%p rc=%d message=%s calls=%u "
+                "eagain=%u recv=%u send=%u state=%u channel=%p\n",
+                send_case ? "send" : "recv", (void *)result, rc,
+                session->err_msg ? session->err_msg : "(null)", api_calls,
+                eagain_returns, ctx.recv_calls, ctx.send_calls,
+                (unsigned int)(send_case ? session->scpSend_state :
+                                           session->scpRecv_state),
+                (void *)(send_case ? session->scpSend_channel :
+                                    session->scpRecv_channel));
+        failed = 1;
+    }
+
+    force_session_free(session);
+    return failed;
+}
+
+static int test_saved_error(int abandon_cleanup)
+{
+    static const char saved_message[] = "owned synthetic error";
+    struct io_context ctx;
+    LIBSSH2_SESSION *session;
+    LIBSSH2_CHANNEL *result;
+    int rc;
+    int failed = 0;
+
+    memset(&ctx, 0, sizeof(ctx));
+    session = prepare_session(&ctx);
+    if(!session)
+        return 1;
+
+    rc = libssh2_session_set_last_error(session, -1234, saved_message);
+    if(rc != -1234 || !(session->err_flags & SSH2_ERR_FLAG_DUP)) {
+        force_session_free(session);
+        return 1;
+    }
+    ctx.tracked_message = SSH2_UNCONST(session->err_msg);
+
+    ctx.channel->write_state = ssh2_NB_state_end;
+    ctx.close_after_call = 1;
+    session->scpRecv_channel = ctx.channel;
+    session->scpRecv_state = ssh2_NB_state_sent1;
+
+    result = libssh2_scp_recv2(session, "synthetic-file", NULL);
+    rc = libssh2_session_last_errno(session);
+    if(result || rc != LIBSSH2_ERROR_EAGAIN ||
+       session->scpRecv_state != ssh2_NB_state_error_closing) {
+        fprintf(stderr,
+                "saved error first call: result=%p rc=%d state=%u\n",
+                (void *)result, rc,
+                (unsigned int)session->scpRecv_state);
+        failed = 1;
+    }
+
+    if(!failed && !abandon_cleanup) {
+        result = libssh2_scp_recv2(session, "synthetic-file", NULL);
+        rc = libssh2_session_last_errno(session);
+        if(result || rc != -1234 || !session->err_msg ||
+           strcmp(session->err_msg, saved_message) ||
+           !(session->err_flags & SSH2_ERR_FLAG_DUP) ||
+           session->scpRecv_state != ssh2_NB_state_idle) {
+            fprintf(stderr,
+                    "saved error restore: result=%p rc=%d message=%s "
+                    "state=%u\n",
+                    (void *)result, rc,
+                    session->err_msg ? session->err_msg : "(null)",
+                    (unsigned int)session->scpRecv_state);
+            failed = 1;
+        }
+    }
+
+    force_session_free(session);
+    if(!ctx.tracked_message_freed) {
+        fprintf(stderr, "saved SCP error was not freed during teardown\n");
+        failed = 1;
+    }
+
+    return failed;
+}
+
+int main(void)
+{
+    int rc;
+
+    rc = libssh2_init(0);
+    if(rc) {
+        fprintf(stderr, "libssh2_init() failed: %d\n", rc);
+        return 1;
+    }
+
+    rc = test_error_cleanup_eagain(0);
+    rc |= test_error_cleanup_eagain(1);
+    rc |= test_saved_error(0);
+    rc |= test_saved_error(1);
+
+    libssh2_exit();
+    return rc;
+}

--- a/tests/test_scp_nonblock.c
+++ b/tests/test_scp_nonblock.c
@@ -3,12 +3,21 @@
  */
 
 #include "libssh2_priv.h"
+#include "misc.h"
 
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define CHECK(condition) do { \
+    if(!(condition)) { \
+        fprintf(stderr, "%s:%d: %s\n", name, __LINE__, #condition); \
+        failed = 1; \
+        goto out; \
+    } \
+} while(0)
 
 struct io_context {
     LIBSSH2_CHANNEL *channel;
@@ -18,12 +27,6 @@ struct io_context {
     unsigned int close_after_call;
     int tracked_message_freed;
 };
-
-static LIBSSH2_ALLOC_FUNC(tracking_alloc)
-{
-    (void)abstract;
-    return malloc(count);
-}
 
 static LIBSSH2_FREE_FUNC(tracking_free)
 {
@@ -65,14 +68,6 @@ static LIBSSH2_SEND_FUNC(synthetic_send)
     return (ssize_t)length;
 }
 
-static void store_u32(unsigned char *buffer, uint32_t value)
-{
-    buffer[0] = (unsigned char)(value >> 24);
-    buffer[1] = (unsigned char)(value >> 16);
-    buffer[2] = (unsigned char)(value >> 8);
-    buffer[3] = (unsigned char)value;
-}
-
 static int queue_channel_data(LIBSSH2_SESSION *session,
                               LIBSSH2_CHANNEL *channel,
                               const unsigned char *payload,
@@ -91,8 +86,8 @@ static int queue_channel_data(LIBSSH2_SESSION *session,
     }
 
     packet->data[0] = SSH_MSG_CHANNEL_DATA;
-    store_u32(packet->data + 1, channel->local.id);
-    store_u32(packet->data + 5, (uint32_t)payload_len);
+    ssh2_htonu32(packet->data + 1, channel->local.id);
+    ssh2_htonu32(packet->data + 5, (uint32_t)payload_len);
     memcpy(packet->data + 9, payload, payload_len);
     packet->data_head = 9;
     channel->read_avail += payload_len;
@@ -100,27 +95,11 @@ static int queue_channel_data(LIBSSH2_SESSION *session,
     return 0;
 }
 
-static LIBSSH2_CHANNEL *prepare_channel(LIBSSH2_SESSION *session)
-{
-    LIBSSH2_CHANNEL *channel = SSH2_CALLOC(session, sizeof(*channel));
-
-    if(!channel)
-        return NULL;
-
-    channel->session = session;
-    channel->local.id = 1;
-    channel->remote.id = 2;
-    channel->remote.window_size_initial = 1024 * 1024;
-    channel->remote.window_size = 1024 * 1024;
-    channel->remote.packet_size = 32768;
-    ssh2_list_add(&session->channels, &channel->node);
-    return channel;
-}
-
 static LIBSSH2_SESSION *prepare_session(struct io_context *ctx)
 {
     LIBSSH2_SESSION *session =
-        libssh2_session_init_ex(tracking_alloc, tracking_free, NULL, ctx);
+        libssh2_session_init_ex(NULL, tracking_free, NULL, ctx);
+    LIBSSH2_CHANNEL *channel;
 
     if(!session)
         return NULL;
@@ -132,13 +111,20 @@ static LIBSSH2_SESSION *prepare_session(struct io_context *ctx)
     session->state = 0;
     libssh2_session_set_blocking(session, 0);
 
-    ctx->channel = prepare_channel(session);
-    if(!ctx->channel) {
+    channel = SSH2_CALLOC(session, sizeof(*channel));
+    if(!channel) {
         session->socket_state = SSH2_SOCKET_DISCONNECTED;
         libssh2_session_free(session);
         return NULL;
     }
-
+    channel->session = session;
+    channel->local.id = 1;
+    channel->remote.id = 2;
+    channel->remote.window_size_initial = 1024 * 1024;
+    channel->remote.window_size = 1024 * 1024;
+    channel->remote.packet_size = 32768;
+    ssh2_list_add(&session->channels, &channel->node);
+    ctx->channel = channel;
     return session;
 }
 
@@ -156,41 +142,34 @@ static int test_error_cleanup_eagain(int send_case)
         1, 'm', 'i', 's', 's', 'i', 'n', 'g', '\n'
     };
     static const char cleanup_error[] = "Would block closing SCP channel";
-    struct io_context ctx;
+    const char *name = send_case ? "send cleanup" : "recv cleanup";
+    struct io_context ctx = { 0 };
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *result = NULL;
     const char *final_message;
+    ssh2_NB_states *state;
+    LIBSSH2_CHANNEL **channel;
     unsigned int api_calls = 0;
     unsigned int eagain_returns = 0;
     unsigned int cleanup_start_call = send_case ? 2 : 3;
     int rc = LIBSSH2_ERROR_NONE;
-    int state_is_closing;
-    int pointer_preserved;
     int failed = 0;
 
-    memset(&ctx, 0, sizeof(ctx));
     /* Return EAGAIN during cleanup four times, keeping the test bounded. */
     ctx.close_after_call = cleanup_start_call + 3;
     session = prepare_session(&ctx);
     if(!session)
         return 1;
 
-    if(queue_channel_data(session, ctx.channel, error_payload,
-                          sizeof(error_payload))) {
-        force_session_free(session);
-        return 1;
-    }
-
-    if(send_case) {
-        session->scpSend_channel = ctx.channel;
-        session->scpSend_state = ssh2_NB_state_sent1;
-        final_message = "Invalid ACK response from remote";
-    }
-    else {
-        session->scpRecv_channel = ctx.channel;
-        session->scpRecv_state = ssh2_NB_state_sent2;
-        final_message = "Failed to recv file";
-    }
+    CHECK(!queue_channel_data(session, ctx.channel, error_payload,
+                             sizeof(error_payload)));
+    state = send_case ? &session->scpSend_state : &session->scpRecv_state;
+    channel = send_case ? &session->scpSend_channel :
+                          &session->scpRecv_channel;
+    *state = send_case ? ssh2_NB_state_sent1 : ssh2_NB_state_sent2;
+    *channel = ctx.channel;
+    final_message = send_case ? "Invalid ACK response from remote" :
+                               "Failed to recv file";
 
     do {
         api_calls++;
@@ -207,49 +186,21 @@ static int test_error_cleanup_eagain(int send_case)
         rc = libssh2_session_last_errno(session);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
             eagain_returns++;
-            state_is_closing = send_case ?
-                session->scpSend_state == ssh2_NB_state_error_closing :
-                session->scpRecv_state == ssh2_NB_state_error_closing;
-            pointer_preserved = send_case ?
-                session->scpSend_channel == ctx.channel :
-                session->scpRecv_channel == ctx.channel;
-            if(result || !state_is_closing || !pointer_preserved ||
-               !session->err_msg ||
-               strcmp(session->err_msg, cleanup_error)) {
-                fprintf(stderr,
-                        "%s cleanup EAGAIN %u: result=%p state=%d "
-                        "channel=%d message=%s\n",
-                        send_case ? "send" : "recv", eagain_returns,
-                        (void *)result, state_is_closing, pointer_preserved,
-                        session->err_msg ? session->err_msg : "(null)");
-                failed = 1;
-                break;
-            }
+            CHECK(!result && *state == ssh2_NB_state_error_closing);
+            CHECK(*channel == ctx.channel);
+            CHECK(session->err_msg &&
+                  !strcmp(session->err_msg, cleanup_error));
         }
     } while(rc == LIBSSH2_ERROR_EAGAIN && api_calls < 16);
 
-    if(result || rc != LIBSSH2_ERROR_SCP_PROTOCOL ||
-       !session->err_msg || strcmp(session->err_msg, final_message) ||
-       api_calls != 5 || eagain_returns != 4 ||
-       ctx.recv_calls != ctx.close_after_call || ctx.send_calls != 2 ||
-       (send_case ? session->scpSend_state : session->scpRecv_state) !=
-           ssh2_NB_state_idle ||
-       (send_case ? session->scpSend_channel : session->scpRecv_channel) ||
-       session->channels.first || session->channels.last ||
-       session->packets.first || session->packets.last) {
-        fprintf(stderr,
-                "%s cleanup final: result=%p rc=%d message=%s calls=%u "
-                "eagain=%u recv=%u send=%u state=%u channel=%p\n",
-                send_case ? "send" : "recv", (void *)result, rc,
-                session->err_msg ? session->err_msg : "(null)", api_calls,
-                eagain_returns, ctx.recv_calls, ctx.send_calls,
-                send_case ? (unsigned int)session->scpSend_state :
-                            (unsigned int)session->scpRecv_state,
-                (void *)(send_case ? session->scpSend_channel :
-                                    session->scpRecv_channel));
-        failed = 1;
-    }
-
+    CHECK(!result && rc == LIBSSH2_ERROR_SCP_PROTOCOL);
+    CHECK(session->err_msg && !strcmp(session->err_msg, final_message));
+    CHECK(api_calls == 5 && eagain_returns == 4);
+    CHECK(ctx.recv_calls == ctx.close_after_call && ctx.send_calls == 2);
+    CHECK(*state == ssh2_NB_state_idle && !*channel);
+    CHECK(!session->channels.first && !session->channels.last);
+    CHECK(!session->packets.first && !session->packets.last);
+out:
     force_session_free(session);
     return failed;
 }
@@ -257,22 +208,20 @@ static int test_error_cleanup_eagain(int send_case)
 static int test_saved_error(int abandon_cleanup)
 {
     static const char saved_message[] = "owned synthetic error";
-    struct io_context ctx;
+    const char *name = abandon_cleanup ? "saved error teardown" :
+                                        "saved error restore";
+    struct io_context ctx = { 0 };
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *result;
     int rc;
     int failed = 0;
 
-    memset(&ctx, 0, sizeof(ctx));
     session = prepare_session(&ctx);
     if(!session)
         return 1;
 
     rc = libssh2_session_set_last_error(session, -1234, saved_message);
-    if(rc != -1234 || !(session->err_flags & SSH2_ERR_FLAG_DUP)) {
-        force_session_free(session);
-        return 1;
-    }
+    CHECK(rc == -1234 && (session->err_flags & SSH2_ERR_FLAG_DUP));
     ctx.tracked_message = SSH2_UNCONST(session->err_msg);
 
     ctx.channel->write_state = ssh2_NB_state_end;
@@ -282,34 +231,20 @@ static int test_saved_error(int abandon_cleanup)
 
     result = libssh2_scp_recv2(session, "synthetic-file", NULL);
     rc = libssh2_session_last_errno(session);
-    if(result || rc != LIBSSH2_ERROR_EAGAIN ||
-       session->scpRecv_state != ssh2_NB_state_error_closing) {
-        fprintf(stderr,
-                "saved error first call: result=%p rc=%d state=%u\n",
-                (void *)result, rc,
-                (unsigned int)session->scpRecv_state);
-        failed = 1;
-    }
+    CHECK(!result && rc == LIBSSH2_ERROR_EAGAIN);
+    CHECK(session->scpRecv_state == ssh2_NB_state_error_closing);
 
-    if(!failed && !abandon_cleanup) {
+    if(!abandon_cleanup) {
         result = libssh2_scp_recv2(session, "synthetic-file", NULL);
         rc = libssh2_session_last_errno(session);
-        if(result || rc != -1234 || !session->err_msg ||
-           strcmp(session->err_msg, saved_message) ||
-           !(session->err_flags & SSH2_ERR_FLAG_DUP) ||
-           session->scpRecv_state != ssh2_NB_state_idle) {
-            fprintf(stderr,
-                    "saved error restore: result=%p rc=%d message=%s "
-                    "state=%u\n",
-                    (void *)result, rc,
-                    session->err_msg ? session->err_msg : "(null)",
-                    (unsigned int)session->scpRecv_state);
-            failed = 1;
-        }
+        CHECK(!result && rc == -1234);
+        CHECK(session->err_msg && !strcmp(session->err_msg, saved_message));
+        CHECK(session->err_flags & SSH2_ERR_FLAG_DUP);
+        CHECK(session->scpRecv_state == ssh2_NB_state_idle);
     }
-
+out:
     force_session_free(session);
-    if(!ctx.tracked_message_freed) {
+    if(ctx.tracked_message && !ctx.tracked_message_freed) {
         fprintf(stderr, "saved SCP error was not freed during teardown\n");
         failed = 1;
     }


### PR DESCRIPTION
SCP receive and send error cleanup currently keeps retrying `libssh2_channel_free()` when it returns `LIBSSH2_ERROR_EAGAIN`, including in non-blocking mode.

Use the existing `ssh2_NB_state_error_closing` state to return control to the caller and resume cleanup on the next call. Preserve the original error code, message, and ownership flags until cleanup finishes. Release a saved heap-owned message if the session is freed before cleanup completes.

Add a bounded, network-free standalone regression covering receive/send cleanup across calls, restoration of the original error, and saved-message lifetime through completion or session teardown. It uses the common SCP/channel code and does not require a particular crypto backend.

Local validation on upstream `bb8e0957` plus this patch:

- Windows/MSVC/WinCNG: Release and Debug builds with warnings as errors; both standalone tests pass.
- Linux/Clang/OpenSSL under WSL: project clang-tidy checks and a build with warnings as errors; both standalone tests pass.
- Linux/Clang/libgcrypt and mbedTLS: builds with warnings as errors; both standalone tests pass on each backend.
- Linux AddressSanitizer, UndefinedBehaviorSanitizer, and leak detection: both standalone tests pass.
- Upstream `checksrc`: passes, including the new test.

Follow-up to https://github.com/libssh2/libssh2/pull/2590#issuecomment-5565371252. I have not established whether this explains the original test 621 CI hang. The curl runtime suite is provided by the CI workflow from master; it was not run locally.
