### PR TITLE
tests: add support for `podman`, Apple `container`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,7 +1196,7 @@ jobs:
       - name: 'tests'
         timeout-minutes: 10
         run: |
-          container system start --disable-kernel-install
+          container system start
           container system kernel set --recommended
           export FIXTURE_CONTAINER_CMD=container
           export OPENSSH_SERVER_PORT=5678

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1195,8 +1195,8 @@ jobs:
       - name: 'tests'
         timeout-minutes: 10
         run: |
-          container system kernel set --recommended
           container system start --disable-kernel-install
+          container system kernel set --recommended
           export FIXTURE_CONTAINER_CMD=container
           export OPENSSH_SERVER_PORT=5678
           export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1017,6 +1017,8 @@ jobs:
       - name: 'presintalled'
         run: |
           docker --version || true
+          wsl --version || true
+          wsl --list --verbose || true
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1195,7 +1195,7 @@ jobs:
       - name: 'tests'
         timeout-minutes: 10
         run: |
-          #container system kernel set --recommended
+          container system kernel set --recommended
           container system start --disable-kernel-install
           export FIXTURE_CONTAINER_CMD=container
           export OPENSSH_SERVER_PORT=5678

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,8 +1196,13 @@ jobs:
       - name: 'tests'
         timeout-minutes: 10
         run: |
-          container system start --disable-kernel-install
+          container system status
+          container system start --enable-kernel-install
+          container system status
+          container system kernel set --recommended --force
+          container system status
           container system kernel set --recommended
+          container system status
           export FIXTURE_CONTAINER_CMD=container
           export OPENSSH_SERVER_PORT=5678
           export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,7 +1079,7 @@ jobs:
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target package
 
       - name: 'install test prereqs'
-        shell: ps
+        shell: powershell
         run: wsl --install --distribution Debian
 
       - name: 'tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,6 +1079,7 @@ jobs:
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target package
 
       - name: 'install test prereqs'
+        shell: ps
         run: wsl --install --distribution Debian
 
       - name: 'tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,7 +612,7 @@ jobs:
         if: ${{ !matrix.target }}
         timeout-minutes: 10
         run: |
-          export DOCKER_CMD='podman'
+          export FIXTURE_CONTAINER_CMD='podman'
           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ] || [[ "${MATRIX_CRYPTO}" = 'OpenSSL' && "${MATRIX_COMPILER}" = 'clang-tidy' ]]; then
             export FIXTURE_TRACE_ALL_CONNECT=1  # to debug OpenSSL (ML-KEM) flaky CI failures
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,7 +1196,7 @@ jobs:
       - name: 'tests'
         timeout-minutes: 10
         run: |
-          container system start
+          container system start --disable-kernel-install
           container system kernel set --recommended
           export FIXTURE_CONTAINER_CMD=container
           export OPENSSH_SERVER_PORT=5678

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1014,6 +1014,10 @@ jobs:
           - { image: 'windows-2025', arch: arm64, plat: uwp    , type: Debug  , crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
           - { image: 'windows-2022', arch: x86  , plat: windows, type: Debug  , crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
     steps:
+      - name: 'presintalled'
+        run: |
+          docker --version || true
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -1126,6 +1130,12 @@ jobs:
         env:
           INSTALL_PACKAGES: ${{ matrix.build == 'AM' && 'automake libtool' || '' }}
         run: brew install ${INSTALL_PACKAGES} ${MATRIX_INSTALL}
+
+      - name: 'presintalled'
+        run: |
+          container --version || true
+          jq --version || true
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1131,7 +1131,7 @@ jobs:
       - name: 'install packages'
         env:
           INSTALL_PACKAGES: ${{ matrix.build == 'AM' && 'automake libtool' || '' }}
-        run: brew install ${INSTALL_PACKAGES} ${MATRIX_INSTALL}
+        run: brew install container ${INSTALL_PACKAGES} ${MATRIX_INSTALL}
 
       - name: 'presintalled'
         run: |
@@ -1160,7 +1160,6 @@ jobs:
               -DENABLE_WERROR=ON \
               -DENABLE_DEBUG_LOGGING=ON \
               -DENABLE_ZLIB_COMPRESSION=ON \
-              -DRUN_DOCKER_TESTS=OFF \
               -DRUN_SSHD_TESTS=OFF
           else
             if [ "${MATRIX_INSTALL}" = 'mbedtls@3' ]; then
@@ -1170,7 +1169,6 @@ jobs:
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               --with-libz ${MATRIX_CONFIGURE} \
-              --disable-docker-tests \
               --disable-sshd-tests \
               --disable-dependency-tracking --disable-examples-build
           fi
@@ -1195,6 +1193,11 @@ jobs:
       - name: 'tests'
         timeout-minutes: 10
         run: |
+          #container system kernel set --recommended
+          container system start --disable-kernel-install
+          export FIXTURE_CONTAINER_CMD=container
+          export OPENSSH_SERVER_PORT=5678
+          export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             cd bld && ctest -VV --output-on-failure
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,6 +1019,10 @@ jobs:
           docker --version || true
           wsl --list --verbose || true
 
+      - name: 'install test prereqs'
+        shell: powershell
+        run: wsl --install --distribution Ubuntu
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -1078,10 +1082,6 @@ jobs:
       - name: 'build'
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target package
 
-      - name: 'install test prereqs'
-        shell: powershell
-        run: wsl --install --distribution Debian
-
       - name: 'tests'
         # UWP binaries require a CRT DLL that is not found. Static CRT not supported.
         if: ${{ matrix.arch != 'arm64' && matrix.plat != 'uwp' }}
@@ -1135,7 +1135,6 @@ jobs:
         env:
           INSTALL_PACKAGES: ${{ matrix.build == 'AM' && 'automake libtool' || '' }}
         run: brew install ${INSTALL_PACKAGES} ${MATRIX_INSTALL}
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1017,7 +1017,6 @@ jobs:
       - name: 'presintalled'
         run: |
           docker --version || true
-          wsl --version || true
           wsl --list --verbose || true
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1078,6 +1077,9 @@ jobs:
 
       - name: 'build'
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target package
+
+      - name: 'install test prereqs'
+        run: wsl --install --distribution Debian
 
       - name: 'tests'
         # UWP binaries require a CRT DLL that is not found. Static CRT not supported.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,6 +597,7 @@ jobs:
         if: ${{ !matrix.target }}
         timeout-minutes: 10
         run: |
+          export DOCKER_CMD='podman'
           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ] || [[ "${MATRIX_CRYPTO}" = 'OpenSSL' && "${MATRIX_COMPILER}" = 'clang-tidy' ]]; then
             export FIXTURE_TRACE_ALL_CONNECT=1  # to debug OpenSSL (ML-KEM) flaky CI failures
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,7 +593,22 @@ jobs:
             make -C bld V=1
           fi
 
-      - name: 'tests'
+      - name: 'tests (docker)'
+        if: ${{ !matrix.target }}
+        timeout-minutes: 10
+        run: |
+          if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ] || [[ "${MATRIX_CRYPTO}" = 'OpenSSL' && "${MATRIX_COMPILER}" = 'clang-tidy' ]]; then
+            export FIXTURE_TRACE_ALL_CONNECT=1  # to debug OpenSSL (ML-KEM) flaky CI failures
+          fi
+          if [ "${MATRIX_BUILD}" = 'CM' ]; then
+            export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
+            [ -d "$HOME"/usr ] && export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/usr/lib"
+            cd bld && ctest -VV --output-on-failure
+          else
+            make -C bld check V=1 || { cat bld/tests/*.log; false; }
+          fi
+
+      - name: 'tests (podman)'
         if: ${{ !matrix.target }}
         timeout-minutes: 10
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1134,12 +1134,7 @@ jobs:
       - name: 'install packages'
         env:
           INSTALL_PACKAGES: ${{ matrix.build == 'AM' && 'automake libtool' || '' }}
-        run: brew install container ${INSTALL_PACKAGES} ${MATRIX_INSTALL}
-
-      - name: 'presintalled'
-        run: |
-          container --version || true
-          jq --version || true
+        run: brew install ${INSTALL_PACKAGES} ${MATRIX_INSTALL}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1163,6 +1158,7 @@ jobs:
               -DENABLE_WERROR=ON \
               -DENABLE_DEBUG_LOGGING=ON \
               -DENABLE_ZLIB_COMPRESSION=ON \
+              -DRUN_DOCKER_TESTS=OFF \
               -DRUN_SSHD_TESTS=OFF
           else
             if [ "${MATRIX_INSTALL}" = 'mbedtls@3' ]; then
@@ -1172,6 +1168,7 @@ jobs:
             mkdir bld && cd bld
             ../configure --enable-option-checking=fatal --enable-werror --enable-debug \
               --with-libz ${MATRIX_CONFIGURE} \
+              --disable-docker-tests \
               --disable-sshd-tests \
               --disable-dependency-tracking --disable-examples-build
           fi
@@ -1196,16 +1193,6 @@ jobs:
       - name: 'tests'
         timeout-minutes: 10
         run: |
-          container system status
-          container system start --enable-kernel-install
-          container system status
-          container system kernel set --recommended --force
-          container system status
-          container system kernel set --recommended
-          container system status
-          export FIXTURE_CONTAINER_CMD=container
-          export OPENSSH_SERVER_PORT=5678
-          export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
           if [ "${MATRIX_BUILD}" = 'CM' ]; then
             cd bld && ctest -VV --output-on-failure
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,12 +259,12 @@ jobs:
           - { compiler: gcc  , arch: amd64, crypto: LibreSSL                , build: 'CM', zlib: 'ON' }
           - { compiler: gcc  , arch: i386 , crypto: mbedTLS-from-source     , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
           - { compiler: gcc  , arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'OFF', test: 'legacy-options' }
-          - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'OFF' }
+          - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'OFF', container: 'podman' }
           - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'ON', target: 'distcheck' }
           - { compiler: clang, arch: amd64, crypto: OpenSSL                 , build: 'AM', zlib: 'ON', target: 'maketgz' }
-          - { compiler: gcc  , arch: amd64, crypto: OpenSSL-3-no-deprecated , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
+          - { compiler: gcc  , arch: amd64, crypto: OpenSSL-3-no-deprecated , build: 'CM', zlib: 'ON', image: ubuntu-26.04, container: 'podman' }
           - { compiler: gcc  , arch: amd64, crypto: OpenSSL-111-from-source , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
-          - { compiler: clang, arch: amd64, crypto: wolfSSL-from-source     , build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
+          - { compiler: clang, arch: amd64, crypto: wolfSSL-from-source     , build: 'CM', zlib: 'ON', image: ubuntu-26.04, container: 'podman' }
           - { compiler: clang, arch: amd64, crypto: wolfSSL-from-source-prev, build: 'CM', zlib: 'ON', image: ubuntu-26.04 }
     env:
       CC: ${{ matrix.compiler == 'clang-tidy' && 'clang' || matrix.compiler }}
@@ -593,7 +593,7 @@ jobs:
             make -C bld V=1
           fi
 
-      - name: 'tests (docker)'
+      - name: 'tests'
         if: ${{ !matrix.target }}
         timeout-minutes: 10
         run: |
@@ -608,11 +608,12 @@ jobs:
             make -C bld check V=1 || { cat bld/tests/*.log; false; }
           fi
 
-      - name: 'tests (podman)'
+      - name: 'tests'
         if: ${{ !matrix.target }}
         timeout-minutes: 10
+        env:
+          FIXTURE_CONTAINER_CMD: ${{ matrix.container || 'docker' }}
         run: |
-          export FIXTURE_CONTAINER_CMD='podman'
           if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ] || [[ "${MATRIX_CRYPTO}" = 'OpenSSL' && "${MATRIX_COMPILER}" = 'clang-tidy' ]]; then
             export FIXTURE_TRACE_ALL_CONNECT=1  # to debug OpenSSL (ML-KEM) flaky CI failures
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1014,15 +1014,6 @@ jobs:
           - { image: 'windows-2025', arch: arm64, plat: uwp    , type: Debug  , crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'OFF' }
           - { image: 'windows-2022', arch: x86  , plat: windows, type: Debug  , crypto: WinCNG , wincng_ecdsa: 'OFF', log: 'OFF', shared: 'ON' , zlib: 'OFF', unity: 'ON' }
     steps:
-      - name: 'presintalled'
-        run: |
-          docker --version || true
-          wsl --list --verbose || true
-
-      - name: 'install test prereqs'
-        shell: powershell
-        run: wsl --install --distribution Ubuntu
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,21 +596,6 @@ jobs:
       - name: 'tests'
         if: ${{ !matrix.target }}
         timeout-minutes: 10
-        run: |
-          if [ "${MATRIX_CRYPTO}" = 'OpenSSL-3-no-deprecated' ] || [[ "${MATRIX_CRYPTO}" = 'OpenSSL' && "${MATRIX_COMPILER}" = 'clang-tidy' ]]; then
-            export FIXTURE_TRACE_ALL_CONNECT=1  # to debug OpenSSL (ML-KEM) flaky CI failures
-          fi
-          if [ "${MATRIX_BUILD}" = 'CM' ]; then
-            export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
-            [ -d "$HOME"/usr ] && export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/usr/lib"
-            cd bld && ctest -VV --output-on-failure
-          else
-            make -C bld check V=1 || { cat bld/tests/*.log; false; }
-          fi
-
-      - name: 'tests'
-        if: ${{ !matrix.target }}
-        timeout-minutes: 10
         env:
           FIXTURE_CONTAINER_CMD: ${{ matrix.container || 'docker' }}
         run: |

--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -93,4 +93,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -93,3 +93,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -66,6 +66,7 @@
 
 static int have_docker = 0;
 static const char *docker_cmd;
+static const char *image_tag;
 
 int openssh_fixture_have_docker(void)
 {
@@ -114,6 +115,7 @@ static int run_command_varg(char **output, const char *command, va_list args)
         return -1;
     }
 
+    fprintf(stderr, "Command: %s\n", command_buf);
     fprintf(stdout, "Command: %s\n", command_buf);
     pipe = popen(buf, "r");
     if(!pipe) {
@@ -170,13 +172,27 @@ static int build_openssh_server_docker_image(void)
     if(have_docker) {
         const char *container_image_name = openssh_server_image();
         if(container_image_name) {
-            int ret = run_command(NULL, "%s pull %s",
+            int ret;
+            if(strstr(docker_cmd, "container")) {
+                ret = run_command(NULL, "%s image pull %s",
                                   docker_cmd, container_image_name);
-            if(ret == 0) {
-                ret = run_command(NULL, "%s tag %s libssh2/openssh_server",
+                if(ret == 0) {
+                    ret = run_command(NULL, "%s image tag %s "
+                                      "libssh2/openssh_server",
+                                      docker_cmd, container_image_name);
+                    if(ret == 0)
+                        return ret;
+                }
+            }
+            else {
+                ret = run_command(NULL, "%s pull %s",
                                   docker_cmd, container_image_name);
-                if(ret == 0)
-                    return ret;
+                if(ret == 0) {
+                    ret = run_command(NULL, "%s tag %s libssh2/openssh_server",
+                                      docker_cmd, container_image_name);
+                    if(ret == 0)
+                        return ret;
+                }
             }
         }
         return run_command(NULL,
@@ -197,12 +213,11 @@ static int start_openssh_server(char **container_id_out)
     if(have_docker) {
         const char *container_host_port = openssh_server_port();
         if(container_host_port)
-            return run_command(container_id_out, "%s run --rm -d -p %s:22 "
-                               "libssh2/openssh_server",
-                               docker_cmd, container_host_port);
+            return run_command(container_id_out, "%s run --rm -d -p %s:22 %s",
+                               docker_cmd, container_host_port, image_tag);
 
-        return run_command(container_id_out, "%s run --rm -d -p 22 "
-                           "libssh2/openssh_server", docker_cmd);
+        return run_command(container_id_out, "%s run --rm -d -p 22 %s",
+                           docker_cmd, image_tag);
     }
     else {
         *container_id_out = libssh2_strdup("");
@@ -451,6 +466,11 @@ int start_openssh_fixture(void)
     if(!docker_cmd)
         docker_cmd = "docker";
     have_docker = !!*docker_cmd;
+    if(have_docker) {
+        image_tag = getenv("OPENSSH_SERVER_TAG");
+        if(!image_tag)
+            image_tag = "libssh2/openssh_server";
+    }
 
     ret = build_openssh_server_docker_image();
     if(!ret)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -304,17 +304,13 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            "\"{{ .NetworkSettings.IPAddress }}\""
                            " %s", docker_cmd, container_id);
     else if(strstr(docker_cmd, "container"))
+        /* Requires jq */
         return run_command(ip_address_out, "%s inspect %s | "
                            "jq --raw-output '.[0].networks[0].gateway'",
                            docker_cmd, container_id);
     else {
         /* Requires podman 6.1.0+
-           https://github.com/podman-container-tools/podman/issues/29164
-           For Apple container, this information is in the 'container inspect'
-           output:
-           $ jq --raw-output '.[0].configuration.publishedPorts[]
-             | select(.hostPort == 8912) | .containerPort'
-         */
+           https://github.com/podman-container-tools/podman/issues/29164 */
         int ret = run_command(ip_address_out, "%s inspect --format "
                               "\"{{ (index (index .NetworkSettings.Ports "
                               "\\\"22/tcp\\\") 0).HostIp }}\" %s",

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -448,9 +448,10 @@ int start_openssh_fixture(void)
     }
 #endif
 
-    have_docker = !getenv("OPENSSH_NO_DOCKER");
-    if(have_docker)
-        docker_cmd = getenv("DOCKER_CMD") ? getenv("DOCKER_CMD") : "docker";
+    docker_cmd = getenv("FIXTURE_CONTAINER_CMD");
+    if(!docker_cmd)
+        docker_cmd = "docker";
+    have_docker = !!*docker_cmd;
 
     ret = build_openssh_server_docker_image();
     if(!ret)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -159,6 +159,11 @@ static int run_command(char **output, const char *command, ...)
     return ret;
 }
 
+static const char *openssh_docker_bin(void)
+{
+    return getenv("DOCKER_BIN") ? getenv("DOCKER_BIN") : "docker";
+}
+
 static const char *openssh_server_image(void)
 {
     return getenv("OPENSSH_SERVER_IMAGE");
@@ -169,18 +174,18 @@ static int build_openssh_server_docker_image(void)
     if(have_docker) {
         const char *container_image_name = openssh_server_image();
         if(container_image_name) {
-            int ret = run_command(NULL, "docker pull %s",
-                                  container_image_name);
+            int ret = run_command(NULL, "%s pull %s",
+                                  openssh_docker_bin(), container_image_name);
             if(ret == 0) {
-                ret = run_command(NULL, "docker tag %s libssh2/openssh_server",
-                                  container_image_name);
+                ret = run_command(NULL, "%s tag %s libssh2/openssh_server",
+                                  openssh_docker_bin(), container_image_name);
                 if(ret == 0)
                     return ret;
             }
         }
         return run_command(NULL,
-                           "docker build --quiet -t libssh2/openssh_server %s",
-                           srcdir_path("openssh_server"));
+                           "%s build --quiet -t libssh2/openssh_server %s",
+                           openssh_docker_bin(), srcdir_path("openssh_server"));
     }
     else
         return 0;
@@ -197,13 +202,13 @@ static int start_openssh_server(char **container_id_out)
         const char *container_host_port = openssh_server_port();
         if(container_host_port)
             return run_command(container_id_out,
-                               "docker run --rm -d -p %s:22 "
+                               "%s run --rm -d -p %s:22 "
                                "libssh2/openssh_server",
-                               container_host_port);
+                               openssh_docker_bin(), container_host_port);
 
         return run_command(container_id_out,
-                           "docker run --rm -d -p 22 "
-                           "libssh2/openssh_server");
+                           "%s run --rm -d -p 22 "
+                           "libssh2/openssh_server", openssh_docker_bin());
     }
     else {
         *container_id_out = libssh2_strdup("");
@@ -214,7 +219,7 @@ static int start_openssh_server(char **container_id_out)
 static int stop_openssh_server(char *container_id)
 {
     if(have_docker)
-        return run_command(NULL, "docker stop %s", container_id);
+        return run_command(NULL, "%s stop %s", openssh_docker_bin(), container_id);
     else
         return 0;
 }
@@ -233,11 +238,12 @@ static int is_running_inside_a_container(void)
     FILE *fp;
     char line[256];
     int found = 0;
+    const char *binary = openssh_docker_bin();
     fp = fopen(cgroup_filename, "r");
     if(!fp)
         return 0;  /* Do not go further, we are not in a container */
     while(fgets(line, sizeof(line), fp)) {
-        if(strstr(line, "docker")) {
+        if(strstr(line, binary)) {
             found = 1;
             break;
         }
@@ -288,17 +294,17 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
     else {
         if(is_running_inside_a_container())
             return run_command(ip_address_out,
-                               "docker inspect --format "
+                               "%s inspect --format "
                                "\"{{ .NetworkSettings.IPAddress }}\""
                                " %s",
-                               container_id);
+                               openssh_docker_bin(), container_id);
         else
             return run_command(ip_address_out,
-                               "docker inspect --format "
+                               "%s inspect --format "
                                "\"{{ index (index (index "
                                ".NetworkSettings.Ports "
                                "\\\"22/tcp\\\") 0) \\\"HostIp\\\" }}\" %s",
-                               container_id);
+                               openssh_docker_bin(), container_id);
     }
 }
 
@@ -310,10 +316,10 @@ static int port_from_container(char *container_id, char **port_out)
     }
     else
         return run_command(port_out,
-                           "docker inspect --format "
+                           "%s inspect --format "
                            "\"{{ index (index (index .NetworkSettings.Ports "
                            "\\\"22/tcp\\\") 0) \\\"HostPort\\\" }}\" %s",
-                           container_id);
+                           openssh_docker_bin(), container_id);
 }
 
 static void close_socket_to_container(libssh2_socket_t sock)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -290,7 +290,12 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            " %s", docker_cmd, container_id);
     else {
         /* Requires podman 6.1.0+
-           https://github.com/podman-container-tools/podman/issues/29164 */
+           https://github.com/podman-container-tools/podman/issues/29164
+           For Apple container, this information is in the 'container inspect'
+           output:
+           $ jq --raw-output '.[0].configuration.publishedPorts[]
+             | select(.hostPort == 8912) | .containerPort'
+         */
         int ret = run_command(ip_address_out, "%s inspect --format "
                               "\"{{ (index (index .NetworkSettings.Ports "
                               "\\\"22/tcp\\\") 0).HostIp }}\" %s",

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -65,6 +65,7 @@
 #endif
 
 static int have_docker = 0;
+static const char *docker_cmd;
 
 int openssh_fixture_have_docker(void)
 {
@@ -159,11 +160,6 @@ static int run_command(char **output, const char *command, ...)
     return ret;
 }
 
-static const char *openssh_docker_bin(void)
-{
-    return getenv("DOCKER_BIN") ? getenv("DOCKER_BIN") : "docker";
-}
-
 static const char *openssh_server_image(void)
 {
     return getenv("OPENSSH_SERVER_IMAGE");
@@ -175,17 +171,17 @@ static int build_openssh_server_docker_image(void)
         const char *container_image_name = openssh_server_image();
         if(container_image_name) {
             int ret = run_command(NULL, "%s pull %s",
-                                  openssh_docker_bin(), container_image_name);
+                                  docker_cmd, container_image_name);
             if(ret == 0) {
                 ret = run_command(NULL, "%s tag %s libssh2/openssh_server",
-                                  openssh_docker_bin(), container_image_name);
+                                  docker_cmd, container_image_name);
                 if(ret == 0)
                     return ret;
             }
         }
         return run_command(NULL,
                            "%s build --quiet -t libssh2/openssh_server %s",
-                           openssh_docker_bin(), srcdir_path("openssh_server"));
+                           docker_cmd, srcdir_path("openssh_server"));
     }
     else
         return 0;
@@ -201,14 +197,12 @@ static int start_openssh_server(char **container_id_out)
     if(have_docker) {
         const char *container_host_port = openssh_server_port();
         if(container_host_port)
-            return run_command(container_id_out,
-                               "%s run --rm -d -p %s:22 "
+            return run_command(container_id_out, "%s run --rm -d -p %s:22 "
                                "libssh2/openssh_server",
-                               openssh_docker_bin(), container_host_port);
+                               docker_cmd, container_host_port);
 
-        return run_command(container_id_out,
-                           "%s run --rm -d -p 22 "
-                           "libssh2/openssh_server", openssh_docker_bin());
+        return run_command(container_id_out, "%s run --rm -d -p 22 "
+                           "libssh2/openssh_server", docker_cmd);
     }
     else {
         *container_id_out = libssh2_strdup("");
@@ -219,7 +213,7 @@ static int start_openssh_server(char **container_id_out)
 static int stop_openssh_server(char *container_id)
 {
     if(have_docker)
-        return run_command(NULL, "%s stop %s", openssh_docker_bin(), container_id);
+        return run_command(NULL, "%s stop %s", docker_cmd, container_id);
     else
         return 0;
 }
@@ -238,12 +232,11 @@ static int is_running_inside_a_container(void)
     FILE *fp;
     char line[256];
     int found = 0;
-    const char *binary = openssh_docker_bin();
     fp = fopen(cgroup_filename, "r");
     if(!fp)
         return 0;  /* Do not go further, we are not in a container */
     while(fgets(line, sizeof(line), fp)) {
-        if(strstr(line, binary)) {
+        if(strstr(line, docker_cmd)) {
             found = 1;
             break;
         }
@@ -293,18 +286,16 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
     }
     else {
         if(is_running_inside_a_container())
-            return run_command(ip_address_out,
-                               "%s inspect --format "
+            return run_command(ip_address_out, "%s inspect --format "
                                "\"{{ .NetworkSettings.IPAddress }}\""
                                " %s",
-                               openssh_docker_bin(), container_id);
+                               docker_cmd, container_id);
         else
-            return run_command(ip_address_out,
-                               "%s inspect --format "
+            return run_command(ip_address_out, "%s inspect --format "
                                "\"{{ index (index (index "
                                ".NetworkSettings.Ports "
                                "\\\"22/tcp\\\") 0) \\\"HostIp\\\" }}\" %s",
-                               openssh_docker_bin(), container_id);
+                               docker_cmd, container_id);
     }
 }
 
@@ -315,11 +306,10 @@ static int port_from_container(char *container_id, char **port_out)
         return 0;
     }
     else
-        return run_command(port_out,
-                           "%s inspect --format "
+        return run_command(port_out, "%s inspect --format "
                            "\"{{ index (index (index .NetworkSettings.Ports "
                            "\\\"22/tcp\\\") 0) \\\"HostPort\\\" }}\" %s",
-                           openssh_docker_bin(), container_id);
+                           docker_cmd, container_id);
 }
 
 static void close_socket_to_container(libssh2_socket_t sock)
@@ -436,6 +426,8 @@ int start_openssh_fixture(void)
 #endif
 
     have_docker = !getenv("OPENSSH_NO_DOCKER");
+    if(have_docker)
+        docker_cmd = getenv("DOCKER_CMD") ? getenv("DOCKER_CMD") : "docker";
 
     ret = build_openssh_server_docker_image();
     if(!ret)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -338,7 +338,11 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
 
 static int port_from_container(char *container_id, char **port_out)
 {
-    if(is_running_inside_a_container()) {
+    if(openssh_server_port()) {
+        *port_out = libssh2_strdup(openssh_server_port());
+        return 0;
+    }
+    else if(is_running_inside_a_container()) {
         *port_out = libssh2_strdup("22");
         return 0;
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -301,15 +301,16 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                               docker_cmd, container_id);
             if(!ret) {
                 char *hit;
-                hit = strchr(ip_address_out, '\r');
+                hit = strchr(*ip_address_out, '\r');
                 if(hit)
                     *hit = '\0';
-                hit = strchr(ip_address_out, '\n');
+                hit = strchr(*ip_address_out, '\n');
                 if(hit)
                     *hit = '\0';
-                hit = strrchr(ip_address_out, ':');
+                hit = strrchr(*ip_address_out, ':');
                 if(hit)
                     *hit = '\0';
+                fprintf(stderr, "||%d||\n", *ip_address_out);
             }
         }
         return ret;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -289,11 +289,19 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            "\"{{ .NetworkSettings.IPAddress }}\""
                            " %s",
                            docker_cmd, container_id);
-    else
-        return run_command(ip_address_out, "%s inspect --format "
-                           "\"{{ (index (index .NetworkSettings.Ports "
-                           "\\\"22/tcp\\\") 0).HostIp }}\" %s",
-                           docker_cmd, container_id);
+    else {
+        int ret;
+        /* Requires podman 6.1.0+
+           https://github.com/podman-container-tools/podman/issues/29164 */
+        ret = run_command(ip_address_out, "%s inspect --format "
+                          "\"{{ (index (index .NetworkSettings.Ports "
+                          "\\\"22/tcp\\\") 0).HostIp }}\" %s",
+                          docker_cmd, container_id);
+        if(ret)
+            /* Another alternative is `%s port "22/tcp"` which works with
+               both docker and podman. */
+            *ip_address_out = libssh2_strdup("0.0.0.0");
+    }
 }
 
 static int port_from_container(char *container_id, char **port_out)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -291,9 +291,8 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            docker_cmd, container_id);
     else
         return run_command(ip_address_out, "%s inspect --format "
-                           "\"{{ index (index (index "
-                           ".NetworkSettings.Ports "
-                           "\\\"22/tcp\\\") 0) \\\"HostIp\\\" }}\" %s",
+                           "\"{{ index (index .NetworkSettings.Ports "
+                           "\\\"22/tcp\\\") 0).HostIp }}\" %s",
                            docker_cmd, container_id);
 }
 
@@ -305,8 +304,8 @@ static int port_from_container(char *container_id, char **port_out)
     }
     else
         return run_command(port_out, "%s inspect --format "
-                           "\"{{ index (index (index .NetworkSettings.Ports "
-                           "\\\"22/tcp\\\") 0) \\\"HostPort\\\" }}\" %s",
+                           "\"{{ index (index .NetworkSettings.Ports "
+                           "\\\"22/tcp\\\") 0).HostPort }}\" %s",
                            docker_cmd, container_id);
 }
 

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -291,7 +291,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            docker_cmd, container_id);
     else
         return run_command(ip_address_out, "%s inspect --format "
-                           "\"{{ index (index .NetworkSettings.Ports "
+                           "\"{{ (index (index .NetworkSettings.Ports "
                            "\\\"22/tcp\\\") 0).HostIp }}\" %s",
                            docker_cmd, container_id);
 }
@@ -304,7 +304,7 @@ static int port_from_container(char *container_id, char **port_out)
     }
     else
         return run_command(port_out, "%s inspect --format "
-                           "\"{{ index (index .NetworkSettings.Ports "
+                           "\"{{ (index (index .NetworkSettings.Ports "
                            "\\\"22/tcp\\\") 0).HostPort }}\" %s",
                            docker_cmd, container_id);
 }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -295,11 +295,22 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                               "\"{{ (index (index .NetworkSettings.Ports "
                               "\\\"22/tcp\\\") 0).HostIp }}\" %s",
                               docker_cmd, container_id);
-        if(ret && !strstr(docker_cmd, "docker")) {
-            /* An alternative is `%s port "22/tcp"` which works with
-               both docker and podman. */
-            *ip_address_out = libssh2_strdup("0.0.0.0");
-            return 0;
+        if(ret && strstr(docker_cmd, "podman")) {
+            /* Also works with both docker. */
+            ret = run_command(ip_address_out, "%s port \"22/tcp\" %s",
+                              docker_cmd, container_id);
+            if(!ret) {
+                char *hit;
+                hit = strchr(ip_address_out, '\r');
+                if(hit)
+                    *hit = '\0';
+                hit = strchr(ip_address_out, '\n');
+                if(hit)
+                    *hit = '\0';
+                hit = strrchr(ip_address_out, ':');
+                if(hit)
+                    *hit = '\0';
+            }
         }
         return ret;
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -66,7 +66,6 @@
 
 static int have_docker = 0;
 static const char *docker_cmd;
-static const char *image_tag;
 
 int openssh_fixture_have_docker(void)
 {
@@ -213,11 +212,12 @@ static int start_openssh_server(char **container_id_out)
     if(have_docker) {
         const char *container_host_port = openssh_server_port();
         if(container_host_port)
-            return run_command(container_id_out, "%s run --rm -d -p %s:22 %s",
-                               docker_cmd, container_host_port, image_tag);
+            return run_command(container_id_out, "%s run --rm -d -p %s:22 "
+                               "libssh2/openssh_server",
+                               docker_cmd, container_host_port);
 
-        return run_command(container_id_out, "%s run --rm -d -p 22 %s",
-                           docker_cmd, image_tag);
+        return run_command(container_id_out, "%s run --rm -d -p 22 "
+                           "libssh2/openssh_server", docker_cmd);
     }
     else {
         *container_id_out = libssh2_strdup("");
@@ -474,11 +474,6 @@ int start_openssh_fixture(void)
     if(!docker_cmd)
         docker_cmd = "docker";
     have_docker = !!*docker_cmd;
-    if(have_docker) {
-        image_tag = getenv("OPENSSH_SERVER_TAG");
-        if(!image_tag)
-            image_tag = "libssh2/openssh_server";
-    }
 
     ret = build_openssh_server_docker_image();
     if(!ret)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -287,8 +287,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
     else if(is_running_inside_a_container())
         return run_command(ip_address_out, "%s inspect --format "
                            "\"{{ .NetworkSettings.IPAddress }}\""
-                           " %s",
-                           docker_cmd, container_id);
+                           " %s", docker_cmd, container_id);
     else {
         /* Requires podman 6.1.0+
            https://github.com/podman-container-tools/podman/issues/29164 */
@@ -296,8 +295,8 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                               "\"{{ (index (index .NetworkSettings.Ports "
                               "\\\"22/tcp\\\") 0).HostIp }}\" %s",
                               docker_cmd, container_id);
-        if(ret && strstr(docker_cmd, "podman")) {
-            /* Another alternative is `%s port "22/tcp"` which works with
+        if(ret && !strstr(docker_cmd, "docker")) {
+            /* An alternative is `%s port "22/tcp"` which works with
                both docker and podman. */
             *ip_address_out = libssh2_strdup("0.0.0.0");
             return 0;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -211,11 +211,16 @@ static int start_openssh_server(char **container_id_out)
 {
     if(have_docker) {
         const char *container_host_port = openssh_server_port();
-        if(container_host_port)
-            return run_command(container_id_out, "%s run --rm -d -p %s:22 "
-                               "libssh2/openssh_server",
-                               docker_cmd, container_host_port);
-
+        if(container_host_port) {
+            if(strstr(docker_cmd, "container"))
+                return run_command(container_id_out, "%s run --progress none "
+                                   "--rm -d -p %s:22 libssh2/openssh_server",
+                                   docker_cmd, container_host_port);
+            else
+                return run_command(container_id_out, "%s run "
+                                   "--rm -d -p %s:22 libssh2/openssh_server",
+                                   docker_cmd, container_host_port);
+        }
         return run_command(container_id_out, "%s run --rm -d -p 22 "
                            "libssh2/openssh_server", docker_cmd);
     }
@@ -305,8 +310,8 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            " %s", docker_cmd, container_id);
     else if(strstr(docker_cmd, "container"))
         /* Requires jq */
-        return run_command(ip_address_out, "%s inspect %s | "
-                           "jq --raw-output '.[0].networks[0].gateway'",
+        return run_command(ip_address_out, "%s inspect %s | jq --raw-output "
+                           "'.[0].status.networks[0].ipv4Gateway'",
                            docker_cmd, container_id);
     else {
         /* Requires podman 6.1.0+

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -302,7 +302,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                               docker_cmd, container_id);
         if(ret && strstr(docker_cmd, "podman")) {
             /* Also works with both docker. */
-            ret = run_command(ip_address_out, "%s port \"22/tcp\" %s",
+            ret = run_command(ip_address_out, "%s port %s \"22/tcp\"",
                               docker_cmd, container_id);
             if(!ret) {
                 char *hit;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -296,10 +296,13 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                               "\"{{ (index (index .NetworkSettings.Ports "
                               "\\\"22/tcp\\\") 0).HostIp }}\" %s",
                               docker_cmd, container_id);
-        if(ret)
+        if(ret && strstr(docker_cmd, "podman")) {
             /* Another alternative is `%s port "22/tcp"` which works with
                both docker and podman. */
             *ip_address_out = libssh2_strdup("0.0.0.0");
+            return 0;
+        }
+        return ret;
     }
 }
 

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -290,13 +290,12 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            " %s",
                            docker_cmd, container_id);
     else {
-        int ret;
         /* Requires podman 6.1.0+
            https://github.com/podman-container-tools/podman/issues/29164 */
-        ret = run_command(ip_address_out, "%s inspect --format "
-                          "\"{{ (index (index .NetworkSettings.Ports "
-                          "\\\"22/tcp\\\") 0).HostIp }}\" %s",
-                          docker_cmd, container_id);
+        int ret = run_command(ip_address_out, "%s inspect --format "
+                              "\"{{ (index (index .NetworkSettings.Ports "
+                              "\\\"22/tcp\\\") 0).HostIp }}\" %s",
+                              docker_cmd, container_id);
         if(ret)
             /* Another alternative is `%s port "22/tcp"` which works with
                both docker and podman. */

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -310,7 +310,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                 hit = strrchr(*ip_address_out, ':');
                 if(hit)
                     *hit = '\0';
-                fprintf(stderr, "||%d||\n", *ip_address_out);
+                fprintf(stderr, "||%s||\n", *ip_address_out);
             }
         }
         return ret;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -315,7 +315,6 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                 hit = strrchr(*ip_address_out, ':');
                 if(hit)
                     *hit = '\0';
-                fprintf(stderr, "||%s||\n", *ip_address_out);
             }
         }
         return ret;

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -284,19 +284,17 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
             }
         }
     }
-    else {
-        if(is_running_inside_a_container())
-            return run_command(ip_address_out, "%s inspect --format "
-                               "\"{{ .NetworkSettings.IPAddress }}\""
-                               " %s",
-                               docker_cmd, container_id);
-        else
-            return run_command(ip_address_out, "%s inspect --format "
-                               "\"{{ index (index (index "
-                               ".NetworkSettings.Ports "
-                               "\\\"22/tcp\\\") 0) \\\"HostIp\\\" }}\" %s",
-                               docker_cmd, container_id);
-    }
+    else if(is_running_inside_a_container())
+        return run_command(ip_address_out, "%s inspect --format "
+                           "\"{{ .NetworkSettings.IPAddress }}\""
+                           " %s",
+                           docker_cmd, container_id);
+    else
+        return run_command(ip_address_out, "%s inspect --format "
+                           "\"{{ index (index (index "
+                           ".NetworkSettings.Ports "
+                           "\\\"22/tcp\\\") 0) \\\"HostIp\\\" }}\" %s",
+                           docker_cmd, container_id);
 }
 
 static int port_from_container(char *container_id, char **port_out)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -303,6 +303,10 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
         return run_command(ip_address_out, "%s inspect --format "
                            "\"{{ .NetworkSettings.IPAddress }}\""
                            " %s", docker_cmd, container_id);
+    else if(strstr(docker_cmd, "container"))
+        return run_command(ip_address_out, "%s inspect %s | "
+                           "jq --raw-output '.[0].networks[0].gateway'",
+                           docker_cmd, container_id);
     else {
         /* Requires podman 6.1.0+
            https://github.com/podman-container-tools/podman/issues/29164

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -310,7 +310,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            "\"{{ .NetworkSettings.IPAddress }}\""
                            " %s", docker_cmd, container_id);
     else if(strstr(docker_cmd, "container"))
-        /* Requires jq */
+        /* Requires jq and Apple container 0.8.0+ */
         return run_command(ip_address_out, "%s inspect %s | jq --raw-output "
                            "'.[0].status.networks[0].ipv4Gateway'",
                            docker_cmd, container_id);

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -475,10 +475,12 @@ int start_openssh_fixture(void)
     }
 #endif
 
-    docker_cmd = getenv("FIXTURE_CONTAINER_CMD");
-    if(!docker_cmd)
-        docker_cmd = "docker";
-    have_docker = !!*docker_cmd;
+    if(!getenv("OPENSSH_NO_DOCKER")) /* for compatibility */
+        docker_cmd = getenv("FIXTURE_CONTAINER_CMD");
+        if(!docker_cmd)
+            docker_cmd = "docker";
+        have_docker = !!*docker_cmd;
+    }
 
     ret = build_openssh_server_docker_image();
     if(!ret)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -327,7 +327,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                               "\\\"22/tcp\\\") 0).HostIp }}\" %s",
                               docker_cmd, container_id);
         if(ret && strstr(docker_cmd, "podman")) {
-            /* Also works with both docker. */
+            /* Also works with docker. */
             ret = run_command(ip_address_out, "%s port %s \"22/tcp\"",
                               docker_cmd, container_id);
             if(!ret) {

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -65,7 +65,7 @@
 #endif
 
 static int have_docker = 0;
-static const char *docker_cmd;
+static const char *docker_cmd = NULL;
 
 int openssh_fixture_have_docker(void)
 {

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -252,8 +252,9 @@ static int is_running_inside_a_container(void)
 {
     int found = 0;
 #ifndef _WIN32
+    const char *env = getenv("container");
     /* Value may be 'podman', 'oci' */
-    if(getenv("container") && getenv("container")[0])
+    if(env && *env)
         found = 1;
     else {
         FILE *fp = fopen("/proc/self/cgroup", "r");

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -317,7 +317,8 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                            " %s", docker_cmd, container_id);
     else if(strstr(docker_cmd, "container")) {
         /* Requires jq and Apple container 0.8.0+ */
-        int ret = run_command(ip_address_out, "%s inspect %s | jq --raw-output "
+        int ret = run_command(ip_address_out, "%s inspect %s | "
+                              "jq --raw-output "
                               "'.[0].status.networks[0].ipv4Gateway'",
                               docker_cmd, container_id);
         if(!ret && *ip_address_out &&

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -331,13 +331,13 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                               docker_cmd, container_id);
             if(!ret) {
                 char *hit;
-                hit = strchr(*ip_address_out, '\r');
+                hit = strchr(*ip_address_out, '\r');  /* ignore CR */
                 if(hit)
                     *hit = '\0';
-                hit = strchr(*ip_address_out, '\n');
+                hit = strchr(*ip_address_out, '\n');  /* pick first line */
                 if(hit)
                     *hit = '\0';
-                hit = strrchr(*ip_address_out, ':');
+                hit = strrchr(*ip_address_out, ':');  /* pick port part */
                 if(hit)
                     *hit = '\0';
             }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -113,7 +113,9 @@ static int run_command_varg(char **output, const char *command, va_list args)
         return -1;
     }
 
+#if 0
     fprintf(stderr, "Command: %s\n", command_buf);
+#endif
     fprintf(stdout, "Command: %s\n", command_buf);
     pipe = popen(buf, "r");
     if(!pipe) {

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -213,6 +213,7 @@ static int start_openssh_server(char **container_id_out)
         const char *container_host_port = openssh_server_port();
         if(container_host_port) {
             if(strstr(docker_cmd, "container"))
+                /* Requires Apple container 0.7.0+ for '--progress none' */
                 return run_command(container_id_out, "%s run --progress none "
                                    "--rm -d -p %s:22 libssh2/openssh_server",
                                    docker_cmd, container_host_port);

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -315,11 +315,19 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
         return run_command(ip_address_out, "%s inspect --format "
                            "\"{{ .NetworkSettings.IPAddress }}\""
                            " %s", docker_cmd, container_id);
-    else if(strstr(docker_cmd, "container"))
+    else if(strstr(docker_cmd, "container")) {
         /* Requires jq and Apple container 0.8.0+ */
-        return run_command(ip_address_out, "%s inspect %s | jq --raw-output "
-                           "'.[0].status.networks[0].ipv4Gateway'",
-                           docker_cmd, container_id);
+        int ret = run_command(ip_address_out, "%s inspect %s | jq --raw-output "
+                              "'.[0].status.networks[0].ipv4Gateway'",
+                              docker_cmd, container_id);
+        if(!ret && *ip_address_out &&
+           (!*ip_address_out[0] || !strcmp(*ip_address_out, "null"))) {
+            free(*ip_address_out);
+            *ip_address_out = NULL;
+            ret = 1;
+        }
+        return ret;
+    }
     else {
         /* Requires podman 6.1.0+
            https://github.com/podman-container-tools/podman/issues/29164 */

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -358,12 +358,12 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
 
 static int port_from_container(char *container_id, char **port_out)
 {
-    if(openssh_server_port()) {
-        *port_out = libssh2_strdup(openssh_server_port());
+    if(is_running_inside_a_container()) {
+        *port_out = libssh2_strdup("22");
         return 0;
     }
-    else if(is_running_inside_a_container()) {
-        *port_out = libssh2_strdup("22");
+    else if(openssh_server_port()) {
+        *port_out = libssh2_strdup(openssh_server_port());
         return 0;
     }
     else

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -211,17 +211,20 @@ static int start_openssh_server(char **container_id_out)
 {
     if(have_docker) {
         const char *container_host_port = openssh_server_port();
-        if(container_host_port) {
-            if(strstr(docker_cmd, "container"))
-                /* Requires Apple container 0.7.0+ for '--progress none' */
-                return run_command(container_id_out, "%s run --progress none "
-                                   "--rm -d -p %s:22 libssh2/openssh_server",
-                                   docker_cmd, container_host_port);
-            else
-                return run_command(container_id_out, "%s run "
-                                   "--rm -d -p %s:22 libssh2/openssh_server",
-                                   docker_cmd, container_host_port);
+        if(strstr(docker_cmd, "container")) {
+            if(!container_host_port) {
+                fprintf(stderr, "OPENSSH_SERVER_PORT must be set\n");
+                return 1;
+            }
+            /* Requires Apple container 0.7.0+ for '--progress none' */
+            return run_command(container_id_out, "%s run --progress none "
+                               "--rm -d -p %s:22 libssh2/openssh_server",
+                               docker_cmd, container_host_port);
         }
+        else if(container_host_port)
+            return run_command(container_id_out, "%s run "
+                               "--rm -d -p %s:22 libssh2/openssh_server",
+                               docker_cmd, container_host_port);
         return run_command(container_id_out, "%s run --rm -d -p 22 "
                            "libssh2/openssh_server", docker_cmd);
     }

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -64,12 +64,11 @@
 #define pclose _pclose
 #endif
 
-static int have_docker = 0;
 static const char *docker_cmd = NULL;
 
 int openssh_fixture_have_docker(void)
 {
-    return have_docker;
+    return !!docker_cmd;
 }
 
 static int run_command_varg(char **output, const char *command, va_list args)
@@ -168,7 +167,7 @@ static const char *openssh_server_image(void)
 
 static int build_openssh_server_docker_image(void)
 {
-    if(have_docker) {
+    if(docker_cmd) {
         const char *container_image_name = openssh_server_image();
         if(container_image_name) {
             int ret;
@@ -209,7 +208,7 @@ static const char *openssh_server_port(void)
 
 static int start_openssh_server(char **container_id_out)
 {
-    if(have_docker) {
+    if(docker_cmd) {
         const char *container_host_port = openssh_server_port();
         if(strstr(docker_cmd, "container")) {
             if(!container_host_port) {
@@ -236,7 +235,7 @@ static int start_openssh_server(char **container_id_out)
 
 static int stop_openssh_server(char *container_id)
 {
-    if(have_docker)
+    if(docker_cmd)
         return run_command(NULL, "%s stop %s", docker_cmd, container_id);
     else
         return 0;
@@ -380,7 +379,7 @@ static libssh2_socket_t open_socket_to_container(char *container_id)
     unsigned int counter;
     libssh2_socket_t ret = LIBSSH2_INVALID_SOCKET;
 
-    if(have_docker) {
+    if(docker_cmd) {
         int res;
         res = ip_address_from_container(container_id, &ip_address);
         if(res) {
@@ -475,11 +474,12 @@ int start_openssh_fixture(void)
     }
 #endif
 
-    if(!getenv("OPENSSH_NO_DOCKER")) /* for compatibility */
+    if(!getenv("OPENSSH_NO_DOCKER")) {  /* for compatibility */
         docker_cmd = getenv("FIXTURE_CONTAINER_CMD");
         if(!docker_cmd)
             docker_cmd = "docker";
-        have_docker = !!*docker_cmd;
+        else if(!*docker_cmd)
+            docker_cmd = NULL;
     }
 
     ret = build_openssh_server_docker_image();
@@ -498,7 +498,7 @@ void stop_openssh_fixture(void)
         free(running_container_id);
         running_container_id = NULL;
     }
-    else if(have_docker)
+    else if(docker_cmd)
         fprintf(stderr, "Cannot stop container - none started\n");
 
 #ifdef _WIN32

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -250,25 +250,26 @@ static const char *docker_machine_name(void)
 
 static int is_running_inside_a_container(void)
 {
-#ifdef _WIN32
-    return 0;
-#else
-    static const char *cgroup_filename = "/proc/self/cgroup";
-    FILE *fp;
-    char line[256];
     int found = 0;
-    fp = fopen(cgroup_filename, "r");
-    if(!fp)
-        return 0;  /* Do not go further, we are not in a container */
-    while(fgets(line, sizeof(line), fp)) {
-        if(strstr(line, docker_cmd)) {
-            found = 1;
-            break;
+#ifndef _WIN32
+    /* Value may be 'podman', 'oci' */
+    if(getenv("container") && getenv("container")[0])
+        found = 1;
+    else {
+        FILE *fp = fopen("/proc/self/cgroup", "r");
+        if(fp) {
+            char line[256];
+            while(fgets(line, sizeof(line), fp)) {
+                if(strstr(line, "docker")) {
+                    found = 1;
+                    break;
+                }
+            }
+            fclose(fp);
         }
     }
-    fclose(fp);
-    return found;
 #endif
+    return found;
 }
 
 static void portable_sleep(unsigned int seconds)

--- a/tests/openssh_fixture.c
+++ b/tests/openssh_fixture.c
@@ -337,6 +337,7 @@ static int ip_address_from_container(char *container_id, char **ip_address_out)
                               "\\\"22/tcp\\\") 0).HostIp }}\" %s",
                               docker_cmd, container_id);
         if(ret && strstr(docker_cmd, "podman")) {
+            free(*ip_address_out);
             /* Also works with docker. */
             ret = run_command(ip_address_out, "%s port %s \"22/tcp\"",
                               docker_cmd, container_id);

--- a/tests/test_sshd.test
+++ b/tests/test_sshd.test
@@ -148,7 +148,7 @@ anyerror=0
 
 echo "${count}..${total}"
 
-export OPENSSH_NO_DOCKER=1
+export FIXTURE_CONTAINER_CMD=''
 
 for test in ${tests}; do
   if ${LIBSSH2_TEST_EXE_RUNNER:-} "${test}"; then


### PR DESCRIPTION
- add `FIXTURE_CONTAINER_CMD` to the container command. Supported:
  `podman`, `container`, `docker` (default).
- deprecate `OPENSSH_NO_DOCKER` env. Replaced by setting
  `FIXTURE_CONTAINER_CMD` to an empty string.
- GHA: replace Docker with `podman` in a some Linux jobs.
- openssh_fixture: fixup `inspect` commands to be compatible with both
  docker and podman.
- openssh_fixture: add `inspect` fallback for podman, which does not
  support `HostIp` before 6.1.0.
  Ref: https://github.com/podman-container-tools/podman/issues/29164
- openssh_fixture: add Apple container alternatives for `pull` and 
  `tag`.
- openssh_fixture: fix `run` command to suppress progress output when
  using Apple container.                
- openssh_fixture: if `OPENSSH_SERVER_PORT` is set, omit querying   
  the port number via the container tool.                           
                                                                    
`podman` seems to be a tiny bit slower than Docker in CI.             

Requirements for Apple container:
- Apple container 0.8.0+ (2026-01-02). Tested with 1.4.1.
- `jq` installed in PATH.
- setting the sshd port manually on the host via `OPENSSH_SERVER_PORT`
  (`container` cannot automatically assign one).
- physical macOS machine.

Example to run conainerized tests on macOS:                         
```sh
brew install container jq
container system start --disable-kernel-install
container system kernel set --recommended
export FIXTURE_CONTAINER_CMD=container
export OPENSSH_SERVER_PORT=<free-port-number>
export OPENSSH_SERVER_IMAGE; OPENSSH_SERVER_IMAGE=ghcr.io/libssh2/ci_tests_openssh_server:$(git rev-parse --short=20 HEAD:tests/openssh_server)
ctest -VV
```

Also tried:
- using Apple container in CI. Does not work because nested
  virtualization is not supported in GHA runners.
- installing WSL on Windows. Failed with cryptic error upon
  `wsl --install --distribution Debian`.
