### PR TITLE
libgcrypt: fix `ssh2_bn_set_word()` return value

### DIFF
--- a/src/libgcrypt.h
+++ b/src/libgcrypt.h
@@ -116,7 +116,7 @@
 
 #define ssh2_bn                        struct gcry_mpi
 #define ssh2_bn_init()                 gcry_mpi_new(0)
-#define ssh2_bn_set_word(bn, word)     gcry_mpi_set_ui(bn, word)
+#define ssh2_bn_set_word(bn, word)     (gcry_mpi_set_ui(bn, word) ? 0 : 1)
 #define ssh2_bn_from_bin(bn, bin, len) \
     gcry_mpi_scan(bn, GCRYMPI_FMT_USG, bin, len, NULL)
 #define ssh2_bn_to_bin(bn, bin) \


### PR DESCRIPTION
It was returning a non-NULL address on success, which translated to
permanent failure as mapped to this internal crypto API. Fix to match it
with the rest of crypto backends and the expectation of callers.

Reported by Copilot
Bug: https://github.com/libssh2/libssh2/pull/2595#discussion_r3950301182
Follow-up to 95c824d5d9555827d5e3616d1404502c052682fb #1354
Follow-up to c9d40afa14cd9400124467ced69fee387f9c50fa
