### PR TITLE
test_simple: make `test_ssh2_dh_validate()` portable

### DIFF
--- a/src/mbedtls.h
+++ b/src/mbedtls.h
@@ -218,7 +218,7 @@ struct ssh2_mbed_cipher_ctx {
  */
 
 #define ssh2_bn                        mbedtls_mpi
-#define ssh2_bn_set_word(bn, word)     mbedtls_mpi_lset(bn, word)
+#define ssh2_bn_set_word(bn, word)     mbedtls_mpi_lset(bn, (long long)(word))
 #define ssh2_bn_to_bin(bn, bin) \
     mbedtls_mpi_write_binary(bn, bin, mbedtls_mpi_size(bn))
 #define ssh2_bn_bytes(bn)              mbedtls_mpi_size(bn)

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3139,13 +3139,6 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, const ssh2_bn *g,
     return 0;
 }
 
-int ssh2_dh_validate(const ssh2_bn *f, const ssh2_bn *p) /* FIXME: implement */
-{
-    (void)f;
-    (void)p;
-    return 0;
-}
-
 /* Computes the Diffie-Hellman secret from the previously created context
  * `*dhctx', the public key `f' from the other party and the same prime `p'
  * used at context creation. The result is stored in `secret'.  0 is returned

--- a/src/wincng.c
+++ b/src/wincng.c
@@ -3139,6 +3139,13 @@ int ssh2_dh_key_pair(ssh2_dh_ctx *dhctx, ssh2_bn *pub, const ssh2_bn *g,
     return 0;
 }
 
+int ssh2_dh_validate(const ssh2_bn *f, const ssh2_bn *p) /* FIXME: implement */
+{
+    (void)f;
+    (void)p;
+    return 0;
+}
+
 /* Computes the Diffie-Hellman secret from the previously created context
  * `*dhctx', the public key `f' from the other party and the same prime `p'
  * used at context creation. The result is stored in `secret'.  0 is returned

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -248,7 +248,7 @@ static int test_ssh2_dh_validate(void)
 
     for(i = 0; i < SSH2_ARRAYSIZE(tests); i++) {
         struct tbn t = tests[i];
-        int got = 0;
+        int got;
         ssh2_bn *f = ssh2_bn_init();
         ssh2_bn *p = ssh2_bn_init();
         ssh2_bn_set_word(f, (uint32_t)atoi(t.f));

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -265,8 +265,7 @@ static int test_ssh2_dh_validate(void)
         if(got != t.expected) {
             fprintf(stderr,
                     "ssh2_dh_validate/%lu: f=%s p=%s: expected %d got %d\n",
-                    (unsigned long)i,
-                    t.f, t.p, t.expected, got);
+                    (unsigned long)i, t.f, t.p, t.expected, got);
             err++;
         }
     }

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -254,7 +254,8 @@ static int test_ssh2_dh_validate(void)
 #else
         ssh2_bn *f = ssh2_bn_init();
         ssh2_bn *p = ssh2_bn_init();
-        if(ssh2_bn_set_word(f, (uint32_t)atoi(t.f)) ||
+        if(!f || !p ||
+           ssh2_bn_set_word(f, (uint32_t)atoi(t.f)) ||
            ssh2_bn_set_word(p, (uint32_t)atoi(t.p)))
             got = -9;
         else

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -250,25 +250,20 @@ static int test_ssh2_dh_validate(void)
     for(i = 0; i < SSH2_ARRAYSIZE(tests); i++) {
         struct tbn t = tests[i];
         int got;
+        ssh2_bn *f = ssh2_bn_init();
+        ssh2_bn *p = ssh2_bn_init();
 #ifdef LIBSSH2_LIBGCRYPT
-        gcry_mpi_t f = gcry_mpi_set_ui(NULL, (unsigned long)abs(atoi(t.f)));
-        gcry_mpi_t p = gcry_mpi_set_ui(NULL, (unsigned long)atoi(t.p));
+        ssh2_bn_set_word(f, (unsigned long)abs(atoi(t.f)));
+        ssh2_bn_set_word(p, (unsigned long)atoi(t.p));
         if(t.f[0] == '-')
             gcry_mpi_neg(f, f);
         got = ssh2_dh_validate(f, p);
-        gcry_mpi_release(f);
-        gcry_mpi_release(p);
 #elif defined(LIBSSH2_MBEDTLS)
-        mbedtls_mpi f, p;
-        mbedtls_mpi_init(&f);
-        mbedtls_mpi_init(&p);
-        if(mbedtls_mpi_read_string(&f, 10, t.f) ||
-           mbedtls_mpi_read_string(&p, 10, t.p))
+        if(mbedtls_mpi_read_string(f, 10, t.f) ||
+           mbedtls_mpi_read_string(p, 10, t.p))
             got = -9;
         else
-            got = ssh2_dh_validate(&f, &p);
-        mbedtls_mpi_free(&f);
-        mbedtls_mpi_free(&p);
+            got = ssh2_dh_validate(f, p);
 #elif defined(LIBSSH2_OPENSSL) || \
     (defined(LIBSSH2_WOLFSSL) && LIBWOLFSSL_VERSION_HEX >= 0x05006000)
         BIGNUM *f = BN_new(), *p = BN_new();
@@ -277,11 +272,11 @@ static int test_ssh2_dh_validate(void)
             got = -9;
         else
             got = ssh2_dh_validate(f, p);
-        BN_free(f);
-        BN_free(p);
 #else
         got = t.expected;
 #endif
+        ssh2_bn_free(f);
+        ssh2_bn_free(p);
         if(got != t.expected) {
             fprintf(stderr,
                     "ssh2_dh_validate/%lu: f=%s p=%s: expected %d got %d\n",

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -254,9 +254,11 @@ static int test_ssh2_dh_validate(void)
 #else
         ssh2_bn *f = ssh2_bn_init();
         ssh2_bn *p = ssh2_bn_init();
-        ssh2_bn_set_word(f, (uint32_t)atoi(t.f));
-        ssh2_bn_set_word(p, (uint32_t)atoi(t.p));
-        got = ssh2_dh_validate(f, p);
+        if(ssh2_bn_set_word(f, (uint32_t)atoi(t.f)) ||
+           ssh2_bn_set_word(p, (uint32_t)atoi(t.p)))
+            got = -9;
+        else
+            got = ssh2_dh_validate(f, p);
         ssh2_bn_free(f);
         ssh2_bn_free(p);
 #endif

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -234,7 +234,6 @@ static int test_ssh2_dh_validate(void)
         const char *f; const char *p; int expected;
     };
     static const struct tbn tests[] = {
-        {  "-1",  "10", -1 },
         {   "2",  "10", -3 },
         {   "1",  "10", -1 },
         {   "0",  "10", -1 },
@@ -249,32 +248,12 @@ static int test_ssh2_dh_validate(void)
 
     for(i = 0; i < SSH2_ARRAYSIZE(tests); i++) {
         struct tbn t = tests[i];
-        int got;
+        int got = 0;
         ssh2_bn *f = ssh2_bn_init();
         ssh2_bn *p = ssh2_bn_init();
-#ifdef LIBSSH2_LIBGCRYPT
-        ssh2_bn_set_word(f, (unsigned long)abs(atoi(t.f)));
-        ssh2_bn_set_word(p, (unsigned long)atoi(t.p));
-        if(t.f[0] == '-')
-            gcry_mpi_neg(f, f);
+        ssh2_bn_set_word(f, (uint32_t)atoi(t.f));
+        ssh2_bn_set_word(p, (uint32_t)atoi(t.p));
         got = ssh2_dh_validate(f, p);
-#elif defined(LIBSSH2_MBEDTLS)
-        if(mbedtls_mpi_read_string(f, 10, t.f) ||
-           mbedtls_mpi_read_string(p, 10, t.p))
-            got = -9;
-        else
-            got = ssh2_dh_validate(f, p);
-#elif defined(LIBSSH2_OPENSSL) || \
-    (defined(LIBSSH2_WOLFSSL) && LIBWOLFSSL_VERSION_HEX >= 0x05006000)
-        BIGNUM *f = BN_new(), *p = BN_new();
-        if(!BN_dec2bn(&f, t.f) ||
-           !BN_dec2bn(&p, t.p))
-            got = -9;
-        else
-            got = ssh2_dh_validate(f, p);
-#else
-        got = t.expected;
-#endif
         ssh2_bn_free(f);
         ssh2_bn_free(p);
         if(got != t.expected) {

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -230,10 +230,9 @@ static int test_knownhost_ipv6(LIBSSH2_SESSION *session)
 
 static int test_ssh2_dh_validate(void)
 {
-    struct tbn {
+    static const struct {
         const char *f; const char *p; int expected;
-    };
-    static const struct tbn tests[] = {
+    } tests[] = {
         {   "2",  "10", -3 },
         {   "1",  "10", -1 },
         {   "0",  "10", -1 },
@@ -249,6 +248,9 @@ static int test_ssh2_dh_validate(void)
     for(i = 0; i < SSH2_ARRAYSIZE(tests); i++) {
         struct tbn t = tests[i];
         int got;
+#ifdef LIBSSH2_WINCNG
+        got = t.expected;
+#else
         ssh2_bn *f = ssh2_bn_init();
         ssh2_bn *p = ssh2_bn_init();
         ssh2_bn_set_word(f, (uint32_t)atoi(t.f));
@@ -256,6 +258,7 @@ static int test_ssh2_dh_validate(void)
         got = ssh2_dh_validate(f, p);
         ssh2_bn_free(f);
         ssh2_bn_free(p);
+#endif
         if(got != t.expected) {
             fprintf(stderr,
                     "ssh2_dh_validate/%lu: f=%s p=%s: expected %d got %d\n",

--- a/tests/test_simple.c
+++ b/tests/test_simple.c
@@ -230,9 +230,10 @@ static int test_knownhost_ipv6(LIBSSH2_SESSION *session)
 
 static int test_ssh2_dh_validate(void)
 {
-    static const struct {
+    struct tbn {
         const char *f; const char *p; int expected;
-    } tests[] = {
+    };
+    static const struct tbn tests[] = {
         {   "2",  "10", -3 },
         {   "1",  "10", -1 },
         {   "0",  "10", -1 },


### PR DESCRIPTION
Omit direct backend-specific API use. Drop one test using negative
input, that's impossible with the internal crypto API. Using 
backend-specific code in tests is highly undesired. It's also
discouraged to special-case any, in this case WinCNG had to be because
it does not implement the DH validation function.

Also:
- mbedtls: fix an internal API type difference with a cast.
- unfold a line.

Follow-up to fcf830788d0c8dcd6bed7dcd532506aabf196523 #2239
