### PR TITLE
tests: drop WinCNG retry workarounds

### DIFF
--- a/tests/runner.c
+++ b/tests/runner.c
@@ -34,37 +34,16 @@
 
 int main(void)
 {
-    int exit_code;
-    int retries = 0, retry = 0;
-
-#ifdef LIBSSH2_WINCNG
-    /* FIXME: Retry tests with WinCNG due to flakiness in hostkey
-       verification: https://github.com/libssh2/libssh2/issues/804 */
-    retries += 2;
-#endif
-
-    do {
-        int skipped, rc;
-        LIBSSH2_SESSION *session = start_session_fixture(&skipped, &rc);
-        if(session)
-            exit_code = (test(session) == 0) ? 0 : 1;
-        else if(skipped) {
-            fprintf(stderr, "Test skipped.\n");
-            exit_code = 0;
-        }
-        else
-            exit_code = 1;
-        stop_session_fixture();
-        if(exit_code == 0 ||
-#ifdef LIBSSH2_WINCNG
-           rc != LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE ||
-#endif
-           ++retry > retries) {
-            break;
-        }
-        fprintf(stderr, "Test failed (%d). Retrying... %d / %d\n",
-                        rc, retry, retries);
-    } while(1);
+    int exit_code = 1;
+    int skipped, rc;
+    LIBSSH2_SESSION *session = start_session_fixture(&skipped, &rc);
+    if(session)
+        exit_code = (test(session) == 0) ? 0 : 1;
+    else if(skipped) {
+        fprintf(stderr, "Test skipped.\n");
+        exit_code = 0;
+    }
+    stop_session_fixture();
 
     return exit_code;
 }

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -144,8 +144,11 @@ int main(int argc, char *argv[])
 
     libssh2_session_set_blocking(session, 1);
 
-    if(libssh2_session_handshake(session, sock))
+    rc = libssh2_session_handshake(session, sock);
+    if(rc) {
         fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
+        goto shutdown;
+    }
 
     rc = 1;
 

--- a/tests/test_ssh2.c
+++ b/tests/test_ssh2.c
@@ -144,27 +144,8 @@ int main(int argc, char *argv[])
 
     libssh2_session_set_blocking(session, 1);
 
-    {
-        int retries = 0, retry = 0;
-#ifdef LIBSSH2_WINCNG
-        /* FIXME: Retry tests with WinCNG due to flakiness in hostkey
-           verification: https://github.com/libssh2/libssh2/issues/804 */
-        retries += 2;
-#endif
-        do {
-            rc = libssh2_session_handshake(session, sock);
-            if(rc == 0)
-                break;
-            fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
-            if(
-#ifdef LIBSSH2_WINCNG
-               rc != LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE ||
-#endif
-               ++retry > retries)
-                break;
-            fprintf(stderr, "Retrying... %d / %d\n", retry, retries);
-        } while(1);
-    }
+    if(libssh2_session_handshake(session, sock))
+        fprintf(stderr, "Failure establishing SSH session: %d\n", rc);
 
     rc = 1;
 


### PR DESCRIPTION
Should no longer be necessary after fixing the root cause.
(Though we do not run these tests in CI at the moment.)

Ref: #804
Follow-up to f216bbe3aa5ec02033de53ed0809a2461fc062c7 #2583
Follow-up to bc120a343bb3cda0985fb06ee491ec5318e98426 #1023
