### PR TITLE
openssl: make `ssh2_bn_bytes()`/`ssh2_bn_bits()` return `size_t`

### DIFF
--- a/src/openssl.h
+++ b/src/openssl.h
@@ -346,8 +346,8 @@ typedef enum {
 #define ssh2_bn_set_word(bn, word)   !BN_set_word(bn, word)
 #define ssh2_bn_from_bin(bn, bin, l) (BN_bin2bn(bin, (int)(l), bn) ? 0 : -1)
 #define ssh2_bn_to_bin(bn, bin)      (BN_bn2bin(bn, bin) <= 0)
-#define ssh2_bn_bytes(bn)            BN_num_bytes(bn)
-#define ssh2_bn_bits(bn)             BN_num_bits(bn)
+#define ssh2_bn_bytes(bn)            ((size_t)BN_num_bytes(bn))
+#define ssh2_bn_bits(bn)             ((size_t)BN_num_bits(bn))
 #define ssh2_bn_free(bn)             BN_clear_free(bn)
 
 #define ssh2_dh_ctx                  BIGNUM *


### PR DESCRIPTION
To match other crypto backends.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
