### PR TITLE
GHA: drop redundant shellcheck expression filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
               echo '#!/usr/bin/env bash'
               echo 'set -eu'
               yq eval '.. | select(has("run") and (.run | type == "!!str")) | .run + "\ntrue\n"' "${f}"
-            } | sed -E 's|\$\{\{ .+ \}\}|GHA_EXPRESSION|g' | shellcheck -
+            } | shellcheck -
           done
 
       - name: 'shellcheck'


### PR DESCRIPTION
GHA expressions are no longer used and no longer allowed in GHA scripts.

Follow-up to d7cf63bb05a51a69a58820255b336a19cfa6b269 #1609

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
