### PR TITLE
GHA: use `cache-mode`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -826,6 +826,7 @@ jobs:
     name: 'msys2'
     runs-on: windows-2022
     timeout-minutes: 10
+    cache-mode: write
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,10 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           actionlint --version
           export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
-          actionlint --ignore ubuntu-26.04 .github/workflows/*.yml
+          actionlint \
+            --ignore ubuntu-26.04 .\
+            --ignore 'unexpected key "cache-mode"' \
+            github/workflows/*.yml
 
       - name: 'shellcheck GHA'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   DO_NOT_TRACK: '1'
@@ -238,6 +239,7 @@ jobs:
     name: 'linux'
     runs-on: ${{ matrix.compiler == 'clang-tidy' && 'ubuntu-26.04' || (matrix.image || 'ubuntu-latest') }}
     timeout-minutes: 10
+    cache-mode: write
     strategy:
       fail-fast: false
       matrix:
@@ -1317,6 +1319,7 @@ jobs:
     name: 'curl, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
     runs-on: '${{ matrix.image }}'
     timeout-minutes: 10
+    cache-mode: write
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
           actionlint --version
           export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
           actionlint \
-            --ignore ubuntu-26.04 .\
+            --ignore ubuntu-26.04 \
             --ignore 'unexpected key "cache-mode"' \
-            github/workflows/*.yml
+            .github/workflows/*.yml
 
       - name: 'shellcheck GHA'
         run: |


### PR DESCRIPTION
Limit cache access to the minimum required.

Refs:
https://github.blog/changelog/2026-09-10-control-github-actions-cache-access-with-cache-mode/
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#cache-mode
https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#bypassing-the-default-untrusted-trigger-cache-restriction

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
