### PR TITLE
openssh_server: build container for arm64 also, fix Dockerfile for trixie

### DIFF
--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -48,6 +48,13 @@ jobs:
       contents: read   # To comply with https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images
       packages: write  # To create/update container
     steps:
+      - name: 'install prereqs'
+        run: |
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
+            qemu-user-static
+
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -77,9 +84,16 @@ jobs:
           tags: |
             type=raw,value=${{ steps.hash.outputs.hash }}
 
+      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+        if: ${{ steps.poll.outcome == 'failure' }}
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        if: ${{ steps.poll.outcome == 'failure' }}
+
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         if: ${{ steps.poll.outcome == 'failure' }}
         with:
+          platforms: linux/amd64,linux/arm64
           context: ./tests/openssh_server
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/openssh_server.yml
+++ b/.github/workflows/openssh_server.yml
@@ -48,13 +48,6 @@ jobs:
       contents: read   # To comply with https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images
       packages: write  # To create/update container
     steps:
-      - name: 'install prereqs'
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install \
-            qemu-user-static
-
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -84,11 +77,13 @@ jobs:
           tags: |
             type=raw,value=${{ steps.hash.outputs.hash }}
 
-      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+      - name: 'install prereqs'
         if: ${{ steps.poll.outcome == 'failure' }}
-
-      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        if: ${{ steps.poll.outcome == 'failure' }}
+        run: |
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
+            qemu-user-static
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         if: ${{ steps.poll.outcome == 'failure' }}

--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:testing-20260824-slim@sha256:b21cba5194c0cddc19b41045ceebce11b5413ac40bac7f2410c066b5acb28091
 
 RUN apt-get update \
- && apt-get install -y openssh-server \
+ && apt-get install -y --no-install-suggests --no-install-recommends openssh-server adduser \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 RUN [ -d /var/run/sshd ] || mkdir /var/run/sshd

--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:testing-20260824-slim@sha256:b21cba5194c0cddc19b41045ceebce11b5413ac40bac7f2410c066b5acb28091
 
 RUN apt-get update \
- && apt-get install -y --no-install-suggests --no-install-recommends openssh-server adduser \
+ && apt-get install -y --no-install-suggests --no-install-recommends adduser openssh-server \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 RUN [ -d /var/run/sshd ] || mkdir /var/run/sshd

--- a/tests/openssh_server/Dockerfile
+++ b/tests/openssh_server/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # To update, get the latest digest e.g. from https://hub.docker.com/_/debian/tags
-FROM debian:trixie-20260824-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
+FROM debian:testing-20260824-slim@sha256:b21cba5194c0cddc19b41045ceebce11b5413ac40bac7f2410c066b5acb28091
 
 RUN apt-get update \
  && apt-get install -y openssh-server \


### PR DESCRIPTION
To enable testing on arm64 Linux and possibly also on macOS, and 
possibly possibly on arm64 Windows.                            

Also:
- switch to debian:testing to trigger a container rebuild.
- Dockerfile: install `adduser` explicitly. Required for debian:forky.
- Dockerfile: stop installing suggested/recommended packages.

Ref: https://github.com/docker/build-push-action
