### PR TITLE
wincng: fix builds with RSA and DSA disabled

### DIFF
--- a/src/wincng.c
+++ b/src/wincng.c
@@ -2705,6 +2705,7 @@ cleanup:
 
     return ret;
 }
+#endif /* LIBSSH2_RSA || LIBSSH2_DSA */
 
 int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      unsigned char **pubkeydata, size_t *pubkeydata_len,
@@ -2712,6 +2713,7 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
                      const char *privkeyblob, size_t privkeyblob_len,
                      const char *passphrase)
 {
+#if LIBSSH2_RSA || LIBSSH2_DSA
     unsigned char *pbEncoded;
     size_t cbEncoded;
 
@@ -2723,8 +2725,21 @@ int ssh2_pub_privkey(LIBSSH2_SESSION *session, char **method,
     return wcng_pub_priv_parse(session, method,
                                pubkeydata, pubkeydata_len,
                                pbEncoded, cbEncoded);
+#else
+    (void)session;
+    (void)method;
+    (void)pubkeydata;
+    (void)pubkeydata_len;
+    (void)privkeyfile;
+    (void)privkeyblob;
+    (void)privkeyblob_len;
+    (void)passphrase;
+
+    /* FIXME: add ECDSA support */
+
+    return -1;
+#endif
 }
-#endif /* LIBSSH2_RSA || LIBSSH2_DSA */
 
 /*******************************************************************/
 /*


### PR DESCRIPTION
Fixing:
```
x86_64-w64-mingw32-ld: src/CMakeFiles/libssh2_shared.dir/Unity/unity_0_c.c.obj: in function `userauth_hostbased_fromfile':
src/userauth.c:923:(.text+0x34c29): undefined reference to `ssh2_pub_privkey'
x86_64-w64-mingw32-ld: src/CMakeFiles/libssh2_shared.dir/Unity/unity_0_c.c.obj: in function `userauth_publickey':
src/userauth.c:1745:(.text+0x37171): undefined reference to `ssh2_pub_privkey'
collect2: error: ld returned 1 exit status
```

Note: This fixes the build, but leaves `ssh2_pub_privkey()` a no-op, because it's not implemented for ECDSA.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
